### PR TITLE
fix: reset model selector when switching adapter providers

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -707,19 +707,19 @@ export function OnboardingWizard() {
                           onClick={() => {
                             if (opt.comingSoon) return;
                             const nextType = opt.value as AdapterType;
+                            if (nextType === adapterType) return;
                             setAdapterType(nextType);
-                            if (nextType === "codex_local" && !model) {
+                            if (nextType === "codex_local") {
                               setModel(DEFAULT_CODEX_LOCAL_MODEL);
-                            } else if (nextType === "cursor" && !model) {
+                            } else if (nextType === "cursor") {
                               setModel(DEFAULT_CURSOR_LOCAL_MODEL);
-                            }
-                            if (nextType === "opencode_local") {
+                            } else if (nextType === "opencode_local") {
                               if (!model.includes("/")) {
                                 setModel("");
                               }
-                              return;
+                            } else {
+                              setModel("");
                             }
-                            setModel("");
                           }}
                         >
                           {opt.recommended && (


### PR DESCRIPTION
Remove `&& !model` guards so the model always resets on provider switch, preventing stale model IDs from showing in the dropdown. Add early return when clicking the already-selected adapter. Consolidate opencode_local branch into the if/else chain.

Fixes #70