### PR TITLE
ci: auto-label PRs by changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,7 @@ docs:
   - changed-files:
       - any-glob-to-any-file:
           - "doc/**"
+          - "docs/**"
           - "*.md"
           - "skills/**/*.md"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,41 @@
+server:
+  - changed-files:
+      - any-glob-to-any-file: "server/**"
+
+ui:
+  - changed-files:
+      - any-glob-to-any-file: "ui/**"
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file: "cli/**"
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/db/**"
+
+adapters:
+  - changed-files:
+      - any-glob-to-any-file: "packages/adapters/**"
+
+shared:
+  - changed-files:
+      - any-glob-to-any-file: "packages/shared/**"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "doc/**"
+          - "*.md"
+          - "skills/**/*.md"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pnpm-lock.yaml"
+          - "**/package.json"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Ensure labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = ['server','ui','cli','database','adapters','shared','docs','ci','dependencies'];
+            for (const name of labels) {
+              try { await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name }); }
+              catch { await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color: 'ededed' }); }
+            }
+
       - uses: actions/labeler@v5
         with:
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Summary

- Adds `actions/labeler@v5` workflow that runs on PR open/sync
- Applies area labels (`server`, `ui`, `cli`, `database`, `adapters`, `shared`, `docs`, `ci`, `dependencies`) based on which files a PR touches
- Gives maintainers and agents instant visibility into what areas a PR affects without reading the diff

## Test plan

- [ ] Open a PR that touches `server/` files — should get `server` label
- [ ] Open a PR that touches `ui/` files — should get `ui` label
- [ ] Open a PR touching multiple areas — should get multiple labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)