### PR TITLE
Fix Windows ENOENT error due to doubled drive letter in migrations path

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -4,10 +4,11 @@ import { migrate as migratePg } from "drizzle-orm/postgres-js/migrator";
 import { readFile, readdir } from "node:fs/promises";
 import postgres from "postgres";
 import * as schema from "./schema/index.js";
+import { fileURLToPath } from "node:url";
 
-const MIGRATIONS_FOLDER = new URL("./migrations", import.meta.url).pathname;
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
-const MIGRATIONS_JOURNAL_JSON = new URL("./migrations/meta/_journal.json", import.meta.url).pathname;
+const MIGRATIONS_JOURNAL_JSON = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
 
 function isSafeIdentifier(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
@@ -702,7 +703,7 @@ export async function migratePostgresIfEmpty(url: string): Promise<MigrationBoot
     }
 
     const db = drizzlePg(sql);
-    const migrationsFolder = new URL("./migrations", import.meta.url).pathname;
+    const migrationsFolder = fileURLToPath(new URL("./migrations", import.meta.url));
     await migratePg(db, { migrationsFolder });
 
     return { migrated: true, reason: "migrated-empty-db", tableCount: 0 };


### PR DESCRIPTION
Fixes #132. On Windows, using .pathname on a URL object created with import.meta.url returns /C:/Users/... with a leading slash, which causes Node to prepend the drive letter again resulting in C:\C:\Users\.... This fix uses fileURLToPath() from node:url which correctly handles Windows paths.