### PR TITLE
feat: add canCreateTasks permission for agents

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -242,7 +242,7 @@ export const PERMISSION_KEYS = [
   "users:manage_permissions",
   "tasks:assign",
   "tasks:assign_scope",
-  "tasks:create",
+  "tasks:create", // agent-only: human users can always create tasks
   "joins:approve",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -242,6 +242,7 @@ export const PERMISSION_KEYS = [
   "users:manage_permissions",
   "tasks:assign",
   "tasks:assign_scope",
+  "tasks:create",
   "joins:approve",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface AgentPermissions {
   canCreateAgents: boolean;
+  canCreateTasks: boolean;
 }
 
 export interface Agent {

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -9,6 +9,7 @@ import { envConfigSchema } from "./secret.js";
 
 export const agentPermissionsSchema = z.object({
   canCreateAgents: z.boolean().optional().default(false),
+  canCreateTasks: z.boolean().optional().default(false),
 });
 
 const adapterConfigSchema = z.record(z.unknown()).superRefine((value, ctx) => {
@@ -95,7 +96,8 @@ export const testAdapterEnvironmentSchema = z.object({
 export type TestAdapterEnvironment = z.infer<typeof testAdapterEnvironmentSchema>;
 
 export const updateAgentPermissionsSchema = z.object({
-  canCreateAgents: z.boolean(),
+  canCreateAgents: z.boolean().optional(),
+  canCreateTasks: z.boolean().optional(),
 });
 
 export type UpdateAgentPermissions = z.infer<typeof updateAgentPermissionsSchema>;

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -98,6 +98,9 @@ export type TestAdapterEnvironment = z.infer<typeof testAdapterEnvironmentSchema
 export const updateAgentPermissionsSchema = z.object({
   canCreateAgents: z.boolean().optional(),
   canCreateTasks: z.boolean().optional(),
-});
+}).refine(
+  (data) => data.canCreateAgents !== undefined || data.canCreateTasks !== undefined,
+  { message: "At least one permission field must be provided" },
+);
 
 export type UpdateAgentPermissions = z.infer<typeof updateAgentPermissionsSchema>;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -431,7 +431,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     if (req.actor.type === "agent") {
       if (req.body.parentId) {
         const parent = await svc.getById(req.body.parentId);
-        if (!parent) {
+        if (!parent || parent.companyId !== companyId) {
           res.status(400).json({ error: "parentId references a non-existent issue" });
           return;
         }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -426,8 +426,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       await assertCanAssignTasks(req, companyId);
     }
 
-    // Agents creating top-level tasks (no parentId) need canCreateTasks permission
-    // Also validate parentId exists if provided, to prevent bypassing the gate with a bogus parentId
+    // Agents creating top-level tasks (no parentId) need canCreateTasks permission.
+    // Uses grant-based check first, falling back to permission object — same two-tier pattern
+    // as assertCanAssignTasks. canCreateAgents in the hiring route will be migrated to match.
+    // Also validate parentId exists if provided, to prevent bypassing the gate with a bogus parentId.
     if (req.actor.type === "agent") {
       if (req.body.parentId) {
         const parent = await svc.getById(req.body.parentId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -89,6 +89,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
+  function canCreateTasksPermission(agent: { permissions: Record<string, unknown> | null | undefined; role: string }) {
+    if (agent.role === "ceo") return true;
+    if (!agent.permissions || typeof agent.permissions !== "object") return false;
+    return Boolean((agent.permissions as Record<string, unknown>).canCreateTasks);
+  }
+
   async function assertCanAssignTasks(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
@@ -418,6 +424,27 @@ export function issueRoutes(db: Db, storage: StorageService) {
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
       await assertCanAssignTasks(req, companyId);
+    }
+
+    // Agents creating top-level tasks (no parentId) need canCreateTasks permission
+    // Also validate parentId exists if provided, to prevent bypassing the gate with a bogus parentId
+    if (req.actor.type === "agent") {
+      if (req.body.parentId) {
+        const parent = await svc.getById(req.body.parentId);
+        if (!parent) {
+          res.status(400).json({ error: "parentId references a non-existent issue" });
+          return;
+        }
+      } else {
+        if (!req.actor.agentId) throw forbidden("Agent authentication required");
+        const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:create");
+        if (!allowedByGrant) {
+          const actorAgent = await agentsSvc.getById(req.actor.agentId);
+          if (!actorAgent || actorAgent.companyId !== companyId || !canCreateTasksPermission(actorAgent)) {
+            throw forbidden("Missing permission: can create tasks");
+          }
+        }
+      }
     }
 
     const actor = getActorInfo(req);

--- a/server/src/services/agent-permissions.ts
+++ b/server/src/services/agent-permissions.ts
@@ -1,10 +1,12 @@
 export type NormalizedAgentPermissions = Record<string, unknown> & {
   canCreateAgents: boolean;
+  canCreateTasks: boolean;
 };
 
 export function defaultPermissionsForRole(role: string): NormalizedAgentPermissions {
   return {
     canCreateAgents: role === "ceo",
+    canCreateTasks: role === "ceo",
   };
 }
 
@@ -23,5 +25,9 @@ export function normalizeAgentPermissions(
       typeof record.canCreateAgents === "boolean"
         ? record.canCreateAgents
         : defaults.canCreateAgents,
+    canCreateTasks:
+      typeof record.canCreateTasks === "boolean"
+        ? record.canCreateTasks
+        : defaults.canCreateTasks,
   };
 }

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -444,14 +444,15 @@ export function agentService(db: Db) {
       return updated ? normalizeAgentRow(updated) : null;
     },
 
-    updatePermissions: async (id: string, permissions: { canCreateAgents: boolean }) => {
+    updatePermissions: async (id: string, permissions: { canCreateAgents?: boolean; canCreateTasks?: boolean }) => {
       const existing = await getById(id);
       if (!existing) return null;
 
+      const merged = { ...existing.permissions, ...permissions };
       const updated = await db
         .update(agents)
         .set({
-          permissions: normalizeAgentPermissions(permissions, existing.role),
+          permissions: normalizeAgentPermissions(merged, existing.role),
           updatedAt: new Date(),
         })
         .where(eq(agents.id, id))

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -44,7 +44,9 @@ If this run was triggered by a comment mention (`PAPERCLIP_WAKE_COMMENT_ID` set;
 If that mentioned comment explicitly asks you to take the task, you may self-assign by checking out `PAPERCLIP_TASK_ID` as yourself, then proceed normally.
 If the comment asks for input/review but not ownership, respond in comments if useful, then continue with assigned work.
 If the comment does not direct you to take ownership, do not self-assign.
-If nothing is assigned and there is no valid mention-based ownership handoff, exit the heartbeat.
+If nothing is assigned and there is no valid mention-based ownership handoff:
+- If your permissions include `canCreateTasks: true`: review company goals, projects, and recent activity (`GET /api/companies/{companyId}/dashboard`) to identify gaps or next steps. Create new top-level tasks (`POST /api/companies/{companyId}/issues`) for actionable work, assign them to appropriate agents (or yourself), and proceed. Focus on high-impact work aligned with existing projects and goals. Do not create duplicate or overlapping tasks — search existing issues first (`GET /api/companies/{companyId}/issues?q=...`).
+- Otherwise, exit the heartbeat.
 
 **Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:
 
@@ -119,7 +121,7 @@ Access control:
 
 - **Always checkout** before working. Never PATCH to `in_progress` manually.
 - **Never retry a 409.** The task belongs to someone else.
-- **Never look for unassigned work.**
+- **Never look for unassigned work** — unless you have `canCreateTasks` permission and no current assignments, in which case you may create new tasks (see Step 4).
 - **Self-assign only for explicit @-mention handoff.** This requires a mention-triggered wake with `PAPERCLIP_WAKE_COMMENT_ID` and a comment that clearly directs you to do the task. Use checkout (never direct assignee patch). Otherwise, no assignments = exit.
 - **Honor "send it back to me" requests from board users.** If a board/user asks for review handoff (e.g. "let me review it", "assign it back to me"), reassign the issue to that user with `assigneeAgentId: null` and `assigneeUserId: "<requesting-user-id>"`, and typically set status to `in_review` instead of `done`.
   Resolve requesting user id from the triggering comment thread (`authorUserId`) when available; otherwise use the issue's `createdByUserId` if it matches the requester context.

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -45,7 +45,7 @@ If that mentioned comment explicitly asks you to take the task, you may self-ass
 If the comment asks for input/review but not ownership, respond in comments if useful, then continue with assigned work.
 If the comment does not direct you to take ownership, do not self-assign.
 If nothing is assigned and there is no valid mention-based ownership handoff:
-- If your permissions include `canCreateTasks: true`: review company goals, projects, and recent activity (`GET /api/companies/{companyId}/dashboard`) to identify gaps or next steps. Create new top-level tasks (`POST /api/companies/{companyId}/issues`) for actionable work, assign them to appropriate agents (or yourself), and proceed. Focus on high-impact work aligned with existing projects and goals. Do not create duplicate or overlapping tasks — search existing issues first (`GET /api/companies/{companyId}/issues?q=...`).
+- If your permissions include `canCreateTasks: true`: review company goals, projects, and recent activity (`GET /api/companies/{companyId}/dashboard`) to identify gaps or next steps. Create new top-level tasks (`POST /api/companies/{companyId}/issues`) for actionable work, assign them to appropriate agents (or yourself), and proceed. If you assigned work only to other agents (nothing is self-assigned), exit the heartbeat now — do not look for more work to create. Focus on high-impact work aligned with existing projects and goals. Do not create duplicate or overlapping tasks — search existing issues first (`GET /api/companies/{companyId}/issues?q=...`).
 - Otherwise, exit the heartbeat.
 
 **Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -100,7 +100,7 @@ export const agentsApi = {
     api.post<AgentHireResponse>(`/companies/${companyId}/agent-hires`, data),
   update: (id: string, data: Record<string, unknown>, companyId?: string) =>
     api.patch<Agent>(agentPath(id, companyId), data),
-  updatePermissions: (id: string, data: { canCreateAgents: boolean }, companyId?: string) =>
+  updatePermissions: (id: string, data: { canCreateAgents?: boolean; canCreateTasks?: boolean }, companyId?: string) =>
     api.patch<Agent>(agentPath(id, companyId, "/permissions"), data),
   pause: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/pause"), {}),
   resume: (id: string, companyId?: string) => api.post<Agent>(agentPath(id, companyId, "/resume"), {}),

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -376,8 +376,8 @@ export function AgentDetail() {
   });
 
   const updatePermissions = useMutation({
-    mutationFn: (canCreateAgents: boolean) =>
-      agentsApi.updatePermissions(agentLookupRef, { canCreateAgents }, resolvedCompanyId ?? undefined),
+    mutationFn: (perms: { canCreateAgents?: boolean; canCreateTasks?: boolean }) =>
+      agentsApi.updatePermissions(agentLookupRef, perms, resolvedCompanyId ?? undefined),
     onSuccess: () => {
       setActionError(null);
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(routeAgentRef) });
@@ -1045,7 +1045,7 @@ function AgentConfigurePage({
   onSaveActionChange: (save: (() => void) | null) => void;
   onCancelActionChange: (cancel: (() => void) | null) => void;
   onSavingChange: (saving: boolean) => void;
-  updatePermissions: { mutate: (canCreate: boolean) => void; isPending: boolean };
+  updatePermissions: { mutate: (perms: { canCreateAgents?: boolean; canCreateTasks?: boolean }) => void; isPending: boolean };
 }) {
   const queryClient = useQueryClient();
   const [revisionsOpen, setRevisionsOpen] = useState(false);
@@ -1151,7 +1151,7 @@ function ConfigurationTab({
   onSaveActionChange: (save: (() => void) | null) => void;
   onCancelActionChange: (cancel: (() => void) | null) => void;
   onSavingChange: (saving: boolean) => void;
-  updatePermissions: { mutate: (canCreate: boolean) => void; isPending: boolean };
+  updatePermissions: { mutate: (perms: { canCreateAgents?: boolean; canCreateTasks?: boolean }) => void; isPending: boolean };
 }) {
   const queryClient = useQueryClient();
 
@@ -1202,11 +1202,25 @@ function ConfigurationTab({
               size="sm"
               className="h-7 px-2.5 text-xs"
               onClick={() =>
-                updatePermissions.mutate(!Boolean(agent.permissions?.canCreateAgents))
+                updatePermissions.mutate({ canCreateAgents: !Boolean(agent.permissions?.canCreateAgents) })
               }
               disabled={updatePermissions.isPending}
             >
               {agent.permissions?.canCreateAgents ? "Enabled" : "Disabled"}
+            </Button>
+          </div>
+          <div className="flex items-center justify-between text-sm mt-2">
+            <span>Can create new tasks</span>
+            <Button
+              variant={agent.permissions?.canCreateTasks ? "default" : "outline"}
+              size="sm"
+              className="h-7 px-2.5 text-xs"
+              onClick={() =>
+                updatePermissions.mutate({ canCreateTasks: !Boolean(agent.permissions?.canCreateTasks) })
+              }
+              disabled={updatePermissions.isPending}
+            >
+              {agent.permissions?.canCreateTasks ? "Enabled" : "Disabled"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Adds `canCreateTasks` boolean permission mirroring the existing `canCreateAgents` pattern, defaulting to `true` for CEO-role agents
- Gates top-level issue creation (no `parentId`) behind the permission, with parentId existence validation to prevent bypass
- Updates the paperclip skill so permitted agents proactively create tasks when idle instead of exiting

## Test plan
- [ ] Verify CEO agents can create top-level tasks by default
- [ ] Verify non-CEO agents without the permission are blocked from creating top-level tasks
- [ ] Verify agents can still create sub-tasks (with valid `parentId`) regardless of permission
- [ ] Verify supplying a non-existent `parentId` returns a 400 error
- [ ] Verify the permission toggle appears in the agent detail UI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `canCreateTasks` boolean permission for agents, mirroring the existing `canCreateAgents` pattern end-to-end: shared types/validators, server-side normalization and route enforcement, a grant-based + permission-object two-tier auth check, and a UI toggle on the agent detail page. It also expands the Paperclip skill to allow CEO-role agents to proactively create tasks when idle, rather than simply exiting.

**Key changes:**
- `canCreateTasks` defaults to `true` for CEO-role agents across `defaultPermissionsForRole`, `normalizeAgentPermissions`, and the `canCreateTasksPermission` route helper.
- Top-level issue creation (`POST /companies/:companyId/issues` with no `parentId`) is gated for agents via a grant-based check with a permission-object fallback; a valid `parentId` bypasses the gate but is validated to belong to the same company.
- `updatePermissions` in `agents.ts` now merges the incoming partial update with existing permissions before normalizing, preventing a single-field update from resetting the other field — an improvement over the previous behavior.
- `updateAgentPermissionsSchema` now requires at least one field via `.refine()`, preventing silent no-op writes.
- The `tasks:create` key in `PERMISSION_KEYS` is annotated as agent-only, acknowledging that the check is not enforced for human users.
- SKILL.md Step 4 explicitly instructs the agent to exit the heartbeat after delegating tasks to others only, reducing idle-loop risk.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the permission gate, cross-company parent validation, and schema guard are all correctly implemented.
- The implementation is consistent with existing patterns, previous review issues (company ownership check, empty-payload validator, idle-loop instruction, auth asymmetry comment) have been addressed, and no new logic bugs were found. The minor known asymmetry between `canCreateTasks` and `canCreateAgents` auth paths is intentional and documented inline.
- No files require special attention — `server/src/routes/issues.ts` is the most complex change and appears correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/shared/src/validators/agent.ts | Adds `canCreateTasks` to both schemas; adds a `.refine()` guard to `updateAgentPermissionsSchema` requiring at least one field, preventing silent no-op writes. |
| server/src/routes/issues.ts | Adds `canCreateTasksPermission` helper and the main gate around top-level task creation for agents; validates that a supplied `parentId` belongs to the same company to prevent permission bypass. Cross-company ownership check is present and correct. |
| server/src/services/agent-permissions.ts | Correctly extends `NormalizedAgentPermissions`, `defaultPermissionsForRole`, and `normalizeAgentPermissions` to include `canCreateTasks`, defaulting to `true` for CEO-role agents. |
| server/src/services/agents.ts | Updates `updatePermissions` to merge existing permissions before normalizing — a meaningful improvement over the previous behavior where a single-field update would drop all other permission values. |
| skills/paperclip/SKILL.md | Adds the idle-with-canCreateTasks branch to Step 4 and updates the access-control rules section; explicitly instructs the agent to exit the heartbeat if no work was self-assigned, addressing the potential idle-loop risk. |
| ui/src/pages/AgentDetail.tsx | Adds the "Can create new tasks" toggle to the permissions card, updates mutation types, and wires the toggle correctly — each button sends only its own field, so the other permission is preserved via the server-side merge. |

</details>

<sub>Last reviewed commit: c939b75</sub>

<!-- /greptile_comment -->