### PR TITLE
feat(heartbeat): add skipIfNoAssignments policy to suppress idle timer wakes

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -802,6 +802,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      skipIfNoAssignments: asBoolean(heartbeat.skipIfNoAssignments, false),
     };
   }
 
@@ -1666,6 +1667,24 @@ export function heartbeatService(db: Db) {
     if (source !== "timer" && !policy.wakeOnDemand) {
       await writeSkippedRequest("heartbeat.wakeOnDemand.disabled");
       return null;
+    }
+
+    if (source === "timer" && policy.skipIfNoAssignments) {
+      const assignedCount = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, agent.companyId),
+            eq(issues.assigneeAgentId, agentId),
+            inArray(issues.status, ["todo", "in_progress", "blocked"]),
+          ),
+        )
+        .then(([row]) => Number(row?.count ?? 0));
+      if (assignedCount === 0) {
+        await writeSkippedRequest("heartbeat.skipIfNoAssignments");
+        return null;
+      }
     }
 
     const bypassIssueExecutionLock =

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1683,6 +1683,11 @@ export function heartbeatService(db: Db) {
         .then(([row]) => Number(row?.count ?? 0));
       if (assignedCount === 0) {
         await writeSkippedRequest("heartbeat.skipIfNoAssignments");
+        // Reset the interval baseline so tickTimers doesn't fire again immediately.
+        await db
+          .update(agents)
+          .set({ lastHeartbeatAt: new Date() })
+          .where(eq(agents.id, agentId));
         return null;
       }
     }


### PR DESCRIPTION
## Problem

Agents with no active work still wake on every heartbeat interval. If an agent has no issues assigned (or all issues are done/cancelled), it fires a full wakeup cycle — consuming resources and polluting wakeup logs with noise.

## Solution

Add a `skipIfNoAssignments` boolean to the heartbeat policy (defaults to `false` for backwards compatibility). When enabled:

1. On a timer-triggered wake, `enqueueWakeup` runs a pre-flight count query for issues assigned to the agent with status in `['todo', 'in_progress', 'blocked']`
2. If the count is 0, it records a skipped request with reason `"heartbeat.skipIfNoAssignments"` and returns early
3. Event-triggered wakes (`assignment`, `on_demand`, `automation`) are **completely unaffected** — the guard is scoped to `source === "timer"` only

## Implementation

Two changes in `server/src/services/heartbeat.ts`:

**`parseHeartbeatPolicy`** — parse the new field:
```ts
skipIfNoAssignments: asBoolean(heartbeat.skipIfNoAssignments, false),
```

**`enqueueWakeup`** — pre-flight guard before processing:
```ts
if (source === "timer" && policy.skipIfNoAssignments) {
  const assignedCount = await db
    .select({ count: sql<number>`count(*)` })
    .from(issues)
    .where(
      and(
        eq(issues.companyId, agent.companyId),
        eq(issues.assigneeAgentId, agentId),
        inArray(issues.status, ["todo", "in_progress", "blocked"]),
      ),
    )
    .then(([row]) => Number(row?.count ?? 0));
  if (assignedCount === 0) {
    await writeSkippedRequest("heartbeat.skipIfNoAssignments");
    return null;
  }
}
```

The query hits the existing `issues_company_assignee_status_idx` index — no additional DB overhead at scale.

No schema migration needed — `skipIfNoAssignments` lives in the existing `runtimeConfig` JSONB column on agents.

Fixes #39