### PR TITLE
fix: cap description editor height in New Issue dialog so image scroll works

### DIFF
--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -1098,7 +1098,7 @@ export function NewIssueDialog() {
 
         {/* Description */}
         <div
-          className={cn("px-4 pb-2 overflow-y-auto min-h-0 border-t border-border/60 pt-3", expanded ? "flex-1" : "")}
+          className={cn("px-4 pb-2 overflow-y-auto min-h-0 border-t border-border/60 pt-3", expanded ? "flex-1" : "max-h-[320px]")}
           onDragEnter={handleFileDragEnter}
           onDragOver={handleFileDragOver}
           onDragLeave={handleFileDragLeave}


### PR DESCRIPTION
## Problem

When an image is inserted into the description field of the New Issue dialog (non-expanded mode), the editor area becomes too small to type above or below the image.

**Root cause:** The description container has `overflow-y-auto` but no upper bound on height in non-expanded mode. When content (e.g. an image) is inserted, the container grows unboundedly — `overflow-y-auto` never activates, so the dialog stretches past the viewport and pushes the property chips and submit button out of view.

## Fix

Add `max-h-[320px]` to the description container in non-expanded mode. The scroll activates when content exceeds the cap, keeping the description area internally scrollable while the property bar and submit button stay anchored.

Expanded mode is unchanged — it already uses `flex-1` bounded by the dialog's `max-h-[calc(100dvh-2rem)]`.

## Change

```diff
- <div className={cn("px-4 pb-2 overflow-y-auto min-h-0 ...", expanded ? "flex-1" : "")}>
+ <div className={cn("px-4 pb-2 overflow-y-auto min-h-0 ...", expanded ? "flex-1" : "max-h-[320px]")}>
```