### PR TITLE
fix: enable shell mode on Windows for adapter child process spawn

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -125,6 +125,22 @@ export function defaultPathForPlatform() {
   return "/usr/local/bin:/opt/homebrew/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin";
 }
 
+/**
+ * Filters an object to only string-valued entries, discarding undefined/non-string values.
+ * Useful for converting NodeJS.ProcessEnv (Record<string, string | undefined>) to Record<string, string>.
+ */
+export function normalizeEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input))
+    return {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(
+    input as Record<string, unknown>,
+  )) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
 export function ensurePathInEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   if (typeof env.PATH === "string" && env.PATH.length > 0) return env;
   if (typeof env.Path === "string" && env.Path.length > 0) return env;

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -223,7 +223,7 @@ export async function runChildProcess(
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env: mergedEnv,
-      shell: false,
+      shell: process.platform === "win32",
       stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
     }) as ChildProcessWithEvents;
 

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -12,6 +12,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  normalizeEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
@@ -47,15 +48,6 @@ function summarizeProbeDetail(stdout: string, stderr: string): string | null {
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
-}
-
-function normalizeEnv(input: unknown): Record<string, string> {
-  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
-    if (typeof value === "string") env[key] = value;
-  }
-  return env;
 }
 
 export async function testEnvironment(

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -49,6 +49,15 @@ function summarizeProbeDetail(stdout: string, stderr: string): string | null {
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
+function normalizeEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
 export async function testEnvironment(
   ctx: AdapterEnvironmentTestContext,
 ): Promise<AdapterEnvironmentTestResult> {
@@ -78,7 +87,7 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
   try {
     await ensureCommandResolvable(command, cwd, runtimeEnv);
     checks.push({
@@ -152,7 +161,7 @@ export async function testEnvironment(
         args,
         {
           cwd,
-          env,
+          env: runtimeEnv,
           timeoutSec: 45,
           graceSec: 5,
           stdin: "Respond with hello.",

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -11,6 +11,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  normalizeEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
@@ -46,15 +47,6 @@ function summarizeProbeDetail(stdout: string, stderr: string, parsedError: strin
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
-}
-
-function normalizeEnv(input: unknown): Record<string, string> {
-  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
-    if (typeof value === "string") env[key] = value;
-  }
-  return env;
 }
 
 const CODEX_AUTH_REQUIRED_RE =

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -48,6 +48,15 @@ function summarizeProbeDetail(stdout: string, stderr: string, parsedError: strin
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
+function normalizeEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
 const CODEX_AUTH_REQUIRED_RE =
   /(?:not\s+logged\s+in|login\s+required|authentication\s+required|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|openai[_\s-]?api[_\s-]?key|api[_\s-]?key.*required|please\s+run\s+`?codex\s+login`?)/i;
 
@@ -80,7 +89,7 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
   try {
     await ensureCommandResolvable(command, cwd, runtimeEnv);
     checks.push({
@@ -160,7 +169,7 @@ export async function testEnvironment(
         args,
         {
           cwd,
-          env,
+          env: runtimeEnv,
           timeoutSec: 45,
           graceSec: 5,
           stdin: "Respond with hello.",

--- a/packages/adapters/cursor-local/src/server/test.ts
+++ b/packages/adapters/cursor-local/src/server/test.ts
@@ -10,6 +10,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  normalizeEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
@@ -47,15 +48,6 @@ function summarizeProbeDetail(stdout: string, stderr: string, parsedError: strin
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
-}
-
-function normalizeEnv(input: unknown): Record<string, string> {
-  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
-    if (typeof value === "string") env[key] = value;
-  }
-  return env;
 }
 
 const CURSOR_AUTH_REQUIRED_RE =

--- a/packages/adapters/cursor-local/src/server/test.ts
+++ b/packages/adapters/cursor-local/src/server/test.ts
@@ -49,6 +49,15 @@ function summarizeProbeDetail(stdout: string, stderr: string, parsedError: strin
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
+function normalizeEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
 const CURSOR_AUTH_REQUIRED_RE =
   /(?:authentication\s+required|not\s+authenticated|not\s+logged\s+in|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|cursor[_\s-]?api[_\s-]?key|run\s+'?agent\s+login'?\s+first|api(?:[_\s-]?key)?(?:\s+is)?\s+required)/i;
 
@@ -81,7 +90,7 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
   try {
     await ensureCommandResolvable(command, cwd, runtimeEnv);
     checks.push({
@@ -148,7 +157,7 @@ export async function testEnvironment(
         args,
         {
           cwd,
-          env,
+          env: runtimeEnv,
           timeoutSec: 45,
           graceSec: 5,
           onLog: async () => {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -124,22 +121,6 @@ importers:
         version: 5.9.3
 
   packages/adapters/cursor-local:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
-  packages/adapters/openclaw:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -261,9 +242,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -379,9 +357,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -30,6 +30,7 @@ if (process.env.npm_config_authenticated_private === "true") {
 const env = {
   ...process.env,
   PAPERCLIP_UI_DEV_MIDDLEWARE: "true",
+  PAPERCLIP_MIGRATION_PROMPT: "never",
 };
 
 if (tailscaleAuth) {

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "dev": "tsx src/index.ts",
-    "dev:watch": "PAPERCLIP_MIGRATION_PROMPT=never tsx watch --ignore ../ui/node_modules --ignore ../ui/.vite --ignore ../ui/dist src/index.ts",
+    "dev:watch": "tsx watch --ignore ../ui/node_modules --ignore ../ui/.vite --ignore ../ui/dist src/index.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary

- **Root cause:** On Windows, CLI tools (`claude`, `codex`, `cursor`) are installed as POSIX shell wrappers + `.cmd` files. `spawn()` with `shell: false` cannot resolve these, causing ENOENT errors on `test-environment` and adapter run endpoints.
- Set `shell: process.platform === "win32"` in `runChildProcess` (`adapter-utils`) so Windows uses the system shell to resolve `.cmd` wrappers while keeping `shell: false` on Unix
- Normalize `process.env` (which contains `string | undefined` values) to `Record<string, string>` via `normalizeEnv()` in all three adapter test files before passing to `runChildProcess`
- Pass the full `runtimeEnv` (with merged PATH) to the probe `runChildProcess` call instead of the partial `env` object
- Move `PAPERCLIP_MIGRATION_PROMPT=never` from `dev:watch` script (Unix-only syntax) to `dev-runner.mjs` for cross-platform compatibility
- Remove stale `@paperclipai/adapter-openclaw` references from `pnpm-lock.yaml`

## Test plan

- [ ] Verify `POST /api/companies/:id/adapters/claude_local/test-environment` returns 200 on Windows
- [ ] Verify adapter test-environment works on macOS/Linux (regression)
- [ ] Verify `pnpm dev` and `pnpm dev watch` work on Windows
- [ ] Run `pnpm -r typecheck` and `pnpm build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Windows compatibility for adapter child process spawning by enabling `shell: true` on Windows so `.cmd` wrappers for `claude`, `codex`, and `cursor` can be resolved by the system shell, and migrates `PAPERCLIP_MIGRATION_PROMPT=never` from a Unix-only inline env syntax to the cross-platform `dev-runner.mjs`. The approach is sound and targets the correct root causes, but the shell-mode change introduces a concern that should be addressed before merging to production:

- **Shell injection on Windows:** Setting `shell: process.platform === "win32"` in `runChildProcess` means the entire command and its arguments are passed through `cmd.exe`. Since `command` and `args` include user-configurable values (e.g., `config.command`, `config.extraArgs`), a malicious adapter configuration could inject shell metacharacters (`&`, `|`, etc.) and execute arbitrary commands on the host. Consider resolving `.cmd` extensions at the call site or at the top of `runChildProcess` (appending `.cmd` on Windows when no extension is present) to keep `shell: false` on all platforms.
- **`normalizeEnv` duplication:** The identical helper function is copy-pasted into all three adapter test files. It should be exported from `adapter-utils/src/server-utils.ts` for consistency with the rest of the shared utility layer.
- **Double `process.env` merge:** `runtimeEnv` is now built from `{ ...process.env, ...env }` in the test files, but `runChildProcess` also internally spreads `process.env` again over `opts.env`. This is harmless today (values are idempotent), but the conceptual contract of `runChildProcess` — that callers pass only adapter-specific vars and the function merges the host environment — is now violated.
- The `dev-runner.mjs` change, `server/package.json` update, and `pnpm-lock.yaml` cleanup are all clean and unambiguous.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for Mac/Linux; the Windows shell-injection risk warrants a follow-up or guard before broad Windows deployment.
- The non-Windows changes are all correct and low-risk. The core Windows fix (`shell: true`) resolves the ENOENT issue but opens a shell-injection surface for user-controlled adapter config values on Windows. The risk is gated to Windows only and requires a malicious adapter configuration to exploit, but it's a real and fixable concern before this reaches production Windows deployments.
- `packages/adapter-utils/src/server-utils.ts` — the `shell` option change is the crux of the Windows fix and the source of the injection risk.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/adapter-utils/src/server-utils.ts | Enables `shell: true` on Windows for child process spawning — correct root cause fix for `.cmd` wrapper resolution, but introduces shell injection risk for user-configurable command/args on Windows. |
| packages/adapters/claude-local/src/server/test.ts | Adds `normalizeEnv` to strip `undefined` values from `process.env` before passing to `runChildProcess`, and fixes the probe call to use the full `runtimeEnv` instead of the partial `env`. Both fixes are correct, but `normalizeEnv` is duplicated from the other two adapter test files and `process.env` ends up being merged twice. |
| packages/adapters/codex-local/src/server/test.ts | Same `normalizeEnv` + `runtimeEnv` probe fix as claude-local. Correct changes, same duplication concern. |
| packages/adapters/cursor-local/src/server/test.ts | Same `normalizeEnv` + `runtimeEnv` probe fix as claude-local and codex-local. Correct changes, same duplication concern. |
| scripts/dev-runner.mjs | Moves `PAPERCLIP_MIGRATION_PROMPT=never` from the Unix-only inline env syntax in `server/package.json` into the cross-platform `dev-runner.mjs` env object. Also correctly sets `shell: process.platform === "win32"` for the `pnpm` spawn. Clean, safe change. |
| server/package.json | Removes the Unix-only `PAPERCLIP_MIGRATION_PROMPT=never` inline env prefix from the `dev:watch` script now that it is set in `dev-runner.mjs`. Safe and correct. |
| pnpm-lock.yaml | Removes stale `@paperclipai/adapter-openclaw` workspace references. Housekeeping change with no functional impact. |

</details>

<sub>Last reviewed commit: b43d181</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->