### PR TITLE
[feature] allow default-permission agents to assign tasks

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -227,7 +227,7 @@ Default behavior:
 
 By default, agent task assignment requires explicit `tasks:assign` grants (or legacy manager permissions).
 
-To allow agents on role-default permissions to assign issues to other agents, set:
+To allow agents with no explicit permission overrides (default permission set) to assign issues to other agents, set:
 
 ```sh
 PAPERCLIP_ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT=true

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -223,6 +223,16 @@ Default behavior:
 - `local_trusted`: enabled
 - `authenticated`: disabled
 
+## Default Agent Task Assignment Toggle
+
+By default, agent task assignment requires explicit `tasks:assign` grants (or legacy manager permissions).
+
+To allow agents on role-default permissions to assign issues to other agents, set:
+
+```sh
+PAPERCLIP_ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT=true
+```
+
 ## CLI Client Operations
 
 Paperclip CLI now includes client-side control-plane commands in addition to setup commands.

--- a/server/src/__tests__/issues-assignment-permission-toggle.test.ts
+++ b/server/src/__tests__/issues-assignment-permission-toggle.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  canAssignTasksWithDefaultPermissionFlag,
+  hasDefaultAgentPermissionSet,
+  type AssignmentTargetType,
+} from "../routes/issues.js";
+
+function canAssign(
+  role: string,
+  permissions: Record<string, unknown> | null | undefined,
+  assignmentTargetType: AssignmentTargetType,
+  flagEnabled: boolean,
+) {
+  return canAssignTasksWithDefaultPermissionFlag(
+    { role, permissions },
+    assignmentTargetType,
+    flagEnabled,
+  );
+}
+
+describe("hasDefaultAgentPermissionSet", () => {
+  it("treats missing permissions as role defaults", () => {
+    expect(hasDefaultAgentPermissionSet({ role: "general", permissions: null })).toBe(true);
+    expect(hasDefaultAgentPermissionSet({ role: "ceo", permissions: null })).toBe(true);
+  });
+
+  it("detects permission overrides that differ from defaults", () => {
+    expect(
+      hasDefaultAgentPermissionSet({
+        role: "general",
+        permissions: { canCreateAgents: true },
+      }),
+    ).toBe(false);
+    expect(
+      hasDefaultAgentPermissionSet({
+        role: "ceo",
+        permissions: { canCreateAgents: false },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("canAssignTasksWithDefaultPermissionFlag", () => {
+  it("allows assigning to agents when flag is enabled and permissions are defaults", () => {
+    expect(canAssign("general", null, "agent", true)).toBe(true);
+  });
+
+  it("blocks non-agent assignment targets even when flag is enabled", () => {
+    expect(canAssign("general", null, "user", true)).toBe(false);
+    expect(canAssign("general", null, "unassigned", true)).toBe(false);
+  });
+
+  it("blocks assignments when flag is disabled", () => {
+    expect(canAssign("general", null, "agent", false)).toBe(false);
+  });
+
+  it("blocks assignments when permissions are not default", () => {
+    expect(canAssign("general", { canCreateAgents: true }, "agent", true)).toBe(false);
+  });
+});

--- a/server/src/__tests__/issues-assignment-permission-toggle.test.ts
+++ b/server/src/__tests__/issues-assignment-permission-toggle.test.ts
@@ -24,6 +24,11 @@ describe("hasDefaultAgentPermissionSet", () => {
     expect(hasDefaultAgentPermissionSet({ role: "ceo", permissions: null })).toBe(true);
   });
 
+  it("treats empty permission objects as defaults", () => {
+    expect(hasDefaultAgentPermissionSet({ role: "general", permissions: {} })).toBe(true);
+    expect(hasDefaultAgentPermissionSet({ role: "ceo", permissions: {} })).toBe(true);
+  });
+
   it("detects permission overrides that differ from defaults", () => {
     expect(
       hasDefaultAgentPermissionSet({
@@ -37,12 +42,19 @@ describe("hasDefaultAgentPermissionSet", () => {
         permissions: { canCreateAgents: false },
       }),
     ).toBe(false);
+    expect(
+      hasDefaultAgentPermissionSet({
+        role: "general",
+        permissions: { canCreateAgents: false },
+      }),
+    ).toBe(false);
   });
 });
 
 describe("canAssignTasksWithDefaultPermissionFlag", () => {
   it("allows assigning to agents when flag is enabled and permissions are defaults", () => {
     expect(canAssign("general", null, "agent", true)).toBe(true);
+    expect(canAssign("general", {}, "agent", true)).toBe(true);
   });
 
   it("blocks non-agent assignment targets even when flag is enabled", () => {
@@ -56,5 +68,6 @@ describe("canAssignTasksWithDefaultPermissionFlag", () => {
 
   it("blocks assignments when permissions are not default", () => {
     expect(canAssign("general", { canCreateAgents: true }, "agent", true)).toBe(false);
+    expect(canAssign("general", { canCreateAgents: false }, "agent", true)).toBe(false);
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -26,8 +26,10 @@ import { logger } from "../middleware/logger.js";
 import { forbidden, HttpError, unauthorized } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { defaultPermissionsForRole, normalizeAgentPermissions } from "../services/agent-permissions.js";
 
 const MAX_ATTACHMENT_BYTES = Number(process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES) || 10 * 1024 * 1024;
+const ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT = process.env.PAPERCLIP_ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT === "true";
 const ALLOWED_ATTACHMENT_CONTENT_TYPES = new Set([
   "image/png",
   "image/jpeg",
@@ -35,6 +37,29 @@ const ALLOWED_ATTACHMENT_CONTENT_TYPES = new Set([
   "image/webp",
   "image/gif",
 ]);
+
+export type AssignmentTargetType = "agent" | "user" | "unassigned";
+
+type AgentPermissionShape = {
+  role: string;
+  permissions: Record<string, unknown> | null | undefined;
+};
+
+export function hasDefaultAgentPermissionSet(agent: AgentPermissionShape) {
+  const defaults = defaultPermissionsForRole(agent.role);
+  const normalized = normalizeAgentPermissions(agent.permissions, agent.role);
+  return Object.entries(defaults).every(([key, value]) => normalized[key] === value);
+}
+
+export function canAssignTasksWithDefaultPermissionFlag(
+  agent: AgentPermissionShape,
+  assignmentTargetType: AssignmentTargetType,
+  flagEnabled = ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT,
+) {
+  if (!flagEnabled) return false;
+  if (assignmentTargetType !== "agent") return false;
+  return hasDefaultAgentPermissionSet(agent);
+}
 
 export function issueRoutes(db: Db, storage: StorageService) {
   const router = Router();
@@ -89,7 +114,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
-  async function assertCanAssignTasks(req: Request, companyId: string) {
+  async function assertCanAssignTasks(req: Request, companyId: string, assignmentTargetType: AssignmentTargetType) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
       if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
@@ -103,6 +128,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
       if (allowedByGrant) return;
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
       if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
+      if (
+        actorAgent &&
+        actorAgent.companyId === companyId &&
+        canAssignTasksWithDefaultPermissionFlag(actorAgent, assignmentTargetType)
+      ) {
+        return;
+      }
       throw forbidden("Missing permission: tasks:assign");
     }
     throw unauthorized();
@@ -417,7 +449,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
-      await assertCanAssignTasks(req, companyId);
+      const assignmentTargetType: AssignmentTargetType = req.body.assigneeAgentId ? "agent" : "user";
+      await assertCanAssignTasks(req, companyId, assignmentTargetType);
     }
 
     const actor = getActorInfo(req);
@@ -479,7 +512,16 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
     if (assigneeWillChange) {
       if (!isAgentReturningIssueToCreator) {
-        await assertCanAssignTasks(req, existing.companyId);
+        const nextAssigneeAgentId =
+          req.body.assigneeAgentId !== undefined ? req.body.assigneeAgentId : existing.assigneeAgentId;
+        const nextAssigneeUserId =
+          req.body.assigneeUserId !== undefined ? req.body.assigneeUserId : existing.assigneeUserId;
+        const assignmentTargetType: AssignmentTargetType = nextAssigneeAgentId
+          ? "agent"
+          : nextAssigneeUserId
+            ? "user"
+            : "unassigned";
+        await assertCanAssignTasks(req, existing.companyId, assignmentTargetType);
       }
     }
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
-import type { Db } from "@paperclipai/db";
+import { agents as agentsTable, type Db } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
 import {
   addIssueCommentSchema,
   createIssueAttachmentMetadataSchema,
@@ -26,10 +27,8 @@ import { logger } from "../middleware/logger.js";
 import { forbidden, HttpError, unauthorized } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
-import { defaultPermissionsForRole, normalizeAgentPermissions } from "../services/agent-permissions.js";
 
 const MAX_ATTACHMENT_BYTES = Number(process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES) || 10 * 1024 * 1024;
-const ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT = process.env.PAPERCLIP_ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT === "true";
 const ALLOWED_ATTACHMENT_CONTENT_TYPES = new Set([
   "image/png",
   "image/jpeg",
@@ -45,16 +44,23 @@ type AgentPermissionShape = {
   permissions: Record<string, unknown> | null | undefined;
 };
 
+function isDefaultAgentTaskAssignmentEnabled() {
+  return process.env.PAPERCLIP_ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT === "true";
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function hasDefaultAgentPermissionSet(agent: AgentPermissionShape) {
-  const defaults = defaultPermissionsForRole(agent.role);
-  const normalized = normalizeAgentPermissions(agent.permissions, agent.role);
-  return Object.entries(defaults).every(([key, value]) => normalized[key] === value);
+  if (!isPlainRecord(agent.permissions)) return true;
+  return Object.keys(agent.permissions).length === 0;
 }
 
 export function canAssignTasksWithDefaultPermissionFlag(
   agent: AgentPermissionShape,
   assignmentTargetType: AssignmentTargetType,
-  flagEnabled = ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT,
+  flagEnabled = isDefaultAgentTaskAssignmentEnabled(),
 ) {
   if (!flagEnabled) return false;
   if (assignmentTargetType !== "agent") return false;
@@ -126,7 +132,16 @@ export function issueRoutes(db: Db, storage: StorageService) {
       if (!req.actor.agentId) throw forbidden("Agent authentication required");
       const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:assign");
       if (allowedByGrant) return;
-      const actorAgent = await agentsSvc.getById(req.actor.agentId);
+      const actorAgent = await db
+        .select({
+          id: agentsTable.id,
+          companyId: agentsTable.companyId,
+          role: agentsTable.role,
+          permissions: agentsTable.permissions,
+        })
+        .from(agentsTable)
+        .where(eq(agentsTable.id, req.actor.agentId))
+        .then((rows) => rows[0] ?? null);
       if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
       if (
         actorAgent &&

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -65,6 +65,12 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function normalizePermissionsForPersistence(permissions: unknown, role: string) {
+  if (permissions === undefined || permissions === null) return {};
+  if (isPlainRecord(permissions) && Object.keys(permissions).length === 0) return {};
+  return normalizeAgentPermissions(permissions, role);
+}
+
 function jsonEqual(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
@@ -289,7 +295,7 @@ export function agentService(db: Db) {
     const normalizedPatch = { ...data } as Partial<typeof agents.$inferInsert>;
     if (data.permissions !== undefined) {
       const role = (data.role ?? existing.role) as string;
-      normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
+      normalizedPatch.permissions = normalizePermissionsForPersistence(data.permissions, role);
     }
 
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
@@ -348,7 +354,7 @@ export function agentService(db: Db) {
       const uniqueName = deduplicateAgentName(data.name, existingAgents);
 
       const role = data.role ?? "general";
-      const normalizedPermissions = normalizeAgentPermissions(data.permissions, role);
+      const normalizedPermissions = normalizePermissionsForPersistence(data.permissions, role);
       const created = await db
         .insert(agents)
         .values({ ...data, name: uniqueName, companyId, role, permissions: normalizedPermissions })


### PR DESCRIPTION
Issue:
Agents using the default permission baseline could not assign issues to other agents unless they had an explicit `tasks:assign` grant (or legacy creator-style permissions). This made default agent setups awkward for delegation-heavy workflows.

Cause and effect on users:
In practice, a freshly joined or newly created non-CEO agent running with default permissions would hit `403 Missing permission: tasks:assign` when trying to delegate work. Operators had to add explicit grants even when they wanted permissive default delegation behaviour.

Root cause:
Task assignment authorisation in the issues route only accepted explicit grants (`tasks:assign`) or legacy `canCreateAgents` checks. There was no runtime toggle to permit assignment for agents that remained on the role-default permission shape.

Fix:
This change adds `PAPERCLIP_ALLOW_DEFAULT_AGENT_TASK_ASSIGNMENT=true` as an opt-in server toggle. When enabled, agent-side assignment is allowed if all of the following are true:
- the assignment target is another agent
- the acting agent is still on its role-default permission set
- existing company boundary checks continue to pass

The existing explicit grant path and legacy `canCreateAgents` behaviour are unchanged. The check is now wired through both create and update assignment flows so behaviour is consistent.

Tests:
- Added unit coverage for default permission detection and flag-gated assignment behaviour in `server/src/__tests__/issues-assignment-permission-toggle.test.ts`.
- Verified the full repository checks locally:
  - `pnpm -r typecheck`
  - `pnpm test:run`
  - `pnpm build`
