### PR TITLE
feat: ACP adapter and Kiro CLI support

### DIFF
--- a/cli/src/adapters/acp/format-event.ts
+++ b/cli/src/adapters/acp/format-event.ts
@@ -1,0 +1,61 @@
+import chalk from "chalk";
+
+export function printAcpStdoutEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  try {
+    const parsed = JSON.parse(line);
+
+    if (parsed.type === "acp:initialized") {
+      const name = parsed.agent?.name ?? "ACP Agent";
+      console.log(chalk.dim(`[ACP] Connected to ${name}`));
+      return;
+    }
+    if (parsed.type === "acp:message") {
+      if (parsed.role === "agent" || parsed.role === "assistant") {
+        console.log(chalk.cyan(parsed.text));
+      } else {
+        console.log(chalk.gray(`[${parsed.role}] ${parsed.text}`));
+      }
+      return;
+    }
+    if (parsed.type === "acp:tool_call") {
+      console.log(chalk.yellow(`[tool] ${parsed.name}`));
+      return;
+    }
+    if (parsed.type === "acp:tool_update") {
+      console.log(chalk.dim(String(parsed.content ?? "")));
+      return;
+    }
+    if (parsed.type === "acp:artifact") {
+      console.log(chalk.green(parsed.text ?? ""));
+      return;
+    }
+    if (parsed.type === "acp:status") {
+      console.log(chalk.dim(`[ACP] Status: ${parsed.state}`));
+      return;
+    }
+
+    // Raw JSON-RPC
+    if (parsed.jsonrpc === "2.0" && parsed.method === "session/notification") {
+      const p = parsed.params ?? {};
+      if (p.type === "AgentMessageChunk") {
+        process.stdout.write(String(p.text ?? p.content ?? ""));
+        return;
+      }
+      if (p.type === "ToolCall") {
+        console.log(chalk.yellow(`[tool] ${p.name ?? p.toolName}`));
+        return;
+      }
+      if (p.type === "TurnEnd") {
+        console.log(chalk.dim("[ACP] Turn complete"));
+        return;
+      }
+    }
+  } catch {
+    // Not JSON
+  }
+
+  console.log(line);
+}

--- a/cli/src/adapters/acp/index.ts
+++ b/cli/src/adapters/acp/index.ts
@@ -1,0 +1,7 @@
+import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
+import { printAcpStdoutEvent } from "./format-event.js";
+
+export const acpCLIAdapter: CLIAdapterModule = {
+  type: "acp",
+  formatStdoutEvent: printAcpStdoutEvent,
+};

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -8,6 +8,11 @@ import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 import { acpCLIAdapter } from "./acp/index.js";
 
+const kiroCliCLIAdapter: CLIAdapterModule = {
+  type: "kiro_cli",
+  formatStdoutEvent: acpCLIAdapter.formatStdoutEvent,
+};
+
 const claudeLocalCLIAdapter: CLIAdapterModule = {
   type: "claude_local",
   formatStdoutEvent: printClaudeStreamEvent,
@@ -34,7 +39,7 @@ const openclawCLIAdapter: CLIAdapterModule = {
 };
 
 const adaptersByType = new Map<string, CLIAdapterModule>(
-  [claudeLocalCLIAdapter, codexLocalCLIAdapter, openCodeLocalCLIAdapter, cursorLocalCLIAdapter, openclawCLIAdapter, processCLIAdapter, httpCLIAdapter, acpCLIAdapter].map((a) => [a.type, a]),
+  [claudeLocalCLIAdapter, codexLocalCLIAdapter, openCodeLocalCLIAdapter, cursorLocalCLIAdapter, openclawCLIAdapter, processCLIAdapter, httpCLIAdapter, acpCLIAdapter, kiroCliCLIAdapter].map((a) => [a.type, a]),
 );
 
 export function getCLIAdapter(type: string): CLIAdapterModule {

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cl
 import { printOpenClawStreamEvent } from "@paperclipai/adapter-openclaw/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
+import { acpCLIAdapter } from "./acp/index.js";
 
 const claudeLocalCLIAdapter: CLIAdapterModule = {
   type: "claude_local",
@@ -33,7 +34,7 @@ const openclawCLIAdapter: CLIAdapterModule = {
 };
 
 const adaptersByType = new Map<string, CLIAdapterModule>(
-  [claudeLocalCLIAdapter, codexLocalCLIAdapter, openCodeLocalCLIAdapter, cursorLocalCLIAdapter, openclawCLIAdapter, processCLIAdapter, httpCLIAdapter].map((a) => [a.type, a]),
+  [claudeLocalCLIAdapter, codexLocalCLIAdapter, openCodeLocalCLIAdapter, cursorLocalCLIAdapter, openclawCLIAdapter, processCLIAdapter, httpCLIAdapter, acpCLIAdapter].map((a) => [a.type, a]),
 );
 
 export function getCLIAdapter(type: string): CLIAdapterModule {

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -19,5 +19,6 @@ export type {
   TranscriptEntry,
   StdoutLineParser,
   CLIAdapterModule,
+  AdapterCapabilities,
   CreateConfigValues,
 } from "./types.js";

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -187,6 +187,33 @@ export interface CLIAdapterModule {
 }
 
 // ---------------------------------------------------------------------------
+// Adapter UI capabilities — drives which config fields the form shows
+// ---------------------------------------------------------------------------
+
+export interface AdapterCapabilities {
+  /** Shows Command field in Permissions section */
+  command?: boolean;
+  /** Shows Model dropdown */
+  model?: boolean;
+  /** Shows Thinking Effort dropdown */
+  thinkingEffort?: boolean;
+  /** Shows Working Directory field */
+  cwd?: boolean;
+  /** Shows Prompt Template editor */
+  promptTemplate?: boolean;
+  /** Shows Bootstrap Prompt (first run) editor */
+  bootstrapPrompt?: boolean;
+  /** Shows Extra Args field */
+  extraArgs?: boolean;
+  /** Shows Environment Variables editor */
+  envVars?: boolean;
+  /** Shows Timeout field */
+  timeout?: boolean;
+  /** Shows Interrupt Grace Period field */
+  gracePeriod?: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // UI config form values (moved from ui/src/components/AgentConfigForm.tsx)
 // ---------------------------------------------------------------------------
 
@@ -208,6 +235,7 @@ export interface CreateConfigValues {
   envBindings: Record<string, unknown>;
   url: string;
   bootstrapPrompt: string;
+  timeoutSec: string;
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;
   intervalSec: number;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,6 +30,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw",
   "acp",
+  "kiro_cli",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -29,6 +29,7 @@ export const AGENT_ADAPTER_TYPES = [
   "opencode_local",
   "cursor",
   "openclaw",
+  "acp",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/server/src/adapters/acp-models.ts
+++ b/server/src/adapters/acp-models.ts
@@ -1,0 +1,160 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import type { AdapterModel } from "./types.js";
+import { asString, asStringArray, parseObject, ensurePathInEnv } from "./utils.js";
+
+const ACP_MODELS_TIMEOUT_MS = 15_000;
+const ACP_MODELS_CACHE_TTL_MS = 120_000;
+
+interface CacheEntry {
+  fingerprint: string;
+  expiresAt: number;
+  models: AdapterModel[];
+}
+
+let cached: CacheEntry | null = null;
+
+function fingerprint(command: string, args: string[]): string {
+  return `${command}:${args.join(",")}`;
+}
+
+function parseAvailableModels(result: Record<string, unknown>): AdapterModel[] {
+  const models: AdapterModel[] = [];
+  const modelsObj = result.models as Record<string, unknown> | undefined;
+  if (!modelsObj || typeof modelsObj !== "object") return models;
+
+  const available = modelsObj.availableModels;
+  if (!Array.isArray(available)) return models;
+
+  const seen = new Set<string>();
+  for (const entry of available) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const rec = entry as Record<string, unknown>;
+    const id = typeof rec.modelId === "string" ? rec.modelId.trim() : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = typeof rec.name === "string" ? rec.name.trim() : id;
+    models.push({ id, label: name });
+  }
+
+  return models;
+}
+
+function probeModels(
+  command: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Promise<AdapterModel[]> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve([]);
+    }, ACP_MODELS_TIMEOUT_MS);
+
+    const proc = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    function cleanup() {
+      clearTimeout(timeout);
+      try { proc.kill("SIGTERM"); } catch { /* ignore */ }
+    }
+
+    proc.on("error", () => {
+      cleanup();
+      resolve([]);
+    });
+
+    const rl = createInterface({ input: proc.stdout! });
+    let initDone = false;
+
+    rl.on("line", (line) => {
+      try {
+        const msg = JSON.parse(line);
+
+        // Response to initialize (id=1)
+        if (msg.id === 1 && !initDone) {
+          initDone = true;
+          if (msg.error) {
+            cleanup();
+            rl.close();
+            resolve([]);
+            return;
+          }
+          // Send session/new to get available models
+          proc.stdin?.write(JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "session/new",
+            params: { cwd, mcpServers: [] },
+          }) + "\n");
+        }
+
+        // Response to session/new (id=2)
+        if (msg.id === 2) {
+          cleanup();
+          rl.close();
+          if (msg.error || !msg.result) {
+            resolve([]);
+            return;
+          }
+          resolve(parseAvailableModels(msg.result));
+        }
+      } catch {
+        // Not JSON — ignore
+      }
+    });
+
+    // Send initialize
+    proc.stdin?.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: 1,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          terminal: true,
+        },
+        clientInfo: { name: "paperclip", version: "1.0.0" },
+      },
+    }) + "\n");
+  });
+}
+
+export async function listAcpModels(config?: Record<string, unknown>): Promise<AdapterModel[]> {
+  const cfg = config ?? {};
+  const command = asString(cfg.command, "kiro-cli");
+  const args = asStringArray(cfg.args).length > 0 ? asStringArray(cfg.args) : ["acp"];
+  const cwd = asString(cfg.cwd, process.cwd());
+  const fp = fingerprint(command, args);
+
+  const now = Date.now();
+  if (cached && cached.fingerprint === fp && cached.expiresAt > now) {
+    return cached.models;
+  }
+
+  const envConfig = parseObject(cfg.env);
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
+  const fullEnv = ensurePathInEnv({ ...process.env, ...env }) as Record<string, string>;
+
+  const discovered = await probeModels(command, args, cwd, fullEnv);
+
+  if (discovered.length > 0) {
+    cached = { fingerprint: fp, expiresAt: now + ACP_MODELS_CACHE_TTL_MS, models: discovered };
+    return discovered;
+  }
+
+  // Return stale cache if probe failed
+  if (cached && cached.fingerprint === fp && cached.models.length > 0) {
+    return cached.models;
+  }
+
+  return [];
+}

