### PR TITLE
Add Me/No Assignee filters to issue list

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { issuesApi } from "../api/issues";
+import { authApi } from "../api/auth";
 import { queryKeys } from "../lib/queryKeys";
 import { groupBy } from "../lib/groupBy";
 import { formatDate, cn } from "../lib/utils";
@@ -86,11 +87,21 @@ function toggleInArray(arr: string[], value: string): string[] {
   return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value];
 }
 
-function applyFilters(issues: Issue[], state: IssueViewState): Issue[] {
+const ASSIGNEE_ME = "__me__";
+const ASSIGNEE_UNASSIGNED = "__unassigned__";
+
+function applyFilters(issues: Issue[], state: IssueViewState, currentUserId?: string | null): Issue[] {
   let result = issues;
   if (state.statuses.length > 0) result = result.filter((i) => state.statuses.includes(i.status));
   if (state.priorities.length > 0) result = result.filter((i) => state.priorities.includes(i.priority));
-  if (state.assignees.length > 0) result = result.filter((i) => i.assigneeAgentId != null && state.assignees.includes(i.assigneeAgentId));
+  if (state.assignees.length > 0) {
+    result = result.filter((i) => {
+      if (state.assignees.includes(ASSIGNEE_UNASSIGNED) && !i.assigneeAgentId && !i.assigneeUserId) return true;
+      if (state.assignees.includes(ASSIGNEE_ME) && currentUserId && i.assigneeUserId === currentUserId) return true;
+      if (i.assigneeAgentId && state.assignees.includes(i.assigneeAgentId)) return true;
+      return false;
+    });
+  }
   if (state.labels.length > 0) result = result.filter((i) => (i.labelIds ?? []).some((id) => state.labels.includes(id)));
   return result;
 }
@@ -162,6 +173,11 @@ export function IssuesList({
 }: IssuesListProps) {
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+  });
+  const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;
@@ -221,9 +237,9 @@ export function IssuesList({
 
   const filtered = useMemo(() => {
     const sourceIssues = normalizedIssueSearch.length > 0 ? searchedIssues : issues;
-    const filteredByControls = applyFilters(sourceIssues, viewState);
+    const filteredByControls = applyFilters(sourceIssues, viewState, currentUserId);
     return sortIssues(filteredByControls, viewState);
-  }, [issues, searchedIssues, viewState, normalizedIssueSearch]);
+  }, [issues, searchedIssues, viewState, normalizedIssueSearch, currentUserId]);
 
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(selectedCompanyId!),
@@ -434,22 +450,36 @@ export function IssuesList({
                     </div>
 
                     {/* Assignee */}
-                    {agents && agents.length > 0 && (
-                      <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">Assignee</span>
-                        <div className="space-y-0.5 max-h-32 overflow-y-auto">
-                          {agents.map((agent) => (
-                            <label key={agent.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
-                              <Checkbox
-                                checked={viewState.assignees.includes(agent.id)}
-                                onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, agent.id) })}
-                              />
-                              <span className="text-sm">{agent.name}</span>
-                            </label>
-                          ))}
-                        </div>
+                    <div className="space-y-1">
+                      <span className="text-xs text-muted-foreground">Assignee</span>
+                      <div className="space-y-0.5 max-h-32 overflow-y-auto">
+                        {currentUserId && (
+                          <label className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                            <Checkbox
+                              checked={viewState.assignees.includes(ASSIGNEE_ME)}
+                              onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, ASSIGNEE_ME) })}
+                            />
+                            <span className="text-sm">Me</span>
+                          </label>
+                        )}
+                        <label className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                          <Checkbox
+                            checked={viewState.assignees.includes(ASSIGNEE_UNASSIGNED)}
+                            onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, ASSIGNEE_UNASSIGNED) })}
+                          />
+                          <span className="text-sm">No Assignee</span>
+                        </label>
+                        {(agents ?? []).map((agent) => (
+                          <label key={agent.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                            <Checkbox
+                              checked={viewState.assignees.includes(agent.id)}
+                              onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, agent.id) })}
+                            />
+                            <span className="text-sm">{agent.name}</span>
+                          </label>
+                        ))}
                       </div>
