### PR TITLE
feat(openclaw): native gateway adapter via WebSocket RPC

### DIFF
--- a/packages/adapters/openclaw/src/index.ts
+++ b/packages/adapters/openclaw/src/index.ts
@@ -1,27 +1,31 @@
 export const type = "openclaw";
 export const label = "OpenClaw";
 
-export const models: { id: string; label: string }[] = [];
+// Static models for v1 — matches our OpenClaw agent config
+export const models = [
+  { id: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6 (via OpenClaw)" },
+  { id: "openai-codex/gpt-5.4", label: "GPT 5.4 (via OpenClaw)" },
+];
 
-export const agentConfigurationDoc = `# openclaw agent configuration
+export const agentConfigurationDoc = `
+# OpenClaw Adapter Configuration
 
-Adapter: openclaw
+Connect to an OpenClaw gateway to orchestrate AI agents.
 
-Use when:
-- You run an OpenClaw agent remotely and wake it via webhook.
-- You want Paperclip heartbeat/task events delivered over HTTP.
+## Configuration Fields
 
-Don't use when:
-- You need local CLI execution inside Paperclip (use claude_local/codex_local/opencode_local/process).
-- The OpenClaw endpoint is not reachable from the Paperclip server.
+- **gatewayUrl** (string, required): WebSocket URL of the OpenClaw gateway. Default: \`ws://127.0.0.1:5555\`
+- **agentId** (string, required): The agent identifier to use. Examples: "main", "researcher"
+- **authToken** (string, optional): Authentication token for the gateway. Required for non-local deployments.
+- **timeoutSec** (number, optional): Maximum execution time in seconds. Default: 120
 
-Core fields:
-- url (string, required): OpenClaw webhook endpoint URL
-- method (string, optional): HTTP method, default POST
-- headers (object, optional): extra HTTP headers for webhook calls
-- webhookAuthHeader (string, optional): Authorization header value if your endpoint requires auth
-- payloadTemplate (object, optional): additional JSON payload fields merged into each wake payload
+## Example
 
-Operational fields:
-- timeoutSec (number, optional): request timeout in seconds (default 30)
+\`\`\`json
+{
+  "gatewayUrl": "ws://127.0.0.1:5555",
+  "agentId": "main",
+  "timeoutSec": 120
+}
+\`\`\`
 `;

--- a/packages/adapters/openclaw/src/server/execute.ts
+++ b/packages/adapters/openclaw/src/server/execute.ts
@@ -1,144 +1,377 @@
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
-import { asNumber, asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
-import { parseOpenClawResponse } from "./parse.js";
+import crypto from "node:crypto";
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  parseObject,
+  renderTemplate,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  parseOpenClawAgentResult,
+  isOpenClawError,
+} from "./parse.js";
 
-function nonEmpty(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+// ---------------------------------------------------------------------------
+// JSON-RPC frame helpers
+// ---------------------------------------------------------------------------
+
+interface RpcRequest {
+  type: "req";
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
 }
 
-export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { config, runId, agent, context, onLog, onMeta } = ctx;
-  const url = asString(config.url, "").trim();
-  if (!url) {
+interface RpcResponse {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload: Record<string, unknown>;
+}
+
+function buildRpcRequest(
+  method: string,
+  params: Record<string, unknown>,
+): { frame: RpcRequest; id: string } {
+  const id = crypto.randomUUID();
+  return {
+    id,
+    frame: { type: "req", id, method, params },
+  };
+}
+
+function isRpcResponse(data: unknown): data is RpcResponse {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return false;
+  const obj = data as Record<string, unknown>;
+  return obj.type === "res" && typeof obj.id === "string";
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket helpers (Node 22 native WebSocket)
+// ---------------------------------------------------------------------------
+
+function openWebSocket(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<WebSocket> {
+  return new Promise<WebSocket>((resolve, reject) => {
+    // Node 22 supports a second options arg with `headers` for the native WS.
+    // The typing is not always present so we cast through unknown.
+    const options: Record<string, unknown> = {};
+    if (headers && Object.keys(headers).length > 0) {
+      options.headers = headers;
+    }
+    const ws: WebSocket =
+      Object.keys(options).length > 0
+        ? new (WebSocket as unknown as new (url: string, protocols?: string | string[], opts?: unknown) => WebSocket)(url, undefined, options)
+        : new WebSocket(url);
+
+    const onOpen = () => {
+      cleanup();
+      resolve(ws);
+    };
+    const onError = (ev: Event) => {
+      cleanup();
+      const msg =
+        (ev as ErrorEvent).message ??
+        `WebSocket connection to ${url} failed`;
+      reject(new Error(msg));
+    };
+    const cleanup = () => {
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("error", onError);
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
+  });
+}
+
+function safeCloseWebSocket(ws: WebSocket) {
+  try {
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close();
+    }
+  } catch {
+    // swallow — best-effort cleanup
+  }
+}
+
+// ---------------------------------------------------------------------------
+// execute()
+// ---------------------------------------------------------------------------
+
+export async function execute(
+  ctx: AdapterExecutionContext,
+): Promise<AdapterExecutionResult> {
+  const { runId, agent, config, context, onLog, onMeta } = ctx;
+
+  // ---- extract config ----
+  const gatewayUrl = asString(config.gatewayUrl, "ws://127.0.0.1:5555").trim();
+  const agentId = asString(config.agentId, "").trim();
+  const authToken = asString(config.authToken, "").trim() || ctx.authToken || "";
+  const timeoutSec = Math.max(1, asNumber(config.timeoutSec, 120));
+  const model = asString(config.model, "unknown");
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+
+  if (!agentId) {
     return {
       exitCode: 1,
       signal: null,
       timedOut: false,
-      errorMessage: "OpenClaw adapter missing url",
-      errorCode: "openclaw_url_missing",
+      errorMessage: "OpenClaw adapter missing agentId in config",
+      errorCode: "openclaw_agent_id_missing",
     };
   }
 
-  const method = asString(config.method, "POST").trim().toUpperCase() || "POST";
-  const timeoutSec = Math.max(1, asNumber(config.timeoutSec, 30));
-  const headersConfig = parseObject(config.headers) as Record<string, unknown>;
-  const payloadTemplate = parseObject(config.payloadTemplate);
-  const webhookAuthHeader = nonEmpty(config.webhookAuthHeader);
-
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-  };
-  for (const [key, value] of Object.entries(headersConfig)) {
-    if (typeof value === "string" && value.trim().length > 0) {
-      headers[key] = value;
-    }
-  }
-  if (webhookAuthHeader && !headers.authorization && !headers.Authorization) {
-    headers.authorization = webhookAuthHeader;
-  }
-
-  const wakePayload = {
-    runId,
+  // ---- build message from prompt template ----
+  const message = renderTemplate(promptTemplate, {
     agentId: agent.id,
     companyId: agent.companyId,
-    taskId: nonEmpty(context.taskId) ?? nonEmpty(context.issueId),
-    issueId: nonEmpty(context.issueId),
-    wakeReason: nonEmpty(context.wakeReason),
-    wakeCommentId: nonEmpty(context.wakeCommentId) ?? nonEmpty(context.commentId),
-    approvalId: nonEmpty(context.approvalId),
-    approvalStatus: nonEmpty(context.approvalStatus),
-    issueIds: Array.isArray(context.issueIds)
-      ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-      : [],
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  });
+
+  // ---- build RPC params ----
+  const sessionKey = `agent:${agentId}:paperclip:${runId}`;
+  const rpcParams: Record<string, unknown> = {
+    message,
+    agentId,
+    sessionKey,
+    idempotencyKey: runId,
+    timeout: timeoutSec,
   };
 
-  const body = {
-    ...payloadTemplate,
-    paperclip: {
-      ...wakePayload,
-      context,
-    },
-  };
+  const extraSystemPrompt = asString(config.extraSystemPrompt, "").trim();
+  if (extraSystemPrompt) {
+    rpcParams.extraSystemPrompt = extraSystemPrompt;
+  }
+  const label = asString(config.label, "").trim();
+  if (label) {
+    rpcParams.label = label;
+  }
 
+  // ---- report invocation metadata ----
   if (onMeta) {
     await onMeta({
       adapterType: "openclaw",
-      command: "webhook",
-      commandArgs: [method, url],
+      command: "websocket-rpc",
+      cwd: undefined,
+      commandArgs: [gatewayUrl, `agent:${agentId}`],
+      prompt: message,
       context,
     });
   }
 
-  await onLog("stdout", `[openclaw] invoking ${method} ${url}\n`);
+  // ---- connect to gateway ----
+  await onLog("stdout", `[openclaw] connecting to gateway ${gatewayUrl}\n`);
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutSec * 1000);
+  let ws: WebSocket;
+  const wsHeaders: Record<string, string> = {};
+  if (authToken) {
+    wsHeaders.authorization = `Bearer ${authToken}`;
+  }
 
   try {
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-
-    const responseText = await response.text();
-    if (responseText.trim().length > 0) {
-      await onLog("stdout", `[openclaw] response (${response.status}) ${responseText.slice(0, 2000)}\n`);
-    } else {
-      await onLog("stdout", `[openclaw] response (${response.status}) <empty>\n`);
-    }
-
-    if (!response.ok) {
-      return {
-        exitCode: 1,
-        signal: null,
-        timedOut: false,
-        errorMessage: `OpenClaw webhook failed with status ${response.status}`,
-        errorCode: "openclaw_http_error",
-        resultJson: {
-          status: response.status,
-          statusText: response.statusText,
-          response: parseOpenClawResponse(responseText) ?? responseText,
-        },
-      };
-    }
-
-    return {
-      exitCode: 0,
-      signal: null,
-      timedOut: false,
-      provider: "openclaw",
-      model: null,
-      summary: `OpenClaw webhook ${method} ${url}`,
-      resultJson: {
-        status: response.status,
-        statusText: response.statusText,
-        response: parseOpenClawResponse(responseText) ?? responseText,
-      },
-    };
+    ws = await openWebSocket(gatewayUrl, wsHeaders);
   } catch (err) {
-    if (err instanceof Error && err.name === "AbortError") {
-      await onLog("stderr", `[openclaw] request timed out after ${timeoutSec}s\n`);
-      return {
-        exitCode: null,
-        signal: null,
-        timedOut: true,
-        errorMessage: `Timed out after ${timeoutSec}s`,
-        errorCode: "timeout",
-      };
-    }
-
-    const message = err instanceof Error ? err.message : String(err);
-    await onLog("stderr", `[openclaw] request failed: ${message}\n`);
+    const errMsg = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[openclaw] gateway connection failed: ${errMsg}\n`);
     return {
       exitCode: 1,
       signal: null,
       timedOut: false,
-      errorMessage: message,
-      errorCode: "openclaw_request_failed",
+      errorMessage: `Failed to connect to OpenClaw gateway at ${gatewayUrl}: ${errMsg}`,
+      errorCode: "openclaw_connection_failed",
+    };
+  }
+
+  await onLog("stdout", `[openclaw] connected to gateway\n`);
+
+  // ---- send agent RPC and await two-phase response ----
+  const { frame, id: requestId } = buildRpcRequest("agent", rpcParams);
+
+  try {
+    const result = await new Promise<AdapterExecutionResult>((resolve) => {
+      let acceptedRunId: string | null = null;
+      let settled = false;
+
+      const settle = (res: AdapterExecutionResult) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(res);
+      };
+
+      // Timeout guard
+      const timer = setTimeout(() => {
+        void onLog(
+          "stderr",
+          `[openclaw] timed out after ${timeoutSec}s waiting for agent result\n`,
+        );
+        settle({
+          exitCode: null,
+          signal: null,
+          timedOut: true,
+          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorCode: "timeout",
+          provider: "openclaw",
+          model,
+        });
+      }, timeoutSec * 1000);
+
+      const onMessage = (ev: MessageEvent) => {
+        let data: unknown;
+        try {
+          data = JSON.parse(typeof ev.data === "string" ? ev.data : String(ev.data));
+        } catch {
+          return; // skip non-JSON frames
+        }
+
+        if (!isRpcResponse(data)) return;
+        if (data.id !== requestId) return;
+
+        const payload = data.payload ?? {};
+
+        // ---- Phase 1: accepted ----
+        if (
+          typeof payload.status === "string" &&
+          payload.status === "accepted"
+        ) {
+          acceptedRunId =
+            typeof payload.runId === "string" ? payload.runId : null;
+          void onLog(
+            "stdout",
+            `[openclaw] agent run accepted${acceptedRunId ? ` (runId: ${acceptedRunId})` : ""}\n`,
+          );
+          return; // wait for Phase 2
+        }
+
+        // ---- Phase 2: final result ----
+        const parsed = parseOpenClawAgentResult(payload);
+
+        if (isOpenClawError(payload)) {
+          void onLog(
+            "stderr",
+            `[openclaw] agent run error: ${parsed.error ?? "unknown error"}\n`,
+          );
+          settle({
+            exitCode: 1,
+            signal: null,
+            timedOut: false,
+            errorMessage: parsed.error ?? "OpenClaw agent run failed",
+            errorCode: "openclaw_agent_error",
+            provider: "openclaw",
+            model,
+            summary: parsed.summary,
+            resultJson: payload,
+          });
+          return;
+        }
+
+        // Success
+        void onLog(
+          "stdout",
+          `[openclaw] agent run completed${parsed.summary ? `: ${parsed.summary.slice(0, 200)}` : ""}\n`,
+        );
+        settle({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          provider: "openclaw",
+          model,
+          summary: parsed.summary ?? `OpenClaw agent ${agentId} completed`,
+          resultJson: payload,
+        });
+      };
+
+      const onWsError = (ev: Event) => {
+        const errMsg =
+          (ev as ErrorEvent).message ?? "WebSocket error during agent run";
+        void onLog("stderr", `[openclaw] websocket error: ${errMsg}\n`);
+        settle({
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage: `WebSocket error: ${errMsg}`,
+          errorCode: "openclaw_ws_error",
+          provider: "openclaw",
+          model,
+        });
+      };
+
+      const onWsClose = () => {
+        // If the connection drops before we get a final result, attempt
+        // to report a clean error rather than hanging.
+        void onLog(
+          "stderr",
+          "[openclaw] websocket closed before receiving final result\n",
+        );
+        settle({
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage:
+            "WebSocket connection closed before agent run completed",
+          errorCode: "openclaw_ws_closed",
+          provider: "openclaw",
+          model,
+        });
+      };
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        ws.removeEventListener("message", onMessage);
+        ws.removeEventListener("error", onWsError);
+        ws.removeEventListener("close", onWsClose);
+      };
+
+      ws.addEventListener("message", onMessage);
+      ws.addEventListener("error", onWsError);
+      ws.addEventListener("close", onWsClose);
+
+      // Send the RPC request
+      try {
+        ws.send(JSON.stringify(frame));
+      } catch (err) {
+        const sendErr = err instanceof Error ? err.message : String(err);
+        void onLog("stderr", `[openclaw] failed to send RPC request: ${sendErr}\n`);
+        settle({
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage: `Failed to send RPC request: ${sendErr}`,
+          errorCode: "openclaw_send_failed",
+          provider: "openclaw",
+          model,
+        });
+      }
+    });
+
+    return result;
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[openclaw] unexpected error: ${errMsg}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: errMsg,
+      errorCode: "openclaw_unexpected_error",
+      provider: "openclaw",
+      model,
     };
   } finally {
-    clearTimeout(timeout);
+    safeCloseWebSocket(ws);
   }
 }

--- a/packages/adapters/openclaw/src/server/execute.ts
+++ b/packages/adapters/openclaw/src/server/execute.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
@@ -13,92 +12,12 @@ import {
   parseOpenClawAgentResult,
   isOpenClawError,
 } from "./parse.js";
-
-// ---------------------------------------------------------------------------
-// JSON-RPC frame helpers
-// ---------------------------------------------------------------------------
-
-interface RpcRequest {
-  type: "req";
-  id: string;
-  method: string;
-  params: Record<string, unknown>;
-}
-
-interface RpcResponse {
-  type: "res";
-  id: string;
-  ok: boolean;
-  payload: Record<string, unknown>;
-}
-
-function buildRpcRequest(
-  method: string,
-  params: Record<string, unknown>,
-): { frame: RpcRequest; id: string } {
-  const id = crypto.randomUUID();
-  return {
-    id,
-    frame: { type: "req", id, method, params },
-  };
-}
-
-function isRpcResponse(data: unknown): data is RpcResponse {
-  if (typeof data !== "object" || data === null || Array.isArray(data)) return false;
-  const obj = data as Record<string, unknown>;
-  return obj.type === "res" && typeof obj.id === "string";
-}
-
-// ---------------------------------------------------------------------------
-// WebSocket helpers (Node 22 native WebSocket)
-// ---------------------------------------------------------------------------
-
-function openWebSocket(
-  url: string,
-  headers?: Record<string, string>,
-): Promise<WebSocket> {
-  return new Promise<WebSocket>((resolve, reject) => {
-    // Node 22 supports a second options arg with `headers` for the native WS.
-    // The typing is not always present so we cast through unknown.
-    const options: Record<string, unknown> = {};
-    if (headers && Object.keys(headers).length > 0) {
-      options.headers = headers;
-    }
-    const ws: WebSocket =
-      Object.keys(options).length > 0
-        ? new (WebSocket as unknown as new (url: string, protocols?: string | string[], opts?: unknown) => WebSocket)(url, undefined, options)
-        : new WebSocket(url);
-
-    const onOpen = () => {
-      cleanup();
-      resolve(ws);
-    };
-    const onError = (ev: Event) => {
-      cleanup();
-      const msg =
-        (ev as ErrorEvent).message ??
-        `WebSocket connection to ${url} failed`;
-      reject(new Error(msg));
-    };
-    const cleanup = () => {
-      ws.removeEventListener("open", onOpen);
-      ws.removeEventListener("error", onError);
-    };
-
-    ws.addEventListener("open", onOpen);
-    ws.addEventListener("error", onError);
-  });
-}
-
-function safeCloseWebSocket(ws: WebSocket) {
-  try {
-    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-      ws.close();
-    }
-  } catch {
-    // swallow — best-effort cleanup
-  }
-}
+import {
+  buildRpcRequest,
+  isRpcResponse,
+  openWebSocket,
+  safeCloseWebSocket,
+} from "./rpc.js";
 
 // ---------------------------------------------------------------------------
 // execute()

--- a/packages/adapters/openclaw/src/server/execute.ts
+++ b/packages/adapters/openclaw/src/server/execute.ts
@@ -112,7 +112,7 @@ export async function execute(
   // ---- extract config ----
   const gatewayUrl = asString(config.gatewayUrl, "ws://127.0.0.1:5555").trim();
   const agentId = asString(config.agentId, "").trim();
-  const authToken = asString(config.authToken, "").trim() || ctx.authToken || "";
+  const authToken = asString(config.authToken, "").trim();
   const timeoutSec = Math.max(1, asNumber(config.timeoutSec, 120));
   const model = asString(config.model, "unknown");
 

--- a/packages/adapters/openclaw/src/server/index.ts
+++ b/packages/adapters/openclaw/src/server/index.ts
@@ -1,3 +1,8 @@
 export { execute } from "./execute.js";
 export { testEnvironment } from "./test.js";
-export { parseOpenClawResponse, isOpenClawUnknownSessionError } from "./parse.js";
+export {
+  parseOpenClawAgentResult,
+  isOpenClawError,
+  extractSummary,
+  parseOpenClawResponse,
+} from "./parse.js";

--- a/packages/adapters/openclaw/src/server/index.ts
+++ b/packages/adapters/openclaw/src/server/index.ts
@@ -6,3 +6,4 @@ export {
   extractSummary,
   parseOpenClawResponse,
 } from "./parse.js";
+export type { RpcRequest, RpcResponse } from "./rpc.js";

--- a/packages/adapters/openclaw/src/server/parse.ts
+++ b/packages/adapters/openclaw/src/server/parse.ts
@@ -1,3 +1,84 @@
+// ---------------------------------------------------------------------------
+// OpenClaw RPC response parsing utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a raw JSON-RPC response payload from the OpenClaw `agent` method
+ * into a normalised shape.
+ */
+export function parseOpenClawAgentResult(payload: Record<string, unknown>): {
+  status: string;
+  summary: string | null;
+  result: Record<string, unknown> | null;
+  error: string | null;
+} {
+  const status =
+    typeof payload.status === "string" && payload.status.length > 0
+      ? payload.status
+      : "unknown";
+
+  const summary = extractSummary(payload);
+
+  const result =
+    typeof payload.result === "object" &&
+    payload.result !== null &&
+    !Array.isArray(payload.result)
+      ? (payload.result as Record<string, unknown>)
+      : null;
+
+  const error = isOpenClawError(payload)
+    ? (typeof payload.summary === "string" && payload.summary.length > 0
+        ? payload.summary
+        : typeof payload.error === "string" && payload.error.length > 0
+          ? payload.error
+          : `Agent run failed with status: ${status}`)
+    : null;
+
+  return { status, summary, result, error };
+}
+
+/**
+ * Returns `true` when the payload represents an error response from the
+ * OpenClaw gateway (status "error" or the top-level `ok` flag is false).
+ */
+export function isOpenClawError(payload: Record<string, unknown>): boolean {
+  if (payload.ok === false) return true;
+  const status =
+    typeof payload.status === "string" ? payload.status.toLowerCase() : "";
+  return status === "error";
+}
+
+/**
+ * Extract a human-readable summary string from an OpenClaw agent result
+ * payload.  Returns `null` when no summary text can be determined.
+ */
+export function extractSummary(payload: Record<string, unknown>): string | null {
+  // The gateway puts a short description in `summary`
+  if (typeof payload.summary === "string" && payload.summary.trim().length > 0) {
+    return payload.summary.trim();
+  }
+  // Fallback: look inside a nested `result` object for a text/summary field
+  if (
+    typeof payload.result === "object" &&
+    payload.result !== null &&
+    !Array.isArray(payload.result)
+  ) {
+    const inner = payload.result as Record<string, unknown>;
+    if (typeof inner.summary === "string" && inner.summary.trim().length > 0) {
+      return inner.summary.trim();
+    }
+    if (typeof inner.text === "string" && inner.text.trim().length > 0) {
+      return inner.text.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Attempt to parse arbitrary text as a JSON object.  Returns `null` for
+ * non-object / unparseable input.  Retained for backward compatibility with
+ * code that imports this helper.
+ */
 export function parseOpenClawResponse(text: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(text);
@@ -8,8 +89,4 @@ export function parseOpenClawResponse(text: string): Record<string, unknown> | n
   } catch {
     return null;
   }
-}
-
-export function isOpenClawUnknownSessionError(_text: string): boolean {
-  return false;
 }

--- a/packages/adapters/openclaw/src/server/parse.ts
+++ b/packages/adapters/openclaw/src/server/parse.ts
@@ -27,10 +27,10 @@ export function parseOpenClawAgentResult(payload: Record<string, unknown>): {
       : null;
 
   const error = isOpenClawError(payload)
-    ? (typeof payload.summary === "string" && payload.summary.length > 0
-        ? payload.summary
-        : typeof payload.error === "string" && payload.error.length > 0
-          ? payload.error
+    ? (typeof payload.error === "string" && payload.error.length > 0
+        ? payload.error
+        : typeof payload.summary === "string" && payload.summary.length > 0
+          ? payload.summary
           : `Agent run failed with status: ${status}`)
     : null;
 

--- a/packages/adapters/openclaw/src/server/rpc.ts
+++ b/packages/adapters/openclaw/src/server/rpc.ts
@@ -1,0 +1,171 @@
+import crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// JSON-RPC frame types
+// ---------------------------------------------------------------------------
+
+export interface RpcRequest {
+  type: "req";
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface RpcResponse {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Frame helpers
+// ---------------------------------------------------------------------------
+
+export function buildRpcRequest(
+  method: string,
+  params: Record<string, unknown>,
+): { frame: RpcRequest; id: string } {
+  const id = crypto.randomUUID();
+  return {
+    id,
+    frame: { type: "req", id, method, params },
+  };
+}
+
+export function isRpcResponse(data: unknown): data is RpcResponse {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return false;
+  const obj = data as Record<string, unknown>;
+  return obj.type === "res" && typeof obj.id === "string";
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket helpers (Node 22 native WebSocket)
+// ---------------------------------------------------------------------------
+
+function createWebSocket(
+  url: string,
+  headers?: Record<string, string>,
+): WebSocket {
+  const options: Record<string, unknown> = {};
+  if (headers && Object.keys(headers).length > 0) {
+    options.headers = headers;
+  }
+  return Object.keys(options).length > 0
+    ? new (WebSocket as unknown as new (url: string, protocols?: string | string[], opts?: unknown) => WebSocket)(url, undefined, options)
+    : new WebSocket(url);
+}
+
+export function openWebSocket(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<WebSocket> {
+  return new Promise<WebSocket>((resolve, reject) => {
+    const ws = createWebSocket(url, headers);
+
+    const onOpen = () => {
+      cleanup();
+      resolve(ws);
+    };
+    const onError = (ev: Event) => {
+      cleanup();
+      const msg =
+        (ev as ErrorEvent).message ??
+        `WebSocket connection to ${url} failed`;
+      reject(new Error(msg));
+    };
+    const cleanup = () => {
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("error", onError);
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
+  });
+}
+
+export function safeCloseWebSocket(ws: WebSocket) {
+  try {
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close();
+    }
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+/**
+ * Open a WebSocket, send a JSON-RPC request, and wait for a single response
+ * frame that matches the request id. Rejects on timeout or connection error.
+ */
+export function rpcCall(
+  url: string,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs: number,
+  headers?: Record<string, string>,
+): Promise<RpcResponse> {
+  return new Promise<RpcResponse>((resolve, reject) => {
+    const { frame, id } = buildRpcRequest(method, params);
+    const ws = createWebSocket(url, headers);
+
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      settle(() => reject(new Error(`RPC call to ${method} timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+
+    const onOpen = () => {
+      try {
+        ws.send(JSON.stringify(frame));
+      } catch (err) {
+        settle(() =>
+          reject(new Error(err instanceof Error ? err.message : String(err))),
+        );
+      }
+    };
+
+    const onMessage = (ev: MessageEvent) => {
+      let data: unknown;
+      try {
+        data = JSON.parse(typeof ev.data === "string" ? ev.data : String(ev.data));
+      } catch {
+        return;
+      }
+      if (!isRpcResponse(data) || data.id !== id) return;
+      settle(() => resolve(data as RpcResponse));
+    };
+
+    const onError = (ev: Event) => {
+      const msg =
+        (ev as ErrorEvent).message ?? `WebSocket connection to ${url} failed`;
+      settle(() => reject(new Error(msg)));
+    };
+
+    const onClose = () => {
+      settle(() =>
+        reject(new Error("WebSocket closed before receiving a response")),
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("message", onMessage);
+      ws.removeEventListener("error", onError);
+      ws.removeEventListener("close", onClose);
+      safeCloseWebSocket(ws);
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("error", onError);
+    ws.addEventListener("close", onClose);
+  });
+}

--- a/packages/adapters/openclaw/src/server/test.ts
+++ b/packages/adapters/openclaw/src/server/test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type {
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestContext,
@@ -5,105 +6,145 @@ import type {
 } from "@paperclipai/adapter-utils";
 import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
 
-function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
-  if (checks.some((check) => check.level === "error")) return "fail";
-  if (checks.some((check) => check.level === "warn")) return "warn";
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function summarizeStatus(
+  checks: AdapterEnvironmentCheck[],
+): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
   return "pass";
 }
 
-function isLoopbackHost(hostname: string): boolean {
-  const value = hostname.trim().toLowerCase();
-  return value === "localhost" || value === "127.0.0.1" || value === "::1";
+interface RpcResponse {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload: Record<string, unknown>;
 }
 
-function normalizeHostname(value: string | null | undefined): string | null {
-  if (!value) return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  if (trimmed.startsWith("[")) {
-    const end = trimmed.indexOf("]");
-    return end > 1 ? trimmed.slice(1, end).toLowerCase() : trimmed.toLowerCase();
-  }
-  const firstColon = trimmed.indexOf(":");
-  if (firstColon > -1) return trimmed.slice(0, firstColon).toLowerCase();
-  return trimmed.toLowerCase();
+function isRpcResponse(data: unknown): data is RpcResponse {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return false;
+  const obj = data as Record<string, unknown>;
+  return obj.type === "res" && typeof obj.id === "string";
 }
 
-function pushDeploymentDiagnostics(
-  checks: AdapterEnvironmentCheck[],
-  ctx: AdapterEnvironmentTestContext,
-  endpointUrl: URL | null,
-) {
-  const mode = ctx.deployment?.mode;
-  const exposure = ctx.deployment?.exposure;
-  const bindHost = normalizeHostname(ctx.deployment?.bindHost ?? null);
-  const allowSet = new Set(
-    (ctx.deployment?.allowedHostnames ?? [])
-      .map((entry) => normalizeHostname(entry))
-      .filter((entry): entry is string => Boolean(entry)),
-  );
-  const endpointHost = endpointUrl ? normalizeHostname(endpointUrl.hostname) : null;
+/**
+ * Open a WebSocket, send a JSON-RPC request, and wait for a single response
+ * frame that matches the request id.  Rejects on timeout or connection error.
+ */
+function rpcCall(
+  url: string,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs: number,
+  headers?: Record<string, string>,
+): Promise<RpcResponse> {
+  return new Promise<RpcResponse>((resolve, reject) => {
+    const id = crypto.randomUUID();
+    const frame = JSON.stringify({ type: "req", id, method, params });
 
-  if (!mode) return;
+    const options: Record<string, unknown> = {};
+    if (headers && Object.keys(headers).length > 0) {
+      options.headers = headers;
+    }
+    const ws: WebSocket =
+      Object.keys(options).length > 0
+        ? new (WebSocket as unknown as new (url: string, protocols?: string | string[], opts?: unknown) => WebSocket)(url, undefined, options)
+        : new WebSocket(url);
 
-  checks.push({
-    code: "openclaw_deployment_context",
-    level: "info",
-    message: `Deployment context: mode=${mode}${exposure ? ` exposure=${exposure}` : ""}`,
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      settle(() => reject(new Error(`RPC call to ${method} timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+
+    const onOpen = () => {
+      try {
+        ws.send(frame);
+      } catch (err) {
+        settle(() =>
+          reject(new Error(err instanceof Error ? err.message : String(err))),
+        );
+      }
+    };
+
+    const onMessage = (ev: MessageEvent) => {
+      let data: unknown;
+      try {
+        data = JSON.parse(typeof ev.data === "string" ? ev.data : String(ev.data));
+      } catch {
+        return;
+      }
+      if (!isRpcResponse(data) || data.id !== id) return;
+      settle(() => resolve(data as RpcResponse));
+    };
+
+    const onError = (ev: Event) => {
+      const msg =
+        (ev as ErrorEvent).message ?? `WebSocket connection to ${url} failed`;
+      settle(() => reject(new Error(msg)));
+    };
+
+    const onClose = () => {
+      settle(() =>
+        reject(new Error("WebSocket closed before receiving a response")),
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("message", onMessage);
+      ws.removeEventListener("error", onError);
+      ws.removeEventListener("close", onClose);
+      try {
+        if (
+          ws.readyState === WebSocket.OPEN ||
+          ws.readyState === WebSocket.CONNECTING
+        ) {
+          ws.close();
+        }
+      } catch {
+        // best-effort
+      }
+    };
+
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("message", onMessage);
+    ws.addEventListener("error", onError);
+    ws.addEventListener("close", onClose);
   });
-
-  if (mode === "authenticated" && exposure === "private") {
-    if (bindHost && !isLoopbackHost(bindHost) && !allowSet.has(bindHost)) {
-      checks.push({
-        code: "openclaw_private_bind_hostname_not_allowed",
-        level: "warn",
-        message: `Paperclip bind host "${bindHost}" is not in allowed hostnames.`,
-        hint: `Run pnpm paperclipai allowed-hostname ${bindHost} so remote OpenClaw callbacks can pass host checks.`,
-      });
-    }
-
-    if (!bindHost || isLoopbackHost(bindHost)) {
-      checks.push({
-        code: "openclaw_private_bind_loopback",
-        level: "warn",
-        message: "Paperclip is bound to loopback in authenticated/private mode.",
-        hint: "Bind to a reachable private hostname/IP so remote OpenClaw agents can call back.",
-      });
-    }
-
-    if (endpointHost && !isLoopbackHost(endpointHost) && allowSet.size === 0) {
-      checks.push({
-        code: "openclaw_private_no_allowed_hostnames",
-        level: "warn",
-        message: "No explicit allowed hostnames are configured for authenticated/private mode.",
-        hint: "Set one with pnpm paperclipai allowed-hostname <host> when OpenClaw runs on another machine.",
-      });
-    }
-  }
-
-  if (mode === "authenticated" && exposure === "public" && endpointUrl && endpointUrl.protocol !== "https:") {
-    checks.push({
-      code: "openclaw_public_http_endpoint",
-      level: "warn",
-      message: "OpenClaw endpoint uses HTTP in authenticated/public mode.",
-      hint: "Prefer HTTPS for public deployments.",
-    });
-  }
 }
+
+// ---------------------------------------------------------------------------
+// testEnvironment()
+// ---------------------------------------------------------------------------
 
 export async function testEnvironment(
   ctx: AdapterEnvironmentTestContext,
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const urlValue = asString(config.url, "");
+  const gatewayUrl = asString(config.gatewayUrl, "").trim();
+  const agentId = asString(config.agentId, "").trim();
+  const authToken = asString(config.authToken, "").trim();
 
-  if (!urlValue) {
+  // ---- Validate gatewayUrl ----
+  if (!gatewayUrl) {
     checks.push({
-      code: "openclaw_url_missing",
+      code: "openclaw_gateway_url_missing",
       level: "error",
-      message: "OpenClaw adapter requires a webhook URL.",
-      hint: "Set adapterConfig.url to your OpenClaw webhook endpoint.",
+      message: "OpenClaw adapter requires a gatewayUrl.",
+      hint: "Set adapterConfig.gatewayUrl to your OpenClaw gateway WebSocket endpoint (e.g. ws://127.0.0.1:5555).",
     });
     return {
       adapterType: ctx.adapterType,
@@ -113,80 +154,141 @@ export async function testEnvironment(
     };
   }
 
-  let url: URL | null = null;
+  let parsedUrl: URL | null = null;
   try {
-    url = new URL(urlValue);
+    parsedUrl = new URL(gatewayUrl);
   } catch {
     checks.push({
-      code: "openclaw_url_invalid",
+      code: "openclaw_gateway_url_invalid",
       level: "error",
-      message: `Invalid URL: ${urlValue}`,
+      message: `Invalid gateway URL: ${gatewayUrl}`,
     });
   }
 
-  if (url && url.protocol !== "http:" && url.protocol !== "https:") {
+  if (parsedUrl && parsedUrl.protocol !== "ws:" && parsedUrl.protocol !== "wss:") {
     checks.push({
-      code: "openclaw_url_protocol_invalid",
+      code: "openclaw_gateway_url_protocol_invalid",
       level: "error",
-      message: `Unsupported URL protocol: ${url.protocol}`,
-      hint: "Use an http:// or https:// endpoint.",
+      message: `Unsupported URL protocol: ${parsedUrl.protocol}`,
+      hint: "Use a ws:// or wss:// endpoint.",
     });
   }
 
-  if (url) {
+  if (parsedUrl) {
     checks.push({
-      code: "openclaw_url_valid",
+      code: "openclaw_gateway_url_valid",
       level: "info",
-      message: `Configured endpoint: ${url.toString()}`,
+      message: `Configured gateway: ${parsedUrl.toString()}`,
     });
-
-    if (isLoopbackHost(url.hostname)) {
-      checks.push({
-        code: "openclaw_loopback_endpoint",
-        level: "warn",
-        message: "Endpoint uses loopback hostname. Remote OpenClaw workers cannot reach localhost on the Paperclip host.",
-        hint: "Use a reachable hostname/IP (for example Tailscale/private hostname or public domain).",
-      });
-    }
   }
 
-  pushDeploymentDiagnostics(checks, ctx, url);
+  // ---- Validate agentId ----
+  if (!agentId) {
+    checks.push({
+      code: "openclaw_agent_id_missing",
+      level: "error",
+      message: "OpenClaw adapter requires an agentId.",
+      hint: "Set adapterConfig.agentId to the OpenClaw agent identifier.",
+    });
+  } else {
+    checks.push({
+      code: "openclaw_agent_id_configured",
+      level: "info",
+      message: `Configured agentId: ${agentId}`,
+    });
+  }
 
-  const method = asString(config.method, "POST").trim().toUpperCase() || "POST";
-  checks.push({
-    code: "openclaw_method_configured",
-    level: "info",
-    message: `Configured method: ${method}`,
-  });
+  // ---- Probe: connect to gateway and call agents.list ----
+  const canProbe =
+    parsedUrl !== null &&
+    (parsedUrl.protocol === "ws:" || parsedUrl.protocol === "wss:") &&
+    checks.every(
+      (c) =>
+        c.code !== "openclaw_gateway_url_invalid" &&
+        c.code !== "openclaw_gateway_url_protocol_invalid",
+    );
 
-  if (url && (url.protocol === "http:" || url.protocol === "https:")) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
+  if (canProbe) {
+    const headers: Record<string, string> = {};
+    if (authToken) {
+      headers.authorization = `Bearer ${authToken}`;
+    }
+
     try {
-      const response = await fetch(url, { method: "HEAD", signal: controller.signal });
-      if (!response.ok && response.status !== 405 && response.status !== 501) {
+      const res = await rpcCall(gatewayUrl, "agents.list", {}, 8000, headers);
+
+      if (!res.ok) {
         checks.push({
-          code: "openclaw_endpoint_probe_unexpected_status",
+          code: "openclaw_agents_list_error",
           level: "warn",
-          message: `Endpoint probe returned HTTP ${response.status}.`,
-          hint: "Verify OpenClaw webhook reachability and auth/network settings.",
+          message: "agents.list RPC returned an error.",
+          detail: JSON.stringify(res.payload).slice(0, 240),
         });
       } else {
         checks.push({
-          code: "openclaw_endpoint_probe_ok",
+          code: "openclaw_gateway_reachable",
           level: "info",
-          message: "Endpoint responded to a HEAD probe.",
+          message: "Successfully connected to gateway and called agents.list.",
         });
+
+        // Verify agentId exists in the returned agents
+        const agents = Array.isArray(res.payload.agents)
+          ? res.payload.agents
+          : [];
+        const defaultId =
+          typeof res.payload.defaultId === "string"
+            ? res.payload.defaultId
+            : null;
+
+        if (agentId) {
+          const found = agents.some(
+            (a: unknown) =>
+              typeof a === "object" &&
+              a !== null &&
+              (a as Record<string, unknown>).id === agentId,
+          );
+
+          if (found) {
+            checks.push({
+              code: "openclaw_agent_found",
+              level: "info",
+              message: `Agent "${agentId}" exists on the gateway.`,
+            });
+          } else if (agentId === defaultId) {
+            checks.push({
+              code: "openclaw_agent_is_default",
+              level: "info",
+              message: `Agent "${agentId}" matches the gateway default agent.`,
+            });
+          } else {
+            const agentIds = agents
+              .map((a: unknown) =>
+                typeof a === "object" && a !== null
+                  ? (a as Record<string, unknown>).id
+                  : null,
+              )
+              .filter((id: unknown): id is string => typeof id === "string");
+            checks.push({
+              code: "openclaw_agent_not_found",
+              level: "warn",
+              message: `Agent "${agentId}" was not found in the gateway's agent list.`,
+              detail:
+                agentIds.length > 0
+                  ? `Available agents: ${agentIds.join(", ")}`
+                  : "No agents returned by gateway.",
+              hint: "Verify the agentId in your adapter config matches an agent registered in the OpenClaw gateway.",
+            });
+          }
+        }
       }
     } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
       checks.push({
-        code: "openclaw_endpoint_probe_failed",
+        code: "openclaw_gateway_probe_failed",
         level: "warn",
-        message: err instanceof Error ? err.message : "Endpoint probe failed",
-        hint: "This may be expected in restricted networks; validate from the Paperclip server host.",
+        message: `Gateway probe failed: ${errMsg}`,
+        hint: "Verify the gateway is running and reachable at the configured URL.",
       });
-    } finally {
-      clearTimeout(timeout);
     }
   }
 

--- a/packages/adapters/openclaw/src/server/test.ts
+++ b/packages/adapters/openclaw/src/server/test.ts
@@ -1,10 +1,10 @@
-import crypto from "node:crypto";
 import type {
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestContext,
   AdapterEnvironmentTestResult,
 } from "@paperclipai/adapter-utils";
 import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { rpcCall } from "./rpc.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,113 +16,6 @@ function summarizeStatus(
   if (checks.some((c) => c.level === "error")) return "fail";
   if (checks.some((c) => c.level === "warn")) return "warn";
   return "pass";
-}
-
-interface RpcResponse {
-  type: "res";
-  id: string;
-  ok: boolean;
-  payload: Record<string, unknown>;
-}
-
-function isRpcResponse(data: unknown): data is RpcResponse {
-  if (typeof data !== "object" || data === null || Array.isArray(data)) return false;
-  const obj = data as Record<string, unknown>;
-  return obj.type === "res" && typeof obj.id === "string";
-}
-
-/**
- * Open a WebSocket, send a JSON-RPC request, and wait for a single response
- * frame that matches the request id.  Rejects on timeout or connection error.
- */
-function rpcCall(
-  url: string,
-  method: string,
-  params: Record<string, unknown>,
-  timeoutMs: number,
-  headers?: Record<string, string>,
-): Promise<RpcResponse> {
-  return new Promise<RpcResponse>((resolve, reject) => {
-    const id = crypto.randomUUID();
-    const frame = JSON.stringify({ type: "req", id, method, params });
-
-    const options: Record<string, unknown> = {};
-    if (headers && Object.keys(headers).length > 0) {
-      options.headers = headers;
-    }
-    const ws: WebSocket =
-      Object.keys(options).length > 0
-        ? new (WebSocket as unknown as new (url: string, protocols?: string | string[], opts?: unknown) => WebSocket)(url, undefined, options)
-        : new WebSocket(url);
-
-    let settled = false;
-    const settle = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      fn();
-    };
-
-    const timer = setTimeout(() => {
-      settle(() => reject(new Error(`RPC call to ${method} timed out after ${timeoutMs}ms`)));
-    }, timeoutMs);
-
-    const onOpen = () => {
-      try {
-        ws.send(frame);
-      } catch (err) {
-        settle(() =>
-          reject(new Error(err instanceof Error ? err.message : String(err))),
-        );
-      }
-    };
-
-    const onMessage = (ev: MessageEvent) => {
-      let data: unknown;
-      try {
-        data = JSON.parse(typeof ev.data === "string" ? ev.data : String(ev.data));
-      } catch {
-        return;
-      }
-      if (!isRpcResponse(data) || data.id !== id) return;
-      settle(() => resolve(data as RpcResponse));
-    };
-
-    const onError = (ev: Event) => {
-      const msg =
-        (ev as ErrorEvent).message ?? `WebSocket connection to ${url} failed`;
-      settle(() => reject(new Error(msg)));
-    };
-
-    const onClose = () => {
-      settle(() =>
-        reject(new Error("WebSocket closed before receiving a response")),
-      );
-    };
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      ws.removeEventListener("open", onOpen);
-      ws.removeEventListener("message", onMessage);
-      ws.removeEventListener("error", onError);
-      ws.removeEventListener("close", onClose);
-      try {
-        if (
-          ws.readyState === WebSocket.OPEN ||
-          ws.readyState === WebSocket.CONNECTING
-        ) {
-          ws.close();
-        }
-      } catch {
-        // best-effort
-      }
-    };
-
-    ws.addEventListener("open", onOpen);
-    ws.addEventListener("message", onMessage);
-    ws.addEventListener("error", onError);
-    ws.addEventListener("close", onClose);
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/adapters/openclaw/src/ui/build-config.ts
+++ b/packages/adapters/openclaw/src/ui/build-config.ts
@@ -2,8 +2,22 @@ import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 
 export function buildOpenClawConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
-  if (v.url) ac.url = v.url;
-  ac.method = "POST";
-  ac.timeoutSec = 30;
+
+  // Gateway URL — default to localhost
+  ac.gatewayUrl = (v as any).gatewayUrl || "ws://127.0.0.1:5555";
+
+  // Agent ID — required
+  if ((v as any).agentId) {
+    ac.agentId = (v as any).agentId;
+  }
+
+  // Auth token — optional
+  if ((v as any).authToken) {
+    ac.authToken = (v as any).authToken;
+  }
+
+  // Timeout
+  ac.timeoutSec = 120;
+
   return ac;
 }

--- a/ui/src/adapters/openclaw/config-fields.tsx
+++ b/ui/src/adapters/openclaw/config-fields.tsx
@@ -2,7 +2,6 @@ import type { AdapterConfigFieldsProps } from "../types";
 import {
   Field,
   DraftInput,
-  help,
 } from "../../components/agent-config-primitives";
 
 const inputClass =
@@ -18,36 +17,57 @@ export function OpenClawConfigFields({
 }: AdapterConfigFieldsProps) {
   return (
     <>
-      <Field label="Webhook URL" hint={help.webhookUrl}>
+      <Field label="Gateway URL" hint="WebSocket URL of the OpenClaw gateway.">
         <DraftInput
           value={
             isCreate
-              ? values!.url
-              : eff("adapterConfig", "url", String(config.url ?? ""))
+              ? (values as any).gatewayUrl ?? "ws://127.0.0.1:5555"
+              : eff("adapterConfig", "gatewayUrl", String(config.gatewayUrl ?? "ws://127.0.0.1:5555"))
           }
           onCommit={(v) =>
             isCreate
-              ? set!({ url: v })
-              : mark("adapterConfig", "url", v || undefined)
+              ? set!({ gatewayUrl: v } as any)
+              : mark("adapterConfig", "gatewayUrl", v || undefined)
           }
           immediate
           className={inputClass}
-          placeholder="https://..."
+          placeholder="ws://127.0.0.1:5555"
         />
       </Field>
-      {!isCreate && (
-        <Field label="Webhook auth header (optional)">
-          <DraftInput
-            value={
-              eff("adapterConfig", "webhookAuthHeader", String(config.webhookAuthHeader ?? ""))
-            }
-            onCommit={(v) => mark("adapterConfig", "webhookAuthHeader", v || undefined)}
-            immediate
-            className={inputClass}
-            placeholder="Bearer <token>"
-          />
-        </Field>
-      )}
+      <Field label="Agent ID" hint="Identifier for the agent on the OpenClaw gateway.">
+        <DraftInput
+          value={
+            isCreate
+              ? (values as any).agentId ?? ""
+              : eff("adapterConfig", "agentId", String(config.agentId ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ agentId: v } as any)
+              : mark("adapterConfig", "agentId", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="main"
+        />
+      </Field>
+      <Field label="Auth Token (optional)" hint="Bearer token for authenticating with the gateway.">
+        <DraftInput
+          value={
+            isCreate
+              ? (values as any).authToken ?? ""
+              : eff("adapterConfig", "authToken", String(config.authToken ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ authToken: v } as any)
+              : mark("adapterConfig", "authToken", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="Bearer token or leave empty"
+        />
+      </Field>
     </>
   );
 }

--- a/ui/src/adapters/openclaw/config-fields.tsx
+++ b/ui/src/adapters/openclaw/config-fields.tsx
@@ -53,6 +53,7 @@ export function OpenClawConfigFields({
       </Field>
       <Field label="Auth Token (optional)" hint="Bearer token for authenticating with the gateway.">
         <DraftInput
+          type="password"
           value={
             isCreate
               ? (values as any).authToken ?? ""

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -89,6 +89,9 @@ export function OnboardingWizard() {
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [url, setUrl] = useState("");
+  const [gatewayUrl, setGatewayUrl] = useState("ws://127.0.0.1:5555");
+  const [agentId, setAgentId] = useState("");
+  const [authToken, setAuthToken] = useState("");
   const [adapterEnvResult, setAdapterEnvResult] =
     useState<AdapterEnvironmentTestResult | null>(null);
   const [adapterEnvError, setAdapterEnvError] = useState<string | null>(null);
@@ -196,6 +199,9 @@ export function OnboardingWizard() {
     setCommand("");
     setArgs("");
     setUrl("");
+    setGatewayUrl("ws://127.0.0.1:5555");
+    setAgentId("");
+    setAuthToken("");
     setAdapterEnvResult(null);
     setAdapterEnvError(null);
     setAdapterEnvLoading(false);
@@ -231,6 +237,9 @@ export function OnboardingWizard() {
       command,
       args,
       url,
+      gatewayUrl,
+      agentId,
+      authToken,
       dangerouslySkipPermissions: adapterType === "claude_local",
       dangerouslyBypassSandbox:
         adapterType === "codex_local"
@@ -597,8 +606,7 @@ export function OnboardingWizard() {
                           value: "openclaw" as const,
                           label: "OpenClaw",
                           icon: Bot,
-                          desc: "Notify OpenClaw webhook",
-                          comingSoon: true
+                          desc: "OpenClaw gateway agent"
                         },
                         {
                           value: "cursor" as const,
@@ -863,7 +871,7 @@ export function OnboardingWizard() {
                     </div>
                   )}
 
-                  {(adapterType === "http" || adapterType === "openclaw") && (
+                  {adapterType === "http" && (
                     <div>
                       <label className="text-xs text-muted-foreground mb-1 block">
                         Webhook URL
@@ -874,6 +882,45 @@ export function OnboardingWizard() {
                         value={url}
                         onChange={(e) => setUrl(e.target.value)}
                       />
+                    </div>
+                  )}
+
+                  {adapterType === "openclaw" && (
+                    <div className="space-y-3">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Gateway URL
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="ws://127.0.0.1:5555"
+                          value={gatewayUrl}
+                          onChange={(e) => setGatewayUrl(e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Agent ID
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="main"
+                          value={agentId}
+                          onChange={(e) => setAgentId(e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Auth Token (optional)
+                        </label>
+                        <input
+                          type="password"
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="Bearer token or leave empty"
+                          value={authToken}
+                          onChange={(e) => setAuthToken(e.target.value)}
+                        />
+                      </div>
                     </div>
                   )}
                 </div>

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -25,7 +25,7 @@ const adapterLabels: Record<string, string> = {
   http: "HTTP",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "openclaw"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();


### PR DESCRIPTION
## Summary

- Rewrites the OpenClaw adapter from a generic HTTP webhook stub to a native integration using the OpenClaw gateway's WebSocket JSON-RPC protocol
- Connects to the gateway, dispatches tasks via the `agent` RPC method, and handles the two-phase response pattern (accepted → final result)
- Adds gateway reachability probe (`agents.list` RPC) for environment testing
- Replaces webhook config fields with gateway URL, agent ID, and auth token
- Removes "Coming soon" flag — OpenClaw is now selectable in the onboarding wizard and invite flow

## Changed files

**Adapter package** (`packages/adapters/openclaw/src/`):
- `server/execute.ts` — Full rewrite: WebSocket RPC connection, `agent` method dispatch, timeout/error handling, `onLog` streaming
- `server/parse.ts` — Full rewrite: `parseOpenClawAgentResult`, `isOpenClawError`, `extractSummary`
- `server/test.ts` — Full rewrite: gateway probe via `agents.list`, agent ID validation
- `server/index.ts` — Updated barrel exports
- `index.ts` — Static models list, updated config documentation
- `ui/build-config.ts` — `gatewayUrl`, `agentId`, `authToken` config fields

**UI** (`ui/src/`):
- `components/OnboardingWizard.tsx` — Removed `comingSoon: true`, added gateway config input fields
- `pages/InviteLanding.tsx` — Added `"openclaw"` to `ENABLED_INVITE_ADAPTERS`
- `adapters/openclaw/config-fields.tsx` — Replaced webhook fields with gateway config fields

## Test plan

- [ ] Select "OpenClaw" in the onboarding wizard (no longer grayed out)
- [ ] Configure gateway URL (`ws://127.0.0.1:5555`) + agent ID (`main`)
- [ ] Environment test passes (gateway reachable, agent found)
- [ ] Send a task to an OpenClaw agent, receive results
- [ ] Agent appears in org chart as online/idle after successful run
- [ ] Verify no TypeScript regressions (baseline `@types/node` issue is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)