### PR TITLE
feat: dynamic Claude model list with Anthropic API + add Sonnet 4.6

### DIFF
--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -2,18 +2,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
 import { resetOpenCodeModelsCacheForTests } from "@paperclipai/adapter-opencode-local/server";
+import { models as claudeFallbackModels } from "@paperclipai/adapter-claude-local";
 import { listAdapterModels } from "../adapters/index.js";
 import { resetCodexModelsCacheForTests } from "../adapters/codex-models.js";
 import { resetCursorModelsCacheForTests, setCursorModelsRunnerForTests } from "../adapters/cursor-models.js";
+import { resetClaudeModelsCacheForTests } from "../adapters/claude-models.js";
 
 describe("adapter model listing", () => {
   beforeEach(() => {
     delete process.env.OPENAI_API_KEY;
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
+    delete process.env.ANTHROPIC_API_KEY;
     resetCodexModelsCacheForTests();
     resetCursorModelsCacheForTests();
     setCursorModelsRunnerForTests(null);
     resetOpenCodeModelsCacheForTests();
+    resetClaudeModelsCacheForTests();
     vi.restoreAllMocks();
   });
 
@@ -100,5 +104,63 @@ describe("adapter model listing", () => {
 
     const models = await listAdapterModels("opencode_local");
     expect(models).toEqual([]);
+  });
+
+  it("returns claude fallback models when no Anthropic API key is available", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const models = await listAdapterModels("claude_local");
+
+    expect(models).toEqual(claudeFallbackModels);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("loads claude models dynamically and merges fallback options", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "claude-opus-5-0", display_name: "Claude Opus 5.0" },
+          { id: "claude-sonnet-5-0", display_name: "Claude Sonnet 5.0" },
+        ],
+      }),
+    } as Response);
+
+    const first = await listAdapterModels("claude_local");
+    const second = await listAdapterModels("claude_local");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+    expect(first.some((m) => m.id === "claude-opus-5-0")).toBe(true);
+    expect(first.some((m) => m.id === "claude-sonnet-4-6")).toBe(true);
+  });
+
+  it("falls back to static claude models when Anthropic model discovery fails", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    } as Response);
+
+    const models = await listAdapterModels("claude_local");
+    expect(models).toEqual(claudeFallbackModels);
+  });
+
+  it("filters non-claude models from Anthropic API response", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "claude-opus-5-0", display_name: "Claude Opus 5.0" },
+          { id: "some-other-model", display_name: "Some Other Model" },
+        ],
+      }),
+    } as Response);
+
+    const models = await listAdapterModels("claude_local");
+    expect(models.some((m) => m.id === "claude-opus-5-0")).toBe(true);
+    expect(models.some((m) => m.id === "some-other-model")).toBe(false);
   });
 });

--- a/server/src/adapters/claude-models.ts
+++ b/server/src/adapters/claude-models.ts
@@ -1,40 +1,30 @@
 import type { AdapterModel } from "./types.js";
-import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
-import { readConfigFile } from "../config-file.js";
+import { models as claudeFallbackModels } from "@paperclipai/adapter-claude-local";
 import { fingerprint, dedupeModels } from "./model-utils.js";
 
-const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
-const OPENAI_MODELS_TIMEOUT_MS = 5000;
-const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
+const ANTHROPIC_MODELS_ENDPOINT = "https://api.anthropic.com/v1/models";
+const ANTHROPIC_MODELS_TIMEOUT_MS = 5000;
+const ANTHROPIC_MODELS_CACHE_TTL_MS = 60_000;
 
-const fallback = dedupeModels(codexFallbackModels);
+const fallback = dedupeModels(claudeFallbackModels);
 
 let cached: { keyFingerprint: string; expiresAt: number; models: AdapterModel[] } | null = null;
 
 function mergedWithFallback(models: AdapterModel[]): AdapterModel[] {
   return dedupeModels([
     ...models,
-    ...codexFallbackModels,
+    ...claudeFallbackModels,
   ]).sort((a, b) => a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }));
 }
 
