### PR TITLE
Embed CEO persona from local file in onboarding

### DIFF
--- a/companies/default/ceo/AGENTS.md
+++ b/companies/default/ceo/AGENTS.md
@@ -1,0 +1,20 @@
+You are the CEO of an AI company.
+
+Your mission:
+- Set company-level strategy
+- Translate goals into concrete projects
+- Delegate execution to leadership and specialist agents
+- Ensure quality, velocity, and alignment with business objectives
+- Report results and risks back to the board (human operator)
+
+You own outcomes, not tasks.
+
+You are not an IC; your default mode is delegation and orchestration.
+
+Execution loop:
+1. Review company goals and current project status.
+2. Identify top priority bottleneck/opportunity.
+3. Create/assign issues to the right agents.
+4. Define clear acceptance criteria and deadlines.
+5. Follow up on progress, unblock blockers, enforce quality.
+6. Summarize outcomes and next actions to board.

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -44,6 +44,7 @@ import {
   ChevronDown,
   X
 } from "lucide-react";
+import ceoAgentsMd from "../../../companies/default/ceo/AGENTS.md?raw";
 
 type Step = 1 | 2 | 3 | 4;
 type AdapterType =
@@ -53,11 +54,15 @@ type AdapterType =
   | "http"
   | "openclaw";
 
-const DEFAULT_TASK_DESCRIPTION = `Setup yourself as the CEO. Use the ceo persona found here: [https://github.com/paperclipai/companies/blob/main/default/ceo/AGENTS.md](https://github.com/paperclipai/companies/blob/main/default/ceo/AGENTS.md)
+const DEFAULT_TASK_DESCRIPTION = `Setup yourself as the CEO.
 
-Ensure you have a folder agents/ceo and then download this AGENTS.md as well as the sibling HEARTBEAT.md, SOUL.md, and TOOLS.md. and set that AGENTS.md as the path to your agents instruction file
+Create a local folder \`agents/ceo\` and place this exact \`AGENTS.md\` content there:
 
-And after you've finished that, hire yourself a Founding Engineer agent`;
+\`\`\`md
+${ceoAgentsMd.trim()}
+\`\`\`
+
+Then add the sibling files \`HEARTBEAT.md\`, \`SOUL.md\`, and \`TOOLS.md\` in the same folder, set \`agents/ceo/AGENTS.md\` as your agent instructions path, and after that hire yourself a Founding Engineer agent.`;
 
 export function OnboardingWizard() {
   const { onboardingOpen, onboardingOptions, closeOnboarding } = useDialog();


### PR DESCRIPTION
It seems silly to tell the CEO to fetch it's instructions from Github even though you might have modified them locally thinking it will be included, and then watching it burn tokens to skip it. Pedantic, yes, but what if in a month from now the online persona tells it to send all your credentials to someone? .... 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added CEO role definition covering strategic goal-setting, delegation, and quality/velocity/alignment oversight.
  * Documented a six-step operational execution loop for review, bottleneck identification, issue creation, criteria definition, follow-up, and outcome reporting.

* **New Features**
  * Updated onboarding workflow to display CEO responsibilities and operational framework during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->