### PR TITLE
feat(ui): add status-color left border to org chart cards

### DIFF
--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -131,6 +131,7 @@ const statusDotColor: Record<string, string> = {
   paused: "#facc15",
   idle: "#facc15",
   error: "#f87171",
+  pending_approval: "#fb923c",
   terminated: "#a3a3a3",
 };
 const defaultDotColor = "#a3a3a3";
@@ -384,6 +385,8 @@ export function OrgChart() {
                 top: node.y,
                 width: CARD_W,
                 minHeight: CARD_H,
+                borderLeftColor: dotColor,
+                borderLeftWidth: "3px",
               }}
               onClick={() => navigate(agent ? agentUrl(agent) : `/agents/${node.id}`)}
             >


### PR DESCRIPTION
Closes #334

## What

Adds a 3px colored left-border accent to each agent node in the org chart, making status immediately visible at a glance — even at small zoom levels where the existing status dot can be subtle.

Also adds the missing `pending_approval` status to the color map (orange `#fb923c`). It was the only value in `AGENT_STATUSES` with no explicit color, silently falling back to gray.

## Why this approach

- Uses the **existing** `statusDotColor` palette — no new colors invented, no new constants
- Inline `borderLeftColor` / `borderLeftWidth` on the card's existing style block — zero extra DOM elements
- Touches **1 file, 3 lines**

## Files changed

- `ui/src/pages/OrgChart.tsx` (+3 lines)