### PR TITLE
feat: drag-and-drop reordering for org chart

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -124,22 +121,6 @@ importers:
         version: 5.9.3
 
   packages/adapters/cursor-local:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
-  packages/adapters/openclaw:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -261,9 +242,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -379,9 +357,6 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
-      '@paperclipai/adapter-openclaw':
-        specifier: workspace:*
-        version: link:../packages/adapters/openclaw
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -180,12 +180,12 @@ interface OrgCardProps {
 }
 
 function OrgCard({ node, agent, isCeo, isDragging, isDropTarget, isInvalidDrop, onNavigate }: OrgCardProps) {
-  const { attributes, listeners, setNodeRef: setDragRef, transform } = useDraggable({
+  const { attributes, listeners, setNodeRef: setDragRef } = useDraggable({
     id: node.id,
     disabled: isCeo,
   });
 
-  const { setNodeRef: setDropRef, isOver } = useDroppable({
+  const { setNodeRef: setDropRef } = useDroppable({
     id: `drop-${node.id}`,
     data: { agentId: node.id, role: node.role },
   });

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -218,23 +218,26 @@ function OrgCard({ node, agent, isCeo, isDragging, isDropTarget, isInvalidDrop, 
         cursor: isCeo ? "default" : "grab",
       }}
     >
-      <div className="flex items-center px-4 py-3 gap-3">
-        {/* Drag handle (not for CEO) */}
-        {!isCeo ? (
-          <div
-            {...listeners}
-            {...attributes}
-            className="shrink-0 cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground/70 transition-colors"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <GripVertical className="h-4 w-4" />
-          </div>
-        ) : (
-          <div className="shrink-0 text-amber-500/60" title="CEO position is locked">
-            <Lock className="h-3.5 w-3.5" />
-          </div>
-        )}
+      {/* Drag handle — top-left absolute overlay */}
+      {!isCeo ? (
+        <div
+          {...listeners}
+          {...attributes}
+          className="absolute -top-2 -left-2 z-10 w-6 h-6 rounded-full bg-background border border-border shadow-sm flex items-center justify-center cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground/80 hover:border-foreground/30 transition-colors"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical className="h-3 w-3" />
+        </div>
+      ) : (
+        <div
+          className="absolute -top-2 -left-2 z-10 w-6 h-6 rounded-full bg-background border border-amber-500/40 shadow-sm flex items-center justify-center text-amber-500/60"
+          title="CEO position is locked"
+        >
+          <Lock className="h-3 w-3" />
+        </div>
+      )}
 
+      <div className="flex items-center px-4 py-3 gap-3">
         {/* Agent icon + status dot */}
         <div className="relative shrink-0" onClick={onNavigate}>
           <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center cursor-pointer">

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { useNavigate } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { agentsApi, type OrgNode } from "../api/agents";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -9,8 +9,19 @@ import { agentUrl } from "../lib/utils";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
-import { Network } from "lucide-react";
+import { Network, Lock, GripVertical } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
+import {
+  DndContext,
+  DragOverlay,
+  useDraggable,
+  useDroppable,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
 
 // Layout constants
 const CARD_W = 200;
@@ -73,8 +84,6 @@ function layoutTree(node: OrgNode, x: number, y: number): LayoutNode {
 function layoutForest(roots: OrgNode[]): LayoutNode[] {
   if (roots.length === 0) return [];
 
-  const totalW = roots.reduce((sum, r) => sum + subtreeWidth(r), 0);
-  const gaps = (roots.length - 1) * GAP_X;
   let x = PADDING;
   const y = PADDING;
 
@@ -85,7 +94,6 @@ function layoutForest(roots: OrgNode[]): LayoutNode[] {
     x += w + GAP_X;
   }
 
-  // Compute bounds and return
   return result;
 }
 
@@ -113,6 +121,30 @@ function collectEdges(nodes: LayoutNode[]): Array<{ parent: LayoutNode; child: L
   return edges;
 }
 
+/** Check if targetId is a descendant of sourceId in the org tree. */
+function isDescendant(nodes: OrgNode[], sourceId: string, targetId: string): boolean {
+  function findNode(tree: OrgNode[], id: string): OrgNode | null {
+    for (const n of tree) {
+      if (n.id === id) return n;
+      const found = findNode(n.reports, id);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  function hasDescendant(node: OrgNode, id: string): boolean {
+    for (const child of node.reports) {
+      if (child.id === id) return true;
+      if (hasDescendant(child, id)) return true;
+    }
+    return false;
+  }
+
+  const source = findNode(nodes, sourceId);
+  if (!source) return false;
+  return hasDescendant(source, targetId);
+}
+
 // ── Status dot colors (raw hex for SVG) ─────────────────────────────────
 
 const adapterLabels: Record<string, string> = {
@@ -135,12 +167,159 @@ const statusDotColor: Record<string, string> = {
 };
 const defaultDotColor = "#a3a3a3";
 
+// ── Draggable card component ────────────────────────────────────────────
+
+interface OrgCardProps {
+  node: LayoutNode;
+  agent: Agent | undefined;
+  isCeo: boolean;
+  isDragging: boolean;
+  isDropTarget: boolean;
+  isInvalidDrop: boolean;
+  onNavigate: () => void;
+}
+
+function OrgCard({ node, agent, isCeo, isDragging, isDropTarget, isInvalidDrop, onNavigate }: OrgCardProps) {
+  const { attributes, listeners, setNodeRef: setDragRef, transform } = useDraggable({
+    id: node.id,
+    disabled: isCeo,
+  });
+
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: `drop-${node.id}`,
+    data: { agentId: node.id, role: node.role },
+  });
+
+  const dotColor = statusDotColor[node.status] ?? defaultDotColor;
+  const showDropHighlight = isDropTarget && !isInvalidDrop;
+  const showDropError = isDropTarget && isInvalidDrop;
+
+  return (
+    <div
+      ref={(el) => {
+        setDragRef(el);
+        setDropRef(el);
+      }}
+      data-org-card
+      className={`absolute bg-card border rounded-lg shadow-sm transition-all duration-150 select-none ${
+        isDragging
+          ? "opacity-30 scale-95"
+          : showDropHighlight
+            ? "border-blue-500 ring-2 ring-blue-500/30 shadow-lg scale-105"
+            : showDropError
+              ? "border-red-400 ring-2 ring-red-400/30"
+              : "border-border hover:shadow-md hover:border-foreground/20"
+      }`}
+      style={{
+        left: node.x,
+        top: node.y,
+        width: CARD_W,
+        minHeight: CARD_H,
+        cursor: isCeo ? "default" : "grab",
+      }}
+    >
+      <div className="flex items-center px-4 py-3 gap-3">
+        {/* Drag handle (not for CEO) */}
+        {!isCeo ? (
+          <div
+            {...listeners}
+            {...attributes}
+            className="shrink-0 cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground/70 transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <GripVertical className="h-4 w-4" />
+          </div>
+        ) : (
+          <div className="shrink-0 text-amber-500/60" title="CEO position is locked">
+            <Lock className="h-3.5 w-3.5" />
+          </div>
+        )}
+
+        {/* Agent icon + status dot */}
+        <div className="relative shrink-0" onClick={onNavigate}>
+          <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center cursor-pointer">
+            <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />
+          </div>
+          <span
+            className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"
+            style={{ backgroundColor: dotColor }}
+          />
+        </div>
+
+        {/* Name + role + adapter type */}
+        <div className="flex flex-col items-start min-w-0 flex-1 cursor-pointer" onClick={onNavigate}>
+          <span className="text-sm font-semibold text-foreground leading-tight">
+            {node.name}
+          </span>
+          <span className="text-[11px] text-muted-foreground leading-tight mt-0.5">
+            {agent?.title ?? roleLabel(node.role)}
+          </span>
+          {agent && (
+            <span className="text-[10px] text-muted-foreground/60 font-mono leading-tight mt-1">
+              {adapterLabels[agent.adapterType] ?? agent.adapterType}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Drop indicator text */}
+      {showDropHighlight && (
+        <div className="absolute -bottom-6 left-0 right-0 text-center text-[10px] text-blue-500 font-medium">
+          Move here
+        </div>
+      )}
+      {showDropError && (
+        <div className="absolute -bottom-6 left-0 right-0 text-center text-[10px] text-red-400 font-medium">
+          Cannot move here
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Drag overlay card (follows cursor) ──────────────────────────────────
+
+function DragOverlayCard({ node, agent }: { node: LayoutNode; agent: Agent | undefined }) {
+  const dotColor = statusDotColor[node.status] ?? defaultDotColor;
+
+  return (
+    <div
+      className="bg-card border border-blue-500 rounded-lg shadow-xl select-none"
+      style={{ width: CARD_W, minHeight: CARD_H }}
+    >
+      <div className="flex items-center px-4 py-3 gap-3">
+        <div className="shrink-0 text-blue-500">
+          <GripVertical className="h-4 w-4" />
+        </div>
+        <div className="relative shrink-0">
+          <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center">
+            <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />
+          </div>
+          <span
+            className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"
+            style={{ backgroundColor: dotColor }}
+          />
+        </div>
+        <div className="flex flex-col items-start min-w-0 flex-1">
+          <span className="text-sm font-semibold text-foreground leading-tight">
+            {node.name}
+          </span>
+          <span className="text-[11px] text-muted-foreground leading-tight mt-0.5">
+            {agent?.title ?? roleLabel(node.role)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Main component ──────────────────────────────────────────────────────
 
 export function OrgChart() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { data: orgTree, isLoading } = useQuery({
     queryKey: queryKeys.org(selectedCompanyId!),
@@ -184,8 +363,88 @@ export function OrgChart() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
-  const [dragging, setDragging] = useState(false);
-  const dragStart = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
+  const [panning, setPanning] = useState(false);
+  const panStart = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
+
+  // Drag & drop state
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [overDropId, setOverDropId] = useState<string | null>(null);
+
+  // Mutation for updating agent reportsTo
+  const updateReportsTo = useMutation({
+    mutationFn: async ({ agentId, reportsTo }: { agentId: string; reportsTo: string | null }) => {
+      return agentsApi.update(agentId, { reportsTo }, selectedCompanyId ?? undefined);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.org(selectedCompanyId!) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId!) });
+    },
+  });
+
+  // DnD sensors — use a distance activation so clicks still work
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(event.active.id as string);
+  }, []);
+
+  const handleDragOver = useCallback((event: { over: { id: string | number } | null }) => {
+    if (event.over) {
+      // Strip `drop-` prefix
+      const dropId = String(event.over.id).replace(/^drop-/, "");
+      setOverDropId(dropId);
+    } else {
+      setOverDropId(null);
+    }
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const draggedId = event.active.id as string;
+      const overId = event.over ? String(event.over.id).replace(/^drop-/, "") : null;
+
+      setActiveDragId(null);
+      setOverDropId(null);
+
+      if (!overId || overId === draggedId) return;
+
+      // Don't allow dropping onto self or descendants
+      if (orgTree && isDescendant(orgTree, draggedId, overId)) return;
+
+      // Don't allow dropping a CEO
+      const draggedNode = allNodes.find((n) => n.id === draggedId);
+      if (draggedNode?.role === "ceo") return;
+
+      // Don't allow dropping onto a terminated agent
+      const targetNode = allNodes.find((n) => n.id === overId);
+      if (targetNode?.status === "terminated") return;
+
+      // Update reportsTo
+      updateReportsTo.mutate({ agentId: draggedId, reportsTo: overId });
+    },
+    [orgTree, allNodes, updateReportsTo],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setActiveDragId(null);
+    setOverDropId(null);
+  }, []);
+
+  // Determine invalid drop
+  const isInvalidDropTarget = useMemo(() => {
+    if (!activeDragId || !overDropId) return false;
+    if (activeDragId === overDropId) return true;
+    if (orgTree && isDescendant(orgTree, activeDragId, overDropId)) return true;
+    const targetNode = allNodes.find((n) => n.id === overDropId);
+    if (targetNode?.status === "terminated") return true;
+    return false;
+  }, [activeDragId, overDropId, orgTree, allNodes]);
 
   // Center the chart on first load
   const hasInitialized = useRef(false);
@@ -197,7 +456,6 @@ export function OrgChart() {
     const containerW = container.clientWidth;
     const containerH = container.clientHeight;
 
-    // Fit chart to container
     const scaleX = (containerW - 40) / bounds.width;
     const scaleY = (containerH - 40) / bounds.height;
     const fitZoom = Math.min(scaleX, scaleY, 1);
@@ -214,22 +472,21 @@ export function OrgChart() {
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
-    // Don't drag if clicking a card
     const target = e.target as HTMLElement;
     if (target.closest("[data-org-card]")) return;
-    setDragging(true);
-    dragStart.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y };
+    setPanning(true);
+    panStart.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y };
   }, [pan]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!dragging) return;
-    const dx = e.clientX - dragStart.current.x;
-    const dy = e.clientY - dragStart.current.y;
-    setPan({ x: dragStart.current.panX + dx, y: dragStart.current.panY + dy });
-  }, [dragging]);
+    if (!panning) return;
+    const dx = e.clientX - panStart.current.x;
+    const dy = e.clientY - panStart.current.y;
+    setPan({ x: panStart.current.panX + dx, y: panStart.current.panY + dy });
+  }, [panning]);
 
   const handleMouseUp = useCallback(() => {
-    setDragging(false);
+    setPanning(false);
   }, []);
 
   const handleWheel = useCallback((e: React.WheelEvent) => {
@@ -244,7 +501,6 @@ export function OrgChart() {
     const factor = e.deltaY < 0 ? 1.1 : 0.9;
     const newZoom = Math.min(Math.max(zoom * factor, 0.2), 2);
 
-    // Zoom toward mouse position
     const scale = newZoom / zoom;
     setPan({
       x: mouseX - scale * (mouseX - pan.x),
@@ -252,6 +508,12 @@ export function OrgChart() {
     });
     setZoom(newZoom);
   }, [zoom, pan]);
+
+  // Active drag node for overlay
+  const activeDragNode = useMemo(
+    () => (activeDragId ? allNodes.find((n) => n.id === activeDragId) ?? null : null),
+    [activeDragId, allNodes],
+  );
 
   if (!selectedCompanyId) {
     return <EmptyState icon={Network} message="Select a company to view the org chart." />;
@@ -266,158 +528,170 @@ export function OrgChart() {
   }
 
   return (
-    <div
-      ref={containerRef}
-      className="w-full h-[calc(100vh-4rem)] overflow-hidden relative bg-muted/20 border border-border rounded-lg"
-      style={{ cursor: dragging ? "grabbing" : "grab" }}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
-      onWheel={handleWheel}
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
-      {/* Zoom controls */}
-      <div className="absolute top-3 right-3 z-10 flex flex-col gap-1">
-        <button
-          className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
-          onClick={() => {
-            const newZoom = Math.min(zoom * 1.2, 2);
-            const container = containerRef.current;
-            if (container) {
-              const cx = container.clientWidth / 2;
-              const cy = container.clientHeight / 2;
-              const scale = newZoom / zoom;
-              setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
-            }
-            setZoom(newZoom);
-          }}
-          aria-label="Zoom in"
-        >
-          +
-        </button>
-        <button
-          className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
-          onClick={() => {
-            const newZoom = Math.max(zoom * 0.8, 0.2);
-            const container = containerRef.current;
-            if (container) {
-              const cx = container.clientWidth / 2;
-              const cy = container.clientHeight / 2;
-              const scale = newZoom / zoom;
-              setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
-            }
-            setZoom(newZoom);
-          }}
-          aria-label="Zoom out"
-        >
-          &minus;
-        </button>
-        <button
-          className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-accent transition-colors"
-          onClick={() => {
-            if (!containerRef.current) return;
-            const cW = containerRef.current.clientWidth;
-            const cH = containerRef.current.clientHeight;
-            const scaleX = (cW - 40) / bounds.width;
-            const scaleY = (cH - 40) / bounds.height;
-            const fitZoom = Math.min(scaleX, scaleY, 1);
-            const chartW = bounds.width * fitZoom;
-            const chartH = bounds.height * fitZoom;
-            setZoom(fitZoom);
-            setPan({ x: (cW - chartW) / 2, y: (cH - chartH) / 2 });
-          }}
-          title="Fit to screen"
-          aria-label="Fit chart to screen"
-        >
-          Fit
-        </button>
-      </div>
-
-      {/* SVG layer for edges */}
-      <svg
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          width: "100%",
-          height: "100%",
-        }}
+      <div
+        ref={containerRef}
+        className="w-full h-[calc(100vh-4rem)] overflow-hidden relative bg-muted/20 border border-border rounded-lg"
+        style={{ cursor: panning ? "grabbing" : activeDragId ? "default" : "grab" }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
       >
-        <g transform={`translate(${pan.x}, ${pan.y}) scale(${zoom})`}>
-          {edges.map(({ parent, child }) => {
-            const x1 = parent.x + CARD_W / 2;
-            const y1 = parent.y + CARD_H;
-            const x2 = child.x + CARD_W / 2;
-            const y2 = child.y;
-            const midY = (y1 + y2) / 2;
+        {/* Drag mode banner */}
+        {activeDragId && (
+          <div className="absolute top-3 left-3 z-10 bg-blue-500/10 border border-blue-500/30 rounded-md px-3 py-1.5 text-xs text-blue-500 font-medium">
+            Drop on another agent to reassign reporting line
+          </div>
+        )}
+
+        {/* Mutation status toast */}
+        {updateReportsTo.isPending && (
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 bg-foreground text-background rounded-md px-4 py-2 text-sm font-medium shadow-lg">
+            Updating org structure…
+          </div>
+        )}
+        {updateReportsTo.isError && (
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 bg-red-500 text-white rounded-md px-4 py-2 text-sm font-medium shadow-lg">
+            Failed to update: {(updateReportsTo.error as Error)?.message ?? "Unknown error"}
+          </div>
+        )}
+
+        {/* Zoom controls */}
+        <div className="absolute top-3 right-3 z-10 flex flex-col gap-1">
+          <button
+            className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+            onClick={() => {
+              const newZoom = Math.min(zoom * 1.2, 2);
+              const container = containerRef.current;
+              if (container) {
+                const cx = container.clientWidth / 2;
+                const cy = container.clientHeight / 2;
+                const scale = newZoom / zoom;
+                setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
+              }
+              setZoom(newZoom);
+            }}
+            aria-label="Zoom in"
+          >
+            +
+          </button>
+          <button
+            className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+            onClick={() => {
+              const newZoom = Math.max(zoom * 0.8, 0.2);
+              const container = containerRef.current;
+              if (container) {
+                const cx = container.clientWidth / 2;
+                const cy = container.clientHeight / 2;
+                const scale = newZoom / zoom;
+                setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
+              }
+              setZoom(newZoom);
+            }}
+            aria-label="Zoom out"
+          >
+            &minus;
+          </button>
+          <button
+            className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-accent transition-colors"
+            onClick={() => {
+              if (!containerRef.current) return;
+              const cW = containerRef.current.clientWidth;
+              const cH = containerRef.current.clientHeight;
+              const scaleX = (cW - 40) / bounds.width;
+              const scaleY = (cH - 40) / bounds.height;
+              const fitZoom = Math.min(scaleX, scaleY, 1);
+              const chartW = bounds.width * fitZoom;
+              const chartH = bounds.height * fitZoom;
+              setZoom(fitZoom);
+              setPan({ x: (cW - chartW) / 2, y: (cH - chartH) / 2 });
+            }}
+            title="Fit to screen"
+            aria-label="Fit chart to screen"
+          >
+            Fit
+          </button>
+        </div>
+
+        {/* SVG layer for edges */}
+        <svg
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            width: "100%",
+            height: "100%",
+          }}
+        >
+          <g transform={`translate(${pan.x}, ${pan.y}) scale(${zoom})`}>
+            {edges.map(({ parent, child }) => {
+              const x1 = parent.x + CARD_W / 2;
+              const y1 = parent.y + CARD_H;
+              const x2 = child.x + CARD_W / 2;
+              const y2 = child.y;
+              const midY = (y1 + y2) / 2;
+
+              // Highlight edge if child is being dragged
+              const isActive = activeDragId === child.id;
+
+              return (
+                <path
+                  key={`${parent.id}-${child.id}`}
+                  d={`M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}`}
+                  fill="none"
+                  stroke={isActive ? "var(--color-blue-500, #3b82f6)" : "var(--border)"}
+                  strokeWidth={isActive ? 2 : 1.5}
+                  strokeDasharray={isActive ? "6 4" : undefined}
+                  opacity={isActive ? 0.5 : 1}
+                />
+              );
+            })}
+          </g>
+        </svg>
+
+        {/* Card layer */}
+        <div
+          className="absolute inset-0"
+          style={{
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {allNodes.map((node) => {
+            const agent = agentMap.get(node.id);
+            const isCeo = node.role === "ceo";
+            const isDragging = activeDragId === node.id;
+            const isDropTarget = overDropId === node.id && activeDragId !== null && activeDragId !== node.id;
 
             return (
-              <path
-                key={`${parent.id}-${child.id}`}
-                d={`M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}`}
-                fill="none"
-                stroke="var(--border)"
-                strokeWidth={1.5}
+              <OrgCard
+                key={node.id}
+                node={node}
+                agent={agent}
+                isCeo={isCeo}
+                isDragging={isDragging}
+                isDropTarget={isDropTarget}
+                isInvalidDrop={isDropTarget && isInvalidDropTarget}
+                onNavigate={() => navigate(agent ? agentUrl(agent) : `/agents/${node.id}`)}
               />
             );
           })}
-        </g>
-      </svg>
-
-      {/* Card layer */}
-      <div
-        className="absolute inset-0"
-        style={{
-          transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
-          transformOrigin: "0 0",
-        }}
-      >
-        {allNodes.map((node) => {
-          const agent = agentMap.get(node.id);
-          const dotColor = statusDotColor[node.status] ?? defaultDotColor;
-
-          return (
-            <div
-              key={node.id}
-              data-org-card
-              className="absolute bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-foreground/20 transition-[box-shadow,border-color] duration-150 cursor-pointer select-none"
-              style={{
-                left: node.x,
-                top: node.y,
-                width: CARD_W,
-                minHeight: CARD_H,
-              }}
-              onClick={() => navigate(agent ? agentUrl(agent) : `/agents/${node.id}`)}
-            >
-              <div className="flex items-center px-4 py-3 gap-3">
-                {/* Agent icon + status dot */}
-                <div className="relative shrink-0">
-                  <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center">
-                    <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />
-                  </div>
-                  <span
-                    className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"
-                    style={{ backgroundColor: dotColor }}
-                  />
-                </div>
-                {/* Name + role + adapter type */}
-                <div className="flex flex-col items-start min-w-0 flex-1">
-                  <span className="text-sm font-semibold text-foreground leading-tight">
-                    {node.name}
-                  </span>
-                  <span className="text-[11px] text-muted-foreground leading-tight mt-0.5">
-                    {agent?.title ?? roleLabel(node.role)}
-                  </span>
-                  {agent && (
-                    <span className="text-[10px] text-muted-foreground/60 font-mono leading-tight mt-1">
-                      {adapterLabels[agent.adapterType] ?? agent.adapterType}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
-          );
-        })}
+        </div>
       </div>
-    </div>
+
+      {/* Drag overlay — follows cursor outside the transform */}
+      <DragOverlay dropAnimation={null}>
+        {activeDragNode ? (
+          <DragOverlayCard node={activeDragNode} agent={agentMap.get(activeDragNode.id)} />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 }
 

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -211,11 +211,12 @@ function OrgCard({ node, agent, isCeo, isDragging, isDropTarget, isInvalidDrop, 
               : "border-border hover:shadow-md hover:border-foreground/20"
       }`}
       style={{
+      style={{
         left: node.x,
         top: node.y,
         width: CARD_W,
         minHeight: CARD_H,
-        cursor: isCeo ? "default" : "grab",
+        cursor: "default",
       }}
     >
       {/* Drag handle — top-left absolute overlay */}

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -376,6 +376,9 @@ export function OrgChart() {
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [overDropId, setOverDropId] = useState<string | null>(null);
 
+  // Timed error toast state
+  const [dragError, setDragError] = useState<string | null>(null);
+
   // Mutation for updating agent reportsTo
   const updateReportsTo = useMutation({
     mutationFn: async ({ agentId, reportsTo }: { agentId: string; reportsTo: string | null }) => {
@@ -384,6 +387,10 @@ export function OrgChart() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.org(selectedCompanyId!) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId!) });
+    },
+    onError: (error: Error) => {
+      setDragError(error.message ?? "Unknown error");
+      setTimeout(() => setDragError(null), 4000);
     },
   });
 
@@ -568,9 +575,10 @@ export function OrgChart() {
             Updating org structure…
           </div>
         )}
-        {updateReportsTo.isError && (
-          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 bg-red-500 text-white rounded-md px-4 py-2 text-sm font-medium shadow-lg">
-            Failed to update: {(updateReportsTo.error as Error)?.message ?? "Unknown error"}
+        {dragError && (
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 bg-red-500 text-white rounded-md px-4 py-2 text-sm font-medium shadow-lg flex items-center gap-2">
+            <span>Failed to update: {dragError}</span>
+            <button onClick={() => setDragError(null)} className="ml-1 hover:text-white/70 text-white font-bold">✕</button>
           </div>
         )}
 

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -420,6 +420,10 @@ export function OrgChart() {
 
       if (!overId || overId === draggedId) return;
 
+      // Don't re-parent to the current parent (no-op)
+      const currentParent = agentMap.get(draggedId)?.reportsTo;
+      if (currentParent === overId) return;
+
       // Don't allow dropping onto self or descendants
       if (orgTree && isDescendant(orgTree, draggedId, overId)) return;
 

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -287,13 +287,15 @@ function DragOverlayCard({ node, agent }: { node: LayoutNode; agent: Agent | und
 
   return (
     <div
-      className="bg-card border border-blue-500 rounded-lg shadow-xl select-none"
+      className="bg-card border border-blue-500 rounded-lg shadow-xl select-none relative"
       style={{ width: CARD_W, minHeight: CARD_H }}
     >
+      {/* Drag handle — same absolute top-left position as OrgCard */}
+      <div className="absolute -top-2 -left-2 z-10 w-6 h-6 rounded-full bg-background border border-blue-500 shadow-sm flex items-center justify-center text-blue-500">
+        <GripVertical className="h-3 w-3" />
+      </div>
+
       <div className="flex items-center px-4 py-3 gap-3">
-        <div className="shrink-0 text-blue-500">
-          <GripVertical className="h-4 w-4" />
-        </div>
         <div className="relative shrink-0">
           <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center">
             <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -399,7 +399,7 @@ export function OrgChart() {
     setActiveDragId(event.active.id as string);
   }, []);
 
-  const handleDragOver = useCallback((event: { over: { id: string | number } | null }) => {
+  const handleDragOver = useCallback((event: DragOverEvent) => {
     if (event.over) {
       // Strip `drop-` prefix
       const dropId = String(event.over.id).replace(/^drop-/, "");


### PR DESCRIPTION
## Changes

- Add drag-and-drop reordering to org chart (reparent agents by dragging)
- CEO position is locked (cannot be dragged)
- Drag handle as absolute-positioned grip icon (top-left corner)
- Drag overlay card mirrors the same grip positioning
- Visual feedback: blue highlight on valid drop targets, red on invalid (descendants)
- Prevents circular references (can't drop parent onto its own descendant)