### PR TITLE
fix:Refactor Dockerfile for production setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:lts-trixie-slim AS base
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl git \
   && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable
+
 
 FROM base AS deps
 WORKDIR /app
+
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 COPY cli/package.json cli/
 COPY server/package.json server/
@@ -22,18 +26,33 @@ COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
 
 RUN pnpm install --frozen-lockfile
 
+
 FROM base AS build
 WORKDIR /app
+
 COPY --from=deps /app /app
 COPY . .
+
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
+
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
+
 
 FROM base AS production
 WORKDIR /app
+
 COPY --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai
+
+# create paperclip directory and set permissions
+RUN mkdir -p /paperclip \
+ && chown -R node:node /app /paperclip
+
+# install global tools
+RUN npm install --global --omit=dev \
+  @anthropic-ai/claude-code@latest \
+  @openai/codex@latest \
+  opencode-ai
 
 ENV NODE_ENV=production \
   HOME=/paperclip \
@@ -47,6 +66,10 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private
 
 VOLUME ["/paperclip"]
+
 EXPOSE 3100
+
+# run container as non-root user
+USER node
 
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]


### PR DESCRIPTION
Fixes #344
Run the server container as a non-root `node` user.

- Added USER node
- Fixed permissions for /app and /paperclip
- Improved Docker security for production

