### PR TITLE
fix(api): return 404 for unknown /api routes

### DIFF
--- a/server/src/__tests__/api-not-found.test.ts
+++ b/server/src/__tests__/api-not-found.test.ts
@@ -19,5 +19,7 @@ describe("unmatched API routes", () => {
 
     expect(res.status).toBe(404);
     expect(res.status).not.toBe(500);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body).toMatchObject({ error: "Not found", path: "/api/issues" });
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -122,7 +122,7 @@ export async function createApp(
   );
   app.use("/api", api);
   app.use("/api", (req, res) => {
-    res.status(404).json({ error: "Not found", path: req.originalUrl });
+    res.status(404).json({ error: "Not found", path: req.originalUrl.split("?")[0] });
   });
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- add an explicit `/api` catch-all after API route mounts
- return JSON 404 for unmatched API paths instead of falling through to Vite middleware
- add a regression test for `GET /api/issues?assigneeId=...` in `vite-dev` mode

## Testing
- `pnpm test:run server/src/__tests__/companies-route-path-guard.test.ts server/src/__tests__/api-not-found.test.ts`

Fixes #193