### PR TITLE
fix: augment PATH with default dirs for daemon-started servers

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -118,11 +118,11 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   return vars;
 }
 
-export function defaultPathForPlatform() {
+export function defaultPathForPlatform(env?: NodeJS.ProcessEnv) {
   if (process.platform === "win32") {
     return "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\Wbem";
   }
-  const home = process.env.HOME ?? "";
+  const home = (env?.HOME ?? process.env.HOME) || "";
   const dirs = [
     "/usr/local/bin",
     "/opt/homebrew/bin",
@@ -142,7 +142,7 @@ export function ensurePathInEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const delimiter = process.platform === "win32" ? ";" : ":";
   const currentPath = (typeof env.PATH === "string" && env.PATH) ||
     (typeof env.Path === "string" && env.Path) || "";
-  const defaultDirs = defaultPathForPlatform().split(delimiter);
+  const defaultDirs = defaultPathForPlatform(env).split(delimiter);
   const currentDirs = new Set(currentPath.split(delimiter).filter(Boolean));
   const missingDirs = defaultDirs.filter(d => d && !currentDirs.has(d));
   if (missingDirs.length === 0 && currentPath.length > 0) return env;

--- a/server/src/__tests__/ensure-path-in-env.test.ts
+++ b/server/src/__tests__/ensure-path-in-env.test.ts
@@ -42,11 +42,21 @@ describe("ensurePathInEnv", () => {
     expect(result.PATH).toContain("/opt/homebrew/bin");
   });
 
-  it("includes $HOME/.local/bin when HOME is set", () => {
-    const home = process.env.HOME;
-    if (!home) return; // skip on systems without HOME
-    const env = { PATH: "/usr/bin" } as NodeJS.ProcessEnv;
-    const result = ensurePathInEnv(env);
-    expect(result.PATH).toContain(`${home}/.local/bin`);
+  it("includes $HOME/.local/bin derived from the merged env", () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/test/home";
+    try {
+      const env = { PATH: "/usr/bin", HOME: "/child/home" } as NodeJS.ProcessEnv;
+      const result = ensurePathInEnv(env);
+      // Should use the child's HOME from the env arg, not process.env.HOME
+      expect(result.PATH).toContain("/child/home/.local/bin");
+      expect(result.PATH).not.toContain("/test/home/.local/bin");
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `ensurePathInEnv` previously only added default PATH directories when PATH was completely empty/missing
- When the server runs as a daemon (launchd), the inherited PATH is minimal (`/usr/bin:/bin`) and misses `/usr/local/bin`, `/opt/homebrew/bin`, etc. where CLI tools like `claude` are installed
- Now `ensurePathInEnv` always merges default platform directories into the existing PATH (appended, preserving original order), and adds `$HOME/.local/bin` for user-installed CLIs
- Fixes RUS-53: timer-driven wakes consistently failing with "Command not found in PATH: claude"

## Test plan

- [x] Added `ensure-path-in-env.test.ts` with 6 test cases covering: augmenting minimal PATH, no-op when defaults present, empty/missing PATH, ordering preservation, HOME-based paths
- [x] All 184 existing tests pass
- [x] `pnpm typecheck` passes (pre-existing cli errors unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)