### PR TITLE
fix: allow dotfile paths in static UI serving

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -131,9 +131,9 @@ export async function createApp(
     ];
     const uiDist = candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
     if (uiDist) {
-      app.use(express.static(uiDist));
+      app.use(express.static(uiDist, { dotfiles: "allow" }));
       app.get(/.*/, (_req, res) => {
-        res.sendFile(path.join(uiDist, "index.html"));
+        res.sendFile(path.join(uiDist, "index.html"), { dotfiles: "allow" });
       });
     } else {
       console.warn("[paperclip] UI dist not found; running in API-only mode");


### PR DESCRIPTION
## Summary

- `express.static` and `res.sendFile` use the [`send`](https://www.npmjs.com/package/send) module, which by default rejects paths containing dot-prefixed directories (dotfiles behavior: `"ignore"` → 404)
- When Paperclip is installed via **nvm** (`~/.nvm/versions/...`) or run via **npx** (`~/.npm/_npx/...`), the resolved `ui-dist/index.html` path passes through a dot-prefixed directory
- This causes all SPA fallback routes (e.g. `/issues/MAN-5`) to return a 500 instead of serving `index.html`

The fix passes `{ dotfiles: "allow" }` to both `express.static` and `res.sendFile` so the bundled UI is served regardless of the install location.

## Test plan

- [ ] Install via nvm (`npm install -g paperclipai`) and navigate to a deep link like `/issues/<key>` — should render the SPA instead of 500
- [ ] Install via npx (`npx paperclipai run`) and verify the same
- [ ] Standard installs (non-dotfile paths) continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)