### PR TITLE
fix(ui): remove derived state effects flagged by react-doctor

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -232,7 +232,8 @@ export function CommentThread({
   const [reopen, setReopen] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [attaching, setAttaching] = useState(false);
-  const [reassignTarget, setReassignTarget] = useState(currentAssigneeValue);
+  const [reassignTargetOverride, setReassignTargetOverride] = useState<string | null>(null);
+  const reassignTarget = reassignTargetOverride ?? currentAssigneeValue;
   const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
   const editorRef = useRef<MarkdownEditorRef>(null);
   const attachInputRef = useRef<HTMLInputElement | null>(null);
@@ -293,9 +294,6 @@ export function CommentThread({
     };
   }, []);
 
-  useEffect(() => {
-    setReassignTarget(currentAssigneeValue);
-  }, [currentAssigneeValue]);
 
   // Scroll to comment when URL hash matches #comment-{id}
   useEffect(() => {
@@ -327,7 +325,7 @@ export function CommentThread({
       setBody("");
       if (draftKey) clearDraft(draftKey);
       setReopen(false);
-      setReassignTarget(currentAssigneeValue);
+      setReassignTargetOverride(null);
     } finally {
       setSubmitting(false);
     }
@@ -406,7 +404,7 @@ export function CommentThread({
               noneLabel="No assignee"
               searchPlaceholder="Search assignees..."
               emptyMessage="No assignees found."
-              onChange={setReassignTarget}
+              onChange={setReassignTargetOverride}
               className="text-xs h-8"
               renderTriggerValue={(option) => {
                 if (!option) return <span className="text-muted-foreground">Assignee</span>;

--- a/ui/src/components/InlineEditor.tsx
+++ b/ui/src/components/InlineEditor.tsx
@@ -32,10 +32,6 @@ export function InlineEditor({
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    setDraft(value);
-  }, [value]);
-
   const autoSize = useCallback((el: HTMLTextAreaElement | null) => {
     if (!el) return;
     el.style.height = "auto";
@@ -137,7 +133,10 @@ export function InlineEditor({
         !value && "text-muted-foreground italic",
         className
       )}
-      onClick={() => setEditing(true)}
+      onClick={() => {
+        setDraft(value);
+        setEditing(true);
+      }}
     >
       {value && multiline ? (
         <MarkdownBody>{value}</MarkdownBody>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -174,13 +174,10 @@ export function IssuesList({
   });
   const [assigneePickerIssueId, setAssigneePickerIssueId] = useState<string | null>(null);
   const [assigneeSearch, setAssigneeSearch] = useState("");
-  const [issueSearch, setIssueSearch] = useState(initialSearch ?? "");
+  const [issueSearchOverride, setIssueSearchOverride] = useState<string | null>(null);
+  const issueSearch = issueSearchOverride ?? (initialSearch ?? "");
   const [debouncedIssueSearch, setDebouncedIssueSearch] = useState(issueSearch);
   const normalizedIssueSearch = debouncedIssueSearch.trim();
-
-  useEffect(() => {
-    setIssueSearch(initialSearch ?? "");
-  }, [initialSearch]);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -307,7 +304,7 @@ export function IssuesList({
             <Input
               value={issueSearch}
               onChange={(e) => {
-                setIssueSearch(e.target.value);
+                setIssueSearchOverride(e.target.value);
                 onSearchChange?.(e.target.value);
               }}
               placeholder="Search issues..."

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -43,11 +43,6 @@ export function CompanySettings() {
     setBrandColor(selectedCompany.brandColor ?? "");
   }, [selectedCompany]);
 
-  const [inviteError, setInviteError] = useState<string | null>(null);
-  const [inviteSnippet, setInviteSnippet] = useState<string | null>(null);
-  const [snippetCopied, setSnippetCopied] = useState(false);
-  const [snippetCopyDelightId, setSnippetCopyDelightId] = useState(0);
-
   const generalDirty =
     !!selectedCompany &&
     (companyName !== selectedCompany.name ||
@@ -75,65 +70,6 @@ export function CompanySettings() {
     }
   });
 
-  const inviteMutation = useMutation({
-    mutationFn: () =>
-      accessApi.createOpenClawInvitePrompt(selectedCompanyId!),
-    onSuccess: async (invite) => {
-      setInviteError(null);
-      const base = window.location.origin.replace(/\/+$/, "");
-      const onboardingTextLink =
-        invite.onboardingTextUrl ??
-        invite.onboardingTextPath ??
-        `/api/invites/${invite.token}/onboarding.txt`;
-      const absoluteUrl = onboardingTextLink.startsWith("http")
-        ? onboardingTextLink
-        : `${base}${onboardingTextLink}`;
-      setSnippetCopied(false);
-      setSnippetCopyDelightId(0);
-      let snippet: string;
-      try {
-        const manifest = await accessApi.getInviteOnboarding(invite.token);
-        snippet = buildAgentSnippet({
-          onboardingTextUrl: absoluteUrl,
-          connectionCandidates:
-            manifest.onboarding.connectivity?.connectionCandidates ?? null,
-          testResolutionUrl:
-            manifest.onboarding.connectivity?.testResolutionEndpoint?.url ??
-            null
-        });
-      } catch {
-        snippet = buildAgentSnippet({
-          onboardingTextUrl: absoluteUrl,
-          connectionCandidates: null,
-          testResolutionUrl: null
-        });
-      }
-      setInviteSnippet(snippet);
-      try {
-        await navigator.clipboard.writeText(snippet);
-        setSnippetCopied(true);
-        setSnippetCopyDelightId((prev) => prev + 1);
-        setTimeout(() => setSnippetCopied(false), 2000);
-      } catch {
-        /* clipboard may not be available */
-      }
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.sidebarBadges(selectedCompanyId!)
-      });
-    },
-    onError: (err) => {
-      setInviteError(
-        err instanceof Error ? err.message : "Failed to create invite"
-      );
-    }
-  });
-
-  useEffect(() => {
-    setInviteError(null);
-    setInviteSnippet(null);
-    setSnippetCopied(false);
-    setSnippetCopyDelightId(0);
-  }, [selectedCompanyId]);
   const archiveMutation = useMutation({
     mutationFn: ({
       companyId,
@@ -307,77 +243,7 @@ export function CompanySettings() {
         </div>
       </div>
 
-      {/* Invites */}
-      <div className="space-y-4">
-        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Invites
-        </div>
-        <div className="space-y-3 rounded-md border border-border px-4 py-4">
-          <div className="flex items-center gap-1.5">
-            <span className="text-xs text-muted-foreground">
-              Generate an OpenClaw agent invite snippet.
-            </span>
-            <HintIcon text="Creates a short-lived OpenClaw agent invite and renders a copy-ready prompt." />
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              size="sm"
-              onClick={() => inviteMutation.mutate()}
-              disabled={inviteMutation.isPending}
-            >
-              {inviteMutation.isPending
-                ? "Generating..."
-                : "Generate OpenClaw Invite Prompt"}
-            </Button>
-          </div>
-          {inviteError && (
-            <p className="text-sm text-destructive">{inviteError}</p>
-          )}
-          {inviteSnippet && (
-            <div className="rounded-md border border-border bg-muted/30 p-2">
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-xs text-muted-foreground">
-                  OpenClaw Invite Prompt
-                </div>
-                {snippetCopied && (
-                  <span
-                    key={snippetCopyDelightId}
-                    className="flex items-center gap-1 text-xs text-green-600 animate-pulse"
-                  >
-                    <Check className="h-3 w-3" />
-                    Copied
-                  </span>
-                )}
-              </div>
-              <div className="mt-1 space-y-1.5">
-                <textarea
-                  className="h-[28rem] w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs outline-none"
-                  value={inviteSnippet}
-                  readOnly
-                />
-                <div className="flex justify-end">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={async () => {
-                      try {
-                        await navigator.clipboard.writeText(inviteSnippet);
-                        setSnippetCopied(true);
-                        setSnippetCopyDelightId((prev) => prev + 1);
-                        setTimeout(() => setSnippetCopied(false), 2000);
-                      } catch {
-                        /* clipboard may not be available */
-                      }
-                    }}
-                  >
-                    {snippetCopied ? "Copied snippet" : "Copy snippet"}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
+      <InviteSection key={selectedCompanyId} selectedCompanyId={selectedCompanyId} />
 
       {/* Danger Zone */}
       <div className="space-y-4">
@@ -430,6 +296,145 @@ export function CompanySettings() {
             )}
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function InviteSection({ selectedCompanyId }: { selectedCompanyId: string | null }) {
+  const queryClient = useQueryClient();
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [inviteSnippet, setInviteSnippet] = useState<string | null>(null);
+  const [snippetCopied, setSnippetCopied] = useState(false);
+  const [snippetCopyDelightId, setSnippetCopyDelightId] = useState(0);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(copyTimerRef.current), []);
+
+  const inviteMutation = useMutation({
+    mutationFn: () =>
+      accessApi.createOpenClawInvitePrompt(selectedCompanyId!),
+    onSuccess: async (invite) => {
+      setInviteError(null);
+      const base = window.location.origin.replace(/\/+$/, "");
+      const onboardingTextLink =
+        invite.onboardingTextUrl ??
+        invite.onboardingTextPath ??
+        `/api/invites/${invite.token}/onboarding.txt`;
+      const absoluteUrl = onboardingTextLink.startsWith("http")
+        ? onboardingTextLink
+        : `${base}${onboardingTextLink}`;
+      setSnippetCopied(false);
+      setSnippetCopyDelightId(0);
+      let snippet: string;
+      try {
+        const manifest = await accessApi.getInviteOnboarding(invite.token);
+        snippet = buildAgentSnippet({
+          onboardingTextUrl: absoluteUrl,
+          connectionCandidates:
+            manifest.onboarding.connectivity?.connectionCandidates ?? null,
+          testResolutionUrl:
+            manifest.onboarding.connectivity?.testResolutionEndpoint?.url ??
+            null
+        });
+      } catch {
+        snippet = buildAgentSnippet({
+          onboardingTextUrl: absoluteUrl,
+          connectionCandidates: null,
+          testResolutionUrl: null
+        });
+      }
+      setInviteSnippet(snippet);
+      try {
+        await navigator.clipboard.writeText(snippet);
+        setSnippetCopied(true);
+        setSnippetCopyDelightId((prev) => prev + 1);
+        clearTimeout(copyTimerRef.current);
+        copyTimerRef.current = setTimeout(() => setSnippetCopied(false), 2000);
+      } catch {
+        /* clipboard may not be available */
+      }
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.sidebarBadges(selectedCompanyId!)
+      });
+    },
+    onError: (err) => {
+      setInviteError(
+        err instanceof Error ? err.message : "Failed to create invite"
+      );
+    }
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Invites
+      </div>
+      <div className="space-y-3 rounded-md border border-border px-4 py-4">
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">
+            Generate an OpenClaw agent invite snippet.
+          </span>
+          <HintIcon text="Creates a short-lived OpenClaw agent invite and renders a copy-ready prompt." />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            onClick={() => inviteMutation.mutate()}
+            disabled={inviteMutation.isPending}
+          >
+            {inviteMutation.isPending
+              ? "Generating..."
+              : "Generate OpenClaw Invite Prompt"}
+          </Button>
+        </div>
+        {inviteError && (
+          <p className="text-sm text-destructive">{inviteError}</p>
+        )}
+        {inviteSnippet && (
+          <div className="rounded-md border border-border bg-muted/30 p-2">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs text-muted-foreground">
+                OpenClaw Invite Prompt
+              </div>
+              {snippetCopied && (
+                <span
+                  key={snippetCopyDelightId}
+                  className="flex items-center gap-1 text-xs text-green-600 animate-pulse"
+                >
+                  <Check className="h-3 w-3" />
+                  Copied
+                </span>
+              )}
+            </div>
+            <div className="mt-1 space-y-1.5">
+              <textarea
+                className="h-[28rem] w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs outline-none"
+                value={inviteSnippet}
+                readOnly
+              />
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(inviteSnippet);
+                      setSnippetCopied(true);
+                      setSnippetCopyDelightId((prev) => prev + 1);
+                      clearTimeout(copyTimerRef.current);
+                      copyTimerRef.current = setTimeout(() => setSnippetCopied(false), 2000);
+                    } catch {
+                      /* clipboard may not be available */
+                    }
+                  }}
+                >
+                  {snippetCopied ? "Copied snippet" : "Copy snippet"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace prop-syncing `useEffect`s with override-pattern state in `CommentThread`, `InlineEditor`, and `IssuesList`
- Extract `InviteSection` into its own component with `key={selectedCompanyId}` to naturally reset state on company change, removing the manual state-reset `useEffect` in `CompanySettings`

These are the patterns recommended by [react.dev/learn/you-might-not-need-an-effect](https://react.dev/learn/you-might-not-need-an-effect) — derived state should be computed during render, not synced via effects.

**react-doctor score: 94/100** (remaining warnings are advisory — a11y hints, useReducer suggestions)

## Test plan
- [x] Verify `CommentThread` reassign picker reflects current assignee and resets after submit
- [x] Verify `InlineEditor` draft syncs correctly when clicking to edit
- [x] Verify `IssuesList` search input reflects `initialSearch` prop and user overrides
- [x] Verify `CompanySettings` invite section resets when switching companies

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes four prop-syncing `useEffect`s flagged by react-doctor, replacing them with the override pattern (derived state computed during render) or component key resets — all approaches recommended by the React docs. The refactors are generally well-executed; a couple of minor issues are worth checking before merging.

- **`CommentThread.tsx`** — override pattern for `reassignTarget` is correctly implemented; on-submit reset via `setReassignTargetOverride(null)` is clean.
- **`InlineEditor.tsx`** — syncing `draft` only when the user clicks to edit is strictly better than the old always-on `useEffect`, which would overwrite in-progress edits.
- **`IssuesList.tsx`** — once `issueSearchOverride` is set, subsequent changes to the `initialSearch` prop are silently ignored. If any parent passes a dynamically updated `initialSearch` to switch search contexts, the input will stay stale.
- **`CompanySettings.tsx`** — `InviteSection` is cleanly extracted; however, two `setTimeout` calls that reset the "Copied" state now have no cleanup when the component unmounts mid-countdown (which can happen on a company switch right after a copy).

<h3>Confidence Score: 4/5</h3>

- Safe to merge after verifying the `initialSearch` semantics in `IssuesList` and optionally adding timer cleanup in `InviteSection`.
- The refactoring is structurally sound and follows React best practices. The one functional concern — `IssuesList` ignoring `initialSearch` changes after user input — is a behavioral regression if `initialSearch` is used dynamically, but is acceptable if the prop truly behaves as an initial seed. The timer-leak in `InviteSection` is low-severity (React 18 no-ops the update) and pre-existed in the parent component.
- `ui/src/components/IssuesList.tsx` — verify that no call-site relies on `initialSearch` changes resetting the search input after user interaction.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/components/CommentThread.tsx | Replaces `useState(currentAssigneeValue)` + sync effect with an override-pattern (`reassignTargetOverride ?? currentAssigneeValue`); reset on submit sets override to null rather than re-reading the prop. Clean and correct. |
| ui/src/components/InlineEditor.tsx | Removes the always-on `useEffect` that synced `draft` to `value` (which incorrectly overwrote in-progress edits) and instead sets `draft = value` only when the user clicks to open the editor. This is strictly more correct behavior. |
| ui/src/components/IssuesList.tsx | Applies the override pattern for `issueSearch`. Once a user types, subsequent `initialSearch` prop changes are ignored — a subtle behavioral regression if any parent drives `initialSearch` dynamically to switch contexts. |
| ui/src/pages/CompanySettings.tsx | Invite UI extracted into a standalone InviteSection component reset via the key prop on company change — correct pattern. Two fire-and-forget setTimeout calls that clear the copy indicator have no unmount cleanup, causing a minor timer leak when the component unmounts mid-countdown. |

</details>

<sub>Last reviewed commit: b648655</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->