### PR TITLE
fix: strip Claude Code env vars to allow nested agent sessions

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -219,7 +219,12 @@ export async function runChildProcess(
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
 
   return new Promise<RunProcessResult>((resolve, reject) => {
-    const mergedEnv = ensurePathInEnv({ ...process.env, ...opts.env });
+    // Strip Claude Code env vars to prevent "cannot launch inside another session" errors
+    const claudeEnvKeys = new Set(["CLAUDECODE", "CLAUDE_CODE_SSE_PORT", "CLAUDE_CODE_ENTRYPOINT", "CK_CLAUDE_SETTINGS_DIR"]);
+    const baseEnv = Object.fromEntries(
+      Object.entries(process.env).filter(([k]) => !k.startsWith("CLAUDE_") && !claudeEnvKeys.has(k))
+    );
+    const mergedEnv = ensurePathInEnv({ ...baseEnv, ...opts.env });
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env: mergedEnv,


### PR DESCRIPTION
## Problem

When Paperclip MC runs inside a Claude Code session and spawns agents via the `claude_local` adapter, the child process inherits `CLAUDE_*` environment variables from the parent. Claude Code detects these and refuses to start:

```
Error: cannot launch inside another session
```

This makes it impossible to use `claude_local` adapter for headless agents when MC itself is running inside Claude Code.

## Fix

Strip Claude Code environment variables (`CLAUDE_*`, `CLAUDECODE`, `CK_CLAUDE_SETTINGS_DIR`) from the child process environment in `runChildProcess()` before spawning. The child gets a fresh Claude Code session with only `PAPERCLIP_*` vars injected by `buildPaperclipEnv()`.

## Changed file

`packages/adapter-utils/src/server-utils.ts` — 6 lines added, 1 removed

## Test plan

- [x] Verified `claude_local` agent spawns successfully with fix applied
- [x] Agent completes full heartbeat cycle (identity check → issue checkout → work → comment → status update → trigger next agent)
- [ ] Existing process adapter tests still pass