### PR TITLE
feat: add copilot_local adapter for GitHub Copilot CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
+COPY packages/adapters/copilot-local/package.json packages/adapters/copilot-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,6 +39,7 @@
     "@clack/prompts": "^0.10.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { printCopilotStreamEvent } from "@paperclipai/adapter-copilot-local/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -44,6 +45,11 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const copilotLocalCLIAdapter: CLIAdapterModule = {
+  type: "copilot_local",
+  formatStdoutEvent: printCopilotStreamEvent,
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
@@ -52,6 +58,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,
+    copilotLocalCLIAdapter,
     openclawGatewayCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,

--- a/packages/adapters/copilot-local/package.json
+++ b/packages/adapters/copilot-local/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@paperclipai/adapter-copilot-local",
+  "version": "0.2.7",
+  "description": "GitHub Copilot CLI adapter for Paperclip",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/copilot-local/src/cli/format-event.ts
+++ b/packages/adapters/copilot-local/src/cli/format-event.ts
@@ -1,0 +1,25 @@
+import pc from "picocolors";
+
+export function printCopilotStreamEvent(raw: string, debug: boolean): void {
+  const trimmed = raw.trim();
+  if (!trimmed) return;
+  if (
+    trimmed.startsWith("─") || trimmed.startsWith("╭") ||
+    trimmed.startsWith("╰") || trimmed.startsWith("│") ||
+    /^GitHub Copilot\s/i.test(trimmed) || /^I'm powered by AI/i.test(trimmed)
+  ) return;
+
+  if (/warning|trust|note:/i.test(trimmed)) {
+    console.log(pc.yellow(`[copilot] ${trimmed}`));
+    return;
+  }
+  if (trimmed.startsWith(">") || trimmed.startsWith("#")) {
+    console.log(pc.gray(trimmed));
+    return;
+  }
+  console.log(pc.cyan(trimmed));
+
+  if (debug) {
+    // nothing extra for copilot — output is plain text, not structured JSON
+  }
+}

--- a/packages/adapters/copilot-local/src/cli/index.ts
+++ b/packages/adapters/copilot-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printCopilotStreamEvent } from "./format-event.js";

