### PR TITLE
fix: add missing @types/node to cursor-local adapter

### DIFF
--- a/packages/adapters/cursor-local/package.json
+++ b/packages/adapters/cursor-local/package.json
@@ -45,6 +45,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
+    "@types/node": "^24.6.0",
     "typescript": "^5.7.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- The `cursor-local` adapter was missing `@types/node` in `devDependencies`, causing `pnpm build` to fail with `TS2307` errors when compiling `adapter-utils` server code that references Node.js APIs (`node:child_process`, `node:fs`, etc.)
- Adds `@types/node` to match all other adapter packages

## Test plan
- [x] `pnpm build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)