### PR TITLE
feat(server): opt-in git worktree isolation for all adapters

### DIFF
--- a/packages/adapter-utils/src/git-worktree.ts
+++ b/packages/adapter-utils/src/git-worktree.ts
@@ -114,14 +114,18 @@ export async function ensureGitWorktree(opts: WorktreeOptions): Promise<Worktree
 
 /**
  * Remove a git worktree. Optionally delete the associated branch via `deleteBranch`.
+ *
+ * Returns `true` if the worktree was successfully removed, `false` otherwise.
  */
-export async function removeGitWorktree(opts: WorktreeRemoveOptions): Promise<void> {
+export async function removeGitWorktree(opts: WorktreeRemoveOptions): Promise<boolean> {
   const { repoCwd, worktreePath, deleteBranch, onLog } = opts;
   const absWorktree = path.resolve(repoCwd, worktreePath);
 
+  let removed = false;
   try {
     await git(repoCwd, ["worktree", "remove", absWorktree, "--force"]);
     await onLog("stderr", `[paperclip] Removed worktree at ${absWorktree}\n`);
+    removed = true;
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     await onLog("stderr", `[paperclip] Warning: failed to remove worktree at ${absWorktree}: ${reason}\n`);
@@ -135,6 +139,8 @@ export async function removeGitWorktree(opts: WorktreeRemoveOptions): Promise<vo
       // Non-fatal: branch may still have unmerged changes or already be gone
     }
   }
+
+  return removed;
 }
 
 /**

--- a/packages/adapter-utils/src/git-worktree.ts
+++ b/packages/adapter-utils/src/git-worktree.ts
@@ -1,0 +1,218 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const GIT_EXEC_TIMEOUT_MS = 30_000;
+
+export interface WorktreeResult {
+  cwd: string;
+  branch: string;
+  created: boolean;
+}
+
+export interface WorktreeOptions {
+  repoCwd: string;
+  branchName: string;
+  worktreePath: string;
+  baseBranch?: string;
+  onLog: (stream: "stdout" | "stderr", msg: string) => Promise<void>;
+}
+
+export interface WorktreeRemoveOptions {
+  repoCwd: string;
+  worktreePath: string;
+  onLog: (stream: "stdout" | "stderr", msg: string) => Promise<void>;
+}
+
+async function git(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync("git", args, { cwd, timeout: GIT_EXEC_TIMEOUT_MS });
+}
+
+/**
+ * Check whether a directory is inside a git repository.
+ */
+export async function isGitRepository(dir: string): Promise<boolean> {
+  try {
+    await git(dir, ["rev-parse", "--is-inside-work-tree"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the root of the git repository containing `dir`.
+ */
+export async function gitRepoRoot(dir: string): Promise<string> {
+  const { stdout } = await git(dir, ["rev-parse", "--show-toplevel"]);
+  return stdout.trim();
+}
+
+/**
+ * Create a git worktree for an agent run, or reuse one if it already exists.
+ *
+ * The worktree is created at `worktreePath` on a new branch `branchName`
+ * based on `baseBranch` (defaults to HEAD). If the branch or worktree
+ * already exists, it is reused without error.
+ */
+export async function ensureGitWorktree(opts: WorktreeOptions): Promise<WorktreeResult> {
+  const { repoCwd, branchName, worktreePath, baseBranch, onLog } = opts;
+  const absWorktree = path.resolve(repoCwd, worktreePath);
+
+  // Check if worktree already exists at this path
+  const worktreeExists = await fs
+    .stat(path.join(absWorktree, ".git"))
+    .then(() => true)
+    .catch(() => false);
+
+  if (worktreeExists) {
+    await onLog("stderr", `[paperclip] Reusing existing worktree at ${absWorktree}\n`);
+    return { cwd: absWorktree, branch: branchName, created: false };
+  }
+
+  // Check if the branch already exists
+  const branchExists = await git(repoCwd, ["rev-parse", "--verify", `refs/heads/${branchName}`])
+    .then(() => true)
+    .catch(() => false);
+
+  // Ensure parent directory exists
+  await fs.mkdir(path.dirname(absWorktree), { recursive: true });
+
+  try {
+    if (branchExists) {
+      // Branch exists but no worktree — attach worktree to existing branch
+      await git(repoCwd, ["worktree", "add", absWorktree, branchName]);
+    } else {
+      // Create new branch + worktree
+      const base = baseBranch || "HEAD";
+      await git(repoCwd, ["worktree", "add", "-b", branchName, absWorktree, base]);
+    }
+
+    await onLog("stderr", `[paperclip] Created worktree at ${absWorktree} on branch ${branchName}\n`);
+    return { cwd: absWorktree, branch: branchName, created: true };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[paperclip] Failed to create worktree: ${reason}\n`);
+    throw new Error(`Failed to create git worktree at "${absWorktree}": ${reason}`);
+  }
+}
+
+/**
+ * Remove a git worktree and optionally delete its branch.
+ */
+export async function removeGitWorktree(opts: WorktreeRemoveOptions): Promise<void> {
+  const { repoCwd, worktreePath, onLog } = opts;
+  const absWorktree = path.resolve(repoCwd, worktreePath);
+
+  try {
+    await git(repoCwd, ["worktree", "remove", absWorktree, "--force"]);
+    await onLog("stderr", `[paperclip] Removed worktree at ${absWorktree}\n`);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[paperclip] Warning: failed to remove worktree at ${absWorktree}: ${reason}\n`);
+  }
+}
+
+/**
+ * List all worktrees for a repository.
+ */
+export async function listGitWorktrees(repoCwd: string): Promise<string[]> {
+  try {
+    const { stdout } = await git(repoCwd, ["worktree", "list", "--porcelain"]);
+    return stdout
+      .split("\n")
+      .filter((line) => line.startsWith("worktree "))
+      .map((line) => line.slice("worktree ".length));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Prune stale worktrees whose directories no longer exist.
+ */
+export async function pruneGitWorktrees(repoCwd: string): Promise<void> {
+  try {
+    await git(repoCwd, ["worktree", "prune"]);
+  } catch {
+    // Non-fatal
+  }
+}
+
+/**
+ * Build a sanitized slug from an agent name, suitable for branch names.
+ */
+export function agentSlug(agentName: string): string {
+  return agentName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 40);
+}
+
+/**
+ * Build the standard worktree path for a Paperclip agent run.
+ */
+export function worktreePath(repoCwd: string, agentName: string, runId: string): string {
+  const slug = agentSlug(agentName);
+  const shortRun = runId.slice(0, 8);
+  return path.join(path.dirname(repoCwd), `.paperclip-worktrees`, `${slug}-${shortRun}`);
+}
+
+/**
+ * Build the standard branch name for a Paperclip agent run.
+ */
+export function worktreeBranch(agentName: string, taskId: string | null): string {
+  const slug = agentSlug(agentName);
+  const suffix = taskId ? taskId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 20) : "general";
+  return `paperclip/${slug}/${suffix}`;
+}
+
+/**
+ * Detect whether `dir` is inside a `.paperclip-worktrees` directory.
+ */
+export function isPaperclipWorktree(dir: string): boolean {
+  return dir.includes(`${path.sep}.paperclip-worktrees${path.sep}`) ||
+    dir.includes("/.paperclip-worktrees/");
+}
+
+/**
+ * Remove all Paperclip worktrees for a specific agent from a repository.
+ *
+ * Scans the `.paperclip-worktrees` directory next to `repoCwd` and removes
+ * any worktree whose directory name starts with the agent's slug.
+ */
+export async function cleanupAgentWorktrees(opts: {
+  repoCwd: string;
+  agentName: string;
+  onLog: (stream: "stdout" | "stderr", msg: string) => Promise<void>;
+}): Promise<number> {
+  const { repoCwd, agentName, onLog } = opts;
+  const slug = agentSlug(agentName);
+  const worktreesDir = path.join(path.dirname(repoCwd), ".paperclip-worktrees");
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(worktreesDir);
+  } catch {
+    return 0;
+  }
+
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.startsWith(slug)) continue;
+    const wtPath = path.join(worktreesDir, entry);
+    try {
+      await removeGitWorktree({ repoCwd, worktreePath: wtPath, onLog });
+      removed++;
+    } catch {
+      // Non-fatal; worktree may already be gone
+    }
+  }
+
+  await pruneGitWorktrees(repoCwd);
+  return removed;
+}