--- a/packages/adapters/copilot-local/src/index.ts
+++ b/packages/adapters/copilot-local/src/index.ts
@@ -1,0 +1,60 @@
+export const type = "copilot_local";
+export const label = "GitHub Copilot CLI";
+
+export const models: { id: string; label: string }[] = [];
+
+export const AUTH_ENV_VARS = [
+  "COPILOT_GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+] as const;
+
+export const agentConfigurationDoc = `# copilot_local agent configuration
+
+Adapter: copilot_local
+
+## Prerequisites
+
+### Install Copilot CLI
+\`\`\`bash
+npm install -g @github/copilot
+# or: brew install copilot-cli
+# or: curl -fsSL https://gh.io/copilot-install | bash
+\`\`\`
+
+### Authenticate
+Set one of the following environment variables (checked in order of precedence):
+- COPILOT_GITHUB_TOKEN (highest priority, fine-grained PAT with "Copilot Requests" permission)
+- GH_TOKEN
+- GITHUB_TOKEN
+
+Classic PATs (ghp_ prefix) are NOT supported. Use a fine-grained PAT (github_pat_ prefix).
+
+If none are set and GitHub CLI is installed and authenticated, Copilot CLI will use its
+token as a lowest-priority fallback.
+
+### Pre-trust your workspace (first run only)
+Copilot CLI prompts for directory trust the first time it runs in a new working
+directory. Run \`copilot\` interactively in your cwd once and choose "Yes, and remember
+this folder", or edit ~/.copilot/config.json to add the path to \`trusted_folders\`.
+
+## Core fields
+- cwd (string, optional): absolute working directory for the agent process
+- promptTemplate (string, optional): run prompt template
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+## Operational fields
+- timeoutSec (number, optional): run timeout in seconds (default: 120)
+- graceSec (number, optional): SIGTERM grace period in seconds (default: 10)
+
+## Permission flags
+The adapter passes --yolo (equivalent to --allow-all) by default, which combines
+--allow-all-tools, --allow-all-paths, and --allow-all-urls. For fine-grained control,
+use extraArgs with --allow-tool, --deny-tool, --allow-url, --deny-url, etc.
+
+## Known limitations
+- No cost tracking. The Copilot CLI does not expose token usage in programmatic output.
+- Output is plain text. Structured JSON output (--format json) is not yet generally available.
+- Enterprise content exclusions are silently enforced per org policy.
+`;

--- a/packages/adapters/copilot-local/src/server/execute.ts
+++ b/packages/adapters/copilot-local/src/server/execute.ts
@@ -1,0 +1,176 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { AUTH_ENV_VARS } from "../index.js";
+import { parseCopilotOutput, isCopilotSessionNotFoundError } from "./parse.js";
+
+function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+  const raw = env[key];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+function resolveAuthToken(env: Record<string, string>): { token: string; source: string } | null {
+  for (const key of AUTH_ENV_VARS) {
+    if (hasNonEmptyEnvValue(env, key)) return { token: env[key], source: key };
+  }
+  return null;
+}
+
+function buildArgs(prompt: string, sessionId: string | null, extraArgs: string[]): string[] {
+  const args: string[] = ["-p", prompt];
+  if (sessionId) args.push("--resume", sessionId);
+  args.push("--yolo");
+  if (extraArgs.length > 0) args.push(...extraArgs);
+  return args;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const configuredCwd = asString(config.cwd, "");
+  const cwd = configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  const auth = resolveAuthToken(env as Record<string, string>);
+  if (!auth) {
+    const hostAuth = resolveAuthToken(process.env as Record<string, string>);
+    if (hostAuth) {
+      env.COPILOT_GITHUB_TOKEN = hostAuth.token;
+    } else {
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage:
+          "No GitHub auth token found. Set COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN in adapter environment, or run `gh auth login`.",
+        errorCode: "copilot_auth_required",
+      };
+    }
+  }
+
+  const command = "copilot";
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+  } catch {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage:
+        "GitHub Copilot CLI not found in PATH. Install: npm install -g @github/copilot, brew install copilot-cli, or curl -fsSL https://gh.io/copilot-install | bash",
+      errorCode: "copilot_not_found",
+    };
+  }
+
+  const timeoutSec = asNumber(config.timeoutSec, 120);
+  const graceSec = asNumber(config.graceSec, 10);
+  const extraArgs = asStringArray(config.extraArgs);
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const sessionId = runtimeSessionId || null;
+
+  const prompt = renderTemplate(promptTemplate, {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  });
+
+  const fullArgs = buildArgs(prompt, sessionId, extraArgs);
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "copilot_local",
+      command,
+      cwd,
+      commandArgs: fullArgs,
+      env: redactEnvForLogs(env),
+      prompt,
+      context,
+    });
+  }
+
+  let proc = await runChildProcess(runId, command, fullArgs, {
+    cwd,
+    env,
+    timeoutSec,
+    graceSec,
+    onLog,
+  });
+
+  const isRetry = !proc.timedOut && (proc.exitCode ?? 0) !== 0 && sessionId !== null && isCopilotSessionNotFoundError(proc.stderr);
+  if (isRetry) {
+    await onLog("stderr", `[paperclip] Copilot session "${sessionId}" not found — retrying with fresh session.\n`);
+    const retryArgs = buildArgs(prompt, null, extraArgs);
+    proc = await runChildProcess(`${runId}-retry`, command, retryArgs, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onLog,
+    });
+  }
+
+  const parsed = parseCopilotOutput(proc.stdout, proc.stderr);
+  const resolvedSessionId = isRetry
+    ? (parsed.sessionId ?? null)
+    : (parsed.sessionId ?? sessionId);
+
+  if (proc.timedOut) {
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: true,
+      errorMessage: `Timed out after ${timeoutSec}s`,
+      errorCode: "timeout",
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionId ? { sessionId: resolvedSessionId, cwd } : null,
+      sessionDisplayId: resolvedSessionId,
+    };
+  }
+
+  return {
+    exitCode: proc.exitCode,
+    signal: proc.signal,
+    timedOut: false,
+    errorMessage:
+      (proc.exitCode ?? 0) === 0
+        ? null
+        : `Copilot exited with code ${proc.exitCode ?? -1}`,
+    sessionId: resolvedSessionId,
+    sessionParams: resolvedSessionId ? { sessionId: resolvedSessionId, cwd } : null,
+    sessionDisplayId: resolvedSessionId,
+    provider: "github",
+    billingType: "subscription",
+    summary: parsed.summary,
+    clearSession: isRetry && !resolvedSessionId,
+  };
+}

