### PR TITLE
fix: SPA catch-all 500 + add bulk issues update API

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -136,12 +136,14 @@ export async function createApp(
         const indexPath = path.join(uiDist, "index.html");
         res.sendFile(indexPath, (err) => {
           if (err) {
+            if (res.headersSent) return;
             // Fallback: read and send index.html directly when sendFile fails
             // (e.g. certain SPA catch-all routes trigger sendFile errors)
             try {
               const html = fs.readFileSync(indexPath, "utf-8");
               res.status(200).set({ "Content-Type": "text/html" }).end(html);
             } catch {
+              if (res.headersSent) return;
               res.status(500).end();
             }
           }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -133,7 +133,19 @@ export async function createApp(
     if (uiDist) {
       app.use(express.static(uiDist));
       app.get(/.*/, (_req, res) => {
-        res.sendFile(path.join(uiDist, "index.html"));
+        const indexPath = path.join(uiDist, "index.html");
+        res.sendFile(indexPath, (err) => {
+          if (err) {
+            // Fallback: read and send index.html directly when sendFile fails
+            // (e.g. certain SPA catch-all routes trigger sendFile errors)
+            try {
+              const html = fs.readFileSync(indexPath, "utf-8");
+              res.status(200).set({ "Content-Type": "text/html" }).end(html);
+            } catch {
+              res.status(500).end();
+            }
+          }
+        });
       });
     } else {
       console.warn("[paperclip] UI dist not found; running in API-only mode");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
+import { z } from "zod";
 import type { Db } from "@paperclipai/db";
 import {
   addIssueCommentSchema,
@@ -182,6 +183,79 @@ export function issueRoutes(db: Db, storage: StorageService) {
     } catch (err) {
       next(err);
     }
+  });
+
+  // ── Bulk update issues ───────────────────────────────────────────────
+  const bulkUpdateIssuesSchema = z.object({
+    issueIds: z.array(z.string().min(1)).min(1).max(100),
+    data: updateIssueSchema.omit({ comment: true, hiddenAt: true }),
+  });
+
+  router.patch("/issues/bulk", async (req, res) => {
+    const parsed = bulkUpdateIssuesSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid request body", details: parsed.error.issues });
+      return;
+    }
+    const { issueIds: rawIds, data } = parsed.data;
+
+    // Normalise identifiers (e.g. "PAP-39") to UUIDs
+    const issueIds = await Promise.all(rawIds.map(normalizeIssueIdentifier));
+
+    // Fetch all issues to verify they exist and belong to the same company
+    const issues = await Promise.all(issueIds.map((id) => svc.getById(id)));
+    const missing = issueIds.filter((_, i) => !issues[i]);
+    if (missing.length > 0) {
+      res.status(404).json({ error: "Issues not found", issueIds: missing });
+      return;
+    }
+
+    // All issues must belong to the same company
+    const companyIds = new Set(issues.map((issue) => issue!.companyId));
+    if (companyIds.size !== 1) {
+      res.status(422).json({ error: "All issues must belong to the same company" });
+      return;
+    }
+    const companyId = [...companyIds][0]!;
+    assertCompanyAccess(req, companyId);
+
+    // Check assignment permission if assignee is being changed
+    if (data.assigneeAgentId !== undefined || data.assigneeUserId !== undefined) {
+      await assertCanAssignTasks(req, companyId);
+    }
+
+    const actor = getActorInfo(req);
+    const results = [];
+    for (const issue of issues) {
+      const updated = await svc.update(issue!.id, data);
+      if (updated) {
+        const previous: Record<string, unknown> = {};
+        for (const key of Object.keys(data)) {
+          if (key in issue! && (issue as Record<string, unknown>)[key] !== (data as Record<string, unknown>)[key]) {
+            previous[key] = (issue as Record<string, unknown>)[key];
+          }
+        }
+        await logActivity(db, {
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "issue.updated",
+          entityType: "issue",
+          entityId: updated.id,
+          details: {
+            ...data,
+            identifier: updated.identifier,
+            _previous: Object.keys(previous).length > 0 ? previous : undefined,
+            bulkUpdate: true,
+          },
+        });
+        results.push(updated);
+      }
+    }
+
+    res.json({ updated: results.length, issues: results });
   });
 
   router.get("/companies/:companyId/issues", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -187,6 +187,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   // ── Bulk update issues ───────────────────────────────────────────────
   const bulkUpdateIssuesSchema = z.object({
+    companyId: z.string().min(1),
     issueIds: z.array(z.string().min(1)).min(1).max(100),
     data: updateIssueSchema.omit({ comment: true, hiddenAt: true }),
   });
@@ -197,12 +198,20 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: "Invalid request body", details: parsed.error.issues });
       return;
     }
-    const { issueIds: rawIds, data } = parsed.data;
+    const { companyId, issueIds: rawIds, data } = parsed.data;
+
+    // ── Access check FIRST (before any DB lookups) ──────────────────
+    assertCompanyAccess(req, companyId);
+
+    // Check assignment permission early if assignee is being changed
+    if (data.assigneeAgentId !== undefined || data.assigneeUserId !== undefined) {
+      await assertCanAssignTasks(req, companyId);
+    }
 
     // Normalise identifiers (e.g. "PAP-39") to UUIDs
     const issueIds = await Promise.all(rawIds.map(normalizeIssueIdentifier));
 
-    // Fetch all issues to verify they exist and belong to the same company
+    // Fetch all issues to verify they exist and belong to the stated company
     const issues = await Promise.all(issueIds.map((id) => svc.getById(id)));
     const missing = issueIds.filter((_, i) => !issues[i]);
     if (missing.length > 0) {
@@ -210,25 +219,28 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
 
-    // All issues must belong to the same company
-    const companyIds = new Set(issues.map((issue) => issue!.companyId));
-    if (companyIds.size !== 1) {
-      res.status(422).json({ error: "All issues must belong to the same company" });
+    // All issues must belong to the declared company
+    const mismatch = issues.filter((issue) => issue!.companyId !== companyId);
+    if (mismatch.length > 0) {
+      res.status(422).json({
+        error: "All issues must belong to the specified company",
+        issueIds: mismatch.map((i) => i!.id),
+      });
       return;
-    }
-    const companyId = [...companyIds][0]!;
-    assertCompanyAccess(req, companyId);
-
-    // Check assignment permission if assignee is being changed
-    if (data.assigneeAgentId !== undefined || data.assigneeUserId !== undefined) {
-      await assertCanAssignTasks(req, companyId);
     }
 
     const actor = getActorInfo(req);
-    const results = [];
+    const results: Array<typeof issues[number]> = [];
+    const failed: Array<{ issueId: string; error: string }> = [];
+
     for (const issue of issues) {
-      const updated = await svc.update(issue!.id, data);
-      if (updated) {
+      try {
+        const updated = await svc.update(issue!.id, data);
+        if (!updated) {
+          failed.push({ issueId: issue!.id, error: "update_returned_null" });
+          continue;
+        }
+
         const previous: Record<string, unknown> = {};
         for (const key of Object.keys(data)) {
           if (key in issue! && (issue as Record<string, unknown>)[key] !== (data as Record<string, unknown>)[key]) {
@@ -252,10 +264,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
           },
         });
         results.push(updated);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "unknown_error";
+        failed.push({ issueId: issue!.id, error: message });
       }
     }
 
-    res.json({ updated: results.length, issues: results });
+    res.json({ updated: results.length, failed, issues: results });
   });
 
   router.get("/companies/:companyId/issues", async (req, res) => {


### PR DESCRIPTION
## Summary

This PR includes two improvements:

### 1. Fix SPA catch-all route 500 error (fixes #189)

**File:** `server/src/app.ts`

When serving the SPA in static mode, `res.sendFile()` can fail on certain catch-all routes (e.g. deep-linked SPA paths), causing a 500 error returned to the client.

**Fix:** Added an error callback to `sendFile()` that falls back to reading `index.html` directly via `fs.readFileSync()` and sending it manually. This ensures SPA routing always works regardless of the path.

### 2. Add bulk issues update API

**File:** `server/src/routes/issues.ts`

Added `PATCH /api/issues/bulk` endpoint for updating multiple issues in a single request.

**Request body:**
```json
{
  "issueIds": ["uuid-1", "PAP-39", "uuid-2"],
  "data": {
    "status": "in_progress",
    "priority": "high",
    "assigneeAgentId": "agent-uuid"
  }
}
```

**Features:**
- Accepts UUIDs or human-readable identifiers (e.g. `PAP-39`)
- Validates data against existing `updateIssueSchema`
- Enforces company access checks (all issues must belong to the same company)
- Checks `tasks:assign` permission when assignee fields are changed
- Logs activity for each updated issue with `bulkUpdate: true` flag
- Supports up to 100 issues per request

**Typecheck:** `pnpm -r typecheck` passes (excluding pre-existing `cursor-local` adapter errors on master)