### PR TITLE
fix: stabilize SPA deep-link refresh and API key copy UX

### DIFF
--- a/server/src/__tests__/spa-fallback.test.ts
+++ b/server/src/__tests__/spa-fallback.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { createApp } from "../app.js";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+const uiDistDir = path.join(repoRoot, "ui", "dist");
+const uiIndexPath = path.join(uiDistDir, "index.html");
+const uiIndexHtml = "<!doctype html><html><body>paperclip-spa</body></html>";
+
+const storageService = {
+  provider: "local" as const,
+  async putFile() {
+    throw new Error("not implemented in test");
+  },
+  async getObject() {
+    throw new Error("not implemented in test");
+  },
+  async headObject() {
+    return { exists: false };
+  },
+  async deleteObject() {
+    throw new Error("not implemented in test");
+  },
+};
+
+beforeAll(() => {
+  fs.mkdirSync(uiDistDir, { recursive: true });
+  fs.writeFileSync(uiIndexPath, uiIndexHtml, "utf8");
+});
+
+afterAll(() => {
+  fs.rmSync(uiDistDir, { recursive: true, force: true });
+});
+
+describe("SPA fallback", () => {
+  it("serves index.html for company-prefixed deep links without intercepting API 404s", async () => {
+    const app = await createApp({} as any, {
+      uiMode: "static",
+      storageService,
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      allowedHostnames: [],
+      bindHost: "127.0.0.1",
+      authReady: true,
+      companyDeletionEnabled: false,
+    });
+
+    const dashboard = await request(app).get("/LAV/dashboard");
+    expect(dashboard.status).toBe(200);
+    expect(dashboard.headers["content-type"]).toContain("text/html");
+    expect(dashboard.text).toContain("paperclip-spa");
+
+    const settings = await request(app).get("/LAV/company/settings");
+    expect(settings.status).toBe(200);
+    expect(settings.headers["content-type"]).toContain("text/html");
+    expect(settings.text).toContain("paperclip-spa");
+
+    const apiMissing = await request(app).get("/api/not-found");
+    expect(apiMissing.status).toBe(404);
+    expect(apiMissing.body).toEqual({ error: "API route not found" });
+  });
+
+  it("serves index.html for invite and board-claim paths", async () => {
+    const app = await createApp({} as any, {
+      uiMode: "static",
+      storageService,
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      allowedHostnames: [],
+      bindHost: "127.0.0.1",
+      authReady: true,
+      companyDeletionEnabled: false,
+    });
+
+    const invitePage = await request(app).get("/invite/test-token");
+    expect(invitePage.status).toBe(200);
+    expect(invitePage.headers["content-type"]).toContain("text/html");
+    expect(invitePage.text).toContain("paperclip-spa");
+
+    const boardClaimPage = await request(app).get("/board-claim/test-token?code=123456");
+    expect(boardClaimPage.status).toBe(200);
+    expect(boardClaimPage.headers["content-type"]).toContain("text/html");
+    expect(boardClaimPage.text).toContain("paperclip-spa");
+  });
+});

--- a/server/src/__tests__/spa-fallback.test.ts
+++ b/server/src/__tests__/spa-fallback.test.ts
@@ -3,11 +3,12 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import request from "supertest";
 import { createApp } from "../app.js";
+import { cleanupSpaFixture, createSpaFixture, type SpaFixture } from "../test-support/spa-fixture.js";
 
 const repoRoot = path.resolve(__dirname, "../../..");
 const uiDistDir = path.join(repoRoot, "ui", "dist");
-const uiIndexPath = path.join(uiDistDir, "index.html");
 const uiIndexHtml = "<!doctype html><html><body>paperclip-spa</body></html>";
