### PR TITLE
feat(prompt): warn on cache-hostile template variables

### DIFF
--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/shared": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import { analyzePromptCacheability } from "@paperclipai/shared";
 import {
   asString,
   asNumber,
@@ -284,6 +285,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
       ]
     : [];
+  const promptCacheWarnings = analyzePromptCacheability(promptTemplate);
 
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
@@ -329,6 +331,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     await onLog(
       "stderr",
       `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+  for (const warning of promptCacheWarnings) {
+    await onLog(
+      "stderr",
+      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
     );
   }
   const prompt = renderTemplate(promptTemplate, {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -333,11 +333,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
     );
   }
-  for (const warning of promptCacheWarnings) {
-    await onLog(
-      "stderr",
-      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
-    );
+  if (promptCacheWarnings.length > 0) {
+    const summary = promptCacheWarnings
+      .map((warning) => `{{ ${warning.variable} }} ${warning.message}`)
+      .join(" | ");
+    await onLog("stderr", `[paperclip] Prompt cache warning: ${summary}\n`);
   }
   const prompt = renderTemplate(promptTemplate, {
     agentId: agent.id,

--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/shared": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -237,11 +237,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Codex session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
     );
   }
-  for (const warning of promptCacheWarnings) {
-    await onLog(
-      "stderr",
-      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
-    );
+  if (promptCacheWarnings.length > 0) {
+    const summary = promptCacheWarnings
+      .map((warning) => `{{ ${warning.variable} }} ${warning.message}`)
+      .join(" | ");
+    await onLog("stderr", `[paperclip] Prompt cache warning: ${summary}\n`);
   }
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { analyzePromptCacheability } from "@paperclipai/shared";
 import {
   asString,
   asNumber,
@@ -122,6 +123,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.dangerouslyBypassApprovalsAndSandbox,
     asBoolean(config.dangerouslyBypassSandbox, false),
   );
+  const promptCacheWarnings = analyzePromptCacheability(promptTemplate);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -233,6 +235,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     await onLog(
       "stderr",
       `[paperclip] Codex session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+  for (const warning of promptCacheWarnings) {
+    await onLog(
+      "stderr",
+      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
     );
   }
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();

--- a/packages/adapters/cursor-local/package.json
+++ b/packages/adapters/cursor-local/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/shared": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { analyzePromptCacheability } from "@paperclipai/shared";
 import {
   asString,
   asNumber,
@@ -158,6 +159,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const command = asString(config.command, "agent");
   const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
   const mode = normalizeMode(asString(config.mode, ""));
+  const promptCacheWarnings = analyzePromptCacheability(promptTemplate);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -271,6 +273,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     await onLog(
       "stderr",
       `[paperclip] Cursor session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+  for (const warning of promptCacheWarnings) {
+    await onLog(
+      "stderr",
+      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
     );
   }
 

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -275,11 +275,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Cursor session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
     );
   }
-  for (const warning of promptCacheWarnings) {
-    await onLog(
-      "stderr",
-      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
-    );
+  if (promptCacheWarnings.length > 0) {
+    const summary = promptCacheWarnings
+      .map((warning) => `{{ ${warning.variable} }} ${warning.message}`)
+      .join(" | ");
+    await onLog("stderr", `[paperclip] Prompt cache warning: ${summary}\n`);
   }
 
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();

--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/shared": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { analyzePromptCacheability } from "@paperclipai/shared";
 import {
   asString,
   asNumber,
@@ -92,6 +93,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
   const variant = asString(config.variant, "").trim();
+  const promptCacheWarnings = analyzePromptCacheability(promptTemplate);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -191,6 +193,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     await onLog(
       "stderr",
       `[paperclip] OpenCode session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+  for (const warning of promptCacheWarnings) {
+    await onLog(
+      "stderr",
+      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
     );
   }
 

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -195,11 +195,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] OpenCode session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
     );
   }
