### PR TITLE
fix(server): auto-deduplicate agent names on creation

### DIFF
--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -341,13 +341,17 @@ export function agentService(db: Db) {
         await ensureManager(companyId, data.reportsTo);
       }
 
-      await assertCompanyShortnameAvailable(companyId, data.name);
+      const existingAgents = await db
+        .select({ id: agents.id, name: agents.name, status: agents.status })
+        .from(agents)
+        .where(eq(agents.companyId, companyId));
+      const uniqueName = deduplicateAgentName(data.name, existingAgents);
 
       const role = data.role ?? "general";
       const normalizedPermissions = normalizeAgentPermissions(data.permissions, role);
       const created = await db
         .insert(agents)
-        .values({ ...data, companyId, role, permissions: normalizedPermissions })
+        .values({ ...data, name: uniqueName, companyId, role, permissions: normalizedPermissions })
         .returning()
         .then((rows) => rows[0]);
 


### PR DESCRIPTION
## Summary

Fixes #232

`deduplicateAgentName()` exists but wasn't used in the `create` path - instead `assertCompanyShortnameAvailable()` threw a conflict error. This meant agent creation via delegation/hire flows could fail on name collisions rather than gracefully deduplicating.

## Fix

Replace the collision check with auto-deduplication in `agentService.create()`:

```typescript
const existingAgents = await db
  .select({ id: agents.id, name: agents.name, status: agents.status })
  .from(agents)
  .where(eq(agents.companyId, companyId));
const uniqueName = deduplicateAgentName(data.name, existingAgents);
```

Now creating an agent with a duplicate name auto-suffixes it (e.g. "Engineer" becomes "Engineer 2").

## Testing

- Server typecheck passes cleanly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>