### PR TITLE
docs: add Vercel deployment guide

### DIFF
--- a/docs/deploy/vercel.md
+++ b/docs/deploy/vercel.md
@@ -1,0 +1,124 @@
+---
+title: Vercel Hosting
+summary: Deploy Paperclip to Vercel
+---
+
+# Vercel Hosting
+
+Paperclip can be deployed to Vercel as a serverless application.
+
+## Prerequisites
+
+1. A [Vercel account](https://vercel.com)
+2. A PostgreSQL database (recommended: [Supabase](https://supabase.com), [Neon](https://neon.tech), or [PlanetScale](https://planetscale.com))
+3. A storage solution (optional: S3-compatible storage for file uploads)
+
+## Deployment Steps
+
+### 1. Fork and Clone
+
+Fork the [Paperclip repository](https://github.com/paperclipai/paperclip) to your GitHub account.
+
+### 2. Create Vercel Project
+
+1. Go to [vercel.com/new](https://vercel.com/new)
+2. Import your forked repository
+3. Vercel will auto-detect the Next.js/Node.js configuration
+
+### 3. Configure Environment Variables
+
+Set these environment variables in Vercel:
+
+```bash
+# Required
+DATABASE_URL=postgres://...    # Your PostgreSQL connection string
+BETTER_AUTH_SECRET=...         # Random 32+ char secret
+PAPERCLIP_AGENT_JWT_SECRET=... # Random 32+ char secret
+
+# Deployment mode
+DEPLOYMENT_MODE=authenticated
+SERVER_EXPOSURE=public
+
+# Auth URLs (replace with your Vercel URL)
+PAPERCLIP_AUTH_BASE_URL_MODE=explicit
+PAPERCLIP_AUTH_PUBLIC_BASE_URL=https://your-app.vercel.app
+
+# Optional: Disable sign-ups for invite-only instances
+PAPERCLIP_AUTH_DISABLE_SIGN_UP=true
+```
+
+### 4. Database Migrations
+
+Before the first deployment, run migrations against your database:
+
+```bash
+# Local terminal with DATABASE_URL set
+npx drizzle-kit push
+```
+
+### 5. Deploy
+
+Click "Deploy" in Vercel. The first deploy may take a few minutes.
+
+## Post-Deployment
+
+### First User
+
+The first user to sign up will become the admin. To restrict sign-ups:
+
+```bash
+PAPERCLIP_AUTH_DISABLE_SIGN_UP=true
+```
+
+### Storage
+
+By default, Paperclip uses local disk storage which won't work on Vercel's ephemeral filesystem. Configure S3-compatible storage:
+
+```bash
+STORAGE_PROVIDER=s3
+STORAGE_S3_BUCKET=your-bucket
+STORAGE_S3_REGION=us-east-1
+STORAGE_S3_ENDPOINT=https://s3.amazonaws.com
+# For cloudflare R2, backblaze, etc:
+# STORAGE_S3_ENDPOINT=https://your-endpoint.com
+```
+
+### Custom Domain
+
+Add a custom domain in Vercel project settings. Update:
+
+```bash
+PAPERCLIP_AUTH_PUBLIC_BASE_URL=https://your-domain.com
+```
+
+## Limitations
+
+- **Serverless**: Heartbeat runs execute in serverless functions with time limits
+- **No embedded PostgreSQL**: Must use external database (Supabase, Neon, etc.)
+- **Ephemeral filesystem**: Must use S3-compatible storage for attachments
+
+## Troubleshooting
+
+### Build Errors
+
+If you see TypeScript errors, ensure all dependencies are installed:
+
+```bash
+pnpm install
+```
+
+### Database Connection
+
+If database connections fail:
+
+1. Verify `DATABASE_URL` is correct
+2. Ensure your database accepts connections from Vercel's IPs
+3. For pooled connections (like Supabase), add `?pgbouncer=true` to the URL
+
+### Auth Issues
+
+If login doesn't work:
+
+1. Verify `PAPERCLIP_AUTH_PUBLIC_BASE_URL` matches your actual URL
+2. Check `BETTER_AUTH_SECRET` is set
+3. Clear browser cookies and try again

--- a/docs/deploy/vercel.md
+++ b/docs/deploy/vercel.md
@@ -10,7 +10,7 @@ Paperclip can be deployed to Vercel as a serverless application.
 ## Prerequisites
 
 1. A [Vercel account](https://vercel.com)
-2. A PostgreSQL database (recommended: [Supabase](https://supabase.com), [Neon](https://neon.tech), or [PlanetScale](https://planetscale.com))
+2. A PostgreSQL database (recommended: [Supabase](https://supabase.com), [Neon](https://neon.tech), or [Railway](https://railway.app))
 3. A storage solution (optional: S3-compatible storage for file uploads)
 
 ## Deployment Steps
@@ -36,8 +36,7 @@ BETTER_AUTH_SECRET=...         # Random 32+ char secret
 PAPERCLIP_AGENT_JWT_SECRET=... # Random 32+ char secret
 
 # Deployment mode
-DEPLOYMENT_MODE=authenticated
-SERVER_EXPOSURE=public
+PAPERCLIP_DEPLOYMENT_MODE=authenticated
 
 # Auth URLs (replace with your Vercel URL)
 PAPERCLIP_AUTH_BASE_URL_MODE=explicit
@@ -75,12 +74,12 @@ PAPERCLIP_AUTH_DISABLE_SIGN_UP=true
 By default, Paperclip uses local disk storage which won't work on Vercel's ephemeral filesystem. Configure S3-compatible storage:
 
 ```bash
-STORAGE_PROVIDER=s3
-STORAGE_S3_BUCKET=your-bucket
-STORAGE_S3_REGION=us-east-1
-STORAGE_S3_ENDPOINT=https://s3.amazonaws.com
+PAPERCLIP_STORAGE_PROVIDER=s3
+PAPERCLIP_STORAGE_S3_BUCKET=your-bucket
+PAPERCLIP_STORAGE_S3_REGION=us-east-1
+PAPERCLIP_STORAGE_S3_ENDPOINT=https://s3.amazonaws.com
 # For cloudflare R2, backblaze, etc:
-# STORAGE_S3_ENDPOINT=https://your-endpoint.com
+# PAPERCLIP_STORAGE_S3_ENDPOINT=https://your-endpoint.com
 ```
 
 ### Custom Domain

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,7 +79,8 @@
               "deploy/database",
               "deploy/secrets",
               "deploy/storage",
-              "deploy/environment-variables"
+              "deploy/environment-variables",
+              "deploy/vercel"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

Implements #249 - Add documentation for deploying Paperclip to Vercel.

## Changes

- Created `docs/deploy/vercel.md` with step-by-step instructions
- Covers prerequisites, environment variables, storage configuration
- Includes post-deployment setup and troubleshooting
- Added to `docs.json` navigation

## Contents

- Prerequisites (Vercel account, PostgreSQL, storage)
- Fork and clone steps
- Vercel project creation
- Environment variable configuration
- Database migration steps
- Post-deployment setup (first user, storage, custom domain)
- Limitations (serverless, no embedded PG, ephemeral filesystem)
- Troubleshooting common issues

Fixes #249

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `docs/deploy/vercel.md` guide covering how to deploy Paperclip to Vercel, along with a sidebar entry in `docs/docs.json`. The guide is a welcome addition for users wanting a serverless hosting option, but it contains two notable issues in the environment variable and migration sections that would cause a broken deployment.

- **Missing `PAPERCLIP_DEPLOYMENT_EXPOSURE=public`**: The guide sets `PAPERCLIP_DEPLOYMENT_MODE=authenticated` but omits `PAPERCLIP_DEPLOYMENT_EXPOSURE=public`. Per `deployment-modes.md` and `server/src/config.ts`, the `authenticated` mode defaults to `private` exposure (VPN/LAN trust policy) unless explicitly overridden. Vercel is an internet-facing deployment and requires `public` exposure — leaving this unset will likely cause host-validation failures in production.
- **Incorrect migration command**: The guide instructs users to run `npx drizzle-kit push`, but the project uses `pnpm` and has a dedicated migration script (`pnpm db:migrate` → `tsx src/migrate.ts` in `@paperclipai/db`). Using `npx drizzle-kit push` can pull an incompatible version of `drizzle-kit` and bypasses the project's migration-file workflow entirely.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the missing `PAPERCLIP_DEPLOYMENT_EXPOSURE=public` env var will cause a silently broken internet-facing deployment.
- The omission of `PAPERCLIP_DEPLOYMENT_EXPOSURE=public` is a functional defect: following the guide as written will produce an `authenticated` + `private` server that enforces private-network host trust policies, making it unusable on Vercel. The incorrect migration command (`npx drizzle-kit push` vs `pnpm db:migrate`) is a secondary but real issue that could corrupt the schema setup for first-time deployers.
- docs/deploy/vercel.md requires fixes before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/deploy/vercel.md | New Vercel deployment guide; missing critical `PAPERCLIP_DEPLOYMENT_EXPOSURE=public` env var (defaults to `private` which breaks public-internet deployments), and uses incorrect `npx drizzle-kit push` instead of the project's `pnpm db:migrate` migration workflow. |
| docs/docs.json | Adds `deploy/vercel` to the navigation sidebar; change is minimal and correct. |

</details>

<sub>Last reviewed commit: 3775139</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->