### PR TITLE
fix: resolve @ mention insertion in task comments

### DIFF
--- a/server/src/__tests__/mention-matching.test.ts
+++ b/server/src/__tests__/mention-matching.test.ts
@@ -84,6 +84,31 @@ describe("bodyContainsMention", () => {
     expect(bodyContainsMention("first line\n@Alice", "Alice")).toBe(true);
   });
 
+  // --- markdown formatting contexts ---
+  it("matches @Name in blockquote", () => {
+    expect(bodyContainsMention(">@Alice said something", "Alice")).toBe(true);
+    expect(bodyContainsMention("> @Alice said something", "Alice")).toBe(true);
+  });
+
+  it("matches @Name in parentheses", () => {
+    expect(bodyContainsMention("(cc @Alice)", "Alice")).toBe(true);
+    expect(bodyContainsMention("(@Alice)", "Alice")).toBe(true);
+  });
+
+  it("matches @Name after bold/italic markers", () => {
+    expect(bodyContainsMention("**@Alice** is great", "Alice")).toBe(true);
+    expect(bodyContainsMention("_@Alice_ is great", "Alice")).toBe(true);
+    expect(bodyContainsMention("*@Alice*", "Alice")).toBe(true);
+  });
+
+  it("matches @Name after list marker", () => {
+    expect(bodyContainsMention("- @Alice", "Alice")).toBe(true);
+  });
+
+  it("does not match when name is part of a hyphenated name", () => {
+    expect(bodyContainsMention("@Alice-bot", "Alice")).toBe(false);
+  });
+
   // --- edge: same-name prefix agents ---
   it("distinguishes between 'Al' and 'Alice'", () => {
     expect(bodyContainsMention("@Alice", "Al")).toBe(false);

--- a/server/src/__tests__/mention-matching.test.ts
+++ b/server/src/__tests__/mention-matching.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { bodyContainsMention } from "../services/issues.ts";
+
+describe("bodyContainsMention", () => {
+  // --- basic matches ---
+  it("matches @Name at start of string", () => {
+    expect(bodyContainsMention("@Alice hello", "Alice")).toBe(true);
+  });
+
+  it("matches @Name at end of string", () => {
+    expect(bodyContainsMention("hello @Alice", "Alice")).toBe(true);
+  });
+
+  it("matches @Name after whitespace", () => {
+    expect(bodyContainsMention("hey @Alice how are you", "Alice")).toBe(true);
+  });
+
+  it("matches @Name followed by punctuation", () => {
+    expect(bodyContainsMention("hey @Alice, how are you", "Alice")).toBe(true);
+    expect(bodyContainsMention("ask @Alice.", "Alice")).toBe(true);
+    expect(bodyContainsMention("ask @Alice!", "Alice")).toBe(true);
+    expect(bodyContainsMention("ask @Alice?", "Alice")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(bodyContainsMention("@alice", "Alice")).toBe(true);
+    expect(bodyContainsMention("@ALICE", "Alice")).toBe(true);
+    expect(bodyContainsMention("@Alice", "alice")).toBe(true);
+  });
+
+  // --- multi-word agent names ---
+  it("matches multi-word agent names", () => {
+    expect(bodyContainsMention("contact @Research Agent for details", "Research Agent")).toBe(true);
+  });
+
+  it("matches multi-word name at start of string", () => {
+    expect(bodyContainsMention("@Research Agent is great", "Research Agent")).toBe(true);
+  });
+
+  it("matches multi-word name at end of string", () => {
+    expect(bodyContainsMention("talk to @Research Agent", "Research Agent")).toBe(true);
+  });
+
+  it("matches multi-word name followed by punctuation", () => {
+    expect(bodyContainsMention("ask @Research Agent, he knows", "Research Agent")).toBe(true);
+  });
+
+  // --- should NOT match ---
+  it("does not match email-style @ (preceded by word char)", () => {
+    expect(bodyContainsMention("user@Alice.com", "Alice")).toBe(false);
+  });
+
+  it("does not match when name is a prefix of a longer word", () => {
+    expect(bodyContainsMention("@Alicex", "Alice")).toBe(false);
+    expect(bodyContainsMention("@Bobby", "Bob")).toBe(false);
+  });
+
+  it("does not match partial multi-word name", () => {
+    // "Research" alone should not match agent named "Research Agent"
+    expect(bodyContainsMention("@Research is cool", "Research Agent")).toBe(false);
+  });
+
+  it("does not match when @ is in the middle of a word", () => {
+    expect(bodyContainsMention("test@Alice", "Alice")).toBe(false);
+  });
+
+  // --- no @ at all ---
+  it("returns false when body has no @", () => {
+    expect(bodyContainsMention("hello world", "Alice")).toBe(false);
+  });
+
+  // --- multiple mentions ---
+  it("matches when multiple agents are mentioned", () => {
+    expect(bodyContainsMention("@Alice and @Bob", "Alice")).toBe(true);
+    expect(bodyContainsMention("@Alice and @Bob", "Bob")).toBe(true);
+  });
+
+  // --- with newlines ---
+  it("matches @Name followed by newline", () => {
+    expect(bodyContainsMention("@Alice\nnext line", "Alice")).toBe(true);
+  });
+
+  it("matches @Name after newline", () => {
+    expect(bodyContainsMention("first line\n@Alice", "Alice")).toBe(true);
+  });
+
+  // --- edge: same-name prefix agents ---
+  it("distinguishes between 'Al' and 'Alice'", () => {
+    expect(bodyContainsMention("@Alice", "Al")).toBe(false);
+    expect(bodyContainsMention("@Al ", "Al")).toBe(true);
+    expect(bodyContainsMention("@Alice", "Alice")).toBe(true);
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -23,8 +23,9 @@ const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "bloc
 
 /**
  * Check whether `@name` appears as a standalone mention in `body`.
- * The `@` must be at the start of the string or preceded by whitespace, and
- * the name must be followed by whitespace, punctuation, or end of string.
+ * The `@` must be at the start of the string or preceded by a non-alphanumeric
+ * character (whitespace, markdown formatting, punctuation). The name must be
+ * followed by whitespace, punctuation, markdown formatting, or end of string.
  * Matching is case-insensitive. Supports multi-word agent names.
  */
 export function bodyContainsMention(body: string, name: string): boolean {
@@ -32,9 +33,12 @@ export function bodyContainsMention(body: string, name: string): boolean {
   const needle = `@${name.toLowerCase()}`;
   let idx = bodyLower.indexOf(needle);
   while (idx !== -1) {
-    if (idx === 0 || /\s/.test(bodyLower[idx - 1])) {
+    // Allow @ after whitespace, start-of-string, or common markdown/punctuation
+    // characters (blockquote >, parens, bold/italic markers, etc.) to avoid
+    // false negatives while still rejecting email-style word@Name patterns.
+    if (idx === 0 || /[^a-z0-9]/.test(bodyLower[idx - 1])) {
       const afterPos = idx + needle.length;
-      if (afterPos >= bodyLower.length || /[\s,!?.;:\])}>]/.test(bodyLower[afterPos])) {
+      if (afterPos >= bodyLower.length || /[\s,!?.;:\])}>*_~`]/.test(bodyLower[afterPos])) {
         return true;
       }
     }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -21,6 +21,28 @@ import { conflict, notFound, unprocessable } from "../errors.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 
+/**
+ * Check whether `@name` appears as a standalone mention in `body`.
+ * The `@` must be at the start of the string or preceded by whitespace, and
+ * the name must be followed by whitespace, punctuation, or end of string.
+ * Matching is case-insensitive. Supports multi-word agent names.
+ */
+export function bodyContainsMention(body: string, name: string): boolean {
+  const bodyLower = body.toLowerCase();
+  const needle = `@${name.toLowerCase()}`;
+  let idx = bodyLower.indexOf(needle);
+  while (idx !== -1) {
+    if (idx === 0 || /\s/.test(bodyLower[idx - 1])) {
+      const afterPos = idx + needle.length;
+      if (afterPos >= bodyLower.length || /[\s,!?.;:\])}>]/.test(bodyLower[afterPos])) {
+        return true;
+      }
+    }
+    idx = bodyLower.indexOf(needle, idx + 1);
+  }
+  return false;
+}
+
 function assertTransition(from: string, to: string) {
   if (from === to) return;
   if (!ALL_ISSUE_STATUSES.includes(to)) {
@@ -1211,14 +1233,10 @@ export function issueService(db: Db) {
       }),
 
     findMentionedAgents: async (companyId: string, body: string) => {
-      const re = /\B@([^\s@,!?.]+)/g;
-      const tokens = new Set<string>();
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(body)) !== null) tokens.add(m[1].toLowerCase());
-      if (tokens.size === 0) return [];
+      if (!body.includes("@")) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      return rows.filter(a => tokens.has(a.name.toLowerCase())).map(a => a.id);
+      return rows.filter(a => bodyContainsMention(body, a.name)).map(a => a.id);
     },
 
     findMentionedProjectIds: async (issueId: string) => {

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -146,20 +146,27 @@ function detectMention(container: HTMLElement): MentionState | null {
   };
 }
 
-function mentionMarkdown(option: MentionOption): string {
+/** @internal exported for testing */
+export function mentionMarkdown(option: MentionOption): string {
   if (option.kind === "project" && option.projectId) {
     return `[@${option.name}](${buildProjectMentionHref(option.projectId, option.projectColor ?? null)}) `;
   }
   return `@${option.name} `;
 }
 
-/** Replace `@<query>` in the markdown string with the selected mention token. */
-function applyMention(markdown: string, query: string, option: MentionOption): string {
+/** Replace `@<query>` in the markdown string with the selected mention token.
+ *  @internal exported for testing */
+export function applyMention(markdown: string, query: string, option: MentionOption): string {
   const search = `@${query}`;
-  const replacement = mentionMarkdown(option);
+  let replacement = mentionMarkdown(option);
   const idx = markdown.lastIndexOf(search);
   if (idx === -1) return markdown;
-  return markdown.slice(0, idx) + replacement + markdown.slice(idx + search.length);
+  const after = markdown.slice(idx + search.length);
+  // Avoid double-space when the text after the mention already starts with a space
+  if (replacement.endsWith(" ") && after.startsWith(" ")) {
+    replacement = replacement.slice(0, -1);
+  }
+  return markdown.slice(0, idx) + replacement + after;
 }
 
 function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
@@ -374,92 +381,20 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       const state = mentionStateRef.current;
       if (!state) return;
 
-      if (option.kind === "project" && option.projectId) {
-        const current = latestValueRef.current;
-        const next = applyMention(current, state.query, option);
-        if (next !== current) {
-          latestValueRef.current = next;
-          ref.current?.setMarkdown(next);
-          onChange(next);
-        }
-        requestAnimationFrame(() => {
-          ref.current?.focus(undefined, { defaultSelection: "rootEnd" });
-          decorateProjectMentions();
-        });
-        mentionStateRef.current = null;
-        setMentionState(null);
-        return;
+      // Use markdown-level replacement for all mention types.
+      // Previously agent mentions used document.execCommand("insertText")
+      // which is deprecated and does not reliably integrate with MDXEditor's
+      // Lexical engine — the DOM change was not reflected in the editor model
+      // so onChange never fired with the updated value.
+      const current = latestValueRef.current;
+      const next = applyMention(current, state.query, option);
+      if (next !== current) {
+        latestValueRef.current = next;
+        ref.current?.setMarkdown(next);
+        onChange(next);
       }
-
-      const replacement = mentionMarkdown(option);
-
-      // Replace @query directly via DOM selection so the cursor naturally
-      // lands after the inserted text. Lexical picks up the change through
-      // its normal input-event handling.
-      const sel = window.getSelection();
-      if (sel && state.textNode.isConnected) {
-        const range = document.createRange();
-        range.setStart(state.textNode, state.atPos);
-        range.setEnd(state.textNode, state.endPos);
-        sel.removeAllRanges();
-        sel.addRange(range);
-        document.execCommand("insertText", false, replacement);
-
-        // After Lexical reconciles the DOM, the cursor position set by
-        // execCommand may be lost. Explicitly reposition it after the
-        // inserted mention text.
-        const cursorTarget = state.atPos + replacement.length;
-        requestAnimationFrame(() => {
-          const newSel = window.getSelection();
-          if (!newSel) return;
-          // Try the original text node first (it may still be valid)
-          if (state.textNode.isConnected) {
-            const len = state.textNode.textContent?.length ?? 0;
-            if (cursorTarget <= len) {
-              const r = document.createRange();
-              r.setStart(state.textNode, cursorTarget);
-              r.collapse(true);
-              newSel.removeAllRanges();
-              newSel.addRange(r);
-              return;
-            }
-          }
-          // Fallback: search for the replacement in text nodes
-          const editable = containerRef.current?.querySelector('[contenteditable="true"]');
-          if (!editable) return;
-          const walker = document.createTreeWalker(editable, NodeFilter.SHOW_TEXT);
-          let node: Text | null;
-          while ((node = walker.nextNode() as Text | null)) {
-            const text = node.textContent ?? "";
-            const idx = text.indexOf(replacement);
-            if (idx !== -1) {
-              const pos = idx + replacement.length;
-              if (pos <= text.length) {
-                const r = document.createRange();
-                r.setStart(node, pos);
-                r.collapse(true);
-                newSel.removeAllRanges();
-                newSel.addRange(r);
-                return;
-              }
-            }
-          }
-        });
-      } else {
-        // Fallback: full markdown replacement when DOM node is stale
-        const current = latestValueRef.current;
-        const next = applyMention(current, state.query, option);
-        if (next !== current) {
-          latestValueRef.current = next;
-          ref.current?.setMarkdown(next);
-          onChange(next);
-        }
-        requestAnimationFrame(() => {
-          ref.current?.focus(undefined, { defaultSelection: "rootEnd" });
-        });
-      }
-
       requestAnimationFrame(() => {
+        ref.current?.focus(undefined, { defaultSelection: "rootEnd" });
         decorateProjectMentions();
       });
 


### PR DESCRIPTION
## Summary

Fixes #448 — `@` mentions in task comments are non-functional: selecting an agent from the dropdown produces no effect, and manually typed mentions are not recognized by the server.

### Root causes & fixes

**1. Frontend — `selectMention` in `MarkdownEditor.tsx`**

Agent mentions used `document.execCommand("insertText")` to insert text into the editor DOM. This API is deprecated and does not reliably integrate with MDXEditor's underlying Lexical engine — the DOM mutation was not reflected in the editor's internal model, so `onChange` never fired with the updated value.

**Fix:** Unified all mention types (agent + project) to use the same markdown-level replacement path (`applyMention` → `setMarkdown` → `onChange`), which was already working correctly for project mentions. Also fixed a double-space edge case when inserting a mention in the middle of existing text.

**2. Backend — `findMentionedAgents` in `issues.ts`**

The regex `/\B@([^\s@,!?.]+)/g` captured only until the first whitespace character, so agent names containing spaces (e.g. "Research Agent") could never be matched.

**Fix:** Replaced the regex-based token extraction with name-driven matching. The new `bodyContainsMention()` helper checks each agent's name against the comment body with proper boundary validation (must be preceded by whitespace/start-of-string and followed by whitespace/punctuation/end-of-string). Matching is case-insensitive and supports multi-word names.

### Changes

| File | Change |
|------|--------|
| `ui/src/components/MarkdownEditor.tsx` | Unified mention insertion to markdown-level replacement; removed deprecated `execCommand` path; fixed double-space edge case |
| `server/src/services/issues.ts` | Extracted `bodyContainsMention()` pure function; rewrote `findMentionedAgents` to support multi-word names |
| `server/src/__tests__/mention-matching.test.ts` | Added 18 unit tests for `bodyContainsMention` |

## Test plan

- [x] `pnpm -r typecheck` — all 12 packages pass
- [x] `pnpm test:run` — 45 test files, 197 tests pass (including 18 new mention tests)
- [x] `pnpm build` — successful
- [x] Manual: type `@` in a task comment, select an agent → mention text inserted correctly
- [ ] Manual: submit comment with `@AgentName` → agent receives wakeup notification
- [ ] Manual: test with multi-word agent name (e.g. "Research Agent")