### PR TITLE
skip agent self-wake on comment and closed-issue wake without reopen

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -588,6 +588,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
         for (const mentionedId of mentionedIds) {
           if (wakeups.has(mentionedId)) continue;
+          if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
           wakeups.set(mentionedId, {
             source: "automation",
             triggerDetail: "system",
@@ -899,7 +900,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     void (async () => {
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
       const assigneeId = currentIssue.assigneeAgentId;
-      if (assigneeId) {
+      const actorIsAgent = actor.actorType === "agent";
+      const selfComment = actorIsAgent && actor.actorId === assigneeId;
+      const skipWake = selfComment || isClosed;
+      if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {
             source: "automation",
@@ -958,6 +962,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
       for (const mentionedId of mentionedIds) {
         if (wakeups.has(mentionedId)) continue;
+        if (actorIsAgent && actor.actorId === mentionedId) continue;
         wakeups.set(mentionedId, {
           source: "automation",
           triggerDetail: "system",


### PR DESCRIPTION
Fixes #88 - Agents reported their status at the end of their run ("Created PR xyz, did ABC....") which then just woke themselves back up to handle their own comment. 

## Summary

Agents were waking themselves up when they commented on their own assigned issues. Three guards added to `server/src/routes/issues.ts`:

1. 🚫 **Assignee wake on comment** — skip if agent is commenting on own issue, or issue is closed (unless `reopen: true`)
2. 🪞 **Self @-mention on comment create** — skip waking agent that @-mentioned itself
3. 🪞 **Self @-mention on issue update** — same guard for the PATCH path

  ### Wake behavior matrix

  | Actor | Issue closed? | Reopen flag? | Wakes assignee? |
  |-------|:---:|:---:|:---:|
  | 🤖 Agent (self) | ❌ | ❌ | 😴 No |
  | 🤖 Agent (self) | ✅ | ✅ | ⏰ Yes |
  | 🤖 Agent (self) | ✅ | ❌ | 😴 No |
  | 🤖 Agent (other) | ❌ | ❌ | ⏰ Yes |
  | 🤖 Agent (other) | ✅ | ❌ | 😴 No |
  | 🤖 Agent (other) | ✅ | ✅ | ⏰ Yes |
  | 👤 User/board | ❌ | ❌ | ⏰ Yes |
  | 👤 User/board | ✅ | ❌ | 😴 No |
  | 👤 User/board | ✅ | ✅ | ⏰ Yes |
