### PR TITLE
ci: add bundle size reporting and migration check to PRs

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pull-requests: write
 
     steps:
@@ -81,6 +82,9 @@ jobs:
           fi
           echo "js_bytes=$js_bytes" >> "$GITHUB_OUTPUT"
           echo "css_bytes=$css_bytes" >> "$GITHUB_OUTPUT"
+
+      - name: Clear PR dist artifacts
+        run: rm -rf ui/dist
 
       - name: Checkout base
         uses: actions/checkout@v4

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -121,7 +121,7 @@ jobs:
             const baseCSS = Number('${{ steps.base_size.outputs.css_bytes }}');
 
             const fmt = (bytes) => {
-              if (bytes >= 1024 * 1024) return (bytes / 1024 / 1024).toFixed(2) + ' MB';
+              if (Math.abs(bytes) >= 1024 * 1024) return (bytes / 1024 / 1024).toFixed(2) + ' MB';
               return (bytes / 1024).toFixed(1) + ' kB';
             };
             const delta = (now, before) => {
@@ -146,6 +146,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c => c.body?.startsWith('## Bundle Size Report'));
             if (existing) {
@@ -168,6 +169,8 @@ jobs:
     name: Migration Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     services:
       postgres:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -10,7 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  verify:
+  typecheck-and-test:
+    name: Typecheck & Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -40,3 +41,167 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  bundle-size:
+    name: Bundle Size
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install and build PR
+        run: |
+          pnpm install --no-frozen-lockfile
+          pnpm build
+
+      - name: Measure PR bundle
+        id: pr_size
+        run: |
+          if [ -d ui/dist/assets ]; then
+            js_bytes=$(find ui/dist/assets -name '*.js' -exec cat {} + | wc -c)
+            css_bytes=$(find ui/dist/assets -name '*.css' -exec cat {} + | wc -c)
+          else
+            js_bytes=0
+            css_bytes=0
+          fi
+          echo "js_bytes=$js_bytes" >> "$GITHUB_OUTPUT"
+          echo "css_bytes=$css_bytes" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          clean: false
+
+      - name: Install and build base
+        run: |
+          pnpm install --no-frozen-lockfile
+          pnpm build
+        continue-on-error: true
+
+      - name: Measure base bundle
+        id: base_size
+        run: |
+          if [ -d ui/dist/assets ]; then
+            js_bytes=$(find ui/dist/assets -name '*.js' -exec cat {} + | wc -c)
+            css_bytes=$(find ui/dist/assets -name '*.css' -exec cat {} + | wc -c)
+          else
+            js_bytes=0
+            css_bytes=0
+          fi
+          echo "js_bytes=$js_bytes" >> "$GITHUB_OUTPUT"
+          echo "css_bytes=$css_bytes" >> "$GITHUB_OUTPUT"
+
+      - name: Comment bundle size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prJS = Number('${{ steps.pr_size.outputs.js_bytes }}');
+            const prCSS = Number('${{ steps.pr_size.outputs.css_bytes }}');
+            const baseJS = Number('${{ steps.base_size.outputs.js_bytes }}');
+            const baseCSS = Number('${{ steps.base_size.outputs.css_bytes }}');
+
+            const fmt = (bytes) => {
+              if (bytes >= 1024 * 1024) return (bytes / 1024 / 1024).toFixed(2) + ' MB';
+              return (bytes / 1024).toFixed(1) + ' kB';
+            };
+            const delta = (now, before) => {
+              const diff = now - before;
+              if (before === 0) return 'new';
+              const pct = ((diff / before) * 100).toFixed(1);
+              const sign = diff >= 0 ? '+' : '';
+              return `${sign}${fmt(diff)} (${sign}${pct}%)`;
+            };
+
+            const body = [
+              '## Bundle Size Report',
+              '',
+              '| Asset | Base | PR | Delta |',
+              '|-------|------|----|-------|',
+              `| JS | ${fmt(baseJS)} | ${fmt(prJS)} | ${delta(prJS, baseJS)} |`,
+              `| CSS | ${fmt(baseCSS)} | ${fmt(prCSS)} | ${delta(prCSS, baseCSS)} |`,
+              `| **Total** | **${fmt(baseJS + baseCSS)}** | **${fmt(prJS + prCSS)}** | **${delta(prJS + prCSS, baseJS + baseCSS)}** |`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.startsWith('## Bundle Size Report'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  migration-check:
+    name: Migration Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: paperclip
+          POSTGRES_PASSWORD: paperclip
+          POSTGRES_DB: paperclip_migrate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U paperclip"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Verify migrations apply cleanly
+        env:
+          DATABASE_URL: postgres://paperclip:paperclip@localhost:5432/paperclip_migrate
+        run: pnpm db:migrate


### PR DESCRIPTION
## Summary

- Splits `pr-verify` into 3 parallel jobs for faster feedback
- **Bundle Size**: builds both PR and base branch, compares UI JS/CSS sizes, posts a delta table as a PR comment (updates on push)
- **Migration Check**: spins up Postgres 16, runs `pnpm db:migrate` to verify all migrations apply cleanly

## Test plan

- [ ] PR with UI changes shows bundle size comment with delta
- [ ] PR with no UI changes shows 0-delta bundle report
- [ ] PR with new migration applies cleanly against fresh Postgres
- [ ] PR with broken migration fails the migration-check job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the monolithic `pr-verify` job into three parallel jobs — `typecheck-and-test`, `bundle-size`, and `migration-check` — reducing wall-clock CI time and adding two new quality gates: a PR-comment bundle size delta report and a clean Postgres 16 migration smoke-test.

The overall structure is well-designed. A few issues worth addressing:

- **`listComments` pagination** (line 145): The API call fetches only 30 comments by default. On a PR with more than 30 existing comments, the existing bundle report won't be found and a new one is created on every push — causing comment accumulation. Adding `per_page: 100` to the call is an easy fix.
- **`fmt` negative delta rendering** (line 123): The MB threshold check (`bytes >= 1024 * 1024`) fails for large negative values, so a `-1.5 MB` reduction renders as `-1464.8 kB`. Switching to `Math.abs(bytes)` for the check corrects this.
- **`migration-check` missing `permissions`** (line 167): The job inherits default repository permissions rather than declaring the minimal `contents: read` that the `bundle-size` job sets as a precedent.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the new jobs are additive and the issues found are non-blocking style/edge-case concerns.
- The logic of both new jobs is correct and the previously raised `contents: read` and stale-artifact issues have been fixed. The remaining issues (pagination, negative fmt, missing permissions on migration-check) are minor and won't cause failures in the common case.
- `.github/workflows/pr-verify.yml` — review the three inline comments before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-verify.yml | Splits the existing `verify` job into three parallel jobs (`typecheck-and-test`, `bundle-size`, `migration-check`). The approach is sound; three minor issues noted: `listComments` pagination could cause duplicate bundle comments on busy PRs, `fmt` mis-formats large negative byte deltas, and `migration-check` lacks an explicit `permissions` block. |

</details>

<sub>Last reviewed commit: 332dad3</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->