### PR TITLE
feat: Create task-backend package structure

### DIFF
--- a/packages/task-backend/package.json
+++ b/packages/task-backend/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@paperclipai/task-backend",
+  "version": "0.2.7",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/db": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/task-backend/src/index.ts
+++ b/packages/task-backend/src/index.ts
@@ -1,0 +1,5 @@
+export const TASK_BACKEND_PACKAGE = '@paperclipai/task-backend';
+
+export interface TaskBackend {
+  name: string;
+}

--- a/packages/task-backend/tsconfig.json
+++ b/packages/task-backend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,25 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/task-backend:
+    dependencies:
+      '@paperclipai/db':
+        specifier: workspace:*
+        version: link:../db
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
   server:
     dependencies:
       '@aws-sdk/client-s3':


### PR DESCRIPTION
## Summary
This PR creates the initial package structure for `@paperclipai/task-backend` as part of Phase 1, Task 1.1 of the Task Backend Integration project.

## Changes
- Created `packages/task-backend/` directory structure
- Added `package.json` with:
  - Package name: `@paperclipai/task-backend`
  - Version: `0.2.7` (aligned with other packages)
  - ESM module type
  - Proper exports configuration for dev and publish
  - Dependencies: `@paperclipai/db` and `@paperclipai/shared`
  - Scripts: build, clean, typecheck
- Added `tsconfig.json` extending root TypeScript configuration
- Created `src/index.ts` with placeholder `TaskBackend` interface
- Updated `pnpm-lock.yaml` for workspace integration

## Testing
- ✅ `pnpm install` - Package integrated into monorepo successfully
- ✅ `pnpm --filter @paperclipai/task-backend typecheck` - Passes with no errors
- ✅ `pnpm --filter @paperclipai/task-backend build` - Builds successfully

## Related
- Plan: `~/repos/paperclip/docs/integrations/TASK-BACKEND-PLAN.md`
- This is Phase 1, Task 1.1 of the Task Backend Integration project

## Next Steps
- Task 1.2: Define types (TaskBackend interface, Issue types, etc.)
- Task 1.3: Implement TaskBackend interface
- Task 1.4: Implement PaperclipBackend

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scaffolds the `@paperclipai/task-backend` package as Phase 1, Task 1.1 of the Task Backend Integration project. The new package follows the established monorepo conventions exactly (same `exports`/`publishConfig` dual-mode pattern, same `tsconfig.json` shape, and same version as sibling packages `@paperclipai/shared` and `@paperclipai/db`).

Key observations:
- The package structure is correct and consistent with the rest of the monorepo.
- `vitest` is included as a devDependency but no `test` script is wired up — this means `pnpm test` will fail for this package until a script is added.
- The `pnpm-lock.yaml` diff silently captures the removal of `@paperclipai/adapter-openclaw` from multiple workspace importers in addition to adding `task-backend`. This removal is not mentioned in the PR description, which could cause reviewer confusion.
- `src/index.ts` is intentionally minimal (stub `TaskBackend` interface) and is appropriate for this scaffolding step.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — this is pure scaffolding with no runtime logic; the two minor issues are non-blocking.
- The new package correctly mirrors established monorepo patterns and the code itself is trivial placeholder content. The missing `test` script is a minor gap, and the undocumented `adapter-openclaw` removal in the lock file is worth clarifying but does not introduce any regression risk.
- `pnpm-lock.yaml` — contains an undocumented removal of `adapter-openclaw` that should be acknowledged in the PR description.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/task-backend/package.json | New package scaffolded correctly, following the same structure as @paperclipai/shared and @paperclipai/db. Minor: vitest is listed as a devDependency but no `test` script is defined. |
| packages/task-backend/src/index.ts | Minimal placeholder for Phase 1, Task 1.1 — exports a package name constant and a stub TaskBackend interface. |
| packages/task-backend/tsconfig.json | Correctly extends the root tsconfig.json and sets outDir/rootDir consistent with all other packages. |
| pnpm-lock.yaml | Adds task-backend workspace entry, but also silently removes all references to @paperclipai/adapter-openclaw (from the root importer, server, and the packages/adapters/openclaw entry) — this removal is not mentioned in the PR description. |

</details>

<sub>Last reviewed commit: 65c1fb2</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->