### PR TITLE
refactor: remove unused adapter-openclaw references and add disableSignUp option to auth configuration

### DIFF
--- a/cli/src/__tests__/allowed-hostname.test.ts
+++ b/cli/src/__tests__/allowed-hostname.test.ts
@@ -42,6 +42,7 @@ function writeBaseConfig(configPath: string) {
     },
     auth: {
       baseUrlMode: "auto",
+      disableSignUp: false,
     },
     storage: {
       provider: "local_disk",

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -61,6 +61,7 @@ function defaultConfig(): PaperclipConfig {
     },
     auth: {
       baseUrlMode: "auto",
+      disableSignUp: false,
     },
     storage: defaultStorageConfig(),
     secrets: defaultSecretsConfig(),

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -186,6 +186,7 @@ function quickstartDefaultsFromEnv(): {
     auth: {
       baseUrlMode: authBaseUrlMode,
       ...(authPublicBaseUrl ? { publicBaseUrl: authPublicBaseUrl } : {}),
+      disableSignUp: parseBooleanFromEnv(process.env.PAPERCLIP_AUTH_DISABLE_SIGN_UP) ?? false,
     },
     storage: {
       provider: storageProvider,

--- a/cli/src/prompts/server.ts
+++ b/cli/src/prompts/server.ts
@@ -113,7 +113,7 @@ export async function promptServer(opts?: {
   }
 
   const port = Number(portStr) || 3100;
-  let auth: AuthConfig = { baseUrlMode: "auto" };
+  let auth: AuthConfig = { baseUrlMode: "auto", disableSignUp: currentAuth?.disableSignUp ?? false };
   if (deploymentMode === "authenticated" && exposure === "public") {
     const urlInput = await p.text({
       message: "Public base URL",
@@ -140,11 +140,13 @@ export async function promptServer(opts?: {
     auth = {
       baseUrlMode: "explicit",
       publicBaseUrl: urlInput.trim().replace(/\/+$/, ""),
+      disableSignUp: currentAuth?.disableSignUp ?? false,
     };
   } else if (currentAuth?.baseUrlMode === "explicit" && currentAuth.publicBaseUrl) {
     auth = {
       baseUrlMode: "explicit",
       publicBaseUrl: currentAuth.publicBaseUrl,
+      disableSignUp: currentAuth.disableSignUp ?? false,
     };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -124,22 +121,6 @@ importers:
         version: 5.9.3
 
   packages/adapters/cursor-local:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
-  packages/adapters/openclaw:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -261,9 +242,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -379,9 +357,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway


### PR DESCRIPTION
Fixes typecheck error

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR does two things: it removes all references to the unused `@paperclipai/adapter-openclaw` workspace package from the lockfile, and it propagates a new `disableSignUp` boolean field through the auth configuration layer (`AuthConfig` schema, default configs, env-var parsing, and the interactive `promptServer` flow).

**Key changes:**
- `pnpm-lock.yaml`: Cleanly removes `@paperclipai/adapter-openclaw` from all importer entries and its own `packages/adapters/openclaw` section.
- `configure.ts` / `allowed-hostname.test.ts`: `defaultConfig()` and the test fixture now include `disableSignUp: false`, matching the Zod schema default already present in `@paperclipai/shared`.
- `onboard.ts`: `quickstartDefaultsFromEnv()` reads `PAPERCLIP_AUTH_DISABLE_SIGN_UP` and writes it into the auth defaults — however, this new env var is **not added to `ONBOARD_ENV_KEYS`**, so it won't be counted or surfaced in the "Environment-aware defaults active" message shown to users.
- `prompts/server.ts`: All three branches that construct an `AuthConfig` now forward `disableSignUp` from the current auth config, correctly preserving any existing value across re-configurations.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor tracking omission that should be fixed.
- The `disableSignUp` field is correctly added to the schema default, env-var parsing, default config objects, and the interactive prompt — so the feature itself works end-to-end. The only issue is that `PAPERCLIP_AUTH_DISABLE_SIGN_UP` is missing from `ONBOARD_ENV_KEYS`, causing it to be silently applied without being reflected in the user-facing "env vars detected" count. This is a UX/observability gap rather than a correctness bug.
- `cli/src/commands/onboard.ts` — `PAPERCLIP_AUTH_DISABLE_SIGN_UP` should be added to the `ONBOARD_ENV_KEYS` array.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cli/src/commands/onboard.ts | Adds `disableSignUp` field to the `auth` defaults object driven by the `PAPERCLIP_AUTH_DISABLE_SIGN_UP` env var, but omits that env var from `ONBOARD_ENV_KEYS`, causing it to be silently applied without being reported to the user in the env-vars-detected summary. |
| cli/src/prompts/server.ts | Correctly preserves `disableSignUp` from the existing auth config in all three code paths (default `auto`, newly-entered `explicit`, and carried-over `explicit`). |
| cli/src/commands/configure.ts | Adds `disableSignUp: false` to the fallback `defaultConfig()` auth object, aligning it with the Zod schema default in `@paperclipai/shared`. |
| cli/src/__tests__/allowed-hostname.test.ts | Test fixture updated to include `disableSignUp: false` so the base config object satisfies the updated `PaperclipConfig` type. |
| pnpm-lock.yaml | Removes the `@paperclipai/adapter-openclaw` workspace package and all its references from the lockfile. Clean removal with no remaining stale entries. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cli/src/commands/onboard.ts`, line 48-75 ([link](https://github.com/paperclipai/paperclip/blob/a97582582f7a84c46a30f149516518ad6e13956f/cli/src/commands/onboard.ts#L48-L75)) 

   **`PAPERCLIP_AUTH_DISABLE_SIGN_UP` missing from `ONBOARD_ENV_KEYS`**

   `PAPERCLIP_AUTH_DISABLE_SIGN_UP` is read and applied at line 189 via `parseBooleanFromEnv(process.env.PAPERCLIP_AUTH_DISABLE_SIGN_UP)`, but it is not included in the `ONBOARD_ENV_KEYS` tuple. As a result:

   - `usedEnvKeys` will never include it, so the "Environment-aware defaults active (X env var(s) detected)" message won't count it.
   - If `PAPERCLIP_AUTH_DISABLE_SIGN_UP` is the only env var set, the user will incorrectly see "No environment overrides detected" instead of being informed that this env var was recognized.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: a975825</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->