### PR TITLE
fix(adapter-utils): strip CLI nesting guards from spawned agent processes

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -110,6 +110,26 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   return vars;
 }
 
+
+/**
+ * Remove env vars that CLI tools (Claude Code, Codex, etc.) set to detect
+ * nested sessions. If Paperclip's own server process was started from inside
+ * such a CLI, these vars leak into child adapter processes and cause them to
+ * refuse to launch ("cannot be launched inside another session").
+ */
+function stripParentCliEnv<T extends Record<string, unknown>>(env: T): T {
+  const keysToStrip = [
+    "CLAUDECODE",              // Claude Code nesting guard
+    "CLAUDE_CODE_ENTRYPOINT",  // Claude Code entry marker
+    "CODEX_CLI_SESSION",       // Codex CLI nesting guard
+  ];
+  const cleaned = { ...env };
+  for (const key of keysToStrip) {
+    delete (cleaned as Record<string, unknown>)[key];
+  }
+  return cleaned;
+}
+
 export function defaultPathForPlatform() {
   if (process.platform === "win32") {
     return "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\Wbem";
@@ -211,7 +231,7 @@ export async function runChildProcess(
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
 
   return new Promise<RunProcessResult>((resolve, reject) => {
-    const mergedEnv = ensurePathInEnv({ ...process.env, ...opts.env });
+    const mergedEnv = ensurePathInEnv(stripParentCliEnv({ ...process.env, ...opts.env }));
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env: mergedEnv,

--- a/server/src/__tests__/adapter-env-isolation.test.ts
+++ b/server/src/__tests__/adapter-env-isolation.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { runChildProcess } from "../adapters/utils.js";
+
+const ORIGINAL_CLAUDECODE = process.env.CLAUDECODE;
+const ORIGINAL_CLAUDE_CODE_ENTRYPOINT = process.env.CLAUDE_CODE_ENTRYPOINT;
+
+afterEach(() => {
+  if (ORIGINAL_CLAUDECODE === undefined) delete process.env.CLAUDECODE;
+  else process.env.CLAUDECODE = ORIGINAL_CLAUDECODE;
+
+  if (ORIGINAL_CLAUDE_CODE_ENTRYPOINT === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+  else process.env.CLAUDE_CODE_ENTRYPOINT = ORIGINAL_CLAUDE_CODE_ENTRYPOINT;
+});
+
+describe("runChildProcess env isolation", () => {
+  it("strips CLAUDECODE nesting guard from child process environment", async () => {
+    process.env.CLAUDECODE = "1";
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+
+    const result = await runChildProcess(
+      "test-nesting-strip",
+      process.execPath,
+      ["-e", "process.stdout.write(JSON.stringify({CLAUDECODE: process.env.CLAUDECODE, CLAUDE_CODE_ENTRYPOINT: process.env.CLAUDE_CODE_ENTRYPOINT}))"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 10,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const childEnv = JSON.parse(result.stdout);
+    expect(childEnv.CLAUDECODE).toBeUndefined();
+    expect(childEnv.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
+  });
+
+  it("preserves PAPERCLIP_* env vars in child process", async () => {
+    const result = await runChildProcess(
+      "test-env-preserved",
+      process.execPath,
+      ["-e", "process.stdout.write(JSON.stringify({url: process.env.PAPERCLIP_API_URL, id: process.env.PAPERCLIP_AGENT_ID}))"],
+      {
+        cwd: process.cwd(),
+        env: {
+          PAPERCLIP_API_URL: "http://localhost:3100",
+          PAPERCLIP_AGENT_ID: "agent-123",
+        },
+        timeoutSec: 10,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const childEnv = JSON.parse(result.stdout);
+    expect(childEnv.url).toBe("http://localhost:3100");
+    expect(childEnv.id).toBe("agent-123");
+  });
+
+  it("preserves PATH so child can resolve commands", async () => {
+    const result = await runChildProcess(
+      "test-path-preserved",
+      process.execPath,
+      ["-e", "process.stdout.write(process.env.PATH || \'\')"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 10,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

When the Paperclip server is launched from inside a Claude Code session, CLAUDECODE and CLAUDE_CODE_ENTRYPOINT are inherited. When the server then spawns a child agent process (via runChildProcess), these vars leak into the child, causing claude to refuse to start.

## Root Cause

In packages/adapter-utils/src/server-utils.ts, runChildProcess merged process.env with adapter env vars but never stripped nesting guards from the parent CLI session.

## Fix

Add stripParentCliEnv() that removes known CLI nesting guard env vars before spawning: CLAUDECODE, CLAUDE_CODE_ENTRYPOINT, CODEX_CLI_SESSION. Applied in runChildProcess so all adapters benefit.

## Tests

Added server/src/__tests__/adapter-env-isolation.test.ts verifying:
1. CLAUDECODE and CLAUDE_CODE_ENTRYPOINT are absent in child process env
2. PAPERCLIP_* env vars still pass through correctly
3. PATH is preserved for command resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced child process environment isolation by removing environment variables used by CLI tools that could interfere with nested session detection. System PATH and other essential variables are properly preserved.

* **Tests**
  * Added comprehensive tests for environment variable isolation, verifying correct stripping and preservation in child processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->