### PR TITLE
Honor auth env in bootstrap-ceo and add localbuild compose

### DIFF
--- a/cli/src/commands/auth-bootstrap-ceo.ts
+++ b/cli/src/commands/auth-bootstrap-ceo.ts
@@ -28,6 +28,8 @@ function resolveDbUrl(configPath?: string) {
 
 function resolveBaseUrl(configPath?: string, explicitBaseUrl?: string) {
   if (explicitBaseUrl) return explicitBaseUrl.replace(/\/+$/, "");
+  const envBaseUrl = process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL ?? process.env.BETTER_AUTH_URL;
+  if (envBaseUrl?.trim()) return envBaseUrl.trim().replace(/\/+$/, "");
   const config = readConfig(configPath);
   if (config?.auth.baseUrlMode === "explicit" && config.auth.publicBaseUrl) {
     return config.auth.publicBaseUrl.replace(/\/+$/, "");
@@ -36,6 +38,15 @@ function resolveBaseUrl(configPath?: string, explicitBaseUrl?: string) {
   const port = config?.server.port ?? 3100;
   const publicHost = host === "0.0.0.0" ? "localhost" : host;
   return `http://${publicHost}:${port}`;
+}
+
+function resolveDeploymentMode(configPath?: string): "authenticated" | "local_trusted" {
+  const deploymentModeFromEnv = process.env.PAPERCLIP_DEPLOYMENT_MODE?.trim();
+  if (deploymentModeFromEnv === "authenticated" || deploymentModeFromEnv === "local_trusted") {
+    return deploymentModeFromEnv;
+  }
+  const config = readConfig(configPath);
+  return config?.server.deploymentMode ?? "local_trusted";
 }
 
 export async function bootstrapCeoInvite(opts: {
@@ -51,7 +62,7 @@ export async function bootstrapCeoInvite(opts: {
     return;
   }
 
-  if (config.server.deploymentMode !== "authenticated") {
+  if (resolveDeploymentMode(configPath) !== "authenticated") {
     p.log.info("Deployment mode is local_trusted. Bootstrap CEO invite is only required for authenticated mode.");
     return;
   }

--- a/docker-compose.localbuild.yml
+++ b/docker-compose.localbuild.yml
@@ -1,0 +1,36 @@
+services:
+  localbuild-db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: paperclip
+      POSTGRES_PASSWORD: paperclip
+      POSTGRES_DB: paperclip
+    ports:
+      - "55432:5432"
+    volumes:
+      - pgdata_localbuild:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U paperclip -d paperclip"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  localbuild-server:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "3200:3100"
+    environment:
+      DATABASE_URL: postgres://paperclip:paperclip@localbuild-db:5432/paperclip
+      PORT: "3100"
+      SERVE_UI: "true"
+      PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:-dev-insecure-change-me}"
+      PAPERCLIP_AUTH_PUBLIC_BASE_URL: "${PAPERCLIP_AUTH_PUBLIC_BASE_URL:-http://localhost:3200}"
+    depends_on:
+      localbuild-db:
+        condition: service_healthy
+
+volumes:
+  pgdata_localbuild:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -8,6 +8,10 @@ services:
     environment:
       HOST: "0.0.0.0"
       PAPERCLIP_HOME: "/paperclip"
+      PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:-dev-insecure-change-me}"
+      PAPERCLIP_AUTH_PUBLIC_BASE_URL: "${PAPERCLIP_AUTH_PUBLIC_BASE_URL:-http://localhost:3100}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       DATABASE_URL: postgres://paperclip:paperclip@db:5432/paperclip
       PORT: "3100"
       SERVE_UI: "true"
+      PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:-dev-insecure-change-me}"
+      PAPERCLIP_AUTH_PUBLIC_BASE_URL: "${PAPERCLIP_AUTH_PUBLIC_BASE_URL:-http://localhost:3100}"
     depends_on:
       - db
 


### PR DESCRIPTION
If you host on nonstandard ports, the messages didn't match up. 

I created `docker-compose.localbuild.yml` as a local staging environment. It's just a clone of `docker-compose.quickstart.yml` but I don't see any harm in including as coding agents should use it without prompting. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added local build Docker Compose configuration with PostgreSQL database and application server for development environments.
  * Enhanced deployment configuration with environment variables for deployment mode, exposure settings, and authentication base URL management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->