### PR TITLE
fix(db): use fileURLToPath for Windows-safe migration paths

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -703,8 +703,7 @@ export async function migratePostgresIfEmpty(url: string): Promise<MigrationBoot
     }
 
     const db = drizzlePg(sql);
-    const migrationsFolder = fileURLToPath(new URL("./migrations", import.meta.url));
-    await migratePg(db, { migrationsFolder });
+    await migratePg(db, { migrationsFolder: MIGRATIONS_FOLDER });
 
     return { migrated: true, reason: "migrated-empty-db", tableCount: 0 };
   } finally {


### PR DESCRIPTION
## Summary

Fixes #132

On Windows, `URL.pathname` returns `/C:/Users/...` (with leading slash). When Node prepends the current drive letter, this produces `C:\C:\Users\...`, causing `ENOENT` on startup.

## Fix

Replace `.pathname` with `fileURLToPath()` from `node:url` at 3 locations in `packages/db/src/client.ts` (lines 8, 10, 705). `fileURLToPath` correctly handles cross-platform path conversion.

## Testing

- Server typecheck passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>