### PR TITLE
fix(scripts): use shell on Windows to fix spawn EINVAL in dev-runner

### DIFF
--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -47,7 +47,7 @@ const serverScript = mode === "watch" ? "dev:watch" : "dev";
 const child = spawn(
   pnpmBin,
   ["--filter", "@paperclipai/server", serverScript, ...forwardedArgs],
-  { stdio: "inherit", env },
+  { stdio: "inherit", env, shell: process.platform === "win32" },
 );
 
 child.on("exit", (code, signal) => {


### PR DESCRIPTION
On Windows, pnpm run dev failed with Error: spawn EINVAL because pnpm.cmd is a batch script and was being spawned without a shell. This change uses shell: true on Windows so the command runs under cmd.exe and the spawn succeeds. Unix behavior is unchanged.