### PR TITLE
fix(cli): prevent URL encoding of query params in heartbeat event polling

### DIFF
--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -104,7 +104,9 @@ export class PaperclipApiClient {
 
 function buildUrl(apiBase: string, path: string): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const [pathname, search] = normalizedPath.split("?", 2);
+  const qIndex = normalizedPath.indexOf("?");
+  const pathname = qIndex === -1 ? normalizedPath : normalizedPath.slice(0, qIndex);
+  const search = qIndex === -1 ? "" : normalizedPath.slice(qIndex + 1);
   const url = new URL(apiBase);
   url.pathname = `${url.pathname.replace(/\/+$/, "")}${pathname}`;
   if (search) url.search = search;

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -104,10 +104,10 @@ export class PaperclipApiClient {
 
 function buildUrl(apiBase: string, path: string): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const [pathname, query] = normalizedPath.split("?");
+  const [pathname, search] = normalizedPath.split("?", 2);
   const url = new URL(apiBase);
   url.pathname = `${url.pathname.replace(/\/+$/, "")}${pathname}`;
-  if (query) url.search = query;
+  if (search) url.search = search;
   return url.toString();
 }
 


### PR DESCRIPTION
## Summary

Fixes #204.

`buildUrl()` in `cli/src/client/http.ts` assigns the entire path string (including query parameters) to `url.pathname`. The `URL` constructor automatically encodes special characters in `pathname`, turning `?` into `%3F`.

This causes the heartbeat event polling endpoint to fail:

```
# What the CLI sent:
GET /api/heartbeat-runs/<id>/events%3FafterSeq=0&limit=100  → 404/500

# What it should send:
GET /api/heartbeat-runs/<id>/events?afterSeq=0&limit=100    → 200
```

## Fix

Split the path and query string before assigning to the URL object:

```typescript
// Before
const normalizedPath = path.startsWith("/") ? path : `/${path}`;
const url = new URL(apiBase);
url.pathname = `${url.pathname.replace(/\/+$/, "")}${normalizedPath}`;

// After
const normalizedPath = path.startsWith("/") ? path : `/${path}`;
const [pathname, search] = normalizedPath.split("?", 2);
const url = new URL(apiBase);
url.pathname = `${url.pathname.replace(/\/+$/, "")}${pathname}`;
if (search) url.search = search;
```

## Impact

This affects any `api.get()` call that includes query parameters in the path string. Currently, the only affected call is heartbeat event polling (`/events?afterSeq=...&limit=...`), which is called in a loop during `paperclipai heartbeat run`.

The heartbeat run itself was always invoked successfully — only the CLI event streaming was broken, causing users to always see "Internal server error" even on successful runs.