### PR TITLE
feat: board terminal with claude -p backend

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -24,6 +24,7 @@ import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { boardChatRoutes } from "./routes/board-chat.js";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 
 type UiMode = "none" | "static" | "vite-dev";
@@ -112,6 +113,7 @@ export async function createApp(
   api.use(activityRoutes(db));
   api.use(dashboardRoutes(db));
   api.use(sidebarBadgeRoutes(db));
+  api.use(boardChatRoutes(db));
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/board-chat.ts
+++ b/server/src/routes/board-chat.ts
@@ -2,9 +2,11 @@ import { Router } from "express";
 import { spawn } from "node:child_process";
 import type { Db } from "@paperclipai/db";
 import { assertBoard } from "./authz.js";
+import { logActivity } from "../services/index.js";
 import { logger } from "../middleware/logger.js";
 
-const CLAUDE_BIN = process.env.CLAUDE_BIN || "/Users/user/.local/bin/claude";
+const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
+const CLAUDE_TIMEOUT_MS = 60_000;
 
 const TOOL_CALL_OPEN = "<tool_call>";
 const TOOL_CALL_CLOSE = "</tool_call>";
@@ -43,11 +45,14 @@ Available endpoints:
 - GET  /api/companies/:id/dashboard → company dashboard
 - GET  /api/companies/:id/agents → list agents
 - POST /api/companies/:id/agents → create agent
-- PATCH /api/companies/:id/agents/:agentId → update agent
-- POST /api/companies/:id/agents/:agentId/wakeup → trigger heartbeat
-- POST /api/companies/:id/agents/:agentId/pause → pause agent
-- POST /api/companies/:id/agents/:agentId/resume → resume agent
-- GET  /api/companies/:id/agents/:agentId/runs → list runs
+- GET  /api/agents/:agentId → get agent details
+- PATCH /api/agents/:agentId → update agent
+- POST /api/agents/:agentId/wakeup → trigger heartbeat
+- POST /api/agents/:agentId/heartbeat/invoke → invoke heartbeat
+- POST /api/agents/:agentId/pause → pause agent
+- POST /api/agents/:agentId/resume → resume agent
+- POST /api/agents/:agentId/terminate → terminate agent (irreversible)
+- GET  /api/companies/:id/heartbeat-runs → list runs
 - GET  /api/companies/:id/issues → list issues/tasks
 - POST /api/companies/:id/issues → create issue {title, description, assignee_id, project_id, goal_id}
 - PATCH /api/companies/:id/issues/:issueId → update issue {status, comment, assignee_id}
@@ -85,6 +90,11 @@ function runClaude(prompt: string): Promise<string> {
       env: { ...process.env },
     });
 
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error("claude -p timed out"));
+    }, CLAUDE_TIMEOUT_MS);
+
     let stdout = "";
     let stderr = "";
 
