### PR TITLE
fix: use fileURLToPath for migrations path on Windows

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -5,9 +5,10 @@ import { readFile, readdir } from "node:fs/promises";
 import postgres from "postgres";
 import * as schema from "./schema/index.js";
 
-const MIGRATIONS_FOLDER = new URL("./migrations", import.meta.url).pathname;
+import { fileURLToPath } from "node:url";
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
-const MIGRATIONS_JOURNAL_JSON = new URL("./migrations/meta/_journal.json", import.meta.url).pathname;
+const MIGRATIONS_JOURNAL_JSON = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
 
 function isSafeIdentifier(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);


### PR DESCRIPTION
## Bug: Double drive letter path on Windows (`C:\C:\...`)

**Environment:** Windows 11, Node.js v20, pnpm

**Problem:**

`new URL(...).pathname` on Windows returns a path with a leading slash (e.g. `/C:/Code/...`). When this gets concatenated elsewhere, it produces an invalid double path like `C:\C:\Code\...`, causing the server to crash on startup:

```
Error: ENOENT: no such file or directory, scandir 'C:\C:\Code\paperclipai\paperclip\packages\db\src\migrations'
```

**Root cause:** `packages/db/src/client.ts`, lines 7 and 9:

```ts
// Before (broken on Windows)
const MIGRATIONS_FOLDER = new URL("./migrations", import.meta.url).pathname;
const MIGRATIONS_JOURNAL_JSON = new URL("./migrations/meta/_journal.json", import.meta.url).pathname;
```

**Fix:** Use `fileURLToPath` instead of `.pathname`:

```ts
import { fileURLToPath } from "node:url";
const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
const MIGRATIONS_JOURNAL_JSON = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
```

This is the standard Node.js way to convert `file://` URLs to filesystem paths `cross-platform.```