+let spaFixture: SpaFixture;
 
 const storageService = {
   provider: "local" as const,
@@ -26,12 +27,11 @@ const storageService = {
 };
 
 beforeAll(() => {
-  fs.mkdirSync(uiDistDir, { recursive: true });
-  fs.writeFileSync(uiIndexPath, uiIndexHtml, "utf8");
+  spaFixture = createSpaFixture(uiDistDir, uiIndexHtml);
 });
 
 afterAll(() => {
-  fs.rmSync(uiDistDir, { recursive: true, force: true });
+  cleanupSpaFixture(spaFixture);
 });
 
 describe("SPA fallback", () => {

--- a/server/src/__tests__/spa-fixture.test.ts
+++ b/server/src/__tests__/spa-fixture.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSpaFixture, cleanupSpaFixture } from "../test-support/spa-fixture.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const tempRoot of tempRoots.splice(0)) {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe("spa fixture helpers", () => {
+  it("preserves pre-existing ui/dist siblings during cleanup", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-spa-fixture-"));
+    tempRoots.push(tempRoot);
+
+    const uiDistDir = path.join(tempRoot, "ui", "dist");
+    fs.mkdirSync(uiDistDir, { recursive: true });
+
+    const siblingPath = path.join(uiDistDir, "asset.txt");
+    fs.writeFileSync(siblingPath, "keep", "utf8");
+
+    const fixture = createSpaFixture(uiDistDir, "<html>fixture</html>");
+    cleanupSpaFixture(fixture);
+
+    expect(fs.existsSync(siblingPath)).toBe(true);
+    expect(fs.existsSync(fixture.uiIndexPath)).toBe(false);
+  });
+
+  it("removes the created ui/dist directory when the fixture created it", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-spa-fixture-"));
+    tempRoots.push(tempRoot);
+
+    const uiDistDir = path.join(tempRoot, "ui", "dist");
+    const fixture = createSpaFixture(uiDistDir, "<html>fixture</html>");
+    cleanupSpaFixture(fixture);
+
+    expect(fs.existsSync(uiDistDir)).toBe(false);
+  });
+});

--- a/server/src/test-support/spa-fixture.ts
+++ b/server/src/test-support/spa-fixture.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface SpaFixture {
+  uiDistDir: string;
+  uiIndexPath: string;
+  createdUiDistDir: boolean;
+}
+
+export function createSpaFixture(uiDistDir: string, uiIndexHtml: string): SpaFixture {
+  const createdUiDistDir = !fs.existsSync(uiDistDir);
+  fs.mkdirSync(uiDistDir, { recursive: true });
+
+  const uiIndexPath = path.join(uiDistDir, "index.html");
+  fs.writeFileSync(uiIndexPath, uiIndexHtml, "utf8");
+
+  return {
+    uiDistDir,
+    uiIndexPath,
+    createdUiDistDir,
+  };
+}
+
+export function cleanupSpaFixture(fixture: SpaFixture): void {
+  fs.rmSync(fixture.uiIndexPath, { force: true });
+
+  if (!fixture.createdUiDistDir) {
+    return;
+  }
+
+  try {
+    fs.rmdirSync(fixture.uiDistDir);
+  } catch {
+    // Leave non-empty or already-removed directories untouched.
+  }
+}

