### PR TITLE
feat: agent notifications endpoint and subtask completion wakeups

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -612,8 +612,12 @@ export function agentRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, agent.companyId);
+    if (req.actor.type === "agent" && req.actor.agentId !== id) {
+      throw forbidden("Agents can only read their own notifications");
+    }
 
-    const limit = req.query.limit ? Math.min(Number(req.query.limit), 200) : 50;
+    const parsedLimit = Number(req.query.limit);
+    const limit = req.query.limit && Number.isFinite(parsedLimit) ? Math.min(Math.max(1, parsedLimit), 200) : 50;
     const status = typeof req.query.status === "string" ? req.query.status : undefined;
     const reason = typeof req.query.reason === "string" ? req.query.reason : undefined;
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -604,6 +604,23 @@ export function agentRoutes(db: Db) {
     );
   });
 
+  router.get("/agents/:id/notifications", async (req, res) => {
+    const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const limit = req.query.limit ? Math.min(Number(req.query.limit), 200) : 50;
+    const status = typeof req.query.status === "string" ? req.query.status : undefined;
+    const reason = typeof req.query.reason === "string" ? req.query.reason : undefined;
+
+    const notifications = await heartbeat.listNotifications(id, { limit, status, reason });
+    res.json(notifications);
+  });
+
   router.post("/agents/:id/runtime-state/reset-session", validate(resetAgentSessionSchema), async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -638,6 +638,33 @@ export function issueRoutes(db: Db, storage: StorageService) {
         }
       }
 
+      // Subtask completion: wake parent task's assignee agent when a subtask is marked done
+      const statusChanged = existing.status !== issue.status;
+      if (statusChanged && issue.status === "done" && issue.parentId) {
+        try {
+          const parent = await svc.getById(issue.parentId);
+          if (parent?.assigneeAgentId && !wakeups.has(parent.assigneeAgentId)) {
+            wakeups.set(parent.assigneeAgentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "subtask_completed",
+              payload: { issueId: parent.id, subtaskId: issue.id, subtaskIdentifier: issue.identifier },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: parent.id,
+                taskId: parent.id,
+                wakeReason: "subtask_completed",
+                source: "issue.subtask.completed",
+                subtaskId: issue.id,
+              },
+            });
+          }
+        } catch (err) {
+          logger.warn({ err, issueId: id, parentId: issue.parentId }, "failed to wake parent assignee on subtask completion");
+        }
+      }
+
       for (const [agentId, wakeup] of wakeups.entries()) {
         heartbeat
           .wakeup(agentId, wakeup)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1673,9 +1673,10 @@ export function heartbeatService(db: Db) {
       return null;
     }
 
+    const bypassReasons = new Set(["issue_comment_mentioned", "subtask_completed"]);
     const bypassIssueExecutionLock =
-      reason === "issue_comment_mentioned" ||
-      readNonEmptyString(enrichedContextSnapshot.wakeReason) === "issue_comment_mentioned";
+      bypassReasons.has(reason ?? "") ||
+      bypassReasons.has(readNonEmptyString(enrichedContextSnapshot.wakeReason) ?? "");
 
     if (issueId && !bypassIssueExecutionLock) {
       const agentNameKey = normalizeAgentNameKey(agent.name);
@@ -2310,6 +2311,34 @@ export function heartbeatService(db: Db) {
       }
 
       return runs.length;
+    },
+
+    listNotifications: async (
+      agentId: string,
+      opts?: { limit?: number; status?: string; reason?: string },
+    ) => {
+      const limit = Math.max(1, Math.min(opts?.limit ?? 50, 200));
+      const agent = await getAgent(agentId);
+      if (!agent) throw notFound("Agent not found");
+
+      const conditions = [
+        eq(agentWakeupRequests.companyId, agent.companyId),
+        eq(agentWakeupRequests.agentId, agentId),
+      ];
+
+      if (opts?.status) {
+        conditions.push(eq(agentWakeupRequests.status, opts.status));
+      }
+      if (opts?.reason) {
+        conditions.push(eq(agentWakeupRequests.reason, opts.reason));
+      }
+
+      return db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(...conditions))
+        .orderBy(desc(agentWakeupRequests.requestedAt))
+        .limit(limit);
     },
 
     getActiveRunForAgent: async (agentId: string) => {


### PR DESCRIPTION
## Summary

- Adds `GET /api/agents/:id/notifications` endpoint — lists wakeup requests (the agent's notification feed) with `status`, `reason`, and `limit` filters
- Wakes the parent task's assignee agent with reason `subtask_completed` when a subtask moves to `done`
- Adds `subtask_completed` to the execution lock bypass list (alongside `issue_comment_mentioned`) so parent agents are notified immediately

## Context

Part of [RUS-28](/RUS/issues/RUS-28) — Agent inbox / notification feed as primary wake trigger. This is the server-side implementation that enables event-driven agent wakeups instead of periodic polling.

## Test plan

- [ ] Verify `GET /api/agents/:id/notifications` returns wakeup history
- [ ] Verify completing a subtask wakes the parent task's assignee
- [ ] Verify subtask_completed bypasses execution lock on parent task

🤖 Generated with [Claude Code](https://claude.com/claude-code)