### PR TITLE
fix: match @-mentions against agent urlKey for wake triggers

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1223,12 +1223,16 @@ export function issueService(db: Db) {
         const camelSplit = normalizeAgentUrlKey(raw.replace(/([a-z])([A-Z])/g, "$1-$2"));
         if (camelSplit && camelSplit !== urlKey) tokens.add(camelSplit);
       }
-      if (tokens.size === 0) return [];
-      const rows = await db.select({ id: agents.id, name: agents.name })
+      const rows = await db.select({ id: agents.id, name: agents.name, urlKey: agents.urlKey })
         .from(agents).where(eq(agents.companyId, companyId));
+      const bodyLower = body.toLowerCase();
       return rows.filter(a => {
+        // Token-based match (handles @ceo, @founding-engineer, @CodeReviewer)
         const nameKey = normalizeAgentUrlKey(a.name);
-        return tokens.has(a.name.toLowerCase()) || (nameKey !== null && tokens.has(nameKey));
+        if (tokens.has(a.name.toLowerCase()) || (nameKey !== null && tokens.has(nameKey))) return true;
+        // Direct substring match for multi-word names (handles "@Code Reviewer")
+        if (a.name.includes(" ") && bodyLower.includes("@" + a.name.toLowerCase())) return true;
+        return false;
       }).map(a => a.id);
     },
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1225,7 +1225,7 @@ export function issueService(db: Db) {
         const camelSplit = normalizeAgentUrlKey(raw.replace(/([a-z])([A-Z])/g, "$1-$2"));
         if (camelSplit && camelSplit !== urlKey) tokens.add(camelSplit);
       }
-      const rows = await db.select({ id: agents.id, name: agents.name, urlKey: agents.urlKey })
+      const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
       const bodyLower = stripped.toLowerCase();
       return rows.filter(a => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -16,7 +16,7 @@ import {
   projectWorkspaces,
   projects,
 } from "@paperclipai/db";
-import { extractProjectMentionIds } from "@paperclipai/shared";
+import { extractProjectMentionIds, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
@@ -1214,11 +1214,19 @@ export function issueService(db: Db) {
       const re = /\B@([^\s@,!?.]+)/g;
       const tokens = new Set<string>();
       let m: RegExpExecArray | null;
-      while ((m = re.exec(body)) !== null) tokens.add(m[1].toLowerCase());
+      while ((m = re.exec(body)) !== null) {
+        const raw = m[1];
+        tokens.add(raw.toLowerCase());
+        const urlKey = normalizeAgentUrlKey(raw);
+        if (urlKey) tokens.add(urlKey);
+      }
       if (tokens.size === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      return rows.filter(a => tokens.has(a.name.toLowerCase())).map(a => a.id);
+      return rows.filter(a => {
+        const nameKey = normalizeAgentUrlKey(a.name);
+        return tokens.has(a.name.toLowerCase()) || (nameKey !== null && tokens.has(nameKey));
+      }).map(a => a.id);
     },
 
     findMentionedProjectIds: async (issueId: string) => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1211,10 +1211,12 @@ export function issueService(db: Db) {
       }),
 
     findMentionedAgents: async (companyId: string, body: string) => {
+      // Strip fenced code blocks and inline code spans so @mentions in examples don't trigger wakes
+      const stripped = body.replace(/```[\s\S]*?```/g, "").replace(/`[^`]+`/g, "");
       const re = /\B@([^\s@,!?.]+)/g;
       const tokens = new Set<string>();
       let m: RegExpExecArray | null;
-      while ((m = re.exec(body)) !== null) {
+      while ((m = re.exec(stripped)) !== null) {
         const raw = m[1];
         tokens.add(raw.toLowerCase());
         const urlKey = normalizeAgentUrlKey(raw);
@@ -1225,7 +1227,7 @@ export function issueService(db: Db) {
       }
       const rows = await db.select({ id: agents.id, name: agents.name, urlKey: agents.urlKey })
         .from(agents).where(eq(agents.companyId, companyId));
-      const bodyLower = body.toLowerCase();
+      const bodyLower = stripped.toLowerCase();
       return rows.filter(a => {
         // Token-based match (handles @ceo, @founding-engineer, @CodeReviewer)
         const nameKey = normalizeAgentUrlKey(a.name);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1219,6 +1219,9 @@ export function issueService(db: Db) {
         tokens.add(raw.toLowerCase());
         const urlKey = normalizeAgentUrlKey(raw);
         if (urlKey) tokens.add(urlKey);
+        // Split CamelCase so @FoundingEngineer → founding-engineer
+        const camelSplit = normalizeAgentUrlKey(raw.replace(/([a-z])([A-Z])/g, "$1-$2"));
+        if (camelSplit && camelSplit !== urlKey) tokens.add(camelSplit);
       }
       if (tokens.size === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })


### PR DESCRIPTION
## Summary

- **Bug:** `findMentionedAgents()` only matched `@mention` tokens against raw agent name. Multi-word names like `@Founding Engineer` only captured `Founding` (regex stops at whitespace), and urlKey formats like `@founding-engineer` had no normalization path.
- **Fix:** Normalize both mention tokens and agent names via `normalizeAgentUrlKey` before comparison. Now `@founding-engineer`, `@FoundingEngineer`, `@CEO`, etc. all correctly resolve and trigger agent wakes.
- 1 file changed, 11 insertions, 3 deletions

## Test plan

- [ ] Post a comment with `@founding-engineer` → agent should wake
- [ ] Post a comment with `@CEO` → agent should wake
- [ ] Post a comment with `@FoundingEngineer` → agent should wake
- [ ] Verify no false-positive matches on partial names

Fixes: RUS-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)