### PR TITLE
fixing overhanging recommended text in onboarding

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -730,7 +730,7 @@ export function OnboardingWizard() {
                           }}
                         >
                           {opt.recommended && (
-                            <span className="absolute -top-1.5 -right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
+                            <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
                               Recommended
                             </span>
                           )}


### PR DESCRIPTION
Before:

<img width="457" height="321" alt="image" src="https://github.com/user-attachments/assets/4975d72f-eeca-46e9-98c2-511f8899f867" />


After:

<img width="390" height="324" alt="image" src="https://github.com/user-attachments/assets/7e18a61f-549e-4f88-b350-a34374e1b586" />
