### PR TITLE
feat(adapters): add claude-sonnet-4-6 and claude-haiku-4-6 to claude_local model list

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -3,6 +3,8 @@ export const label = "Claude Code (local)";
 
 export const models = [
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },
   { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 ];


### PR DESCRIPTION
## Summary

Adds `claude-sonnet-4-6` and `claude-haiku-4-6` to the claude_local adapter model list alongside the existing models.

The 4.6 model family is now available via the Claude CLI but was missing from the adapter's model picker, leaving users on 4.5 by default with no UI option to upgrade.

## Changes

- `packages/adapters/claude-local/src/index.ts`: adds `claude-sonnet-4-6` and `claude-haiku-4-6` entries, preserving existing 4.5 models for backwards compatibility

## Notes

- Existing agents with no explicit model set will continue to use whatever the Claude CLI defaults to — this change only affects the available options in the model picker UI
- `claude-haiku-4-6` is included speculatively alongside Sonnet; if it hasn't been released yet it will fail gracefully at runtime

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `claude-sonnet-4-6` and `claude-haiku-4-6` to the claude_local adapter's model picker list, sitting alongside the pre-existing `claude-opus-4-6` and the date-pinned 4.5 models. The change is minimal and backwards-compatible — existing agents are unaffected.

**Key points:**
- `claude-sonnet-4-6` is a straightforward addition, following the same unpinned-alias format already used by `claude-opus-4-6`.
- `claude-haiku-4-6` is noted as speculative in the PR description; surfacing it in the UI before confirming availability means users may select it and hit a runtime failure with a raw CLI error rather than a clean message.
- The model list now mixes date-stamped snapshot IDs (4.5 entries) with unpinned aliases (4.6 entries) — this is consistent within the 4.6 group but worth being intentional about for reproducibility and billing predictability.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor UX considerations around the speculative Haiku model entry.
- The change is a two-line addition to a static list — no logic, no new code paths, and no breaking changes. The main risks are a potential UX degradation if `claude-haiku-4-6` is not yet available (users see a runtime error) and a long-term reproducibility concern from using unpinned aliases. Neither is a blocker.
- No files require special attention beyond `packages/adapters/claude-local/src/index.ts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/adapters/claude-local/src/index.ts | Adds `claude-sonnet-4-6` and `claude-haiku-4-6` to the UI model list; `claude-haiku-4-6` is acknowledged as speculative in the PR description, and the new IDs use unpinned aliases rather than the date-stamped format used by the existing 4.5 models. |

</details>

<sub>Last reviewed commit: 4e01633</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->