### PR TITLE
fix: show webhookAuthHeader and gatewayAuthToken fields during OpenClaw agent creation

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -207,8 +207,8 @@ export interface CreateConfigValues {
   envVars: string;
   envBindings: Record<string, unknown>;
   url: string;
-  webhookAuthHeader: string;
-  gatewayAuthToken: string;
+  webhookAuthHeader?: string;
+  gatewayAuthToken?: string;
   bootstrapPrompt: string;
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -207,6 +207,8 @@ export interface CreateConfigValues {
   envVars: string;
   envBindings: Record<string, unknown>;
   url: string;
+  webhookAuthHeader: string;
+  gatewayAuthToken: string;
   bootstrapPrompt: string;
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;

--- a/packages/adapters/openclaw/src/ui/build-config.ts
+++ b/packages/adapters/openclaw/src/ui/build-config.ts
@@ -8,5 +8,9 @@ export function buildOpenClawConfig(v: CreateConfigValues): Record<string, unkno
   ac.streamTransport = "sse";
   ac.sessionKeyStrategy = "fixed";
   ac.sessionKey = "paperclip";
+  if (v.webhookAuthHeader?.trim()) ac.webhookAuthHeader = v.webhookAuthHeader.trim();
+  if (v.gatewayAuthToken?.trim()) {
+    ac.headers = { "x-openclaw-auth": v.gatewayAuthToken.trim() };
+  }
   return ac;
 }

--- a/ui/src/adapters/openclaw/config-fields.tsx
+++ b/ui/src/adapters/openclaw/config-fields.tsx
@@ -59,19 +59,26 @@ export function OpenClawConfigFields({
       : {};
   const effectiveHeaders =
     (eff("adapterConfig", "headers", configuredHeaders) as Record<string, unknown>) ?? {};
-  const effectiveGatewayAuthHeader = typeof effectiveHeaders["x-openclaw-auth"] === "string"
-    ? String(effectiveHeaders["x-openclaw-auth"])
-    : "";
+
+  const effectiveGatewayAuthHeader = isCreate
+    ? String(values?.gatewayAuthToken ?? "")
+    : typeof effectiveHeaders["x-openclaw-auth"] === "string"
+      ? String(effectiveHeaders["x-openclaw-auth"])
+      : "";
 
   const commitGatewayAuthHeader = (rawValue: string) => {
     const nextValue = rawValue.trim();
-    const nextHeaders: Record<string, unknown> = { ...effectiveHeaders };
-    if (nextValue) {
-      nextHeaders["x-openclaw-auth"] = nextValue;
+    if (isCreate) {
+      set!({ gatewayAuthToken: nextValue || undefined });
     } else {
-      delete nextHeaders["x-openclaw-auth"];
+      const nextHeaders: Record<string, unknown> = { ...effectiveHeaders };
+      if (nextValue) {
+        nextHeaders["x-openclaw-auth"] = nextValue;
+      } else {
+        delete nextHeaders["x-openclaw-auth"];
+      }
+      mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
     }
-    mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
   };
 
   const transport = eff(
@@ -104,6 +111,29 @@ export function OpenClawConfigFields({
           placeholder="https://..."
         />
       </Field>
+
+      <SecretField
+        label="Webhook auth header (optional)"
+        value={
+          isCreate
+            ? String(values?.webhookAuthHeader ?? "")
+            : eff("adapterConfig", "webhookAuthHeader", String(config.webhookAuthHeader ?? ""))
+        }
+        onCommit={(v) =>
+          isCreate
+            ? set!({ webhookAuthHeader: v.trim() || undefined })
+            : mark("adapterConfig", "webhookAuthHeader", v || undefined)
+        }
+        placeholder="Bearer <token>"
+      />
+
+      <SecretField
+        label="Gateway auth token (x-openclaw-auth)"
+        value={effectiveGatewayAuthHeader}
+        onCommit={commitGatewayAuthHeader}
+        placeholder="OpenClaw gateway token"
+      />
+
       {!isCreate && (
         <>
           <Field label="Paperclip API URL override">
@@ -156,20 +186,6 @@ export function OpenClawConfigFields({
               />
             </Field>
           )}
-
-          <SecretField
-            label="Webhook auth header (optional)"
-            value={eff("adapterConfig", "webhookAuthHeader", String(config.webhookAuthHeader ?? ""))}
-            onCommit={(v) => mark("adapterConfig", "webhookAuthHeader", v || undefined)}
-            placeholder="Bearer <token>"
-          />
-
-          <SecretField
-            label="Gateway auth token (x-openclaw-auth)"
-            value={effectiveGatewayAuthHeader}
-            onCommit={commitGatewayAuthHeader}
-            placeholder="OpenClaw gateway token"
-          />
         </>
       )}
     </>

--- a/ui/src/adapters/openclaw/config-fields.tsx
+++ b/ui/src/adapters/openclaw/config-fields.tsx
@@ -69,7 +69,7 @@ export function OpenClawConfigFields({
   const commitGatewayAuthHeader = (rawValue: string) => {
     const nextValue = rawValue.trim();
     if (isCreate) {
-      set!({ gatewayAuthToken: nextValue || undefined });
+      set!({ gatewayAuthToken: nextValue || "" });
     } else {
       const nextHeaders: Record<string, unknown> = { ...effectiveHeaders };
       if (nextValue) {
@@ -119,11 +119,14 @@ export function OpenClawConfigFields({
             ? String(values?.webhookAuthHeader ?? "")
             : eff("adapterConfig", "webhookAuthHeader", String(config.webhookAuthHeader ?? ""))
         }
-        onCommit={(v) =>
-          isCreate
-            ? set!({ webhookAuthHeader: v.trim() || undefined })
-            : mark("adapterConfig", "webhookAuthHeader", v || undefined)
-        }
+        onCommit={(v) => {
+          const trimmed = v.trim();
+          if (isCreate) {
+            set!({ webhookAuthHeader: trimmed || "" });
+          } else {
+            mark("adapterConfig", "webhookAuthHeader", trimmed || undefined);
+          }
+        }}
         placeholder="Bearer <token>"
       />
 

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -17,8 +17,6 @@ export const defaultCreateValues: CreateConfigValues = {
   envVars: "",
   envBindings: {},
   url: "",
-  webhookAuthHeader: "",
-  gatewayAuthToken: "",
   bootstrapPrompt: "",
   maxTurnsPerRun: 80,
   heartbeatEnabled: false,

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -17,6 +17,8 @@ export const defaultCreateValues: CreateConfigValues = {
   envVars: "",
   envBindings: {},
   url: "",
+  webhookAuthHeader: "",
+  gatewayAuthToken: "",
   bootstrapPrompt: "",
   maxTurnsPerRun: 80,
   heartbeatEnabled: false,


### PR DESCRIPTION
Fixes #83

Both auth fields were hidden inside a `!isCreate` block, so they only appeared after save-then-edit. Users had no way to configure auth credentials at agent creation time.

## Changes

- **`ui/src/adapters/openclaw/config-fields.tsx`** — Moved both `SecretField` components (Webhook auth header, Gateway auth token) above the `!isCreate` block so they render on both create and edit forms
- **`packages/adapter-utils/src/types.ts`** — Added `webhookAuthHeader` and `gatewayAuthToken` to `CreateConfigValues` so create mode can hold these values in typed form state
- **`packages/adapters/openclaw/src/ui/build-config.ts`** — Updated `buildOpenClawConfig` to write both fields into the adapter config on create (`webhookAuthHeader → adapterConfig.webhookAuthHeader`, `gatewayAuthToken → adapterConfig.headers["x-openclaw-auth"]`)
- **`ui/src/components/agent-config-defaults.ts`** — Added empty string defaults for both new fields

## Before / After

**Before:** Auth fields only appeared when re-opening an already-created agent for edit.

**After:** Both fields are visible at creation time — users can configure auth in a single step.