### PR TITLE
fix: strip CLAUDECODE env var from spawned child processes

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -220,6 +220,9 @@ export async function runChildProcess(
 
   return new Promise<RunProcessResult>((resolve, reject) => {
     const mergedEnv = ensurePathInEnv({ ...process.env, ...opts.env });
+    // Remove CLAUDECODE to prevent "cannot be launched inside another Claude Code
+    // session" errors when Paperclip itself is running inside a Claude Code session.
+    delete mergedEnv.CLAUDECODE;
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env: mergedEnv,


### PR DESCRIPTION
## Summary

- When Paperclip is running inside a Claude Code session, the `CLAUDECODE` environment variable leaks into child processes via `...process.env` in `runChildProcess()`. This causes all Claude Code adapter invocations to fail with:

  ```
  Error: Claude Code cannot be launched inside another Claude Code session.
  Nested sessions share runtime resources and will crash all active sessions.
  To bypass this check, unset the CLAUDECODE environment variable.
  ```

- Fix: delete `CLAUDECODE` from the merged environment before calling `spawn()` in `packages/adapter-utils/src/server-utils.ts`.

## Reproduction

1. Run `pnpm dev` from inside a Claude Code session (e.g. via `claude` CLI)
2. Trigger any agent run using the `claude_local` adapter
3. Agent fails immediately with the nested session error

## Test plan

- [x] Verified locally: agent runs succeed after the fix when Paperclip is launched from within a Claude Code session
- [x] No behavior change when Paperclip is launched outside of Claude Code (`CLAUDECODE` is not set, so the `delete` is a no-op)