### PR TITLE
fix(ui): render sub-goals on goal detail pages

### DIFF
--- a/ui/src/components/GoalTree.tsx
+++ b/ui/src/components/GoalTree.tsx
@@ -92,7 +92,8 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
 }
 
 export function GoalTree({ goals, goalLink, onSelect }: GoalTreeProps) {
-  const roots = goals.filter((g) => !g.parentId);
+  const goalIds = new Set(goals.map((g) => g.id));
+  const roots = goals.filter((g) => !g.parentId || !goalIds.has(g.parentId));
 
   if (goals.length === 0) {
     return <p className="text-sm text-muted-foreground">No goals.</p>;


### PR DESCRIPTION
## Summary
- fix goal detail sub-goal tab rendering when the tree receives a subset of goals
- treat goals as roots when their parent is missing from the provided dataset

## Problem
On `/goals/:goalId`, the UI passed only direct children into `GoalTree`.
`GoalTree` only rendered nodes with `parentId = null` as roots, so child-only datasets produced an empty list while still showing a non-zero sub-goal count.

## Fix
- updated `GoalTree` root detection to include goals whose `parentId` is not present in the current `goals` list
- this preserves existing behavior for full trees while allowing detail-page subsets to render correctly

## Validation
- `pnpm --filter @paperclipai/ui typecheck`

## Scope
- UI only
- file changed: `ui/src/components/GoalTree.tsx`
