### PR TITLE
fix: add "No assignee" and "Me" options to issue filter (#170)

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -92,11 +92,16 @@ function applyFilters(issues: Issue[], state: IssueViewState, currentUserId?: st
   let result = issues;
   if (state.statuses.length > 0) result = result.filter((i) => state.statuses.includes(i.status));
   if (state.priorities.length > 0) result = result.filter((i) => state.priorities.includes(i.priority));
-  if (state.assignees.length > 0) {
+  // Exclude __me from effective assignees while the session is still loading
+  // to avoid showing a blank list with no way to clear the filter.
+  const effectiveAssignees = currentUserId
+    ? state.assignees
+    : state.assignees.filter((a) => a !== "__me");
+  if (effectiveAssignees.length > 0) {
     result = result.filter((i) => {
-      if (state.assignees.includes("__unassigned") && i.assigneeAgentId == null && i.assigneeUserId == null) return true;
-      if (state.assignees.includes("__me") && currentUserId && i.assigneeUserId === currentUserId) return true;
-      if (i.assigneeAgentId != null && state.assignees.includes(i.assigneeAgentId)) return true;
+      if (effectiveAssignees.includes("__unassigned") && i.assigneeAgentId == null && i.assigneeUserId == null) return true;
+      if (effectiveAssignees.includes("__me") && currentUserId && i.assigneeUserId === currentUserId) return true;
+      if (i.assigneeAgentId != null && effectiveAssignees.includes(i.assigneeAgentId)) return true;
       return false;
     });
   }
@@ -175,7 +180,7 @@ export function IssuesList({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
   });
-  const currentUserId = session?.user?.id ?? session?.session?.userId;
+  const currentUserId = session?.user?.id;
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;
@@ -263,14 +268,20 @@ export function IssuesList({
         .filter((p) => groups[p]?.length)
         .map((p) => ({ key: p, label: statusLabel(p), items: groups[p]! }));
     }
-    // assignee
-    const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? "__unassigned");
+    // assignee — group by agent, user, or unassigned
+    const groups = groupBy(filtered, (i) =>
+      i.assigneeAgentId ?? (i.assigneeUserId ? `__user:${i.assigneeUserId}` : "__unassigned"),
+    );
     return Object.keys(groups).map((key) => ({
       key,
-      label: key === "__unassigned" ? "Unassigned" : (agentName(key) ?? key.slice(0, 8)),
+      label: key === "__unassigned"
+        ? "Unassigned"
+        : key.startsWith("__user:")
+          ? (key === `__user:${currentUserId}` ? "Me" : key.slice(7, 15))
+          : (agentName(key) ?? key.slice(0, 8)),
       items: groups[key]!,
     }));
-  }, [filtered, viewState.groupBy, agents]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filtered, viewState.groupBy, agents, currentUserId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const newIssueDefaults = (groupKey?: string) => {
     const defaults: Record<string, string> = {};

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { issuesApi } from "../api/issues";
+import { authApi } from "../api/auth";
 import { queryKeys } from "../lib/queryKeys";
 import { groupBy } from "../lib/groupBy";
 import { formatDate, cn } from "../lib/utils";
@@ -87,11 +88,18 @@ function toggleInArray(arr: string[], value: string): string[] {
   return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value];
 }
 
-function applyFilters(issues: Issue[], state: IssueViewState): Issue[] {
+function applyFilters(issues: Issue[], state: IssueViewState, currentUserId?: string): Issue[] {
   let result = issues;
   if (state.statuses.length > 0) result = result.filter((i) => state.statuses.includes(i.status));
   if (state.priorities.length > 0) result = result.filter((i) => state.priorities.includes(i.priority));
-  if (state.assignees.length > 0) result = result.filter((i) => i.assigneeAgentId != null && state.assignees.includes(i.assigneeAgentId));
+  if (state.assignees.length > 0) {
+    result = result.filter((i) => {
+      if (state.assignees.includes("__unassigned") && i.assigneeAgentId == null && i.assigneeUserId == null) return true;
+      if (state.assignees.includes("__me") && currentUserId && i.assigneeUserId === currentUserId) return true;
+      if (i.assigneeAgentId != null && state.assignees.includes(i.assigneeAgentId)) return true;
+      return false;
+    });
+  }
   if (state.labels.length > 0) result = result.filter((i) => (i.labelIds ?? []).some((id) => state.labels.includes(id)));
   return result;
 }
@@ -163,6 +171,11 @@ export function IssuesList({
 }: IssuesListProps) {
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+  });
+  const currentUserId = session?.user?.id ?? session?.session?.userId;
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;
@@ -222,9 +235,9 @@ export function IssuesList({
 
   const filtered = useMemo(() => {
     const sourceIssues = normalizedIssueSearch.length > 0 ? searchedIssues : issues;
-    const filteredByControls = applyFilters(sourceIssues, viewState);
+    const filteredByControls = applyFilters(sourceIssues, viewState, currentUserId);
     return sortIssues(filteredByControls, viewState);
-  }, [issues, searchedIssues, viewState, normalizedIssueSearch]);
+  }, [issues, searchedIssues, viewState, normalizedIssueSearch, currentUserId]);
 
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(selectedCompanyId!),
@@ -417,22 +430,36 @@ export function IssuesList({
                     </div>
 
                     {/* Assignee */}
-                    {agents && agents.length > 0 && (
-                      <div className="space-y-1">
-                        <span className="text-xs text-muted-foreground">Assignee</span>
-                        <div className="space-y-0.5 max-h-32 overflow-y-auto">
-                          {agents.map((agent) => (
-                            <label key={agent.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
-                              <Checkbox
-                                checked={viewState.assignees.includes(agent.id)}
-                                onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, agent.id) })}
-                              />
-                              <span className="text-sm">{agent.name}</span>
-                            </label>
-                          ))}
-                        </div>
+                    <div className="space-y-1">
+                      <span className="text-xs text-muted-foreground">Assignee</span>
+                      <div className="space-y-0.5 max-h-32 overflow-y-auto">
+                        <label className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                          <Checkbox
+                            checked={viewState.assignees.includes("__unassigned")}
+                            onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, "__unassigned") })}
+                          />
+                          <span className="text-sm text-muted-foreground">No assignee</span>
+                        </label>
+                        {currentUserId && (
+                          <label className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                            <Checkbox
+                              checked={viewState.assignees.includes("__me")}
+                              onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, "__me") })}
+                            />
+                            <span className="text-sm">Me</span>
+                          </label>
+                        )}
+                        {(agents ?? []).map((agent) => (
+                          <label key={agent.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                            <Checkbox
+                              checked={viewState.assignees.includes(agent.id)}
+                              onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, agent.id) })}
+                            />
+                            <span className="text-sm">{agent.name}</span>
+                          </label>
+                        ))}
                       </div>
-                    )}
+                    </div>
 
                     {labels && labels.length > 0 && (
                       <div className="space-y-1">


### PR DESCRIPTION
## Summary

Adds two missing options to the issue assignee filter:

- **No assignee** — shows issues where neither an agent nor a user is assigned
- **Me** — shows issues assigned to the currently logged-in board user

Previously the filter only supported selecting agents, making it impossible to find unassigned issues or issues assigned to yourself.

## Changes

Single file: `ui/src/components/IssuesList.tsx`

- Added `__unassigned` and `__me` sentinel values to the assignee filter
- Updated `applyFilters()` to check both `assigneeAgentId` and `assigneeUserId`
- Fetches session via existing `authApi.getSession()` (same pattern as `IssueProperties.tsx`)
- Assignee filter section now always renders (was previously hidden when no agents exist)

## Test plan

- [x] TypeScript compiles clean
- [x] No new dependencies
- [ ] Manual: verify "No assignee" filters to unassigned issues
- [ ] Manual: verify "Me" filters to current user's assigned issues
- [ ] Manual: verify agent filter checkboxes still work as before

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)