### PR TITLE
fix(server): use home-based path for run logs instead of cwd

### DIFF
--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -2,6 +2,7 @@ import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -148,7 +149,7 @@ let cachedStore: RunLogStore | null = null;
 
 export function getRunLogStore() {
   if (cachedStore) return cachedStore;
-  const basePath = process.env.RUN_LOG_BASE_PATH ?? path.resolve(process.cwd(), "data/run-logs");
+  const basePath = process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
   cachedStore = createLocalFileRunLogStore(basePath);
   return cachedStore;
 }


### PR DESCRIPTION
## Summary

Fixes #89

Run logs defaulted to `process.cwd()/data/run-logs`, placing them in unexpected locations when `paperclipai` is launched from a non-home directory.

## Fix

Replace `process.cwd()` with `resolvePaperclipInstanceRoot()` in `run-log-store.ts`, matching how all other Paperclip data paths are resolved. Logs now default to `~/.paperclip/instances/<id>/data/run-logs/`. The `RUN_LOG_BASE_PATH` env var override still works.

## Testing

- Server typecheck passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>