### PR TITLE
fix(adapter-utils): strip Claude Code env vars from child processes

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -279,10 +279,15 @@ export async function runChildProcess(
     // These vars leak in when the Paperclip server itself is started from
     // within a Claude Code session (e.g. `npx paperclipai run` in a terminal
     // owned by Claude Code) or when cron inherits a contaminated shell env.
-    delete rawMerged.CLAUDECODE;
-    delete rawMerged.CLAUDE_CODE_ENTRYPOINT;
-    delete rawMerged.CLAUDE_CODE_SESSION;
-    delete rawMerged.CLAUDE_CODE_PARENT_SESSION;
+    const CLAUDE_CODE_NESTING_VARS = [
+      "CLAUDECODE",
+      "CLAUDE_CODE_ENTRYPOINT",
+      "CLAUDE_CODE_SESSION",
+      "CLAUDE_CODE_PARENT_SESSION",
+    ] as const;
+    for (const key of CLAUDE_CODE_NESTING_VARS) {
+      delete rawMerged[key];
+    }
 
     const mergedEnv = ensurePathInEnv(rawMerged);
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv)


### PR DESCRIPTION
## Summary

- **Bug**: When the Paperclip server is started from within a Claude Code session (e.g. `npx paperclipai run` in a Claude Code terminal), `process.env` contains `CLAUDECODE=1` and related nesting-guard variables. `runChildProcess()` in `@paperclipai/adapter-utils` spreads `process.env` into every child process, so spawned `claude` CLI processes inherit these vars and immediately exit with: *"Claude Code cannot be launched inside another Claude Code session."*
- **Impact**: Silently breaks all `claude-local` adapter agent runs. Every agent execution fails with `adapter_failed` or produces zero output. The failure persists until the server is restarted in a clean (non-Claude-Code) environment. Cron jobs that inherit a contaminated shell env also trigger this.
- **Fix**: Delete the four known Claude Code nesting-guard env vars (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SESSION`, `CLAUDE_CODE_PARENT_SESSION`) from the merged environment in `runChildProcess()` before passing it to `spawn()`.

## Reproduction

1. Open a Claude Code session in a terminal
2. Run `npx paperclipai run` from within that session
3. Trigger any agent that uses the `claude-local` adapter
4. Observe the agent run fails immediately — the spawned `claude` process exits with: "Claude Code cannot be launched inside another Claude Code session"

## Changes

- `packages/adapter-utils/src/server-utils.ts`: In `runChildProcess()`, split the env merge into two steps — first spread into `rawMerged`, delete the four Claude Code env vars, then pass to `ensurePathInEnv()`.

## Test plan

- [ ] Start Paperclip server from within a Claude Code session (`CLAUDECODE=1` in env)
- [ ] Trigger a `claude-local` agent run
- [ ] Verify the spawned `claude` process starts successfully (no "cannot be launched inside another session" error)
- [ ] Verify agent runs still receive all other expected env vars (PAPERCLIP_AGENT_ID, PAPERCLIP_API_URL, etc.)
- [ ] Run `pnpm typecheck` to confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)