### PR TITLE
fix: attach images to comments via issueCommentId

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -378,36 +378,38 @@ export function CommentThread({
         />
         <div className="flex items-center justify-end gap-3">
           {onAttachImage && (
-            <div className="mr-auto flex items-center gap-3">
-              <input
-                ref={attachInputRef}
-                type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif"
-                className="hidden"
-                onChange={handleAttachFile}
-              />
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => attachInputRef.current?.click()}
-                disabled={attaching}
-                title="Attach image"
-              >
-                <Paperclip className="h-4 w-4" />
-              </Button>
-            </div>
-            {pendingFile && (
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 px-2 py-1 rounded">
-                <span className="truncate max-w-[150px]">{pendingFile.name}</span>
-                <button
-                  type="button"
-                  onClick={() => setPendingFile(null)}
-                  className="hover:text-foreground"
+            <>
+              <div className="mr-auto flex items-center gap-3">
+                <input
+                  ref={attachInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  className="hidden"
+                  onChange={handleAttachFile}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => attachInputRef.current?.click()}
+                  disabled={attaching}
+                  title="Attach image"
                 >
-                  ×
-                </button>
+                  <Paperclip className="h-4 w-4" />
+                </Button>
               </div>
-            )}
+              {pendingFile && (
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 px-2 py-1 rounded">
+                  <span className="truncate max-w-[150px]">{pendingFile.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => setPendingFile(null)}
+                    className="hover:text-foreground"
+                  >
+                    ×
+                  </button>
+                </div>
+              )}
+            </>
           )}
           {isClosed && (
             <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -32,12 +32,12 @@ interface CommentReassignment {
 interface CommentThreadProps {
   comments: CommentWithRunMeta[];
   linkedRuns?: LinkedRunItem[];
-  onAdd: (body: string, reopen?: boolean, reassignment?: CommentReassignment) => Promise<void>;
+  onAdd: (body: string, reopen?: boolean, reassignment?: CommentReassignment) => Promise<string>;
   issueStatus?: string;
   agentMap?: Map<string, Agent>;
   imageUploadHandler?: (file: File) => Promise<string>;
   /** Callback to attach an image file to the parent issue (not inline in a comment). */
-  onAttachImage?: (file: File) => Promise<void>;
+  onAttachImage?: (file: File, commentId?: string) => Promise<void>;
   draftKey?: string;
   liveRunSlot?: React.ReactNode;
   enableReassign?: boolean;
@@ -232,6 +232,7 @@ export function CommentThread({
   const [reopen, setReopen] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [attaching, setAttaching] = useState(false);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [reassignTarget, setReassignTarget] = useState(currentAssigneeValue);
   const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
   const editorRef = useRef<MarkdownEditorRef>(null);
@@ -323,7 +324,20 @@ export function CommentThread({
 
     setSubmitting(true);
     try {
-      await onAdd(trimmed, isClosed && reopen ? true : undefined, reassignment ?? undefined);
+      // Submit comment and get comment ID
+      const commentId = await onAdd(trimmed, isClosed && reopen ? true : undefined, reassignment ?? undefined);
+      
+      // If there's a pending file, upload it with the comment ID
+      if (pendingFile && onAttachImage && commentId) {
+        setAttaching(true);
+        try {
+          await onAttachImage(pendingFile, commentId);
+        } finally {
+          setAttaching(false);
+        }
+        setPendingFile(null);
+      }
+      
       setBody("");
       if (draftKey) clearDraft(draftKey);
       setReopen(false);
@@ -335,14 +349,10 @@ export function CommentThread({
 
   async function handleAttachFile(evt: ChangeEvent<HTMLInputElement>) {
     const file = evt.target.files?.[0];
-    if (!file || !onAttachImage) return;
-    setAttaching(true);
-    try {
-      await onAttachImage(file);
-    } finally {
-      setAttaching(false);
-      if (attachInputRef.current) attachInputRef.current.value = "";
-    }
+    if (!file) return;
+    // Store file for later upload after comment is submitted
+    setPendingFile(file);
+    if (attachInputRef.current) attachInputRef.current.value = "";
   }
 
   const canSubmit = !submitting && !!body.trim();

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -334,8 +334,8 @@ export function CommentThread({
           await onAttachImage(pendingFile, commentId);
         } finally {
           setAttaching(false);
+          setPendingFile(null);
         }
-        setPendingFile(null);
       }
       
       setBody("");

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -396,6 +396,18 @@ export function CommentThread({
                 <Paperclip className="h-4 w-4" />
               </Button>
             </div>
+            {pendingFile && (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 px-2 py-1 rounded">
+                <span className="truncate max-w-[150px]">{pendingFile.name}</span>
+                <button
+                  type="button"
+                  onClick={() => setPendingFile(null)}
+                  className="hover:text-foreground"
+                >
+                  ×
+                </button>
+              </div>
+            )}
           )}
           {isClosed && (
             <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -408,7 +408,7 @@ export function IssueDetail() {
 
   const addComment = useMutation({
     mutationFn: ({ body, reopen }: { body: string; reopen?: boolean }) =>
-      issuesApi.addComment(issueId!, body, reopen),
+      issuesApi.addComment(issueId!, body, reopen).then(c => c.id),
     onSuccess: () => {
       invalidateIssue();
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
@@ -438,9 +438,9 @@ export function IssueDetail() {
   });
 
   const uploadAttachment = useMutation({
-    mutationFn: async (file: File) => {
+    mutationFn: async ({ file, commentId }: { file: File; commentId?: string }) => {
       if (!selectedCompanyId) throw new Error("No company selected");
-      return issuesApi.uploadAttachment(selectedCompanyId, issueId!, file);
+      return issuesApi.uploadAttachment(selectedCompanyId, issueId!, file, commentId);
     },
     onSuccess: () => {
       setAttachmentError(null);
@@ -505,7 +505,7 @@ export function IssueDetail() {
   const handleFilePicked = async (evt: ChangeEvent<HTMLInputElement>) => {
     const file = evt.target.files?.[0];
     if (!file) return;
-    await uploadAttachment.mutateAsync(file);
+    await uploadAttachment.mutateAsync({ file });
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -665,7 +665,7 @@ export function IssueDetail() {
           multiline
           mentions={mentionOptions}
           imageUploadHandler={async (file) => {
-            const attachment = await uploadAttachment.mutateAsync(file);
+            const attachment = await uploadAttachment.mutateAsync({ file });
             return attachment.contentPath;
           }}
         />
@@ -780,11 +780,11 @@ export function IssueDetail() {
               await addComment.mutateAsync({ body, reopen });
             }}
             imageUploadHandler={async (file) => {
-              const attachment = await uploadAttachment.mutateAsync(file);
+              const attachment = await uploadAttachment.mutateAsync({ file });
               return attachment.contentPath;
             }}
             onAttachImage={async (file) => {
-              await uploadAttachment.mutateAsync(file);
+              await uploadAttachment.mutateAsync({ file });
             }}
             liveRunSlot={<LiveRunWidget issueId={issueId!} companyId={issue.companyId} />}
           />

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -777,7 +777,7 @@ export function IssueDetail() {
                 await addCommentAndReassign.mutateAsync({ body, reopen, reassignment });
                 return;
               }
-              await addComment.mutateAsync({ body, reopen });
+              return await addComment.mutateAsync({ body, reopen });
             }}
             imageUploadHandler={async (file) => {
               const attachment = await uploadAttachment.mutateAsync({ file });

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -783,8 +783,8 @@ export function IssueDetail() {
               const attachment = await uploadAttachment.mutateAsync({ file });
               return attachment.contentPath;
             }}
-            onAttachImage={async (file) => {
-              await uploadAttachment.mutateAsync({ file });
+            onAttachImage={async (file, commentId) => {
+              await uploadAttachment.mutateAsync({ file, commentId });
             }}
             liveRunSlot={<LiveRunWidget issueId={issueId!} companyId={issue.companyId} />}
           />


### PR DESCRIPTION
## Summary

- Modified CommentThread to store pending file and upload after comment submission
- Updated `onAdd` to return `commentId` for attachment linking
- Updated `onAttachImage` to accept optional `commentId` parameter
- Modified `uploadAttachment` mutation to accept `{ file, commentId }`
- Images uploaded from comment section now correctly link to the comment

## Problem

As described in #272, images uploaded via the 📎 button in the comment section were appearing in the top Attachments section instead of being linked to the comment. The backend already supported `issueCommentId`, but the frontend was not passing it.

## Solution

1. User clicks 📎 to select an image → file is stored in `pendingFile` state
2. User submits comment → `onAdd` returns the new comment ID
3. If there is a pending file, upload it with the comment ID
4. The attachment is now linked to the comment via `issueCommentId`

## Testing

1. Open any issue
2. Click 📎 in comment section and select an image
3. Write a comment and submit
4. Image should be uploaded and linked to the comment

Fixes #272

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #272 by deferring image uploads in the comment section until after the comment is submitted, then linking the attachment to the comment via `issueCommentId`. The approach — storing the file in `pendingFile` state and uploading it with the returned comment ID — is sound, but there are two blocking issues that need to be resolved before this can merge.

- **JSX syntax error** (`CommentThread.tsx` lines 399–411): `{pendingFile && (...)}` is placed as a bare sibling to a `<div>` inside `{onAttachImage && (...)}` without a Fragment wrapper, which is invalid JSX and will prevent the component from compiling.
- **`onAdd` returns `undefined` on the reassignment path** (`IssueDetail.tsx` lines 775–778): When a user submits a comment that also reassigns the issue, the `addCommentAndReassign` path does `return;` without returning the comment ID. The guard `if (pendingFile && onAttachImage && commentId)` in `CommentThread.tsx` then silently skips the attachment upload.
- The `setBody("")` / `clearDraft` calls remain unreachable if `onAttachImage` throws after the comment is already posted, leaving the user at risk of submitting a duplicate comment (noted in a prior review thread).

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — a JSX syntax error will prevent the component from compiling, and a logic bug silently drops attachments on the reassignment path.
- The JSX fragment error in `CommentThread.tsx` is a hard compile failure that blocks the entire feature. The missing comment ID return on the reassignment path is a silent data-loss bug. Both must be fixed before the PR achieves its stated goal.
- `ui/src/components/CommentThread.tsx` (JSX syntax error at line 399) and `ui/src/pages/IssueDetail.tsx` (missing comment ID return on reassignment path at line 778).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ui/src/components/CommentThread.tsx | Introduces `pendingFile` state and deferred upload logic, but contains a JSX syntax error: `{pendingFile && (...)}` is placed as an unwrapped sibling inside `{onAttachImage && (...)}`, which will fail to compile. |
| ui/src/pages/IssueDetail.tsx | Correctly threads `commentId` through `uploadAttachment` and returns it from `addComment`, but the reassignment code path returns `undefined` instead of the comment ID, silently dropping any pending file attachment when reassignment is combined with a comment. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ui/src/pages/IssueDetail.tsx`, line 775-781 ([link](https://github.com/paperclipai/paperclip/blob/942cb4211d9c38e84404912fc4a6639a7d6fdb4b/ui/src/pages/IssueDetail.tsx#L775-L781)) 

   **`onAdd` silently drops pending file when reassignment is included**

   When `reassignment` is set, the handler calls `addCommentAndReassign.mutateAsync(...)` and then returns via `return;`, which resolves to `undefined`. Back in `CommentThread.tsx`, the upload guard is `if (pendingFile && onAttachImage && commentId)` — because `commentId` is `undefined` this branch is skipped, so a queued image attachment is silently lost whenever the user also changes the assignee.

   Additionally, `addCommentAndReassign` calls `issuesApi.update()` (not `addComment`), so it likely doesn't return a comment object with an `id` at all. This path needs to be updated to either return the new comment ID from the update response, or use a separate `addComment` call to obtain the ID before passing it back.

   

   If `issuesApi.update()` does not return the new comment ID, consider refactoring `addCommentAndReassign` or issuing a separate `addComment` call to ensure the ID is always available for attachment linking.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ui/src/pages/IssueDetail.tsx
   Line: 775-781

   Comment:
   **`onAdd` silently drops pending file when reassignment is included**

   When `reassignment` is set, the handler calls `addCommentAndReassign.mutateAsync(...)` and then returns via `return;`, which resolves to `undefined`. Back in `CommentThread.tsx`, the upload guard is `if (pendingFile && onAttachImage && commentId)` — because `commentId` is `undefined` this branch is skipped, so a queued image attachment is silently lost whenever the user also changes the assignee.

   Additionally, `addCommentAndReassign` calls `issuesApi.update()` (not `addComment`), so it likely doesn't return a comment object with an `id` at all. This path needs to be updated to either return the new comment ID from the update response, or use a separate `addComment` call to obtain the ID before passing it back.

   

   If `issuesApi.update()` does not return the new comment ID, consider refactoring `addCommentAndReassign` or issuing a separate `addComment` call to ensure the ID is always available for attachment linking.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 942cb42</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->