### PR TITLE
fix: navigate to dashboard after onboarding, not first issue

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -500,10 +500,6 @@ export function OnboardingWizard() {
     setLoading(false);
     reset();
     closeOnboarding();
-    if (createdCompanyPrefix && createdIssueRef) {
-      navigate(`/${createdCompanyPrefix}/issues/${createdIssueRef}`);
-      return;
-    }
     if (createdCompanyPrefix) {
       navigate(`/${createdCompanyPrefix}/dashboard`);
       return;


### PR DESCRIPTION
## Summary
- Removes the issue-specific navigation in `OnboardingWizard.handleLaunch()` so onboarding always lands on the dashboard
- Fixes #422 — company switch was permanently stuck on the first onboarding issue due to `useCompanyPageMemory` caching that path

## Test plan
- [ ] Create a new company via onboarding wizard
- [ ] Verify onboarding completion lands on `/<PREFIX>/dashboard`
- [ ] Switch away and back — confirm dashboard is shown, not the first issue
- [ ] Clear `localStorage.removeItem("paperclip.companyPaths")` for existing companies to reset stale paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)