--- a/server/src/adapters/acp/execute.ts
+++ b/server/src/adapters/acp/execute.ts
@@ -1,0 +1,374 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import type { AdapterAgent, AdapterExecutionContext, AdapterExecutionResult, UsageSummary } from "../types.js";
+import { asString, asNumber, asStringArray, parseObject, buildPaperclipEnv, ensurePathInEnv, redactEnvForLogs, renderTemplate } from "../utils.js";
+
+// ---------------------------------------------------------------------------
+// ACP (Agent Client Protocol) adapter — execute
+//
+// ACP is a stdio-based JSON-RPC 2.0 protocol (like MCP) where the client
+// spawns an agent process and communicates over stdin/stdout.
+//
+// Lifecycle (per ACP spec — https://agentclientprotocol.com/protocol/prompt-turn):
+//   1. Spawn the ACP agent command (e.g. `kiro-cli acp`)
+//   2. Send `initialize` request → wait for response
+//   3. Send `session/new` or `session/load` request
+//   4. Send `session/prompt` request with prompt content array
+//   5. Agent streams `session/update` notifications (agent_message_chunk,
+//      tool_call, tool_call_update, plan, etc.)
+//   6. Agent responds to session/prompt with { stopReason: "end_turn" }
+//   7. Close stdin and wait for process exit
+// ---------------------------------------------------------------------------
+
+function buildAcpPrompt(agent: AdapterAgent, context: Record<string, unknown>): string {
+  const a = agent as Record<string, unknown>;
+  const name = asString(a.name, "Agent");
+  const title = asString(a.title, "");
+  const capabilities = asString(a.capabilities, "");
+  const issueTitle = asString(context.issueTitle, "");
+  const issueDescription = asString(context.issueDescription, "");
+
+  const lines: string[] = [];
+  lines.push(`You are ${name}${title ? `, the ${title}` : ""}.`);
+  if (capabilities) {
+    lines.push(`Your capabilities: ${capabilities}`);
+  }
+  lines.push("");
+
+  if (issueTitle) {
+    lines.push("## Your current task");
+    lines.push(issueTitle);
+    if (issueDescription) {
+      lines.push("");
+      lines.push(issueDescription);
+    }
+  } else {
+    lines.push("You have no specific task assigned. Check the project directory for relevant work and report what you find.");
+  }
+
+  lines.push("");
+  lines.push("Work in the current directory. Be thorough and produce concrete output.");
+  return lines.join("\n");
+}
+
+let nextRpcId = 1;
+function rpcId(): number { return nextRpcId++; }
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+type JsonRpcMessage = JsonRpcResponse | JsonRpcNotification;
+
+function sendRequest(proc: ChildProcess, id: number, method: string, params: Record<string, unknown>): void {
+  proc.stdin?.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+}
+
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { config, runId, agent, onLog, onMeta } = ctx;
+
+  const command = asString(config.command, "kiro-cli");
+  const args = asStringArray(config.args).length > 0 ? asStringArray(config.args) : ["acp"];
+  const cwd = asString(config.cwd, process.cwd());
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const configuredModel = asString(config.model, "");
+  const envConfig = parseObject(config.env);
+
+  const sessionId = ctx.runtime.sessionId;
+
+  // Build environment
+  const env: Record<string, string> = {
+    ...buildPaperclipEnv(agent),
+  };
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
+  const fullEnv = ensurePathInEnv({ ...process.env, ...env }) as Record<string, string>;
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "acp",
+      command,
+      cwd,
+      commandArgs: args,
+      commandNotes: [
+        sessionId ? `Resuming session: ${sessionId}` : "New session",
+        "Protocol: ACP (JSON-RPC 2.0 over stdio)",
+      ],
+      env: redactEnvForLogs(env),
+    });
+  }
+
+  // --- Spawn the ACP agent process ---
+  const proc = spawn(command, args, {
+    cwd,
+    env: fullEnv,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  // Track pending RPC responses
+  const pendingRequests = new Map<number, {
+    resolve: (res: JsonRpcResponse) => void;
+    reject: (err: Error) => void;
+  }>();
+
+  // State
+  let acpSessionId: string | null = sessionId;
+  const usage: UsageSummary = { inputTokens: 0, outputTokens: 0 };
+  let model: string | null = null;
+  let summary: string | null = null;
+  let errorMessage: string | null = null;
+
+  // Process exit promise
+  let resolveExit: ((result: { exitCode: number | null; signal: string | null }) => void) | null = null;
+  const exitPromise = new Promise<{ exitCode: number | null; signal: string | null }>((resolve) => {
+    resolveExit = resolve;
+  });
+  proc.on("close", (code, signal) => {
+    resolveExit?.({ exitCode: code, signal: signal ?? null });
+  });
+
+  // --- Parse stdout as newline-delimited JSON-RPC ---
+  const rl = createInterface({ input: proc.stdout! });
+
+  rl.on("line", (line) => {
+    // Log raw line for visibility
+    void onLog("stdout", line + "\n");
+
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // Not JSON — skip
+    }
+
+    // Response to a request we sent
+    if ("id" in msg && msg.id != null) {
+      const pending = pendingRequests.get(msg.id as number);
+      if (pending) {
+        pendingRequests.delete(msg.id as number);
+        pending.resolve(msg as JsonRpcResponse);
+      }
+      return;
+    }
+
+    // Notification from the agent
+    if ("method" in msg) {
+      void handleNotification(msg as JsonRpcNotification);
+    }
+  });
+
+  async function handleNotification(notif: JsonRpcNotification): Promise<void> {
+    const params = notif.params ?? {};
+
+    // Kiro sends "session/update" with params.update.sessionUpdate
+    if (notif.method === "session/update") {
+      const update = params.update as Record<string, unknown> | undefined;
+      if (!update) return;
+      const updateType = update.sessionUpdate as string | undefined;
+      switch (updateType) {
+        case "agent_message_chunk": {
+          const content = update.content as Record<string, unknown> | undefined;
+          const text = content?.text ?? "";
+          if (text) summary = (summary ?? "") + String(text);
+          break;
+        }
+        case "tool_call": {
+          await onLog("stdout", JSON.stringify({
+            type: "acp:tool_call",
+            toolCallId: update.toolCallId,
+            name: update.title ?? update.name,
+          }) + "\n");
+          break;
+        }
+        case "tool_call_update": {
+          await onLog("stdout", JSON.stringify({
+            type: "acp:tool_update",
+            toolCallId: update.toolCallId,
+            kind: update.kind,
+          }) + "\n");
+          break;
+        }
+        case "turn_end": {
+          if (update.usage && typeof update.usage === "object") {
+            const u = update.usage as Record<string, unknown>;
+            if (typeof u.inputTokens === "number") usage.inputTokens += u.inputTokens;
+            if (typeof u.outputTokens === "number") usage.outputTokens += u.outputTokens;
+          }
+          if (typeof update.model === "string") model = update.model;
+          break;
+        }
+        default: {
+          await onLog("stdout", JSON.stringify({ type: "acp:notification", updateType, ...params }) + "\n");
+        }
+      }
+      return;
+    }
+
+    // Log other notification methods (Kiro extensions, etc.)
+    await onLog("stdout", JSON.stringify({ type: "acp:notification", method: notif.method, ...params }) + "\n");
+  }
+
+  // --- Collect stderr ---
+  proc.stderr?.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    void onLog("stderr", text);
+  });
+
+  // --- Send RPC request and wait for response ---
+  function request(method: string, params: Record<string, unknown>): Promise<JsonRpcResponse> {
+    return new Promise<JsonRpcResponse>((resolve, reject) => {
+      const id = rpcId();
+      const timer = timeoutSec > 0
+        ? setTimeout(() => {
+            pendingRequests.delete(id);
+            reject(new Error(`ACP request ${method} timed out (${timeoutSec}s)`));
+          }, timeoutSec * 1000)
+        : null;
+
+      pendingRequests.set(id, {
+        resolve: (res) => {
+          if (timer) clearTimeout(timer);
+          resolve(res);
+        },
+        reject: (err) => {
+          if (timer) clearTimeout(timer);
+          reject(err);
+        },
+      });
+
+      sendRequest(proc, id, method, params);
+    });
+  }
+
+  // --- ACP Protocol Flow ---
+  try {
+    // 1. Initialize (request — expects response)
+    const initRes = await request("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+      clientInfo: { name: "paperclip", version: "1.0.0" },
+    });
+
+    if (initRes.error) {
+      throw new Error(`ACP initialize failed: ${initRes.error.message}`);
+    }
+
+    await onLog("stdout", JSON.stringify({
+      type: "acp:initialized",
+      agent: initRes.result?.agentInfo,
+      capabilities: initRes.result?.agentCapabilities,
+    }) + "\n");
+
+    // 2. Create or load session (request — expects response)
+    if (acpSessionId) {
+      const loadRes = await request("session/load", { sessionId: acpSessionId, cwd, mcpServers: [] });
+      if (loadRes.error) {
+        await onLog("stderr", `ACP session/load failed (${loadRes.error.message}), creating new session\n`);
+        const newRes = await request("session/new", { cwd, mcpServers: [] });
+        if (newRes.error) throw new Error(`ACP session/new failed: ${newRes.error.message}`);
+        acpSessionId = (newRes.result?.sessionId as string) ?? null;
+      }
+    } else {
+      const newRes = await request("session/new", { cwd, mcpServers: [] });
+      if (newRes.error) throw new Error(`ACP session/new failed: ${newRes.error.message}`);
+      acpSessionId = (newRes.result?.sessionId as string) ?? null;
+    }
+
+    // 2b. Set model if configured
+    if (configuredModel) {
+      const modelRes = await request("session/set_model", {
+        sessionId: acpSessionId,
+        modelId: configuredModel,
+      });
+      if (modelRes.error) {
+        await onLog("stderr", `ACP session/set_model warning: ${modelRes.error.message}\n`);
+      } else {
+        await onLog("stdout", JSON.stringify({ type: "acp:model_set", modelId: configuredModel }) + "\n");
+      }
+    }
+
+    // 3. Build prompt — ACP agents don't have system prompt injection like
+    // Claude's --append-system-prompt-file, so we build a rich prompt that
+    // includes role, capabilities, and task context.
+    const customTemplate = asString(config.promptTemplate, "");
+    let prompt: string;
+    if (customTemplate) {
+      prompt = renderTemplate(customTemplate, {
+        agentId: agent.id,
+        companyId: agent.companyId,
+        runId,
+        company: { id: agent.companyId },
+        agent,
+        run: { id: runId, source: "on_demand" },
+        context: ctx.context,
+      });
+    } else {
+      prompt = buildAcpPrompt(agent, ctx.context);
+    }
+
+    // Send prompt as request — per ACP spec, the response to session/prompt
+    // signals turn end with { result: { stopReason: "end_turn" } }.
+    // All session/update notifications stream before the response arrives.
+    const promptRes = await request("session/prompt", {
+      sessionId: acpSessionId,
+      prompt: [{ type: "text", text: prompt }],
+    });
+
+    if (promptRes.error) {
+      throw new Error(`ACP session/prompt failed: ${promptRes.error.message}`);
+    }
+
+    // The prompt response itself signals turn completion
+    const stopReason = (promptRes.result?.stopReason as string) ?? "unknown";
+    await onLog("stdout", JSON.stringify({ type: "acp:turn_end", stopReason }) + "\n");
+
+  } catch (err) {
+    errorMessage = err instanceof Error ? err.message : String(err);
+  }
+
+  // Close stdin to signal we're done, then wait for process exit
+  try { proc.stdin?.end(); } catch { /* ignore */ }
+
+  // Give the process a few seconds to exit gracefully
+  const graceTimeout = new Promise<{ exitCode: number | null; signal: string | null }>((resolve) =>
+    setTimeout(() => {
+      try { proc.kill("SIGTERM"); } catch { /* ignore */ }
+      resolve({ exitCode: 1, signal: "SIGTERM" });
+    }, 10_000)
+  );
+
+  const exitResult = await Promise.race([exitPromise, graceTimeout]);
+
+  rl.close();
+
+  // ACP agents may exit with non-zero after stdin close (broken pipe).
+  // If the prompt completed successfully, normalize exit code to 0.
+  const exitCode = !errorMessage ? 0 : exitResult.exitCode;
+
+  return {
+    exitCode,
+    signal: exitResult.signal,
+    timedOut: errorMessage?.includes("timed out") ?? false,
+    errorMessage,
+    usage: usage.inputTokens > 0 || usage.outputTokens > 0 ? usage : undefined,
+    model,
+    sessionId: acpSessionId,
+    sessionParams: acpSessionId ? { sessionId: acpSessionId } : null,
+    sessionDisplayId: acpSessionId,
+    summary: summary?.slice(0, 500) ?? null,
+  };
+}

