### PR TITLE
fix: exclude terminated agents from list and org chart endpoints

### DIFF
--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -251,8 +251,12 @@ export function agentService(db: Db) {
   }
 
   return {
-    list: async (companyId: string) => {
-      const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
+    list: async (companyId: string, options?: { includeTerminated?: boolean }) => {
+      const conditions = [eq(agents.companyId, companyId)];
+      if (!options?.includeTerminated) {
+        conditions.push(ne(agents.status, "terminated"));
+      }
+      const rows = await db.select().from(agents).where(and(...conditions));
       return rows.map(normalizeAgentRow);
     },
 
@@ -469,7 +473,10 @@ export function agentService(db: Db) {
     },
 
     orgForCompany: async (companyId: string) => {
-      const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
+      const rows = await db
+        .select()
+        .from(agents)
+        .where(and(eq(agents.companyId, companyId), ne(agents.status, "terminated")));
       const normalizedRows = rows.map(normalizeAgentRow);
       const byManager = new Map<string | null, typeof normalizedRows>();
       for (const row of normalizedRows) {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -556,7 +556,7 @@ export function companyPortabilityService(db: Db) {
       requiredSecrets: [],
     };
 
-    const allAgentRows = include.agents ? await agents.list(companyId) : [];
+    const allAgentRows = include.agents ? await agents.list(companyId, { includeTerminated: true }) : [];
     const agentRows = allAgentRows.filter((agent) => agent.status !== "terminated");
     if (include.agents) {
       const skipped = allAgentRows.length - agentRows.length;


### PR DESCRIPTION
## Summary

Terminated agents (from rejected hire approvals) were visible in the agents list and org chart because `list()` and `orgForCompany()` in `server/src/services/agents.ts` had no status filtering.

- Add `ne(agents.status, "terminated")` filter to `list()` (line 254) and `orgForCompany()` (line 471)
- Add optional `{ includeTerminated: true }` param to `list()` for callers that need all agents
- Update `company-portability.ts` export path to explicitly opt in to terminated agents (preserves skip-count warning)
- `orgForCompany()` always excludes terminated — no escape hatch needed since the only caller is the org chart route

## Root cause

Both queries selected all agents for a company with no status filter:

```ts
// Before
const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
```

Other parts of the codebase already excluded terminated agents: `resolveByReference` (line 536), `company-portability` export (line 560), sidebar badge counts, and heartbeat logic.

## Testing

- **Typecheck**: No new errors in modified files (pre-existing errors in `adapter-utils` and `live-events-ws.ts` from missing `@types/node` and `@types/ws`)
- **All 75 existing tests pass**
- **No service-layer test infrastructure exists** (PostgreSQL-backed, no test DB harness). Integration tests for this fix would require standing up a test database — recommend as a follow-up.

Fixes #5