-  for (const warning of promptCacheWarnings) {
-    await onLog(
-      "stderr",
-      `[paperclip] Prompt cache warning: {{ ${warning.variable} }} ${warning.message}\n`,
-    );
+  if (promptCacheWarnings.length > 0) {
+    const summary = promptCacheWarnings
+      .map((warning) => `{{ ${warning.variable} }} ${warning.message}`)
+      .join(" | ");
+    await onLog("stderr", `[paperclip] Prompt cache warning: ${summary}\n`);
   }
 
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -125,6 +125,11 @@ export type {
 } from "./types/index.js";
 
 export {
+  analyzePromptCacheability,
+  type PromptCacheWarning,
+} from "./prompt-cache.js";
+
+export {
   createCompanySchema,
   updateCompanySchema,
   type CreateCompany,

--- a/packages/shared/src/prompt-cache.test.ts
+++ b/packages/shared/src/prompt-cache.test.ts
@@ -19,7 +19,8 @@ describe("analyzePromptCacheability", () => {
     expect(analyzePromptCacheability("Wake context: {{ context }}")).toEqual([
       {
         variable: "context",
-        message: "Serializes the entire wake context, which is bulky and often includes volatile fields.",
+        message:
+          "Serializes the entire wake context, including volatile sub-fields like now and run IDs, which defeats prompt-prefix stability.",
       },
     ]);
   });
@@ -49,7 +50,8 @@ describe("analyzePromptCacheability", () => {
     ).toEqual([
       {
         variable: "context",
-        message: "Serializes the entire wake context, which is bulky and often includes volatile fields.",
+        message:
+          "Serializes the entire wake context, including volatile sub-fields like now and run IDs, which defeats prompt-prefix stability.",
       },
       {
         variable: "context.now",

--- a/packages/shared/src/prompt-cache.test.ts
+++ b/packages/shared/src/prompt-cache.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { analyzePromptCacheability } from "./prompt-cache.js";
+
+describe("analyzePromptCacheability", () => {
+  it("returns no warnings for stable prompt variables", () => {
+    expect(
+      analyzePromptCacheability("You are {{ agent.name }} working on issue {{ context.issueId }}."),
+    ).toEqual([]);
+  });
+
+  it("warns when the whole context object is interpolated", () => {
+    expect(analyzePromptCacheability("Wake context: {{ context }}")).toEqual([
+      {
+        variable: "context",
+        message: "Serializes the entire wake context, which is bulky and often includes volatile fields.",
+      },
+    ]);
+  });
+
+  it("warns for volatile run identifiers and timestamps", () => {
+    expect(
+      analyzePromptCacheability("Run {{ run.id }} at {{ context.now }} with fallback {{ runId }}."),
+    ).toEqual([
+      {
+        variable: "runId",
+        message: "Includes a unique run ID on every heartbeat, which defeats prompt-prefix stability.",
+      },
+      {
+        variable: "run.id",
+        message: "Includes a unique run ID on every heartbeat, which defeats prompt-prefix stability.",
+      },
+      {
+        variable: "context.now",
+        message: "Includes a fresh timestamp on each wake, which defeats prompt-prefix stability.",
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/prompt-cache.test.ts
+++ b/packages/shared/src/prompt-cache.test.ts
@@ -8,6 +8,13 @@ describe("analyzePromptCacheability", () => {
     ).toEqual([]);
   });
 
+  it("returns no warnings for null, undefined, or empty templates", () => {
+    expect(analyzePromptCacheability(null)).toEqual([]);
+    expect(analyzePromptCacheability(undefined)).toEqual([]);
+    expect(analyzePromptCacheability("")).toEqual([]);
+    expect(analyzePromptCacheability("   ")).toEqual([]);
+  });
+
   it("warns when the whole context object is interpolated", () => {
     expect(analyzePromptCacheability("Wake context: {{ context }}")).toEqual([
       {
@@ -28,6 +35,21 @@ describe("analyzePromptCacheability", () => {
       {
         variable: "run.id",
         message: "Includes a unique run ID on every heartbeat, which defeats prompt-prefix stability.",
+      },
+      {
+        variable: "context.now",
+        message: "Includes a fresh timestamp on each wake, which defeats prompt-prefix stability.",
+      },
+    ]);
+  });
+
+  it("emits both context and context.now warnings when both are present", () => {
+    expect(
+      analyzePromptCacheability("Context: {{ context }} timestamp: {{ context.now }}"),
+    ).toEqual([
+      {
+        variable: "context",
+        message: "Serializes the entire wake context, which is bulky and often includes volatile fields.",
       },
       {
         variable: "context.now",

--- a/packages/shared/src/prompt-cache.ts
+++ b/packages/shared/src/prompt-cache.ts
@@ -14,7 +14,8 @@ const VOLATILE_TEMPLATE_WARNINGS: Array<PromptCacheWarning> = [
   },
   {
     variable: "context",
-    message: "Serializes the entire wake context, which is bulky and often includes volatile fields.",
+    message:
+      "Serializes the entire wake context, including volatile sub-fields like now and run IDs, which defeats prompt-prefix stability.",
   },
   {
     variable: "context.now",

--- a/packages/shared/src/prompt-cache.ts
+++ b/packages/shared/src/prompt-cache.ts
@@ -1,0 +1,36 @@
+export interface PromptCacheWarning {
+  variable: string;
+  message: string;
+}
+
+const VOLATILE_TEMPLATE_WARNINGS: Array<PromptCacheWarning> = [
+  {
+    variable: "runId",
+    message: "Includes a unique run ID on every heartbeat, which defeats prompt-prefix stability.",
+  },
+  {
+    variable: "run.id",
+    message: "Includes a unique run ID on every heartbeat, which defeats prompt-prefix stability.",
+  },
+  {
+    variable: "context",
+    message: "Serializes the entire wake context, which is bulky and often includes volatile fields.",
+  },
+  {
+    variable: "context.now",
+    message: "Includes a fresh timestamp on each wake, which defeats prompt-prefix stability.",
+  },
+];
+
+function templateIncludesVariable(template: string, variable: string) {
+  const escaped = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`{{\\s*${escaped}\\s*}}`);
+  return pattern.test(template);
+}
+
+export function analyzePromptCacheability(template: string | null | undefined): PromptCacheWarning[] {
+  if (typeof template !== "string" || template.trim().length === 0) return [];
+  return VOLATILE_TEMPLATE_WARNINGS.filter((warning) =>
+    templateIncludesVariable(template, warning.variable),
+  );
+}

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AGENT_ADAPTER_TYPES } from "@paperclipai/shared";
+import { AGENT_ADAPTER_TYPES, analyzePromptCacheability } from "@paperclipai/shared";
 import type {
   Agent,
   AdapterEnvironmentTestResult,
@@ -108,6 +108,20 @@ function isOverlayDirty(o: Overlay): boolean {
 /* ---- Shared input class ---- */
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function PromptCacheWarnings({ template }: { template: string }) {
+  const warnings = useMemo(() => analyzePromptCacheability(template), [template]);
+  if (warnings.length === 0) return null;
+  return (
+    <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+      {warnings.map((warning) => (
+        <p key={warning.variable}>
+          <code>{`{{ ${warning.variable} }}`}</code> {warning.message}
+        </p>
+      ))}
+    </div>
+  );
+}
 
 function parseCommaArgs(value: string): string[] {
   return value
@@ -316,6 +330,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const set = isCreate
     ? (patch: Partial<CreateConfigValues>) => props.onChange(patch)
     : null;
+  const currentPromptTemplate = isCreate
+    ? val?.promptTemplate ?? ""
+    : String(eff("adapterConfig", "promptTemplate", String(config.promptTemplate ?? "")));
 
   function buildAdapterConfigForTest(): Record<string, unknown> {
     if (isCreate) {
@@ -434,23 +451,26 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               />
             </Field>
             {isLocal && (
-              <Field label="Prompt Template" hint={help.promptTemplate}>
-                <MarkdownEditor
-                  value={eff(
-                    "adapterConfig",
-                    "promptTemplate",
-                    String(config.promptTemplate ?? ""),
-                  )}
-                  onChange={(v) => mark("adapterConfig", "promptTemplate", v ?? "")}
-                  placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
-                  contentClassName="min-h-[88px] text-sm font-mono"
-                  imageUploadHandler={async (file) => {
-                    const namespace = `agents/${props.agent.id}/prompt-template`;
-                    const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
-                    return asset.contentPath;
-                  }}
-                />
-              </Field>
+              <>
+                <Field label="Prompt Template" hint={help.promptTemplate}>
+                  <MarkdownEditor
+                    value={eff(
+                      "adapterConfig",
+                      "promptTemplate",
+                      String(config.promptTemplate ?? ""),
+                    )}
+                    onChange={(v) => mark("adapterConfig", "promptTemplate", v ?? "")}
+                    placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
+                    contentClassName="min-h-[88px] text-sm font-mono"
+                    imageUploadHandler={async (file) => {
+                      const namespace = `agents/${props.agent.id}/prompt-template`;
+                      const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
+                      return asset.contentPath;
+                    }}
+                  />
+                </Field>
+                <PromptCacheWarnings template={currentPromptTemplate} />
+              </>
             )}
           </div>
         </div>
@@ -562,19 +582,22 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
 
           {/* Prompt template (create mode only — edit mode shows this in Identity) */}
           {isLocal && isCreate && (
-            <Field label="Prompt Template" hint={help.promptTemplate}>
-              <MarkdownEditor
-                value={val!.promptTemplate}
-                onChange={(v) => set!({ promptTemplate: v })}
-                placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
-                contentClassName="min-h-[88px] text-sm font-mono"
-                imageUploadHandler={async (file) => {
-                  const namespace = "agents/drafts/prompt-template";
-                  const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
-                  return asset.contentPath;
-                }}
-              />
-            </Field>
+            <>
+              <Field label="Prompt Template" hint={help.promptTemplate}>
+                <MarkdownEditor
+                  value={val!.promptTemplate}
+                  onChange={(v) => set!({ promptTemplate: v })}
+                  placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
+                  contentClassName="min-h-[88px] text-sm font-mono"
+                  imageUploadHandler={async (file) => {
+                    const namespace = "agents/drafts/prompt-template";
+                    const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
+                    return asset.contentPath;
+                  }}
+                />
+              </Field>
+              <PromptCacheWarnings template={currentPromptTemplate} />
+            </>
           )}
 
           {/* Adapter-specific fields */}

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -26,7 +26,7 @@ export const help: Record<string, string> = {
   capabilities: "Describes what this agent can do. Shown in the org chart and used for task routing.",
   adapterType: "How this agent runs: local CLI (Claude/Codex/OpenCode), OpenClaw Gateway, spawned process, or generic HTTP webhook.",
   cwd: "Default working directory fallback for local adapters. Use an absolute path on the machine running Paperclip.",
-  promptTemplate: "The prompt sent to the agent on each heartbeat. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} variables.",
+  promptTemplate: "The prompt sent to the agent on each heartbeat. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} variables. Avoid volatile fields like {{ runId }} or {{ context.now }} if you want prompt-cache reuse.",
   model: "Override the default model used by the adapter.",
   thinkingEffort: "Control model reasoning depth. Supported values vary by adapter/model.",
   chrome: "Enable Claude's Chrome integration by passing --chrome.",


### PR DESCRIPTION
## Summary
- add a shared analyzer for prompt-template variables that are hostile to prompt-cache reuse
- surface those warnings in the agent config form while editing local-adapter prompt templates
- emit the same warnings at runtime in the local adapters so existing configs also get signal
- add coverage for the shared analyzer

## Why
This PR focuses on cache guardrails rather than cache mechanics. It helps operators avoid prompt-template patterns that defeat prompt-prefix reuse, especially:
- `{{ runId }}`
- `{{ run.id }}`
- `{{ context.now }}`
- `{{ context }}`

That keeps this work distinct from heartbeat triage/model-selection efforts and also distinct from the timer-session/cache-artifact changes in #481.

## Testing
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`
