### PR TITLE
feat(ui): add role-based color coding and legend to org chart

### DIFF
--- a/ui/src/lib/status-colors.ts
+++ b/ui/src/lib/status-colors.ts
@@ -106,3 +106,39 @@ export const priorityColor: Record<string, string> = {
 };
 
 export const priorityColorDefault = "text-yellow-600 dark:text-yellow-400";
+
+// ---------------------------------------------------------------------------
+// Agent role colors — left-border accent for org chart nodes
+// ---------------------------------------------------------------------------
+
+export const agentRoleBorder: Record<string, string> = {
+  ceo: "border-l-purple-500",
+  cto: "border-l-blue-500",
+  cmo: "border-l-pink-500",
+  cfo: "border-l-emerald-500",
+  engineer: "border-l-sky-500",
+  designer: "border-l-rose-500",
+  pm: "border-l-amber-500",
+  qa: "border-l-orange-500",
+  devops: "border-l-teal-500",
+  researcher: "border-l-violet-500",
+  general: "border-l-neutral-400",
+};
+
+export const agentRoleBorderDefault = "border-l-neutral-400";
+
+export const agentRoleDot: Record<string, string> = {
+  ceo: "bg-purple-500",
+  cto: "bg-blue-500",
+  cmo: "bg-pink-500",
+  cfo: "bg-emerald-500",
+  engineer: "bg-sky-500",
+  designer: "bg-rose-500",
+  pm: "bg-amber-500",
+  qa: "bg-orange-500",
+  devops: "bg-teal-500",
+  researcher: "bg-violet-500",
+  general: "bg-neutral-400",
+};
+
+export const agentRoleDotDefault = "bg-neutral-400";

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -9,6 +9,8 @@ import { agentUrl } from "../lib/utils";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
+import { cn } from "../lib/utils";
+import { agentRoleBorder, agentRoleBorderDefault, agentRoleDot, agentRoleDotDefault, agentStatusDot, agentStatusDotDefault } from "../lib/status-colors";
 import { Network } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
 
@@ -134,6 +136,12 @@ const statusDotColor: Record<string, string> = {
   terminated: "#a3a3a3",
 };
 const defaultDotColor = "#a3a3a3";
+
+const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
+
+function roleLabel(role: string): string {
+  return roleLabels[role] ?? role;
+}
 
 // ── Main component ──────────────────────────────────────────────────────
 
@@ -373,12 +381,16 @@ export function OrgChart() {
         {allNodes.map((node) => {
           const agent = agentMap.get(node.id);
           const dotColor = statusDotColor[node.status] ?? defaultDotColor;
+          const roleBorderClass = agentRoleBorder[node.role] ?? agentRoleBorderDefault;
 
           return (
             <div
               key={node.id}
               data-org-card
-              className="absolute bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-foreground/20 transition-[box-shadow,border-color] duration-150 cursor-pointer select-none"
+              className={cn(
+                "absolute bg-card border border-border border-l-[3px] rounded-lg shadow-sm hover:shadow-md hover:border-foreground/20 hover:border-l-[3px] transition-[box-shadow,border-color] duration-150 cursor-pointer select-none",
+                roleBorderClass,
+              )}
               style={{
                 left: node.x,
                 top: node.y,
@@ -411,18 +423,41 @@ export function OrgChart() {
                       {adapterLabels[agent.adapterType] ?? agent.adapterType}
                     </span>
                   )}
+                  {agent && (
+                    <span className="inline-flex items-center gap-1 text-[10px] leading-tight mt-1">
+                      <span className={cn("h-1.5 w-1.5 rounded-full", agentStatusDot[node.status] ?? agentStatusDotDefault)} />
+                      <span className="text-muted-foreground/60 capitalize">{node.status}</span>
+                    </span>
+                  )}
                 </div>
               </div>
             </div>
           );
         })}
       </div>
+
+      {/* Legend */}
+      <div className="absolute bottom-3 left-3 z-10 bg-background/90 backdrop-blur-sm border border-border rounded-lg p-3 text-xs space-y-2">
+        <div className="font-medium text-foreground/80 mb-1">Legend</div>
+        <div className="space-y-1">
+          <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Roles</div>
+          {Object.entries(roleLabels).map(([role, label]) => (
+            <div key={role} className="flex items-center gap-2">
+              <span className={cn("h-2 w-2 rounded-full", agentRoleDot[role] ?? agentRoleDotDefault)} />
+              <span className="text-muted-foreground">{label}</span>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-border pt-1.5 space-y-1">
+          <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Status</div>
+          {Object.entries(statusDotColor).map(([status, color]) => (
+            <div key={status} className="flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} />
+              <span className="text-muted-foreground capitalize">{status}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
-}
-
-const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
-
-function roleLabel(role: string): string {
-  return roleLabels[role] ?? role;
 }


### PR DESCRIPTION
## Summary
- Add role-based color coding (left border accent) to org chart agent nodes — each role (CEO, CTO, Engineer, etc.) gets a distinct color for at-a-glance identification
- Add inline status indicator (dot + label) to each agent card
- Add a legend panel (bottom-left) showing all role colors and status colors

## Details
- Role colors are defined in `status-colors.ts` alongside existing status color definitions for consistency
- Uses Tailwind `border-l-*` classes with a 3px left border accent
- Legend is positioned bottom-left to avoid overlapping with zoom controls (top-right)
- Works with both light and dark themes
- Responsive — legend uses compact sizing

Closes #334

## Test plan
- [ ] Verify each role displays its correct left-border color
- [ ] Verify status dots match existing status colors
- [ ] Verify legend displays correctly in both light and dark mode
- [ ] Verify legend doesn't overlap zoom controls
- [ ] Verify hover states preserve the left border styling