### PR TITLE
fix: Dockerfile build filters and default deployment mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
-RUN pnpm --filter @paperclip/ui build
-RUN pnpm --filter @paperclip/server build
+RUN pnpm --filter @paperclipai/ui build
+RUN pnpm --filter @paperclipai/server build
 
 FROM base AS production
 WORKDIR /app
@@ -37,7 +37,7 @@ ENV NODE_ENV=production \
   PAPERCLIP_HOME=/paperclip \
   PAPERCLIP_INSTANCE_ID=default \
   PAPERCLIP_CONFIG=/paperclip/instances/default/config.json \
-  PAPERCLIP_DEPLOYMENT_MODE=local_trusted \
+  PAPERCLIP_DEPLOYMENT_MODE=cloud_untrusted \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private
 
 VOLUME ["/paperclip"]


### PR DESCRIPTION
This PR fixes two critical issues in the Dockerfile: 1. Corrects the pnpm filter names from @paperclip/ to @paperclipai/ to ensure the build step actually runs. 2. Changes the default PAPERCLIP_DEPLOYMENT_MODE to cloud_untrusted to allow binding to 0.0.0.0, which is required for Docker containers to be accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to latest package versions
  * Updated production deployment configuration for cloud environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->