-function resolveOpenAiApiKey(): string | null {
-  const envKey = process.env.OPENAI_API_KEY?.trim();
-  if (envKey) return envKey;
-
-  const config = readConfigFile();
-  if (config?.llm?.provider !== "openai") return null;
-  const configKey = config.llm.apiKey?.trim();
-  return configKey && configKey.length > 0 ? configKey : null;
-}
-
-async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
+async function fetchAnthropicModels(apiKey: string): Promise<AdapterModel[]> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), OPENAI_MODELS_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), ANTHROPIC_MODELS_TIMEOUT_MS);
   try {
-    const response = await fetch(OPENAI_MODELS_ENDPOINT, {
+    const response = await fetch(ANTHROPIC_MODELS_ENDPOINT, {
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
       },
       signal: controller.signal,
     });
@@ -46,8 +36,10 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
     for (const item of data) {
       if (typeof item !== "object" || item === null) continue;
       const id = (item as { id?: unknown }).id;
-      if (typeof id !== "string" || id.trim().length === 0) continue;
-      models.push({ id, label: id });
+      if (typeof id !== "string" || !id.startsWith("claude-")) continue;
+      const displayName = (item as { display_name?: unknown }).display_name;
+      const label = typeof displayName === "string" && displayName.trim() ? displayName.trim() : id;
+      models.push({ id, label });
     }
     return models;
   } catch {
@@ -57,8 +49,8 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
   }
 }
 
-export async function listCodexModels(): Promise<AdapterModel[]> {
-  const apiKey = resolveOpenAiApiKey();
+export async function listClaudeModels(): Promise<AdapterModel[]> {
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
   if (!apiKey) return fallback;
 
   const now = Date.now();
@@ -67,12 +59,12 @@ export async function listCodexModels(): Promise<AdapterModel[]> {
     return cached.models;
   }
 
-  const fetched = await fetchOpenAiModels(apiKey);
+  const fetched = await fetchAnthropicModels(apiKey);
   if (fetched.length > 0) {
     const merged = mergedWithFallback(fetched);
     cached = {
       keyFingerprint,
-      expiresAt: now + OPENAI_MODELS_CACHE_TTL_MS,
+      expiresAt: now + ANTHROPIC_MODELS_CACHE_TTL_MS,
       models: merged,
     };
     return merged;
@@ -85,6 +77,6 @@ export async function listCodexModels(): Promise<AdapterModel[]> {
   return fallback;
 }
 
-export function resetCodexModelsCacheForTests() {
+export function resetClaudeModelsCacheForTests() {
   cached = null;
 }

--- a/server/src/adapters/model-utils.ts
+++ b/server/src/adapters/model-utils.ts
@@ -1,0 +1,17 @@
+import type { AdapterModel } from "./types.js";
+
+export function fingerprint(apiKey: string): string {
+  return `${apiKey.length}:${apiKey.slice(-6)}`;
+}
+
+export function dedupeModels(models: AdapterModel[]): AdapterModel[] {
+  const seen = new Set<string>();
+  const deduped: AdapterModel[] = [];
+  for (const model of models) {
+    const id = model.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    deduped.push({ id, label: model.label.trim() || id });
+  }
+  return deduped;
+}

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -60,6 +60,7 @@ import {
   agentConfigurationDoc as hermesAgentConfigurationDoc,
   models as hermesModels,
 } from "hermes-paperclip-adapter";
+import { listClaudeModels } from "./claude-models.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
@@ -69,6 +70,7 @@ const claudeLocalAdapter: ServerAdapterModule = {
   testEnvironment: claudeTestEnvironment,
   sessionCodec: claudeSessionCodec,
   models: claudeModels,
+  listModels: listClaudeModels,
   supportsLocalAgentJwt: true,
   agentConfigurationDoc: claudeAgentConfigurationDoc,
 };


### PR DESCRIPTION
## Summary

- **Adds `claude-sonnet-4-6`** to the static fallback model list (it was missing; only Opus 4.6 and Sonnet 4.5 were present)
- **Creates `server/src/adapters/claude-models.ts`** — dynamically fetches Claude models from Anthropic's `/v1/models` API when `ANTHROPIC_API_KEY` is set, with a 60s in-memory cache and automatic fallback to the static list on failure
- **Wires `listModels` into `claudeLocalAdapter`** in `registry.ts`, mirroring the existing codex dynamic model pattern
- Filters non-`claude-*` models from the Anthropic API response

<img width="425" height="310" alt="image" src="https://github.com/user-attachments/assets/c4600c89-b0c7-49d5-9487-bbe6d9d20ea1" />


## Behavior

| Condition | Result |
|-----------|--------|
| No `ANTHROPIC_API_KEY` | Returns static fallback list (subscription auth users) |
| API key set, fetch succeeds | Returns live list merged with fallback, cached 60s |
| API key set, fetch fails | Returns stale cache if available, otherwise static fallback |

## Test plan

- [x] No-key fallback returns static models without calling fetch
- [x] Dynamic fetch merges API models with fallback
- [x] Fetch cached — API only called once across multiple calls
- [x] API failure falls back to static models
- [x] Non-`claude-*` models from API response are filtered out
- [x] All 8 tests pass (`pnpm test:run server/src/__tests__/adapter-models.test.ts`)
- [x] Typecheck passes
