### PR TITLE
feat(company): support custom logo in appearance settings

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -124,6 +124,8 @@ Human auth tables (`users`, `sessions`, and provider-specific auth artifacts) ar
 - `name` text not null
 - `description` text null
 - `status` enum: `active | paused | archived`
+- `brand_color` text null
+- `logo_asset_id` uuid null (references an uploaded image asset owned by the same company)
 
 Invariant: every business record belongs to exactly one company.
 

--- a/packages/db/src/migrations/0024_company_logo_asset.sql
+++ b/packages/db/src/migrations/0024_company_logo_asset.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "companies" ADD COLUMN "logo_asset_id" uuid;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1772139727599,
       "tag": "0023_fair_lethal_legion",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1772697600000,
+      "tag": "0024_company_logo_asset",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -15,6 +15,7 @@ export const companies = pgTable(
       .notNull()
       .default(true),
     brandColor: text("brand_color"),
+    logoAssetId: uuid("logo_asset_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -11,6 +11,7 @@ export interface Company {
   spentMonthlyCents: number;
   requireBoardApprovalForNewAgents: boolean;
   brandColor: string | null;
+  logoAssetId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -16,6 +16,7 @@ export const updateCompanySchema = createCompanySchema
     spentMonthlyCents: z.number().int().nonnegative().optional(),
     requireBoardApprovalForNewAgents: z.boolean().optional(),
     brandColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).nullable().optional(),
+    logoAssetId: z.string().uuid().nullable().optional(),
   });
 
 export type UpdateCompany = z.infer<typeof updateCompanySchema>;

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -9,7 +9,7 @@ import {
 } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
