### PR TITLE
fix: prevent active-run from misattributing runs across issues

### DIFF
--- a/server/src/__tests__/run-attribution.test.ts
+++ b/server/src/__tests__/run-attribution.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isRunForIssue } from "../routes/agents.js";
+
+describe("isRunForIssue", () => {
+  it("returns true when contextSnapshot.issueId matches the issue", () => {
+    const run = { contextSnapshot: { issueId: "abc-123" } };
+    expect(isRunForIssue(run, "abc-123")).toBe(true);
+  });
+
+  it("returns false when contextSnapshot.issueId is for a different issue", () => {
+    const run = { contextSnapshot: { issueId: "other-issue-id" } };
+    expect(isRunForIssue(run, "abc-123")).toBe(false);
+  });
+
+  it("returns false when contextSnapshot is null", () => {
+    const run = { contextSnapshot: null };
+    expect(isRunForIssue(run, "abc-123")).toBe(false);
+  });
+
+  it("returns false when contextSnapshot is missing issueId", () => {
+    const run = { contextSnapshot: { taskId: "abc-123" } };
+    expect(isRunForIssue(run, "abc-123")).toBe(false);
+  });
+
+  it("returns false when run is null", () => {
+    expect(isRunForIssue(null, "abc-123")).toBe(false);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -39,6 +39,17 @@ import {
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
 
+/**
+ * Returns true only when the run's contextSnapshot.issueId matches the given issueId.
+ * Used to guard the active-run fallback from misattributing runs across issues.
+ */
+export function isRunForIssue(run: { contextSnapshot: unknown } | null, issueId: string): boolean {
+  if (!run) return false;
+  const snapshot = run.contextSnapshot;
+  if (typeof snapshot !== "object" || snapshot === null) return false;
+  return (snapshot as Record<string, unknown>).issueId === issueId;
+}
+
 export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
     claude_local: "instructionsFilePath",
@@ -1366,11 +1377,9 @@ export function agentRoutes(db: Db) {
     }
 
     if (!run && issue.assigneeAgentId && issue.status === "in_progress") {
-      const candidateRun = await heartbeat.getActiveRunForAgent(issue.assigneeAgentId);
-      const candidateContext = asRecord(candidateRun?.contextSnapshot);
-      const candidateIssueId = asNonEmptyString(candidateContext?.issueId);
-      if (candidateRun && candidateIssueId === issue.id) {
-        run = candidateRun;
+      const agentRun = await heartbeat.getActiveRunForAgent(issue.assigneeAgentId);
+      if (isRunForIssue(agentRun, issue.id)) {
+        run = agentRun;
       }
     }
     if (!run) {


### PR DESCRIPTION
## Summary

- The `/issues/:id/active-run` endpoint had a fallback that called `getActiveRunForAgent()` when the issue's `executionRunId` was stale or inactive
- This returned the agent's currently active run regardless of which issue it belonged to, causing live run widgets to appear on the wrong issue's detail page
- Added `isRunForIssue()` guard that checks `contextSnapshot.issueId` matches the requested issue before returning the fallback run

## Root Cause

The `live-runs` endpoint already filtered correctly via SQL (`contextSnapshot ->> 'issueId' = issue.id`), but the `active-run` fallback did not check which issue the run belonged to.

## Test plan

- [x] Unit tests for `isRunForIssue()` cover: matching issueId, mismatching issueId, null snapshot, missing issueId, null run
- [x] All server tests pass
