### PR TITLE
ui: filter dashboard agent cards to show only assistant messages

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -414,7 +414,7 @@ function AgentRunCard({
   isActive: boolean;
 }) {
   const bodyRef = useRef<HTMLDivElement>(null);
-  const recent = feed.slice(-20);
+  const recent = feed.filter((item) => item.tone === "assistant").slice(-20);
 
   useEffect(() => {
     const body = bodyRef.current;


### PR DESCRIPTION
## Summary
- Dashboard Agents section now shows **only assistant messages** instead of all transcript entries
- Filters out tool calls, raw JSON, stderr, and other noise from the agent run cards
- Gives a cleaner, more readable overview of what each agent is actually doing

## Before
Agent cards showed all stdout/stderr entries including raw JSON payloads, tool call details, and system messages — making it hard to quickly understand agent activity.

## After
Only `assistant`-tone messages are displayed, showing the agent's actual thoughts and decisions.

## Change
One-line filter in `AgentRunCard`:
```diff
- const recent = feed.slice(-20);
+ const recent = feed.filter((item) => item.tone === "assistant").slice(-20);
```

## Test plan
- [ ] Open dashboard with active agents running
- [ ] Verify agent cards show only assistant messages (green text)
- [ ] Verify tool calls, JSON payloads, and stderr are no longer shown
- [ ] Verify scrolling and auto-scroll still work correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a focused one-line change to `AgentRunCard` in `ActiveAgentsPanel.tsx`, filtering the live feed to display only `assistant`-tone entries before rendering. This cleans up the dashboard cards by hiding tool calls, raw JSON, stderr, and other noise, surfacing only the messages that reflect the agent's actual narrated activity.

Key points:
- The filter logic (`item.tone === "assistant"`) is correct and aligns with how `FeedTone` values are assigned throughout the file (assistant text, streaming deltas, etc. all receive `tone: "assistant"`).
- Streaming assistant message merging happens upstream in `appendItems` on the shared `feedByRun` state, so the filter does not break incremental text accumulation.
- The empty-state handling ("Waiting for output…") still works correctly when no assistant messages have arrived yet.
- The auto-scroll `useEffect` still references `feed.length` rather than `recent.length` — after the filter, this causes the smooth-scroll to fire on every non-assistant message arrival even though the rendered list is unchanged. This is the one actionable fix needed before merging.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the mismatched auto-scroll dependency.
- The change is minimal and well-scoped. The filtering logic is correct and consistent with the rest of the component. The only issue is a pre-existing `useEffect` whose dependency (`feed.length`) is now misaligned with the filtered `recent` list, causing spurious scroll events — a behavioural bug that is easy to fix.
- ui/src/components/ActiveAgentsPanel.tsx — review the auto-scroll `useEffect` dependency.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ui/src/components/ActiveAgentsPanel.tsx | One-line filter added to `AgentRunCard` to show only `assistant`-tone feed items. The change itself is correct, but the pre-existing auto-scroll `useEffect` still depends on `feed.length` rather than `recent.length`, causing unnecessary scroll triggers when non-visible (non-assistant) messages arrive. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ui/src/components/ActiveAgentsPanel.tsx`, line 423 ([link](https://github.com/paperclipai/paperclip/blob/62f7c75c67cecd7da4c3d2c9293dd43dded56f6a/ui/src/components/ActiveAgentsPanel.tsx#L423)) 

   **Auto-scroll fires on invisible feed changes**

   After the filter was introduced, `recent` now only contains `assistant`-tone items, but the auto-scroll effect still depends on `feed.length`. This means the card scrolls (firing a smooth `scrollTo`) every time **any** non-assistant message arrives (tool calls, stderr, heartbeat events, etc.), even though the visible content of `recent` didn't change. For a busy agent this could cause continuous scrolling of an otherwise-static list.

   The dependency should track the filtered list length instead:

   

   This ensures the scroll only fires when a new item is actually rendered in the card body.

   Note: since `recent` is derived from `feed` directly above the effect, this doesn't require moving any variable — it is already in scope at the point the hook is defined.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 62f7c75</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->