-import { accessService, companyPortabilityService, companyService, logActivity } from "../services/index.js";
+import { accessService, assetService, companyPortabilityService, companyService, logActivity } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 
 export function companyRoutes(db: Db) {
@@ -17,6 +17,7 @@ export function companyRoutes(db: Db) {
   const svc = companyService(db);
   const portability = companyPortabilityService(db);
   const access = accessService(db);
+  const assets = assetService(db);
 
   router.get("/", async (req, res) => {
     assertBoard(req);
@@ -122,6 +123,13 @@ export function companyRoutes(db: Db) {
     assertBoard(req);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    if (req.body.logoAssetId) {
+      const logo = await assets.getById(req.body.logoAssetId);
+      if (!logo || logo.companyId !== companyId) {
+        res.status(422).json({ error: "Logo asset must belong to the selected company" });
+        return;
+      }
+    }
     const company = await svc.update(companyId, req.body);
     if (!company) {
       res.status(404).json({ error: "Company not found" });

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -21,7 +21,13 @@ export const companiesApi = {
     data: Partial<
       Pick<
         Company,
-        "name" | "description" | "status" | "budgetMonthlyCents" | "requireBoardApprovalForNewAgents" | "brandColor"
+        | "name"
+        | "description"
+        | "status"
+        | "budgetMonthlyCents"
+        | "requireBoardApprovalForNewAgents"
+        | "brandColor"
+        | "logoAssetId"
       >
     >,
   ) => api.patch<Company>(`/companies/${companyId}`, data),

--- a/ui/src/components/CompanyPatternIcon.tsx
+++ b/ui/src/components/CompanyPatternIcon.tsx
@@ -11,6 +11,7 @@ const BAYER_4X4 = [
 interface CompanyPatternIconProps {
   companyName: string;
   brandColor?: string | null;
+  logoSrc?: string | null;
   className?: string;
 }
 
@@ -159,7 +160,7 @@ function makeCompanyPatternDataUrl(seed: string, brandColor?: string | null, log
   return canvas.toDataURL("image/png");
 }
 
-export function CompanyPatternIcon({ companyName, brandColor, className }: CompanyPatternIconProps) {
+export function CompanyPatternIcon({ companyName, brandColor, logoSrc, className }: CompanyPatternIconProps) {
   const initial = companyName.trim().charAt(0).toUpperCase() || "?";
   const patternDataUrl = useMemo(
     () => makeCompanyPatternDataUrl(companyName.trim().toLowerCase(), brandColor),
@@ -173,7 +174,13 @@ export function CompanyPatternIcon({ companyName, brandColor, className }: Compa
         className,
       )}
     >
-      {patternDataUrl ? (
+      {logoSrc ? (
+        <img
+          src={logoSrc}
+          alt={`${companyName} logo`}
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      ) : patternDataUrl ? (
         <img
           src={patternDataUrl}
           alt=""
@@ -184,9 +191,11 @@ export function CompanyPatternIcon({ companyName, brandColor, className }: Compa
       ) : (
         <div className="absolute inset-0 bg-muted" />
       )}
-      <span className="relative z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.65)]">
-        {initial}
-      </span>
+      {!logoSrc && (
+        <span className="relative z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.65)]">
+          {initial}
+        </span>
+      )}
     </div>
   );
 }

--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -22,6 +22,7 @@ import { cn } from "../lib/utils";
 import { queryKeys } from "../lib/queryKeys";
 import { sidebarBadgesApi } from "../api/sidebarBadges";
 import { heartbeatsApi } from "../api/heartbeats";
+import { getCompanyLogoPath } from "../lib/companyBranding";
 import {
   Tooltip,
   TooltipContent,
@@ -122,6 +123,7 @@ function SortableCompanyItem({
               <CompanyPatternIcon
                 companyName={company.name}
                 brandColor={company.brandColor}
+                logoSrc={getCompanyLogoPath(company.logoAssetId)}
                 className={cn(
                   isSelected
                     ? "rounded-[14px]"

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -20,6 +20,8 @@ import { useCompany } from "../context/CompanyContext";
 import { sidebarBadgesApi } from "../api/sidebarBadges";
 import { heartbeatsApi } from "../api/heartbeats";
 import { queryKeys } from "../lib/queryKeys";
+import { getCompanyLogoPath } from "../lib/companyBranding";
+import { CompanyPatternIcon } from "./CompanyPatternIcon";
 import { Button } from "@/components/ui/button";
 
 export function Sidebar() {
@@ -46,10 +48,12 @@ export function Sidebar() {
     <aside className="w-60 h-full min-h-0 border-r border-border bg-background flex flex-col">
       {/* Top bar: Company name (bold) + Search — aligned with top sections (no visible border) */}
       <div className="flex items-center gap-1 px-3 h-12 shrink-0">
-        {selectedCompany?.brandColor && (
-          <div
-            className="w-4 h-4 rounded-sm shrink-0 ml-1"
-            style={{ backgroundColor: selectedCompany.brandColor }}
+        {selectedCompany && (
+          <CompanyPatternIcon
+            companyName={selectedCompany.name}
+            brandColor={selectedCompany.brandColor}
+            logoSrc={getCompanyLogoPath(selectedCompany.logoAssetId)}
+            className="h-5 w-5 rounded-md text-[10px] ml-1"
           />
         )}
         <span className="flex-1 text-sm font-bold text-foreground truncate pl-1">

--- a/ui/src/lib/companyBranding.ts
+++ b/ui/src/lib/companyBranding.ts
@@ -1,0 +1,4 @@
+export function getCompanyLogoPath(logoAssetId: string | null | undefined): string | null {
+  if (!logoAssetId) return null;
+  return `/api/assets/${logoAssetId}/content`;
+}

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { companiesApi } from "../api/companies";
 import { accessApi } from "../api/access";
+import { assetsApi } from "../api/assets";
 import { queryKeys } from "../lib/queryKeys";
+import { getCompanyLogoPath } from "../lib/companyBranding";
 import { Button } from "@/components/ui/button";
 import { Settings } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
@@ -19,6 +21,8 @@ export function CompanySettings() {
   const [companyName, setCompanyName] = useState("");
   const [description, setDescription] = useState("");
   const [brandColor, setBrandColor] = useState("");
+  const [logoAssetId, setLogoAssetId] = useState<string | null>(null);
+  const logoInputRef = useRef<HTMLInputElement | null>(null);
 
   // Sync local state from selected company
   useEffect(() => {
@@ -26,6 +30,7 @@ export function CompanySettings() {
     setCompanyName(selectedCompany.name);
     setDescription(selectedCompany.description ?? "");
     setBrandColor(selectedCompany.brandColor ?? "");
+    setLogoAssetId(selectedCompany.logoAssetId ?? null);
   }, [selectedCompany]);
 
   const [inviteLink, setInviteLink] = useState<string | null>(null);
@@ -35,13 +40,28 @@ export function CompanySettings() {
     !!selectedCompany &&
     (companyName !== selectedCompany.name ||
       description !== (selectedCompany.description ?? "") ||
-      brandColor !== (selectedCompany.brandColor ?? ""));
+      brandColor !== (selectedCompany.brandColor ?? "") ||
+      logoAssetId !== (selectedCompany.logoAssetId ?? null));
 
   const generalMutation = useMutation({
-    mutationFn: (data: { name: string; description: string | null; brandColor: string | null }) =>
+    mutationFn: (data: {
+      name: string;
+      description: string | null;
+      brandColor: string | null;
+      logoAssetId: string | null;
+    }) =>
       companiesApi.update(selectedCompanyId!, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
+  const logoUploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      if (!selectedCompanyId) throw new Error("No company selected");
+      return assetsApi.uploadImage(selectedCompanyId, file, "companies/logos");
+    },
+    onSuccess: (asset) => {
+      setLogoAssetId(asset.assetId);
     },
   });
 
@@ -111,6 +131,7 @@ export function CompanySettings() {
       name: companyName.trim(),
       description: description.trim() || null,
       brandColor: brandColor || null,
+      logoAssetId,
     });
   }
 
@@ -158,10 +179,57 @@ export function CompanySettings() {
               <CompanyPatternIcon
                 companyName={companyName || selectedCompany.name}
                 brandColor={brandColor || null}
+                logoSrc={getCompanyLogoPath(logoAssetId)}
                 className="rounded-[14px]"
               />
             </div>
             <div className="flex-1 space-y-2">
+              <Field
+                label="Company logo"
+                hint="PNG, JPG, WEBP, or GIF. Upload overrides the generated icon."
+              >
+                <div className="flex items-center gap-2">
+                  <input
+                    ref={logoInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/gif"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      logoUploadMutation.mutate(file);
+                      e.target.value = "";
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => logoInputRef.current?.click()}
+                    disabled={logoUploadMutation.isPending}
+                  >
+                    {logoUploadMutation.isPending ? "Uploading..." : "Upload logo"}
+                  </Button>
+                  {logoAssetId && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setLogoAssetId(null)}
+                      className="text-xs text-muted-foreground"
+                    >
+                      Remove logo
+                    </Button>
+                  )}
+                </div>
+                {logoUploadMutation.isError && (
+                  <p className="text-xs text-destructive">
+                    {logoUploadMutation.error instanceof Error
+                      ? logoUploadMutation.error.message
+                      : "Failed to upload logo"}
+                  </p>
+                )}
+              </Field>
               <Field label="Brand color" hint="Sets the hue for the company icon. Leave empty for auto-generated color.">
                 <div className="flex items-center gap-2">
                   <input


### PR DESCRIPTION
## Summary

This PR adds support for custom company logos in **Company Settings → Appearance**.
Previously, appearance customization only supported `brandColor`.

With this change:
- users can upload a company logo image from Company Settings
- the selected logo is persisted on `companies.logo_asset_id`
- company icon rendering now prioritizes logo when present, and falls back to the generated pattern icon when absent
- server-side validation enforces that the selected logo asset belongs to the same company

## Why

The current appearance model is limited to a color tint. This PR enables a practical branding workflow for multi-company operators while preserving existing fallback behavior.

## Changes

### Database / schema
- add nullable `logo_asset_id` column to `companies`
- add migration `0024_company_logo_asset.sql`

### Shared contracts
- extend `Company` type with `logoAssetId: string | null`
- extend `updateCompanySchema` with `logoAssetId` (`uuid | null`)

### Server
- update `PATCH /api/companies/:companyId` handling to validate `logoAssetId`:
  - asset must exist
  - asset must belong to the same company
  - otherwise return `422`

### UI
- Company Settings Appearance now includes:
  - logo upload button (reuses existing `/companies/:companyId/assets/images` endpoint)
  - remove logo action
  - live preview
- company icon component (`CompanyPatternIcon`) now supports optional `logoSrc`
- company switcher / sidebar top area now display logo when available
- add helper `getCompanyLogoPath(logoAssetId)` for consistent asset path generation

### Docs
- update V1 companies model notes to include `brand_color` and `logo_asset_id`

## Validation

Ran:
- `pnpm test:run` ✅ (75/75)
- `pnpm --filter @paperclipai/shared typecheck` ✅
- `pnpm --filter @paperclipai/ui typecheck` ✅
- `pnpm --filter @paperclipai/shared build` ✅
- `pnpm --filter @paperclipai/ui build` ✅

Known baseline issues in repo (not introduced by this PR):
- `pnpm -r typecheck` fails in `packages/adapter-utils` due missing Node typings/config
- `pnpm build` fails for the same baseline reason
- `pnpm db:generate` also fails under same baseline TypeScript issue, so migration was added manually (SQL + journal entry)

## Backward compatibility

- Existing companies without logos continue to render pattern icons.
- Existing `brandColor` behavior is unchanged.
