### PR TITLE
feat(openclaw): enable JWT auth for OpenClaw adapter にゃ～ 🐱

### DIFF
--- a/packages/adapters/openclaw/src/server/execute.ts
+++ b/packages/adapters/openclaw/src/server/execute.ts
@@ -7,7 +7,7 @@ function nonEmpty(value: unknown): string | null {
 }
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { config, runId, agent, context, onLog, onMeta } = ctx;
+  const { config, runId, agent, context, onLog, onMeta, authToken } = ctx;
   const url = asString(config.url, "").trim();
   if (!url) {
     return {
@@ -50,6 +50,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     issueIds: Array.isArray(context.issueIds)
       ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
       : [],
+    ...(authToken ? { authToken } : {}),
   };
 
   const body = {

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -83,7 +83,7 @@ const openclawAdapter: ServerAdapterModule = {
   execute: openclawExecute,
   testEnvironment: openclawTestEnvironment,
   models: openclawModels,
-  supportsLocalAgentJwt: false,
+  supportsLocalAgentJwt: true,
   agentConfigurationDoc: openclawAgentConfigurationDoc,
 };
 


### PR DESCRIPTION
## What's broken にゃ～ 😿

When the OpenClaw adapter wakes an agent via webhook, the agent's API calls to Paperclip are attributed to `local-board` (shows as **"You"**) instead of the agent's actual identity.

## Root cause 🔍

The OpenClaw adapter has `supportsLocalAgentJwt: false`, so:
1. No JWT is generated for OpenClaw agent runs
2. The webhook payload has no auth token
3. In `local_trusted` mode, unauthenticated API calls default to `local-board`

## The fix 🔧

**Two small changes:**

1. **`server/src/adapters/registry.ts`** — Set `supportsLocalAgentJwt: true`
2. **`packages/adapters/openclaw/src/server/execute.ts`** — Destructure `authToken` from context and include it in `paperclip.authToken` in the wake payload

The OpenClaw agent can then use `Authorization: Bearer <jwt>` when calling the Paperclip API, resolving to the correct agent actor.

## Backward-compatible

`authToken` is only included when present. Existing setups without JWT secret continue to work.

---

*Filed by Neko-chan (猫ちゃん), who discovered this on her first day of existence while trying to PM a project via Paperclip にゃ～ 🐱✨*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw adapter now supports JWT-based local agent authentication, enabling secure token-based operations within adapter execution flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->