### PR TITLE
fix: SPA fallback returns 500 for direct client-side route navigation

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -135,8 +135,9 @@ export async function createApp(
     const uiDist = candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
     if (uiDist) {
       const indexHtml = fs.readFileSync(path.join(uiDist, "index.html"), "utf-8");
-      app.use(express.static(uiDist));
-      app.get(/.*/, (_req, res) => {
+      app.use(express.static(uiDist, { fallthrough: true }));
+      app.use((_req, res, next) => {
+        if (_req.path.startsWith("/api/")) return next();
         res.status(200).set("Content-Type", "text/html").end(indexHtml);
       });
     } else {


### PR DESCRIPTION
## Summary

- Direct navigation to client-side routes (e.g. `/RAN/agents/lead-auditor`) returns 500 instead of serving the SPA
- `express.static` throws a `NotFoundError` for non-existent paths, which gets caught by `errorHandler` before the catch-all can serve `index.html`
- Added `{ fallthrough: true }` to `express.static` so it calls `next()` instead of throwing
- Changed `app.get(/.*/)` to `app.use()` with an explicit `/api/` guard for the SPA fallback

## Test plan

- [ ] Navigate directly to a client-side route like `/RAN/agents/lead-auditor` — should render the SPA
- [ ] API routes (`/api/health`, etc.) still work normally
- [ ] Static assets (JS, CSS, images) still served correctly
- [ ] Navigation within the SPA still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)