### PR TITLE
Fix observability runs endpoint and dashboard run series

### DIFF
--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -20,9 +20,18 @@ Returns a summary including:
 - **Stale tasks** — tasks in progress with no recent activity
 - **Cost summary** — current month spend vs budget
 - **Recent activity** — latest mutations
+- **Run success/failure series** — 14-day heartbeat outcome trend
 
 ## Use Cases
 
 - Board operators: quick health check from the web UI
 - CEO agents: situational awareness at the start of each heartbeat
 - Manager agents: check team status and identify blockers
+
+## Run Series Shape
+
+`runs.successFailureSeries` contains 14 UTC day buckets:
+
+- `date` (`YYYY-MM-DD`)
+- `succeeded` — succeeded run count
+- `failed` — failed + timed_out + cancelled run count

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -19,4 +19,11 @@ export interface DashboardSummary {
   };
   pendingApprovals: number;
   staleTasks: number;
+  runs: {
+    successFailureSeries: Array<{
+      date: string;
+      succeeded: number;
+      failed: number;
+    }>;
+  };
 }

--- a/server/src/__tests__/agents-runs-route.test.ts
+++ b/server/src/__tests__/agents-runs-route.test.ts
@@ -1,0 +1,73 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+
+const mocks = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+    resolveByReference: vi.fn(),
+    getChainOfCommand: vi.fn(),
+  }),
+  approvalService: () => ({}),
+  heartbeatService: () => ({
+    list: mocks.listRuns,
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => ({}),
+  logActivity: vi.fn(),
+  secretService: () => ({
+    resolveAdapterConfigForRuntime: vi.fn(),
+  }),
+}));
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source: "local_implicit",
+      userId: "local-board",
+      isInstanceAdmin: true,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  return app;
+}
+
+describe("company runs routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listRuns.mockResolvedValue([{ id: "run-1", status: "succeeded" }]);
+  });
+
+  it("serves /companies/:companyId/runs", async () => {
+    const app = makeApp();
+
+    const res = await request(app).get("/api/companies/company-1/runs?agentId=agent-1&limit=200");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: "run-1", status: "succeeded" }]);
+    expect(mocks.listRuns).toHaveBeenCalledWith("company-1", "agent-1", 200);
+  });
+
+  it("keeps /companies/:companyId/heartbeat-runs behavior", async () => {
+    const app = makeApp();
+
+    const res = await request(app).get("/api/companies/company-1/heartbeat-runs?limit=200");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: "run-1", status: "succeeded" }]);
+    expect(mocks.listRuns).toHaveBeenCalledWith("company-1", undefined, 200);
+  });
+});

