### PR TITLE
docs: remove obsolete TODO for CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,6 @@ See [doc/DEVELOPING.md](doc/DEVELOPING.md) for the full development guide.
 
 We welcome contributions. See the [contributing guide](CONTRIBUTING.md) for details.
 
-<!-- TODO: add CONTRIBUTING.md -->
-
 <br/>
 
 ## Community


### PR DESCRIPTION
The `CONTRIBUTING.md` file is already present in the repository, so the TODO comment is no longer needed.