### PR TITLE
fix(adapter-utils): strip CLI nesting guards from spawned agent processes

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -110,6 +110,25 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   return vars;
 }
 
+/**
+ * Remove env vars that CLI tools (Claude Code, Codex, etc.) set to detect
+ * nested sessions. If Paperclip's own server process was started from inside
+ * such a CLI, these vars leak into child adapter processes and cause them to
+ * refuse to launch ("cannot be launched inside another session").
+ */
+function stripParentCliEnv<T extends Record<string, unknown>>(env: T): T {
+  const keysToStrip = [
+    "CLAUDECODE",              // Claude Code nesting guard
+    "CLAUDE_CODE_ENTRYPOINT",  // Claude Code entry marker
+    "CODEX_CLI_SESSION",       // Codex CLI nesting guard
+  ];
+  const cleaned = { ...env };
+  for (const key of keysToStrip) {
+    delete (cleaned as Record<string, unknown>)[key];
+  }
+  return cleaned;
+}
+
 export function defaultPathForPlatform() {
   if (process.platform === "win32") {
     return "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\Wbem";
@@ -211,7 +230,7 @@ export async function runChildProcess(
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
 
   return new Promise<RunProcessResult>((resolve, reject) => {
-    const mergedEnv = ensurePathInEnv({ ...process.env, ...opts.env });
+    const mergedEnv = ensurePathInEnv(stripParentCliEnv({ ...process.env, ...opts.env }));
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env: mergedEnv,

--- a/server/src/__tests__/adapter-env-isolation.test.ts
+++ b/server/src/__tests__/adapter-env-isolation.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { runChildProcess } from "../adapters/utils.js";
+
+const ORIGINAL_CLAUDECODE = process.env.CLAUDECODE;
+const ORIGINAL_CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT;
+
+afterEach(() => {
+  if (ORIGINAL_CLAUDECODE === undefined) delete process.env.CLAUDECODE;
+  else process.env.CLAUDECODE = ORIGINAL_CLAUDECODE;
+
+  if (ORIGINAL_CLAUDE_CODE_ENTRYPOINT === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+  else process.env.CLAUDE_CODE_ENTRYPOINT = ORIGINAL_CLAUDE_CODE_ENTRYPOINT;
+});
+
+describe("runChildProcess env isolation", () => {
+  it("strips CLAUDECODE nesting guard from child process environment", async () => {
+    process.env.CLAUDECODE = "1";
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+
+    const result = await runChildProcess(
+      "test-nesting-strip",
+      process.execPath,
+      ["-e", "process.stdout.write(JSON.stringify({CLAUDECODE: process.env.CLAUDECODE, CLAUDE_CODE_ENTRYPOINT: process.env.CLAUDE_CODE_ENTRYPOINT}))"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 10,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const childEnv = JSON.parse(result.stdout);
+    expect(childEnv.CLAUDECODE).toBeUndefined();
+    expect(childEnv.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
+  });
+
+  it("preserves PAPERCLIP_* env vars in child process", async () => {
+    const result = await runChildProcess(
+      "test-env-preserved",
+      process.execPath,
+      ["-e", "process.stdout.write(JSON.stringify({url: process.env.PAPERCLIP_API_URL, id: process.env.PAPERCLIP_AGENT_ID}))"],
+      {
+        cwd: process.cwd(),
+        env: {
+          PAPERCLIP_API_URL: "http://localhost:3100",
+          PAPERCLIP_AGENT_ID: "agent-123",
+        },
+        timeoutSec: 10,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const childEnv = JSON.parse(result.stdout);
+    expect(childEnv.url).toBe("http://localhost:3100");
+    expect(childEnv.id).toBe("agent-123");
+  });
+
+  it("preserves PATH so child can resolve commands", async () => {
+    const result = await runChildProcess(
+      "test-path-preserved",
+      process.execPath,
+      ["-e", "process.stdout.write(process.env.PATH || '')"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 10,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- When users run Paperclip via Claude Code (the expected workflow), session-scoped env vars (`CLAUDECODE=1`, `CLAUDE_CODE_ENTRYPOINT`) leak into spawned agent processes, causing false "cannot be launched inside another session" errors
- The spawned agent is a fully independent process — not a nested session — but the nesting guard can't tell the difference
- Strips known CLI nesting guard env vars in `runChildProcess` before spawning, so all adapter types benefit

## Test plan

- [x] New test: verifies `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` are stripped from child process env
- [x] New test: verifies `PAPERCLIP_*` vars are preserved in child process env
- [x] New test: verifies `PATH` is preserved so commands resolve
- [x] Full test suite passes (122/122)
- [ ] Manual: run `pnpm dev` inside Claude Code, create an agent, trigger heartbeat — agent should spawn without nesting error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed leakage of internal environment variables that were inadvertently passed to adapter processes.

* **Tests**
  * Added a comprehensive test suite to validate environment isolation behavior and confirm that required variables are properly preserved during subprocess execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->