### PR TITLE
docs: add PR triage report for 2026-03-09

### DIFF
--- a/doc/plans/pr-triage-2026-03-09.md
+++ b/doc/plans/pr-triage-2026-03-09.md
@@ -1,0 +1,222 @@
+# PR Triage — paperclipai/paperclip — 2026-03-09
+
+Contributor: MatB57 (claude/paperclip-contributor-mR7bs)
+
+---
+
+## Windows Migrations Path Fix — Status: Already Merged
+
+The `fileURLToPath` fix for the Windows `C:\C:\` path bug was already merged upstream as commit:
+
+```
+c59e059 fix(db): use fileURLToPath for Windows-safe migration paths
+```
+
+Current state of `packages/db/src/client.ts`:
+
+```ts
+import { fileURLToPath } from "node:url";
+
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
+const MIGRATIONS_JOURNAL_JSON = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
+```
+
+No `.pathname` usages remain anywhere in `packages/db/`. Branch
+`fix/windows-migrations-path-filepathurl` was created locally to confirm there is nothing
+further to contribute — the idiomatic fix is already in production.
+
+---
+
+## Open PR Triage
+
+| # | Title | Recommendation | Key Feedback |
+|---|-------|---------------|--------------|
+| #423 | fix: navigate to dashboard after onboarding | **Approve** | Correct fix. Minor: remove orphaned `createdIssueRef` dead code. |
+| #421 | feat: add agent role templates system | **Request changes** | **Blocker**: `getTemplateDir()` lacks input validation — `../` in role string = path traversal. Apply `PATH_SEGMENT_RE` from `home-paths.ts`. Fix inconsistent `cwd` base in listing vs copying. Use `logger.warn()` not `console.warn()`. |
+| #420 | Dotta releases | **Approve** | Core-team release commit. |
+| #419 | fix: Refactor Dockerfile for production setup | **Close** | Duplicate of #400. #400 uses `COPY --chown` (fewer layers, idiomatic Docker). Prefer #400. |
+| #414 | feat(ui): Enable OpenClaw Gateway adapter type | **Approve** | One-line enablement of fully-implemented adapter. Bot: 4/5. |
+| #413 | fix: support Windows command wrappers | **Approve** | Idiomatic fix; tests included; all 4 bot issues addressed in follow-up. `pnpm-lock.yaml` change is legitimate (new `cross-env` dep, not manual edit). |
+| #411 | fix: stabilize SPA deep-link refresh and API key copy | **Request changes** | **Blocker**: `afterAll` deletes entire `ui/dist` — destroys CI build artifacts. One copy button still calls `navigator.clipboard` directly (incomplete migration). |
+| #409 | feat(plugins): add agent-routines plugin | **Hold** | Depends on unmerged #408 → #403 → #396 chain. Merge chain too deep. Good design + 30 tests; hold for base PRs. |
+| #408 | feat(plugins): agents.invoke capability | **Hold** | Depends on #396. |
+| #407 | feat(plugins): Telegram notifier example | **Hold** | Depends on #396. |
+| #404 | docs: add agent runtime noise reduction roadmap | **Approve** | Docs-only. Minor: fix phase ordering, add `opencode_local`, promote headings under `## Roadmap`. |
+| #403 | feat(plugins): agents.pause and agents.resume | **Hold** | Depends on #396. |
+| #402 | feat(plugins): email notifier plugin | **Hold** | Depends on #396. |
+| #401 | fix(auth): attribute agent API calls via run-ID header | **Request changes** | **Security blockers**: (1) no run status check — expired/failed run-IDs become permanent credentials; (2) run-ID elevation not gated to `local_trusted` mode; (3) dismissed runs reappear in inbox. Also: mixes two unrelated fixes (#337 + #314), should be split. |
+| #400 | fix(docker): run production server as non-root | **Approve** | Clean Dockerfile fix. Suggestion: add `&& npm cache clean --force` to trim image size. |
+| #399 | feat(approvals): general action approvals | **Request changes** | Large (15+ files). Bugs: trust promotion window (process_lost consumes slots); safety gate missing from `hire_agent`; activity log ordering inversion; duplicate instructions in openclaw wake. |
+| #398 | feat(plugins): webhook and discord notifier plugins | **Hold** | Depends on #396. |
+| #396 | Feat: Plugin Support | **Request changes** | 296 files — too large. Must be split: core engine / examples / CLI / SDK as separate PRs. Author acknowledged this. |
+| #395 | feat(ui): Claude CLI permissions (Draft) | **Hold** | Draft — not ready. |
+| #393 | feat(notifications): Telnyx SMS channel | **Approve** | Depends on #389. API key redaction + code duplication fixed in follow-up commits. E.164 validation is a suggestion, not a blocker. |
+| #392 | fix(deploy): railway health check | **Approve** | Small infra fix, no red flags. |
+| #391 | feat(server): agent circuit breaker | **Request changes** | Core detection bugs: velocity check skips failed/timed_out runs; race condition in `tripCircuitBreaker`; sub-cent precision loss zeroes costs; hardcoded output schema keys (`issuesModified`) not portable across adapters. Bot: 2/5. |
+| #389 | feat(notifications): notification channels backend | **Hold** | Base for #393 — review first, dependents after. |
+| #388 | fix: default dangerouslySkipPermissions to true | **Request changes** | Applies to ALL adapter types via shared defaults — wrong. `dangerouslySkipPermissions` is only meaningful for `claude_local`. Narrow scope. Update `docs/adapters/claude-local.md` to reflect the change. |
+| #387 | feat: add i18n support (English + Chinese) | **Request changes** | Not production-ready: missing `issueDetail` + `agentDetail` namespaces (raw key strings rendered on two high-traffic pages); broken language toggle (`"zh"` vs `"zh-CN"`); stale group labels (missing `t` in `useMemo` deps). |
+
+---
+
+## Feedback Comments to Post
+
+### #421 — Role Templates (path traversal blocker)
+
+```
+Hi @notacryptodad — good idea to bundle templates directly, but there's a security concern
+in `getTemplateDir()` (role-templates.ts, lines 8–18):
+
+The `role` parameter is used unsanitized in path construction. A role string containing
+`../` sequences could resolve outside the intended templates directory (path traversal).
+
+The codebase already has the right pattern — see `PATH_SEGMENT_RE = /^[a-zA-Z0-9_-]+$/`
+in `home-paths.ts`. Apply the same guard to `role` before constructing the path.
+
+Additionally:
+- `listAvailableRoleTemplates()` hardcodes `cwd/server/templates/roles` while `getTemplateDir`
+  uses `cwd/templates/roles` when available — this causes the list to return empty in
+  server-rooted envs where copying succeeds.
+- `console.warn()` → use `logger.warn()` for structured logging (see AGENTS.md §5).
+
+The path traversal issue is a blocker. The others are quality items. Happy to review a v2!
+```
+
+### #401 — Auth Run-ID (security blockers)
+
+```
+Hi @AiMagic5000 — the goal here is solid (fix audit trail in local_trusted mode), but there
+are three security issues that need to be addressed before merge:
+
+**1. Run status not validated (blocker)**
+`auth.ts` line ~96 selects the run but never checks its status. A historical run ID
+(failed, timed-out, cancelled) becomes a permanent credential. Fix:
+add `inArray(heartbeatRuns.status, ["queued", "running"])` to the query.
+
+**2. Not gated to local_trusted (blocker)**
+The run-ID elevation block fires in all deployment modes. In authenticated deployments,
+an unauthenticated request with any valid run-ID gets elevated to agent actor without a
+session or bearer token. Fix:
+`if (runIdHeader && opts.deploymentMode === "local_trusted") { ... }`
+
+**3. Dismissed runs reappear in inbox**
+`heartbeat.list()` doesn't filter `dismissed_at IS NULL`, so dismissed items return on
+fresh browser sessions. The sidebar badge filter is correct; align the list query.
+
+Also: this PR mixes two unrelated changes (#337 run-ID attribution + #314 dismiss persistence).
+Per AGENTS.md §5, prefer focused PRs — splitting makes review and rollback cleaner.
+
+These are blockers per AGENTS.md rules. Happy to help review once addressed!
+```
+
+### #411 — SPA/Clipboard (destructive test cleanup blocker)
+
+```
+Hi @lazyeo — the SPA fallback tests and clipboard fallback are great additions. Two issues:
+
+**1. Destructive test cleanup (blocker)**
+`afterAll` in `spa-fallback.test.ts` deletes the entire `ui/dist` directory. In CI, the
+UI build often runs before server tests — this would destroy build artifacts mid-pipeline.
+Fix: only delete the specific test-created file, not the whole directory.
+
+**2. Incomplete migration**
+`AgentDetail.tsx` line 530 still calls `navigator.clipboard.writeText` directly,
+contradicting the PR's stated goal. The new `clipboard.ts` helper should be used there too.
+
+Otherwise the approach is clean — the execCommand fallback is the right pattern.
+```
+
+### #391 — Circuit Breaker (core detection bugs)
+
+```
+Hi @mvanhorn — love the circuit breaker concept, this fills a real gap. A few correctness
+issues before merge:
+
+**1. Velocity check misses expensive failures**
+`checkTokenVelocity` filters to `status = 'succeeded'` only. If an agent burns tokens on a
+failed/timed-out run, the spike goes undetected. Remove the status filter (or include
+`failed`/`timed_out`) so all runs contribute to velocity.
+
+**2. Race condition in tripCircuitBreaker**
+The pattern reads agent status, then issues a separate UPDATE without holding a transaction
+or including the status guard in the WHERE clause. Concurrent operations can overwrite.
+Fix: use a single UPDATE with `WHERE status != 'paused'` (or wrap in a transaction).
+
+**3. Sub-cent precision loss**
+Rounding to cents before averaging zeroes out cheap runs (cost < $0.005). These show as
+0 in the average, causing subsequent velocity multiplier checks to divide by near-zero.
+Keep full precision until final comparison.
+
+**4. Output schema coupling**
+No-progress detection checks `issuesModified`, `issuesCreated`, `commentsPosted` — these
+are undocumented fields that not all adapters produce. False positives will fire for any
+adapter using different result structures. Consider a more adapter-agnostic signal
+(e.g., issue `updatedAt` timestamp change).
+
+Bot: 2/5. Architecture is right — these are fixable. Happy to review a v2.
+```
+
+### #388 — dangerouslySkipPermissions default
+
+```
+Hi @ohld — I understand the frustration with agents failing to write files after setup.
+However, defaulting `dangerouslySkipPermissions: true` in the shared `agent-config-defaults.ts`
+applies this to ALL adapter types — not just `claude_local`.
+
+`dangerouslySkipPermissions` is a Claude CLI-specific flag. Other adapters ignore it, but
+applying it as a universal default is semantically wrong and could cause confusion when
+adding new adapters.
+
+The fix should be scoped: only set this default when `adapterType === "claude_local"`.
+The OnboardingWizard already does this correctly — `NewAgent.tsx` and `AgentConfigForm.tsx`
+should apply the same conditional.
+
+Also: `docs/adapters/claude-local.md` still labels this flag "dev only" — update it to
+reflect that it's required for unattended production use.
+
+(See AGENTS.md §5 rule 2: keep contracts synchronized across all layers.)
+```
+
+### #387 — i18n (broken on two high-traffic pages)
+
+```
+Hi @JOHNadonis — i18n support is a great addition to the project. However there are issues
+that make this not production-ready for two high-traffic pages:
+
+**1. Missing namespaces (blocker)**
+`IssueDetail.tsx` references 30+ keys under `issueDetail.*` and `AgentDetail.tsx` references
+20+ keys under `agentDetail.*` — neither namespace exists in the translation files. Users
+see raw key strings like `"issueDetail.system"` instead of text, in both languages.
+
+**2. Broken language toggle (blocker)**
+The toggle checks `=== "zh"` but `navigator.language` returns `"zh-CN"` for Chinese browsers.
+Chinese users can switch to Chinese but cannot toggle back to English.
+
+**3. Stale group labels**
+`t` is missing from the `useMemo` dependency array in `IssuesList.tsx`. Group headers won't
+update after a language switch until a re-render is triggered by something else.
+
+**4. Inconsistent hardcoding**
+Theme toggle `aria-label` is hardcoded English while surrounding elements use `t()`.
+
+Items 1 and 2 are blockers — they break core functionality on the two busiest pages.
+Looking forward to a v2!
+```
+
+### #396 — Plugin Support (size blocker)
+
+```
+Hi @gsxdsm — the plugin architecture is exciting and clearly a lot of work has gone into it.
+However at 296 files this is beyond what can be reviewed safely as a single PR.
+
+Per AGENTS.md contributor guidelines, please split into focused PRs:
+1. **Core engine only** — plugin host, worker isolation, JSON-RPC, manifest validation
+2. **SDK package** (`@paperclipai/plugin-sdk`) + `create-paperclip-plugin` scaffolding
+3. **CLI commands** — plugin install/list/enable/disable
+4. **Example plugins** — webhook, Discord, email, Telegram (as separate small PRs)
+
+Each PR should be independently reviewable and mergeable. The community PRs building on
+top of this (#402, #403, #407, #408, #409, #398) can land once the core engine merges.
+
+I know you already mentioned splitting — looking forward to the focused PRs!
+```


