### PR TITLE
fix(server): prevent agent shortname lookup from crashing /api/agents/:id

### DIFF
--- a/server/src/__tests__/agents-service.test.ts
+++ b/server/src/__tests__/agents-service.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { agentService } from "../services/agents.js";
+
+describe("agentService.getById", () => {
+  it("returns null for non-uuid references without hitting the database", async () => {
+    const selectSpy = vi.fn(() => {
+      throw new Error("db.select should not be called for non-uuid agent ids");
+    });
+    const db = { select: selectSpy } as unknown as Db;
+    const svc = agentService(db);
+
+    const result = await svc.getById("mobile-engineer");
+
+    expect(result).toBeNull();
+    expect(selectSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -156,6 +156,7 @@ export function agentService(db: Db) {
   }
 
   async function getById(id: string) {
+    if (!isUuidLike(id)) return null;
     const row = await db
       .select()
       .from(agents)


### PR DESCRIPTION
## Summary
- Guard `agentService.getById` against non-UUID inputs.
- Return `null` for non-UUID agent references so `/api/agents/:id` responds with `404` instead of surfacing a DB error.
- Add a regression test proving non-UUID IDs do not hit the DB query path.

## Root Cause
When an unresolved agent shortname/reference (for example `mobile-engineer`) reached the route parameter path, `getById` could be called with a non-UUID string. The service then queried `agents.id` (UUID column) with that value, which caused a database error and returned `500`.

## Validation
- `pnpm install`
- `pnpm test:run` ✅ (22 files, 76 tests)
- `pnpm -r typecheck` ❌ fails in existing `packages/adapter-utils` Node typings setup (unrelated to this change)
- `pnpm build` ❌ fails for the same existing `packages/adapter-utils` issue
