### PR TITLE
fix: surface actionable message for EBADF spawn error

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -276,7 +276,9 @@ export async function runChildProcess(
       const msg =
         errno === "ENOENT"
           ? `Failed to start command "${command}" in "${opts.cwd}". Verify adapter command, working directory, and PATH (${pathValue}).`
-          : `Failed to start command "${command}" in "${opts.cwd}": ${err.message}`;
+          : errno === "EBADF"
+            ? `Failed to start command "${command}": bad file descriptor (EBADF). The server process has accumulated stale file descriptors — restarting Paperclip should resolve this.`
+            : `Failed to start command "${command}" in "${opts.cwd}": ${err.message}`;
       reject(new Error(msg));
     });
 


### PR DESCRIPTION
Closes #174

## Problem

When the Paperclip server process accumulates stale file descriptors after extended uptime, `spawn` fails with `EBADF` (Bad File Descriptor). This previously fell through to a generic error message:

```
Failed to start command "claude" in "/...": spawn EBADF
```

No indication of cause or fix. Users are left guessing.

## Fix

Add `EBADF` as a specifically handled error code in the `runChildProcess` error handler, following the same pattern as the existing `ENOENT` special-case:

```
Failed to start command "claude": bad file descriptor (EBADF).
The server process has accumulated stale file descriptors — restarting Paperclip should resolve this.
```

## Scope

`runChildProcess` in `packages/adapter-utils` is the single spawn point used by all spawn-based adapters (`claude_local`, `codex_local`, `opencode_local`, `cursor`, `process`). One fix covers all of them.

The root cause (fd accumulation in the server process) is a Node.js / pnpm dev process lifetime issue that is outside Paperclip's control to prevent. Surfacing a clear, actionable message is the appropriate response.