### PR TITLE
fix(server): serve cached index.html in SPA catch-all to prevent 500

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -134,9 +134,10 @@ export async function createApp(
     ];
     const uiDist = candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
     if (uiDist) {
+      const indexHtml = fs.readFileSync(path.join(uiDist, "index.html"), "utf-8");
       app.use(express.static(uiDist));
       app.get(/.*/, (_req, res) => {
-        res.sendFile("index.html", { root: uiDist });
+        res.status(200).set("Content-Type", "text/html").end(indexHtml);
       });
     } else {
       console.warn("[paperclip] UI dist not found; running in API-only mode");


### PR DESCRIPTION
## Summary

Fixes #233

Company-scoped client-side routes (e.g. \`/<COMPANY>/dashboard\`) returned 500 on direct navigation or page refresh. The \`send\` module used by \`res.sendFile()\` could emit \`NotFoundError\` in certain path resolution scenarios.

## Fix

Cache \`index.html\` content at startup and serve it directly with \`res.end()\`, bypassing the \`send\` module entirely. This is both more reliable and slightly faster (no filesystem hit per request).

## Testing

- Server typecheck passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>