### PR TITLE
chore: sync pnpm-lock.yaml with opencode-local package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@types/node':
-        specifier: ^22.12.0
-        version: 22.19.11
+        specifier: ^24.6.0
+        version: 24.12.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -8162,7 +8162,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -8171,7 +8171,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
 
   '@types/cookiejar@2.1.5': {}
 
@@ -8189,7 +8189,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -8246,18 +8246,18 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
 
   '@types/superagent@8.1.9':
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':
@@ -8271,7 +8271,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.2.3
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
CI is currently broken on `master` — every PR fails at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_OUTDATED_LOCKFILE: pnpm-lock.yaml is not up to date with packages/adapters/opencode-local/package.json

specifiers in lockfile: @types/node ^22.12.0
specs in package.json:  @types/node ^24.6.0
```

This PR runs `pnpm install` to sync the lockfile. 9 lines changed.