### PR TITLE
fix: exclude done/cancelled issues from default issue list view

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -134,7 +134,12 @@ function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
 
 function countActiveFilters(state: IssueViewState): number {
   let count = 0;
-  if (state.statuses.length > 0) count++;
+  const defaultStatuses = new Set(defaultViewState.statuses);
+  const currentStatuses = new Set(state.statuses);
+  const statusesMatchDefault =
+    defaultStatuses.size === currentStatuses.size &&
+    [...defaultStatuses].every((s) => currentStatuses.has(s));
+  if (!statusesMatchDefault) count++;
   if (state.priorities.length > 0) count++;
   if (state.assignees.length > 0) count++;
   if (state.labels.length > 0) count++;
@@ -623,7 +628,7 @@ export function IssuesList({
                     className="h-3 w-3 ml-1 hidden sm:block"
                     onClick={(e) => {
                       e.stopPropagation();
-                      updateView({ statuses: [], priorities: [], assignees: [], labels: [], projects: [] });
+                      updateView({ statuses: defaultViewState.statuses, priorities: [], assignees: [], labels: [], projects: [] });
                     }}
                   />
                 )}
@@ -636,7 +641,7 @@ export function IssuesList({
                   {activeFilterCount > 0 && (
                     <button
                       className="text-xs text-muted-foreground hover:text-foreground"
-                      onClick={() => updateView({ statuses: [], priorities: [], assignees: [], labels: [] })}
+                      onClick={() => updateView({ statuses: defaultViewState.statuses, priorities: [], assignees: [], labels: [] })}
                     >
                       Clear
                     </button>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -50,7 +50,7 @@ export type IssueViewState = {
 };
 
 const defaultViewState: IssueViewState = {
-  statuses: [],
+  statuses: ["todo", "in_progress", "in_review", "blocked", "backlog"],
   priorities: [],
   assignees: [],
   labels: [],


### PR DESCRIPTION
## Summary

The default `IssueViewState` had `statuses: []` which means "show all statuses" — so done and cancelled issues always appeared alongside active work. This is noisy and buries the issues that actually need attention.

## Change

```ts
// Before
const defaultViewState: IssueViewState = {
  statuses: [], // shows everything including done/cancelled
  ...
};

// After
const defaultViewState: IssueViewState = {
  statuses: ["todo", "in_progress", "in_review", "blocked", "backlog"],
  ...
};
```

Completed work is still accessible via the existing "Done" quick-filter preset — this change just makes the default view focus on open work.

## Behavior

- Default view: shows backlog, todo, in_progress, in_review, blocked
- Clicking "Done" preset still shows completed issues
- Clicking "All" still shows everything
- User preference is still persisted to localStorage as before