--- a/server/src/adapters/acp/index.ts
+++ b/server/src/adapters/acp/index.ts
@@ -1,0 +1,67 @@
+import type { ServerAdapterModule } from "../types.js";
+import { execute } from "./execute.js";
+import { testEnvironment } from "./test.js";
+import { listAcpModels } from "../acp-models.js";
+
+export const acpAdapter: ServerAdapterModule = {
+  type: "acp",
+  execute,
+  testEnvironment,
+  listModels: () => listAcpModels(),
+  sessionCodec: {
+    deserialize(raw: unknown) {
+      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+      const record = raw as Record<string, unknown>;
+      const sessionId = typeof record.sessionId === "string" ? record.sessionId : null;
+      if (!sessionId) return null;
+      return { sessionId };
+    },
+    serialize(params: Record<string, unknown> | null) {
+      if (!params) return null;
+      const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+      if (!sessionId) return null;
+      return { sessionId };
+    },
+    getDisplayId(params: Record<string, unknown> | null) {
+      if (!params) return null;
+      return typeof params.sessionId === "string" ? params.sessionId : null;
+    },
+  },
+  models: [],
+  agentConfigurationDoc: `# ACP (Agent Client Protocol) adapter
+
+Connects Paperclip to any ACP-compatible agent via stdio JSON-RPC 2.0.
+Works with Kiro CLI, or any agent implementing the ACP spec.
+
+## Config fields
+
+- **command** (string, default: "kiro-cli"): The ACP agent command to spawn
+- **args** (string[], default: ["acp"]): Command arguments
+- **cwd** (string, optional): Working directory for the agent process
+- **env** (object, optional): Additional environment variables
+- **timeoutSec** (number, default: 0 = unlimited): Per-request timeout
+
+## Protocol flow
+
+1. Spawn \`command args\` as a child process
+2. Send \`initialize\` with client capabilities over stdin
+3. Send \`session/new\` or \`session/load\` (if resuming a session)
+4. Send \`session/prompt\` with the task prompt
+5. Receive streaming notifications: AgentMessageChunk, ToolCall, ToolCallUpdate, TurnEnd
+6. Close stdin when complete
+
+## Session management
+
+ACP session IDs are persisted across Paperclip runs, enabling \`session/load\` resumption.
+
+## Example config
+
+\`\`\`json
+{
+  "command": "kiro-cli",
+  "args": ["acp", "--agent", "my-agent"],
+  "cwd": "/path/to/project"
+}
+\`\`\`
+`,
+};