--- a/ui/src/components/CopyText.tsx
+++ b/ui/src/components/CopyText.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 interface CopyTextProps {
   text: string;
@@ -31,23 +32,8 @@ export function CopyText({
 
   const handleClick = useCallback(async () => {
     try {
-      if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(text);
-      } else {
-        // Fallback for non-secure contexts (e.g. HTTP on non-localhost)
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        textarea.style.position = "fixed";
-        textarea.style.left = "-9999px";
-        document.body.appendChild(textarea);
-        try {
-          textarea.select();
-          const success = document.execCommand("copy");
-          if (!success) throw new Error("execCommand copy failed");
-        } finally {
-          document.body.removeChild(textarea);
-        }
-      }
+      const copied = await copyTextToClipboard(text);
+      if (!copied) throw new Error("copy failed");
       setLabel(copiedLabel);
     } catch {
       setLabel("Copy failed");

--- a/ui/src/lib/agent-copy.test.ts
+++ b/ui/src/lib/agent-copy.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { copyAgentId } from "./agent-copy";
+import { copyTextToClipboard } from "./clipboard";
+
+vi.mock("./clipboard", () => ({
+  copyTextToClipboard: vi.fn(),
+}));
+
+describe("copyAgentId", () => {
+  it("uses the clipboard fallback helper and reports success", async () => {
+    const pushToast = vi.fn();
+    vi.mocked(copyTextToClipboard).mockResolvedValue(true);
+
+    await expect(copyAgentId("agent-123", pushToast)).resolves.toBe(true);
+
+    expect(copyTextToClipboard).toHaveBeenCalledWith("agent-123");
+    expect(pushToast).toHaveBeenCalledWith({
+      title: "Agent ID copied",
+      tone: "success",
+    });
+  });
+
+  it("reports a visible error when clipboard copy fails", async () => {
+    const pushToast = vi.fn();
+    vi.mocked(copyTextToClipboard).mockResolvedValue(false);
+
+    await expect(copyAgentId("agent-123", pushToast)).resolves.toBe(false);
+
+    expect(pushToast).toHaveBeenCalledWith({
+      title: "Copy failed",
+      body: "Clipboard access was blocked. Try again from a secure browser context.",
+      tone: "error",
+    });
+  });
+});

--- a/ui/src/lib/agent-copy.ts
+++ b/ui/src/lib/agent-copy.ts
@@ -1,0 +1,23 @@
+import type { ToastInput } from "../context/ToastContext";
+import { copyTextToClipboard } from "./clipboard";
+
+type PushToast = (input: ToastInput) => string | null;
+
+export async function copyAgentId(agentId: string, pushToast: PushToast): Promise<boolean> {
+  const copied = await copyTextToClipboard(agentId);
+
+  pushToast(
+    copied
+      ? {
+          title: "Agent ID copied",
+          tone: "success",
+        }
+      : {
+          title: "Copy failed",
+          body: "Clipboard access was blocked. Try again from a secure browser context.",
+          tone: "error",
+        },
+  );
+
+  return copied;
+}

--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyTextToClipboard } from "./clipboard";
+
+describe("copyTextToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the async clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const execCommand = vi.fn();
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    vi.stubGlobal("document", { execCommand });
+
+    await expect(copyTextToClipboard("secret-token")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("secret-token");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when clipboard.writeText rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("NotAllowedError"));
+    const textarea = {
+      value: "",
+      setAttribute: vi.fn(),
+      style: {},
+      focus: vi.fn(),
+      select: vi.fn(),
+    };
+    const execCommand = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    vi.stubGlobal("document", {
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand,
+    });
+
+    await expect(copyTextToClipboard("secret-token")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("secret-token");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("returns false when both clipboard strategies fail", async () => {
+    const textarea = {
+      value: "",
+      setAttribute: vi.fn(),
+      style: {},
+      focus: vi.fn(),
+      select: vi.fn(),
+    };
+    vi.stubGlobal("navigator", { clipboard: undefined });
+    vi.stubGlobal("document", {
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand: vi.fn().mockReturnValue(false),
+    });
+
+    await expect(copyTextToClipboard("secret-token")).resolves.toBe(false);
+  });
+});

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -1,0 +1,37 @@
+function legacyCopyTextToClipboard(text: string): boolean {
+  if (typeof document === "undefined" || typeof document.execCommand !== "function") {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy path for non-secure or denied clipboard contexts.
+    }
+  }
+
+  return legacyCopyTextToClipboard(text);
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -21,6 +21,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useToastActions } from "../context/ToastContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { copyAgentId } from "../lib/agent-copy";
 import { queryKeys } from "../lib/queryKeys";
 import { AgentConfigForm } from "../components/AgentConfigForm";
 import { PageTabBar } from "../components/PageTabBar";
@@ -622,6 +623,7 @@ export function AgentDetail() {
     runId?: string;
   }>();
   const { companies, selectedCompanyId, setSelectedCompanyId } = useCompany();
+  const { pushToast } = useToastActions();
   const { closePanel } = usePanel();
   const { openNewIssue } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -968,8 +970,8 @@ export function AgentDetail() {
             <PopoverContent className="w-44 p-1" align="end">
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
-                onClick={() => {
-                  navigator.clipboard.writeText(agent.id);
+                onClick={async () => {
+                  await copyAgentId(agent.id, pushToast);
                   setMoreOpen(false);
                 }}
               >

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -98,6 +98,7 @@ import {
   arraysEqual,
   isReadOnlyUnmanagedSkillEntry,
 } from "../lib/agent-skills-state";
+import { copyTextToClipboard } from "../lib/clipboard";
 
 const runStatusIcons: Record<string, { icon: typeof CheckCircle2; color: string }> = {
   succeeded: { icon: CheckCircle2, color: "text-green-600 dark:text-green-400" },
@@ -3960,7 +3961,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
   const [newKeyName, setNewKeyName] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
   const [tokenVisible, setTokenVisible] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "success" | "error">("idle");
 
   const { data: keys, isLoading } = useQuery({
     queryKey: queryKeys.agents.keys(agentId),
@@ -3984,11 +3985,11 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
     },
   });
 
-  function copyToken() {
+  async function copyToken() {
     if (!newToken) return;
-    navigator.clipboard.writeText(newToken);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    const copied = await copyTextToClipboard(newToken);
+    setCopyStatus(copied ? "success" : "error");
+    setTimeout(() => setCopyStatus("idle"), 2000);
   }
 
   const activeKeys = (keys ?? []).filter((k: AgentKey) => !k.revokedAt);
@@ -4022,7 +4023,16 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
             >
               <Copy className="h-3.5 w-3.5" />
             </Button>
-            {copied && <span className="text-xs text-green-400">Copied!</span>}
+            {copyStatus !== "idle" && (
+              <span
+                className={cn(
+                  "text-xs",
+                  copyStatus === "success" ? "text-green-400" : "text-red-400",
+                )}
+              >
+                {copyStatus === "success" ? "Copied!" : "Copy failed"}
+              </span>
+            )}
           </div>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary

This PR addresses two production issues observed in local/self-hosted Paperclip setups:

1. Deep-link refreshes like `/LAV/dashboard` and `/LAV/company/settings` returning 500
2. API key copy action failing silently in some browser contexts

## What changed

### Server
- Added regression coverage for SPA fallback behavior in `server/src/__tests__/spa-fallback.test.ts`
- Tests cover:
  - company-prefixed deep links (`/LAV/dashboard`, `/LAV/company/settings`)
  - invite and board-claim routes (`/invite/*`, `/board-claim/*`)
  - API route isolation (`/api/*` still returns API 404 instead of HTML fallback)

### UI
- Introduced `ui/src/lib/clipboard.ts` with robust copy helper:
  - tries `navigator.clipboard.writeText`
  - falls back to `document.execCommand("copy")` when needed
- Added tests in `ui/src/lib/clipboard.test.ts`
- Updated:
  - `ui/src/components/CopyText.tsx`
  - `ui/src/pages/AgentDetail.tsx`
  to use the helper and show explicit success/failure states

## Validation

Executed locally on branch `fix/spa-fallback-and-key-copy`:

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/spa-fallback.test.ts` ✅
- `pnpm --filter @paperclipai/server typecheck` ✅
- `pnpm --dir ui exec vitest run src/lib/clipboard.test.ts --environment node` ✅
- `pnpm --filter @paperclipai/ui build` ✅

Manual smoke checks on isolated local instance also passed for:
- `/LAV/dashboard`
- `/invite/test`
- `/board-claim/test?code=x`

---

If maintainers prefer, I can split this into two PRs (server fallback and clipboard UX) for easier review.
