### PR TITLE
fix(ui): auto-linkify file reference paths in markdown

### DIFF
--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -242,6 +242,29 @@ The name must match the agent's `name` field exactly (case-insensitive). This tr
 - If an agent is explicitly @-mentioned with a clear directive to take the task, that agent may read the thread and self-assign via checkout for that issue.
 - This is a narrow fallback for missed assignment flow, not a replacement for normal assignment discipline.
 
+**Sharing files (screenshots, research, work products):**
+
+When you generate files that others need to see (screenshots, reports, research documents, diagrams), upload them as assets and reference the returned `contentPath` in your comment using markdown link or image syntax:
+
+```
+# 1. Upload the file
+POST /api/companies/{companyId}/assets/images
+Content-Type: multipart/form-data
+# Form field: "file" = <your file>
+
+# Response:
+# { "assetId": "asset-1", "contentPath": "/api/assets/asset-1/content", ... }
+
+# 2. Reference in a comment using the contentPath
+POST /api/issues/{issueId}/comments
+{ "body": "Here's the analysis: [research.pdf](/api/assets/asset-1/content)" }
+
+# For images, use image syntax for inline display:
+{ "body": "Screenshot of the bug:\n![screenshot](/api/assets/asset-1/content)" }
+```
+
+**Do NOT** reference local file paths (e.g. `docs/report.pdf`, `/home/user/output.png`) in comments — these are inaccessible to other agents and board users. Always upload as an asset first.
+
 ---
 
 ## Cross-Team Work and Delegation
@@ -524,6 +547,13 @@ Terminal states: `done`, `cancelled`
 | PATCH  | `/api/goals/:goalId`                 | Update goal        |
 | POST   | `/api/companies/:companyId/openclaw/invite-prompt` | Generate OpenClaw invite prompt (CEO/board only) |
 
+### Assets (File Uploads)
+
+| Method | Path                                          | Description                                      |
+| ------ | --------------------------------------------- | ------------------------------------------------ |
+| POST   | `/api/companies/:companyId/assets/images`     | Upload a file (multipart form, field name `file`) |
+| GET    | `/api/assets/:assetId/content`                | Serve asset content (use returned `contentPath`)  |
+
 ### Approvals, Costs, Activity, Dashboard
 
 | Method | Path                                         | Description                        |
@@ -559,3 +589,4 @@ Terminal states: `done`, `cancelled`
 | @-mention agents for no reason              | Each mention triggers a budget-consuming heartbeat    | Only mention agents who need to act                     |
 | Sit silently on blocked work                | Nobody knows you're stuck; the task rots              | Comment the blocker and escalate immediately            |
 | Leave tasks in ambiguous states             | Others can't tell if work is progressing              | Always update status: `blocked`, `in_review`, or `done` |
+| Reference local file paths in comments      | Board users and other agents can't access local files | Upload as asset first, then reference the `contentPath` |

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -112,6 +112,21 @@ function MermaidDiagramBlock({ source, darkMode }: { source: string; darkMode: b
   );
 }
 
+const FILE_REF_RE = /\/api\/(?:assets|attachments)\/[^/]+\/content/;
+
+/**
+ * Auto-linkify bare file reference paths (e.g. `/api/assets/{id}/content`)
+ * that appear in plain text (not already inside a markdown link).
+ */
+function linkifyFileReferences(md: string): string {
+  // Match bare file paths that are NOT already inside markdown link syntax [text](url)
+  // Negative lookbehind for ]( and negative lookbehind for ![ prevents double-wrapping
+  return md.replace(
+    /(?<!\]\()(?<!\()(?<!")(?:^|(?<=\s))(\/api\/(?:assets|attachments)\/[^\s)]+\/content)(?=[\s),.]|$)/gm,
+    "[$1]($1)",
+  );
+}
+
 export function MarkdownBody({ children, className }: MarkdownBodyProps) {
   const { theme } = useTheme();
   return (
@@ -146,6 +161,13 @@ export function MarkdownBody({ children, className }: MarkdownBodyProps) {
                 </a>
               );
             }
+            if (href && FILE_REF_RE.test(href)) {
+              return (
+                <a href={href} target="_blank" rel="noreferrer">
+                  {linkChildren}
+                </a>
+              );
+            }
             return (
               <a href={href} rel="noreferrer">
                 {linkChildren}
@@ -154,7 +176,7 @@ export function MarkdownBody({ children, className }: MarkdownBodyProps) {
           },
         }}
       >
-        {children}
+        {linkifyFileReferences(children)}
       </Markdown>
     </div>
   );


### PR DESCRIPTION
## Summary
- Agents post file references (e.g. `/api/assets/{id}/content`) in markdown comments as bare text paths
- This change auto-converts them into clickable links so users can access uploaded assets directly
- File reference links open in a new tab (`target="_blank"`)
- Also adds asset upload workflow documentation to the API reference skill

## Test plan
- [ ] Verify bare `/api/assets/{id}/content` paths in markdown comments render as clickable links
- [ ] Verify bare `/api/attachments/{id}/content` paths also render as clickable links
- [ ] Verify paths already inside markdown link syntax `[text](url)` are not double-wrapped
- [ ] Verify file reference links open in a new tab

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR auto-converts bare `/api/assets/{id}/content` and `/api/attachments/{id}/content` paths in agent-posted markdown into clickable links (opening in a new tab), and adds asset-upload workflow documentation to the API reference skill.

- `linkifyFileReferences` is inserted as a raw-string pre-processor before react-markdown parses the input. The regex correctly guards against double-wrapping existing `[text](url)` and `![img](url)` syntax via negative lookbehinds, but because it operates on the raw markdown it **will transform paths that appear on standalone lines inside fenced code blocks**, replacing them with `[path](path)` literal text in the rendered code block.
- The ID-segment pattern is slightly inconsistent between `linkifyFileReferences` (`[^\s)]+`, allows slashes) and `FILE_REF_RE` (`[^/]+`, no slashes). A path with slashes in the ID would be linkified but the resulting `<a>` would not receive `target="_blank"`.
- The documentation additions in `api-reference.md` are clear and well-structured. The specific path examples in the code block happen to be protected by the `(?<!")` and `(?<!\()` lookbehinds, so they are not affected by the bug described above.
- The `rel="noreferrer"` on the new `target="_blank"` link is correct (implies `noopener`).

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the common case, but the raw-string pre-processing approach introduces a code-block corruption bug that should be addressed.
- The feature works correctly for the primary use case (bare paths in plain text). However, the regex transformation of raw markdown before parsing means paths on standalone lines inside fenced code blocks are inadvertently rewritten, and the two path-matching regexes are slightly inconsistent. Neither issue is a security risk, but the code-block issue is a genuine logic bug that could surface if agents ever show path examples inside code fences.
- ui/src/components/MarkdownBody.tsx — specifically the `linkifyFileReferences` raw-string pre-processing approach.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/components/MarkdownBody.tsx | Adds `linkifyFileReferences` to auto-convert bare `/api/assets|attachments/{id}/content` paths into markdown links before passing to react-markdown, and adds `target="_blank"` for those links in the `a` component renderer. The raw-string pre-processing approach can inadvertently transform paths inside fenced code blocks, and the ID-segment pattern differs slightly between the linkify regex and `FILE_REF_RE`. |
| skills/paperclip/references/api-reference.md | Adds asset upload workflow documentation (POST /api/companies/:companyId/assets/images and GET /api/assets/:assetId/content) and a new anti-pattern row in the common-mistakes table. Documentation is clear, accurate, and consistent with the UI change. |

</details>

<sub>Last reviewed commit: e786168</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->