--- a/server/src/adapters/acp/test.ts
+++ b/server/src/adapters/acp/test.ts
@@ -1,0 +1,204 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "../types.js";
+import { asString, asStringArray, parseObject, ensurePathInEnv, ensureAbsoluteDirectory, ensureCommandResolvable } from "../utils.js";
+
+// ---------------------------------------------------------------------------
+// ACP adapter — environment test
+//
+// Validates the ACP agent by:
+//   1. Checking the command is resolvable
+//   2. Checking the working directory
+//   3. Spawning the process and sending `initialize`
+//   4. Verifying the agent responds with valid capabilities
+// ---------------------------------------------------------------------------
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "kiro-cli");
+  const args = asStringArray(config.args).length > 0 ? asStringArray(config.args) : ["acp"];
+  const cwd = asString(config.cwd, process.cwd());
+  const envConfig = parseObject(config.env);
+
+  // --- Check working directory ---
+  try {
+    await ensureAbsoluteDirectory(cwd);
+    checks.push({
+      code: "acp_cwd_valid",
+      level: "info",
+      message: `Working directory: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "acp_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+    return { adapterType: ctx.adapterType, status: "fail", checks, testedAt: new Date().toISOString() };
+  }
+
+  // --- Check command resolvable ---
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "acp_command_found",
+      level: "info",
+      message: `Command resolvable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "acp_command_not_found",
+      level: "error",
+      message: err instanceof Error ? err.message : `Command not found: ${command}`,
+      hint: "Install the ACP agent CLI (e.g. `npm i -g kiro-cli`) or set adapterConfig.command to the full path.",
+    });
+    return { adapterType: ctx.adapterType, status: "fail", checks, testedAt: new Date().toISOString() };
+  }
+
+  // --- Spawn and test initialize handshake ---
+  try {
+    const result = await probeInitialize(command, args, cwd, runtimeEnv as Record<string, string>);
+    if (result.success) {
+      checks.push({
+        code: "acp_initialize_ok",
+        level: "info",
+        message: `ACP agent responded: ${result.agentName ?? "unnamed"} v${result.agentVersion ?? "?"}`,
+      });
+      if (result.capabilities) {
+        checks.push({
+          code: "acp_capabilities",
+          level: "info",
+          message: `Capabilities: ${JSON.stringify(result.capabilities)}`,
+        });
+      }
+    } else {
+      checks.push({
+        code: "acp_initialize_failed",
+        level: "error",
+        message: result.error ?? "ACP initialize handshake failed",
+        hint: "Verify the agent supports ACP protocol version 1.",
+      });
+    }
+  } catch (err) {
+    checks.push({
+      code: "acp_probe_error",
+      level: "error",
+      message: err instanceof Error ? err.message : "ACP probe failed",
+    });
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Probe: spawn, initialize, kill
+// ---------------------------------------------------------------------------
+
+interface ProbeResult {
+  success: boolean;
+  agentName?: string;
+  agentVersion?: string;
+  capabilities?: Record<string, unknown>;
+  error?: string;
+}
+
+function probeInitialize(
+  command: string,
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Promise<ProbeResult> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve({ success: false, error: "ACP initialize timed out (10s)" });
+    }, 10_000);
+
+    const proc = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    function cleanup() {
+      clearTimeout(timeout);
+      try { proc.kill("SIGTERM"); } catch { /* ignore */ }
+    }
+
+    proc.on("error", (err) => {
+      cleanup();
+      resolve({ success: false, error: err.message });
+    });
+
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      if (code !== 0 && code !== null) {
+        resolve({ success: false, error: `Process exited with code ${code}` });
+      }
+    });
+
+    const rl = createInterface({ input: proc.stdout! });
+    rl.on("line", (line) => {
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id === 1 && msg.result) {
+          const agentInfo = msg.result.agentInfo as Record<string, unknown> | undefined;
+          cleanup();
+          rl.close();
+          resolve({
+            success: true,
+            agentName: agentInfo?.name as string | undefined,
+            agentVersion: agentInfo?.version as string | undefined,
+            capabilities: msg.result.agentCapabilities as Record<string, unknown> | undefined,
+          });
+        } else if (msg.id === 1 && msg.error) {
+          cleanup();
+          rl.close();
+          resolve({ success: false, error: msg.error.message ?? "Initialize error" });
+        }
+      } catch {
+        // Not JSON — ignore
+      }
+    });
+
+    // Send initialize request
+    proc.stdin?.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: 1,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          terminal: true,
+        },
+        clientInfo: { name: "paperclip", version: "1.0.0" },
+      },
+    }) + "\n");
+  });
+}

--- a/server/src/adapters/kiro-cli/execute.ts
+++ b/server/src/adapters/kiro-cli/execute.ts
@@ -1,0 +1,50 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
+import { execute as acpExecute } from "../acp/execute.js";
+import { asString, asStringArray, asBoolean } from "../utils.js";
+
+// ---------------------------------------------------------------------------
+// Kiro CLI adapter — execute
+//
+// Thin wrapper around the ACP adapter that passes Kiro-specific CLI flags:
+//   --model <MODEL>         Model to use for the session
+//   --agent <AGENT>         Named agent profile
+//   --trust-all-tools       Auto-approve all tool permission requests
+//   --verbose               Increase logging verbosity
+// ---------------------------------------------------------------------------
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { config } = ctx;
+
+  // Build Kiro-specific CLI args
+  const baseArgs = asStringArray(config.args).length > 0 ? asStringArray(config.args) : ["acp"];
+  const extraArgs: string[] = [];
+
+  const model = asString(config.model, "");
+  if (model) {
+    extraArgs.push("--model", model);
+  }
+
+  const agent = asString(config.agent, "");
+  if (agent) {
+    extraArgs.push("--agent", agent);
+  }
+
+  if (asBoolean(config.trustAllTools, false)) {
+    extraArgs.push("--trust-all-tools");
+  }
+
+  // Delegate to ACP execute with modified config:
+  // - Override args to include Kiro flags
+  // - Clear model so ACP doesn't also call session/set_model
+  const kiroConfig: Record<string, unknown> = {
+    ...config,
+    command: asString(config.command, "kiro-cli"),
+    args: [...baseArgs, ...extraArgs],
+    model: "", // model is passed via CLI, not session/set_model
+  };
+
+  return acpExecute({
+    ...ctx,
+    config: kiroConfig,
+  });
+}

