### PR TITLE
fix(cli): split path and query in buildUrl to prevent %3F encoding

### DIFF
--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -104,8 +104,10 @@ export class PaperclipApiClient {
 
 function buildUrl(apiBase: string, path: string): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const [pathname, query] = normalizedPath.split("?");
   const url = new URL(apiBase);
-  url.pathname = `${url.pathname.replace(/\/+$/, "")}${normalizedPath}`;
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}${pathname}`;
+  if (query) url.search = query;
   return url.toString();
 }
 


### PR DESCRIPTION
## Summary

Fixes #204

`buildUrl()` in `cli/src/client/http.ts` assigns the full path (including query string) to `url.pathname`, which encodes `?` as `%3F`. This breaks heartbeat event polling - the server sees `events%3FafterSeq=0` as a path segment instead of a query parameter.

## Fix

Split the path and query string before assignment:

```typescript
const [pathname, query] = normalizedPath.split("?");
url.pathname = `${url.pathname.replace(/\/+$/, "")}${pathname}`;
if (query) url.search = query;
```

## Testing

- `buildUrl("http://localhost:3000", "/api/heartbeat-runs/abc/events?afterSeq=0&limit=100")` now produces a URL with `?` not `%3F`
- CLI typecheck passes (no new errors)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>