### PR TITLE
fix: inject PAPERCLIP_API_KEY into process adapter environment

### DIFF
--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -18,6 +18,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  if (ctx.authToken) env.PAPERCLIP_API_KEY = ctx.authToken;
+  if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }

--- a/server/src/adapters/process/index.ts
+++ b/server/src/adapters/process/index.ts
@@ -7,6 +7,7 @@ export const processAdapter: ServerAdapterModule = {
   execute,
   testEnvironment,
   models: [],
+  supportsLocalAgentJwt: true,
   agentConfigurationDoc: `# process agent configuration
 
 Adapter: process


### PR DESCRIPTION
## Summary

- The `process` adapter was not setting `supportsLocalAgentJwt: true`, so the heartbeat service never generated an auth token for it
- Even if a token were available, the adapter's `execute` function never read `ctx.authToken` and never set `PAPERCLIP_API_KEY` in the child process environment
- This caused agents using the `process` adapter (and any unknown adapter type that falls back to it) to get `401 Unauthorized` on every Paperclip API call

The fix adds two lines to `execute.ts`:
```ts
if (ctx.authToken) env.PAPERCLIP_API_KEY = ctx.authToken;
if (ctx.runId)    env.PAPERCLIP_RUN_ID  = ctx.runId;
```
And sets `supportsLocalAgentJwt: true` on the adapter module so the heartbeat service generates the JWT in the first place.

## Test plan

- [ ] Create an agent using the `process` adapter type
- [ ] Run a heartbeat and confirm `PAPERCLIP_API_KEY` is present in the child process environment
- [ ] Verify `curl "$PAPERCLIP_API_URL/api/issues/<id>" -H "Authorization: Bearer $PAPERCLIP_API_KEY"` returns issue data instead of `{"error":"Unauthorized"}`
- [ ] Confirm that agents using unknown/custom adapter types (which fall back to `process`) also receive the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)