### PR TITLE
Rename Invoke button to Run Heartbeat for UX consistency

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -468,7 +468,7 @@ export function AgentDetail() {
             disabled={agentAction.isPending || isPendingApproval}
           >
             <Play className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">Invoke</span>
+            <span className="hidden sm:inline">Run Heartbeat</span>
           </Button>
           {agent.status === "paused" ? (
             <Button


### PR DESCRIPTION
Existing UX evidence this is what we should be calling it

<img width="1380" height="361" alt="image" src="https://github.com/user-attachments/assets/84f27cbf-2502-49a7-91e3-a4e542352ea9" />

New name

<img width="928" height="307" alt="image" src="https://github.com/user-attachments/assets/e0c47e35-18bc-4327-89c2-771f9cf81155" />

Still looks okay with mobile