### PR TITLE
feat(ui): add Copy Prompt to issue detail menu

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -40,8 +40,10 @@ import {
   MoreHorizontal,
   Paperclip,
   SlidersHorizontal,
+  ClipboardCopy,
   Trash2,
 } from "lucide-react";
+import { useToast } from "../context/ToastContext";
 import type { ActivityEvent } from "@paperclipai/shared";
 import type { Agent, IssueAttachment } from "@paperclipai/shared";
 
@@ -149,6 +151,7 @@ export function IssueDetail() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { pushToast } = useToast();
   const [moreOpen, setMoreOpen] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
   const [detailTab, setDetailTab] = useState("comments");
@@ -631,6 +634,19 @@ export function IssueDetail() {
                 </Button>
               </PopoverTrigger>
             <PopoverContent className="w-44 p-1" align="end">
+              {issue.description && (
+                <button
+                  className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
+                  onClick={() => {
+                    navigator.clipboard.writeText(issue.description!);
+                    pushToast({ title: "Prompt copied to clipboard" });
+                    setMoreOpen(false);
+                  }}
+                >
+                  <ClipboardCopy className="h-3 w-3" />
+                  Copy Prompt
+                </button>
+              )}
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
                 onClick={() => {


### PR DESCRIPTION
## Summary
- Adds a "Copy Prompt" button to the ⋯ more menu in the issue detail view
- Copies the issue description (prompt) to clipboard with toast confirmation
- Only appears when the issue has a description
- **Not** in the list view — only in the detail view per user request

## Test plan
- [ ] Open an issue with a description
- [ ] Click the ⋯ menu → "Copy Prompt"
- [ ] Verify description is copied to clipboard and toast appears
- [ ] Verify issues without descriptions don't show the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)