--- a/packages/adapters/copilot-local/src/server/execute.ts
+++ b/packages/adapters/copilot-local/src/server/execute.ts
@@ -90,6 +90,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const graceSec = asNumber(config.graceSec, 10);
   const extraArgs = asStringArray(config.extraArgs);
 
+  // Copilot CLI --resume is cwd-agnostic (session state is server-side, not directory-bound),
+  // so we intentionally skip cwd validation on resume unlike some other adapters.
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const sessionId = runtimeSessionId || null;

--- a/packages/adapters/copilot-local/src/server/index.ts
+++ b/packages/adapters/copilot-local/src/server/index.ts
@@ -1,0 +1,37 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { parseCopilotOutput, isCopilotSessionNotFoundError } from "./parse.js";
+
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(record.cwd);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};

--- a/packages/adapters/copilot-local/src/server/parse.ts
+++ b/packages/adapters/copilot-local/src/server/parse.ts
@@ -1,0 +1,29 @@
+export interface CopilotParseResult {
+  sessionId: string | null;
+  summary: string;
+  stdout: string;
+  stderr: string;
+}
+
+const SESSION_ID_RE = /(?:session[:\s]+)([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i;
+
+export function parseCopilotOutput(stdout: string, stderr: string): CopilotParseResult {
+  const sessionMatch = stderr.match(SESSION_ID_RE) ?? stdout.match(SESSION_ID_RE);
+  const sessionId = sessionMatch ? sessionMatch[1] : null;
+  const summary = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0 && !l.startsWith("─") && !l.startsWith("╭") && !l.startsWith("╰"))
+    ?? "";
+  return { sessionId, summary, stdout, stderr };
+}
+
+export function isCopilotSessionNotFoundError(stderr: string): boolean {
+  const lower = stderr.toLowerCase();
+  return (
+    lower.includes("session not found") ||
+    lower.includes("session expired") ||
+    lower.includes("could not resume") ||
+    lower.includes("no session with id")
+  );
+}

--- a/packages/adapters/copilot-local/src/server/test.ts
+++ b/packages/adapters/copilot-local/src/server/test.ts
@@ -87,6 +87,12 @@ export async function testEnvironment(
     });
   }
 
