### PR TITLE
feat(ui): auto-select project when only one exists

### DIFF
--- a/cli/src/__tests__/allowed-hostname.test.ts
+++ b/cli/src/__tests__/allowed-hostname.test.ts
@@ -42,6 +42,7 @@ function writeBaseConfig(configPath: string) {
     },
     auth: {
       baseUrlMode: "auto",
+      disableSignUp: false,
     },
     storage: {
       provider: "local_disk",

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -61,6 +61,7 @@ function defaultConfig(): PaperclipConfig {
     },
     auth: {
       baseUrlMode: "auto",
+      disableSignUp: false,
     },
     storage: defaultStorageConfig(),
     secrets: defaultSecretsConfig(),

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -185,6 +185,7 @@ function quickstartDefaultsFromEnv(): {
     },
     auth: {
       baseUrlMode: authBaseUrlMode,
+      disableSignUp: false,
       ...(authPublicBaseUrl ? { publicBaseUrl: authPublicBaseUrl } : {}),
     },
     storage: {

--- a/cli/src/prompts/server.ts
+++ b/cli/src/prompts/server.ts
@@ -113,7 +113,7 @@ export async function promptServer(opts?: {
   }
 
   const port = Number(portStr) || 3100;
-  let auth: AuthConfig = { baseUrlMode: "auto" };
+  let auth: AuthConfig = { baseUrlMode: "auto", disableSignUp: false };
   if (deploymentMode === "authenticated" && exposure === "public") {
     const urlInput = await p.text({
       message: "Public base URL",
@@ -139,11 +139,13 @@ export async function promptServer(opts?: {
     }
     auth = {
       baseUrlMode: "explicit",
+      disableSignUp: false,
       publicBaseUrl: urlInput.trim().replace(/\/+$/, ""),
     };
   } else if (currentAuth?.baseUrlMode === "explicit" && currentAuth.publicBaseUrl) {
     auth = {
       baseUrlMode: "explicit",
+      disableSignUp: false,
       publicBaseUrl: currentAuth.publicBaseUrl,
     };
   }

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -357,6 +357,15 @@ export function NewIssueDialog() {
     }
   }, [newIssueOpen, newIssueDefaults]);
 
+  // Auto-select project when there is exactly one
+  useEffect(() => {
+    if (!newIssueOpen) return;
+    if (projectId) return; // already selected (from defaults or draft)
+    if (orderedProjects.length === 1) {
+      setProjectId(orderedProjects[0]!.id);
+    }
+  }, [newIssueOpen, orderedProjects, projectId]);
+
   useEffect(() => {
     if (!supportsAssigneeOverrides) {
       setAssigneeOptionsOpen(false);


### PR DESCRIPTION
## Summary

When creating a new issue, users must manually select a project even when there's only one project available. Without a project selected, the agent won't see the project's context (code paths, docs), which costs users time and causes confusion.

This PR adds a `useEffect` in `NewIssueDialog.tsx` that auto-selects the project when exactly one project exists and no project is already selected.

## Changes

- Added a new `useEffect` hook in `NewIssueDialog.tsx` (after the existing "Restore draft or apply defaults" effect)
- The effect fires when the dialog opens and checks:
  1. Is the dialog open? (`newIssueOpen`)
  2. Is a project already selected? (`projectId` — from defaults, draft, or user selection)
  3. Is there exactly one project? (`orderedProjects.length === 1`)
- If all conditions are met, it calls `setProjectId(orderedProjects[0]!.id)`

## Behavior

| Scenario | Result |
|----------|--------|
| 1 project exists, no default/draft | Auto-selected |
| 2+ projects exist | No auto-selection, user picks |
| Opened from project page (`defaults.projectId` set) | Default respected, no override |
| Draft has a project saved | Draft respected, no override |
| User clears the project field | Re-selects automatically (intentional — agents need project context) |

## Why this approach

- `orderedProjects` is derived from the `projects` query, so it updates reactively when projects load
- Placed after the draft-restore effect since React processes effects in declaration order, ensuring defaults and drafts take priority
- The re-selection on clear is intentional: agents require project context to function properly, and a single-project workspace has no valid reason to leave it unselected

## Test plan

- [x] Open new issue dialog with exactly 1 project → project auto-selected
- [x] Open with 2+ projects → no auto-selection, user picks
- [x] Open from a project page (defaults.projectId set) → default respected
- [x] Clear the project field → it re-selects automatically
- [x] Open dialog, close, reopen → still auto-selects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)