### PR TITLE
fix: default dangerouslySkipPermissions to true

### DIFF
--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -8,7 +8,7 @@ export const defaultCreateValues: CreateConfigValues = {
   model: "",
   thinkingEffort: "",
   chrome: false,
-  dangerouslySkipPermissions: false,
+  dangerouslySkipPermissions: true,
   search: false,
   dangerouslyBypassSandbox: false,
   command: "",


### PR DESCRIPTION
## Problem

Agents created or edited outside the Onboarding Wizard cannot write files. Claude Code blocks every file operation with:

```
Claude requested permissions to write to /path/file, but you haven't granted it yet.
```

This happens because `dangerouslySkipPermissions` defaults to `false` in `agent-config-defaults.ts`. Since agents run **unattended**, there is nobody to approve the interactive permission prompt — so the agent is stuck and cannot complete its task.

## Root Cause

- The **OnboardingWizard** correctly sets `dangerouslySkipPermissions: true` for `claude_local` agents (`OnboardingWizard.tsx:277`)
- But the **default config** in `agent-config-defaults.ts` is `false`
- Any agent created or reconfigured outside the wizard inherits this broken default

## Fix

Change the default from `false` to `true`. Agents are unattended by design — they need `--dangerously-skip-permissions` to function.

## Change

```diff
- dangerouslySkipPermissions: false,
+ dangerouslySkipPermissions: true,
```

One line, one file: `ui/src/components/agent-config-defaults.ts`