### PR TITLE
fix(ui): generic type-aware approval payload renderer

### DIFF
--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -25,7 +25,7 @@ export const typeIcon: Record<string, typeof UserPlus> = {
 export const defaultTypeIcon = ShieldCheck;
 
 function PayloadField({ label, value }: { label: string; value: unknown }) {
-  if (!value) return null;
+  if (value == null) return null;
   return (
     <div className="flex items-center gap-2">
       <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs">{label}</span>
@@ -88,21 +88,80 @@ export function HireAgentPayload({ payload }: { payload: Record<string, unknown>
   );
 }
 
-export function CeoStrategyPayload({ payload }: { payload: Record<string, unknown> }) {
-  const plan = payload.plan ?? payload.description ?? payload.strategy ?? payload.text;
-  return (
-    <div className="mt-3 space-y-1.5 text-sm">
-      <PayloadField label="Title" value={payload.title} />
-      {!!plan && (
-        <div className="mt-2 rounded-md bg-muted/40 px-3 py-2 text-sm text-muted-foreground whitespace-pre-wrap font-mono text-xs max-h-48 overflow-y-auto">
-          {String(plan)}
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string");
+}
+
+function PayloadValue({ label, value }: { label: string; value: unknown }) {
+  if (value == null || value === "") return null;
+
+  if (isStringArray(value)) {
+    return (
+      <div>
+        <span className="text-muted-foreground text-xs">{label}</span>
+        <div className="mt-1 space-y-2">
+          {value.map((item, i) => (
+            <div key={i} className="rounded-md border bg-card px-3 py-2">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs text-muted-foreground font-medium">
+                  {value.length > 1 ? `${i + 1} of ${value.length}` : label}
+                </span>
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={() => navigator.clipboard?.writeText(item).catch(() => {})}
+                >
+                  Copy
+                </button>
+              </div>
+              <div className="text-sm whitespace-pre-wrap">{item}</div>
+            </div>
+          ))}
         </div>
-      )}
-      {!plan && (
-        <pre className="mt-2 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground overflow-x-auto max-h-48">
-          {JSON.stringify(payload, null, 2)}
-        </pre>
-      )}
+      </div>
+    );
+  }
+
+  if (typeof value === "string" && value.length > 80) {
+    return (
+      <div>
+        <span className="text-muted-foreground text-xs">{label}</span>
+        <div className="mt-1 rounded-md bg-muted/40 px-3 py-2 text-sm whitespace-pre-wrap max-h-48 overflow-y-auto">
+          {value}
+        </div>
+      </div>
+    );
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return <PayloadField label={label} value={value} />;
+  }
+
+  return (
+    <div>
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <pre className="mt-1 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground overflow-x-auto max-h-32">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function formatLabel(key: string): string {
+  const spaced = key.replace(/([A-Z])/g, " $1").replace(/[_-]/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function GenericPayload({ payload }: { payload: Record<string, unknown> }) {
+  const entries = Object.entries(payload).filter(([, v]) => v != null && v !== "");
+  if (entries.length === 0) {
+    return <p className="mt-3 text-sm text-muted-foreground">No payload data.</p>;
+  }
+  return (
+    <div className="mt-3 space-y-2 text-sm">
+      {entries.map(([key, value]) => (
+        <PayloadValue key={key} label={formatLabel(key)} value={value} />
+      ))}
     </div>
   );
 }
@@ -130,5 +189,5 @@ export function BudgetOverridePayload({ payload }: { payload: Record<string, unk
 export function ApprovalPayloadRenderer({ type, payload }: { type: string; payload: Record<string, unknown> }) {
   if (type === "hire_agent") return <HireAgentPayload payload={payload} />;
   if (type === "budget_override_required") return <BudgetOverridePayload payload={payload} />;
-  return <CeoStrategyPayload payload={payload} />;
+  return <GenericPayload payload={payload} />;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents submit approval requests with arbitrary payload shapes to the board UI
> - The board UI must render those payloads readably so humans can approve or reject them
> - The old renderer only handled a few hardcoded keys and dumped everything else as raw JSON
> - This PR replaces the hardcoded renderer with a generic type-aware component that introspects payload values
> - Any agent can now send any payload shape and get readable, copy-friendly rendering without further UI changes

## Summary
- The fallback `CeoStrategyPayload` renderer only handled a few hardcoded keys (`plan`, `description`, `strategy`, `text`) and dumped everything else as `JSON.stringify`
- Replace with `GenericPayload` that introspects payload values and renders based on type:
  - **String arrays** - copyable cards with "Copy" button (any multi-item content: action items, messages, steps, etc.)
  - **Long strings** (>80 chars) - scrollable text block
  - **Short scalars** - inline key-value pairs
  - **Objects/nested arrays** - formatted JSON
- Labels are auto-generated from camelCase/snake_case keys (`draftFile` -> `draft File`, `stats_line` -> `stats line`)
- Any agent can send any payload shape and get readable rendering without UI changes

## Before/After

**Before:** Non-`hire_agent` approvals with unrecognized keys render as raw JSON in a `<pre>` tag.

**After:** Each payload field renders with appropriate UI based on its data type. String arrays get individual cards with copy buttons.

## Test plan
- [ ] `hire_agent` approvals still use the dedicated `HireAgentPayload` renderer
- [ ] Approval with `payload.plan` (string) renders as scrollable text block
- [ ] Approval with string array field renders as individual copyable cards
- [ ] Approval with mixed types (strings, numbers, arrays, objects) renders each appropriately
- [ ] "Copy" button copies the correct text to clipboard
- [ ] Empty/null payload values are filtered out

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: UI-only change with no backend impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the narrow, hardcoded `CeoStrategyPayload` component with a type-aware `GenericPayload` renderer that inspects each payload value at runtime and picks an appropriate UI (copyable cards for string arrays, scrollable block for long strings, inline key-value for short scalars, formatted JSON for objects). The change is UI-only and makes the approval panel usable for any agent payload shape without requiring future UI edits.

Key points to address before merging:
- **Logic bug** – `PayloadField` uses a falsy guard (`if (!value) return null`), so numeric `0` and boolean `false` values that pass the `GenericPayload` filter are silently swallowed and never rendered.
- **Clipboard crash** – The Copy button calls `navigator.clipboard.writeText` directly; in non-secure (HTTP) contexts `navigator.clipboard` is `undefined`, producing a runtime `TypeError`. The returned Promise is also unhandled, so failures are silent.
- **Label capitalisation** – `formatLabel` does not capitalise the leading character, producing labels like `"draft File"` that are inconsistent with the title-cased hardcoded labels used in `HireAgentPayload`.

<h3>Confidence Score: 3/5</h3>

- Safe to merge in HTTPS-only environments after fixing the `PayloadField` falsy-guard logic bug; the clipboard crash is a real risk in non-secure contexts.
- The change is UI-only with no backend impact, but it contains a confirmed logic bug (0/false values silently dropped) and a potential runtime crash (clipboard API in non-HTTPS). Both are straightforward to fix but should be addressed before shipping.
- ui/src/components/ApprovalPayload.tsx – `PayloadField` falsy guard and clipboard safety.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/components/ApprovalPayload.tsx | Replaces the hardcoded `CeoStrategyPayload` with a type-aware `GenericPayload` renderer; has a logic bug where `0`/`false` scalar values are silently dropped by `PayloadField`'s falsy guard, a clipboard crash risk in non-HTTPS contexts, and a minor label capitalisation inconsistency. |

</details>

<sub>Last reviewed commit: 21c1dd5</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->
