### PR TITLE
fix: show elapsed timer on run cards for cloud adapters (#235)

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -428,7 +428,8 @@ function AgentRunCard({
 }) {
   const bodyRef = useRef<HTMLDivElement>(null);
   const recent = feed.slice(-20);
-  const elapsed = useElapsedTime(run.createdAt, isActive && recent.length === 0);
+  const isRunning = run.status === "running";
+  const elapsed = useElapsedTime(run.startedAt ?? run.createdAt, isActive && recent.length === 0);
 
   useEffect(() => {
     const body = bodyRef.current;
@@ -489,7 +490,7 @@ function AgentRunCard({
       {/* Feed body */}
       <div ref={bodyRef} className="flex-1 max-h-[140px] overflow-y-auto p-2 font-mono text-[11px] space-y-1">
         {isActive && recent.length === 0 && (
-          <div className="text-xs text-muted-foreground">Running ({elapsed})...</div>
+          <div className="text-xs text-muted-foreground">{isRunning ? `Running (${elapsed})` : `Queued (${elapsed})`}...</div>
         )}
         {!isActive && recent.length === 0 && (
           <div className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Replaces the static "Waiting for output..." placeholder on agent run cards with a live elapsed timer ("Running (1m 23s)...") that updates every second.

Cloud adapters (SSE/WebSocket) don't stream stdout line-by-line like `claude_local`, so the feed stays empty and the card previously showed a static message indefinitely — no indication whether the agent has been running for 5 seconds or 5 minutes.

## Changes

Single file: `ui/src/components/ActiveAgentsPanel.tsx`

- Added `useElapsedTime(since, enabled)` hook — ticks a `setInterval` every second, formats as `Xs` or `Xm Ys`
- Timer only runs when the card is active AND has no feed output (stops ticking once output arrives or run finishes)
- Replaces `Waiting for output...` with `Running (42s)...`

## Test plan

- [x] TypeScript compiles clean
- [x] No new dependencies
- [ ] Manual: verify timer ticks on active run with no stdout
- [ ] Manual: verify timer stops when output arrives or run finishes

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)