### PR TITLE
fix(ui): stop dashboard live panel websocket churn

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -253,7 +253,7 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
         pendingByRunRef.current.delete(key);
       }
     }
-  }, [runs, runIdsKey]);
+  }, [runIdsKey]);
 
   useEffect(() => {
     setFeedByRun(new Map());
@@ -415,7 +415,7 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
         socket.close(1000, "active_agents_panel_unmount");
       }
     };
-  }, [activeRunIdsKey, companyId, activeRuns.length]);
+  }, [activeRunIdsKey, companyId]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- stabilize the dashboard live-run websocket effect so it does not reconnect on every feed update
- prune per-run feed and pending log buffers when runs disappear from the dashboard
- reset panel-local feed state when switching companies

## Root cause
`ActiveAgentsPanel` derived `runById` and `activeRunIds` with `useMemo`, then used those `Map`/`Set` objects directly in the websocket effect dependency list.

Each incoming log append updates local panel state, which triggers a rerender and recreates those objects. Because the dependencies changed by identity, React tore down and recreated the websocket connection repeatedly while runs were active. The panel also retained feed state for runs that had rotated off the dashboard.

On a busy dashboard this causes sustained websocket churn and unnecessary retained client memory.

## Fix
- move current run lookup and active run ids into refs refreshed by effect
- key the websocket effect off a stable active-run-id signature instead of `Map`/`Set` identity
- evict stale feed and pending buffer entries when runs disappear
- clear panel-local buffers on company change

## Verification
- verified the same patch in the downstream fork with `pnpm --filter ui typecheck`
- verified the same patch in the downstream fork with `pnpm --filter ui build`
- this clean upstream worktree did not have `node_modules`, so I did not re-run those commands in this checkout