### PR TITLE
chore: sync Paperclip vendor branch and preserve Lionroot patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build
-RUN pnpm --filter @paperclipai/server build
-RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
+# Server dist is pre-built in repo; keep the Lionroot Docker workaround until
+# the server build is confirmed stable in this image.
 
 FROM base AS production
 WORKDIR /app

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -155,7 +155,7 @@ async function ensureMigrations(
 
 function isLoopbackHost(host: string): boolean {
   const normalized = host.trim().toLowerCase();
-  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1" || normalized === "0.0.0.0";
 }
 
 const LOCAL_BOARD_USER_ID = "local-board";


### PR DESCRIPTION
## Summary
- sync the vendor checkout onto the latest upstream `master`
- preserve the Lionroot Docker/runtime patches needed for local deployment
- keep the local loopback allowance for `0.0.0.0`

## Local patches kept
- Dockerfile keeps the prebuilt-server workaround instead of rebuilding `@paperclipai/server` in-image
- `server/src/index.ts` still accepts `0.0.0.0` as a loopback host

## Validation
- `pnpm build`
