### PR TITLE
feat(server): auto-requeue agent on failure with strike counting

### DIFF
--- a/packages/db/src/migrations/0026_agent_consecutive_failures.sql
+++ b/packages/db/src/migrations/0026_agent_consecutive_failures.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN "consecutive_failures" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1772807461603,
       "tag": "0025_nasty_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1772900000000,
+      "tag": "0026_agent_consecutive_failures",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -27,6 +27,7 @@ export const agents = pgTable(
     runtimeConfig: jsonb("runtime_config").$type<Record<string, unknown>>().notNull().default({}),
     budgetMonthlyCents: integer("budget_monthly_cents").notNull().default(0),
     spentMonthlyCents: integer("spent_monthly_cents").notNull().default(0),
+    consecutiveFailures: integer("consecutive_failures").notNull().default(0),
     permissions: jsonb("permissions").$type<Record<string, unknown>>().notNull().default({}),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -30,7 +30,8 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
-const AGENT_MAX_CONSECUTIVE_FAILURES = Number(process.env.PAPERCLIP_AGENT_MAX_FAILURES) || 3;
+const _parsedMaxFailures = Number(process.env.PAPERCLIP_AGENT_MAX_FAILURES);
+const AGENT_MAX_CONSECUTIVE_FAILURES = Number.isFinite(_parsedMaxFailures) && process.env.PAPERCLIP_AGENT_MAX_FAILURES !== "" ? _parsedMaxFailures : 3;
 
 function appendExcerpt(prev: string, chunk: string) {
   return appendWithCap(prev, chunk, MAX_EXCERPT_BYTES);
@@ -863,23 +864,22 @@ export function heartbeatService(db: Db) {
     const runningCount = await countRunningRunsForAgent(agentId);
 
     const isFailure = outcome === "failed" || outcome === "timed_out";
-    const newFailures = isFailure ? existing.consecutiveFailures + 1 : 0;
-    const underThreshold = isFailure && newFailures < AGENT_MAX_CONSECUTIVE_FAILURES;
 
-    const nextStatus =
-      runningCount > 0
-        ? "running"
-        : outcome === "succeeded" || outcome === "cancelled"
-          ? "idle"
-          : underThreshold
-            ? "idle"
-            : "error";
-
+    // Use atomic SQL increment to avoid race conditions when concurrent runs
+    // finish simultaneously for the same agent (maxConcurrentRuns > 1).
     const updated = await db
       .update(agents)
       .set({
-        status: nextStatus,
-        consecutiveFailures: newFailures,
+        consecutiveFailures: isFailure
+          ? sql`${agents.consecutiveFailures} + 1`
+          : 0,
+        status: runningCount > 0
+          ? sql`'running'`
+          : outcome === "succeeded" || outcome === "cancelled"
+            ? sql`'idle'`
+            : isFailure
+              ? sql`CASE WHEN ${agents.consecutiveFailures} + 1 < ${AGENT_MAX_CONSECUTIVE_FAILURES} THEN 'idle' ELSE 'error' END`
+              : sql`'error'`,
         lastHeartbeatAt: new Date(),
         updatedAt: new Date(),
       })
@@ -888,6 +888,7 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
 
     if (updated) {
+      const underThreshold = isFailure && updated.consecutiveFailures < AGENT_MAX_CONSECUTIVE_FAILURES;
       publishLiveEvent({
         companyId: updated.companyId,
         type: "agent.status",
@@ -898,7 +899,7 @@ export function heartbeatService(db: Db) {
             ? new Date(updated.lastHeartbeatAt).toISOString()
             : null,
           outcome,
-          ...(underThreshold ? { retriesRemaining: AGENT_MAX_CONSECUTIVE_FAILURES - newFailures } : {}),
+          ...(underThreshold ? { retriesRemaining: AGENT_MAX_CONSECUTIVE_FAILURES - updated.consecutiveFailures } : {}),
         },
       });
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -30,6 +30,7 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
+const AGENT_MAX_CONSECUTIVE_FAILURES = Number(process.env.PAPERCLIP_AGENT_MAX_FAILURES) || 3;
 
 function appendExcerpt(prev: string, chunk: string) {
   return appendWithCap(prev, chunk, MAX_EXCERPT_BYTES);
@@ -860,17 +861,25 @@ export function heartbeatService(db: Db) {
     }
 
     const runningCount = await countRunningRunsForAgent(agentId);
+
+    const isFailure = outcome === "failed" || outcome === "timed_out";
+    const newFailures = isFailure ? existing.consecutiveFailures + 1 : 0;
+    const underThreshold = isFailure && newFailures < AGENT_MAX_CONSECUTIVE_FAILURES;
+
     const nextStatus =
       runningCount > 0
         ? "running"
         : outcome === "succeeded" || outcome === "cancelled"
           ? "idle"
-          : "error";
+          : underThreshold
+            ? "idle"
+            : "error";
 
     const updated = await db
       .update(agents)
       .set({
         status: nextStatus,
+        consecutiveFailures: newFailures,
         lastHeartbeatAt: new Date(),
         updatedAt: new Date(),
       })
@@ -889,6 +898,7 @@ export function heartbeatService(db: Db) {
             ? new Date(updated.lastHeartbeatAt).toISOString()
             : null,
           outcome,
+          ...(underThreshold ? { retriesRemaining: AGENT_MAX_CONSECUTIVE_FAILURES - newFailures } : {}),
         },
       });
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents can fail due to transient errors (API timeouts, rate limits, temporary outages)
> - A single transient failure immediately put the agent into error state, halting all queued work
> - This meant humans had to manually intervene to restart agents after recoverable failures
> - This PR adds automatic requeue with a configurable strike counter so agents retry before giving up
> - Agents now self-heal through transient failures, only entering error state after repeated consecutive failures

## Summary
Fixes #276

Adds automatic retry logic so agents are requeued as idle after transient failures instead of immediately entering error status. A configurable strike counter (`PAPERCLIP_AGENT_MAX_FAILURES`, default 3) controls how many consecutive failures are tolerated before the agent enters error state.

## Changes
- Add `consecutiveFailures` column to `agents` table (migration `0026`)
- Modify `finalizeAgentStatus` to increment counter on failure/timeout, reset on success/cancel
- Keep agent `idle` (requeued) when under the failure threshold
- Set `error` status only after max retries exhausted
- Emit `retriesRemaining` in live event payload when retrying

## Testing
- Verify agent stays idle after 1-2 failures and picks up next queued run
- Verify agent enters error state after 3 consecutive failures
- Verify counter resets to 0 on a successful run
- Verify `PAPERCLIP_AGENT_MAX_FAILURES` env var overrides default

This contribution was developed with AI assistance (Claude Code).