+  // Forward host auth token into env if not already present (mirrors execute.ts logic)
+  if (authSource && !hasNonEmptyEnvValue(env, authSource)) {
+    const hostValue = mergedEnv[authSource];
+    if (typeof hostValue === "string") env.COPILOT_GITHUB_TOKEN = hostValue;
+  }
+
   // Run probe if binary and auth are available
   const canProbe = commandFound && authSource !== null;
   if (canProbe) {
@@ -153,7 +159,7 @@ export async function testEnvironment(
 
   checks.push({
     code: "copilot_no_cost_tracking",
-    level: "warn",
+    level: "info",
     message: "Cost tracking is not available for copilot_local. The Copilot CLI does not report token usage.",
   });
 

--- a/packages/adapters/copilot-local/src/server/test.ts
+++ b/packages/adapters/copilot-local/src/server/test.ts
@@ -1,0 +1,166 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { AUTH_ENV_VARS } from "../index.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+function hasNonEmptyEnvValue(env: Record<string, string | undefined>, key: string): boolean {
+  const raw = env[key];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({ code: "copilot_cwd_valid", level: "info", message: `Working directory is valid: ${cwd}` });
+  } catch (err) {
+    checks.push({
+      code: "copilot_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  const command = "copilot";
+  let commandFound = false;
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    commandFound = true;
+    checks.push({ code: "copilot_command_resolvable", level: "info", message: "Command is executable: copilot" });
+  } catch {
+    checks.push({
+      code: "copilot_command_unresolvable",
+      level: "error",
+      message: "GitHub Copilot CLI not found in PATH. Install: npm install -g @github/copilot, brew install copilot-cli, or curl -fsSL https://gh.io/copilot-install | bash",
+    });
+  }
+
+  // Check auth token
+  const mergedEnv: Record<string, string | undefined> = { ...process.env, ...env };
+  let authSource: string | null = null;
+  for (const key of AUTH_ENV_VARS) {
+    if (hasNonEmptyEnvValue(mergedEnv, key)) {
+      authSource = key;
+      break;
+    }
+  }
+  if (authSource) {
+    checks.push({
+      code: "copilot_auth_found",
+      level: "info",
+      message: `GitHub auth token found via ${authSource}.`,
+    });
+  } else {
+    checks.push({
+      code: "copilot_auth_missing",
+      level: "error",
+      message: "No GitHub auth token found. Set COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN, or run `gh auth login`.",
+    });
+  }
+
+  // Run probe if binary and auth are available
+  const canProbe = commandFound && authSource !== null;
+  if (canProbe) {
+    const probeArgs = ["-p", "Respond with the single word: ready", "--yolo"];
+    try {
+      const probe = await runChildProcess(
+        `copilot-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        probeArgs,
+        {
+          cwd,
+          env,
+          timeoutSec: 45,
+          graceSec: 5,
+          onLog: async () => {},
+        },
+      );
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "copilot_probe_timed_out",
+          level: "warn",
+          message: "Copilot probe timed out.",
+          hint: "Retry the probe. If this persists, verify Copilot can run from this directory manually.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        checks.push({
+          code: "copilot_probe_passed",
+          level: "info",
+          message: "Copilot CLI probe succeeded.",
+        });
+      } else {
+        const stderr = probe.stderr.toLowerCase();
+        if (stderr.includes("401") || stderr.includes("unauthorized")) {
+          checks.push({
+            code: "copilot_probe_auth_failed",
+            level: "error",
+            message: `Authentication failed (${authSource}). Verify your GitHub token has Copilot access.`,
+          });
+        } else if (stderr.includes("subscription")) {
+          checks.push({
+            code: "copilot_probe_no_subscription",
+            level: "error",
+            message: "No active Copilot subscription found. Verify at github.com/settings/copilot.",
+          });
+        } else {
+          const detail = probe.stderr.trim().slice(0, 300) || null;
+          checks.push({
+            code: "copilot_probe_failed",
+            level: "error",
+            message: `Copilot CLI probe failed (exit ${probe.exitCode ?? "?"}).`,
+            ...(detail ? { detail } : {}),
+          });
+        }
+      }
+    } catch (err) {
+      checks.push({
+        code: "copilot_probe_error",
+        level: "error",
+        message: `Copilot CLI probe error: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  checks.push({
+    code: "copilot_no_cost_tracking",
+    level: "warn",
+    message: "Cost tracking is not available for copilot_local. The Copilot CLI does not report token usage.",
+  });
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/copilot-local/src/ui/build-config.ts
+++ b/packages/adapters/copilot-local/src/ui/build-config.ts
@@ -1,0 +1,69 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildCopilotLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  ac.timeoutSec = 120;
+  ac.graceSec = 10;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/copilot-local/src/ui/index.ts
+++ b/packages/adapters/copilot-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseCopilotStdoutLine } from "./parse-stdout.js";
+export { buildCopilotLocalConfig } from "./build-config.js";

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.ts
@@ -1,0 +1,12 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+export function parseCopilotStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+  if (
+    trimmed.startsWith("─") || trimmed.startsWith("╭") ||
+    trimmed.startsWith("╰") || trimmed.startsWith("│") ||
+    /^GitHub Copilot\s/i.test(trimmed) || /^I'm powered by AI/i.test(trimmed)
+  ) return [];
+  return [{ kind: "assistant", ts, text: trimmed }];
+}

--- a/packages/adapters/copilot-local/tsconfig.json
+++ b/packages/adapters/copilot-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -29,6 +29,7 @@ export const AGENT_ADAPTER_TYPES = [
   "opencode_local",
   "pi_local",
   "cursor",
+  "copilot_local",
   "openclaw_gateway",
   "hermes_local",
 ] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
-      '@paperclipai/adapter-copilot-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -133,19 +130,6 @@ importers:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
-  packages/adapters/copilot-local:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -462,9 +446,6 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
-      '@paperclipai/adapter-copilot-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -619,9 +600,6 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
-      '@paperclipai/adapter-copilot-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -130,6 +133,19 @@ importers:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/copilot-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -446,6 +462,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -600,6 +619,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local

--- a/server/package.json
+++ b/server/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -13,6 +13,10 @@ import {
   sessionCodec as opencodeSessionCodec,
   isOpenCodeUnknownSessionError,
 } from "@paperclipai/adapter-opencode-local/server";
+import {
+  sessionCodec as copilotSessionCodec,
+  isCopilotSessionNotFoundError,
+} from "@paperclipai/adapter-copilot-local/server";
 
 describe("adapter session codecs", () => {
   it("normalizes claude session params with cwd", () => {
@@ -103,6 +107,34 @@ describe("adapter session codecs", () => {
       cwd: "/tmp/gemini",
     });
     expect(geminiSessionCodec.getDisplayId?.(serialized ?? null)).toBe("gemini-session-1");
+  });
+
+  it("normalizes copilot session params with cwd", () => {
+    const parsed = copilotSessionCodec.deserialize({
+      sessionId: "copilot-session-1",
+      cwd: "/tmp/copilot",
+    });
+    expect(parsed).toEqual({
+      sessionId: "copilot-session-1",
+      cwd: "/tmp/copilot",
+    });
+
+    const serialized = copilotSessionCodec.serialize(parsed);
+    expect(serialized).toEqual({
+      sessionId: "copilot-session-1",
+      cwd: "/tmp/copilot",
+    });
+    expect(copilotSessionCodec.getDisplayId?.(serialized ?? null)).toBe("copilot-session-1");
+  });
+});
+
+describe("copilot resume recovery detection", () => {
+  it("detects session not found errors from copilot output", () => {
+    expect(isCopilotSessionNotFoundError("Error: session not found")).toBe(true);
+    expect(isCopilotSessionNotFoundError("session expired")).toBe(true);
+    expect(isCopilotSessionNotFoundError("could not resume abc")).toBe(true);
+    expect(isCopilotSessionNotFoundError("no session with id abc")).toBe(true);
+    expect(isCopilotSessionNotFoundError("everything is fine")).toBe(false);
   });
 });
 

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -54,6 +54,12 @@ import {
   agentConfigurationDoc as openclawGatewayAgentConfigurationDoc,
   models as openclawGatewayModels,
 } from "@paperclipai/adapter-openclaw-gateway";
+import {
+  execute as copilotExecute,
+  testEnvironment as copilotTestEnvironment,
+  sessionCodec as copilotSessionCodec,
+} from "@paperclipai/adapter-copilot-local/server";
+import { agentConfigurationDoc as copilotAgentConfigurationDoc, models as copilotModels } from "@paperclipai/adapter-copilot-local";
 import { listCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
@@ -188,6 +194,16 @@ const hermesLocalAdapter: ServerAdapterModule = {
   detectModel: () => detectModelFromHermes(),
 };
 
+const copilotLocalAdapter: ServerAdapterModule = {
+  type: "copilot_local",
+  execute: copilotExecute,
+  testEnvironment: copilotTestEnvironment,
+  sessionCodec: copilotSessionCodec,
+  models: copilotModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: copilotAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
@@ -196,6 +212,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     piLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    copilotLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
     processAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@mdxeditor/editor": "^3.52.4",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/ui/src/adapters/copilot-local/config-fields.tsx
+++ b/ui/src/adapters/copilot-local/config-fields.tsx
@@ -1,0 +1,60 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+export function CopilotLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="Working directory" hint="Absolute path to the project root. Copilot runs here. Must be pre-trusted via interactive session or ~/.copilot/config.json trusted_folders.">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.cwd
+              : eff("adapterConfig", "cwd", String(config.cwd ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ cwd: v })
+              : mark("adapterConfig", "cwd", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="/absolute/path/to/project"
+        />
+      </Field>
+
+      <Field
+        label="Environment variables"
+        hint="One per line (KEY=VALUE). Set COPILOT_GITHUB_TOKEN with a fine-grained PAT that has the 'Copilot Requests' permission."
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? values!.envVars
+              : eff("adapterConfig", "envVars", String(config.envVars ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ envVars: v })
+              : mark("adapterConfig", "envVars", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="COPILOT_GITHUB_TOKEN=github_pat_..."
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/copilot-local/index.ts
+++ b/ui/src/adapters/copilot-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseCopilotStdoutLine } from "@paperclipai/adapter-copilot-local/ui";
+import { CopilotLocalConfigFields } from "./config-fields";
+import { buildCopilotLocalConfig } from "@paperclipai/adapter-copilot-local/ui";
+
+export const copilotLocalUIAdapter: UIAdapterModule = {
+  type: "copilot_local",
+  label: "GitHub Copilot CLI",
+  parseStdoutLine: parseCopilotStdoutLine,
+  ConfigFields: CopilotLocalConfigFields,
+  buildAdapterConfig: buildCopilotLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -7,6 +7,7 @@ import { hermesLocalUIAdapter } from "./hermes-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
+import { copilotLocalUIAdapter } from "./copilot-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 
@@ -18,6 +19,7 @@ const uiAdapters: UIAdapterModule[] = [
   openCodeLocalUIAdapter,
   piLocalUIAdapter,
   cursorLocalUIAdapter,
+  copilotLocalUIAdapter,
   openClawGatewayUIAdapter,
   processUIAdapter,
   httpUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -318,7 +318,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     adapterType === "hermes_local" ||
     adapterType === "opencode_local" ||
     adapterType === "pi_local" ||
-    adapterType === "cursor";
+    adapterType === "cursor" ||
+    adapterType === "copilot_local";
   const isHermesLocal = adapterType === "hermes_local";
   const showLegacyWorkingDirectoryField =
     isLocal && shouldShowLegacyWorkingDirectoryField({ isCreate, adapterConfig: config });
@@ -1024,7 +1025,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local", "copilot_local"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -21,6 +21,7 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",
+  copilot_local: "GitHub Copilot CLI",
   process: "Process",
   http: "HTTP",
 };

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -67,6 +67,8 @@ type AdapterType =
   | "opencode_local"
   | "pi_local"
   | "cursor"
+  | "copilot_local"
+  | "process"
   | "http"
   | "openclaw_gateway";
 
@@ -213,7 +215,8 @@ export function OnboardingWizard() {
     adapterType === "hermes_local" ||
     adapterType === "opencode_local" ||
     adapterType === "pi_local" ||
-    adapterType === "cursor";
+    adapterType === "cursor" ||
+    adapterType === "copilot_local";
   const effectiveAdapterCommand =
     command.trim() ||
     (adapterType === "codex_local"

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -65,6 +65,7 @@ export const adapterLabels: Record<string, string> = {
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",
   hermes_local: "Hermes Agent",
+  copilot_local: "GitHub Copilot CLI",
   process: "Process",
   http: "HTTP",
 };

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -27,6 +27,7 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode",
   cursor: "Cursor",
   hermes_local: "Hermes",
+  copilot_local: "Copilot",
   openclaw_gateway: "OpenClaw Gateway",
   process: "Process",
   http: "HTTP",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -21,11 +21,12 @@ const adapterLabels: Record<string, string> = {
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",
   hermes_local: "Hermes Agent",
+  copilot_local: "GitHub Copilot CLI",
   process: "Process",
   http: "HTTP",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local", "copilot_local"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -123,6 +123,7 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode",
   cursor: "Cursor",
   hermes_local: "Hermes",
+  copilot_local: "Copilot",
   openclaw_gateway: "OpenClaw Gateway",
   process: "Process",
   http: "HTTP",


### PR DESCRIPTION
## Summary

- Adds `@paperclipai/adapter-copilot-local` package wrapping the standalone GitHub Copilot CLI (`copilot`) as a Paperclip agent runtime
- Registered in all three adapter registries (server, UI, CLI) with full type coverage
- Supports auth via `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` (fine-grained PATs required)
- Session resume via `--resume`, with automatic retry on session-not-found
- Uses `--yolo` permissions mode (equivalent to `--allow-all`)
- Environment test probe validates CLI installation, auth, and connectivity
- No cost tracking (Copilot CLI does not expose token usage)

## Test plan

- [x] `pnpm -r typecheck` — passes (no new errors)
- [x] `pnpm test:run` — 121 tests pass, including new session codec + session-not-found tests
- [ ] Manual: install Copilot CLI, configure token, run agent through Paperclip UI
- [ ] Manual: verify session resume works across runs
- [ ] Manual: verify environment test catches missing CLI / bad token