### PR TITLE
feat: add local agent execution mode (--local flag)

### DIFF
--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -1,6 +1,7 @@
 import { setTimeout as delay } from "node:timers/promises";
 import pc from "picocolors";
 import type { Agent, HeartbeatRun, HeartbeatRunEvent, HeartbeatRunStatus } from "@paperclipai/shared";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import { getCLIAdapter } from "../adapters/index.js";
 import { resolveCommandContext } from "./client/common.js";
 
@@ -28,6 +29,8 @@ interface HeartbeatRunOptions {
   timeoutMs: string;
   debug?: boolean;
   json?: boolean;
+  local?: boolean;
+  cwd?: string;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -79,6 +82,11 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
   const agent = await api.get<Agent>(`/api/agents/${opts.agentId}`);
   if (!agent || typeof agent !== "object" || !agent.id) {
     console.error(pc.red(`Agent not found: ${opts.agentId}`));
+    return;
+  }
+
+  if (opts.local) {
+    await runLocalExecution(api, agent, { source, triggerDetail, cwd: opts.cwd, debug, timeoutMs });
     return;
   }
 
@@ -320,6 +328,224 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
   } else {
     process.exitCode = 1;
     console.log(pc.gray("Heartbeat stream ended without terminal status"));
+  }
+}
+
+interface ClaimLocalResult {
+  run: HeartbeatRun;
+  agent: { id: string; companyId: string; name: string; adapterType: string };
+  config: Record<string, unknown>;
+  context: Record<string, unknown>;
+  authToken: string | null;
+}
+
+type ApiClient = ReturnType<typeof resolveCommandContext>["api"];
+
+async function getAdapterExecute(adapterType: string): Promise<((ctx: AdapterExecutionContext) => Promise<AdapterExecutionResult>) | null> {
+  try {
+    switch (adapterType) {
+      case "claude_local": {
+        const mod = await import("@paperclipai/adapter-claude-local/server");
+        return mod.execute;
+      }
+      case "codex_local": {
+        const mod = await import("@paperclipai/adapter-codex-local/server");
+        return mod.execute;
+      }
+      case "opencode_local": {
+        const mod = await import("@paperclipai/adapter-opencode-local/server");
+        return mod.execute;
+      }
+      case "cursor": {
+        const mod = await import("@paperclipai/adapter-cursor-local/server");
+        return mod.execute;
+      }
+      case "openclaw": {
+        const mod = await import("@paperclipai/adapter-openclaw/server");
+        return mod.execute;
+      }
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function runLocalExecution(
+  api: ApiClient,
+  agent: Agent,
+  opts: {
+    source: string;
+    triggerDetail: string;
+    cwd?: string;
+    debug: boolean;
+    timeoutMs: number;
+  },
+): Promise<void> {
+  console.log(pc.cyan(`[local] Starting local execution for agent ${agent.name} (${agent.id})`));
+
+  // 1. Wakeup with executionMode: "local" via payload
+  const payload: Record<string, unknown> = { executionMode: "local" };
+  if (opts.cwd) {
+    payload.localCwd = opts.cwd;
+  }
+
+  const invokeRes = await api.post<InvokedHeartbeat>(
+    `/api/agents/${agent.id}/wakeup`,
+    {
+      source: opts.source,
+      triggerDetail: opts.triggerDetail,
+      payload,
+    },
+  );
+  if (!invokeRes) {
+    console.error(pc.red("Failed to invoke heartbeat"));
+    return;
+  }
+  if ((invokeRes as { status?: string }).status === "skipped") {
+    console.log(pc.yellow("Heartbeat invocation was skipped"));
+    return;
+  }
+
+  const run = invokeRes as HeartbeatRun;
+  console.log(pc.cyan(`[local] Created run ${run.id}, claiming for local execution...`));
+
+  // 2. Claim the run for local execution
+  const claimRes = await api.post<ClaimLocalResult>(
+    `/api/heartbeat-runs/${run.id}/claim-local`,
+    {},
+  );
+  if (!claimRes || !claimRes.run) {
+    console.error(pc.red("Failed to claim run for local execution"));
+    return;
+  }
+
+  console.log(pc.green(`[local] Claimed run ${run.id}`));
+  console.log(pc.cyan(`[local] Adapter: ${claimRes.agent.adapterType}`));
+
+  // 3. Get the adapter execute function
+  const adapterExecute = await getAdapterExecute(claimRes.agent.adapterType);
+  if (!adapterExecute) {
+    console.error(pc.red(`Adapter type "${claimRes.agent.adapterType}" not supported for local execution`));
+    await api.post(`/api/heartbeat-runs/${run.id}/complete`, {
+      status: "failed",
+      error: `Adapter type "${claimRes.agent.adapterType}" not supported for local execution`,
+      errorCode: "unsupported_adapter",
+    });
+    return;
+  }
+
+  // 4. Build execution context
+  const cwd = opts.cwd || process.cwd();
+  const context = claimRes.context ?? {};
+  if (!context.paperclipWorkspace || !(context.paperclipWorkspace as Record<string, unknown>).cwd) {
+    context.paperclipWorkspace = { cwd, source: "local_cli" };
+  }
+
+  const cliAdapter = getCLIAdapter(claimRes.agent.adapterType);
+  let stdoutJsonBuffer = "";
+
+  const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
+    // Display locally
+    if (opts.debug) {
+      if (stream === "stdout") process.stdout.write(pc.green("[stdout] ") + chunk);
+      else process.stdout.write(pc.red("[stderr] ") + chunk);
+    } else if (stream === "stdout") {
+      const combined = stdoutJsonBuffer + chunk;
+      const lines = combined.split(/\r?\n/);
+      stdoutJsonBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        cliAdapter.formatStdoutEvent(line, opts.debug);
+      }
+    } else {
+      process.stdout.write(pc.red("[stderr] ") + chunk);
+    }
+
+    // Stream back to server (fire-and-forget)
+    api.post(`/api/heartbeat-runs/${run.id}/append-log`, { stream, chunk }).catch(() => {});
+  };
+
+  const executionContext: AdapterExecutionContext = {
+    runId: run.id,
+    agent: {
+      id: claimRes.agent.id,
+      companyId: claimRes.agent.companyId,
+      name: claimRes.agent.name,
+      adapterType: claimRes.agent.adapterType,
+      adapterConfig: claimRes.config,
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: claimRes.config,
+    context,
+    onLog,
+    authToken: claimRes.authToken ?? undefined,
+  };
+
+  // 5. Execute the adapter locally
+  console.log(pc.cyan(`[local] Executing adapter in ${cwd}...`));
+
+  let adapterResult: AdapterExecutionResult;
+  try {
+    adapterResult = await adapterExecute(executionContext);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Local adapter execution failed";
+    console.error(pc.red(`[local] Execution failed: ${message}`));
+    await api.post(`/api/heartbeat-runs/${run.id}/complete`, {
+      status: "failed",
+      error: message,
+      errorCode: "adapter_failed",
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  // Flush remaining stdout buffer
+  if (stdoutJsonBuffer.trim()) {
+    cliAdapter.formatStdoutEvent(stdoutJsonBuffer, opts.debug);
+    stdoutJsonBuffer = "";
+  }
+
+  // 6. Report completion
+  const status = adapterResult.timedOut
+    ? "timed_out"
+    : (adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage
+      ? "succeeded"
+      : "failed";
+
+  const usageJson = adapterResult.usage || adapterResult.costUsd != null
+    ? {
+        ...(adapterResult.usage ?? {}),
+        ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
+        ...(adapterResult.billingType ? { billingType: adapterResult.billingType } : {}),
+      }
+    : null;
+
+  await api.post(`/api/heartbeat-runs/${run.id}/complete`, {
+    status,
+    exitCode: adapterResult.exitCode ?? null,
+    signal: adapterResult.signal ?? null,
+    error: adapterResult.errorMessage ?? null,
+    errorCode: adapterResult.errorCode ?? null,
+    resultJson: adapterResult.resultJson ?? null,
+    usageJson,
+    sessionIdAfter: adapterResult.sessionId ?? null,
+  });
+
+  const label = `[local] Run ${run.id} completed with status ${status}`;
+  if (status === "succeeded") {
+    console.log(pc.green(label));
+  } else {
+    console.log(pc.red(label));
+    if (adapterResult.errorMessage) {
+      console.log(pc.red(`Error: ${adapterResult.errorMessage}`));
+    }
+    process.exitCode = 1;
   }
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -123,6 +123,8 @@ heartbeat
   .option("--timeout-ms <ms>", "Max time to wait before giving up", "0")
   .option("--json", "Output raw JSON where applicable")
   .option("--debug", "Show raw adapter stdout/stderr JSON chunks")
+  .option("--local", "Execute the adapter locally instead of on the server")
+  .option("--cwd <path>", "Working directory for local execution (requires --local)")
   .action(heartbeatRun);
 
 registerContextCommands(program);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1311,6 +1311,63 @@ export function agentRoutes(db: Db) {
     res.json(result);
   });
 
+  // ── Local Agent Execution endpoints ──────────────────────────────────
+
+  router.post("/heartbeat-runs/:runId/claim-local", async (req, res) => {
+    const runId = req.params.runId as string;
+    try {
+      const result = await heartbeat.claimForLocalExecution(runId);
+      res.json(result);
+    } catch (err: unknown) {
+      const status = (err as { statusCode?: number }).statusCode ?? 500;
+      const message = err instanceof Error ? err.message : "Failed to claim run";
+      res.status(status).json({ error: message });
+    }
+  });
+
+  router.post("/heartbeat-runs/:runId/append-log", async (req, res) => {
+    const runId = req.params.runId as string;
+    const stream = req.body.stream as "stdout" | "stderr" | undefined;
+    const chunk = req.body.chunk as string | undefined;
+    if (!stream || !chunk) {
+      res.status(400).json({ error: "stream and chunk are required" });
+      return;
+    }
+    try {
+      await heartbeat.appendLocalRunLog(runId, stream, chunk);
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      const status = (err as { statusCode?: number }).statusCode ?? 500;
+      const message = err instanceof Error ? err.message : "Failed to append log";
+      res.status(status).json({ error: message });
+    }
+  });
+
+  router.post("/heartbeat-runs/:runId/complete", async (req, res) => {
+    const runId = req.params.runId as string;
+    try {
+      const finalRun = await heartbeat.completeLocalRun(runId, {
+        status: req.body.status,
+        exitCode: req.body.exitCode ?? null,
+        signal: req.body.signal ?? null,
+        error: req.body.error ?? null,
+        errorCode: req.body.errorCode ?? null,
+        resultJson: req.body.resultJson ?? null,
+        usageJson: req.body.usageJson ?? null,
+        sessionIdAfter: req.body.sessionIdAfter ?? null,
+        stdoutExcerpt: req.body.stdoutExcerpt ?? null,
+        stderrExcerpt: req.body.stderrExcerpt ?? null,
+      });
+      res.json(finalRun);
+    } catch (err: unknown) {
+      const status = (err as { statusCode?: number }).statusCode ?? 500;
+      const message = err instanceof Error ? err.message : "Failed to complete run";
+      res.status(status).json({ error: message });
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+
   router.get("/issues/:issueId/live-runs", async (req, res) => {
     const rawId = req.params.issueId as string;
     const issueSvc = issueService(db);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -273,6 +273,10 @@ function enrichWakeContextSnapshot(input: {
   if (!readNonEmptyString(contextSnapshot["wakeTriggerDetail"]) && triggerDetail) {
     contextSnapshot.wakeTriggerDetail = triggerDetail;
   }
+  // Propagate executionMode from payload for local agent execution
+  if (payload?.["executionMode"] === "local" && !contextSnapshot.executionMode) {
+    contextSnapshot.executionMode = "local";
+  }
 
   return {
     contextSnapshot,
@@ -1015,10 +1019,15 @@ export function heartbeatService(db: Db) {
         .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
         .orderBy(asc(heartbeatRuns.createdAt))
         .limit(availableSlots);
-      if (queuedRuns.length === 0) return [];
+      // Filter out runs marked for local execution — those are claimed by the CLI.
+      const serverRuns = queuedRuns.filter((r) => {
+        const ctx = parseObject(r.contextSnapshot);
+        return ctx.executionMode !== "local";
+      });
+      if (serverRuns.length === 0) return [];
 
       const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
-      for (const queuedRun of queuedRuns) {
+      for (const queuedRun of serverRuns) {
         const claimed = await claimQueuedRun(queuedRun);
         if (claimed) claimedRuns.push(claimed);
       }
@@ -2197,6 +2206,127 @@ export function heartbeatService(db: Db) {
       }),
 
     wakeup: enqueueWakeup,
+
+    claimForLocalExecution: async (runId: string) => {
+      const run = await getRun(runId);
+      if (!run) throw notFound("Heartbeat run not found");
+      if (run.status !== "queued") {
+        throw conflict("Run is not in queued state", { status: run.status });
+      }
+      const ctx = parseObject(run.contextSnapshot);
+      if (ctx.executionMode !== "local") {
+        throw conflict("Run is not marked for local execution");
+      }
+      const claimed = await claimQueuedRun(run);
+      if (!claimed) throw conflict("Run already claimed by another worker");
+
+      const agent = await getAgent(run.agentId);
+      if (!agent) throw notFound("Agent not found");
+
+      const config = parseObject(agent.adapterConfig);
+      const resolvedConfig = await secretsSvc.resolveAdapterConfigForRuntime(
+        agent.companyId,
+        config,
+      );
+
+      const adapter = getServerAdapter(agent.adapterType);
+      const authToken = adapter.supportsLocalAgentJwt
+        ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
+        : null;
+
+      await appendRunEvent(claimed, 1, {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "run claimed for local execution",
+      });
+
+      return {
+        run: claimed,
+        agent: {
+          id: agent.id,
+          companyId: agent.companyId,
+          name: agent.name,
+          adapterType: agent.adapterType,
+        },
+        config: resolvedConfig,
+        context: ctx,
+        authToken,
+      };
+    },
+
+    appendLocalRunLog: async (runId: string, stream: "stdout" | "stderr", chunk: string) => {
+      const run = await getRun(runId);
+      if (!run) throw notFound("Heartbeat run not found");
+      if (run.status !== "running") return;
+
+      publishLiveEvent({
+        companyId: run.companyId,
+        type: "heartbeat.run.log",
+        payload: {
+          runId: run.id,
+          agentId: run.agentId,
+          stream,
+          chunk: chunk.length > MAX_LIVE_LOG_CHUNK_BYTES ? chunk.slice(chunk.length - MAX_LIVE_LOG_CHUNK_BYTES) : chunk,
+          truncated: chunk.length > MAX_LIVE_LOG_CHUNK_BYTES,
+        },
+      });
+    },
+
+    completeLocalRun: async (
+      runId: string,
+      result: {
+        status: "succeeded" | "failed" | "timed_out";
+        exitCode?: number | null;
+        signal?: string | null;
+        error?: string | null;
+        errorCode?: string | null;
+        resultJson?: Record<string, unknown> | null;
+        usageJson?: Record<string, unknown> | null;
+        sessionIdAfter?: string | null;
+        stdoutExcerpt?: string | null;
+        stderrExcerpt?: string | null;
+      },
+    ) => {
+      const run = await getRun(runId);
+      if (!run) throw notFound("Heartbeat run not found");
+      if (run.status !== "running") {
+        throw conflict("Run is not in running state", { status: run.status });
+      }
+
+      const finalRun = await setRunStatus(run.id, result.status, {
+        finishedAt: new Date(),
+        error: result.error ?? null,
+        errorCode: result.errorCode ?? null,
+        exitCode: result.exitCode ?? null,
+        signal: result.signal ?? null,
+        resultJson: result.resultJson ?? null,
+        usageJson: result.usageJson ?? null,
+        sessionIdAfter: result.sessionIdAfter ?? null,
+        stdoutExcerpt: result.stdoutExcerpt ?? null,
+        stderrExcerpt: result.stderrExcerpt ?? null,
+      });
+
+      await setWakeupStatus(run.wakeupRequestId, result.status === "succeeded" ? "completed" : result.status, {
+        finishedAt: new Date(),
+        error: result.error ?? null,
+      });
+
+      if (finalRun) {
+        await appendRunEvent(finalRun, 2, {
+          eventType: "lifecycle",
+          stream: "system",
+          level: result.status === "succeeded" ? "info" : "error",
+          message: `run ${result.status} (local execution)`,
+          payload: { status: result.status, exitCode: result.exitCode },
+        });
+        await releaseIssueExecutionAndPromote(finalRun);
+      }
+
+      await finalizeAgentStatus(run.agentId, result.status === "succeeded" ? "succeeded" : "failed");
+      await startNextQueuedRunForAgent(run.agentId);
+      return finalRun;
+    },
 
     reapOrphanedRuns,
 


### PR DESCRIPTION
## Summary
- Adds `--local` and `--cwd` flags to `paperclipai heartbeat run` CLI command
- Allows adapter processes (claude, codex, opencode, cursor, openclaw) to run on the user's local machine instead of the server
- Server marks local runs with `executionMode: "local"` in context and skips server-side execution
- CLI claims the run, spawns the adapter locally, streams logs back to the server, and reports completion

## New Server Endpoints
- `POST /heartbeat-runs/:runId/claim-local` — CLI claims a queued run for local execution
- `POST /heartbeat-runs/:runId/append-log` — CLI streams logs back to the server
- `POST /heartbeat-runs/:runId/complete` — CLI reports run completion with results

## Usage
```bash
paperclipai heartbeat run \
  -a <agent-id> \
  --api-base https://my-paperclip.example.com \
  --api-key <api-key> \
  --local \
  --cwd ~/my-project
```

## Test plan
- [ ] Verify `--local` flag triggers local execution path
- [ ] Verify server skips execution for `executionMode: "local"` runs
- [ ] Verify CLI can claim, execute, and report results for claude_local adapter
- [ ] Verify logs are streamed to server and visible in the UI
- [ ] Verify run status updates correctly (succeeded/failed/timed_out)
- [ ] Verify existing server-side execution is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added local execution mode for adapters via new CLI flags `--local` and `--cwd <path>`, enabling adapters to run locally through the CLI instead of on the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->