### PR TITLE
fix(server): allow local_trusted non-loopback binding via env var

### DIFF
--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -32,6 +32,7 @@ This keeps one authenticated auth stack while still separating low-friction priv
 - loopback-only host binding
 - no human login flow
 - optimized for fastest local startup
+- to bind to a non-loopback interface (e.g. when using exe.dev as a host), set `PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK=true` — a startup warning will be emitted
 
 ## `authenticated + private`
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -372,10 +372,19 @@ if (config.databaseUrl) {
   startupDbInfo = { mode: "embedded-postgres", dataDir, port };
 }
 
-if (config.deploymentMode === "local_trusted" && !isLoopbackHost(config.host)) {
-  throw new Error(
-    `local_trusted mode requires loopback host binding (received: ${config.host}). ` +
-      "Use authenticated mode for non-loopback deployments.",
+if (
+  config.deploymentMode === "local_trusted" &&
+  !isLoopbackHost(config.host)
+) {
+  if (process.env.PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK !== "true") {
+    throw new Error(
+      `local_trusted mode requires loopback host binding (received: ${config.host}). ` +
+        "Use authenticated mode for non-loopback deployments, or set PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK=true to override.",
+    );
+  }
+  logger.warn(
+    { host: config.host },
+    "PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK is set: local_trusted mode is running on a non-loopback interface without authentication. Ensure this is intentional.",
   );
 }
 


### PR DESCRIPTION
## Summary
- When using exe.dev as a host, `local_trusted` mode needs to bind to non-loopback interfaces, but the existing guard unconditionally rejects this
- Adds `PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK=true` environment variable to opt in to non-loopback binding in `local_trusted` mode
- Emits a `logger.warn` at startup when the override is active
- The guard remains active by default — only explicitly opting in bypasses it
- Documents the env var in `doc/DEPLOYMENT-MODES.md`

## Test plan
- [ ] Verify `local_trusted` mode still rejects non-loopback binding by default
- [ ] Verify setting `PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK=true` allows non-loopback binding and logs a warning
- [ ] Verify `local_trusted` with loopback host continues to work regardless of env var

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the `local_trusted` non-loopback guard by making it opt-in via `PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK=true`, primarily to support `exe.dev`-style hosting. The guard still throws by default; the new code path only activates when the env var is explicitly set and correctly emits a `logger.warn` so operators are aware they're running without authentication on a non-loopback interface.

- The nested `if` structure in `server/src/index.ts` is clean and correct — the warning is placed after the `throw` guard, meaning it only fires when the override is active.
- The error message was improved to mention the override option, aiding discoverability.
- `doc/DEPLOYMENT-MODES.md` accurately documents the new env var under the `local_trusted` security policy section.
- No logic, syntax, or security issues found in the implementation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the default behavior is unchanged and the opt-in path is gated behind an explicit env var with a visible startup warning.
- The change is small and focused. The guard remains active by default; the bypass is explicit and logged. The code structure is clean, the documentation is updated, and no bugs or regressions were found.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/index.ts | Guard refactored to a nested `if` — throws by default, emits `logger.warn` when `PAPERCLIP_ALLOW_LOCAL_TRUSTED_NON_LOOPBACK=true`. Logic is correct and clean; no issues found. |
| doc/DEPLOYMENT-MODES.md | Adds a bullet documenting the new env var under the `local_trusted` security policy section. Accurate and concise. |

</details>

<sub>Last reviewed commit: 19bba46</sub>

<!-- /greptile_comment -->