--- a/server/src/adapters/kiro-cli/index.ts
+++ b/server/src/adapters/kiro-cli/index.ts
@@ -1,0 +1,63 @@
+import type { ServerAdapterModule } from "../types.js";
+import { execute } from "./execute.js";
+import { testEnvironment } from "../acp/test.js";
+import { listAcpModels } from "../acp-models.js";
+
+export const kiroCliAdapter: ServerAdapterModule = {
+  type: "kiro_cli",
+  execute,
+  testEnvironment,
+  listModels: () => listAcpModels(),
+  sessionCodec: {
+    deserialize(raw: unknown) {
+      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+      const record = raw as Record<string, unknown>;
+      const sessionId = typeof record.sessionId === "string" ? record.sessionId : null;
+      if (!sessionId) return null;
+      return { sessionId };
+    },
+    serialize(params: Record<string, unknown> | null) {
+      if (!params) return null;
+      const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+      if (!sessionId) return null;
+      return { sessionId };
+    },
+    getDisplayId(params: Record<string, unknown> | null) {
+      if (!params) return null;
+      return typeof params.sessionId === "string" ? params.sessionId : null;
+    },
+  },
+  models: [],
+  agentConfigurationDoc: `# Kiro CLI adapter
+
+Runs Kiro CLI as an ACP agent with first-class support for Kiro-specific options.
+
+## Config fields
+
+- **command** (string, default: "kiro-cli"): Path to the kiro-cli binary
+- **args** (string[], default: ["acp"]): Base command arguments
+- **model** (string, optional): Model ID passed via \`--model\` flag
+- **agent** (string, optional): Named agent profile passed via \`--agent\` flag
+- **trustAllTools** (boolean, default: false): Pass \`--trust-all-tools\` to auto-approve permissions
+- **cwd** (string, optional): Working directory for the agent process
+- **env** (object, optional): Additional environment variables
+- **timeoutSec** (number, default: 0 = unlimited): Per-request timeout
+
+## Protocol
+
+Uses ACP (Agent Client Protocol) — stdio-based JSON-RPC 2.0.
+Model selection is done via CLI \`--model\` flag at spawn time rather than \`session/set_model\`.
+
+## Example config
+
+\`\`\`json
+{
+  "command": "kiro-cli",
+  "model": "claude-sonnet-4.6",
+  "agent": "my-agent",
+  "trustAllTools": true,
+  "cwd": "/path/to/project"
+}
+\`\`\`
+`,
+};

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -41,6 +41,7 @@ import { listAcpModels } from "./acp-models.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 import { acpAdapter } from "./acp/index.js";
+import { kiroCliAdapter } from "./kiro-cli/index.js";
 
 const claudeLocalAdapter: ServerAdapterModule = {
   type: "claude_local",
@@ -96,7 +97,7 @@ const openCodeLocalAdapter: ServerAdapterModule = {
 };
 
 const adaptersByType = new Map<string, ServerAdapterModule>(
-  [claudeLocalAdapter, codexLocalAdapter, openCodeLocalAdapter, cursorLocalAdapter, openclawAdapter, processAdapter, httpAdapter, acpAdapter].map((a) => [a.type, a]),
+  [claudeLocalAdapter, codexLocalAdapter, openCodeLocalAdapter, cursorLocalAdapter, openclawAdapter, processAdapter, httpAdapter, acpAdapter, kiroCliAdapter].map((a) => [a.type, a]),
 );
 
 export function getServerAdapter(type: string): ServerAdapterModule {

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -37,8 +37,10 @@ import {
 } from "@paperclipai/adapter-openclaw";
 import { listCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
+import { listAcpModels } from "./acp-models.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
+import { acpAdapter } from "./acp/index.js";
 
 const claudeLocalAdapter: ServerAdapterModule = {
   type: "claude_local",
@@ -94,7 +96,7 @@ const openCodeLocalAdapter: ServerAdapterModule = {
 };
 
 const adaptersByType = new Map<string, ServerAdapterModule>(
-  [claudeLocalAdapter, codexLocalAdapter, openCodeLocalAdapter, cursorLocalAdapter, openclawAdapter, processAdapter, httpAdapter].map((a) => [a.type, a]),
+  [claudeLocalAdapter, codexLocalAdapter, openCodeLocalAdapter, cursorLocalAdapter, openclawAdapter, processAdapter, httpAdapter, acpAdapter].map((a) => [a.type, a]),
 );
 
 export function getServerAdapter(type: string): ServerAdapterModule {

--- a/ui/src/adapters/acp/build-config.ts
+++ b/ui/src/adapters/acp/build-config.ts
@@ -1,0 +1,24 @@
+import type { CreateConfigValues } from "../types";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function buildAcpConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  ac.command = v.command || "kiro-cli";
+  if (v.args) {
+    ac.args = parseCommaArgs(v.args);
+  } else {
+    ac.args = ["acp"];
+  }
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.model) ac.model = v.model;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  const timeout = parseInt(v.timeoutSec ?? "", 10);
+  ac.timeoutSec = isNaN(timeout) ? 0 : timeout;
+  return ac;
+}

--- a/ui/src/adapters/acp/config-fields.tsx
+++ b/ui/src/adapters/acp/config-fields.tsx
@@ -1,0 +1,57 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function formatArgList(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === "string")
+      .join(", ");
+  }
+  return typeof value === "string" ? value : "";
+}
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function AcpConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <Field label="Args (comma-separated)" hint="Command arguments (default: acp)">
+      <DraftInput
+        value={
+          isCreate
+            ? values!.args || "acp"
+            : eff("adapterConfig", "args", formatArgList(config.args))
+        }
+        onCommit={(v) =>
+          isCreate
+            ? set!({ args: v })
+            : mark(
+                "adapterConfig",
+                "args",
+                v ? parseCommaArgs(v) : undefined,
+              )
+        }
+        immediate
+        className={inputClass}
+        placeholder="acp, --agent, my-agent"
+      />
+    </Field>
+  );
+}

--- a/ui/src/adapters/acp/index.ts
+++ b/ui/src/adapters/acp/index.ts
@@ -1,0 +1,20 @@
+import type { UIAdapterModule } from "../types";
+import { parseAcpStdoutLine } from "./parse-stdout";
+import { AcpConfigFields } from "./config-fields";
+import { buildAcpConfig } from "./build-config";
+
+export const acpUIAdapter: UIAdapterModule = {
+  type: "acp",
+  label: "ACP (Agent Client Protocol)",
+  capabilities: {
+    command: true,
+    model: true,
+    cwd: true,
+    promptTemplate: true,
+    envVars: true,
+    timeout: true,
+  },
+  parseStdoutLine: parseAcpStdoutLine,
+  ConfigFields: AcpConfigFields,
+  buildAdapterConfig: buildAcpConfig,
+};

--- a/ui/src/adapters/acp/parse-stdout.ts
+++ b/ui/src/adapters/acp/parse-stdout.ts
@@ -1,0 +1,74 @@
+import type { TranscriptEntry } from "../types";
+
+export function parseAcpStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  try {
+    const parsed = JSON.parse(trimmed);
+
+    // --- Structured events from our ACP adapter ---
+    if (parsed.type === "acp:initialized") {
+      const name = parsed.agent?.name ?? "ACP Agent";
+      return [{ kind: "system", ts, text: `Connected to ${name}` }];
+    }
+    if (parsed.type === "acp:tool_call") {
+      return [{ kind: "tool_call", ts, name: parsed.name ?? "unknown", input: parsed.input }];
+    }
+    if (parsed.type === "acp:tool_update") {
+      return [{ kind: "tool_result", ts, toolUseId: parsed.toolCallId ?? "", content: String(parsed.content ?? ""), isError: false }];
+    }
+    if (parsed.type === "acp:turn_end") {
+      return [{ kind: "system", ts, text: "Turn complete" }];
+    }
+    if (parsed.type === "acp:notification") {
+      // Skip noisy Kiro extension notifications in the transcript
+      if (parsed.method?.startsWith("_kiro.dev/")) return [];
+      return [{ kind: "system", ts, text: JSON.stringify(parsed) }];
+    }
+
+    // --- Raw JSON-RPC session/update notifications (ACP spec format) ---
+    if (parsed.jsonrpc === "2.0" && parsed.method === "session/update") {
+      const update = parsed.params?.update;
+      if (!update) return [];
+      switch (update.sessionUpdate) {
+        case "agent_message_chunk": {
+          const text = update.content?.text ?? "";
+          if (!text) return [];
+          return [{ kind: "assistant", ts, text }];
+        }
+        case "tool_call":
+          return [{ kind: "tool_call", ts, name: update.title ?? "tool", input: undefined }];
+        case "tool_call_update": {
+          if (update.status === "completed" && update.content) {
+            const output = Array.isArray(update.content)
+              ? update.content.map((c: { content?: { text?: string } }) => c.content?.text ?? "").join("")
+              : String(update.content);
+            return [{ kind: "tool_result", ts, toolUseId: update.toolCallId ?? "", content: output, isError: false }];
+          }
+          // in_progress updates — skip to avoid noise
+          return [];
+        }
+        case "turn_end":
+          return [{ kind: "system", ts, text: "Turn complete" }];
+        default:
+          return [];
+      }
+    }
+
+    // Skip Kiro extension notifications (_kiro.dev/*)
+    if (parsed.jsonrpc === "2.0" && parsed.method?.startsWith("_kiro.dev/")) {
+      return [];
+    }
+
+    // JSON-RPC responses (initialize, session/new, session/prompt) — skip
+    if (parsed.jsonrpc === "2.0" && "id" in parsed) {
+      return [];
+    }
+  } catch {
+    // Not JSON
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}
+

