### PR TITLE
feat: add quick-add plus icon to Agents sidebar

### DIFF
--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
 import { NavLink, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Plus } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
+import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
 import { agentsApi } from "../api/agents";
 import { heartbeatsApi } from "../api/heartbeats";
@@ -40,6 +41,7 @@ function sortByHierarchy(agents: Agent[]): Agent[] {
 export function SidebarAgents() {
   const [open, setOpen] = useState(true);
   const { selectedCompanyId } = useCompany();
+  const { openNewAgent } = useDialog();
   const { isMobile, setSidebarOpen } = useSidebar();
   const location = useLocation();
 
@@ -89,6 +91,16 @@ export function SidebarAgents() {
               Agents
             </span>
           </CollapsibleTrigger>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              openNewAgent();
+            }}
+            className="flex items-center justify-center h-4 w-4 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer"
+            aria-label="New agent"
+          >
+            <Plus className="h-3 w-3" />
+          </button>
         </div>
       </div>
 

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -155,7 +155,7 @@ export function SidebarProjects() {
               e.stopPropagation();
               openNewProject();
             }}
-            className="flex items-center justify-center h-4 w-4 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50 transition-colors"
+            className="flex items-center justify-center h-4 w-4 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer"
             aria-label="New project"
           >
             <Plus className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- Add a plus icon button to the Agents sidebar section header, matching the existing Projects sidebar pattern
- Opens the New Agent dialog on click
- Add `cursor-pointer` to both Agents and Projects sidebar plus icons for better UX

## Test plan
- [x] Verify plus icon appears next to "Agents" label in sidebar
- [x] Click the plus icon and confirm the New Agent dialog opens
- [x] Verify the Projects plus icon still works as before
- [x] Confirm cursor changes to pointer on hover for both icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar control to create new agents directly, with an accessible "New agent" button.

* **Style**
  * Improved cursor indicator on the New Project button for clearer interactivity.
  * Minor UX improvement to the new-agent button for better accessibility and click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->