### PR TITLE
fix: route heartbeat cost recording through costService

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9,7 +9,6 @@ import {
   agentWakeupRequests,
   heartbeatRunEvents,
   heartbeatRuns,
-  costEvents,
   issues,
   projectWorkspaces,
 } from "@paperclipai/db";
@@ -21,6 +20,7 @@ import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import { costService } from "./costs.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 
@@ -977,8 +977,8 @@ export function heartbeatService(db: Db) {
       .where(eq(agentRuntimeState.agentId, agent.id));
 
     if (additionalCostCents > 0 || hasTokenUsage) {
-      await db.insert(costEvents).values({
-        companyId: agent.companyId,
+      const costs = costService(db);
+      await costs.createEvent(agent.companyId, {
         agentId: agent.id,
         provider: result.provider ?? "unknown",
         model: result.model ?? "unknown",
@@ -987,16 +987,6 @@ export function heartbeatService(db: Db) {
         costCents: additionalCostCents,
         occurredAt: new Date(),
       });
-    }
-
-    if (additionalCostCents > 0) {
-      await db
-        .update(agents)
-        .set({
-          spentMonthlyCents: sql`${agents.spentMonthlyCents} + ${additionalCostCents}`,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, agent.id));
     }
   }
 


### PR DESCRIPTION
## Summary

Heartbeat runs recorded costs via direct SQL inserts into `costEvents` and `agents.spentMonthlyCents`, bypassing `costService.createEvent()`. This caused two gaps:

1. **`companies.spentMonthlyCents` never updated** — company-level budget tracking showed $0 regardless of actual agent spend
2. **Agent auto-pause on budget exceeded never triggered** — the budget enforcement check in `costService.createEvent()` (lines 53-64 of `costs.ts`) was never reached

## Fix

Replace the direct SQL cost recording in `updateRuntimeState()` (heartbeat.ts) with a call to `costService(db).createEvent()`, which already handles all three operations:
- Insert cost event
- Update `agents.spentMonthlyCents`
- Update `companies.spentMonthlyCents`
- Auto-pause agent when `budgetMonthlyCents` is exceeded

## Changes

- `server/src/services/heartbeat.ts`: Import `costService`, replace direct SQL insert + agent spend update with `costService(db).createEvent()`. Remove unused `costEvents` import.

## Testing

Verified locally:
- Before fix: Agent spend = 117c, Company spend = **0c** (bug)
- After fix: Agent spend = 158c (+41c), Company spend = **41c** (correct)
- TypeScript compilation: clean (`npx tsc --noEmit`)
- Heartbeat run: succeeded with cost properly tracked

## Breaking Changes

None. The `heartbeatService(db)` function signature is unchanged. The fix is internal to `updateRuntimeState()`.