### PR TITLE
fix(openclaw): auto-use webhook transport for /hooks/* endpoints

### DIFF
--- a/packages/adapters/openclaw/README.md
+++ b/packages/adapters/openclaw/README.md
@@ -16,7 +16,7 @@ Configured via `adapterConfig.streamTransport` (or legacy `adapterConfig.transpo
 | streamTransport | configured URL path | behavior |
 | --- | --- | --- |
 | `sse` | `/v1/responses` | Sends OpenResponses request with `stream: true`, expects `text/event-stream` response until terminal event. |
-| `sse` | `/hooks/*` | Rejected (`openclaw_sse_incompatible_endpoint`). Hooks are not stream-capable. |
+| `sse` | `/hooks/*` | Automatically rerouted to webhook transport (fire-and-forget HTTP). A log line is emitted to indicate the override. |
 | `sse` | other endpoint | Sends generic streaming payload (`stream: true`, `text`, `paperclip`) and expects SSE response. |
 | `webhook` | `/hooks/wake` | Sends wake payload `{ text, mode }`. |
 | `webhook` | `/hooks/agent` | Sends agent payload `{ message, ...hook fields }`. |

--- a/packages/adapters/openclaw/src/server/execute.ts
+++ b/packages/adapters/openclaw/src/server/execute.ts
@@ -35,14 +35,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   }
 
+  // /hooks/* endpoints (e.g. /hooks/wake, /hooks/agent) are fire-and-forget HTTP;
+  // they do not support SSE streaming. Automatically fall back to webhook transport
+  // so users don't need to set `transport: "webhook"` manually when using these URLs.
   if (transport === "sse" && isHookEndpoint(url)) {
-    return {
-      exitCode: 1,
-      signal: null,
-      timedOut: false,
-      errorMessage: "OpenClaw /hooks/* endpoints are not stream-capable. Use webhook transport for hooks.",
-      errorCode: "openclaw_sse_incompatible_endpoint",
-    };
+    return executeWebhook(ctx, url);
   }
 
   if (transport === "webhook") {

--- a/packages/adapters/openclaw/src/server/execute.ts
+++ b/packages/adapters/openclaw/src/server/execute.ts
@@ -39,6 +39,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   // they do not support SSE streaming. Automatically fall back to webhook transport
   // so users don't need to set `transport: "webhook"` manually when using these URLs.
   if (transport === "sse" && isHookEndpoint(url)) {
+    await ctx.onLog("stdout", "[openclaw] hook endpoint detected; using webhook transport (fire-and-forget)\n");
     return executeWebhook(ctx, url);
   }
 

--- a/server/src/__tests__/openclaw-adapter.test.ts
+++ b/server/src/__tests__/openclaw-adapter.test.ts
@@ -870,8 +870,10 @@ describe("openclaw adapter execute", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects /hooks/wake compatibility endpoints in SSE mode", async () => {
-    const fetchMock = vi.fn();
+  it("auto-routes /hooks/wake endpoints to webhook transport when SSE is default", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await execute(
@@ -880,13 +882,20 @@ describe("openclaw adapter execute", () => {
       }),
     );
 
-    expect(result.exitCode).toBe(1);
-    expect(result.errorCode).toBe("openclaw_sse_incompatible_endpoint");
-    expect(fetchMock).not.toHaveBeenCalled();
+    // Should succeed via webhook fallback, not reject with an error
+    expect(result.exitCode).toBe(0);
+    expect(result.errorCode).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agent.example/hooks/wake",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
-  it("rejects /hooks/agent endpoints in SSE mode", async () => {
-    const fetchMock = vi.fn();
+  it("auto-routes /hooks/agent endpoints to webhook transport when SSE is default", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await execute(
@@ -895,9 +904,13 @@ describe("openclaw adapter execute", () => {
       }),
     );
 
-    expect(result.exitCode).toBe(1);
-    expect(result.errorCode).toBe("openclaw_sse_incompatible_endpoint");
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    expect(result.errorCode).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agent.example/hooks/agent",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

When an OpenClaw agent is configured with a `/hooks/wake` or `/hooks/agent` URL and no explicit `transport` is set, the adapter defaults to SSE and immediately fails with `openclaw_sse_incompatible_endpoint`. This breaks all OpenClaw agents using the standard hook URLs out of the box — there's no way to fix it through the UI since the `transport` field isn't exposed in the agent config form.

## Root Cause

`normalizeTransport()` defaults to `"sse"` when no transport is configured. The subsequent check correctly identifies that hook endpoints don't support SSE — but instead of falling back gracefully, it returns an error.

## Fix

When SSE transport is selected but the URL is a hook endpoint, automatically route through webhook transport instead of erroring. The URL already encodes the correct transport — `/hooks/*` is unambiguously fire-and-forget HTTP. No user configuration needed.

```ts
// Before: hard error
if (transport === "sse" && isHookEndpoint(url)) {
  return { exitCode: 1, errorCode: "openclaw_sse_incompatible_endpoint", ... };
}

// After: silent fallback
if (transport === "sse" && isHookEndpoint(url)) {
  return executeWebhook(ctx, url);
}
```

## Impact

Anyone setting up an OpenClaw agent with `/hooks/wake` (the documented URL) and not explicitly setting `transport: "webhook"` would see silent failures on every heartbeat run. This affects the default out-of-the-box setup.