### PR TITLE
fix(docker): run production server as non-root node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,10 @@ RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" &
 
 FROM base AS production
 WORKDIR /app
-COPY --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai
+COPY --chown=node:node --from=build /app /app
+RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+  && mkdir -p /paperclip \
+  && chown node:node /paperclip
 
 ENV NODE_ENV=production \
   HOME=/paperclip \
@@ -49,4 +51,5 @@ ENV NODE_ENV=production \
 VOLUME ["/paperclip"]
 EXPOSE 3100
 
+USER node
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]


### PR DESCRIPTION
## Summary

Fixes #344 — Docker container runs as root, breaking the Claude adapter and causing `/paperclip` volume permission errors at startup.

Two bugs fixed by a single change:

1. **Claude adapter blocked** — `claude --dangerously-skip-permissions` refuses to run as root. Adding `USER node` makes the Claude adapter functional in Docker.
2. **EACCES on startup** — the `/paperclip` volume is created root-owned by Docker before the `USER` directive runs. Pre-creating the directory with `chown node:node` during the build stage resolves the write error.

**Changes:**

- `COPY --chown=node:node` in the production stage so app files are owned by `node`
- `mkdir -p /paperclip && chown node:node /paperclip` ensures the data volume mount point is writable by the non-root user
- `USER node` before `CMD` so the server process runs as the non-root `node` user (already present in the `node:lts-trixie-slim` base image — no new system user required)

## Test plan

- [ ] Build the Docker image locally: `docker build -t paperclip-test .`
- [ ] Run with default env: `docker run --rm -p 3100:3100 paperclip-test` — server starts without EACCES
- [ ] Confirm process is non-root: `docker exec <cid> id` shows `uid=1000(node)`
- [ ] Claude adapter invocation no longer blocked by root check

🤖 Generated with [Claude Code](https://claude.com/claude-code)