-                    )}
+                    </div>
 
                     {labels && labels.length > 0 && (
                       <div className="space-y-1">


### PR DESCRIPTION
## Summary
- Adds "Me" and "No Assignee" options to the assignee filter in the issues list
- **Me** = issues assigned to the current user (human, via `assigneeUserId`)
- **No Assignee** = issues with no assignee at all (neither agent nor user)
- Assignee filter section now always visible (previously hidden when no agents existed)

Closes #170

<img width="924" height="968" alt="image" src="https://github.com/user-attachments/assets/b782e622-5605-47f8-90c6-533e268e8ead" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds "Me" and "No Assignee" filter entries to the assignee filter panel in the issues list, making the section always visible. The filter logic in `applyFilters` is correctly extended with OR-based matching for the two new sentinel values (`__me__`, `__unassigned__`), and the session query is reused (from the shared React Query cache) to resolve the current user's ID.

Key observations:
- **Group-by-assignee ignores human assignees** — `groupedContent` still keys only on `assigneeAgentId`, so issues assigned to a user via `assigneeUserId` land in the "Unassigned" group even after this change.
- **Stale `ASSIGNEE_ME` in localStorage** — if the filter is persisted and the session hasn't resolved, the "Me" checkbox is hidden while the filter still appears active in the toolbar badge, which is confusing.
- **Inline issue row** — the per-issue assignee display only renders agent names; human-assigned issues still show the "Assignee" placeholder, which is now inconsistent with the new "Me" filter.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor caveats — the core filtering logic is correct but a few UX inconsistencies around human assignees should be addressed in a follow-up.
- The new filter logic is sound and the session query is properly shared via the React Query cache. The main concerns are UX-level: persisted `ASSIGNEE_ME` state becoming invisible when the session is unavailable, and the group-by / inline assignee display not yet accounting for human assignees — none of which are data-corrupting or security issues.
- ui/src/components/IssuesList.tsx — specifically the `groupedContent` assignee grouping (line 287) and the inline issue assignee display (line 701).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ui/src/components/IssuesList.tsx | Adds "Me" and "No Assignee" filter options to the assignee filter panel; the core filtering logic is correct, but the "Me" filter state can become invisible/stranded in localStorage when the session is unavailable, the group-by-assignee view still ignores `assigneeUserId`, and the inline issue row doesn't display human assignees. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `ui/src/components/IssuesList.tsx`, line 287-292 ([link](https://github.com/paperclipai/paperclip/blob/a608e778e660df7f9392438b6dcfb25302b1d5e7/ui/src/components/IssuesList.tsx#L287-L292)) 

   **Assignee group-by ignores `assigneeUserId`**

   The "Group by assignee" feature only groups on `assigneeAgentId`, so issues assigned to a human user (via `assigneeUserId`) always fall into the "Unassigned" bucket. This PR introduces the ability to filter by "Me" (human assignees), making the inconsistency more noticeable: a user can filter by their own assignments successfully, but when grouping by assignee those same issues appear under "Unassigned."

   ```ts
   // current
   const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? "__unassigned");

   // consider accounting for user assignees
   const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? i.assigneeUserId ?? "__unassigned");
   ```

   The label resolution at line 290 would also need updating to look up a display name for user IDs, similar to how `agentName` works for agent IDs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ui/src/components/IssuesList.tsx
   Line: 287-292

   Comment:
   **Assignee group-by ignores `assigneeUserId`**

   The "Group by assignee" feature only groups on `assigneeAgentId`, so issues assigned to a human user (via `assigneeUserId`) always fall into the "Unassigned" bucket. This PR introduces the ability to filter by "Me" (human assignees), making the inconsistency more noticeable: a user can filter by their own assignments successfully, but when grouping by assignee those same issues appear under "Unassigned."

   ```ts
   // current
   const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? "__unassigned");

   // consider accounting for user assignees
   const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? i.assigneeUserId ?? "__unassigned");
   ```

   The label resolution at line 290 would also need updating to look up a display name for user IDs, similar to how `agentName` works for agent IDs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `ui/src/components/IssuesList.tsx`, line 701-709 ([link](https://github.com/paperclipai/paperclip/blob/a608e778e660df7f9392438b6dcfb25302b1d5e7/ui/src/components/IssuesList.tsx#L701-L709)) 

   **Issue row doesn't display human assignees**

   The inline assignee display in the issue row only checks `issue.assigneeAgentId` (line 701). If an issue is assigned to a user via `assigneeUserId` (which can now be filtered with "Me"), the row shows the "Assignee" placeholder instead of the user's name/avatar. This makes the UI inconsistent: a user can filter to "assigned to me," see the correct list of issues, but each row shows them as unassigned.

   This is pre-existing behaviour, but it's become more visible now that user assignments are a first-class filter option.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ui/src/components/IssuesList.tsx
   Line: 701-709

   Comment:
   **Issue row doesn't display human assignees**

   The inline assignee display in the issue row only checks `issue.assigneeAgentId` (line 701). If an issue is assigned to a user via `assigneeUserId` (which can now be filtered with "Me"), the row shows the "Assignee" placeholder instead of the user's name/avatar. This makes the UI inconsistent: a user can filter to "assigned to me," see the correct list of issues, but each row shows them as unassigned.

   This is pre-existing behaviour, but it's become more visible now that user assignments are a first-class filter option.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: a608e77</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->