--- a/ui/src/adapters/claude-local/index.ts
+++ b/ui/src/adapters/claude-local/index.ts
@@ -6,6 +6,18 @@ import { buildClaudeLocalConfig } from "@paperclipai/adapter-claude-local/ui";
 export const claudeLocalUIAdapter: UIAdapterModule = {
   type: "claude_local",
   label: "Claude Code (local)",
+  capabilities: {
+    command: true,
+    model: true,
+    thinkingEffort: true,
+    cwd: true,
+    promptTemplate: true,
+    bootstrapPrompt: true,
+    extraArgs: true,
+    envVars: true,
+    timeout: true,
+    gracePeriod: true,
+  },
   parseStdoutLine: parseClaudeStdoutLine,
   ConfigFields: ClaudeLocalConfigFields,
   buildAdapterConfig: buildClaudeLocalConfig,

--- a/ui/src/adapters/codex-local/index.ts
+++ b/ui/src/adapters/codex-local/index.ts
@@ -6,6 +6,18 @@ import { buildCodexLocalConfig } from "@paperclipai/adapter-codex-local/ui";
 export const codexLocalUIAdapter: UIAdapterModule = {
   type: "codex_local",
   label: "Codex (local)",
+  capabilities: {
+    command: true,
+    model: true,
+    thinkingEffort: true,
+    cwd: true,
+    promptTemplate: true,
+    bootstrapPrompt: true,
+    extraArgs: true,
+    envVars: true,
+    timeout: true,
+    gracePeriod: true,
+  },
   parseStdoutLine: parseCodexStdoutLine,
   ConfigFields: CodexLocalConfigFields,
   buildAdapterConfig: buildCodexLocalConfig,

--- a/ui/src/adapters/cursor/index.ts
+++ b/ui/src/adapters/cursor/index.ts
@@ -6,6 +6,18 @@ import { buildCursorLocalConfig } from "@paperclipai/adapter-cursor-local/ui";
 export const cursorLocalUIAdapter: UIAdapterModule = {
   type: "cursor",
   label: "Cursor CLI (local)",
+  capabilities: {
+    command: true,
+    model: true,
+    thinkingEffort: true,
+    cwd: true,
+    promptTemplate: true,
+    bootstrapPrompt: true,
+    extraArgs: true,
+    envVars: true,
+    timeout: true,
+    gracePeriod: true,
+  },
   parseStdoutLine: parseCursorStdoutLine,
   ConfigFields: CursorLocalConfigFields,
   buildAdapterConfig: buildCursorLocalConfig,

--- a/ui/src/adapters/http/index.ts
+++ b/ui/src/adapters/http/index.ts
@@ -6,6 +6,7 @@ import { buildHttpConfig } from "./build-config";
 export const httpUIAdapter: UIAdapterModule = {
   type: "http",
   label: "HTTP Webhook",
+  capabilities: {},
   parseStdoutLine: parseHttpStdoutLine,
   ConfigFields: HttpConfigFields,
   buildAdapterConfig: buildHttpConfig,

--- a/ui/src/adapters/kiro-cli/build-config.ts
+++ b/ui/src/adapters/kiro-cli/build-config.ts
@@ -1,0 +1,25 @@
+import type { CreateConfigValues } from "../types";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function buildKiroCliConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  ac.command = v.command || "kiro-cli";
+  if (v.args) {
+    ac.args = parseCommaArgs(v.args);
+  }
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.model) ac.model = v.model;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  const ext = v as unknown as Record<string, unknown>;
+  if (ext.agent) ac.agent = ext.agent;
+  if (ext.trustAllTools) ac.trustAllTools = true;
+  const timeout = parseInt(v.timeoutSec ?? "", 10);
+  ac.timeoutSec = isNaN(timeout) ? 0 : timeout;
+  return ac;
+}

--- a/ui/src/adapters/kiro-cli/config-fields.tsx
+++ b/ui/src/adapters/kiro-cli/config-fields.tsx
@@ -1,0 +1,96 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  ToggleField,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function formatArgList(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === "string")
+      .join(", ");
+  }
+  return typeof value === "string" ? value : "";
+}
+
+function parseCommaArgs(value: string): string[] {
+  return value.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+export function KiroCliConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  // Access Kiro-specific create-mode values via the generic bag
+  const v = values as unknown as Record<string, unknown> | null;
+  const patchSet = set as unknown as ((patch: Record<string, unknown>) => void) | null;
+
+  return (
+    <>
+      <Field label="Agent profile" hint="Named agent profile (--agent flag)">
+        <DraftInput
+          value={
+            isCreate
+              ? String(v?.agent ?? "")
+              : eff("adapterConfig", "agent", String(config.agent ?? ""))
+          }
+          onCommit={(val) =>
+            isCreate
+              ? patchSet!({ agent: val })
+              : mark("adapterConfig", "agent", val || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="my-agent"
+        />
+      </Field>
+      <Field label="Extra args (comma-separated)" hint="Additional command arguments appended after acp">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.args || ""
+              : eff("adapterConfig", "args", formatArgList(config.args))
+          }
+          onCommit={(val) =>
+            isCreate
+              ? set!({ args: val })
+              : mark(
+                  "adapterConfig",
+                  "args",
+                  val ? parseCommaArgs(val) : undefined,
+                )
+          }
+          immediate
+          className={inputClass}
+          placeholder="--verbose"
+        />
+      </Field>
+      <ToggleField
+        label="Trust all tools"
+        hint="Auto-approve all tool permission requests (--trust-all-tools)"
+        checked={
+          isCreate
+            ? v?.trustAllTools === true
+            : eff(
+                "adapterConfig",
+                "trustAllTools",
+                config.trustAllTools === true,
+              )
+        }
+        onChange={(val) =>
+          isCreate
+            ? patchSet!({ trustAllTools: val })
+            : mark("adapterConfig", "trustAllTools", val)
+        }
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/kiro-cli/index.ts
+++ b/ui/src/adapters/kiro-cli/index.ts
@@ -1,0 +1,20 @@
+import type { UIAdapterModule } from "../types";
+import { parseAcpStdoutLine } from "../acp/parse-stdout";
+import { KiroCliConfigFields } from "./config-fields";
+import { buildKiroCliConfig } from "./build-config";
+
+export const kiroCliUIAdapter: UIAdapterModule = {
+  type: "kiro_cli",
+  label: "Kiro CLI (local)",
+  capabilities: {
+    command: true,
+    model: true,
+    cwd: true,
+    promptTemplate: true,
+    envVars: true,
+    timeout: true,
+  },
+  parseStdoutLine: parseAcpStdoutLine,
+  ConfigFields: KiroCliConfigFields,
+  buildAdapterConfig: buildKiroCliConfig,
+};

--- a/ui/src/adapters/openclaw/index.ts
+++ b/ui/src/adapters/openclaw/index.ts
@@ -6,6 +6,9 @@ import { OpenClawConfigFields } from "./config-fields";
 export const openClawUIAdapter: UIAdapterModule = {
   type: "openclaw",
   label: "OpenClaw",
+  capabilities: {
+    model: true,
+  },
   parseStdoutLine: parseOpenClawStdoutLine,
   ConfigFields: OpenClawConfigFields,
   buildAdapterConfig: buildOpenClawConfig,

--- a/ui/src/adapters/opencode-local/index.ts
+++ b/ui/src/adapters/opencode-local/index.ts
@@ -6,6 +6,18 @@ import { buildOpenCodeLocalConfig } from "@paperclipai/adapter-opencode-local/ui
 export const openCodeLocalUIAdapter: UIAdapterModule = {
   type: "opencode_local",
   label: "OpenCode (local)",
+  capabilities: {
+    command: true,
+    model: true,
+    thinkingEffort: true,
+    cwd: true,
+    promptTemplate: true,
+    bootstrapPrompt: true,
+    extraArgs: true,
+    envVars: true,
+    timeout: true,
+    gracePeriod: true,
+  },
   parseStdoutLine: parseOpenCodeStdoutLine,
   ConfigFields: OpenCodeLocalConfigFields,
   buildAdapterConfig: buildOpenCodeLocalConfig,

--- a/ui/src/adapters/process/index.ts
+++ b/ui/src/adapters/process/index.ts
@@ -6,6 +6,7 @@ import { buildProcessConfig } from "./build-config";
 export const processUIAdapter: UIAdapterModule = {
   type: "process",
   label: "Shell Process",
+  capabilities: {},
   parseStdoutLine: parseProcessStdoutLine,
   ConfigFields: ProcessConfigFields,
   buildAdapterConfig: buildProcessConfig,

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -7,9 +7,10 @@ import { openClawUIAdapter } from "./openclaw";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 import { acpUIAdapter } from "./acp";
+import { kiroCliUIAdapter } from "./kiro-cli";
 
 const adaptersByType = new Map<string, UIAdapterModule>(
-  [claudeLocalUIAdapter, codexLocalUIAdapter, openCodeLocalUIAdapter, cursorLocalUIAdapter, openClawUIAdapter, processUIAdapter, httpUIAdapter, acpUIAdapter].map((a) => [a.type, a]),
+  [claudeLocalUIAdapter, codexLocalUIAdapter, openCodeLocalUIAdapter, cursorLocalUIAdapter, openClawUIAdapter, processUIAdapter, httpUIAdapter, acpUIAdapter, kiroCliUIAdapter].map((a) => [a.type, a]),
 );
 
 export function getUIAdapter(type: string): UIAdapterModule {

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -6,9 +6,10 @@ import { openCodeLocalUIAdapter } from "./opencode-local";
 import { openClawUIAdapter } from "./openclaw";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
+import { acpUIAdapter } from "./acp";
 
 const adaptersByType = new Map<string, UIAdapterModule>(
-  [claudeLocalUIAdapter, codexLocalUIAdapter, openCodeLocalUIAdapter, cursorLocalUIAdapter, openClawUIAdapter, processUIAdapter, httpUIAdapter].map((a) => [a.type, a]),
+  [claudeLocalUIAdapter, codexLocalUIAdapter, openCodeLocalUIAdapter, cursorLocalUIAdapter, openClawUIAdapter, processUIAdapter, httpUIAdapter, acpUIAdapter].map((a) => [a.type, a]),
 );
 
 export function getUIAdapter(type: string): UIAdapterModule {

--- a/ui/src/adapters/transcript.ts
+++ b/ui/src/adapters/transcript.ts
@@ -11,6 +11,15 @@ function appendTranscriptEntry(entries: TranscriptEntry[], entry: TranscriptEntr
       return;
     }
   }
+  // Merge adjacent assistant chunks (e.g. ACP agent_message_chunk streaming)
+  if (entry.kind === "assistant") {
+    const last = entries[entries.length - 1];
+    if (last && last.kind === "assistant") {
+      last.text += entry.text;
+      last.ts = entry.ts;
+      return;
+    }
+  }
   entries.push(entry);
 }
 

--- a/ui/src/adapters/types.ts
+++ b/ui/src/adapters/types.ts
@@ -1,8 +1,8 @@
 import type { ComponentType } from "react";
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import type { CreateConfigValues, AdapterCapabilities } from "@paperclipai/adapter-utils";
 
 // Re-export shared types so local consumers don't need to change imports
-export type { TranscriptEntry, StdoutLineParser, CreateConfigValues } from "@paperclipai/adapter-utils";
+export type { TranscriptEntry, StdoutLineParser, CreateConfigValues, AdapterCapabilities } from "@paperclipai/adapter-utils";
 
 export interface AdapterConfigFieldsProps {
   mode: "create" | "edit";
@@ -25,6 +25,7 @@ export interface AdapterConfigFieldsProps {
 export interface UIAdapterModule {
   type: string;
   label: string;
+  capabilities: AdapterCapabilities;
   parseStdoutLine: (line: string, ts: string) => import("@paperclipai/adapter-utils").TranscriptEntry[];
   ConfigFields: ComponentType<AdapterConfigFieldsProps>;
   buildAdapterConfig: (values: CreateConfigValues) => Record<string, unknown>;

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -610,7 +610,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                           ? "agent"
                         : adapterType === "opencode_local"
                           ? "opencode"
-                        : adapterType === "acp"
+                        : adapterType === "acp" || adapterType === "kiro_cli"
                           ? "kiro-cli"
                           : "claude"
                     }
@@ -907,7 +907,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "acp"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "acp", "kiro_cli"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -272,12 +272,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const adapterType = isCreate
     ? props.values.adapterType
     : overlay.adapterType ?? props.agent.adapterType;
-  const isLocal =
-    adapterType === "claude_local" ||
-    adapterType === "codex_local" ||
-    adapterType === "opencode_local" ||
-    adapterType === "cursor";
   const uiAdapter = useMemo(() => getUIAdapter(adapterType), [adapterType]);
+  const caps = uiAdapter.capabilities;
+  const hasAnyCaps = Object.values(caps).some(Boolean);
 
   // Fetch adapter models for the effective adapter type
   const {
@@ -433,7 +430,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 }}
               />
             </Field>
-            {isLocal && (
+            {caps.promptTemplate && (
               <Field label="Prompt Template" hint={help.promptTemplate}>
                 <MarkdownEditor
                   value={eff(
@@ -536,7 +533,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
           )}
 
           {/* Working directory */}
-          {isLocal && (
+          {caps.cwd && (
             <Field label="Working directory" hint={help.cwd}>
               <div className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1.5">
                 <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
@@ -561,7 +558,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
           )}
 
           {/* Prompt template (create mode only — edit mode shows this in Identity) */}
-          {isLocal && isCreate && (
+          {caps.promptTemplate && isCreate && (
             <Field label="Prompt Template" hint={help.promptTemplate}>
               <MarkdownEditor
                 value={val!.promptTemplate}
@@ -584,54 +581,60 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       </div>
 
       {/* ---- Permissions & Configuration ---- */}
-      {isLocal && (
+      {hasAnyCaps && (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
             ? <h3 className="text-sm font-medium mb-3">Permissions &amp; Configuration</h3>
             : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Permissions &amp; Configuration</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
-              <Field label="Command" hint={help.localCommand}>
-                <DraftInput
-                  value={
-                    isCreate
-                      ? val!.command
-                      : eff("adapterConfig", "command", String(config.command ?? ""))
-                  }
-                  onCommit={(v) =>
-                    isCreate
-                      ? set!({ command: v })
-                      : mark("adapterConfig", "command", v || undefined)
-                  }
-                  immediate
-                  className={inputClass}
-                  placeholder={
-                    adapterType === "codex_local"
-                      ? "codex"
-                      : adapterType === "cursor"
-                        ? "agent"
+              {caps.command && (
+                <Field label="Command" hint={help.localCommand}>
+                  <DraftInput
+                    value={
+                      isCreate
+                        ? val!.command
+                        : eff("adapterConfig", "command", String(config.command ?? ""))
+                    }
+                    onCommit={(v) =>
+                      isCreate
+                        ? set!({ command: v })
+                        : mark("adapterConfig", "command", v || undefined)
+                    }
+                    immediate
+                    className={inputClass}
+                    placeholder={
+                      adapterType === "codex_local"
+                        ? "codex"
+                        : adapterType === "cursor"
+                          ? "agent"
                         : adapterType === "opencode_local"
                           ? "opencode"
+                        : adapterType === "acp"
+                          ? "kiro-cli"
                           : "claude"
-                  }
-                />
-              </Field>
+                    }
+                  />
+                </Field>
+              )}
 
-              <ModelDropdown
-                models={models}
-                value={currentModelId}
-                onChange={(v) =>
-                  isCreate
-                    ? set!({ model: v })
-                    : mark("adapterConfig", "model", v || undefined)
-                }
-                open={modelOpen}
-                onOpenChange={setModelOpen}
-                allowDefault={adapterType !== "opencode_local"}
-                required={adapterType === "opencode_local"}
-                groupByProvider={adapterType === "opencode_local"}
-              />
-              {fetchedModelsError && (
+              {caps.model && (
+                <ModelDropdown
+                  models={models}
+                  value={currentModelId}
+                  onChange={(v) =>
+                    isCreate
+                      ? set!({ model: v })
+                      : mark("adapterConfig", "model", v || undefined)
+                  }
+                  open={modelOpen}
+                  onOpenChange={setModelOpen}
+                  allowDefault={adapterType !== "opencode_local"}
+                  required={adapterType === "opencode_local"}
+                  groupByProvider={adapterType === "opencode_local"}
+                />
+              )}
+              {caps.model && fetchedModelsError && (
                 <p className="text-xs text-destructive">
                   {fetchedModelsError instanceof Error
                     ? fetchedModelsError.message
@@ -639,122 +642,135 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 </p>
               )}
 
-              <ThinkingEffortDropdown
-                value={currentThinkingEffort}
-                options={thinkingEffortOptions}
-                onChange={(v) =>
-                  isCreate
-                    ? set!({ thinkingEffort: v })
-                    : mark("adapterConfig", thinkingEffortKey, v || undefined)
-                }
-                open={thinkingEffortOpen}
-                onOpenChange={setThinkingEffortOpen}
-              />
-              {adapterType === "codex_local" &&
-                codexSearchEnabled &&
-                currentThinkingEffort === "minimal" && (
-                  <p className="text-xs text-amber-400">
-                    Codex may reject `minimal` thinking when search is enabled.
-                  </p>
-                )}
-              <Field label="Bootstrap prompt (first run)" hint={help.bootstrapPrompt}>
-                <MarkdownEditor
-                  value={
-                    isCreate
-                      ? val!.bootstrapPrompt
-                      : eff(
-                          "adapterConfig",
-                          "bootstrapPromptTemplate",
-                          String(config.bootstrapPromptTemplate ?? ""),
-                        )
-                  }
-                  onChange={(v) =>
-                    isCreate
-                      ? set!({ bootstrapPrompt: v })
-                      : mark("adapterConfig", "bootstrapPromptTemplate", v || undefined)
-                  }
-                  placeholder="Optional initial setup prompt for the first run"
-                  contentClassName="min-h-[44px] text-sm font-mono"
-                  imageUploadHandler={async (file) => {
-                    const namespace = isCreate
-                      ? "agents/drafts/bootstrap-prompt"
-                      : `agents/${props.agent.id}/bootstrap-prompt`;
-                    const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
-                    return asset.contentPath;
-                  }}
-                />
-              </Field>
+              {caps.thinkingEffort && (
+                <>
+                  <ThinkingEffortDropdown
+                    value={currentThinkingEffort}
+                    options={thinkingEffortOptions}
+                    onChange={(v) =>
+                      isCreate
+                        ? set!({ thinkingEffort: v })
+                        : mark("adapterConfig", thinkingEffortKey, v || undefined)
+                    }
+                    open={thinkingEffortOpen}
+                    onOpenChange={setThinkingEffortOpen}
+                  />
+                  {adapterType === "codex_local" &&
+                    codexSearchEnabled &&
+                    currentThinkingEffort === "minimal" && (
+                      <p className="text-xs text-amber-400">
+                        Codex may reject `minimal` thinking when search is enabled.
+                      </p>
+                    )}
+                </>
+              )}
+
+              {caps.bootstrapPrompt && (
+                <Field label="Bootstrap prompt (first run)" hint={help.bootstrapPrompt}>
+                  <MarkdownEditor
+                    value={
+                      isCreate
+                        ? val!.bootstrapPrompt
+                        : eff(
+                            "adapterConfig",
+                            "bootstrapPromptTemplate",
+                            String(config.bootstrapPromptTemplate ?? ""),
+                          )
+                    }
+                    onChange={(v) =>
+                      isCreate
+                        ? set!({ bootstrapPrompt: v })
+                        : mark("adapterConfig", "bootstrapPromptTemplate", v || undefined)
+                    }
+                    placeholder="Optional initial setup prompt for the first run"
+                    contentClassName="min-h-[44px] text-sm font-mono"
+                    imageUploadHandler={async (file) => {
+                      const namespace = isCreate
+                        ? "agents/drafts/bootstrap-prompt"
+                        : `agents/${props.agent.id}/bootstrap-prompt`;
+                      const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
+                      return asset.contentPath;
+                    }}
+                  />
+                </Field>
+              )}
+
               {adapterType === "claude_local" && (
                 <ClaudeLocalAdvancedFields {...adapterFieldProps} />
               )}
 
-              <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
-                <DraftInput
-                  value={
-                    isCreate
-                      ? val!.extraArgs
-                      : eff("adapterConfig", "extraArgs", formatArgList(config.extraArgs))
-                  }
-                  onCommit={(v) =>
-                    isCreate
-                      ? set!({ extraArgs: v })
-                      : mark("adapterConfig", "extraArgs", v ? parseCommaArgs(v) : undefined)
-                  }
-                  immediate
-                  className={inputClass}
-                  placeholder="e.g. --verbose, --foo=bar"
-                />
-              </Field>
+              {caps.extraArgs && (
+                <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
+                  <DraftInput
+                    value={
+                      isCreate
+                        ? val!.extraArgs
+                        : eff("adapterConfig", "extraArgs", formatArgList(config.extraArgs))
+                    }
+                    onCommit={(v) =>
+                      isCreate
+                        ? set!({ extraArgs: v })
+                        : mark("adapterConfig", "extraArgs", v ? parseCommaArgs(v) : undefined)
+                    }
+                    immediate
+                    className={inputClass}
+                    placeholder="e.g. --verbose, --foo=bar"
+                  />
+                </Field>
+              )}
 
-              <Field label="Environment variables" hint={help.envVars}>
-                <EnvVarEditor
-                  value={
-                    isCreate
-                      ? ((val!.envBindings ?? EMPTY_ENV) as Record<string, EnvBinding>)
-                      : ((eff("adapterConfig", "env", (config.env ?? EMPTY_ENV) as Record<string, EnvBinding>))
-                      )
-                  }
-                  secrets={availableSecrets}
-                  onCreateSecret={async (name, value) => {
-                    const created = await createSecret.mutateAsync({ name, value });
-                    return created;
-                  }}
-                  onChange={(env) =>
-                    isCreate
-                      ? set!({ envBindings: env ?? {}, envVars: "" })
-                      : mark("adapterConfig", "env", env)
-                  }
-                />
-              </Field>
+              {caps.envVars && (
+                <Field label="Environment variables" hint={help.envVars}>
+                  <EnvVarEditor
+                    value={
+                      isCreate
+                        ? ((val!.envBindings ?? EMPTY_ENV) as Record<string, EnvBinding>)
+                        : ((eff("adapterConfig", "env", (config.env ?? EMPTY_ENV) as Record<string, EnvBinding>))
+                        )
+                    }
+                    secrets={availableSecrets}
+                    onCreateSecret={async (name, value) => {
+                      const created = await createSecret.mutateAsync({ name, value });
+                      return created;
+                    }}
+                    onChange={(env) =>
+                      isCreate
+                        ? set!({ envBindings: env ?? {}, envVars: "" })
+                        : mark("adapterConfig", "env", env)
+                    }
+                  />
+                </Field>
+              )}
 
-              {/* Edit-only: timeout + grace period */}
-              {!isCreate && (
-                <>
-                  <Field label="Timeout (sec)" hint={help.timeoutSec}>
-                    <DraftNumberInput
-                      value={eff(
-                        "adapterConfig",
-                        "timeoutSec",
-                        Number(config.timeoutSec ?? 0),
-                      )}
-                      onCommit={(v) => mark("adapterConfig", "timeoutSec", v)}
-                      immediate
-                      className={inputClass}
-                    />
-                  </Field>
-                  <Field label="Interrupt grace period (sec)" hint={help.graceSec}>
-                    <DraftNumberInput
-                      value={eff(
-                        "adapterConfig",
-                        "graceSec",
-                        Number(config.graceSec ?? 15),
-                      )}
-                      onCommit={(v) => mark("adapterConfig", "graceSec", v)}
-                      immediate
-                      className={inputClass}
-                    />
-                  </Field>
-                </>
+              {/* Edit-only: timeout */}
+              {caps.timeout && !isCreate && (
+                <Field label="Timeout (sec)" hint={help.timeoutSec}>
+                  <DraftNumberInput
+                    value={eff(
+                      "adapterConfig",
+                      "timeoutSec",
+                      Number(config.timeoutSec ?? 0),
+                    )}
+                    onCommit={(v) => mark("adapterConfig", "timeoutSec", v)}
+                    immediate
+                    className={inputClass}
+                  />
+                </Field>
+              )}
+              {/* Edit-only: grace period */}
+              {caps.gracePeriod && !isCreate && (
+                <Field label="Interrupt grace period (sec)" hint={help.graceSec}>
+                  <DraftNumberInput
+                    value={eff(
+                      "adapterConfig",
+                      "graceSec",
+                      Number(config.graceSec ?? 15),
+                    )}
+                    onCommit={(v) => mark("adapterConfig", "graceSec", v)}
+                    immediate
+                    className={inputClass}
+                  />
+                </Field>
               )}
           </div>
         </div>
@@ -891,7 +907,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "acp"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -18,6 +18,7 @@ export const defaultCreateValues: CreateConfigValues = {
   envBindings: {},
   url: "",
   bootstrapPrompt: "",
+  timeoutSec: "",
   maxTurnsPerRun: 80,
   heartbeatEnabled: false,
   intervalSec: 300,

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -58,6 +58,7 @@ export const adapterLabels: Record<string, string> = {
   process: "Process",
   http: "HTTP",
   acp: "ACP Compatible (local)",
+  kiro_cli: "Kiro CLI (local)",
 };
 
 export const roleLabels: Record<string, string> = {

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -57,6 +57,7 @@ export const adapterLabels: Record<string, string> = {
   cursor: "Cursor (local)",
   process: "Process",
   http: "HTTP",
+  acp: "ACP Compatible (local)",
 };
 
 export const roleLabels: Record<string, string> = {

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -24,9 +24,10 @@ const adapterLabels: Record<string, string> = {
   process: "Process",
   http: "HTTP",
   acp: "ACP (stdio)",
+  kiro_cli: "Kiro CLI (local)",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "acp"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "acp", "kiro_cli"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -23,9 +23,10 @@ const adapterLabels: Record<string, string> = {
   cursor: "Cursor (local)",
   process: "Process",
   http: "HTTP",
+  acp: "ACP (stdio)",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "acp"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();


### PR DESCRIPTION
## Summary
- Add ACP (Agent Client Protocol) adapter - a generic stdio adapter for ACP-compatible agents
- Add Kiro CLI adapter extending ACP with model, agent, and trust-all-tools flags
- Add capability-driven config UI for ACP adapters

## Changes
- Server: ACP execute with full protocol lifecycle, model discovery, environment test
- CLI: ACP stdout event formatter for live transcription  
- UI: ACP adapter config fields, model dropdown, and stdout parser
- Introduce AdapterCapabilities interface for declarative UI control

## Testing
- Includes unit tests for ACP adapter
- Model discovery with 2-minute cache

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>