### PR TITLE
fix(auth): include port in trusted origins and detect http-only from trusted origins

### DIFF
--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -59,6 +59,10 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
       if (!trimmed) continue;
       trustedOrigins.add(`https://${trimmed}`);
       trustedOrigins.add(`http://${trimmed}`);
+      // Also add with the configured port so non-standard ports match the
+      // browser Origin header (e.g. http://192.168.1.1:3100).
+      if (config.port !== 443) trustedOrigins.add(`https://${trimmed}:${config.port}`);
+      if (config.port !== 80) trustedOrigins.add(`http://${trimmed}:${config.port}`);
     }
   }
 
@@ -71,7 +75,9 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
   const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);
 
   const publicUrl = process.env.PAPERCLIP_PUBLIC_URL ?? baseUrl;
-  const isHttpOnly = publicUrl ? publicUrl.startsWith("http://") : false;
+  const isHttpOnly = publicUrl
+    ? publicUrl.startsWith("http://")
+    : effectiveTrustedOrigins.some((o) => o.startsWith("http://"));
 
   const authConfig = {
     baseURL: baseUrl,


### PR DESCRIPTION
## Summary

- deriveAuthTrustedOrigins now includes the configured port in generated origins (e.g. http://192.168.1.1:3100), so non-standard ports match the browser Origin header and session cookies are no longer rejected
- useSecureCookies falls back to checking trustedOrigins for http:// entries when no explicit PAPERCLIP_PUBLIC_URL is set, so HTTP-only deployments correctly disable secure cookies without requiring the env var

## Test plan

- [ ] Deploy on a non-standard port (e.g. :3100) without PAPERCLIP_PUBLIC_URL -- verify login works and cookies are set correctly
- [ ] Deploy with PAPERCLIP_PUBLIC_URL=http://... -- existing behavior unchanged
- [ ] Deploy with PAPERCLIP_PUBLIC_URL=https://... -- secure cookies still enabled