### PR TITLE
fix(docker): run server as non-root node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ FROM base AS production
 WORKDIR /app
 COPY --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai
+RUN chown -R node:node /app && mkdir -p /paperclip && chown node:node /paperclip
 
 ENV NODE_ENV=production \
   HOME=/paperclip \
@@ -49,4 +50,5 @@ ENV NODE_ENV=production \
 VOLUME ["/paperclip"]
 EXPOSE 3100
 
+USER node
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]


### PR DESCRIPTION
The node:lts-trixie-slim base image ships with a built-in 'node' user. Switch to it in the production stage to avoid two runtime failures:

1. Claude CLI rejects --dangerously-skip-permissions when running as root, causing adapter_failed errors.
2. The server could not write to /paperclip (logs, instance data) because the volume mount point was owned by root.

Changes:
- chown /app to node:node after installing global tools
- mkdir /paperclip and chown to node:node before VOLUME declaration
- Add USER node before CMD

fixes: #344

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two production runtime failures by switching the container from root to the built-in `node` user in the `node:lts-trixie-slim` base image. The changes are logically sound: `/paperclip` ownership is set **before** the `VOLUME` declaration (ensuring freshly-created anonymous/named volumes are initialised with the correct ownership), and `USER node` is placed correctly just before `CMD`.

Key changes:
- `chown -R node:node /app` — grants the `node` user ownership of the application files after the global tool install (which still runs as root, as required).
- `mkdir -p /paperclip && chown node:node /paperclip` — creates and owns the writable data directory before Docker's `VOLUME` instruction locks it in.
- `USER node` — ensures the process runs as non-root, satisfying Claude CLI's `--dangerously-skip-permissions` requirement.

One style improvement worth considering: the `chown -R /app` step creates a duplicate image layer. Replacing `COPY --from=build /app /app` with `COPY --chown=node:node --from=build /app /app` achieves the same result without the overhead.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the security fix is correct and the only concern is a minor image-size inefficiency.
- The ownership setup, VOLUME ordering, and USER placement are all correct. The only issue is that using `chown -R` after `COPY` adds an unnecessary duplicate layer rather than using `COPY --chown`, which is a style/size concern rather than a correctness problem.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Dockerfile | Switches the production container from root to the built-in `node` user; correctly sets up `/app` and `/paperclip` ownership before the VOLUME declaration. Minor opportunity to eliminate a duplicate image layer by using `COPY --chown` instead of a separate `chown -R` RUN step. |

</details>

<sub>Last reviewed commit: 6f5525e</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->