### PR TITLE
fix(sidebar-badges): include approvals in inbox badge count

### DIFF
--- a/server/src/routes/sidebar-badges.ts
+++ b/server/src/routes/sidebar-badges.ts
@@ -45,7 +45,7 @@ export function sidebarBadgeRoutes(db: Db) {
     const alertsCount =
       (summary.agents.error > 0 && !hasFailedRuns ? 1 : 0) +
       (summary.costs.monthBudgetCents > 0 && summary.costs.monthUtilizationPercent >= 80 ? 1 : 0);
-    badges.inbox = badges.failedRuns + alertsCount + staleIssueCount + joinRequestCount;
+    badges.inbox = badges.failedRuns + alertsCount + staleIssueCount + joinRequestCount + badges.approvals;
 
     res.json(badges);
   });


### PR DESCRIPTION
## Summary

- Pending approvals (e.g. agent hire requests requiring board approval) were not included in the sidebar inbox badge count, so users had no visual indicator that approvals were waiting
- The root cause: the route handler in `sidebar-badges.ts` recalculates `badges.inbox` to add `alertsCount` and `staleIssueCount` (which the service layer doesn't know about), but in doing so it overwrites the service's value and drops `badges.approvals` from the sum
- Added `badges.approvals` back into the inbox count calculation

## The Problem

```
Service layer (correct):
  inbox = approvals + failedRuns + joinRequests  ✅

Route layer (bug — overwrites service value):
  inbox = failedRuns + alertsCount + staleIssueCount + joinRequests  ❌ approvals dropped

Route layer (fix):
  inbox = failedRuns + alertsCount + staleIssueCount + joinRequests + approvals  ✅
```

When `requireBoardApprovalForNewAgents` is enabled on a company, hiring an agent creates a pending approval. The user (as board member) must approve it before the agent can work. But without a badge on the Inbox, there's no way to know an approval is waiting unless you manually open the Inbox page.

## Test plan

- [ ] Enable "require board approval for new agents" on a company
- [ ] Trigger an agent hire that requires approval
- [ ] Verify the sidebar Inbox badge now shows a count reflecting the pending approval
- [ ] Verify approving/rejecting the request decrements the badge count
- [ ] Verify other inbox items (failed runs, alerts, stale work, join requests) still count correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)