### PR TITLE
fix: skip pending_approval agents in heartbeat tickTimers

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2034,7 +2034,7 @@ export function heartbeatService(db: Db) {
       let skipped = 0;
 
       for (const agent of allAgents) {
-        if (agent.status === "paused" || agent.status === "terminated") continue;
+        if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 


### PR DESCRIPTION
## Summary

- `tickTimers` iterates all agents and calls `enqueueWakeup` for those whose heartbeat interval has elapsed
- `enqueueWakeup` throws a 409 conflict for agents in `pending_approval`, `paused`, or `terminated` states
- `tickTimers` only filtered out `paused` and `terminated`, leaving `pending_approval` agents to hit the error every tick
- This produced repeated `ERROR: heartbeat timer tick failed` log noise for any agent awaiting approval

## Fix

Added `pending_approval` to the early-continue guard in `tickTimers` (line 2037), matching the existing guard in `enqueueWakeup`.

## Test plan

- [ ] Verify no `heartbeat timer tick failed` errors appear in logs when an agent is in `pending_approval` state
- [ ] Confirm agents in `paused`, `terminated`, and `pending_approval` states are all skipped cleanly by the timer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Agents with pending approval status are now properly skipped during system heartbeat checks, aligning with the handling of other inactive agent states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->