--- a/packages/adapter-utils/src/git-worktree.ts
+++ b/packages/adapter-utils/src/git-worktree.ts
@@ -24,6 +24,8 @@ export interface WorktreeOptions {
 export interface WorktreeRemoveOptions {
   repoCwd: string;
   worktreePath: string;
+  /** If provided, the branch is deleted after the worktree is removed. */
+  deleteBranch?: { branchName: string };
   onLog: (stream: "stdout" | "stderr", msg: string) => Promise<void>;
 }
 
@@ -62,11 +64,16 @@ export async function ensureGitWorktree(opts: WorktreeOptions): Promise<Worktree
   const { repoCwd, branchName, worktreePath, baseBranch, onLog } = opts;
   const absWorktree = path.resolve(repoCwd, worktreePath);
 
-  // Check if worktree already exists at this path
-  const worktreeExists = await fs
-    .stat(path.join(absWorktree, ".git"))
-    .then(() => true)
-    .catch(() => false);
+  // Check if worktree already exists by querying git directly.
+  // Resolve symlinks (e.g., /tmp → /private/tmp on macOS) for reliable comparison.
+  const existingWorktrees = await listGitWorktrees(repoCwd);
+  const realAbsWorktree = await fs.realpath(path.dirname(absWorktree)).then(
+    (real) => path.join(real, path.basename(absWorktree)),
+    () => absWorktree,
+  );
+  const worktreeExists = existingWorktrees.some(
+    (wt) => path.resolve(wt) === realAbsWorktree,
+  );
 
   if (worktreeExists) {
     await onLog("stderr", `[paperclip] Reusing existing worktree at ${absWorktree}\n`);
@@ -101,10 +108,10 @@ export async function ensureGitWorktree(opts: WorktreeOptions): Promise<Worktree
 }
 
 /**
- * Remove a git worktree and optionally delete its branch.
+ * Remove a git worktree. Optionally delete the associated branch via `deleteBranch`.
  */
 export async function removeGitWorktree(opts: WorktreeRemoveOptions): Promise<void> {
-  const { repoCwd, worktreePath, onLog } = opts;
+  const { repoCwd, worktreePath, deleteBranch, onLog } = opts;
   const absWorktree = path.resolve(repoCwd, worktreePath);
 
   try {
@@ -113,6 +120,15 @@ export async function removeGitWorktree(opts: WorktreeRemoveOptions): Promise<vo
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     await onLog("stderr", `[paperclip] Warning: failed to remove worktree at ${absWorktree}: ${reason}\n`);
+  }
+
+  if (deleteBranch) {
+    try {
+      await git(repoCwd, ["branch", "-d", deleteBranch.branchName]);
+      await onLog("stderr", `[paperclip] Deleted branch ${deleteBranch.branchName}\n`);
+    } catch {
+      // Non-fatal: branch may still have unmerged changes or already be gone
+    }
   }
 }
 
@@ -146,11 +162,12 @@ export async function pruneGitWorktrees(repoCwd: string): Promise<void> {
  * Build a sanitized slug from an agent name, suitable for branch names.
  */
 export function agentSlug(agentName: string): string {
-  return agentName
+  const slug = agentName
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 40);
+  return slug || "agent";
 }
 
 /**
@@ -159,7 +176,8 @@ export function agentSlug(agentName: string): string {
 export function worktreePath(repoCwd: string, agentName: string, runId: string): string {
   const slug = agentSlug(agentName);
   const shortRun = runId.slice(0, 8);
-  return path.join(path.dirname(repoCwd), `.paperclip-worktrees`, `${slug}-${shortRun}`);
+  const normalizedRoot = path.resolve(repoCwd);
+  return path.join(path.dirname(normalizedRoot), `.paperclip-worktrees`, `${slug}-${shortRun}`);
 }
 
 /**
@@ -169,50 +187,4 @@ export function worktreeBranch(agentName: string, taskId: string | null): string
   const slug = agentSlug(agentName);
   const suffix = taskId ? taskId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 20) : "general";
   return `paperclip/${slug}/${suffix}`;
-}
-
-/**
- * Detect whether `dir` is inside a `.paperclip-worktrees` directory.
- */
-export function isPaperclipWorktree(dir: string): boolean {
-  return dir.includes(`${path.sep}.paperclip-worktrees${path.sep}`) ||
-    dir.includes("/.paperclip-worktrees/");
-}
-
-/**
- * Remove all Paperclip worktrees for a specific agent from a repository.
- *
- * Scans the `.paperclip-worktrees` directory next to `repoCwd` and removes
- * any worktree whose directory name starts with the agent's slug.
- */
-export async function cleanupAgentWorktrees(opts: {
-  repoCwd: string;
-  agentName: string;
-  onLog: (stream: "stdout" | "stderr", msg: string) => Promise<void>;
-}): Promise<number> {
-  const { repoCwd, agentName, onLog } = opts;
-  const slug = agentSlug(agentName);
-  const worktreesDir = path.join(path.dirname(repoCwd), ".paperclip-worktrees");
-
-  let entries: string[];
-  try {
-    entries = await fs.readdir(worktreesDir);
-  } catch {
-    return 0;
-  }
-
-  let removed = 0;
-  for (const entry of entries) {
-    if (!entry.startsWith(slug)) continue;
-    const wtPath = path.join(worktreesDir, entry);
-    try {
-      await removeGitWorktree({ repoCwd, worktreePath: wtPath, onLog });
-      removed++;
-    } catch {
-      // Non-fatal; worktree may already be gone
-    }
-  }
-
-  await pruneGitWorktrees(repoCwd);
-  return removed;
 }

--- a/packages/adapter-utils/src/git-worktree.ts
+++ b/packages/adapter-utils/src/git-worktree.ts
@@ -88,6 +88,11 @@ export async function ensureGitWorktree(opts: WorktreeOptions): Promise<Worktree
   // Ensure parent directory exists
   await fs.mkdir(path.dirname(absWorktree), { recursive: true });
 
+  // Prune stale worktree bookkeeping before adding. If a previous worktree
+  // directory was deleted without `git worktree remove`, the branch is still
+  // recorded as checked-out and `worktree add` will fail.
+  await pruneGitWorktrees(repoCwd);
+
   try {
     if (branchExists) {
       // Branch exists but no worktree — attach worktree to existing branch
@@ -171,13 +176,24 @@ export function agentSlug(agentName: string): string {
 }
 
 /**
- * Build the standard worktree path for a Paperclip agent run.
+ * Sanitize a task/issue ID into a suffix safe for branch names and paths.
+ * Returns `"general"` when no ID is provided.
  */
-export function worktreePath(repoCwd: string, agentName: string, runId: string): string {
+export function taskSuffix(taskId: string | null | undefined): string {
+  if (!taskId || taskId.trim().length === 0) return "general";
+  return taskId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 20);
+}
+
+/**
+ * Build the standard worktree directory path for a Paperclip agent run.
+ *
+ * The worktree is placed next to the repo root under `.paperclip-worktrees/`.
+ */
+export function worktreeDir(repoCwd: string, agentName: string, taskId: string | null): string {
   const slug = agentSlug(agentName);
-  const shortRun = runId.slice(0, 8);
+  const suffix = taskSuffix(taskId);
   const normalizedRoot = path.resolve(repoCwd);
-  return path.join(path.dirname(normalizedRoot), `.paperclip-worktrees`, `${slug}-${shortRun}`);
+  return path.join(path.dirname(normalizedRoot), `.paperclip-worktrees`, `${slug}-${suffix}`);
 }
 
 /**
@@ -185,6 +201,13 @@ export function worktreePath(repoCwd: string, agentName: string, runId: string):
  */
 export function worktreeBranch(agentName: string, taskId: string | null): string {
   const slug = agentSlug(agentName);
-  const suffix = taskId ? taskId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 20) : "general";
+  const suffix = taskSuffix(taskId);
   return `paperclip/${slug}/${suffix}`;
+}
+
+/**
+ * Check whether a directory path looks like a Paperclip-managed worktree.
+ */
+export function isPaperclipWorktree(dir: string): boolean {
+  return path.resolve(dir).includes(`${path.sep}.paperclip-worktrees${path.sep}`);
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -25,8 +25,8 @@ import {
   isGitRepository,
   gitRepoRoot,
   ensureGitWorktree,
-  agentSlug,
   worktreeBranch,
+  worktreeDir,
   isPaperclipWorktree,
 } from "@paperclipai/adapter-utils/git-worktree";
 import { secretService } from "./secrets.js";
@@ -1125,9 +1125,7 @@ export function heartbeatService(db: Db) {
           const repoRoot = await gitRepoRoot(baseCwd);
           const issueId = readNonEmptyString(context.issueId);
           const branch = worktreeBranch(agent.name, issueId);
-          const slug = agentSlug(agent.name);
-          const suffix = issueId ? issueId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 20) : "general";
-          const wtPath = path.join(path.dirname(repoRoot), ".paperclip-worktrees", `${slug}-${suffix}`);
+          const wtPath = worktreeDir(repoRoot, agent.name, issueId);
           const wt = await ensureGitWorktree({
             repoCwd: repoRoot,
             branchName: branch,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21,6 +21,14 @@ import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import {
+  isGitRepository,
+  gitRepoRoot,
+  ensureGitWorktree,
+  agentSlug,
+  worktreeBranch,
+  isPaperclipWorktree,
+} from "@paperclipai/adapter-utils/git-worktree";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 
@@ -76,11 +84,12 @@ interface ParsedIssueAssigneeAdapterOverrides {
 
 export type ResolvedWorkspaceForRun = {
   cwd: string;
-  source: "project_primary" | "task_session" | "agent_home";
+  source: "project_primary" | "task_session" | "agent_home" | "worktree";
   projectId: string | null;
   workspaceId: string | null;
   repoUrl: string | null;
   repoRef: string | null;
+  worktreeBranch: string | null;
   workspaceHints: Array<{
     workspaceId: string;
     cwd: string | null;
@@ -537,6 +546,7 @@ export function heartbeatService(db: Db) {
             workspaceId: workspace.id,
             repoUrl: workspace.repoUrl,
             repoRef: workspace.repoRef,
+            worktreeBranch: null,
             workspaceHints,
             warnings: [],
           };
@@ -567,6 +577,7 @@ export function heartbeatService(db: Db) {
         workspaceId: projectWorkspaceRows[0]?.id ?? null,
         repoUrl: projectWorkspaceRows[0]?.repoUrl ?? null,
         repoRef: projectWorkspaceRows[0]?.repoRef ?? null,
+        worktreeBranch: null,
         workspaceHints,
         warnings,
       };
@@ -586,6 +597,7 @@ export function heartbeatService(db: Db) {
           workspaceId: readNonEmptyString(previousSessionParams?.workspaceId),
           repoUrl: readNonEmptyString(previousSessionParams?.repoUrl),
           repoRef: readNonEmptyString(previousSessionParams?.repoRef),
+          worktreeBranch: readNonEmptyString(previousSessionParams?.worktreeBranch),
           workspaceHints,
           warnings: [],
         };
@@ -615,6 +627,7 @@ export function heartbeatService(db: Db) {
       workspaceId: null,
       repoUrl: null,
       repoRef: null,
+      worktreeBranch: null,
       workspaceHints,
       warnings,
     };
@@ -1093,12 +1106,52 @@ export function heartbeatService(db: Db) {
     const previousSessionParams = normalizeSessionParams(
       sessionCodec.deserialize(taskSessionForRun?.sessionParamsJson ?? null),
     );
-    const resolvedWorkspace = await resolveWorkspaceForRun(
+    let resolvedWorkspace = await resolveWorkspaceForRun(
       agent,
       context,
       previousSessionParams,
       { useProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null },
     );
+
+    // Worktree isolation: when enabled in adapter config, wrap the resolved cwd
+    // in a dedicated git worktree so each agent+task gets its own working copy.
+    // This applies to ALL adapters (codex-local, claude-local, cursor-local, etc.).
+    const adapterConfig = parseObject(agent.adapterConfig);
+    if (asBoolean(adapterConfig.worktreeIsolation, false)) {
+      const baseCwd = resolvedWorkspace.cwd;
+      const isRepo = await isGitRepository(baseCwd);
+      if (isRepo && !isPaperclipWorktree(baseCwd)) {
+        try {
+          const repoRoot = await gitRepoRoot(baseCwd);
+          const issueId = readNonEmptyString(context.issueId);
+          const branch = worktreeBranch(agent.name, issueId);
+          const slug = agentSlug(agent.name);
+          const suffix = issueId ? issueId.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 20) : "general";
+          const wtPath = path.join(path.dirname(repoRoot), ".paperclip-worktrees", `${slug}-${suffix}`);
+          const wt = await ensureGitWorktree({
+            repoCwd: repoRoot,
+            branchName: branch,
+            worktreePath: wtPath,
+            onLog: async (_stream, msg) => {
+              logger.info({ runId, agentId: agent.id }, msg.trim());
+            },
+          });
+          resolvedWorkspace = {
+            ...resolvedWorkspace,
+            cwd: wt.cwd,
+            source: "worktree",
+            worktreeBranch: wt.branch,
+          };
+        } catch (wtErr) {
+          const reason = wtErr instanceof Error ? wtErr.message : String(wtErr);
+          resolvedWorkspace.warnings.push(
+            `Failed to create worktree for agent "${agent.name}": ${reason}. Running in original workspace.`,
+          );
+          logger.warn({ err: wtErr, runId, agentId: agent.id }, "worktree creation failed; falling back");
+        }
+      }
+    }
+
     const runtimeSessionResolution = resolveRuntimeSessionParamsForWorkspace({
       agentId: agent.id,
       previousSessionParams,
@@ -1123,6 +1176,7 @@ export function heartbeatService(db: Db) {
       workspaceId: resolvedWorkspace.workspaceId,
       repoUrl: resolvedWorkspace.repoUrl,
       repoRef: resolvedWorkspace.repoRef,
+      ...(resolvedWorkspace.worktreeBranch ? { worktreeBranch: resolvedWorkspace.worktreeBranch } : {}),
     };
     context.paperclipWorkspaces = resolvedWorkspace.workspaceHints;
     if (resolvedWorkspace.projectId && !readNonEmptyString(context.projectId)) {


### PR DESCRIPTION
## Summary

Adds opt-in git worktree isolation at the **server level**, so every adapter (codex-local, claude-local, cursor-local, opencode-local, and future adapters) automatically benefits without any adapter-specific changes.

When `worktreeIsolation: true` is set in an agent's adapter config, the heartbeat service creates a dedicated git worktree during workspace resolution — before the adapter's `execute()` is called. Each agent+issue combination gets its own worktree directory and branch.

### Changes

- **`server/src/services/heartbeat.ts`** — after `resolveWorkspaceForRun()`, wraps the resolved cwd in a git worktree when `worktreeIsolation` is enabled
- **`ResolvedWorkspaceForRun`** — new `"worktree"` source type and `worktreeBranch` field
- **Context propagation** — `worktreeBranch` flows through `context.paperclipWorkspace` to adapters
- **`@paperclipai/adapter-utils/git-worktree`** — shared utility module for worktree operations

### How it works

```
Agent Config: { "worktreeIsolation": true }

                    ┌─────────────────────────┐
                    │  heartbeat.ts            │
                    │  resolveWorkspaceForRun  │
                    │  ↓                       │
                    │  cwd: /repo              │
                    │  ↓ worktreeIsolation     │
                    │  cwd: ../.paperclip-     │
                    │    worktrees/agent-A-3   │
                    └────────────┬────────────┘
                                 │
              ┌──────────────────┼──────────────────┐
              ▼                  ▼                   ▼
        codex-local       claude-local        cursor-local
        (no changes)      (no changes)        (no changes)
```

### Key behaviors

| Behavior | Detail |
|----------|--------|
| Worktree path | `../.paperclip-worktrees/<agent-slug>-<issue-id>` |
| Branch name | `paperclip/<agent-slug>/<issue-id>` |
| Idempotent | Reuses existing worktrees/branches across runs |
| Already in worktree | Skips (detects `.paperclip-worktrees` in path) |
| Not a git repo | Skips silently with warning |
| Creation failure | Falls back to original cwd with logged warning |
| Default | Off (`worktreeIsolation` defaults to `false`) |

### Example

Agent "Founding Engineer" assigned to issue "A-3":
- Directory: `/home/user/.paperclip-worktrees/founding-engineer-A-3`
- Branch: `paperclip/founding-engineer/A-3`

Part of RFC #175.

## Test plan

- [x] `tsc --noEmit` passes for `@paperclipai/server` and `@paperclipai/adapter-utils`
- [x] Existing server tests pass (9/9)
- [x] Manual E2E: worktree create → reuse → list → remove verified
- [ ] Integration test with live agent (set `worktreeIsolation: true` in adapter config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)