### PR TITLE
fix(deploy): add railway health check and remove docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private
 
-VOLUME ["/paperclip"]
 EXPOSE 3100
 
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,3 @@
+[deploy]
+healthcheckPath = "/api/health/"
+healthcheckTimeout = 60


### PR DESCRIPTION
This pull request makes minor adjustments to deployment configuration files. The changes focus on improving health monitoring and simplifying Docker setup.

Deployment configuration updates:

* Added a health check endpoint and timeout to the `[deploy]` section in `railway.toml`, which will help monitor service health during deployment.

Docker setup simplification:

* Removed the `VOLUME ["/paperclip"]` directive from the `Dockerfile`, streamlining the container configuration.