### PR TITLE
fix(issues): skip agent wakeup when issue status is backlog

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -432,7 +432,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       details: { title: issue.title, identifier: issue.identifier },
     });
 
-    if (issue.assigneeAgentId) {
+    if (issue.assigneeAgentId && issue.status !== "backlog") {
       void heartbeat
         .wakeup(issue.assigneeAgentId, {
           source: "assignment",
@@ -566,7 +566,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     void (async () => {
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
 
-      if (assigneeChanged && issue.assigneeAgentId) {
+      if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
         wakeups.set(issue.assigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",


### PR DESCRIPTION
Fixes #96

## Summary

- Agents were being woken immediately when an issue was created or assigned with `status: "backlog"`, defeating the purpose of backlog as "not ready to work on yet"
- Added `&& issue.status !== "backlog"` guard to both the **CREATE** path (`issues.ts:435`) and the **PATCH** path (`issues.ts:569`)
- Mirrors the existing `done`/`cancelled` suppression pattern already present in the same file

## Behaviour after this fix

| Action | Status | Wakes agent? |
|---|---|---|
| Create issue with assignee | `backlog` | No |
| Assign agent to issue | `backlog` | No |
| Create issue with assignee | `todo` / `in_progress` | Yes |
| Move `backlog` → `todo` + assign | `todo` | Yes |

## Test plan

- [x] Create an issue with `status: "backlog"` and an `assigneeAgentId` — agent should not wake
- [x] PATCH an issue to assign an agent while `status` remains `"backlog"` — agent should not wake
- [x] PATCH an issue from `backlog` → `todo` with an assignee — agent should wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)