### PR TITLE
fix(ui): prevent blank screen when prompt template is emptied

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -441,7 +441,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     "promptTemplate",
                     String(config.promptTemplate ?? ""),
                   )}
-                  onChange={(v) => mark("adapterConfig", "promptTemplate", v || undefined)}
+                  onChange={(v) => mark("adapterConfig", "promptTemplate", v ?? "")}
                   placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
                   contentClassName="min-h-[88px] text-sm font-mono"
                   imageUploadHandler={async (file) => {


### PR DESCRIPTION
## Summary

Fixes #191

Clearing all text from the prompt template input crashes the UI with `Uncaught TypeError: Cannot read properties of undefined (reading 'trim')`.

## Root Cause

The `onChange` handler passes `v || undefined` when the value is an empty string. This stores `undefined` in the config, which crashes downstream code calling `.trim()`.

## Fix

One-line change in `AgentConfigForm.tsx`:

```diff
- onChange={(v) => mark("adapterConfig", "promptTemplate", v || undefined)}
+ onChange={(v) => mark("adapterConfig", "promptTemplate", v ?? "")}
```

## Testing

- UI typecheck passes cleanly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>