### PR TITLE
Docs need improvements plz

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Paperclip
+
+Thanks for your interest in contributing! Whether it's a bug fix, documentation improvement, or new feature, we appreciate your help.
+
+- [Discord](https://discord.gg/m4HZY7xNG3) — chat with the community
+- [GitHub Issues](https://github.com/paperclipai/paperclip/issues) — bugs and feature requests
+- [GitHub Discussions](https://github.com/paperclipai/paperclip/discussions) — ideas and RFCs
+
+## Getting Started
+
+```sh
+git clone https://github.com/paperclipai/paperclip.git
+cd paperclip
+pnpm install
+pnpm dev
+```
+
+See `doc/DEVELOPING.md` for detailed dev setup and `AGENTS.md` for engineering rules and repo structure.
+
+## Contribution Pathways
+
+- **Bug fixes and small improvements** — open a PR directly.
+- **Docs and typos** — open a PR directly; no issue needed.
+- **New features or significant changes** — open a [GitHub Discussion](https://github.com/paperclipai/paperclip/discussions) first so we can align on scope and approach before you invest time.
+- **Security vulnerabilities** — use [GitHub's private vulnerability reporting](https://github.com/paperclipai/paperclip/security/advisories/new). Do **not** open a public issue.
+
+## Pre-Submission Checklist
+
+Before opening a PR, make sure everything passes:
+
+```sh
+pnpm -r typecheck && pnpm test:run && pnpm build
+```
+
+- If your change touches the DB schema, include a migration (`pnpm db:generate`).
+- If your change touches an API, update all impacted layers (db, shared, server, ui) per `AGENTS.md`.
+- Keep PRs focused — one concern per PR.
+
+## Code Style
+
+- TypeScript throughout. Avoid `any`.
+- Keep entities company-scoped (see `AGENTS.md` rule 1).
+- Follow existing patterns in the codebase rather than introducing new conventions.
+- Prefer simple, direct solutions over abstractions for one-time operations.
+
+## AI-Generated Code
+
+AI-generated contributions are welcome. The same quality bar applies: you must understand the code you submit and ensure it passes the full check suite. If you're an AI agent contributing directly, see `AGENTS.md` for detailed guidance.
+
+## Current Priorities
+
+See the **Roadmap** section in `README.md`. Contributions to docs, OpenClaw integration, and adapter development are especially welcome.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -247,8 +247,6 @@ See [doc/DEVELOPING.md](doc/DEVELOPING.md) for the full development guide.
 
 We welcome contributions. See the [contributing guide](CONTRIBUTING.md) for details.
 
-<!-- TODO: add CONTRIBUTING.md -->
-
 <br/>
 
 ## Community

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -62,6 +62,12 @@
               "guides/agent-developer/handling-approvals",
               "guides/agent-developer/cost-reporting"
             ]
+          },
+          {
+            "group": "Integration Guides",
+            "pages": [
+              "guides/openclaw-onboarding"
+            ]
           }
         ]
       },

--- a/docs/guides/openclaw-docker-setup.md
+++ b/docs/guides/openclaw-docker-setup.md
@@ -2,6 +2,8 @@
 
 How to get OpenClaw running in a Docker container for local development and testing the Paperclip OpenClaw adapter integration.
 
+> **Looking to connect an existing OpenClaw instance to Paperclip?** See the [OpenClaw + Paperclip onboarding guide](/guides/openclaw-onboarding) for a step-by-step walkthrough.
+
 ## Automated Join Smoke Test (Recommended First)
 
 Paperclip includes an end-to-end join smoke harness:

--- a/docs/guides/openclaw-onboarding.md
+++ b/docs/guides/openclaw-onboarding.md
@@ -1,0 +1,92 @@
+---
+title: "OpenClaw + Paperclip"
+summary: "Connect your OpenClaw agent to Paperclip in minutes"
+---
+
+## Why Paperclip?
+
+If OpenClaw is an employee, Paperclip is the company. OpenClaw gives you a capable AI agent — Paperclip gives that agent a place to work.
+
+By connecting OpenClaw to Paperclip you gain:
+
+- **Task management** — assign, track, and prioritize work across agents
+- **Cost tracking** — monitor spend per agent with budget hard-stops
+- **Goal alignment** — tie agent work back to company-level objectives
+- **Governance** — approval gates for sensitive actions
+- **Multi-agent coordination** — build an org chart and let agents collaborate
+
+## Prerequisites
+
+- A running OpenClaw instance (local, Docker, or cloud/Lightsail)
+- Your OpenClaw gateway URL and auth token (from `~/.openclaw/openclaw.json`)
+- Node.js 20+ and pnpm 9+ (for Paperclip), or Docker
+
+## Step 1: Start Paperclip
+
+The fastest way to get Paperclip running:
+
+```sh
+npx paperclipai onboard --yes
+```
+
+This walks you through setup and starts the server. Once it's running, open [http://localhost:3100](http://localhost:3100).
+
+Alternatively, use Docker Compose — see the [Docker deployment guide](/deploy/docker) for details.
+
+For a full walkthrough, see the [Quickstart](/start/quickstart).
+
+## Step 2: Create a Company
+
+In the Paperclip web UI:
+
+1. Click **Create Company** and give it a name.
+2. Set an initial **company goal** — this is what your agents will work toward.
+
+The company is the top-level container for all agents, tasks, budgets, and org structure. See [Core Concepts](/start/core-concepts) for more.
+
+## Step 3: Add Your OpenClaw Agent
+
+This is the key step that connects OpenClaw to Paperclip.
+
+1. In the Paperclip UI, navigate to **Agents** and click **Create Agent**.
+2. Select the **OpenClaw** adapter type.
+3. Configure the adapter settings:
+   - **`url`** — the endpoint where OpenClaw receives incoming webhooks. This depends on your OpenClaw setup (e.g. `http://<your-openclaw-host>:18789/...`). Check your OpenClaw configuration for the correct webhook endpoint.
+   - **`webhookAuthHeader`** — set to `Bearer <gateway-token>`, where `<gateway-token>` is the value from `gateway.auth.token` in your `~/.openclaw/openclaw.json`.
+4. Assign the agent a **role** in the org chart (e.g. CEO, Engineer).
+5. Set a **budget** to cap how much the agent can spend.
+
+**How it works:** Paperclip sends periodic heartbeat webhooks to OpenClaw at the configured URL. Each heartbeat wakes the agent, which checks for assigned tasks and does work. See [Heartbeat Protocol](/guides/agent-developer/heartbeat-protocol) for details.
+
+## Step 4: Assign Work
+
+1. In the Paperclip UI, create a **task** (or issue) describing the work to be done.
+2. Assign the task to your OpenClaw agent.
+3. On the next heartbeat, Paperclip sends a webhook to OpenClaw. The agent wakes up, picks up the task, and starts working.
+
+You can monitor progress in the Paperclip dashboard — task status, agent activity, and cost all update in real time.
+
+## Cloud / Lightsail Tips
+
+If your OpenClaw instance runs on AWS Lightsail or another cloud provider:
+
+- Use the instance's **public IP or domain** as the adapter URL (not `localhost`).
+- Ensure **bidirectional network access** — Paperclip must reach OpenClaw's webhook endpoint, and OpenClaw must reach Paperclip's API to report results.
+- If Paperclip also runs remotely, make sure both services can communicate (security groups, firewall rules, etc.).
+
+See [Deployment Modes](/deploy/deployment-modes) for more on running Paperclip in different environments.
+
+## What's Next
+
+- **Add more agents** — build out your org chart with specialized roles
+- **Configure heartbeat schedules** — control how often agents wake up
+- **Set budgets and approvals** — govern what agents can do autonomously
+
+<CardGroup cols={2}>
+  <Card title="Managing Agents" href="/guides/board-operator/managing-agents">
+    Add, configure, and monitor agents
+  </Card>
+  <Card title="Adapters Overview" href="/adapters/overview">
+    Learn about adapter types and configuration
+  </Card>
+</CardGroup>

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -48,3 +48,7 @@ Once Paperclip is running:
 <Card title="Core Concepts" href="/start/core-concepts">
   Learn the key concepts behind Paperclip
 </Card>
+
+<Card title="OpenClaw Users" href="/guides/openclaw-onboarding">
+  Already running OpenClaw? Connect it to Paperclip in minutes.
+</Card>


### PR DESCRIPTION
## Summary

Our README has been lying to people — it links to a `CONTRIBUTING.md` that doesn't exist. Meanwhile, OpenClaw users have to reverse-engineer how to connect their agent to Paperclip by reading Docker smoke test scripts. Nobody deserves that.

This PR fixes both crimes against documentation:

- **`CONTRIBUTING.md`** — now actually exists (revolutionary). Covers contribution pathways, pre-submission checklist, code style, security reporting, and AI-generated code policy.
- **OpenClaw onboarding guide** — step-by-step walkthrough for connecting an existing OpenClaw instance to Paperclip. No Docker knowledge required, no PhD in YAML needed.
- Wires everything into Mintlify nav, quickstart cards, and cross-links from the Docker setup guide.

## Test plan

- [ ] Verify `docs/docs.json` is valid JSON (validated locally)
- [ ] Verify "Integration Guides" group appears in Mintlify Guides tab
- [ ] Verify quickstart Card links to `/guides/openclaw-onboarding`
- [ ] Verify cross-link in `openclaw-docker-setup.md` resolves
- [ ] Verify `CONTRIBUTING.md` link in README resolves
- [ ] Confirm no code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributing guide with contact channels, setup steps, contribution pathways, code style rules, AI guidance, and a pre-submission checklist.
  * Added an OpenClaw onboarding guide with step‑by‑step integration and deployment tips.
  * Created a new Integration Guides group in the docs navigation and updated quickstart to reference the onboarding guide.
  * Removed a CONTRIBUTING TODO from the README and added a cross‑reference note in the Docker guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->