### PR TITLE
fix(ui): render tweet approvals as copy-pastable cards

### DIFF
--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -51,20 +51,43 @@ export function HireAgentPayload({ payload }: { payload: Record<string, unknown>
 }
 
 export function CeoStrategyPayload({ payload }: { payload: Record<string, unknown> }) {
+  const tweets = Array.isArray(payload.tweets) ? (payload.tweets as string[]) : null;
   const plan = payload.plan ?? payload.description ?? payload.strategy ?? payload.text;
   return (
     <div className="mt-3 space-y-1.5 text-sm">
+      <PayloadField label="Topic" value={payload.topic} />
+      <PayloadField label="Account" value={payload.account} />
       <PayloadField label="Title" value={payload.title} />
-      {!!plan && (
+      {tweets && (
+        <div className="mt-2 space-y-3">
+          {tweets.map((tweet, i) => (
+            <div key={i} className="rounded-md border bg-card px-3 py-2">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs text-muted-foreground font-medium">Tweet {i + 1}</span>
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={() => navigator.clipboard.writeText(tweet)}
+                >
+                  Copy
+                </button>
+              </div>
+              <div className="text-sm whitespace-pre-wrap">{tweet}</div>
+            </div>
+          ))}
+        </div>
+      )}
+      {!tweets && !!plan && (
         <div className="mt-2 rounded-md bg-muted/40 px-3 py-2 text-sm text-muted-foreground whitespace-pre-wrap font-mono text-xs max-h-48 overflow-y-auto">
           {String(plan)}
         </div>
       )}
-      {!plan && (
+      {!tweets && !plan && (
         <pre className="mt-2 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground overflow-x-auto max-h-48">
           {JSON.stringify(payload, null, 2)}
         </pre>
       )}
+      <PayloadField label="Stats" value={payload.stats} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The `CeoStrategyPayload` component looked for `payload.plan`/`payload.description`/`payload.text` but agents sending tweet drafts use `payload.tweets` (an array)
- Since no keys matched, the UI fell through to `JSON.stringify(payload)` in a `<pre>` tag - showing raw JSON instead of readable tweets
- Now renders each tweet in its own card with a **Copy** button, plus shows topic/account/stats fields

## Changes
- `ui/src/components/ApprovalPayload.tsx`: Handle `tweets` array in `CeoStrategyPayload`, render as individual cards with copy-to-clipboard

## Test plan
- [ ] Create an approval with `payload.tweets` array - verify tweets render as individual cards
- [ ] Click "Copy" button on a tweet card - verify clipboard contains the tweet text
- [ ] Verify existing approval types (`hire_agent`, strategy with `plan`/`description`) still render correctly
- [ ] Verify fallback to JSON.stringify still works when no known keys match

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: UI-only change, no backend impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `CeoStrategyPayload` to properly render `payload.tweets` arrays as individual copy-pastable cards rather than falling through to a raw `JSON.stringify` dump. The logic change is straightforward and the existing plan/description/fallback paths are correctly preserved.

- **Clipboard safety**: `navigator.clipboard.writeText(tweet)` is called without guarding against `navigator.clipboard` being `undefined` (non-HTTPS / older browsers), and the returned `Promise` rejection is not handled — silent failures with no user feedback.
- **Runtime type safety**: `payload.tweets as string[]` is a TypeScript-only cast; non-string elements in the array would cause React render errors and pass wrong types to `writeText`. Using `String(tweet)` at call sites would be safer.
- **Stats object rendering**: `payload.stats` could be an object; `PayloadField` calls `String(value)` on it, producing `[object Object]` in the UI. A `JSON.stringify` fallback for object values would improve readability.
- **Empty tweets array**: An empty `[]` is truthy, so `{tweets && (...)}` will render a blank container when the array is empty — minor UI artifact.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for HTTPS-only deployments, but the unguarded clipboard call and unhandled Promise should be addressed before shipping to broader environments.
- The core rendering logic is correct and existing paths are preserved. However, the `navigator.clipboard` call can throw in non-secure contexts, the async rejection is silently dropped, and the type assertion provides no runtime protection — these are real edge-case bugs rather than theoretical ones.
- ui/src/components/ApprovalPayload.tsx — clipboard handling and type safety in the new tweets branch

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/components/ApprovalPayload.tsx | Adds tweet-card rendering to `CeoStrategyPayload` with a Copy button, but `navigator.clipboard` is unguarded (can throw in HTTP contexts), the Promise rejection is unhandled, the `tweets` type assertion is unchecked at runtime, and `payload.stats` objects will render as `[object Object]`. |

</details>

<sub>Last reviewed commit: 5f74073</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->