### PR TITLE
fix(ui): show full Prompt Template with scroll instead of truncating

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -861,7 +861,7 @@ function ConfigSummary({
           Manage &rarr;
         </Link>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
         <div className="border border-border rounded-lg p-4 space-y-3">
           <h4 className="text-xs text-muted-foreground font-medium">Agent Details</h4>
           <div className="space-y-2 text-sm">
@@ -940,7 +940,7 @@ function ConfigSummary({
         {promptText && (
           <div className="border border-border rounded-lg p-4 space-y-2">
             <h4 className="text-xs text-muted-foreground font-medium">Prompt Template</h4>
-            <pre className="text-xs text-muted-foreground line-clamp-[12] font-mono whitespace-pre-wrap">{promptText}</pre>
+            <pre className="text-xs text-muted-foreground font-mono whitespace-pre-wrap max-h-96 overflow-y-auto">{promptText}</pre>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Remove `line-clamp-[12]` that truncated long prompt templates with `...`
- Add `items-start` to the grid container so the Prompt Template card doesn't stretch to match the height of the adjacent Agent Details card
- Add `max-h-96 overflow-y-auto` so very long prompts get a scrollbar instead of expanding the page infinitely

## Before / After

**Before**: Long prompt templates were truncated with `...` and no way to see the full content.

**After**: Full prompt template is visible with scroll support. Short prompts show without extra whitespace. Very long prompts are capped at 384px height with a scrollbar.

## Test plan

- [ ] Verify short prompt templates display fully without extra whitespace
- [ ] Verify long prompt templates show scrollbar at max height
- [ ] Verify Agent Details and Prompt Template cards have independent heights

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a minimal, focused UI fix in the `ConfigSummary` component on the Agent Detail page to show the full Prompt Template text with a scrollable container instead of truncating it. The changes are well-scoped and low-risk.

**Changes:**
- Adds `items-start` to the `md:grid-cols-2` grid container so the Prompt Template card aligns to the top independently, rather than stretching to the full height of the adjacent Agent Details card.
- Removes `line-clamp-[12]` from the prompt `<pre>` element, eliminating the hard text truncation.
- Adds `max-h-96 overflow-y-auto` to the same `<pre>` element, capping the visible height at 384px and enabling vertical scrolling for longer prompts.

The combination of `whitespace-pre-wrap` (already present) and the new `overflow-y-auto` works correctly — long lines will wrap rather than cause horizontal overflow, and the scrollbar only appears when content exceeds the max height.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the changes are purely presentational Tailwind class modifications with no logic or data changes.
- Only two CSS class modifications in a single component. The changes correctly address the stated UX problem, are non-breaking, and do not touch any application logic, state, or API interactions.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/pages/AgentDetail.tsx | Two targeted CSS class changes in the ConfigSummary component: adds `items-start` to the grid container for independent card heights, and replaces `line-clamp-[12]` on the prompt `<pre>` element with `max-h-96 overflow-y-auto` to enable scrollable full-content display. |

</details>

<sub>Last reviewed commit: 1467f25</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->