@@ -96,10 +106,12 @@ function runClaude(prompt: string): Promise<string> {
     });
 
     child.on("error", (err) => {
+      clearTimeout(timer);
       reject(new Error(`Failed to spawn claude: ${err.message}`));
     });
 
     child.on("close", (code) => {
+      clearTimeout(timer);
       if (code !== 0) {
         reject(new Error(`claude exited with code ${code}: ${stderr}`));
       } else {
@@ -155,12 +167,17 @@ async function executeApiCall(
   path: string,
   body: unknown,
   port: number,
+  cookie?: string,
 ): Promise<{ ok: boolean; status: number; data: unknown }> {
   const url = `http://127.0.0.1:${port}${path.startsWith("/") ? path : "/" + path}`;
   try {
     const opts: RequestInit = {
       method,
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
     };
     if (body && (method === "POST" || method === "PATCH")) {
       opts.body = JSON.stringify(body);
@@ -180,16 +197,37 @@ async function executeApiCall(
   }
 }
 
-export function boardChatRoutes(_db: Db) {
+const VALID_ROLES = new Set(["user", "assistant", "tool_call", "tool_result"]);
+
+function validateHistory(history: unknown): DisplayMessage[] {
+  if (!Array.isArray(history)) return [];
+  const validated: DisplayMessage[] = [];
+  for (const entry of history) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    if (!VALID_ROLES.has(e.role as string)) continue;
+    validated.push({
+      role: e.role as DisplayMessage["role"],
+      ...(typeof e.content === "string" ? { content: e.content } : {}),
+      ...(typeof e.method === "string" ? { method: e.method } : {}),
+      ...(typeof e.path === "string" ? { path: e.path } : {}),
+      ...(e.body !== undefined ? { body: e.body } : {}),
+      ...(typeof e.isError === "boolean" ? { isError: e.isError } : {}),
+    });
+  }
+  return validated;
+}
+
+export function boardChatRoutes(db: Db) {
   const router = Router();
 
   router.post("/board/chat", async (req, res, next) => {
     try {
       assertBoard(req);
 
-      const { message, history } = req.body as {
+      const { message, history: rawHistory } = req.body as {
         message: string;
-        history?: DisplayMessage[];
+        history?: unknown;
       };
 
       if (!message?.trim()) {
@@ -198,8 +236,9 @@ export function boardChatRoutes(_db: Db) {
       }
 
       const port = Number(process.env.PORT) || 3100;
+      const cookie = req.headers.cookie;
       const displayMessages: DisplayMessage[] = [];
-      const fullHistory: DisplayMessage[] = [...(history ?? [])];
+      const fullHistory: DisplayMessage[] = validateHistory(rawHistory);
       let maxTurns = 10;
 
       while (maxTurns-- > 0) {
@@ -234,12 +273,31 @@ export function boardChatRoutes(_db: Db) {
           displayMessages.push({ role: "tool_call", method: call.method, path: call.path, body: call.body });
           fullHistory.push({ role: "tool_call", method: call.method, path: call.path, body: call.body });
 
-          const result = await executeApiCall(call.method, call.path, call.body, port);
+          const result = await executeApiCall(call.method, call.path, call.body, port, cookie);
           const resultText = JSON.stringify(result.data, null, 2);
           const isError = !result.ok;
 
           displayMessages.push({ role: "tool_result", content: resultText, isError });
           fullHistory.push({ role: "tool_result", content: resultText, isError });
+
+          // Log mutating API calls for audit trail
+          if (call.method !== "GET" && result.ok) {
+            const companyMatch = call.path.match(/\/api\/companies\/([^/]+)/);
+            const companyId = companyMatch?.[1];
+            if (companyId) {
+              await logActivity(db, {
+                companyId,
+                actorType: "user",
+                actorId: req.actor.userId ?? "board",
+                action: "board_terminal.api_call",
+                entityType: "board_terminal",
+                entityId: "board_terminal",
+                details: { method: call.method, path: call.path },
+              }).catch((err) => {
+                logger.warn({ err }, "Failed to log board terminal activity");
+              });
+            }
+          }
         }
       }
 

--- a/server/src/routes/board-chat.ts
+++ b/server/src/routes/board-chat.ts
@@ -1,0 +1,253 @@
+import { Router } from "express";
+import { spawn } from "node:child_process";
+import type { Db } from "@paperclipai/db";
+import { assertBoard } from "./authz.js";
+import { logger } from "../middleware/logger.js";
+
+const CLAUDE_BIN = process.env.CLAUDE_BIN || "/Users/user/.local/bin/claude";
+
+const TOOL_CALL_OPEN = "<tool_call>";
+const TOOL_CALL_CLOSE = "</tool_call>";
+const TOOL_RESULT_OPEN = "<tool_result>";
+const TOOL_RESULT_CLOSE = "</tool_result>";
+
+interface DisplayMessage {
+  role: "user" | "assistant" | "tool_call" | "tool_result";
+  content?: string;
+  method?: string;
+  path?: string;
+  body?: unknown;
+  isError?: boolean;
+}
+
+function buildPrompt(
+  userMessage: string,
+  history: DisplayMessage[],
+): string {
+  const systemBlock = `You are a Paperclip board control agent. Paperclip is an AI company orchestration platform running on this server.
+
+You can make REST API calls to control everything: companies, agents, tasks (issues), goals, projects, budgets, and governance.
+
+To make an API call, output exactly this format (one per call):
+${TOOL_CALL_OPEN}{"method":"GET","path":"/api/companies"}${TOOL_CALL_CLOSE}
+
+For POST/PATCH, include a body:
+${TOOL_CALL_OPEN}{"method":"POST","path":"/api/companies/abc/issues","body":{"title":"Fix bug","description":"Details here"}}${TOOL_CALL_CLOSE}
+
+After each tool call block, STOP and wait. The system will execute the call and provide results in ${TOOL_RESULT_OPEN}...${TOOL_RESULT_CLOSE} blocks, then you continue.
+
+Available endpoints:
+- GET  /api/health → health check
+- GET  /api/companies → list companies
+- POST /api/companies → create company {name, mission}
+- GET  /api/companies/:id/dashboard → company dashboard
+- GET  /api/companies/:id/agents → list agents
+- POST /api/companies/:id/agents → create agent
+- PATCH /api/companies/:id/agents/:agentId → update agent
+- POST /api/companies/:id/agents/:agentId/wakeup → trigger heartbeat
+- POST /api/companies/:id/agents/:agentId/pause → pause agent
+- POST /api/companies/:id/agents/:agentId/resume → resume agent
+- GET  /api/companies/:id/agents/:agentId/runs → list runs
+- GET  /api/companies/:id/issues → list issues/tasks
+- POST /api/companies/:id/issues → create issue {title, description, assignee_id, project_id, goal_id}
+- PATCH /api/companies/:id/issues/:issueId → update issue {status, comment, assignee_id}
+- GET  /api/companies/:id/goals → list goals
+- POST /api/companies/:id/goals → create goal {title, description, parent_id}
+- GET  /api/companies/:id/projects → list projects
+- POST /api/companies/:id/projects → create project {name, goal_id}
+- GET  /api/companies/:id/costs → cost data
+
+Always start by fetching /api/health then /api/companies. Be proactive — fetch data rather than asking the user. Format output clearly.`;
+
+  let prompt = systemBlock + "\n\n";
+
+  // Append conversation history
+  for (const msg of history) {
+    if (msg.role === "user") {
+      prompt += `User: ${msg.content}\n\n`;
+    } else if (msg.role === "assistant") {
+      prompt += `Assistant: ${msg.content}\n\n`;
+    } else if (msg.role === "tool_call") {
+      prompt += `${TOOL_CALL_OPEN}{"method":"${msg.method}","path":"${msg.path}"${msg.body ? `,"body":${JSON.stringify(msg.body)}` : ""}}${TOOL_CALL_CLOSE}\n\n`;
+    } else if (msg.role === "tool_result") {
+      prompt += `${TOOL_RESULT_OPEN}${msg.content}${TOOL_RESULT_CLOSE}\n\n`;
+    }
+  }
+
+  prompt += `User: ${userMessage}\n\nAssistant:`;
+  return prompt;
+}
+
+function runClaude(prompt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(CLAUDE_BIN, ["-p", "--output-format", "text"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      reject(new Error(`Failed to spawn claude: ${err.message}`));
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`claude exited with code ${code}: ${stderr}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
+function parseToolCalls(
+  text: string,
+): { segments: Array<{ type: "text"; content: string } | { type: "tool_call"; method: string; path: string; body?: unknown }> } {
+  const segments: Array<{ type: "text"; content: string } | { type: "tool_call"; method: string; path: string; body?: unknown }> = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    const openIdx = remaining.indexOf(TOOL_CALL_OPEN);
+    if (openIdx === -1) {
+      const trimmed = remaining.trim();
+      if (trimmed) segments.push({ type: "text", content: trimmed });
+      break;
+    }
+
+    const before = remaining.slice(0, openIdx).trim();
+    if (before) segments.push({ type: "text", content: before });
+
+    const closeIdx = remaining.indexOf(TOOL_CALL_CLOSE, openIdx);
+    if (closeIdx === -1) {
+      const rest = remaining.slice(openIdx).trim();
+      if (rest) segments.push({ type: "text", content: rest });
+      break;
+    }
+
+    const jsonStr = remaining.slice(openIdx + TOOL_CALL_OPEN.length, closeIdx);
+    try {
+      const parsed = JSON.parse(jsonStr);
+      segments.push({ type: "tool_call", method: parsed.method, path: parsed.path, body: parsed.body });
+    } catch {
+      segments.push({ type: "text", content: jsonStr });
+    }
+
+    remaining = remaining.slice(closeIdx + TOOL_CALL_CLOSE.length);
+  }
+
+  return { segments };
+}
+
+async function executeApiCall(
+  method: string,
+  path: string,
+  body: unknown,
+  port: number,
+): Promise<{ ok: boolean; status: number; data: unknown }> {
+  const url = `http://127.0.0.1:${port}${path.startsWith("/") ? path : "/" + path}`;
+  try {
+    const opts: RequestInit = {
+      method,
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+    };
+    if (body && (method === "POST" || method === "PATCH")) {
+      opts.body = JSON.stringify(body);
+    }
+    const res = await fetch(url, opts);
+    const text = await res.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    return { ok: res.ok, status: res.status, data: parsed };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: 0, data: { error: message } };
+  }
+}
+
+export function boardChatRoutes(_db: Db) {
+  const router = Router();
+
+  router.post("/board/chat", async (req, res, next) => {
+    try {
+      assertBoard(req);
+
+      const { message, history } = req.body as {
+        message: string;
+        history?: DisplayMessage[];
+      };
+
+      if (!message?.trim()) {
+        res.status(400).json({ error: "message is required" });
+        return;
+      }
+
+      const port = Number(process.env.PORT) || 3100;
+      const displayMessages: DisplayMessage[] = [];
+      const fullHistory: DisplayMessage[] = [...(history ?? [])];
+      let maxTurns = 10;
+
+      while (maxTurns-- > 0) {
+        const prompt = buildPrompt(message, fullHistory);
+        let claudeOutput: string;
+        try {
+          claudeOutput = await runClaude(prompt);
+        } catch (err: unknown) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          logger.error({ err: errMsg }, "claude -p failed");
+          displayMessages.push({ role: "assistant", content: `Error running claude: ${errMsg}` });
+          break;
+        }
+
+        const { segments } = parseToolCalls(claudeOutput);
+        const toolCalls = segments.filter((s) => s.type === "tool_call");
+
+        // Add text segments as assistant messages
+        for (const seg of segments) {
+          if (seg.type === "text") {
+            displayMessages.push({ role: "assistant", content: seg.content });
+            fullHistory.push({ role: "assistant", content: seg.content });
+          }
+        }
+
+        if (toolCalls.length === 0) break;
+
+        // Execute tool calls
+        for (const call of toolCalls) {
+          if (call.type !== "tool_call") continue;
+
+          displayMessages.push({ role: "tool_call", method: call.method, path: call.path, body: call.body });
+          fullHistory.push({ role: "tool_call", method: call.method, path: call.path, body: call.body });
+
+          const result = await executeApiCall(call.method, call.path, call.body, port);
+          const resultText = JSON.stringify(result.data, null, 2);
+          const isError = !result.ok;
+
+          displayMessages.push({ role: "tool_result", content: resultText, isError });
+          fullHistory.push({ role: "tool_result", content: resultText, isError });
+        }
+      }
+
+      res.json({ messages: displayMessages });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -12,3 +12,4 @@ export { dashboardRoutes } from "./dashboard.js";
 export { sidebarBadgeRoutes } from "./sidebar-badges.js";
 export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
+export { boardChatRoutes } from "./board-chat.js";

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -27,6 +27,7 @@ import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
+import { BoardTerminal } from "./pages/BoardTerminal";
 import { InviteLandingPage } from "./pages/InviteLanding";
 import { queryKeys } from "./lib/queryKeys";
 import { useCompany } from "./context/CompanyContext";
@@ -129,6 +130,7 @@ function boardRoutes() {
       <Route path="inbox" element={<Navigate to="/inbox/new" replace />} />
       <Route path="inbox/new" element={<Inbox />} />
       <Route path="inbox/all" element={<Inbox />} />
+      <Route path="board" element={<BoardTerminal />} />
       <Route path="design-guide" element={<DesignGuide />} />
     </>
   );

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   SquarePen,
   Network,
   Settings,
+  TerminalSquare,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -100,6 +101,7 @@ export function Sidebar() {
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+          <SidebarNavItem to="/board" label="Board Terminal" icon={TerminalSquare} />
         </SidebarSection>
       </nav>
     </aside>

--- a/ui/src/pages/BoardTerminal.tsx
+++ b/ui/src/pages/BoardTerminal.tsx
@@ -1,0 +1,564 @@
+import { useState, useRef, useEffect } from "react";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface UserMessage {
+  role: "user";
+  content: string;
+}
+
+interface AssistantMessage {
+  role: "assistant";
+  content: string;
+}
+
+interface ToolCallMessage {
+  role: "tool_call";
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+interface ToolResultMessage {
+  role: "tool_result";
+  content: string;
+  isError: boolean;
+}
+
+type DisplayMessage =
+  | UserMessage
+  | AssistantMessage
+  | ToolCallMessage
+  | ToolResultMessage;
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function Terminal({
+  messages,
+  isLoading,
+}: {
+  messages: DisplayMessage[];
+  isLoading: boolean;
+}) {
+  const endRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        overflowY: "auto",
+        padding: "24px 28px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "20px",
+        fontFamily:
+          "'Berkeley Mono', 'JetBrains Mono', 'Fira Code', monospace",
+      }}
+    >
+      {messages.length === 0 && (
+        <div style={{ color: "#4a5568", fontSize: "13px", marginTop: "8px" }}>
+          <div
+            style={{
+              color: "#718096",
+              marginBottom: "16px",
+              fontSize: "12px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+            }}
+          >
+            Paperclip Board Terminal
+          </div>
+          <div style={{ color: "#a0aec0", lineHeight: 1.8 }}>
+            {[
+              "→ What companies are running?",
+              "→ Show me the status of all agents",
+              "→ Create a task: 'Update customer pricing page'",
+              "→ Trigger a heartbeat on the CTO agent",
+              "→ What's the dashboard look like?",
+              "→ Pause the content writer — it's over budget",
+            ].map((hint, i) => (
+              <div
+                key={i}
+                style={{ color: i === 0 ? "#718096" : "#4a5568" }}
+              >
+                {hint}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {messages.map((msg, i) => (
+        <MessageBlock key={i} msg={msg} />
+      ))}
+
+      {isLoading && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            color: "#4a5568",
+          }}
+        >
+          <span
+            style={{ color: "#e53e3e", fontWeight: 700, fontSize: "11px" }}
+          >
+            CLIP
+          </span>
+          <LoadingDots />
+        </div>
+      )}
+      <div ref={endRef} />
+    </div>
+  );
+}
+
+function LoadingDots() {
+  return (
+    <span
+      style={{ display: "inline-flex", gap: "3px", alignItems: "center" }}
+    >
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          style={{
+            width: "4px",
+            height: "4px",
+            borderRadius: "50%",
+            background: "#4a5568",
+            animation: `pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
+          }}
+        />
+      ))}
+      <style>{`@keyframes pulse { 0%,100%{opacity:.3;transform:scale(.8)} 50%{opacity:1;transform:scale(1)} }`}</style>
+    </span>
+  );
+}
+
+function MessageBlock({ msg }: { msg: DisplayMessage }) {
+  if (msg.role === "user") {
+    return (
+      <div
+        style={{ display: "flex", gap: "10px", alignItems: "flex-start" }}
+      >
+        <span
+          style={{
+            color: "#4299e1",
+            fontWeight: 700,
+            fontSize: "11px",
+            letterSpacing: "0.05em",
+            marginTop: "2px",
+            minWidth: "32px",
+          }}
+        >
+          YOU
+        </span>
+        <div
+          style={{
+            color: "#e2e8f0",
+            fontSize: "13px",
+            lineHeight: 1.7,
+            flex: 1,
+          }}
+        >
+          {msg.content}
+        </div>
+      </div>
+    );
+  }
+
+  if (msg.role === "tool_call") {
+    return (
+      <div
+        style={{
+          background: "#1a1f2e",
+          border: "1px solid #2d3748",
+          borderLeft: "2px solid #2b6cb0",
+          borderRadius: "4px",
+          padding: "10px 14px",
+          fontSize: "11px",
+          color: "#4a5568",
+        }}
+      >
+        <div
+          style={{
+            color: "#2b6cb0",
+            marginBottom: "4px",
+            letterSpacing: "0.08em",
+          }}
+        >
+          ⬡ {msg.method} {msg.path}
+        </div>
+        {msg.body && (
+          <pre
+            style={{
+              margin: 0,
+              color: "#4a5568",
+              fontSize: "10px",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {JSON.stringify(msg.body, null, 2)}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  if (msg.role === "tool_result") {
+    const isError = msg.isError;
+    return (
+      <div
+        style={{
+          background: "#111318",
+          border: `1px solid ${isError ? "#742a2a" : "#1a202c"}`,
+          borderRadius: "4px",
+          padding: "10px 14px",
+          fontSize: "10px",
+          color: isError ? "#fc8181" : "#2d3748",
+          maxHeight: "160px",
+          overflowY: "auto",
+        }}
+      >
+        <div
+          style={{
+            color: isError ? "#fc8181" : "#2d3748",
+            marginBottom: "4px",
+            letterSpacing: "0.08em",
+          }}
+        >
+          {isError ? "✗ ERROR" : "✓ RESPONSE"}
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            color: isError ? "#feb2b2" : "#4a5568",
+            whiteSpace: "pre-wrap",
+            fontSize: "10px",
+          }}
+        >
+          {msg.content}
+        </pre>
+      </div>
+    );
+  }
+
+  // assistant message
+  return (
+    <div style={{ display: "flex", gap: "10px", alignItems: "flex-start" }}>
+      <span
+        style={{
+          color: "#e53e3e",
+          fontWeight: 700,
+          fontSize: "11px",
+          letterSpacing: "0.05em",
+          marginTop: "2px",
+          minWidth: "32px",
+        }}
+      >
+        CLIP
+      </span>
+      <div
+        style={{
+          color: "#cbd5e0",
+          fontSize: "13px",
+          lineHeight: 1.8,
+          flex: 1,
+        }}
+      >
+        <RichText text={msg.content} />
+      </div>
+    </div>
+  );
+}
+
+function RichText({ text }: { text: string }) {
+  if (!text) return null;
+  const lines = text.split("\n");
+  return (
+    <div>
+      {lines.map((line, i) => {
+        if (line.startsWith("### "))
+          return (
+            <div
+              key={i}
+              style={{
+                color: "#e2e8f0",
+                fontWeight: 700,
+                marginTop: "12px",
+                marginBottom: "4px",
+              }}
+            >
+              {line.slice(4)}
+            </div>
+          );
+        if (line.startsWith("## "))
+          return (
+            <div
+              key={i}
+              style={{
+                color: "#e2e8f0",
+                fontWeight: 700,
+                fontSize: "14px",
+                marginTop: "14px",
+                marginBottom: "6px",
+                borderBottom: "1px solid #2d3748",
+                paddingBottom: "4px",
+              }}
+            >
+              {line.slice(3)}
+            </div>
+          );
+        if (line.startsWith("# "))
+          return (
+            <div
+              key={i}
+              style={{
+                color: "#fff",
+                fontWeight: 700,
+                fontSize: "15px",
+                marginTop: "16px",
+                marginBottom: "8px",
+              }}
+            >
+              {line.slice(2)}
+            </div>
+          );
+        if (line.startsWith("- ") || line.startsWith("* "))
+          return (
+            <div key={i} style={{ paddingLeft: "12px", color: "#a0aec0" }}>
+              · {line.slice(2)}
+            </div>
+          );
+        if (line.startsWith("  - "))
+          return (
+            <div key={i} style={{ paddingLeft: "24px", color: "#718096" }}>
+              · {line.slice(4)}
+            </div>
+          );
+        if (/^\d+\./.test(line))
+          return (
+            <div key={i} style={{ paddingLeft: "12px", color: "#a0aec0" }}>
+              {line}
+            </div>
+          );
+        if (line === "") return <div key={i} style={{ height: "6px" }} />;
+        const parts = line.split(/(`[^`]+`)/g);
+        return (
+          <div key={i}>
+            {parts.map((part, j) =>
+              part.startsWith("`") && part.endsWith("`") ? (
+                <code
+                  key={j}
+                  style={{
+                    background: "#1a202c",
+                    color: "#68d391",
+                    padding: "1px 5px",
+                    borderRadius: "3px",
+                    fontSize: "11px",
+                  }}
+                >
+                  {part.slice(1, -1)}
+                </code>
+              ) : (
+                <span key={j}>{part}</span>
+              ),
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Main component ──────────────────────────────────────────────────────────
+
+export function BoardTerminal() {
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [history, setHistory] = useState<DisplayMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  async function handleSubmit() {
+    const trimmed = input.trim();
+    if (!trimmed || isLoading) return;
+    setInput("");
+
+    const userMsg: DisplayMessage = { role: "user", content: trimmed };
+    setMessages((prev) => [...prev, userMsg]);
+    const currentHistory = [...history, userMsg];
+
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/board/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ message: trimmed, history }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        const errMsg: DisplayMessage = {
+          role: "assistant",
+          content: `Error: ${data.error || JSON.stringify(data)}`,
+        };
+        setMessages((prev) => [...prev, errMsg]);
+        return;
+      }
+
+      const newMessages: DisplayMessage[] = data.messages ?? [];
+      setMessages((prev) => [...prev, ...newMessages]);
+      setHistory([...currentHistory, ...newMessages]);
+    } catch (err: unknown) {
+      const errMsg: DisplayMessage = {
+        role: "assistant",
+        content: `Connection error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+      setMessages((prev) => [...prev, errMsg]);
+    } finally {
+      setIsLoading(false);
+      inputRef.current?.focus();
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        background: "#0d0f14",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily:
+          "'Berkeley Mono', 'JetBrains Mono', 'Fira Code', monospace",
+        color: "#cbd5e0",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 28px",
+          borderBottom: "1px solid #1a202c",
+          background: "#0a0c10",
+        }}
+      >
+        <div
+          style={{ display: "flex", alignItems: "center", gap: "12px" }}
+        >
+          <div
+            style={{
+              width: "8px",
+              height: "8px",
+              borderRadius: "50%",
+              background: "#e53e3e",
+              boxShadow: "0 0 6px #e53e3e",
+            }}
+          />
+          <span
+            style={{
+              color: "#e2e8f0",
+              fontWeight: 700,
+              fontSize: "13px",
+              letterSpacing: "0.1em",
+            }}
+          >
+            PAPERCLIP
+          </span>
+          <span style={{ color: "#2d3748", fontSize: "11px" }}>
+            board terminal
+          </span>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <Terminal messages={messages} isLoading={isLoading} />
+
+      {/* Input */}
+      <div
+        style={{
+          borderTop: "1px solid #1a202c",
+          padding: "16px 28px",
+          background: "#0a0c10",
+          display: "flex",
+          gap: "12px",
+          alignItems: "flex-end",
+        }}
+      >
+        <div style={{ flex: 1, position: "relative" }}>
+          <span
+            style={{
+              position: "absolute",
+              left: "12px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              color: "#4299e1",
+              fontSize: "12px",
+              fontWeight: 700,
+              pointerEvents: "none",
+            }}
+          >
+            ›
+          </span>
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about your Paperclip instance..."
+            rows={1}
+            style={{
+              width: "100%",
+              background: "#111318",
+              border: "1px solid #1e2533",
+              borderRadius: "4px",
+              color: "#e2e8f0",
+              fontSize: "13px",
+              padding: "10px 12px 10px 28px",
+              resize: "none",
+              outline: "none",
+              fontFamily: "inherit",
+              boxSizing: "border-box",
+              lineHeight: 1.5,
+            }}
+          />
+        </div>
+        <button
+          onClick={handleSubmit}
+          disabled={isLoading || !input.trim()}
+          style={{
+            background: isLoading || !input.trim() ? "#1a202c" : "#e53e3e",
+            border: "none",
+            borderRadius: "4px",
+            color: isLoading || !input.trim() ? "#2d3748" : "#fff",
+            fontSize: "11px",
+            fontWeight: 700,
+            letterSpacing: "0.1em",
+            padding: "10px 16px",
+            cursor:
+              isLoading || !input.trim() ? "default" : "pointer",
+            transition: "background 0.15s",
+            fontFamily: "inherit",
+          }}
+        >
+          RUN
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **Board Terminal** page at `/board` for conversational control of the Paperclip platform
- Server-side agent loop spawns `claude -p`, parses tool calls, and executes them against the local Paperclip API
- Supports up to 10 agentic turns per request with full tool call/result display
- Adds sidebar link under Company section

## Files
- `server/src/routes/board-chat.ts` — new route with claude -p agent loop
- `ui/src/pages/BoardTerminal.tsx` — terminal UI page
- `ui/src/App.tsx` — route registration
- `ui/src/components/Sidebar.tsx` — sidebar nav item
- `server/src/app.ts`, `server/src/routes/index.ts` — wiring

## Test plan
- [ ] Start Paperclip, navigate to `/board`
- [ ] Send a message and verify claude -p responds with tool calls
- [ ] Verify tool results are displayed inline
- [ ] Confirm sidebar link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)