### PR TITLE
feat: add run failure rate metrics to dashboard endpoint

### DIFF
--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -111,15 +111,19 @@ export function dashboardService(db: Db) {
       const runCounts: Record<string, number> = {};
       let totalRuns = 0;
       let failedRuns = 0;
+      let terminalRuns = 0;
       for (const row of runRows) {
         const count = Number(row.count);
         runCounts[row.status] = count;
         totalRuns += count;
         if (row.status === "failed" || row.status === "timed_out") {
           failedRuns += count;
+          terminalRuns += count;
+        } else if (row.status === "succeeded" || row.status === "cancelled") {
+          terminalRuns += count;
         }
       }
-      const failureRate = totalRuns > 0 ? failedRuns / totalRuns : 0;
+      const failureRate = terminalRuns > 0 ? failedRuns / terminalRuns : 0;
 
       return {
         companyId,
@@ -140,6 +144,8 @@ export function dashboardService(db: Db) {
           succeeded: runCounts.succeeded ?? 0,
           failed: failedRuns,
           cancelled: runCounts.cancelled ?? 0,
+          queued: runCounts.queued ?? 0,
+          running: runCounts.running ?? 0,
           failureRatePercent: Number((failureRate * 100).toFixed(2)),
         },
         pendingApprovals,

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, companies, costEvents, issues } from "@paperclipai/db";
+import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
 
 export function dashboardService(db: Db) {
@@ -92,6 +92,35 @@ export function dashboardService(db: Db) {
           ? (monthSpendCents / company.budgetMonthlyCents) * 100
           : 0;
 
+      // Run health: failure rates over the last 24 hours
+      const runCutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const runRows = await db
+        .select({
+          status: heartbeatRuns.status,
+          count: sql<number>`count(*)`,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            gte(heartbeatRuns.createdAt, runCutoff),
+          ),
+        )
+        .groupBy(heartbeatRuns.status);
+
+      const runCounts: Record<string, number> = {};
+      let totalRuns = 0;
+      let failedRuns = 0;
+      for (const row of runRows) {
+        const count = Number(row.count);
+        runCounts[row.status] = count;
+        totalRuns += count;
+        if (row.status === "failed" || row.status === "timed_out") {
+          failedRuns += count;
+        }
+      }
+      const failureRate = totalRuns > 0 ? failedRuns / totalRuns : 0;
+
       return {
         companyId,
         agents: {
@@ -105,6 +134,13 @@ export function dashboardService(db: Db) {
           monthSpendCents,
           monthBudgetCents: company.budgetMonthlyCents,
           monthUtilizationPercent: Number(utilization.toFixed(2)),
+        },
+        runs: {
+          last24h: totalRuns,
+          succeeded: runCounts.succeeded ?? 0,
+          failed: failedRuns,
+          cancelled: runCounts.cancelled ?? 0,
+          failureRatePercent: Number((failureRate * 100).toFixed(2)),
         },
         pendingApprovals,
         staleTasks,


### PR DESCRIPTION
## Summary

- Adds a `runs` section to `GET /companies/:companyId/dashboard` with 24-hour run health metrics
- Returns: `last24h`, `succeeded`, `failed`, `cancelled`, `failureRatePercent`
- Failed runs include both `failed` and `timed_out` statuses

## Motivation

Run failure rates were tracked in the database but not exposed on the dashboard. Operators had no way to see agent reliability at a glance without querying individual run logs.

## Change

One query added to `server/src/services/dashboard.ts` — aggregates `heartbeat_runs` by status over the last 24 hours.

## Test plan

- [ ] Dashboard endpoint returns `runs` section with correct counts
- [ ] `failureRatePercent` is 0 when no runs exist
- [ ] `failureRatePercent` correctly includes `timed_out` in the failure count

🤖 Generated with [Claude Code](https://claude.com/claude-code)