### PR TITLE
fix: wire parentId query filter into issues list endpoint

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -230,6 +230,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       touchedByUserId,
       unreadForUserId,
       projectId: req.query.projectId as string | undefined,
+      parentId: req.query.parentId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       q: req.query.q as string | undefined,
     });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -53,6 +53,7 @@ export interface IssueFilters {
   touchedByUserId?: string;
   unreadForUserId?: string;
   projectId?: string;
+  parentId?: string;
   labelId?: string;
   q?: string;
 }
@@ -458,6 +459,7 @@ export function issueService(db: Db) {
         conditions.push(unreadForUserCondition(companyId, unreadForUserId));
       }
       if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
+      if (filters?.parentId) conditions.push(eq(issues.parentId, filters.parentId));
       if (filters?.labelId) {
         const labeledIssueIds = await db
           .select({ issueId: issueLabels.issueId })


### PR DESCRIPTION
## Summary

The `parentId` query parameter on `GET /api/companies/:companyId/issues` was silently ignored — never extracted from the query string, never passed to the service layer.

**Before:** `?parentId={uuid}` returns ALL company issues (101)
**After:** `?parentId={uuid}` returns only direct children (3)

## Changes

3 lines across 2 files:

| File | Change |
|------|--------|
| `server/src/services/issues.ts:50` | Add `parentId?: string` to `IssueFilters` |
| `server/src/services/issues.ts:462` | Add `eq(issues.parentId, filters.parentId)` condition |
| `server/src/routes/issues.ts:233` | Extract `parentId` from `req.query` |

## Testing

- Verified live on paperclip.lasse.dev
- Combined filters (`parentId` + `status`) confirmed working
- Full e2e subtask handling test passed

## Related

- **Paperclip issue:** LAS-106
- **Dependency for:** LAS-107 (SKILL.md subtask handling — requires this filter to work)
- **Original bug report:** LAS-101