--- a/server/src/__tests__/dashboard-route.test.ts
+++ b/server/src/__tests__/dashboard-route.test.ts
@@ -1,0 +1,60 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { dashboardRoutes } from "../routes/dashboard.js";
+
+const mocks = vi.hoisted(() => ({
+  summary: vi.fn(),
+}));
+
+vi.mock("../services/dashboard.js", () => ({
+  dashboardService: () => ({
+    summary: mocks.summary,
+  }),
+}));
+
+function makeApp() {
+  const app = express();
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source: "local_implicit",
+      userId: "local-board",
+      isInstanceAdmin: true,
+    };
+    next();
+  });
+  app.use("/api", dashboardRoutes({} as any));
+  return app;
+}
+
+describe("dashboard route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.summary.mockResolvedValue({
+      companyId: "company-1",
+      agents: { active: 0, running: 0, paused: 0, error: 0 },
+      tasks: { open: 0, inProgress: 0, blocked: 0, done: 0 },
+      costs: { monthSpendCents: 0, monthBudgetCents: 0, monthUtilizationPercent: 0 },
+      pendingApprovals: 0,
+      staleTasks: 0,
+      runs: {
+        successFailureSeries: [
+          { date: "2026-03-01", succeeded: 1, failed: 0 },
+        ],
+      },
+    });
+  });
+
+  it("returns dashboard summary including run success/failure series", async () => {
+    const app = makeApp();
+
+    const res = await request(app).get("/api/companies/company-1/dashboard");
+
+    expect(res.status).toBe(200);
+    expect(res.body.runs.successFailureSeries).toEqual([
+      { date: "2026-03-01", succeeded: 1, failed: 0 },
+    ]);
+    expect(mocks.summary).toHaveBeenCalledWith("company-1");
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,4 +1,4 @@
-import { Router, type Request } from "express";
+import { Router, type Request, type Response } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
@@ -1280,7 +1280,7 @@ export function agentRoutes(db: Db) {
     res.json(result);
   });
 
-  router.get("/companies/:companyId/heartbeat-runs", async (req, res) => {
+  async function listCompanyRuns(req: Request, res: Response) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const agentId = req.query.agentId as string | undefined;
@@ -1288,7 +1288,10 @@ export function agentRoutes(db: Db) {
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
     const runs = await heartbeat.list(companyId, agentId, limit);
     res.json(runs);
-  });
+  }
+
+  router.get("/companies/:companyId/heartbeat-runs", listCompanyRuns);
+  router.get("/companies/:companyId/runs", listCompanyRuns);
 
   router.get("/companies/:companyId/live-runs", async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,6 +1,6 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, companies, costEvents, issues } from "@paperclipai/db";
+import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
 
 export function dashboardService(db: Db) {
@@ -92,6 +92,48 @@ export function dashboardService(db: Db) {
           ? (monthSpendCents / company.budgetMonthlyCents) * 100
           : 0;
 
+      const runSeriesStart = new Date();
+      runSeriesStart.setUTCHours(0, 0, 0, 0);
+      runSeriesStart.setUTCDate(runSeriesStart.getUTCDate() - 13);
+
+      const runSeriesRows = await db
+        .select({
+          day: sql<string>`to_char(date_trunc('day', ${heartbeatRuns.createdAt}), 'YYYY-MM-DD')`,
+          status: heartbeatRuns.status,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            gte(heartbeatRuns.createdAt, runSeriesStart),
+            inArray(heartbeatRuns.status, ["succeeded", "failed", "cancelled", "timed_out"]),
+          ),
+        )
+        .groupBy(sql`date_trunc('day', ${heartbeatRuns.createdAt})`, heartbeatRuns.status);
+
+      const successFailureSeries = Array.from({ length: 14 }, (_value, index) => {
+        const day = new Date(runSeriesStart);
+        day.setUTCDate(runSeriesStart.getUTCDate() + index);
+        return {
+          date: day.toISOString().slice(0, 10),
+          succeeded: 0,
+          failed: 0,
+        };
+      });
+      const runSeriesByDate = new Map(successFailureSeries.map((entry) => [entry.date, entry]));
+
+      for (const row of runSeriesRows) {
+        const bucket = runSeriesByDate.get(row.day);
+        if (!bucket) continue;
+        const count = Number(row.count);
+        if (row.status === "succeeded") {
+          bucket.succeeded += count;
+          continue;
+        }
+        bucket.failed += count;
+      }
+
       return {
         companyId,
         agents: {
@@ -108,6 +150,9 @@ export function dashboardService(db: Db) {
         },
         pendingApprovals,
         staleTasks,
+        runs: {
+          successFailureSeries,
+        },
       };
     },
   };


### PR DESCRIPTION
## Summary
- add GET /api/companies/:companyId/runs as an alias of /heartbeat-runs for observability clients
- extend dashboard summary with runs.successFailureSeries (14 UTC day buckets)
- document the dashboard runs field in API docs
- add route tests for runs alias and dashboard runs payload

## Validation
- pnpm --filter @paperclipai/shared typecheck
- full workspace/server checks are currently blocked in this environment by existing module resolution and sandbox listen restrictions