### PR TITLE
fix: child issues inherit projectId and goalId from parent

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1080,13 +1080,6 @@ export function issueService(db: Db) {
       companyId: string,
       data: IssueCreateInput,
     ) => {
-      const { labelIds: inputLabelIds, inheritExecutionWorkspaceFromIssueId, ...issueData } = data;
-      const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
-      if (!isolatedWorkspacesEnabled) {
-        delete issueData.executionWorkspaceId;
-        delete issueData.executionWorkspacePreference;
-        delete issueData.executionWorkspaceSettings;
-      }
       if (data.assigneeAgentId && data.assigneeUserId) {
         throw unprocessable("Issue can only have one assignee");
       }
@@ -1099,13 +1092,23 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      // Auto-inherit projectId and goalId from parent when not explicitly provided
-      if (data.parentId && !data.projectId && !data.goalId) {
+      // Auto-inherit projectId and goalId from parent when not explicitly provided.
+      // Use || so each field is inherited independently — an explicit projectId still
+      // allows goalId to be inherited, and vice versa.
+      if (data.parentId && (!data.projectId || !data.goalId)) {
         const [parent] = await db.select().from(issues).where(eq(issues.id, data.parentId));
         if (parent) {
           if (parent.projectId && !data.projectId) data = { ...data, projectId: parent.projectId };
           if (parent.goalId && !data.goalId) data = { ...data, goalId: parent.goalId };
         }
+      }
+      // Destructure AFTER inheritance so issueData includes any inherited fields.
+      const { labelIds: inputLabelIds, inheritExecutionWorkspaceFromIssueId, ...issueData } = data;
+      const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
+      if (!isolatedWorkspacesEnabled) {
+        delete issueData.executionWorkspaceId;
+        delete issueData.executionWorkspacePreference;
+        delete issueData.executionWorkspaceSettings;
       }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1099,6 +1099,14 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      // Auto-inherit projectId and goalId from parent when not explicitly provided
+      if (data.parentId && !data.projectId && !data.goalId) {
+        const [parent] = await db.select().from(issues).where(eq(issues.id, data.parentId));
+        if (parent) {
+          if (parent.projectId && !data.projectId) data = { ...data, projectId: parent.projectId };
+          if (parent.goalId && !data.goalId) data = { ...data, goalId: parent.goalId };
+        }
+      }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);


### PR DESCRIPTION
## Problem

Sub-issues created with a `parentId` but without an explicit `projectId` are silently dropped from project issue lists. They exist in the database with the correct `parentId` but have `projectId: null`, making them invisible in the project issues view (`/projects/{id}/issues`).

This is particularly painful for agent workflows — when an agent creates child issues (e.g. bug reports under a QA task), those bugs don't appear where the user expects them.

## Root Cause

`issues.create()` inserts child issues without looking up the parent's `projectId` or `goalId`. There's no inheritance logic.

## Fix

Before inserting, if `parentId` is set and `projectId`/`goalId` are not explicitly provided, look up the parent and inherit those values:

```ts
if (data.parentId && !data.projectId && !data.goalId) {
  const [parent] = await db.select().from(issues).where(eq(issues.id, data.parentId));
  if (parent) {
    if (parent.projectId && !data.projectId) data = { ...data, projectId: parent.projectId };
    if (parent.goalId && !data.goalId) data = { ...data, goalId: parent.goalId };
  }
}
```

Callers that explicitly pass `projectId` are unaffected (explicit always wins).

## Repro

1. Create an issue in a project (e.g. SignUpSpark)
2. Create a child issue via API with only `parentId` set, no `projectId`
3. Navigate to the project issues list
4. **Before:** child issue missing from list
5. **After:** child issue appears under the parent's project