### PR TITLE
Fall back to agent adapter_config.cwd before generic workspace dir

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -76,7 +76,7 @@ interface ParsedIssueAssigneeAdapterOverrides {
 
 export type ResolvedWorkspaceForRun = {
   cwd: string;
-  source: "project_primary" | "task_session" | "agent_home";
+  source: "project_primary" | "task_session" | "agent_adapter_cwd" | "agent_home";
   projectId: string | null;
   workspaceId: string | null;
   repoUrl: string | null;
@@ -568,6 +568,33 @@ export function heartbeatService(db: Db) {
           warnings: [],
         };
       }
+    }
+
+    const agentCwd = readNonEmptyString(parseObject(agent.adapterConfig)?.cwd);
+    const agentCwdExists = agentCwd
+      ? await fs
+          .stat(agentCwd)
+          .then((stats) => stats.isDirectory())
+          .catch(() => false)
+      : false;
+
+    if (agentCwdExists) {
+      const warnings: string[] = [];
+      if (sessionCwd) {
+        warnings.push(
+          `Saved session workspace "${sessionCwd}" is not available. Falling back to agent cwd "${agentCwd}".`,
+        );
+      }
+      return {
+        cwd: agentCwd!,
+        source: "agent_adapter_cwd" as const,
+        projectId: resolvedProjectId,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        workspaceHints,
+        warnings,
+      };
     }
 
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);


### PR DESCRIPTION
My agent didn't know where it was working, wasn't in the right project dir.

## Summary

- When `resolveWorkspaceForRun` has no project workspace and no prior session, it now checks `agent.adapterConfig.cwd` before falling back to the generic `~/.paperclip/workspaces/<agentId>` directory
- Fixes timer-triggered heartbeats landing in empty fallback dirs when the agent has a configured `cwd`
- New workspace source type `agent_adapter_cwd` added to the resolution chain: `project_primary` → `task_session` → **`agent_adapter_cwd`** → `agent_home`

## Problem

Agents with `adapterConfig.cwd` set (e.g. to `/home/user/Code/MyProject`) were getting dropped into `~/.paperclip/instances/default/workspaces/<agentId>` on timer-triggered runs because there was no project or session context to resolve a workspace from. The agent's own configured cwd was never consulted.

## Test plan

- [x] Existing `heartbeat-workspace-session` tests pass (8/8)
- [ ] Timer-triggered heartbeat for an agent with `adapterConfig.cwd` set resolves to that dir instead of the fallback
- [ ] Agent with no `adapterConfig.cwd` still falls back to generic workspace dir
- [ ] Agent with invalid/missing `adapterConfig.cwd` path still falls back to generic workspace dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system now supports workspace detection through agent adapter configuration settings. When available, these settings are used to determine the workspace environment, providing an alternative source for workspace resolution alongside existing project and session-based approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->