### PR TITLE
feat: folder picker for new project workspace setup

### DIFF
--- a/server/src/__tests__/fs-browse.test.ts
+++ b/server/src/__tests__/fs-browse.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import os from "node:os";
+import path from "node:path";
+import { fsRoutes } from "../routes/fs.js";
+
+// Mock fs.promises so tests don't depend on real filesystem
+const { mockReaddir } = vi.hoisted(() => ({ mockReaddir: vi.fn() }));
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readdir: mockReaddir,
+  },
+  readdir: mockReaddir,
+}));
+
+function createApp(actorType: "board" | "agent") {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor =
+      actorType === "board"
+        ? { type: "board", userId: "user-1", source: "local_implicit" }
+        : { type: "agent", agentId: "agent-1", companyId: "co-1" };
+    next();
+  });
+  app.use(fsRoutes());
+  app.use(
+    (
+      err: { status?: number; message?: string },
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      res.status(err.status ?? 500).json({ error: err.message ?? "Internal error" });
+    },
+  );
+  return app;
+}
+
+describe("GET /api/fs/browse", () => {
+  beforeEach(() => {
+    mockReaddir.mockReset();
+  });
+
+  it("returns 403 for agent actors", async () => {
+    const app = createApp("agent");
+    const res = await request(app).get("/api/fs/browse");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns home directory listing when no path specified", async () => {
+    const home = os.homedir();
+    mockReaddir.mockResolvedValueOnce([
+      { name: "Documents", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "Downloads", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "file.txt", isDirectory: () => false } as unknown as import("node:fs").Dirent,
+    ]);
+
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse");
+
+    expect(res.status).toBe(200);
+    expect(res.body.path).toBe(home);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.entries[0]).toEqual({ name: "Documents", path: path.join(home, "Documents") });
+    expect(res.body.entries[1]).toEqual({ name: "Downloads", path: path.join(home, "Downloads") });
+    expect(res.body.parent).toBe(path.dirname(home));
+  });
+
+  it("returns directory listing for specified path", async () => {
+    mockReaddir.mockResolvedValueOnce([
+      { name: "src", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "README.md", isDirectory: () => false } as unknown as import("node:fs").Dirent,
+    ]);
+
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse?path=/Users/foo/project");
+
+    expect(res.status).toBe(200);
+    expect(res.body.path).toBe("/Users/foo/project");
+    expect(res.body.parent).toBe("/Users/foo");
+    expect(res.body.entries).toHaveLength(1);
+    expect(res.body.entries[0]).toEqual({ name: "src", path: "/Users/foo/project/src" });
+  });
+
+  it("returns 400 for relative paths", async () => {
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse?path=relative/path");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns null parent when at filesystem root", async () => {
+    mockReaddir.mockResolvedValueOnce([]);
+
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse?path=/");
+
+    expect(res.status).toBe(200);
+    expect(res.body.parent).toBeNull();
+  });
+
+  it("returns 404 when path does not exist", async () => {
+    const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    mockReaddir.mockRejectedValueOnce(err);
+
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse?path=/nonexistent");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when path is a file not a directory", async () => {
+    const err = Object.assign(new Error("ENOTDIR"), { code: "ENOTDIR" });
+    mockReaddir.mockRejectedValueOnce(err);
+
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse?path=/etc/hosts");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns sorted entries", async () => {
+    mockReaddir.mockResolvedValueOnce([
+      { name: "zzz", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "aaa", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "mmm", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+    ]);
+
+    const app = createApp("board");
+    const res = await request(app).get("/api/fs/browse?path=/some/path");
+    expect(res.status).toBe(200);
+    expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["aaa", "mmm", "zzz"]);
+  });
+});

--- a/server/src/__tests__/fs-browse.test.ts
+++ b/server/src/__tests__/fs-browse.test.ts
@@ -45,7 +45,7 @@ describe("GET /fs/browse", () => {
 
   it("returns 403 for agent actors", async () => {
     const app = createApp("agent");
-    const res = await request(app).get("/api/fs/browse");
+    const res = await request(app).get("/fs/browse");
     expect(res.status).toBe(403);
   });
 
@@ -58,7 +58,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse");
+    const res = await request(app).get("/fs/browse");
 
     expect(res.status).toBe(200);
     expect(res.body.path).toBe(home);
@@ -90,7 +90,7 @@ describe("GET /fs/browse", () => {
 
   it("returns 400 for relative paths", async () => {
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=relative/path");
+    const res = await request(app).get("/fs/browse?path=relative/path");
     expect(res.status).toBe(400);
   });
 
@@ -98,7 +98,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockResolvedValueOnce([]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/");
+    const res = await request(app).get("/fs/browse?path=/");
 
     expect(res.status).toBe(200);
     expect(res.body.parent).toBeNull();
@@ -109,7 +109,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/nonexistent");
+    const res = await request(app).get("/fs/browse?path=/nonexistent");
     expect(res.status).toBe(404);
   });
 
@@ -118,7 +118,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/etc/hosts");
+    const res = await request(app).get("/fs/browse?path=/etc/hosts");
     expect(res.status).toBe(400);
   });
 
@@ -156,7 +156,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/some/path");
+    const res = await request(app).get("/fs/browse?path=/some/path");
     expect(res.status).toBe(200);
     expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["aaa", "mmm", "zzz"]);
   });

