### PR TITLE
feat(ui): Enable OpenClaw Gateway adapter type in agent creation UI

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -891,7 +891,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "openclaw_gateway"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [


### PR DESCRIPTION
## Summary

Enable OpenClaw Gateway adapter type in the agent creation UI.

## Testing

- Verified OpenClaw Gateway appears in dropdown
- Successfully created agent and ran heartbeat
- WebSocket connected (protocol=3)