### PR DESCRIPTION
## Summary

Add a comprehensive PR triage report documenting the status of open pull requests as of March 9, 2026, along with detailed feedback for contributors on issues requiring attention.

## Changes

- **New triage document** (`doc/plans/pr-triage-2026-03-09.md`):
  - Documents completion of Windows migrations path fix (already merged upstream)
  - Provides structured triage of 24 open PRs with recommendations (Approve/Request Changes/Hold/Close)
  - Includes detailed feedback comments for 7 PRs with blockers or significant issues:
    - **#421** (Role Templates): Path traversal vulnerability in `getTemplateDir()` requiring input validation
    - **#401** (Auth Run-ID): Three security blockers around run status validation, deployment mode gating, and dismissed run filtering
    - **#411** (SPA/Clipboard): Destructive test cleanup deleting entire `ui/dist` directory and incomplete clipboard migration
    - **#391** (Circuit Breaker): Core detection bugs in velocity checks, race conditions, precision loss, and adapter coupling
    - **#388** (dangerouslySkipPermissions): Overly broad default scope affecting all adapter types instead of just `claude_local`
    - **#387** (i18n): Missing translation namespaces on high-traffic pages, broken language toggle, and stale dependency arrays
    - **#396** (Plugin Support): PR too large (296 files) requiring split into focused, independently reviewable PRs

## Notable Details

- Triage follows structured format with recommendation levels and key feedback for each PR
- Security issues are clearly marked as blockers (path traversal, auth elevation, run status validation)
- Feedback comments are ready to post as-is to respective PRs
- Includes actionable guidance referencing project conventions (AGENTS.md, home-paths.ts patterns)