### PR TITLE
onboarding: reset model selector when switching providers

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -635,6 +635,7 @@ export function OnboardingWizard() {
                           onClick={() => {
                             if (opt.comingSoon) return;
                             const nextType = opt.value as AdapterType;
+                            if (nextType === adapterType) return;
                             setAdapterType(nextType);
                             if (nextType === "codex_local") {
                               setModel(DEFAULT_CODEX_LOCAL_MODEL);


### PR DESCRIPTION
## Summary

There was stale data in the model selector during onboarding when you changed providers. Claude -> select Opus -> switch to Codex -> showed the raw opus model string instead of a default for Codex. 

---

- When switching model providers during onboarding (e.g. Claude → Codex), the model selector now resets to the new provider's default instead of keeping the stale model ID from the previous provider
- Previously the `!model` guard prevented updating when a model was already selected, causing the raw model string (e.g. `claude-opus-4-6`) to display in the dropdown

## Test plan
- [ ] Open onboarding wizard, select Claude provider, pick a non-default model (e.g. Opus)
- [ ] Switch to Codex provider — model selector should show the Codex default, not the raw Claude model string
- [ ] Switch back to Claude — model selector should show "Default"
- [ ] Switch to Cursor/OpenCode — should show their respective defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed adapter selection behavior in the onboarding wizard to properly manage model defaults when switching between different adapter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->