### PR TITLE
fix(server): wake agent when issue status changes from backlog

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -575,6 +575,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
 
     const assigneeChanged = assigneeWillChange;
+    const statusChangedFromBacklog =
+      existing.status === "backlog" &&
+      issue.status !== "backlog" &&
+      req.body.status !== undefined;
 
     // Merge all wakeups from this update into one enqueue per agent to avoid duplicate runs.
     void (async () => {
@@ -589,6 +593,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
           requestedByActorType: actor.actorType,
           requestedByActorId: actor.actorId,
           contextSnapshot: { issueId: issue.id, source: "issue.update" },
+        });
+      }
+
+      if (!assigneeChanged && statusChangedFromBacklog && issue.assigneeAgentId) {
+        wakeups.set(issue.assigneeAgentId, {
+          source: "automation",
+          triggerDetail: "system",
+          reason: "issue_status_changed",
+          payload: { issueId: issue.id, mutation: "update" },
+          requestedByActorType: actor.actorType,
+          requestedByActorId: actor.actorId,
+          contextSnapshot: { issueId: issue.id, source: "issue.status_change" },
         });
       }
 


### PR DESCRIPTION
## Summary

Fixes #167

When an issue status changes from "backlog" to "todo" without changing the assignee, the existing assignee agent was never woken because wake-up only fired on `assigneeChanged`.

## Fix

Add a second wake condition in `routes/issues.ts` that detects status transitions out of backlog:

```typescript
const statusChangedFromBacklog =
  existing.status === "backlog" &&
  issue.status !== "backlog" &&
  req.body.status !== undefined;

if (!assigneeChanged && statusChangedFromBacklog && issue.assigneeAgentId) {
  wakeups.set(issue.assigneeAgentId, { ... reason: "issue_status_changed" ... });
}
```

Uses `!assigneeChanged` guard to prevent duplicate wakes when both assignee and status change.

## Testing

- Server typecheck passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>