### PR TITLE
feat(claude-local): add Claude Sonnet 4.6 to model list

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -3,6 +3,7 @@ export const label = "Claude Code (local)";
 
 export const models = [
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
   { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 ];


### PR DESCRIPTION
Adds `claude-sonnet-4-6` to the Claude Code (local) adapter model list. Currently only Opus 4.6, Sonnet 4.5, and Haiku 4.5 are available — Sonnet 4.6 is missing despite being a widely used model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Sonnet 4.6 as a new model option to the Claude Local adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->