### PR TITLE
Fix comment attachments: inline rendering & upload

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { Link, useLocation } from "react-router-dom";
-import type { IssueComment, Agent } from "@paperclipai/shared";
+import type { IssueComment, IssueAttachment, Agent } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
 import { Check, Copy, Paperclip } from "lucide-react";
 import { Identity } from "./Identity";
@@ -38,6 +38,8 @@ interface CommentThreadProps {
   imageUploadHandler?: (file: File) => Promise<string>;
   /** Callback to attach an image file to the parent issue (not inline in a comment). */
   onAttachImage?: (file: File) => Promise<void>;
+  /** All attachments for the issue – used to render comment-linked images inline. */
+  attachments?: IssueAttachment[];
   draftKey?: string;
   liveRunSlot?: React.ReactNode;
   enableReassign?: boolean;
@@ -119,10 +121,12 @@ const TimelineList = memo(function TimelineList({
   timeline,
   agentMap,
   highlightCommentId,
+  attachmentsByCommentId,
 }: {
   timeline: TimelineItem[];
   agentMap?: Map<string, Agent>;
   highlightCommentId?: string | null;
+  attachmentsByCommentId?: Map<string, IssueAttachment[]>;
 }) {
   if (timeline.length === 0) {
     return <p className="text-sm text-muted-foreground">No comments or runs yet.</p>;
@@ -190,6 +194,24 @@ const TimelineList = memo(function TimelineList({
               </span>
             </div>
             <MarkdownBody className="text-sm">{comment.body}</MarkdownBody>
+            {(() => {
+              const commentAttachments = attachmentsByCommentId?.get(comment.id);
+              if (!commentAttachments || commentAttachments.length === 0) return null;
+              return (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {commentAttachments.filter((a) => a.contentType.startsWith("image/")).map((a) => (
+                    <a key={a.id} href={a.contentPath} target="_blank" rel="noreferrer">
+                      <img
+                        src={a.contentPath}
+                        alt={a.originalFilename ?? "attachment"}
+                        className="max-h-48 rounded border border-border object-contain bg-accent/10"
+                        loading="lazy"
+                      />
+                    </a>
+                  ))}
+                </div>
+              );
+            })()}
             {comment.runId && (
               <div className="mt-2 pt-2 border-t border-border/60">
                 {comment.runAgentId ? (
@@ -221,6 +243,7 @@ export function CommentThread({
   agentMap,
   imageUploadHandler,
   onAttachImage,
+  attachments = [],
   draftKey,
   liveRunSlot,
   enableReassign = false,
@@ -261,6 +284,18 @@ export function CommentThread({
       return a.kind === "comment" ? -1 : 1;
     });
   }, [comments, linkedRuns]);
+
+  // Build a map from commentId -> attachments for rendering inline images in comments
+  const attachmentsByCommentId = useMemo(() => {
+    const map = new Map<string, IssueAttachment[]>();
+    for (const a of attachments) {
+      if (!a.issueCommentId) continue;
+      const list = map.get(a.issueCommentId);
+      if (list) list.push(a);
+      else map.set(a.issueCommentId, [a]);
+    }
+    return map;
+  }, [attachments]);
 
   // Build mention options from agent map (exclude terminated agents)
   const mentions = useMemo<MentionOption[]>(() => {
@@ -335,10 +370,18 @@ export function CommentThread({
 
   async function handleAttachFile(evt: ChangeEvent<HTMLInputElement>) {
     const file = evt.target.files?.[0];
-    if (!file || !onAttachImage) return;
+    if (!file) return;
     setAttaching(true);
     try {
-      await onAttachImage(file);
+      // Prefer inserting the image inline in the comment via imageUploadHandler
+      if (imageUploadHandler) {
+        const url = await imageUploadHandler(file);
+        const imgMarkdown = `![${file.name}](${url})`;
+        setBody((prev) => (prev ? `${prev}\n${imgMarkdown}` : imgMarkdown));
+      } else if (onAttachImage) {
+        // Fallback: attach at issue level
+        await onAttachImage(file);
+      }
     } finally {
       setAttaching(false);
       if (attachInputRef.current) attachInputRef.current.value = "";
@@ -351,7 +394,7 @@ export function CommentThread({
     <div className="space-y-4">
       <h3 className="text-sm font-semibold">Comments &amp; Runs ({timeline.length})</h3>
 
-      <TimelineList timeline={timeline} agentMap={agentMap} highlightCommentId={highlightCommentId} />
+      <TimelineList timeline={timeline} agentMap={agentMap} highlightCommentId={highlightCommentId} attachmentsByCommentId={attachmentsByCommentId} />
 
       {liveRunSlot}
 
@@ -367,7 +410,7 @@ export function CommentThread({
           contentClassName="min-h-[60px] text-sm"
         />
         <div className="flex items-center justify-end gap-3">
-          {onAttachImage && (
+          {(imageUploadHandler || onAttachImage) && (
             <div className="mr-auto flex items-center gap-3">
               <input
                 ref={attachInputRef}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -513,6 +513,9 @@ export function IssueDetail() {
 
   const isImageAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("image/");
 
+  // Issue-level attachments (not linked to any comment) for the top Attachments section
+  const issueAttachments = (attachments ?? []).filter((a) => !a.issueCommentId);
+
   return (
     <div className="max-w-2xl space-y-6">
       {/* Parent chain breadcrumb */}
@@ -698,11 +701,11 @@ export function IssueDetail() {
           <p className="text-xs text-destructive">{attachmentError}</p>
         )}
 
-        {(!attachments || attachments.length === 0) ? (
+        {issueAttachments.length === 0 ? (
           <p className="text-xs text-muted-foreground">No attachments yet.</p>
         ) : (
           <div className="space-y-2">
-            {attachments.map((attachment) => (
+            {issueAttachments.map((attachment) => (
               <div key={attachment.id} className="border border-border rounded-md p-2">
                 <div className="flex items-center justify-between gap-2">
                   <a
@@ -767,6 +770,7 @@ export function IssueDetail() {
             linkedRuns={timelineRuns}
             issueStatus={issue.status}
             agentMap={agentMap}
+            attachments={attachments ?? []}
             draftKey={`paperclip:issue-comment-draft:${issue.id}`}
             enableReassign
             reassignOptions={commentReassignOptions}


### PR DESCRIPTION
## Summary
- Comment 📎 button now inserts images as inline markdown via `imageUploadHandler` instead of attaching at issue level only
- Comments with linked attachments (`issueCommentId`) render images inline below the comment body
- Top "Attachments" section filters out comment-linked attachments to avoid duplication
- 📎 button visibility broadened to show when either `imageUploadHandler` or `onAttachImage` is available

Fixes #272

## Test plan
- [ ] Upload image via comment 📎 button → should insert `![filename](url)` markdown into comment body
- [ ] Post comment with image → image renders inline in the comment
- [ ] Upload image via top "Upload image" button → still appears in Attachments section
- [ ] Comment-linked attachments don't appear in top Attachments section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves comment attachment handling in two ways: the comment 📎 button now inserts images as inline markdown (via `imageUploadHandler`) instead of only attaching at the issue level, and server-linked comment attachments (those with an `issueCommentId`) are rendered inline below the comment body. The top "Attachments" section is also updated to filter out comment-linked attachments.

Key issues found:
- **Duplicate image display (logic bug):** Images uploaded via the comment 📎 button are uploaded before the comment exists, so they never receive an `issueCommentId`. The `!a.issueCommentId` filter in `issueAttachments` therefore does not exclude them, and they appear in both the top Attachments section and inline in the comment body via markdown.
- **Silent drop of non-image attachments:** Comment-linked attachments that are not images (e.g., PDFs linked to a comment by an agent) are filtered out with no fallback download link, making those files inaccessible in the UI.
- **Filename special characters in markdown:** Filenames containing `]` can produce malformed markdown alt-text (e.g., `screenshot].png` → `![screenshot]](url)`), which may render incorrectly depending on the markdown parser.

<h3>Confidence Score: 2/5</h3>

- PR has a logic bug that causes duplicate image display for the primary use case (comment 📎 upload), requiring a fix before merging.
- The core goal of inserting images inline is sound, but the de-duplication mechanism (`!a.issueCommentId` filter) doesn't work for the comment 📎 upload flow since the attachment is always created before the comment and therefore always lacks `issueCommentId`. This means the main advertised benefit (avoiding duplication) is not achieved for the most common user action.
- Both changed files warrant attention: `IssueDetail.tsx` for the duplication bug, and `CommentThread.tsx` for the silent drop of non-image attachments.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/components/CommentThread.tsx | Adds inline rendering of comment-linked attachments, `attachmentsByCommentId` map, and switches the 📎 button to prefer `imageUploadHandler`. Minor issues: non-image comment attachments are silently dropped, and filenames with `]` can break markdown alt-text syntax. |
| ui/src/pages/IssueDetail.tsx | Passes full attachments list to CommentThread and filters to issue-level attachments for the Attachments section. Core bug: images uploaded via the comment 📎 button lack `issueCommentId` (uploaded before comment exists) so they still appear in the Attachments section despite also being inline in the comment body, causing duplication. |

</details>

<sub>Last reviewed commit: 6afd26a</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->