--- a/server/src/__tests__/fs-browse.test.ts
+++ b/server/src/__tests__/fs-browse.test.ts
@@ -24,7 +24,7 @@ function createApp(actorType: "board" | "agent") {
         : { type: "agent", agentId: "agent-1", companyId: "co-1" };
     next();
   });
-  app.use(fsRoutes());
+  app.use("/api", fsRoutes());
   app.use(
     (
       err: { status?: number; message?: string },
@@ -45,7 +45,7 @@ describe("GET /fs/browse", () => {
 
   it("returns 403 for agent actors", async () => {
     const app = createApp("agent");
-    const res = await request(app).get("/fs/browse");
+    const res = await request(app).get("/api/fs/browse");
     expect(res.status).toBe(403);
   });
 
@@ -58,7 +58,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse");
+    const res = await request(app).get("/api/fs/browse");
 
     expect(res.status).toBe(200);
     expect(res.body.path).toBe(home);
@@ -74,19 +74,23 @@ describe("GET /fs/browse", () => {
       { name: "README.md", isDirectory: () => false } as unknown as import("node:fs").Dirent,
     ]);
 
+    const expectedPath = path.join(path.sep, "Users", "foo", "project");
+    const expectedParent = path.dirname(expectedPath);
+    const expectedEntryPath = path.join(expectedPath, "src");
+
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/Users/foo/project");
+    const res = await request(app).get(`/api/fs/browse?path=${expectedPath}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.path).toBe("/Users/foo/project");
-    expect(res.body.parent).toBe("/Users/foo");
+    expect(res.body.path).toBe(expectedPath);
+    expect(res.body.parent).toBe(expectedParent);
     expect(res.body.entries).toHaveLength(1);
-    expect(res.body.entries[0]).toEqual({ name: "src", path: "/Users/foo/project/src" });
+    expect(res.body.entries[0]).toEqual({ name: "src", path: expectedEntryPath });
   });
 
   it("returns 400 for relative paths", async () => {
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=relative/path");
+    const res = await request(app).get("/api/fs/browse?path=relative/path");
     expect(res.status).toBe(400);
   });
 
@@ -94,7 +98,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockResolvedValueOnce([]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/");
+    const res = await request(app).get("/api/fs/browse?path=/");
 
     expect(res.status).toBe(200);
     expect(res.body.parent).toBeNull();
@@ -105,7 +109,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/nonexistent");
+    const res = await request(app).get("/api/fs/browse?path=/nonexistent");
     expect(res.status).toBe(404);
   });
 
@@ -114,7 +118,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/etc/hosts");
+    const res = await request(app).get("/api/fs/browse?path=/etc/hosts");
     expect(res.status).toBe(400);
   });
 
@@ -126,7 +130,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/some/path");
+    const res = await request(app).get("/api/fs/browse?path=/some/path");
     expect(res.status).toBe(200);
     expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["src"]);
   });
@@ -139,7 +143,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/some/path&showHidden=true");
+    const res = await request(app).get("/api/fs/browse?path=/some/path&showHidden=true");
     expect(res.status).toBe(200);
     expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual([".git", ".hidden", "src"]);
   });
@@ -152,7 +156,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/some/path");
+    const res = await request(app).get("/api/fs/browse?path=/some/path");
     expect(res.status).toBe(200);
     expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["aaa", "mmm", "zzz"]);
   });

--- a/server/src/__tests__/fs-browse.test.ts
+++ b/server/src/__tests__/fs-browse.test.ts
@@ -38,14 +38,14 @@ function createApp(actorType: "board" | "agent") {
   return app;
 }
 
-describe("GET /api/fs/browse", () => {
+describe("GET /fs/browse", () => {
   beforeEach(() => {
     mockReaddir.mockReset();
   });
 
   it("returns 403 for agent actors", async () => {
     const app = createApp("agent");
-    const res = await request(app).get("/api/fs/browse");
+    const res = await request(app).get("/fs/browse");
     expect(res.status).toBe(403);
   });
 
@@ -58,7 +58,7 @@ describe("GET /api/fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse");
+    const res = await request(app).get("/fs/browse");
 
     expect(res.status).toBe(200);
     expect(res.body.path).toBe(home);
@@ -75,7 +75,7 @@ describe("GET /api/fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/Users/foo/project");
+    const res = await request(app).get("/fs/browse?path=/Users/foo/project");
 
     expect(res.status).toBe(200);
     expect(res.body.path).toBe("/Users/foo/project");
@@ -86,7 +86,7 @@ describe("GET /api/fs/browse", () => {
 
   it("returns 400 for relative paths", async () => {
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=relative/path");
+    const res = await request(app).get("/fs/browse?path=relative/path");
     expect(res.status).toBe(400);
   });
 
@@ -94,7 +94,7 @@ describe("GET /api/fs/browse", () => {
     mockReaddir.mockResolvedValueOnce([]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/");
+    const res = await request(app).get("/fs/browse?path=/");
 
     expect(res.status).toBe(200);
     expect(res.body.parent).toBeNull();
@@ -105,7 +105,7 @@ describe("GET /api/fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/nonexistent");
+    const res = await request(app).get("/fs/browse?path=/nonexistent");
     expect(res.status).toBe(404);
   });
 
@@ -114,8 +114,34 @@ describe("GET /api/fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/etc/hosts");
+    const res = await request(app).get("/fs/browse?path=/etc/hosts");
     expect(res.status).toBe(400);
+  });
+
+  it("hides dotfile directories by default", async () => {
+    mockReaddir.mockResolvedValueOnce([
+      { name: ".git", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "src", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: ".hidden", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+    ]);
+
+    const app = createApp("board");
+    const res = await request(app).get("/fs/browse?path=/some/path");
+    expect(res.status).toBe(200);
+    expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["src"]);
+  });
+
+  it("shows dotfile directories when showHidden=true", async () => {
+    mockReaddir.mockResolvedValueOnce([
+      { name: ".git", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: "src", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+      { name: ".hidden", isDirectory: () => true } as unknown as import("node:fs").Dirent,
+    ]);
+
+    const app = createApp("board");
+    const res = await request(app).get("/fs/browse?path=/some/path&showHidden=true");
+    expect(res.status).toBe(200);
+    expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual([".git", ".hidden", "src"]);
   });
 
   it("returns sorted entries", async () => {
@@ -126,7 +152,7 @@ describe("GET /api/fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/api/fs/browse?path=/some/path");
+    const res = await request(app).get("/fs/browse?path=/some/path");
     expect(res.status).toBe(200);
     expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["aaa", "mmm", "zzz"]);
   });

--- a/server/src/__tests__/fs-browse.test.ts
+++ b/server/src/__tests__/fs-browse.test.ts
@@ -45,7 +45,7 @@ describe("GET /fs/browse", () => {
 
   it("returns 403 for agent actors", async () => {
     const app = createApp("agent");
-    const res = await request(app).get("/fs/browse");
+    const res = await request(app).get("/api/fs/browse");
     expect(res.status).toBe(403);
   });
 
@@ -58,7 +58,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse");
+    const res = await request(app).get("/api/fs/browse");
 
     expect(res.status).toBe(200);
     expect(res.body.path).toBe(home);
@@ -90,7 +90,7 @@ describe("GET /fs/browse", () => {
 
   it("returns 400 for relative paths", async () => {
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=relative/path");
+    const res = await request(app).get("/api/fs/browse?path=relative/path");
     expect(res.status).toBe(400);
   });
 
@@ -98,7 +98,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockResolvedValueOnce([]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/");
+    const res = await request(app).get("/api/fs/browse?path=/");
 
     expect(res.status).toBe(200);
     expect(res.body.parent).toBeNull();
@@ -109,7 +109,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/nonexistent");
+    const res = await request(app).get("/api/fs/browse?path=/nonexistent");
     expect(res.status).toBe(404);
   });
 
@@ -118,7 +118,7 @@ describe("GET /fs/browse", () => {
     mockReaddir.mockRejectedValueOnce(err);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/etc/hosts");
+    const res = await request(app).get("/api/fs/browse?path=/etc/hosts");
     expect(res.status).toBe(400);
   });
 
@@ -156,7 +156,7 @@ describe("GET /fs/browse", () => {
     ]);
 
     const app = createApp("board");
-    const res = await request(app).get("/fs/browse?path=/some/path");
+    const res = await request(app).get("/api/fs/browse?path=/some/path");
     expect(res.status).toBe(200);
     expect(res.body.entries.map((e: { name: string }) => e.name)).toEqual(["aaa", "mmm", "zzz"]);
   });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -42,6 +42,7 @@ import { createPluginDevWatcher } from "./services/plugin-dev-watcher.js";
 import { createPluginHostServiceCleanup } from "./services/plugin-host-service-cleanup.js";
 import { pluginRegistryService } from "./services/plugin-registry.js";
 import { createHostClientHandlers } from "@paperclipai/plugin-sdk";
+import { fsRoutes } from "./routes/fs.js";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 
 type UiMode = "none" | "static" | "vite-dev";
@@ -201,6 +202,7 @@ export async function createApp(
       { workerManager },
     ),
   );
+  api.use(fsRoutes());
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/fs.ts
+++ b/server/src/routes/fs.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { assertBoard } from "./authz.js";
+import { badRequest, notFound } from "../errors.js";
+
+export function fsRoutes() {
+  const router = Router();
+
+  router.get("/api/fs/browse", async (req, res, next) => {
+    try {
+      assertBoard(req);
+
+      const rawPath = typeof req.query.path === "string" ? req.query.path.trim() : "";
+      const targetPath = rawPath || os.homedir();
+
+      if (rawPath && !path.isAbsolute(rawPath)) {
+        throw badRequest("path must be absolute");
+      }
+
+      const resolved = path.resolve(targetPath);
+      const parentDir = path.dirname(resolved);
+      const parent = parentDir !== resolved ? parentDir : null;
+
+      let dirents: import("node:fs").Dirent[];
+      try {
+        dirents = await fs.readdir(resolved, { withFileTypes: true });
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") throw notFound(`Directory not found: ${resolved}`);
+        if (code === "ENOTDIR") throw badRequest(`Path is not a directory: ${resolved}`);
+        throw err;
+      }
+
+      const entries = dirents
+        .filter((d) => d.isDirectory())
+        .map((d) => ({ name: d.name, path: path.join(resolved, d.name) }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      res.json({ path: resolved, parent, entries });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/fs.ts
+++ b/server/src/routes/fs.ts
@@ -8,7 +8,7 @@ import { badRequest, notFound } from "../errors.js";
 export function fsRoutes() {
   const router = Router();
 
-  router.get("/api/fs/browse", async (req, res, next) => {
+  router.get("/fs/browse", async (req, res, next) => {
     try {
       assertBoard(req);
 
@@ -33,8 +33,9 @@ export function fsRoutes() {
         throw err;
       }
 
+      const showHidden = req.query.showHidden === "true";
       const entries = dirents
-        .filter((d) => d.isDirectory())
+        .filter((d) => d.isDirectory() && (showHidden || !d.name.startsWith(".")))
         .map((d) => ({ name: d.name, path: path.join(resolved, d.name) }))
         .sort((a, b) => a.name.localeCompare(b.name));
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -12,3 +12,4 @@ export { dashboardRoutes } from "./dashboard.js";
 export { sidebarBadgeRoutes } from "./sidebar-badges.js";
 export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
+export { fsRoutes } from "./fs.js";

--- a/ui/src/api/fs.ts
+++ b/ui/src/api/fs.ts
@@ -12,8 +12,11 @@ export interface FsBrowseResult {
 }
 
 export const fsApi = {
-  browse: (dirPath?: string) => {
-    const qs = dirPath ? `?path=${encodeURIComponent(dirPath)}` : "";
+  browse: (dirPath?: string, showHidden?: boolean) => {
+    const params = new URLSearchParams();
+    if (dirPath) params.set("path", dirPath);
+    if (showHidden) params.set("showHidden", "true");
+    const qs = params.size > 0 ? `?${params}` : "";
     return api.get<FsBrowseResult>(`/fs/browse${qs}`);
   },
 };

--- a/ui/src/api/fs.ts
+++ b/ui/src/api/fs.ts
@@ -1,0 +1,19 @@
+import { api } from "./client";
+
+export interface FsBrowseEntry {
+  name: string;
+  path: string;
+}
+
+export interface FsBrowseResult {
+  path: string;
+  parent: string | null;
+  entries: FsBrowseEntry[];
+}
+
+export const fsApi = {
+  browse: (dirPath?: string) => {
+    const qs = dirPath ? `?path=${encodeURIComponent(dirPath)}` : "";
+    return api.get<FsBrowseResult>(`/fs/browse${qs}`);
+  },
+};

--- a/ui/src/components/FolderPickerDialog.tsx
+++ b/ui/src/components/FolderPickerDialog.tsx
@@ -54,7 +54,10 @@ export function FolderPickerDialog({
 
   // Reset to initial when dialog opens/closes
   function handleOpenChange(next: boolean) {
-    if (!next) setCurrentPath(initialPath);
+    if (!next) {
+      setCurrentPath(initialPath);
+      setShowHidden(false);
+    }
     onOpenChange(next);
   }
 

--- a/ui/src/components/FolderPickerDialog.tsx
+++ b/ui/src/components/FolderPickerDialog.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronRight, Folder, FolderOpen, Loader2, ArrowLeft } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { fsApi } from "../api/fs";
+import { cn } from "../lib/utils";
+
+interface FolderPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (path: string) => void;
+  initialPath?: string;
+}
+
+export function FolderPickerDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  initialPath,
+}: FolderPickerDialogProps) {
+  const [currentPath, setCurrentPath] = useState<string | undefined>(initialPath);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["fs-browse", currentPath ?? "__home__"],
+    queryFn: () => fsApi.browse(currentPath),
+    enabled: open,
+    staleTime: 10_000,
+  });
+
+  function handleSelect() {
+    if (data?.path) {
+      onSelect(data.path);
+      onOpenChange(false);
+    }
+  }
+
+  function handleNavigate(path: string) {
+    setCurrentPath(path);
+  }
+
+  function handleBack() {
+    if (data?.parent) {
+      setCurrentPath(data.parent);
+    }
+  }
+
+  // Reset to initial when dialog opens/closes
+  function handleOpenChange(next: boolean) {
+    if (!next) setCurrentPath(initialPath);
+    onOpenChange(next);
+  }
+
+  const pathSegments = data?.path?.split("/").filter(Boolean) ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md p-0 gap-0">
+        <DialogHeader className="px-4 pt-4 pb-2">
+          <DialogTitle className="text-sm font-medium">Choose a folder</DialogTitle>
+        </DialogHeader>
+
+        {/* Breadcrumb */}
+        <div className="px-4 pb-2 flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto whitespace-nowrap">
+          <button
+            className="hover:text-foreground transition-colors shrink-0"
+            onClick={() => setCurrentPath(undefined)}
+          >
+            Home
+          </button>
+          {pathSegments.map((seg, i) => {
+            const segPath = "/" + pathSegments.slice(0, i + 1).join("/");
+            return (
+              <span key={segPath} className="flex items-center gap-1 shrink-0">
+                <ChevronRight className="h-3 w-3" />
+                <button
+                  className={cn(
+                    "hover:text-foreground transition-colors",
+                    i === pathSegments.length - 1 && "text-foreground font-medium",
+                  )}
+                  onClick={() => setCurrentPath(segPath)}
+                >
+                  {seg}
+                </button>
+              </span>
+            );
+          })}
+        </div>
+
+        {/* Directory listing */}
+        <div className="border-t border-border mx-4" />
+        <div className="mx-4 my-2 h-56 overflow-y-auto rounded-md border border-border">
+          {isLoading && (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-xs gap-2">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading…
+            </div>
+          )}
+          {isError && (
+            <div className="flex items-center justify-center h-full text-destructive text-xs px-4 text-center">
+              Could not read directory. Check that the path exists and is accessible.
+            </div>
+          )}
+          {!isLoading && !isError && data && (
+            <>
+              {data.parent && (
+                <button
+                  className="flex items-center gap-2 w-full px-3 py-2 text-xs hover:bg-accent/50 transition-colors text-muted-foreground border-b border-border"
+                  onClick={handleBack}
+                >
+                  <ArrowLeft className="h-3.5 w-3.5 shrink-0" />
+                  <span className="truncate">..</span>
+                </button>
+              )}
+              {data.entries.length === 0 && (
+                <div className="flex items-center justify-center h-full text-muted-foreground text-xs py-8">
+                  No subdirectories
+                </div>
+              )}
+              {data.entries.map((entry) => (
+                <button
+                  key={entry.path}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-xs hover:bg-accent/50 transition-colors"
+                  onClick={() => handleNavigate(entry.path)}
+                >
+                  <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{entry.name}</span>
+                  <ChevronRight className="h-3 w-3 ml-auto shrink-0 text-muted-foreground" />
+                </button>
+              ))}
+            </>
+          )}
+        </div>
+
+        {/* Current selection + actions */}
+        <div className="px-4 pb-4 pt-2 space-y-3">
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-xs font-mono text-muted-foreground min-h-[28px]">
+            <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{data?.path ?? "Loading…"}</span>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => handleOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button size="sm" disabled={!data?.path} onClick={handleSelect}>
+              Select this folder
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/FolderPickerDialog.tsx
+++ b/ui/src/components/FolderPickerDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { fsApi } from "../api/fs";
 import { cn } from "../lib/utils";
 
@@ -25,10 +26,11 @@ export function FolderPickerDialog({
   initialPath,
 }: FolderPickerDialogProps) {
   const [currentPath, setCurrentPath] = useState<string | undefined>(initialPath);
+  const [showHidden, setShowHidden] = useState(false);
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["fs-browse", currentPath ?? "__home__"],
-    queryFn: () => fsApi.browse(currentPath),
+    queryKey: ["fs-browse", currentPath ?? "__home__", showHidden],
+    queryFn: () => fsApi.browse(currentPath, showHidden),
     enabled: open,
     staleTime: 10_000,
   });
@@ -56,7 +58,7 @@ export function FolderPickerDialog({
     onOpenChange(next);
   }
 
-  const pathSegments = data?.path?.split("/").filter(Boolean) ?? [];
+  const pathSegments = (data?.path ?? "").split("/").filter(Boolean);
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -69,9 +71,9 @@ export function FolderPickerDialog({
         <div className="px-4 pb-2 flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto whitespace-nowrap">
           <button
             className="hover:text-foreground transition-colors shrink-0"
-            onClick={() => setCurrentPath(undefined)}
+            onClick={() => setCurrentPath("/")}
           >
-            Home
+            /
           </button>
           {pathSegments.map((seg, i) => {
             const segPath = "/" + pathSegments.slice(0, i + 1).join("/");
@@ -143,13 +145,23 @@ export function FolderPickerDialog({
             <FolderOpen className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{data?.path ?? "Loading…"}</span>
           </div>
-          <div className="flex items-center justify-end gap-2">
-            <Button variant="ghost" size="sm" onClick={() => handleOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button size="sm" disabled={!data?.path} onClick={handleSelect}>
-              Select this folder
-            </Button>
+          <div className="flex items-center justify-between gap-2">
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
+              <Checkbox
+                id="show-hidden"
+                checked={showHidden}
+                onCheckedChange={(checked) => setShowHidden(checked === true)}
+              />
+              Show hidden folders
+            </label>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" disabled={!data?.path} onClick={handleSelect}>
+                Select this folder
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -341,7 +341,10 @@ export function NewProjectDialog() {
                   onChange={(e) => setWorkspaceLocalPath(e.target.value)}
                   placeholder="/absolute/path/to/workspace"
                 />
-                <ChoosePathButton />
+                <ChoosePathButton
+                    onSelect={setWorkspaceLocalPath}
+                    currentPath={workspaceLocalPath || undefined}
+                  />
               </div>
             </div>
           )}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -858,7 +858,7 @@ export function OnboardingWizard() {
                             value={cwd}
                             onChange={(e) => setCwd(e.target.value)}
                           />
-                          <ChoosePathButton />
+                          <ChoosePathButton onSelect={setCwd} currentPath={cwd || undefined} />
                         </div>
                       </div>
                       <div>

--- a/ui/src/components/PathInstructionsModal.tsx
+++ b/ui/src/components/PathInstructionsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Apple, Monitor, Terminal } from "lucide-react";
+import { FolderPickerDialog } from "./FolderPickerDialog";
 import {
   Dialog,
   DialogContent,
@@ -120,11 +121,43 @@ export function PathInstructionsModal({
 }
 
 /**
- * Small "Choose" button that opens the PathInstructionsModal.
- * Drop-in replacement for the old showDirectoryPicker buttons.
+ * "Choose" button that opens a native folder picker dialog.
+ * Falls back to path instructions modal when no onSelect callback is provided.
  */
-export function ChoosePathButton({ className }: { className?: string }) {
+export function ChoosePathButton({
+  className,
+  onSelect,
+  currentPath,
+}: {
+  className?: string;
+  onSelect?: (path: string) => void;
+  currentPath?: string;
+}) {
   const [open, setOpen] = useState(false);
+
+  if (onSelect) {
+    return (
+      <>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 transition-colors shrink-0",
+            className,
+          )}
+          onClick={() => setOpen(true)}
+        >
+          Browse
+        </button>
+        <FolderPickerDialog
+          open={open}
+          onOpenChange={setOpen}
+          onSelect={onSelect}
+          initialPath={currentPath}
+        />
+      </>
+    );
+  }
+
   return (
     <>
       <button

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -636,7 +636,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                   onChange={(e) => setWorkspaceCwd(e.target.value)}
                   placeholder="/absolute/path/to/workspace"
                 />
-                <ChoosePathButton />
+                <ChoosePathButton onSelect={setWorkspaceCwd} currentPath={workspaceCwd || undefined} />
               </div>
               <div className="flex items-center gap-2">
                 <Button


### PR DESCRIPTION
## Summary

- Adds `GET /api/fs/browse` endpoint (board-only) that lists subdirectories at a given absolute path, defaulting to the home directory
- Introduces `FolderPickerDialog` — a navigable directory picker with breadcrumbs, back-navigation, and a "Select this folder" action
- Extends `ChoosePathButton` with `onSelect` + `currentPath` props; opens the new picker when wired, falls back to `PathInstructionsModal` otherwise
- Wires the picker into `NewProjectDialog` so the local folder input has a real Browse button instead of copy-path instructions

## Test plan

- [x] All 57 server tests pass (`pnpm test` in `server/`)
- [x] New `src/__tests__/fs-browse.test.ts`: 8 tests covering 403 for agents, home-dir default, absolute-path validation, ENOENT/ENOTDIR error codes, sort order
- [x] Open "New project" dialog → select "A local folder" → click Browse → picker opens at home dir, navigate into subdirectories, click "Select this folder" → path populates the input
- [x] Without `onSelect` prop, `ChoosePathButton` still shows the old instructions modal (fallback path unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive folder picker dialog for browsing and selecting directories, with breadcrumb navigation, parent/back controls, and loading/error states.
  * Option to show hidden folders when browsing.
  * Folder picker integrated into project creation for streamlined path selection.
  * Client API now returns path, parent, and sorted directory entries for navigation.

* **Tests**
  * Added comprehensive tests for the filesystem browsing API covering access control, validation, error cases, and hidden-entry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="453" height="413" alt="image" src="https://github.com/user-attachments/assets/d5ab3171-3afa-4f2e-b74d-1adbb11c3d97" />
