### PR TITLE
Align Paperclip UI with agents/projects/folders command center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tmp/
 .vscode/
 .claude/settings.local.json
 .paperclip-local/
+.vercel

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
+    "@types/node": "^25.3.5",
     "esbuild": "^0.27.3",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import { Companies } from "./pages/Companies";
 import { Agents } from "./pages/Agents";
 import { AgentDetail } from "./pages/AgentDetail";
 import { Projects } from "./pages/Projects";
+import { Folders } from "./pages/Folders";
 import { ProjectDetail } from "./pages/ProjectDetail";
 import { Issues } from "./pages/Issues";
 import { IssueDetail } from "./pages/IssueDetail";
@@ -107,6 +108,7 @@ function boardRoutes() {
       <Route path="agents/:agentId/:tab" element={<AgentDetail />} />
       <Route path="agents/:agentId/runs/:runId" element={<AgentDetail />} />
       <Route path="projects" element={<Projects />} />
+      <Route path="folders" element={<Folders />} />
       <Route path="projects/:projectId" element={<ProjectDetail />} />
       <Route path="projects/:projectId/overview" element={<ProjectDetail />} />
       <Route path="projects/:projectId/issues" element={<ProjectDetail />} />
@@ -190,12 +192,12 @@ function NoCompaniesStartPage({ autoOpen = true }: { autoOpen?: boolean }) {
   return (
     <div className="mx-auto max-w-xl py-10">
       <div className="rounded-lg border border-border bg-card p-6">
-        <h1 className="text-xl font-semibold">Create your first company</h1>
+        <h1 className="text-xl font-semibold">Create your first system</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Get started by creating a company.
+          Get started by creating a system for your agents, projects, and folders.
         </p>
         <div className="mt-4">
-          <Button onClick={() => openOnboarding()}>New Company</Button>
+          <Button onClick={() => openOnboarding()}>New System</Button>
         </div>
       </div>
     </div>
@@ -221,6 +223,7 @@ export function App() {
           <Route path="agents/:agentId/:tab" element={<UnprefixedBoardRedirect />} />
           <Route path="agents/:agentId/runs/:runId" element={<UnprefixedBoardRedirect />} />
           <Route path="projects" element={<UnprefixedBoardRedirect />} />
+          <Route path="folders" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/overview" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/issues" element={<UnprefixedBoardRedirect />} />

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -8,7 +8,7 @@ import { getUIAdapter } from "../adapters";
 import type { TranscriptEntry } from "../adapters";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, relativeTime } from "../lib/utils";
-import { ExternalLink } from "lucide-react";
+import { Activity, Bot, ExternalLink } from "lucide-react";
 import { Identity } from "./Identity";
 
 type FeedTone = "info" | "warn" | "error" | "assistant" | "tool";
@@ -222,6 +222,8 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
 
   const runById = useMemo(() => new Map(runs.map((r) => [r.id, r])), [runs]);
   const activeRunIds = useMemo(() => new Set(runs.filter(isRunActive).map((r) => r.id)), [runs]);
+  const liveCount = activeRunIds.size;
+  const completedCount = Math.max(runs.length - liveCount, 0);
 
   // Clean up pending buffers for runs that ended
   useEffect(() => {
@@ -377,16 +379,40 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
   }, [activeRunIds, companyId, runById]);
 
   return (
-    <div>
-      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-        Agents
-      </h3>
+    <section className="space-y-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="section-kicker">Live fleet</p>
+          <h3 className="editorial-title mt-3 text-[2rem] leading-none text-foreground">
+            Agent runs and command output
+          </h3>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Keep the active operators visible without dropping into a detail page. Running lanes stay highlighted and the latest transcript lines stay pinned in view.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:w-[23rem]">
+          <div className="command-metric rounded-[1.15rem] px-4 py-4">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Live now</p>
+            <p className="mt-2 text-2xl font-semibold text-foreground">{liveCount}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Queued or running</p>
+          </div>
+          <div className="command-metric rounded-[1.15rem] px-4 py-4">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Recent lanes</p>
+            <p className="mt-2 text-2xl font-semibold text-foreground">{runs.length}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{completedCount} completed</p>
+          </div>
+        </div>
+      </div>
+
       {runs.length === 0 ? (
-        <div className="border border-border rounded-lg p-4">
-          <p className="text-sm text-muted-foreground">No recent agent runs.</p>
+        <div className="command-card-soft rounded-[1.2rem] px-4 py-5">
+          <div className="flex items-center gap-3">
+            <Bot className="h-4 w-4 shrink-0 text-[var(--surface-highlight)]" />
+            <p className="text-sm text-muted-foreground">No recent agent runs.</p>
+          </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-2 sm:gap-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {runs.map((run) => (
             <AgentRunCard
               key={run.id}
@@ -398,7 +424,7 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }
 
@@ -423,19 +449,20 @@ function AgentRunCard({
   }, [feed.length]);
 
   return (
-    <div className={cn(
-      "flex flex-col rounded-lg border overflow-hidden min-h-[200px]",
-      isActive
-        ? "border-blue-500/30 bg-background/80 shadow-[0_0_12px_rgba(59,130,246,0.08)]"
-        : "border-border bg-background/50",
-    )}>
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border/50">
+    <div
+      className={cn(
+        "page-frame flex min-h-[220px] flex-col overflow-hidden rounded-[1.2rem]",
+        isActive
+          ? "border-[color:var(--surface-highlight)] shadow-[0_20px_60px_-38px_rgba(178,111,62,0.75)]"
+          : "bg-background/65",
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-border/60 px-3 py-2.5">
         <div className="flex items-center gap-2 min-w-0">
           {isActive ? (
             <span className="relative flex h-2 w-2 shrink-0">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--surface-highlight)] opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--surface-highlight)]" />
             </span>
           ) : (
             <span className="flex h-2 w-2 shrink-0">
@@ -443,26 +470,35 @@ function AgentRunCard({
             </span>
           )}
           <Identity name={run.agentName} size="sm" />
-          {isActive && (
-            <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">Live</span>
-          )}
+          <span
+            className={cn(
+              "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]",
+              isActive
+                ? "bg-[var(--surface-highlight)]/12 text-foreground"
+                : "bg-muted text-muted-foreground",
+            )}
+          >
+            {run.status}
+          </span>
         </div>
         <Link
           to={`/agents/${run.agentId}/runs/${run.id}`}
-          className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground shrink-0"
+          className="inline-flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
         >
           <ExternalLink className="h-2.5 w-2.5" />
         </Link>
       </div>
 
-      {/* Issue context */}
       {run.issueId && (
-        <div className="px-3 py-1.5 border-b border-border/40 text-xs flex items-center gap-1 min-w-0">
+        <div className="flex min-w-0 items-center gap-1 border-b border-border/40 px-3 py-1.5 text-xs">
+          <Activity className="h-3 w-3 shrink-0 text-muted-foreground" />
           <Link
             to={`/issues/${issue?.identifier ?? run.issueId}`}
             className={cn(
               "hover:underline min-w-0 line-clamp-2 min-h-[2rem]",
-              isActive ? "text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300" : "text-muted-foreground hover:text-foreground",
+              isActive
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground",
             )}
             title={issue?.title ? `${issue?.identifier ?? run.issueId.slice(0, 8)} - ${issue.title}` : issue?.identifier ?? run.issueId.slice(0, 8)}
           >
@@ -472,8 +508,10 @@ function AgentRunCard({
         </div>
       )}
 
-      {/* Feed body */}
-      <div ref={bodyRef} className="flex-1 max-h-[140px] overflow-y-auto p-2 font-mono text-[11px] space-y-1">
+      <div
+        ref={bodyRef}
+        className="flex-1 max-h-[152px] space-y-1 overflow-y-auto bg-background/45 p-2 font-mono text-[11px]"
+      >
         {isActive && recent.length === 0 && (
           <div className="text-xs text-muted-foreground">Waiting for output...</div>
         )}

--- a/ui/src/components/ActivityCharts.tsx
+++ b/ui/src/components/ActivityCharts.tsx
@@ -46,10 +46,10 @@ function ChartLegend({ items }: { items: { color: string; label: string }[] }) {
 
 export function ChartCard({ title, subtitle, children }: { title: string; subtitle?: string; children: React.ReactNode }) {
   return (
-    <div className="border border-border rounded-lg p-4 space-y-3">
+    <div className="command-card-soft space-y-3 rounded-[1.3rem] p-4">
       <div>
-        <h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
-        {subtitle && <span className="text-[10px] text-muted-foreground/60">{subtitle}</span>}
+        <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">{title}</h3>
+        {subtitle && <span className="text-[10px] text-muted-foreground/70">{subtitle}</span>}
       </div>
       {children}
     </div>

--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -34,18 +34,19 @@ export function BreadcrumbBar() {
   // Single breadcrumb = page title (uppercase)
   if (breadcrumbs.length === 1) {
     return (
-      <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center min-w-0 overflow-hidden">
+      <div className="flex h-16 shrink-0 items-center overflow-hidden border-b border-border px-4 md:px-6 lg:px-8">
         {menuButton}
-        <h1 className="text-sm font-semibold uppercase tracking-wider truncate">
-          {breadcrumbs[0].label}
-        </h1>
+        <div className="min-w-0">
+          <p className="section-kicker">Workspace</p>
+          <h1 className="editorial-title truncate text-[1.9rem] leading-none">{breadcrumbs[0].label}</h1>
+        </div>
       </div>
     );
   }
 
   // Multiple breadcrumbs = breadcrumb trail
   return (
-    <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center min-w-0 overflow-hidden">
+    <div className="flex h-16 shrink-0 items-center overflow-hidden border-b border-border px-4 md:px-6 lg:px-8">
       {menuButton}
       <Breadcrumb className="min-w-0 overflow-hidden">
         <BreadcrumbList className="flex-nowrap">

--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -261,10 +261,11 @@ export function CompanyRail() {
   );
 
   return (
-    <div className="flex flex-col items-center w-[72px] shrink-0 h-full bg-background border-r border-border">
-      {/* Paperclip icon - aligned with top sections (implied line, no visible border) */}
-      <div className="flex items-center justify-center h-12 w-full shrink-0">
-        <Paperclip className="h-5 w-5 text-foreground" />
+    <div className="sidebar-surface flex h-full w-[72px] shrink-0 flex-col items-center border-r border-border">
+      <div className="flex h-16 w-full shrink-0 items-center justify-center">
+        <div className="rounded-full border border-border bg-background/55 p-2">
+          <Paperclip className="h-4 w-4 text-foreground" />
+        </div>
       </div>
 
       {/* Company list */}
@@ -292,23 +293,21 @@ export function CompanyRail() {
         </DndContext>
       </div>
 
-      {/* Separator before add button */}
-      <div className="w-8 h-px bg-border mx-auto shrink-0" />
+      <div className="mx-auto h-px w-8 shrink-0 bg-border" />
 
-      {/* Add company button */}
       <div className="flex items-center justify-center py-2 shrink-0">
         <Tooltip delayDuration={300}>
           <TooltipTrigger asChild>
             <button
               onClick={() => openOnboarding()}
-              className="flex items-center justify-center w-11 h-11 rounded-[22px] hover:rounded-[14px] border-2 border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground transition-[border-color,color,border-radius] duration-150"
-              aria-label="Add company"
+              className="flex h-11 w-11 items-center justify-center rounded-[22px] border-2 border-dashed border-border text-muted-foreground transition-[border-color,color,border-radius] duration-150 hover:rounded-[14px] hover:border-foreground/30 hover:text-foreground"
+              aria-label="Add system"
             >
               <Plus className="h-5 w-5" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right" sideOffset={8}>
-            <p>Add company</p>
+            <p>Add system</p>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/ui/src/components/CompanySwitcher.tsx
+++ b/ui/src/components/CompanySwitcher.tsx
@@ -33,21 +33,21 @@ export function CompanySwitcher() {
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="w-full justify-between px-2 py-1.5 h-auto text-left"
+          className="h-auto w-full justify-between rounded-[0.9rem] px-2 py-2 text-left hover:bg-accent/65"
         >
           <div className="flex items-center gap-2 min-w-0">
             {selectedCompany && (
               <span className={`h-2 w-2 rounded-full shrink-0 ${statusDotColor(selectedCompany.status)}`} />
             )}
             <span className="text-sm font-medium truncate">
-              {selectedCompany?.name ?? "Select company"}
+              {selectedCompany?.name ?? "Select system"}
             </span>
           </div>
           <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-[220px]">
-        <DropdownMenuLabel>Companies</DropdownMenuLabel>
+      <DropdownMenuContent align="start" className="w-[240px] rounded-[1rem] border-border bg-popover/95 backdrop-blur">
+        <DropdownMenuLabel className="section-kicker px-2 py-2 text-muted-foreground">Systems</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {sidebarCompanies.map((company) => (
           <DropdownMenuItem
@@ -60,19 +60,19 @@ export function CompanySwitcher() {
           </DropdownMenuItem>
         ))}
         {sidebarCompanies.length === 0 && (
-          <DropdownMenuItem disabled>No companies</DropdownMenuItem>
+          <DropdownMenuItem disabled>No systems</DropdownMenuItem>
         )}
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link to="/company/settings" className="no-underline text-inherit">
             <Settings className="h-4 w-4 mr-2" />
-            Company Settings
+            System Settings
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
           <Link to="/companies" className="no-underline text-inherit">
             <Plus className="h-4 w-4 mr-2" />
-            Manage Companies
+            Manage Systems
           </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/ui/src/components/EntityRow.tsx
+++ b/ui/src/components/EntityRow.tsx
@@ -27,9 +27,9 @@ export function EntityRow({
 }: EntityRowProps) {
   const isClickable = !!(to || onClick);
   const classes = cn(
-    "flex items-center gap-3 px-4 py-2 text-sm border-b border-border last:border-b-0 transition-colors",
-    isClickable && "cursor-pointer hover:bg-accent/50",
-    selected && "bg-accent/30",
+    "flex items-center gap-3 border-b border-border px-4 py-3 text-sm last:border-b-0 transition-all",
+    isClickable && "cursor-pointer hover:bg-accent/45",
+    selected && "bg-accent/35",
     className
   );
 
@@ -43,10 +43,10 @@ export function EntityRow({
               {identifier}
             </span>
           )}
-          <span className="truncate">{title}</span>
+          <span className="truncate font-medium">{title}</span>
         </div>
         {subtitle && (
-          <p className="text-xs text-muted-foreground truncate mt-0.5">{subtitle}</p>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</p>
         )}
       </div>
       {trailing && <div className="flex items-center gap-2 shrink-0">{trailing}</div>}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -184,7 +184,7 @@ export function Layout() {
   );
 
   return (
-    <div className="flex h-dvh bg-background text-foreground overflow-hidden pt-[env(safe-area-inset-top)]">
+    <div className="relative z-10 flex h-dvh overflow-hidden bg-transparent text-foreground pt-[env(safe-area-inset-top)]">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[200] focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -205,7 +205,7 @@ export function Layout() {
       {isMobile ? (
         <div
           className={cn(
-            "fixed inset-y-0 left-0 z-50 flex flex-col overflow-hidden pt-[env(safe-area-inset-top)] transition-transform duration-100 ease-out",
+            "fixed inset-y-0 left-0 z-50 flex flex-col overflow-hidden border-r border-border pt-[env(safe-area-inset-top)] transition-transform duration-100 ease-out sidebar-surface",
             sidebarOpen ? "translate-x-0" : "-translate-x-full"
           )}
         >
@@ -213,7 +213,7 @@ export function Layout() {
             <CompanyRail />
             <Sidebar />
           </div>
-          <div className="border-t border-r border-border px-3 py-2 bg-background">
+          <div className="border-t border-border px-3 py-2">
             <div className="flex items-center gap-1">
               <SidebarNavItem
                 to="/docs"
@@ -236,7 +236,7 @@ export function Layout() {
           </div>
         </div>
       ) : (
-        <div className="flex flex-col shrink-0 h-full">
+        <div className="sidebar-surface flex h-full shrink-0 border-r border-border">
           <div className="flex flex-1 min-h-0">
             <CompanyRail />
             <div
@@ -248,7 +248,7 @@ export function Layout() {
               <Sidebar />
             </div>
           </div>
-          <div className="border-t border-r border-border px-3 py-2">
+          <div className="border-t border-border px-3 py-2">
             <div className="flex items-center gap-1">
               <SidebarNavItem
                 to="/docs"
@@ -273,13 +273,16 @@ export function Layout() {
       )}
 
       {/* Main content */}
-      <div className="flex-1 flex flex-col min-w-0 h-full">
+      <div className="flex min-w-0 flex-1 flex-col h-full">
         <BreadcrumbBar />
         <div className="flex flex-1 min-h-0">
           <main
             id="main-content"
             tabIndex={-1}
-            className={cn("flex-1 overflow-auto p-4 md:p-6", isMobile && "pb-[calc(5rem+env(safe-area-inset-bottom))]")}
+            className={cn(
+              "flex-1 overflow-auto px-4 py-4 md:px-6 md:py-6 lg:px-8",
+              isMobile && "pb-[calc(5rem+env(safe-area-inset-bottom))]"
+            )}
             onScroll={handleMainScroll}
           >
             <Outlet />

--- a/ui/src/components/MetricCard.tsx
+++ b/ui/src/components/MetricCard.tsx
@@ -15,20 +15,22 @@ export function MetricCard({ icon: Icon, value, label, description, to, onClick 
   const isClickable = !!(to || onClick);
 
   const inner = (
-    <div className={`h-full px-4 py-4 sm:px-5 sm:py-5 rounded-lg transition-colors${isClickable ? " hover:bg-accent/50 cursor-pointer" : ""}`}>
+    <div className={`command-metric h-full rounded-[1.25rem] px-4 py-4 sm:px-5 sm:py-5 transition-all${isClickable ? " cursor-pointer hover:-translate-y-0.5 hover:bg-accent/55" : ""}`}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
-          <p className="text-2xl sm:text-3xl font-semibold tracking-tight">
+          <p className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground">
             {value}
           </p>
-          <p className="text-xs sm:text-sm font-medium text-muted-foreground mt-1">
+          <p className="mt-1 text-xs sm:text-sm font-medium text-muted-foreground">
             {label}
           </p>
           {description && (
-            <div className="text-xs text-muted-foreground/70 mt-1.5 hidden sm:block">{description}</div>
+            <div className="mt-1.5 hidden text-xs text-muted-foreground/80 sm:block">{description}</div>
           )}
         </div>
-        <Icon className="h-4 w-4 text-muted-foreground/50 shrink-0 mt-1.5" />
+        <div className="rounded-full border border-border bg-background/55 p-2">
+          <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { NavLink, useLocation } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
 import {
   House,
   LayoutGrid,
@@ -8,10 +7,7 @@ import {
   Users,
   FolderOpen,
 } from "lucide-react";
-import { sidebarBadgesApi } from "../api/sidebarBadges";
-import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
-import { queryKeys } from "../lib/queryKeys";
 import { cn } from "../lib/utils";
 
 interface MobileBottomNavProps {
@@ -37,14 +33,7 @@ type MobileNavItem = MobileNavLinkItem | MobileNavActionItem;
 
 export function MobileBottomNav({ visible }: MobileBottomNavProps) {
   const location = useLocation();
-  const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
-
-  const { data: sidebarBadges } = useQuery({
-    queryKey: queryKeys.sidebarBadges(selectedCompanyId!),
-    queryFn: () => sidebarBadgesApi.get(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
-  });
 
   const items = useMemo<MobileNavItem[]>(
     () => [
@@ -52,15 +41,9 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
       { type: "link", to: "/projects", label: "Projects", icon: LayoutGrid },
       { type: "action", label: "Create", icon: SquarePen, onClick: () => openNewIssue() },
       { type: "link", to: "/agents/all", label: "Agents", icon: Users },
-      {
-        type: "link",
-        to: "/folders",
-        label: "Folders",
-        icon: FolderOpen,
-        badge: sidebarBadges?.inbox,
-      },
+      { type: "link", to: "/folders", label: "Folders", icon: FolderOpen },
     ],
-    [openNewIssue, sidebarBadges?.inbox],
+    [openNewIssue],
   );
 
   return (

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -3,10 +3,10 @@ import { NavLink, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import {
   House,
-  CircleDot,
+  LayoutGrid,
   SquarePen,
   Users,
-  Inbox,
+  FolderOpen,
 } from "lucide-react";
 import { sidebarBadgesApi } from "../api/sidebarBadges";
 import { useCompany } from "../context/CompanyContext";
@@ -49,14 +49,14 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
   const items = useMemo<MobileNavItem[]>(
     () => [
       { type: "link", to: "/dashboard", label: "Home", icon: House },
-      { type: "link", to: "/issues", label: "Issues", icon: CircleDot },
+      { type: "link", to: "/projects", label: "Projects", icon: LayoutGrid },
       { type: "action", label: "Create", icon: SquarePen, onClick: () => openNewIssue() },
       { type: "link", to: "/agents/all", label: "Agents", icon: Users },
       {
         type: "link",
-        to: "/inbox",
-        label: "Inbox",
-        icon: Inbox,
+        to: "/folders",
+        label: "Folders",
+        icon: FolderOpen,
         badge: sidebarBadges?.inbox,
       },
     ],
@@ -66,12 +66,12 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
   return (
     <nav
       className={cn(
-        "fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-transform duration-200 ease-out md:hidden pb-[env(safe-area-inset-bottom)]",
+        "fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-transform duration-200 ease-out md:hidden pb-[env(safe-area-inset-bottom)] shadow-[0_-20px_50px_-32px_rgba(0,0,0,0.65)]",
         visible ? "translate-y-0" : "translate-y-full",
       )}
       aria-label="Mobile navigation"
     >
-      <div className="grid h-16 grid-cols-5 px-1">
+      <div className="grid h-16 grid-cols-5 gap-1 px-2">
         {items.map((item) => {
           if (item.type === "action") {
             const Icon = item.icon;
@@ -82,10 +82,10 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
                 type="button"
                 onClick={item.onClick}
                 className={cn(
-                  "relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-md text-[10px] font-medium transition-colors",
+                  "relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-xl text-[10px] font-medium transition-colors",
                   active
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
+                    ? "bg-[var(--surface-highlight)]/12 text-foreground"
+                    : "text-muted-foreground hover:bg-accent/45 hover:text-foreground",
                 )}
               >
                 <Icon className="h-[18px] w-[18px]" />
@@ -101,10 +101,10 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
               to={item.to}
               className={({ isActive }) =>
                 cn(
-                  "relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-md text-[10px] font-medium transition-colors",
+                  "relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-xl text-[10px] font-medium transition-colors",
                   isActive
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
+                    ? "bg-[var(--surface-highlight)]/12 text-foreground"
+                    : "text-muted-foreground hover:bg-accent/45 hover:text-foreground",
                 )
               }
             >

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -111,7 +111,7 @@ export function NewProjectDialog() {
   const deriveWorkspaceNameFromPath = (value: string) => {
     const normalized = value.trim().replace(/[\\/]+$/, "");
     const segments = normalized.split(/[\\/]/).filter(Boolean);
-    return segments[segments.length - 1] ?? "Local folder";
+    return segments[segments.length - 1] ?? "Folder";
   };
 
   const deriveWorkspaceNameFromRepo = (value: string) => {
@@ -138,11 +138,11 @@ export function NewProjectDialog() {
     const repoUrl = workspaceRepoUrl.trim();
 
     if (localRequired && !isAbsolutePath(localPath)) {
-      setWorkspaceError("Local folder must be a full absolute path.");
+      setWorkspaceError("Folder path must be a full absolute path.");
       return;
     }
     if (repoRequired && !isGitHubRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo workspace must use a valid GitHub repo URL.");
+      setWorkspaceError("Linked repo must use a valid GitHub URL.");
       return;
     }
 
@@ -283,8 +283,8 @@ export function NewProjectDialog() {
 
         <div className="px-4 pb-3 space-y-3 border-t border-border">
           <div className="pt-3">
-            <p className="text-sm font-medium">Where will work be done on this project?</p>
-            <p className="text-xs text-muted-foreground">Add local folder and/or GitHub repo workspace hints.</p>
+            <p className="text-sm font-medium">Where does this project live?</p>
+            <p className="text-xs text-muted-foreground">Add the folder path and/or GitHub repo your agents should use.</p>
           </div>
           <div className="grid gap-2 sm:grid-cols-3">
             <button
@@ -297,9 +297,9 @@ export function NewProjectDialog() {
             >
               <div className="flex items-center gap-2 text-sm font-medium">
                 <FolderOpen className="h-4 w-4" />
-                A local folder
+                A folder
               </div>
-              <p className="mt-1 text-xs text-muted-foreground">Use a full path on this machine.</p>
+              <p className="mt-1 text-xs text-muted-foreground">Use the full absolute path on this machine.</p>
             </button>
             <button
               type="button"
@@ -311,7 +311,7 @@ export function NewProjectDialog() {
             >
               <div className="flex items-center gap-2 text-sm font-medium">
                 <Github className="h-4 w-4" />
-                A github repo
+                A repo
               </div>
               <p className="mt-1 text-xs text-muted-foreground">Paste a GitHub URL.</p>
             </button>
@@ -339,7 +339,7 @@ export function NewProjectDialog() {
                   className="w-full rounded border border-border bg-transparent px-2 py-1 text-xs font-mono outline-none"
                   value={workspaceLocalPath}
                   onChange={(e) => setWorkspaceLocalPath(e.target.value)}
-                  placeholder="/absolute/path/to/workspace"
+                  placeholder="/absolute/path/to/folder"
                 />
                 <ChoosePathButton />
               </div>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -298,7 +298,7 @@ export function OnboardingWizard() {
   ): Promise<AdapterEnvironmentTestResult | null> {
     if (!createdCompanyId) {
       setAdapterEnvError(
-        "Create or select a company before testing adapter environment."
+        "Create or select a system before testing adapter environment."
       );
       return null;
     }
@@ -347,7 +347,7 @@ export function OnboardingWizard() {
 
       setStep(2);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create company");
+      setError(err instanceof Error ? err.message : "Failed to create system");
     } finally {
       setLoading(false);
     }
@@ -580,15 +580,15 @@ export function OnboardingWizard() {
                       <Building2 className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <h3 className="font-medium">Name your company</h3>
+                      <h3 className="font-medium">Name your system</h3>
                       <p className="text-xs text-muted-foreground">
-                        This is the organization your agents will work for.
+                        This is the system your agents, projects, and folders will live inside.
                       </p>
                     </div>
                   </div>
                   <div>
                     <label className="text-xs text-muted-foreground mb-1 block">
-                      Company name
+                      System name
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
@@ -604,7 +604,7 @@ export function OnboardingWizard() {
                     </label>
                     <textarea
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 resize-none min-h-[60px]"
-                      placeholder="What is this company trying to achieve?"
+                      placeholder="What is this system trying to achieve?"
                       value={companyGoal}
                       onChange={(e) => setCompanyGoal(e.target.value)}
                     />
@@ -1048,7 +1048,7 @@ export function OnboardingWizard() {
                         <p className="text-sm font-medium truncate">
                           {companyName}
                         </p>
-                        <p className="text-xs text-muted-foreground">Company</p>
+                        <p className="text-xs text-muted-foreground">System</p>
                       </div>
                       <Check className="h-4 w-4 text-green-500 shrink-0" />
                     </div>

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -163,7 +163,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   const deriveWorkspaceNameFromPath = (value: string) => {
     const normalized = value.trim().replace(/[\\/]+$/, "");
     const segments = normalized.split(/[\\/]/).filter(Boolean);
-    return segments[segments.length - 1] ?? "Local folder";
+    return segments[segments.length - 1] ?? "Folder";
   };
 
   const deriveWorkspaceNameFromRepo = (value: string) => {
@@ -194,7 +194,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   const submitLocalWorkspace = () => {
     const cwd = workspaceCwd.trim();
     if (!isAbsolutePath(cwd)) {
-      setWorkspaceError("Local folder must be a full absolute path.");
+      setWorkspaceError("Folder path must be a full absolute path.");
       return;
     }
     setWorkspaceError(null);
@@ -207,7 +207,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   const submitRepoWorkspace = () => {
     const repoUrl = workspaceRepoUrl.trim();
     if (!isGitHubRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo workspace must use a valid GitHub repo URL.");
+      setWorkspaceError("Linked repo must use a valid GitHub URL.");
       return;
     }
     setWorkspaceError(null);
@@ -221,8 +221,8 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   const clearLocalWorkspace = (workspace: Project["workspaces"][number]) => {
     const confirmed = window.confirm(
       workspace.repoUrl
-        ? "Clear local folder from this workspace?"
-        : "Delete this workspace local folder?",
+        ? "Clear the local folder path from this folder?"
+        : "Delete this folder path?",
     );
     if (!confirmed) return;
     if (workspace.repoUrl) {
@@ -239,8 +239,8 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
     const hasLocalFolder = Boolean(workspace.cwd && workspace.cwd !== REPO_ONLY_CWD_SENTINEL);
     const confirmed = window.confirm(
       hasLocalFolder
-        ? "Clear GitHub repo from this workspace?"
-        : "Delete this workspace repo?",
+        ? "Clear the GitHub repo from this folder?"
+        : "Delete this linked repo?",
     );
     if (!confirmed) return;
     if (hasLocalFolder) {
@@ -348,7 +348,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
       <div className="space-y-1">
         <div className="py-1.5 space-y-2">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span>Workspaces</span>
+            <span>Folders</span>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -360,13 +360,13 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">
-                Workspaces give your agents hints about where the work is
+                Folders tell your agents where this project lives
               </TooltipContent>
             </Tooltip>
           </div>
           {workspaces.length === 0 ? (
             <p className="rounded-md border border-dashed border-border px-3 py-2 text-sm text-muted-foreground">
-              No workspace configured.
+              No folders linked.
             </p>
           ) : (
             <div className="space-y-1">
@@ -379,7 +379,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                         variant="ghost"
                         size="icon-xs"
                         onClick={() => clearLocalWorkspace(workspace)}
-                        aria-label="Delete local folder"
+                        aria-label="Delete folder path"
                       >
                         <Trash2 className="h-3 w-3" />
                       </Button>
@@ -401,7 +401,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                         variant="ghost"
                         size="icon-xs"
                         onClick={() => clearRepoWorkspace(workspace)}
-                        aria-label="Delete workspace repo"
+                        aria-label="Delete linked repo"
                       >
                         <Trash2 className="h-3 w-3" />
                       </Button>
@@ -421,7 +421,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                 setWorkspaceError(null);
               }}
             >
-              Add workspace local folder
+              Add folder path
             </Button>
             <Button
               variant="outline"
@@ -432,7 +432,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                 setWorkspaceError(null);
               }}
             >
-              Add workspace repo
+              Link repo
             </Button>
           </div>
           {workspaceMode === "local" && (
@@ -442,7 +442,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                   className="w-full rounded border border-border bg-transparent px-2 py-1 text-xs font-mono outline-none"
                   value={workspaceCwd}
                   onChange={(e) => setWorkspaceCwd(e.target.value)}
-                  placeholder="/absolute/path/to/workspace"
+                  placeholder="/absolute/path/to/folder"
                 />
                 <ChoosePathButton />
               </div>
@@ -508,13 +508,13 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
             <p className="text-xs text-destructive">{workspaceError}</p>
           )}
           {createWorkspace.isError && (
-            <p className="text-xs text-destructive">Failed to save workspace.</p>
+            <p className="text-xs text-destructive">Failed to save folder.</p>
           )}
           {removeWorkspace.isError && (
-            <p className="text-xs text-destructive">Failed to delete workspace.</p>
+            <p className="text-xs text-destructive">Failed to delete folder.</p>
           )}
           {updateWorkspace.isError && (
-            <p className="text-xs text-destructive">Failed to update workspace.</p>
+            <p className="text-xs text-destructive">Failed to update folder.</p>
           )}
         </div>
 

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   Inbox,
   CircleDot,
   Target,
+  FolderOpen,
   LayoutDashboard,
   DollarSign,
   History,
@@ -21,6 +22,7 @@ import { sidebarBadgesApi } from "../api/sidebarBadges";
 import { heartbeatsApi } from "../api/heartbeats";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
+import { CompanySwitcher } from "./CompanySwitcher";
 
 export function Sidebar() {
   const { openNewIssue } = useDialog();
@@ -43,37 +45,49 @@ export function Sidebar() {
   }
 
   return (
-    <aside className="w-60 h-full min-h-0 border-r border-border bg-background flex flex-col">
-      {/* Top bar: Company name (bold) + Search — aligned with top sections (no visible border) */}
-      <div className="flex items-center gap-1 px-3 h-12 shrink-0">
-        {selectedCompany?.brandColor && (
-          <div
-            className="w-4 h-4 rounded-sm shrink-0 ml-1"
-            style={{ backgroundColor: selectedCompany.brandColor }}
-          />
-        )}
-        <span className="flex-1 text-sm font-bold text-foreground truncate pl-1">
-          {selectedCompany?.name ?? "Select company"}
-        </span>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground shrink-0"
-          onClick={openSearch}
-        >
-          <Search className="h-4 w-4" />
-        </Button>
+    <aside className="sidebar-surface flex h-full min-h-0 w-64 flex-col">
+      <div className="shrink-0 border-b border-border px-3 pb-3 pt-4">
+        <div className="mb-3 flex items-center justify-between gap-3 px-1">
+          <div className="min-w-0">
+            <p className="section-kicker">Paperclip OS</p>
+            <p className="editorial-title truncate text-[1.55rem] leading-none text-foreground">
+              Command center
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="shrink-0 rounded-full text-muted-foreground hover:bg-accent/70"
+            onClick={openSearch}
+          >
+            <Search className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="page-frame rounded-[1.1rem] p-2">
+          <CompanySwitcher />
+          {selectedCompany?.brandColor && (
+            <div className="mt-2 flex items-center gap-2 px-2">
+              <span
+                className="h-2.5 w-2.5 rounded-full border border-white/20"
+                style={{ backgroundColor: selectedCompany.brandColor }}
+              />
+              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                Active system
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 px-3 py-2">
         <div className="flex flex-col gap-0.5">
-          {/* New Issue button aligned with nav items */}
           <button
             onClick={() => openNewIssue()}
-            className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+            className="command-card flex items-center gap-2.5 rounded-[1rem] px-3 py-3 text-[13px] font-semibold text-foreground transition-colors hover:bg-accent/70"
           >
             <SquarePen className="h-4 w-4 shrink-0" />
-            <span className="truncate">New Issue</span>
+            <span className="truncate">Open new task</span>
           </button>
           <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
@@ -89,13 +103,14 @@ export function Sidebar() {
         <SidebarSection label="Work">
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          <SidebarNavItem to="/folders" label="Folders" icon={FolderOpen} />
         </SidebarSection>
 
         <SidebarProjects />
 
         <SidebarAgents />
 
-        <SidebarSection label="Company">
+        <SidebarSection label="System">
           <SidebarNavItem to="/org" label="Org" icon={Network} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />

--- a/ui/src/components/SidebarNavItem.tsx
+++ b/ui/src/components/SidebarNavItem.tsx
@@ -35,10 +35,10 @@ export function SidebarNavItem({
       onClick={() => { if (isMobile) setSidebarOpen(false); }}
       className={({ isActive }) =>
         cn(
-          "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors",
+          "flex items-center gap-2.5 rounded-[0.95rem] px-3 py-2.5 text-[13px] font-medium transition-all",
           isActive
-            ? "bg-accent text-foreground"
-            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+            ? "bg-primary text-primary-foreground shadow-[0_12px_30px_rgba(22,60,51,0.18)]"
+            : "text-foreground/80 hover:bg-accent/65 hover:text-foreground",
           className,
         )
       }
@@ -56,7 +56,7 @@ export function SidebarNavItem({
             <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
             <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
           </span>
-          <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">{liveCount} live</span>
+          <span className="text-[11px] font-medium text-blue-600 dark:text-blue-300">{liveCount} live</span>
         </span>
       )}
       {badge != null && badge > 0 && (

--- a/ui/src/components/SidebarSection.tsx
+++ b/ui/src/components/SidebarSection.tsx
@@ -8,7 +8,7 @@ interface SidebarSectionProps {
 export function SidebarSection({ label, children }: SidebarSectionProps) {
   return (
     <div>
-      <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
+      <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70">
         {label}
       </div>
       <div className="flex flex-col gap-0.5 mt-0.5">{children}</div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Manrope:wght@400;500;600;700;800&display=swap");
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
@@ -36,82 +37,94 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
-  --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0px;
-  --radius-xl: 0px;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.875rem;
+  --radius-lg: 1.25rem;
+  --radius-xl: 1.75rem;
 }
 
 :root {
   color-scheme: light;
-  --radius: 0;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --radius: 1.25rem;
+  --background: #f3ede3;
+  --foreground: #1f241f;
+  --card: rgba(255, 252, 246, 0.88);
+  --card-foreground: #1f241f;
+  --popover: rgba(255, 252, 246, 0.98);
+  --popover-foreground: #1f241f;
+  --primary: #163c33;
+  --primary-foreground: #f7f1e7;
+  --secondary: #e2d6c5;
+  --secondary-foreground: #2f342f;
+  --muted: rgba(222, 212, 196, 0.7);
+  --muted-foreground: #635d52;
+  --accent: rgba(212, 198, 174, 0.42);
+  --accent-foreground: #1f241f;
+  --destructive: #c25c44;
+  --destructive-foreground: #fff8f2;
+  --border: rgba(54, 48, 37, 0.14);
+  --input: rgba(54, 48, 37, 0.12);
+  --ring: rgba(22, 60, 51, 0.32);
+  --chart-1: #163c33;
+  --chart-2: #a65a3a;
+  --chart-3: #7a8562;
+  --chart-4: #c89c4b;
+  --chart-5: #6f5f9d;
+  --sidebar: rgba(247, 241, 231, 0.78);
+  --sidebar-foreground: #1f241f;
+  --sidebar-primary: #163c33;
+  --sidebar-primary-foreground: #f7f1e7;
+  --sidebar-accent: rgba(212, 198, 174, 0.4);
+  --sidebar-accent-foreground: #1f241f;
+  --sidebar-border: rgba(54, 48, 37, 0.14);
+  --sidebar-ring: rgba(22, 60, 51, 0.32);
+  --surface-strong: rgba(255, 251, 246, 0.8);
+  --surface-soft: rgba(249, 244, 236, 0.62);
+  --surface-ink: #17322b;
+  --surface-highlight: #b26e45;
+  --shadow-soft: 0 18px 50px rgba(45, 39, 31, 0.1);
+  --shadow-strong: 0 30px 80px rgba(45, 39, 31, 0.16);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.637 0.237 25.331);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.145 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  --background: #121714;
+  --foreground: #f6f1e7;
+  --card: rgba(24, 31, 28, 0.84);
+  --card-foreground: #f6f1e7;
+  --popover: rgba(24, 31, 28, 0.96);
+  --popover-foreground: #f6f1e7;
+  --primary: #e8dbc4;
+  --primary-foreground: #163c33;
+  --secondary: rgba(54, 63, 58, 0.88);
+  --secondary-foreground: #f6f1e7;
+  --muted: rgba(39, 47, 43, 0.9);
+  --muted-foreground: #a8ada1;
+  --accent: rgba(80, 92, 85, 0.68);
+  --accent-foreground: #f6f1e7;
+  --destructive: #d9745d;
+  --destructive-foreground: #fff6f1;
+  --border: rgba(232, 219, 196, 0.12);
+  --input: rgba(232, 219, 196, 0.11);
+  --ring: rgba(232, 219, 196, 0.26);
+  --chart-1: #8dd8bc;
+  --chart-2: #e79c72;
+  --chart-3: #bed789;
+  --chart-4: #f0c879;
+  --chart-5: #b8a8ee;
+  --sidebar: rgba(18, 23, 20, 0.88);
+  --sidebar-foreground: #f6f1e7;
+  --sidebar-primary: #e8dbc4;
+  --sidebar-primary-foreground: #163c33;
+  --sidebar-accent: rgba(58, 67, 62, 0.86);
+  --sidebar-accent-foreground: #f6f1e7;
+  --sidebar-border: rgba(232, 219, 196, 0.12);
+  --sidebar-ring: rgba(232, 219, 196, 0.26);
+  --surface-strong: rgba(24, 31, 28, 0.84);
+  --surface-soft: rgba(30, 39, 35, 0.66);
+  --surface-ink: #f0e4cb;
+  --surface-highlight: #d48c5e;
+  --shadow-soft: 0 22px 60px rgba(0, 0, 0, 0.3);
+  --shadow-strong: 0 36px 100px rgba(0, 0, 0, 0.42);
 }
 
 @layer base {
@@ -126,6 +139,11 @@
     @apply bg-background text-foreground;
     height: 100%;
     overflow: hidden;
+    font-family: "Manrope", ui-sans-serif, system-ui, sans-serif;
+    background-image:
+      radial-gradient(circle at top left, rgba(178, 110, 69, 0.14), transparent 26%),
+      radial-gradient(circle at 80% 0%, rgba(22, 60, 51, 0.16), transparent 24%),
+      linear-gradient(180deg, color-mix(in oklab, var(--background) 92%, white 8%), var(--background));
   }
   h1,
   h2,
@@ -142,6 +160,25 @@
   label {
     touch-action: manipulation;
   }
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.02) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask-image: radial-gradient(circle at center, black 42%, transparent 88%);
+}
+
+.dark body::before {
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
 }
 
 @media (pointer: coarse) {
@@ -497,4 +534,67 @@ a.paperclip-project-mention-chip {
 .paperclip-mdxeditor [class*="_toolbarButtonDropdownContainer_"],
 .paperclip-mdxeditor [class*="_toolbarNodeKindSelectContainer_"] {
   z-index: 81 !important;
+}
+
+.editorial-title {
+  font-family: "Instrument Serif", Georgia, serif;
+  letter-spacing: -0.04em;
+}
+
+.section-kicker {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--foreground) 44%, transparent);
+}
+
+.paperclip-shell {
+  position: relative;
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--card) 92%, transparent), color-mix(in oklab, var(--card) 72%, transparent));
+  backdrop-filter: blur(20px) saturate(1.05);
+  box-shadow: var(--shadow-soft);
+}
+
+.sidebar-surface {
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--sidebar) 98%, transparent), color-mix(in oklab, var(--sidebar) 88%, transparent));
+  backdrop-filter: blur(18px);
+}
+
+.page-frame {
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--card) 92%, transparent);
+  box-shadow: var(--shadow-soft);
+}
+
+.command-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background:
+    linear-gradient(135deg, color-mix(in oklab, var(--card) 94%, transparent), color-mix(in oklab, var(--accent) 40%, transparent));
+  box-shadow: var(--shadow-soft);
+}
+
+.command-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top right, color-mix(in oklab, var(--surface-highlight) 24%, transparent), transparent 35%);
+  opacity: 0.7;
+}
+
+.command-card-soft {
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--card) 80%, transparent);
+  box-shadow: var(--shadow-soft);
+}
+
+.command-metric {
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--card) 72%, transparent);
+  backdrop-filter: blur(10px);
 }

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -5,6 +5,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "org",
   "agents",
   "projects",
+  "folders",
   "issues",
   "goals",
   "approvals",

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -147,78 +147,78 @@ export function Agents() {
 
       <div className="command-card-soft rounded-[1.2rem] p-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
-          <PageTabBar
-            items={[
-              { value: "all", label: "All" },
-              { value: "active", label: "Active" },
-              { value: "paused", label: "Paused" },
-              { value: "error", label: "Error" },
-            ]}
-            value={tab}
-            onValueChange={(v) => navigate(`/agents/${v}`)}
-          />
-        </Tabs>
-        <div className="flex items-center gap-2">
-          {/* Filters */}
-          <div className="relative">
-            <button
-              className={cn(
-                "flex items-center gap-1.5 px-2 py-1.5 text-xs transition-colors border border-border",
-                filtersOpen || showTerminated ? "text-foreground bg-accent" : "text-muted-foreground hover:bg-accent/50"
+          <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
+            <PageTabBar
+              items={[
+                { value: "all", label: "All" },
+                { value: "active", label: "Active" },
+                { value: "paused", label: "Paused" },
+                { value: "error", label: "Error" },
+              ]}
+              value={tab}
+              onValueChange={(v) => navigate(`/agents/${v}`)}
+            />
+          </Tabs>
+          <div className="flex items-center gap-2">
+            {/* Filters */}
+            <div className="relative">
+              <button
+                className={cn(
+                  "flex items-center gap-1.5 px-2 py-1.5 text-xs transition-colors border border-border",
+                  filtersOpen || showTerminated ? "text-foreground bg-accent" : "text-muted-foreground hover:bg-accent/50"
+                )}
+                onClick={() => setFiltersOpen(!filtersOpen)}
+              >
+                <SlidersHorizontal className="h-3 w-3" />
+                Filters
+                {showTerminated && <span className="ml-0.5 px-1 bg-foreground/10 rounded text-[10px]">1</span>}
+              </button>
+              {filtersOpen && (
+                <div className="absolute right-0 top-full mt-1 z-50 w-48 border border-border bg-popover shadow-md p-1">
+                  <button
+                    className="flex items-center gap-2 w-full px-2 py-1.5 text-xs text-left hover:bg-accent/50 transition-colors"
+                    onClick={() => setShowTerminated(!showTerminated)}
+                  >
+                    <span className={cn(
+                      "flex items-center justify-center h-3.5 w-3.5 border border-border rounded-sm",
+                      showTerminated && "bg-foreground"
+                    )}>
+                      {showTerminated && <span className="text-background text-[10px] leading-none">&#10003;</span>}
+                    </span>
+                    Show terminated
+                  </button>
+                </div>
               )}
-              onClick={() => setFiltersOpen(!filtersOpen)}
-            >
-              <SlidersHorizontal className="h-3 w-3" />
-              Filters
-              {showTerminated && <span className="ml-0.5 px-1 bg-foreground/10 rounded text-[10px]">1</span>}
-            </button>
-            {filtersOpen && (
-              <div className="absolute right-0 top-full mt-1 z-50 w-48 border border-border bg-popover shadow-md p-1">
+            </div>
+            {/* View toggle */}
+            {!forceListView && (
+              <div className="flex items-center border border-border">
                 <button
-                  className="flex items-center gap-2 w-full px-2 py-1.5 text-xs text-left hover:bg-accent/50 transition-colors"
-                  onClick={() => setShowTerminated(!showTerminated)}
+                  className={cn(
+                    "p-1.5 transition-colors",
+                    effectiveView === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
+                  )}
+                  onClick={() => setView("list")}
                 >
-                  <span className={cn(
-                    "flex items-center justify-center h-3.5 w-3.5 border border-border rounded-sm",
-                    showTerminated && "bg-foreground"
-                  )}>
-                    {showTerminated && <span className="text-background text-[10px] leading-none">&#10003;</span>}
-                  </span>
-                  Show terminated
+                  <List className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  className={cn(
+                    "p-1.5 transition-colors",
+                    effectiveView === "org" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
+                  )}
+                  onClick={() => setView("org")}
+                >
+                  <GitBranch className="h-3.5 w-3.5" />
                 </button>
               </div>
             )}
+            <Button size="sm" variant="outline" onClick={openNewAgent} className="rounded-full sm:hidden">
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              New Agent
+            </Button>
           </div>
-          {/* View toggle */}
-          {!forceListView && (
-            <div className="flex items-center border border-border">
-              <button
-                className={cn(
-                  "p-1.5 transition-colors",
-                  effectiveView === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
-                )}
-                onClick={() => setView("list")}
-              >
-                <List className="h-3.5 w-3.5" />
-              </button>
-              <button
-                className={cn(
-                  "p-1.5 transition-colors",
-                  effectiveView === "org" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
-                )}
-                onClick={() => setView("org")}
-              >
-                <GitBranch className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          )}
-          <Button size="sm" variant="outline" onClick={openNewAgent} className="rounded-full sm:hidden">
-            <Plus className="h-3.5 w-3.5 mr-1.5" />
-            New Agent
-          </Button>
         </div>
-      </div>
       </div>
 
       {filtered.length > 0 && (

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -117,7 +117,7 @@ export function Agents() {
   }, [setBreadcrumbs]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Bot} message="Select a company to view agents." />;
+    return <EmptyState icon={Bot} message="Select a system to view agents." />;
   }
 
   if (isLoading) {
@@ -129,7 +129,24 @@ export function Agents() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <section className="command-card rounded-[1.6rem] px-5 py-5 sm:px-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="section-kicker">Fleet control</p>
+            <h2 className="editorial-title mt-3 text-[2.3rem] leading-none text-foreground">Agents, runtime state, and live command lanes</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+              Move between org view and list view, watch live runs, and keep terminated agents out of the way until you need them.
+            </p>
+          </div>
+          <Button size="sm" variant="outline" onClick={openNewAgent} className="rounded-full">
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            New Agent
+          </Button>
+        </div>
+      </section>
+
+      <div className="command-card-soft rounded-[1.2rem] p-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
           <PageTabBar
             items={[
@@ -196,15 +213,16 @@ export function Agents() {
               </button>
             </div>
           )}
-          <Button size="sm" variant="outline" onClick={openNewAgent}>
+          <Button size="sm" variant="outline" onClick={openNewAgent} className="rounded-full sm:hidden">
             <Plus className="h-3.5 w-3.5 mr-1.5" />
             New Agent
           </Button>
         </div>
       </div>
+      </div>
 
       {filtered.length > 0 && (
-        <p className="text-xs text-muted-foreground">{filtered.length} agent{filtered.length !== 1 ? "s" : ""}</p>
+        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">{filtered.length} agent{filtered.length !== 1 ? "s" : ""}</p>
       )}
 
       {error && <p className="text-sm text-destructive">{error.message}</p>}
@@ -220,7 +238,7 @@ export function Agents() {
 
       {/* List view */}
       {effectiveView === "list" && filtered.length > 0 && (
-        <div className="border border-border">
+        <div className="page-frame overflow-hidden rounded-[1.3rem]">
           {filtered.map((agent) => {
             return (
               <EntityRow

--- a/ui/src/pages/Companies.tsx
+++ b/ui/src/pages/Companies.tsx
@@ -27,7 +27,6 @@ import {
   DollarSign,
   Calendar,
   FolderOpen,
-  ArrowRight,
 } from "lucide-react";
 
 function systemStatusClasses(status?: string): string {
@@ -351,10 +350,7 @@ export function Companies() {
                   />
                   <span>{selected ? "Current board context" : "Click to make active"}</span>
                 </div>
-                <div className="inline-flex items-center gap-1 text-foreground">
-                  <span>Open dashboard</span>
-                  <ArrowRight className="h-3.5 w-3.5" />
-                </div>
+                <span className="text-foreground">{selected ? "Active system" : "Make active"}</span>
               </div>
 
               {isConfirmingDelete && (

--- a/ui/src/pages/Companies.tsx
+++ b/ui/src/pages/Companies.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { companiesApi } from "../api/companies";
 import { queryKeys } from "../lib/queryKeys";
-import { formatCents, relativeTime } from "../lib/utils";
+import { cn, formatCents, relativeTime } from "../lib/utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
@@ -26,7 +26,19 @@ import {
   CircleDot,
   DollarSign,
   Calendar,
+  FolderOpen,
+  ArrowRight,
 } from "lucide-react";
+
+function systemStatusClasses(status?: string): string {
+  if (status === "active") {
+    return "bg-emerald-500/12 text-emerald-700 dark:text-emerald-300";
+  }
+  if (status === "paused") {
+    return "bg-amber-500/12 text-amber-700 dark:text-amber-300";
+  }
+  return "bg-muted text-muted-foreground";
+}
 
 export function Companies() {
   const {
@@ -45,7 +57,6 @@ export function Companies() {
     queryFn: () => companiesApi.stats(),
   });
 
-  // Inline edit state
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
@@ -72,6 +83,25 @@ export function Companies() {
     setBreadcrumbs([{ label: "Systems" }]);
   }, [setBreadcrumbs]);
 
+  const summary = useMemo(() => {
+    const totalSystems = companies.length;
+    const activeSystems = companies.filter((company) => company.status === "active").length;
+    const totalAgents = companies.reduce(
+      (sum, company) => sum + (stats?.[company.id]?.agentCount ?? 0),
+      0,
+    );
+    const totalIssues = companies.reduce(
+      (sum, company) => sum + (stats?.[company.id]?.issueCount ?? 0),
+      0,
+    );
+    const trackedBudget = companies.reduce(
+      (sum, company) => sum + company.budgetMonthlyCents,
+      0,
+    );
+
+    return { totalSystems, activeSystems, totalAgents, totalIssues, trackedBudget };
+  }, [companies, stats]);
+
   function startEdit(companyId: string, currentName: string) {
     setEditingId(companyId);
     setEditName(currentName);
@@ -89,14 +119,59 @@ export function Companies() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-end">
-        <Button size="sm" onClick={() => openOnboarding()}>
-          <Plus className="h-3.5 w-3.5 mr-1.5" />
-          New System
-        </Button>
-      </div>
+      <section className="command-card rounded-[1.7rem] px-5 py-5 sm:px-6 sm:py-6">
+        <div className="grid gap-5 xl:grid-cols-[1.2fr_0.95fr]">
+          <div>
+            <p className="section-kicker">System registry</p>
+            <h2 className="editorial-title mt-3 text-[2.25rem] leading-none text-foreground sm:text-[3rem]">
+              Systems, prefixes, and budgets on one board.
+            </h2>
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
+              Keep the operational map clean here: pick the active system, rename prefixes before they leak into work, and watch whether each environment still has real agent capacity behind it.
+            </p>
 
-      <div className="h-6">
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <div className="command-metric rounded-[1.2rem] px-4 py-4">
+                <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Systems</p>
+                <p className="mt-2 text-2xl font-semibold text-foreground">{summary.totalSystems}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{summary.activeSystems} active</p>
+              </div>
+              <div className="command-metric rounded-[1.2rem] px-4 py-4">
+                <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Fleet</p>
+                <p className="mt-2 text-2xl font-semibold text-foreground">{summary.totalAgents}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{summary.totalIssues} open issues</p>
+              </div>
+              <div className="command-metric rounded-[1.2rem] px-4 py-4">
+                <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Tracked budget</p>
+                <p className="mt-2 text-2xl font-semibold text-foreground">
+                  {summary.trackedBudget > 0 ? formatCents(summary.trackedBudget) : "Flexible"}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">Monthly cap across configured systems</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="page-frame rounded-[1.4rem] px-5 py-5">
+            <p className="section-kicker">Control notes</p>
+            <div className="mt-4 space-y-4 text-sm text-muted-foreground">
+              <div className="flex items-start gap-3">
+                <Users className="mt-0.5 h-4 w-4 shrink-0 text-[var(--surface-highlight)]" />
+                <p>Selecting a system switches the whole board context, including agents, projects, and folder paths.</p>
+              </div>
+              <div className="flex items-start gap-3">
+                <FolderOpen className="mt-0.5 h-4 w-4 shrink-0 text-[var(--surface-highlight)]" />
+                <p>Use stable prefixes and names here so routes and linked folders stay readable across every page.</p>
+              </div>
+            </div>
+            <Button size="sm" onClick={() => openOnboarding()} className="mt-5 rounded-full">
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              New System
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <div className="space-y-2">
         {loading && <p className="text-sm text-muted-foreground">Loading systems...</p>}
         {error && <p className="text-sm text-destructive">{error.message}</p>}
       </div>
@@ -111,9 +186,7 @@ export function Companies() {
           const issueCount = companyStats?.issueCount ?? 0;
           const budgetPct =
             company.budgetMonthlyCents > 0
-              ? Math.round(
-                  (company.spentMonthlyCents / company.budgetMonthlyCents) * 100,
-                )
+              ? Math.round((company.spentMonthlyCents / company.budgetMonthlyCents) * 100)
               : 0;
 
           return (
@@ -128,24 +201,21 @@ export function Companies() {
                   setSelectedCompanyId(company.id);
                 }
               }}
-              className={`group text-left bg-card border rounded-lg p-5 transition-colors cursor-pointer ${
+              className={cn(
+                "group page-frame rounded-[1.35rem] p-5 text-left transition-all cursor-pointer",
                 selected
-                  ? "border-primary ring-1 ring-primary"
-                  : "border-border hover:border-muted-foreground/30"
-              }`}
+                  ? "border-[color:var(--surface-highlight)] shadow-[0_20px_60px_-36px_rgba(178,111,62,0.85)]"
+                  : "hover:-translate-y-0.5 hover:border-[color:var(--surface-highlight)]/40",
+              )}
             >
-              {/* Header row: name + menu */}
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
                   {isEditing ? (
-                    <div
-                      className="flex items-center gap-2"
-                      onClick={(e) => e.stopPropagation()}
-                    >
+                    <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
                       <Input
                         value={editName}
                         onChange={(e) => setEditName(e.target.value)}
-                        className="h-7 text-sm"
+                        className="h-8 text-sm"
                         autoFocus
                         onKeyDown={(e) => {
                           if (e.key === "Enter") saveEdit();
@@ -165,16 +235,16 @@ export function Companies() {
                       </Button>
                     </div>
                   ) : (
-                    <div className="flex items-center gap-2">
-                      <h3 className="font-semibold text-base">{company.name}</h3>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-border bg-background/60 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                        {company.issuePrefix}
+                      </span>
+                      <h3 className="text-lg font-semibold text-foreground">{company.name}</h3>
                       <span
-                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                          company.status === "active"
-                            ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                            : company.status === "paused"
-                              ? "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400"
-                              : "bg-muted text-muted-foreground"
-                        }`}
+                        className={cn(
+                          "inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]",
+                          systemStatusClasses(company.status),
+                        )}
                       >
                         {company.status}
                       </span>
@@ -192,13 +262,12 @@ export function Companies() {
                     </div>
                   )}
                   {company.description && !isEditing && (
-                    <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                    <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground line-clamp-2">
                       {company.description}
                     </p>
                   )}
                 </div>
 
-                {/* Three-dot menu */}
                 <div onClick={(e) => e.stopPropagation()}>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -211,9 +280,7 @@ export function Companies() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={() => startEdit(company.id, company.name)}
-                      >
+                      <DropdownMenuItem onClick={() => startEdit(company.id, company.name)}>
                         <Pencil className="h-3.5 w-3.5" />
                         Rename
                       </DropdownMenuItem>
@@ -223,52 +290,82 @@ export function Companies() {
                         onClick={() => setConfirmDeleteId(company.id)}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
-                        Delete Company
+                        Delete System
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>
               </div>
 
-              {/* Stats row */}
-              <div className="flex items-center gap-3 sm:gap-5 mt-4 text-sm text-muted-foreground flex-wrap">
-                <div className="flex items-center gap-1.5">
-                  <Users className="h-3.5 w-3.5" />
-                  <span>
+              <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="command-card-soft rounded-[1rem] px-3 py-3">
+                  <div className="flex items-center gap-1.5 text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                    <Users className="h-3.5 w-3.5" />
+                    Fleet
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
                     {agentCount} {agentCount === 1 ? "agent" : "agents"}
-                  </span>
+                  </p>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  <CircleDot className="h-3.5 w-3.5" />
-                  <span>
+                <div className="command-card-soft rounded-[1rem] px-3 py-3">
+                  <div className="flex items-center gap-1.5 text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                    <CircleDot className="h-3.5 w-3.5" />
+                    Issues
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
                     {issueCount} {issueCount === 1 ? "issue" : "issues"}
-                  </span>
+                  </p>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  <DollarSign className="h-3.5 w-3.5" />
-                  <span>
+                <div className="command-card-soft rounded-[1rem] px-3 py-3">
+                  <div className="flex items-center gap-1.5 text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                    <DollarSign className="h-3.5 w-3.5" />
+                    Spend
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
                     {formatCents(company.spentMonthlyCents)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
                     {company.budgetMonthlyCents > 0
-                      ? <> / {formatCents(company.budgetMonthlyCents)} <span className="text-xs">({budgetPct}%)</span></>
-                      : <span className="text-xs ml-1">Unlimited budget</span>}
-                  </span>
+                      ? `${formatCents(company.budgetMonthlyCents)} cap · ${budgetPct}% used`
+                      : "Unlimited budget"}
+                  </p>
                 </div>
-                <div className="flex items-center gap-1.5 ml-auto">
-                  <Calendar className="h-3.5 w-3.5" />
-                  <span>Created {relativeTime(company.createdAt)}</span>
+                <div className="command-card-soft rounded-[1rem] px-3 py-3">
+                  <div className="flex items-center gap-1.5 text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                    <Calendar className="h-3.5 w-3.5" />
+                    Started
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
+                    {relativeTime(company.createdAt)}
+                  </p>
                 </div>
               </div>
 
-              {/* Delete confirmation */}
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-4 text-sm text-muted-foreground">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "h-2.5 w-2.5 rounded-full",
+                      selected ? "bg-[var(--surface-highlight)]" : "bg-muted-foreground/40",
+                    )}
+                  />
+                  <span>{selected ? "Current board context" : "Click to make active"}</span>
+                </div>
+                <div className="inline-flex items-center gap-1 text-foreground">
+                  <span>Open dashboard</span>
+                  <ArrowRight className="h-3.5 w-3.5" />
+                </div>
+              </div>
+
               {isConfirmingDelete && (
                 <div
-                  className="mt-4 flex items-center justify-between bg-destructive/5 border border-destructive/20 rounded-md px-4 py-3"
+                  className="mt-4 flex flex-col gap-3 rounded-[1rem] border border-destructive/20 bg-destructive/5 px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <p className="text-sm text-destructive font-medium">
-                    Delete this company and all its data? This cannot be undone.
+                  <p className="text-sm font-medium text-destructive">
+                    Delete this system and all of its data? This cannot be undone.
                   </p>
-                  <div className="flex items-center gap-2 ml-4 shrink-0">
+                  <div className="flex items-center gap-2 shrink-0">
                     <Button
                       variant="ghost"
                       size="sm"

--- a/ui/src/pages/Companies.tsx
+++ b/ui/src/pages/Companies.tsx
@@ -69,7 +69,7 @@ export function Companies() {
   });
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Companies" }]);
+    setBreadcrumbs([{ label: "Systems" }]);
   }, [setBreadcrumbs]);
 
   function startEdit(companyId: string, currentName: string) {
@@ -92,12 +92,12 @@ export function Companies() {
       <div className="flex items-center justify-end">
         <Button size="sm" onClick={() => openOnboarding()}>
           <Plus className="h-3.5 w-3.5 mr-1.5" />
-          New Company
+          New System
         </Button>
       </div>
 
       <div className="h-6">
-        {loading && <p className="text-sm text-muted-foreground">Loading companies...</p>}
+        {loading && <p className="text-sm text-muted-foreground">Loading systems...</p>}
         {error && <p className="text-sm text-destructive">{error.message}</p>}
       </div>
 

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -19,7 +19,7 @@ import { ActivityRow } from "../components/ActivityRow";
 import { Identity } from "../components/Identity";
 import { timeAgo } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
-import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard } from "lucide-react";
+import { ArrowRight, Bot, CircleDot, DollarSign, FolderOpen, LayoutDashboard, ShieldCheck } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
@@ -81,6 +81,10 @@ export function Dashboard() {
 
   const recentIssues = issues ? getRecentIssues(issues) : [];
   const recentActivity = useMemo(() => (activity ?? []).slice(0, 10), [activity]);
+  const folderCount = useMemo(
+    () => (projects ?? []).reduce((sum, project) => sum + (project.workspaces?.length ?? 0), 0),
+    [projects],
+  );
 
   useEffect(() => {
     for (const timer of activityAnimationTimersRef.current) {
@@ -167,14 +171,14 @@ export function Dashboard() {
       return (
         <EmptyState
           icon={LayoutDashboard}
-          message="Welcome to Paperclip. Set up your first company and agent to get started."
+          message="Welcome to Paperclip. Set up your first system and agent to get started."
           action="Get Started"
           onAction={openOnboarding}
         />
       );
     }
     return (
-      <EmptyState icon={LayoutDashboard} message="Create or select a company to view the dashboard." />
+      <EmptyState icon={LayoutDashboard} message="Create or select a system to view the dashboard." />
     );
   }
 
@@ -189,27 +193,86 @@ export function Dashboard() {
       {error && <p className="text-sm text-destructive">{error.message}</p>}
 
       {hasNoAgents && (
-        <div className="flex items-center justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-500/25 dark:bg-amber-950/60">
+        <div className="page-frame flex items-center justify-between gap-3 rounded-[1.2rem] px-4 py-3">
           <div className="flex items-center gap-2.5">
-            <Bot className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
-            <p className="text-sm text-amber-900 dark:text-amber-100">
+            <Bot className="h-4 w-4 shrink-0 text-[var(--surface-highlight)]" />
+            <p className="text-sm text-foreground">
               You have no agents.
             </p>
           </div>
           <button
             onClick={() => openOnboarding({ initialStep: 2, companyId: selectedCompanyId! })}
-            className="text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100 underline underline-offset-2 shrink-0"
+            className="shrink-0 text-sm font-medium text-foreground underline underline-offset-2"
           >
             Create one here
           </button>
         </div>
       )}
 
-      <ActiveAgentsPanel companyId={selectedCompanyId!} />
-
       {data && (
         <>
-          <div className="grid grid-cols-2 xl:grid-cols-4 gap-1 sm:gap-2">
+          <section className="command-card rounded-[1.8rem] px-5 py-5 sm:px-6 sm:py-6">
+            <div className="grid gap-5 xl:grid-cols-[1.25fr_0.95fr]">
+              <div>
+                <p className="section-kicker">System overview</p>
+                <h2 className="editorial-title mt-3 text-[2.4rem] leading-none text-foreground sm:text-[3.4rem]">
+                  Agents, projects, and folders on one operational board.
+                </h2>
+                <p className="mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
+                  Paperclip should behave like a control surface, not a stack of generic lists. Start from the live fleet, move into active work, then drop into folders and approvals.
+                </p>
+
+                <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                  <CommandLink
+                    to="/agents/all"
+                    label="Open fleet"
+                    detail={`${data.agents.running} running · ${data.agents.active} active`}
+                  />
+                  <CommandLink
+                    to="/projects"
+                    label="Review projects"
+                    detail={`${projects?.length ?? 0} tracked · ${folderCount} folders`}
+                  />
+                  <CommandLink
+                    to="/folders"
+                    label="Inspect folders"
+                    detail="Local paths and linked repos"
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <HeroStat
+                  icon={Bot}
+                  label="Live agents"
+                  value={data.agents.active + data.agents.running}
+                  detail={`${data.agents.paused} paused · ${data.agents.error} error`}
+                />
+                <HeroStat
+                  icon={CircleDot}
+                  label="Tasks in motion"
+                  value={data.tasks.inProgress}
+                  detail={`${data.tasks.open} open · ${data.tasks.blocked} blocked`}
+                />
+                <HeroStat
+                  icon={FolderOpen}
+                  label="Linked folders"
+                  value={folderCount}
+                  detail={`${projects?.length ?? 0} projects`}
+                />
+                <HeroStat
+                  icon={ShieldCheck}
+                  label="Approvals waiting"
+                  value={data.pendingApprovals}
+                  detail={`${data.staleTasks} stale tasks`}
+                />
+              </div>
+            </div>
+          </section>
+
+          <ActiveAgentsPanel companyId={selectedCompanyId!} />
+
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
             <MetricCard
               icon={Bot}
               value={data.agents.active + data.agents.running + data.agents.paused + data.agents.error}
@@ -261,7 +324,7 @@ export function Dashboard() {
             />
           </div>
 
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
             <ChartCard title="Run Activity" subtitle="Last 14 days">
               <RunActivityChart runs={runs ?? []} />
             </ChartCard>
@@ -276,14 +339,14 @@ export function Dashboard() {
             </ChartCard>
           </div>
 
-          <div className="grid md:grid-cols-2 gap-4">
+          <div className="grid gap-4 md:grid-cols-2">
             {/* Recent Activity */}
             {recentActivity.length > 0 && (
-              <div className="min-w-0">
-                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+              <div className="command-card-soft min-w-0 rounded-[1.4rem] p-4">
+                <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   Recent Activity
                 </h3>
-                <div className="border border-border divide-y divide-border overflow-hidden">
+                <div className="overflow-hidden rounded-[1rem] border border-border divide-y divide-border bg-background/40">
                   {recentActivity.map((event) => (
                     <ActivityRow
                       key={event.id}
@@ -299,16 +362,16 @@ export function Dashboard() {
             )}
 
             {/* Recent Tasks */}
-            <div className="min-w-0">
-              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+            <div className="command-card-soft min-w-0 rounded-[1.4rem] p-4">
+              <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                 Recent Tasks
               </h3>
               {recentIssues.length === 0 ? (
-                <div className="border border-border p-4">
+                <div className="rounded-[1rem] border border-border bg-background/40 p-4">
                   <p className="text-sm text-muted-foreground">No tasks yet.</p>
                 </div>
               ) : (
-                <div className="border border-border divide-y divide-border overflow-hidden">
+                <div className="overflow-hidden rounded-[1rem] border border-border divide-y divide-border bg-background/40">
                   {recentIssues.slice(0, 10).map((issue) => (
                     <Link
                       key={issue.id}
@@ -345,5 +408,47 @@ export function Dashboard() {
         </>
       )}
     </div>
+  );
+}
+
+function HeroStat({
+  icon: Icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: typeof Bot;
+  label: string;
+  value: string | number;
+  detail: string;
+}) {
+  return (
+    <div className="command-metric rounded-[1.25rem] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">{label}</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-foreground">{value}</p>
+          <p className="mt-2 text-xs leading-5 text-muted-foreground">{detail}</p>
+        </div>
+        <div className="rounded-full border border-border bg-background/55 p-2">
+          <Icon className="h-4 w-4 text-muted-foreground" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CommandLink({ to, label, detail }: { to: string; label: string; detail: string }) {
+  return (
+    <Link
+      to={to}
+      className="command-metric flex items-center justify-between rounded-[1.1rem] px-4 py-3 no-underline text-inherit transition-all hover:-translate-y-0.5 hover:bg-accent/55"
+    >
+      <div>
+        <p className="text-sm font-semibold text-foreground">{label}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      </div>
+      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+    </Link>
   );
 }

--- a/ui/src/pages/Folders.tsx
+++ b/ui/src/pages/Folders.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { Project, ProjectWorkspace } from "@paperclipai/shared";
+import { FolderOpen, Github, HardDrive, Star } from "lucide-react";
+import { projectsApi } from "../api/projects";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EntityRow } from "../components/EntityRow";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { projectUrl } from "../lib/utils";
+
+const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
+
+function deriveFolderName(folder: ProjectWorkspace): string {
+  if (folder.name.trim().length > 0) return folder.name;
+
+  if (folder.cwd && folder.cwd !== REPO_ONLY_CWD_SENTINEL) {
+    const normalized = folder.cwd.replace(/[\\/]+$/, "");
+    const segments = normalized.split(/[\\/]/).filter(Boolean);
+    return segments[segments.length - 1] ?? "Folder";
+  }
+
+  if (folder.repoUrl) {
+    try {
+      const parsed = new URL(folder.repoUrl);
+      const segments = parsed.pathname.split("/").filter(Boolean);
+      const repo = segments[segments.length - 1]?.replace(/\.git$/i, "");
+      return repo || "Repo";
+    } catch {
+      return "Repo";
+    }
+  }
+
+  return "Folder";
+}
+
+function formatRepoLabel(repoUrl: string): string {
+  try {
+    const parsed = new URL(repoUrl);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length < 2) return repoUrl;
+    return `${segments[0]}/${segments[1]!.replace(/\.git$/i, "")}`;
+  } catch {
+    return repoUrl;
+  }
+}
+
+type FolderRecord = {
+  project: Project;
+  folder: ProjectWorkspace;
+};
+
+export function Folders() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Folders" }]);
+  }, [setBreadcrumbs]);
+
+  const { data: projects, isLoading, error } = useQuery({
+    queryKey: queryKeys.projects.list(selectedCompanyId!),
+    queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const folders = useMemo<FolderRecord[]>(() => {
+    return (projects ?? [])
+      .flatMap((project) => (project.workspaces ?? []).map((folder) => ({ project, folder })))
+      .sort((a, b) => {
+        const projectCompare = a.project.name.localeCompare(b.project.name);
+        if (projectCompare !== 0) return projectCompare;
+        return deriveFolderName(a.folder).localeCompare(deriveFolderName(b.folder));
+      });
+  }, [projects]);
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={FolderOpen} message="Select a system to view folders." />;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton variant="list" />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <section className="command-card rounded-[1.6rem] px-5 py-5 sm:px-6">
+        <p className="section-kicker">Folder map</p>
+        <h2 className="editorial-title mt-3 text-[2.3rem] leading-none text-foreground">Folders, local paths, and repo links</h2>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+          This is the cleanest place to see where projects actually live: local folders, GitHub repos, and which path is primary.
+        </p>
+      </section>
+
+      {folders.length > 0 && (
+        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+          {folders.length} folder{folders.length !== 1 ? "s" : ""} linked across {projects?.length ?? 0} project{projects?.length === 1 ? "" : "s"}
+        </p>
+      )}
+
+      {error && <p className="text-sm text-destructive">{error.message}</p>}
+
+      {projects && folders.length === 0 && (
+        <EmptyState
+          icon={FolderOpen}
+          message="No folders linked yet."
+        />
+      )}
+
+      {folders.length > 0 && (
+        <div className="page-frame overflow-hidden rounded-[1.3rem]">
+          {folders.map(({ project, folder }) => {
+            const hasLocalPath = Boolean(folder.cwd && folder.cwd !== REPO_ONLY_CWD_SENTINEL);
+            const localPath = hasLocalPath ? folder.cwd : null;
+            const repoLabel = folder.repoUrl ? formatRepoLabel(folder.repoUrl) : null;
+            const subtitle = [project.name, localPath ?? repoLabel].filter(Boolean).join(" · ");
+
+            return (
+              <EntityRow
+                key={folder.id}
+                title={deriveFolderName(folder)}
+                subtitle={subtitle}
+                to={`${projectUrl(project)}/overview`}
+                leading={<FolderOpen className="h-4 w-4 text-muted-foreground" />}
+                trailing={
+                  <div className="flex items-center gap-2">
+                    {folder.isPrimary && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground">
+                        <Star className="h-3 w-3" />
+                        Primary
+                      </span>
+                    )}
+                    {hasLocalPath && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground">
+                        <HardDrive className="h-3 w-3" />
+                        Local
+                      </span>
+                    )}
+                    {repoLabel && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground">
+                        <Github className="h-3 w-3" />
+                        Repo
+                      </span>
+                    )}
+                  </div>
+                }
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -224,7 +224,7 @@ export function InviteLandingPage() {
     <div className="mx-auto max-w-xl py-10">
       <div className="rounded-lg border border-border bg-card p-6">
         <h1 className="text-xl font-semibold">
-          {invite.inviteType === "bootstrap_ceo" ? "Bootstrap your Paperclip instance" : "Join this Paperclip company"}
+          {invite.inviteType === "bootstrap_ceo" ? "Bootstrap your Paperclip instance" : "Join this Paperclip system"}
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">Invite expires {dateTime(invite.expiresAt)}.</p>
 

--- a/ui/src/pages/Org.tsx
+++ b/ui/src/pages/Org.tsx
@@ -104,7 +104,7 @@ export function Org() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={GitBranch} message="Select a company to view org chart." />;
+    return <EmptyState icon={GitBranch} message="Select a system to view org chart." />;
   }
 
   if (isLoading) {

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -254,7 +254,7 @@ export function OrgChart() {
   }, [zoom, pan]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Network} message="Select a company to view the org chart." />;
+    return <EmptyState icon={Network} message="Select a system to view the org chart." />;
   }
 
   if (isLoading) {

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -29,7 +29,7 @@ export function Projects() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Hexagon} message="Select a company to view projects." />;
+    return <EmptyState icon={Hexagon} message="Select a system to view projects." />;
   }
 
   if (isLoading) {
@@ -38,8 +38,27 @@ export function Projects() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-end">
-        <Button size="sm" variant="outline" onClick={openNewProject}>
+      <section className="command-card rounded-[1.6rem] px-5 py-5 sm:px-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="section-kicker">Project ledger</p>
+            <h2 className="editorial-title mt-3 text-[2.3rem] leading-none text-foreground">Projects and execution tracks</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+              Each project can carry multiple folders and linked repos. Keep the working surface compact and operational.
+            </p>
+          </div>
+          <Button size="sm" variant="outline" onClick={openNewProject} className="rounded-full">
+            <Plus className="mr-1 h-4 w-4" />
+            Add Project
+          </Button>
+        </div>
+      </section>
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+          {projects?.length ?? 0} projects
+        </p>
+        <Button size="sm" variant="outline" onClick={openNewProject} className="rounded-full sm:hidden">
           <Plus className="h-4 w-4 mr-1" />
           Add Project
         </Button>
@@ -57,7 +76,7 @@ export function Projects() {
       )}
 
       {projects && projects.length > 0 && (
-        <div className="border border-border">
+        <div className="page-frame overflow-hidden rounded-[1.3rem]">
           {projects.map((project) => (
             <EntityRow
               key={project.id}
@@ -66,6 +85,11 @@ export function Projects() {
               to={projectUrl(project)}
               trailing={
                 <div className="flex items-center gap-3">
+                  {(project.workspaces?.length ?? 0) > 0 && (
+                    <span className="text-xs text-muted-foreground">
+                      {project.workspaces.length} folder{project.workspaces.length === 1 ? "" : "s"}
+                    </span>
+                  )}
                   {project.targetDate && (
                     <span className="text-xs text-muted-foreground">
                       {formatDate(project.targetDate)}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
   },
   server: {
     port: 5173,
-    allowedHosts: ["paperclip.atayil.com"],
     proxy: {
       "/api": {
         target: "http://localhost:3100",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    allowedHosts: ["paperclip.atayil.com"],
     proxy: {
       "/api": {
         target: "http://localhost:3100",


### PR DESCRIPTION
## Summary
- redesign the Paperclip shell around a command-center visual system
- align visible terminology to systems, agents, projects, and folders
- add and route a folders surface plus clean up remaining inconsistent pages

## Verification
- pnpm --filter @paperclipai/ui build
- browser smoke checks on dashboard, systems, and folders

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a broad visual and terminology overhaul of the Paperclip shell — renaming "company" to "system" throughout, introducing a command-center design language (warm-toned palette, `Instrument Serif` editorial headings, `command-card`/`command-metric` CSS utilities), adding a new `/folders` surface that surfaces project workspaces across the board, and wiring up all the necessary routes and redirects.

Key changes:
- **New `Folders` page** (`ui/src/pages/Folders.tsx`): flat, sorted list of all project workspaces with local-path and repo badges; routing correctly added in `App.tsx` and `company-routes.ts`.
- **Full design token replacement** (`ui/src/index.css`): earthy OKLCH → hex color palette, Google Fonts import (Instrument Serif + Manrope), new `.command-card`, `.command-metric`, `.page-frame`, `.sidebar-surface` utility classes, and a decorative grid overlay via `body::before`.
- **Terminology rename**: "company" → "system" across all user-facing strings in dialogs, empty states, breadcrumbs, nav labels, and error messages.
- **Hero sections** added to Dashboard, Agents, Projects, and Companies pages with large editorial headings and summary metric tiles.
- **`vite.config.ts` adds `allowedHosts: ["paperclip.atayil.com"]`** — a hardcoded personal domain that should not be committed to the shared repo; it enables external access to the local dev server and will confuse other contributors.
- **`MobileBottomNav` badge bug**: the Folders nav item (which replaced Inbox) still references `sidebarBadges?.inbox`, so inbox notification counts will incorrectly appear on the Folders icon on mobile.
- **"Open dashboard" UX**: the company card in `Companies.tsx` renders an "Open dashboard →" affordance inside a button that only selects the active system, not navigate — visually implies navigation but doesn't deliver it.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the `allowedHosts` personal domain and the inbox badge on the Folders mobile nav item.
- Two actionable bugs block a clean merge: the hardcoded personal hostname in `vite.config.ts` (security/maintainability) and the misrouted inbox badge on the Folders mobile nav item (functional UI bug). The rest of the changes are extensive but mechanical — terminology renames, visual redesign, and a straightforward new page — with no logic errors in routing or data handling.
- `ui/vite.config.ts` (personal domain in `allowedHosts`) and `ui/src/components/MobileBottomNav.tsx` (inbox badge on Folders item) need fixes before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/vite.config.ts | Adds `allowedHosts: ["paperclip.atayil.com"]` — a hardcoded personal domain that should not be committed to the shared repo; potential security issue for other developers. |
| ui/src/components/MobileBottomNav.tsx | Replaces Inbox nav item with Folders but leaves `badge: sidebarBadges?.inbox` in place, causing inbox notification counts to incorrectly display on the Folders button. |
| ui/src/pages/Folders.tsx | New page that lists all project workspaces (folders) as a flat, sorted list with local path / repo badges. Logic is clean; derives display names safely from cwd and repoUrl. |
| ui/src/pages/Dashboard.tsx | Adds a large hero section with `HeroStat` and `CommandLink` sub-components and moves `ActiveAgentsPanel` below the hero. `folderCount` derived safely; no logic errors found. |
| ui/src/pages/Companies.tsx | Major redesign of the Systems/Companies page; "Open dashboard" CTA inside a selection-only button implies navigation but does not navigate — UX confusion. |
| ui/src/pages/Agents.tsx | Adds a command-card hero section and wraps the existing tab/filter bar; structurally valid JSX but inconsistent indentation makes nesting hard to read. |
| ui/src/index.css | Full design-token overhaul with warm/earthy color palette, new custom utility classes (`.editorial-title`, `.command-card`, etc.), and Google Fonts import. The external font load is a notable privacy addition. |
| ui/src/App.tsx | Adds `/folders` route in board routes and the unprefixed redirect set. Looks correct and consistent with how other routes are registered. |
| ui/src/lib/company-routes.ts | Adds `"folders"` to the board route roots set so company-prefixed routing works for the new Folders page. One-line, correct change. |

</details>

<sub>Last reviewed commit: e5ebdf1</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->