### PR TITLE
fix: disable secure cookies for HTTP deployments

### DIFF
--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -70,6 +70,9 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET ?? "paperclip-dev-secret";
   const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);
 
+  const publicUrl = process.env.PAPERCLIP_PUBLIC_URL ?? baseUrl;
+  const isHttpOnly = publicUrl ? publicUrl.startsWith("http://") : false;
+
   const authConfig = {
     baseURL: baseUrl,
     secret,
@@ -88,6 +91,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
     },
+    ...(isHttpOnly ? { advanced: { useSecureCookies: false } } : {}),
   };
 
   if (!baseUrl) {


### PR DESCRIPTION
## Summary

- Fixes login failing silently on `authenticated + private` deployments served over plain HTTP (e.g. Tailscale, LAN)
- Users can sign up and sign in (200 response), but the session cookie is rejected by the browser so they are immediately redirected back to the login page
- Better Auth defaults to `__Secure-` prefixed cookies with the `Secure` flag when `NODE_ENV=production` — browsers silently reject these on non-HTTPS origins
- Detects when `PAPERCLIP_PUBLIC_URL` uses `http://` and sets `useSecureCookies: false`

## Test plan

- [ ] Deploy with `PAPERCLIP_PUBLIC_URL=http://<host>:3100` in `authenticated + private` mode
- [ ] Sign up / sign in over HTTP — verify session persists and user is not redirected back to login
- [ ] Verify HTTPS deployments are unaffected (secure cookies still used when URL is `https://`)