### PR TITLE
fix: guard DELETE /api/projects/:id against FK violations

### DIFF
--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -266,24 +266,31 @@ export function projectRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    const project = await svc.remove(id);
-    if (!project) {
+    const result = await svc.remove(id);
+    if (!result) {
       res.status(404).json({ error: "Project not found" });
+      return;
+    }
+    if ("rejected" in result) {
+      res.status(409).json({
+        error:
+          "Cannot delete a project that has issues. Set the project status to 'cancelled' instead.",
+      });
       return;
     }
 
     const actor = getActorInfo(req);
     await logActivity(db, {
-      companyId: project.companyId,
+      companyId: result.companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
       action: "project.deleted",
       entityType: "project",
-      entityId: project.id,
+      entityId: result.id,
     });
 
-    res.json(project);
+    res.json(result);
   });
 
   return router;

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { projects, projectGoals, goals, projectWorkspaces } from "@paperclipai/db";
+import { projects, projectGoals, goals, projectWorkspaces, issues, costEvents } from "@paperclipai/db";
 import {
   PROJECT_COLORS,
   deriveProjectUrlKey,
@@ -385,16 +385,31 @@ export function projectService(db: Db) {
       return enriched ?? null;
     },
 
-    remove: (id: string) =>
-      db
+    remove: async (id: string) => {
+      // Reject if any issues reference this project
+      const relatedIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.projectId, id))
+        .limit(1);
+      if (relatedIssues.length > 0) {
+        return { rejected: true as const };
+      }
+
+      // Null out cost_events references before deleting
+      await db
+        .update(costEvents)
+        .set({ projectId: null })
+        .where(eq(costEvents.projectId, id));
+
+      const rows = await db
         .delete(projects)
         .where(eq(projects.id, id))
-        .returning()
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          if (!row) return null;
-          return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
-        }),
+        .returning();
+      const row = rows[0] ?? null;
+      if (!row) return null;
+      return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
+    },
 
     listWorkspaces: async (projectId: string): Promise<ProjectWorkspace[]> => {
       const rows = await db

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -386,29 +386,31 @@ export function projectService(db: Db) {
     },
 
     remove: async (id: string) => {
-      // Reject if any issues reference this project
-      const relatedIssues = await db
-        .select({ id: issues.id })
-        .from(issues)
-        .where(eq(issues.projectId, id))
-        .limit(1);
-      if (relatedIssues.length > 0) {
-        return { rejected: true as const };
-      }
+      return db.transaction(async (tx) => {
+        // Reject if any issues reference this project
+        const relatedIssues = await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(eq(issues.projectId, id))
+          .limit(1);
+        if (relatedIssues.length > 0) {
+          return { rejected: true as const };
+        }
 
-      // Null out cost_events references before deleting
-      await db
-        .update(costEvents)
-        .set({ projectId: null })
-        .where(eq(costEvents.projectId, id));
+        // Null out cost_events references before deleting
+        await tx
+          .update(costEvents)
+          .set({ projectId: null })
+          .where(eq(costEvents.projectId, id));
 
-      const rows = await db
-        .delete(projects)
-        .where(eq(projects.id, id))
-        .returning();
-      const row = rows[0] ?? null;
-      if (!row) return null;
-      return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
+        const rows = await tx
+          .delete(projects)
+          .where(eq(projects.id, id))
+          .returning();
+        const row = rows[0] ?? null;
+        if (!row) return null;
+        return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
+      });
     },
 
     listWorkspaces: async (projectId: string): Promise<ProjectWorkspace[]> => {


### PR DESCRIPTION
## Summary

- `DELETE /api/projects/:id` was returning 500 on real projects due to FK constraint violations from `issues` and `cost_events` tables referencing the project
- Now rejects deletion with **409** if any issues reference the project, with guidance to use `cancelled` status instead
- Nulls out `cost_events.projectId` references before deletion to prevent FK errors on that table
- `project_workspaces` and `project_goals` already had `onDelete: "cascade"` and were not affected

## Test plan

- [ ] `DELETE /api/projects/:id` on a project with issues → returns 409 with helpful error message
- [ ] `DELETE /api/projects/:id` on a project with no issues but cost_events → succeeds, cost_events.projectId nulled
- [ ] `DELETE /api/projects/:id` on an empty project → succeeds as before
- [ ] `DELETE /api/projects/nonexistent-uuid` → still returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)