### PR TITLE
fix:Change UI mode from 'vite-dev' to 'static' 

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -162,7 +162,7 @@ export async function createApp(
         const templatePath = path.resolve(uiRoot, "index.html");
         const template = fs.readFileSync(templatePath, "utf-8");
         const html = await vite.transformIndexHtml(req.originalUrl, template);
-        res.status(200).set("Content-Type", "text/html").end(indexHtml);
+        res.status(200).set("Content-Type", "text/html").end(html);
       } catch (err) {
         next(err);
       }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -144,7 +144,7 @@ export async function createApp(
     }
   }
 
-  if (opts.uiMode === "vite-dev") {
+  if (opts.uiMode === "static") {
     const uiRoot = path.resolve(__dirname, "../../ui");
     const { createServer: createViteServer } = await import("vite");
     const vite = await createViteServer({
@@ -162,7 +162,7 @@ export async function createApp(
         const templatePath = path.resolve(uiRoot, "index.html");
         const template = fs.readFileSync(templatePath, "utf-8");
         const html = await vite.transformIndexHtml(req.originalUrl, template);
-        res.status(200).set({ "Content-Type": "text/html" }).end(html);
+        res.status(200).set("Content-Type", "text/html").end(indexHtml);
       } catch (err) {
         next(err);
       }


### PR DESCRIPTION
id:#312
When running the application with uiMode === "static" (for example when installing the package from npm and serving the built UI), client-side SPA routes such as:

1./invite/:token

2./companies/:id

3.other non-root routes

can return 500 Internal Server Error instead of loading the frontend.

The issue happens because the server previously used res.sendFile() to serve index.html. In certain environments (especially when the package is installed from npm), the send module may fail to resolve the path correctly and throw a NotFoundError.

To fix this, the fallback route now reads index.html once and returns it directly from memory, ensuring that all SPA routes correctly return the frontend entry point.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix SPA fallback routing for `uiMode === "static"` by reading `index.html` into memory instead of using `res.sendFile()`. However, the fix introduces two significant regressions in `server/src/app.ts`:

- **`vite-dev` mode is completely broken:** The condition on the Vite dev-server block (line 147) was changed from `"vite-dev"` to `"static"`, meaning no Vite dev server will ever be started when running in development mode.
- **Duplicate `static` block and undefined variable:** With both blocks now gated on `"static"`, two `app.get(/.*/, ...)` catch-all handlers are registered. The second one is unreachable, and it also references `indexHtml` — a variable only defined in the first block — and discards the Vite-transformed `html` output, which would break HMR if the handler were ever reached.

The correct fix (already present in the existing first `static` block at lines 129–145) is complete on its own. The changes to lines 147 and 165 should be reverted.

<h3>Confidence Score: 1/5</h3>

- This PR should not be merged — it breaks vite-dev mode and introduces an out-of-scope variable reference.
- The two-line change introduces two independent regressions: (1) the `vite-dev` condition is gone, so development mode is silently broken, and (2) an out-of-scope variable `indexHtml` is used where the correctly computed `html` should be, discarding all Vite transforms. The static-mode fix the PR intended to make already exists correctly in the first `static` block and didn't need changes to the `vite-dev` block at all.
- server/src/app.ts — both changed lines introduce regressions and should be reverted.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/app.ts | Two regressions introduced: the `vite-dev` condition was changed to `static`, breaking vite-dev mode entirely and creating a duplicate static block; and `indexHtml` (out-of-scope) replaces `html` (the Vite-transformed output), causing undefined responses and discarding all HMR transforms. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/app.ts`, line 147-170 ([link](https://github.com/paperclipai/paperclip/blob/c9939b655223c9672a6a4bd0e73cc7136eb702c9/server/src/app.ts#L147-L170)) 

   **Condition changed to wrong mode — `vite-dev` block is now broken**

   The original condition here was `if (opts.uiMode === "vite-dev")`, but this PR changed it to `if (opts.uiMode === "static")`. This creates two serious problems simultaneously:

   1. **`vite-dev` mode is now completely broken.** This block contains all the Vite dev server setup code (`createViteServer`, `vite.middlewares`, `vite.transformIndexHtml`). Since the condition is now `"static"`, vite-dev mode will never start a dev server — it silently does nothing.

   2. **Duplicate `static` block.** When `uiMode === "static"`, *both* the block starting at line 129 and this block at line 147 execute. This registers two overlapping `app.get(/.*/, ...)` catch-all handlers. The second one will never be reached by Express since the first catch-all (line 139) consumes all matching requests.

   The condition should be reverted to `"vite-dev"`:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/app.ts
   Line: 147-170

   Comment:
   **Condition changed to wrong mode — `vite-dev` block is now broken**

   The original condition here was `if (opts.uiMode === "vite-dev")`, but this PR changed it to `if (opts.uiMode === "static")`. This creates two serious problems simultaneously:

   1. **`vite-dev` mode is now completely broken.** This block contains all the Vite dev server setup code (`createViteServer`, `vite.middlewares`, `vite.transformIndexHtml`). Since the condition is now `"static"`, vite-dev mode will never start a dev server — it silently does nothing.

   2. **Duplicate `static` block.** When `uiMode === "static"`, *both* the block starting at line 129 and this block at line 147 execute. This registers two overlapping `app.get(/.*/, ...)` catch-all handlers. The second one will never be reached by Express since the first catch-all (line 139) consumes all matching requests.

   The condition should be reverted to `"vite-dev"`:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: c9939b6</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->