### PR TITLE
fix: resolve 500 error on SPA route refresh (#48)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -133,7 +133,7 @@ export async function createApp(
     if (uiDist) {
       app.use(express.static(uiDist));
       app.get(/.*/, (_req, res) => {
-        res.sendFile(path.join(uiDist, "index.html"));
+        res.sendFile("index.html", { root: uiDist });
       });
     } else {
       console.warn("[paperclip] UI dist not found; running in API-only mode");


### PR DESCRIPTION
## Summary

- Fix `res.sendFile` call in the SPA fallback route to use the `root` option instead of an absolute path
- When served via `npx`, the absolute path traverses `~/.npm/_npx/...` and `.npm` triggers Express 5 / `send`'s dotfile guard, causing a 500 error on page refresh
- Using `res.sendFile("index.html", { root: uiDist })` makes `send` only check the relative filename for dotfiles

## Change

```diff
- res.sendFile(path.join(uiDist, "index.html"));
+ res.sendFile("index.html", { root: uiDist });
```

Fixes #48

## Test plan

- [ ] Run server via `npx` and verify SPA routes load correctly on refresh
- [ ] Navigate to a nested route (e.g. `/WOR/company/settings`) and reload — should serve the SPA, not 500
- [ ] Verify normal page navigation still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal file serving mechanism for static assets in single-page application mode, enhancing reliability of static file delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->