### PR TITLE
fix(opencode-local): improve local auth defaults

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -271,6 +271,7 @@ export interface CLIAdapterModule {
 export interface CreateConfigValues {
   adapterType: string;
   cwd: string;
+  agent?: string;
   instructionsFilePath?: string;
   promptTemplate: string;
   model: string;

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -19,11 +19,12 @@ Don't use when:
 
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- agent (string, optional): OpenCode agent profile name from \`agent.<name>\` in \`opencode.json\`; passed as \`opencode run --agent <name>\`
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
-- model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
+- model (string, optional): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
 - variant (string, optional): provider-specific model variant (for example minimal|low|medium|high|max)
 - promptTemplate (string, optional): run prompt template
-- command (string, optional): defaults to "opencode"
+- command (string, optional): defaults to "opencode"; Paperclip also auto-detects common local installs such as ~/.opencode/bin/opencode
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables
 
@@ -34,7 +35,9 @@ Operational fields:
 Notes:
 - OpenCode supports multiple providers and models. Use \
   \`opencode models\` to list available options in provider/model format.
-- Paperclip requires an explicit \`model\` value for \`opencode_local\` agents.
+- OpenCode agent profiles can be listed with \`opencode agent list\`; Paperclip also reads \`agent\` / \`default_agent\` from \`~/.config/opencode/opencode.json\` (and \`.jsonc\`) as a fallback source.
+- Paperclip also reads \`~/.config/opencode/opencode.json\` (and \`.jsonc\`) as a fallback source for configured custom provider models.
+- Configure at least one of \`model\` or \`agent\`. If both are set, Paperclip passes both \`--agent\` and \`--model\`, so the explicit model can still override the agent profile's default model.
 - Runs are executed with: opencode run --format json ...
 - Sessions are resumed with --session when stored session cwd matches current cwd.
 `;

--- a/packages/adapters/opencode-local/src/server/auth.test.ts
+++ b/packages/adapters/opencode-local/src/server/auth.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { hydrateLiteLlmApiKey } from "./auth.js";
+
+describe("hydrateLiteLlmApiKey", () => {
+  it("reuses an existing LITELLM_API_KEY", async () => {
+    const result = await hydrateLiteLlmApiKey({
+      LITELLM_API_KEY: "litellm-key",
+      OPENAI_API_KEY: "openai-key",
+    });
+
+    expect(result.source).toBe("existing_litellm_env");
+    expect(result.env.LITELLM_API_KEY).toBe("litellm-key");
+  });
+
+  it("copies OPENAI_API_KEY when LITELLM_API_KEY is absent", async () => {
+    const result = await hydrateLiteLlmApiKey({
+      OPENAI_API_KEY: "openai-key",
+    });
+
+    expect(result.source).toBe("openai_env");
+    expect(result.env.LITELLM_API_KEY).toBe("openai-key");
+  });
+
+  it("loads the key from OpenCode auth storage when env keys are absent", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-auth-home-"));
+    const authPath = path.join(homeDir, ".local", "share", "opencode", "auth.json");
+
+    try {
+      await fs.mkdir(path.dirname(authPath), { recursive: true });
+      await fs.writeFile(
+        authPath,
+        JSON.stringify({
+          litellm: {
+            type: "api-key",
+            key: "auth-store-key",
+          },
+        }),
+        "utf8",
+      );
+
+      const result = await hydrateLiteLlmApiKey({}, { homeDir });
+      expect(result.source).toBe("opencode_auth");
+      expect(result.env.LITELLM_API_KEY).toBe("auth-store-key");
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adapters/opencode-local/src/server/auth.test.ts
+++ b/packages/adapters/opencode-local/src/server/auth.test.ts
@@ -48,4 +48,16 @@ describe("hydrateLiteLlmApiKey", () => {
       await fs.rm(homeDir, { recursive: true, force: true });
     }
   });
+
+  it("returns missing without mutating env when no key source is available", async () => {
+    const env = {};
+
+    const result = await hydrateLiteLlmApiKey(env, {
+      authPaths: [path.join(os.tmpdir(), "paperclip-opencode-auth-does-not-exist", "auth.json")],
+    });
+
+    expect(result.source).toBe("missing");
+    expect(result.env).toBe(env);
+    expect(result.env.LITELLM_API_KEY).toBeUndefined();
+  });
 });

--- a/packages/adapters/opencode-local/src/server/auth.ts
+++ b/packages/adapters/opencode-local/src/server/auth.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+  return typeof env[key] === "string" && env[key].trim().length > 0;
+}
+
+function defaultOpenCodeAuthPaths(homeDir: string): string[] {
+  return [
+    path.join(homeDir, ".local", "share", "opencode", "auth.json"),
+    path.join(homeDir, ".config", "opencode", "auth.json"),
+  ];
+}
+
+async function readLiteLlmApiKeyFromOpenCodeAuth(
+  authPaths: string[],
+): Promise<{ key: string; source: string } | null> {
+  for (const authPath of authPaths) {
+    try {
+      const raw = await fs.readFile(authPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        litellm?: {
+          key?: unknown;
+        };
+      };
+      const key = typeof parsed?.litellm?.key === "string" ? parsed.litellm.key.trim() : "";
+      if (key) {
+        return { key, source: authPath };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export async function hydrateLiteLlmApiKey(
+  env: Record<string, string>,
+  options?: { homeDir?: string; authPaths?: string[] },
+): Promise<
+  | { env: Record<string, string>; source: "existing_litellm_env" | "openai_env" | "opencode_auth" | "missing"; detail?: string }
+> {
+  if (hasNonEmptyEnvValue(env, "LITELLM_API_KEY")) {
+    return { env, source: "existing_litellm_env" };
+  }
+
+  const openAiKey = typeof env.OPENAI_API_KEY === "string" ? env.OPENAI_API_KEY.trim() : "";
+  if (openAiKey) {
+    return {
+      env: { ...env, LITELLM_API_KEY: openAiKey },
+      source: "openai_env",
+      detail: "Copied OPENAI_API_KEY into LITELLM_API_KEY for the OpenCode litellm provider.",
+    };
+  }
+
+  const homeDir = options?.homeDir ?? os.homedir();
+  const authPaths = options?.authPaths ?? defaultOpenCodeAuthPaths(homeDir);
+  const auth = await readLiteLlmApiKeyFromOpenCodeAuth(authPaths);
+  if (auth) {
+    return {
+      env: { ...env, LITELLM_API_KEY: auth.key },
+      source: "opencode_auth",
+      detail: auth.source,
+    };
+  }
+
+  return { env, source: "missing" };
+}

--- a/packages/adapters/opencode-local/src/server/auth.ts
+++ b/packages/adapters/opencode-local/src/server/auth.ts
@@ -6,6 +6,10 @@ function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean 
   return typeof env[key] === "string" && env[key].trim().length > 0;
 }
 
+export function isLiteLlmModel(model: string | null | undefined): boolean {
+  return typeof model === "string" && model.trim().startsWith("litellm/");
+}
+
 function defaultOpenCodeAuthPaths(homeDir: string): string[] {
   return [
     path.join(homeDir, ".local", "share", "opencode", "auth.json"),
@@ -36,12 +40,16 @@ async function readLiteLlmApiKeyFromOpenCodeAuth(
   return null;
 }
 
+export type HydrateLiteLlmApiKeyResult = {
+  env: Record<string, string>;
+  source: "existing_litellm_env" | "openai_env" | "opencode_auth" | "missing";
+  detail?: string;
+};
+
 export async function hydrateLiteLlmApiKey(
   env: Record<string, string>,
   options?: { homeDir?: string; authPaths?: string[] },
-): Promise<
-  | { env: Record<string, string>; source: "existing_litellm_env" | "openai_env" | "opencode_auth" | "missing"; detail?: string }
-> {
+): Promise<HydrateLiteLlmApiKeyResult> {
   if (hasNonEmptyEnvValue(env, "LITELLM_API_KEY")) {
     return { env, source: "existing_litellm_env" };
   }

--- a/packages/adapters/opencode-local/src/server/auth.ts
+++ b/packages/adapters/opencode-local/src/server/auth.ts
@@ -6,8 +6,15 @@ function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean 
   return typeof env[key] === "string" && env[key].trim().length > 0;
 }
 
+export function parseModelProvider(model: string | null | undefined): string | null {
+  if (typeof model !== "string") return null;
+  const trimmed = model.trim();
+  if (!trimmed.includes("/")) return null;
+  return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
+}
+
 export function isLiteLlmModel(model: string | null | undefined): boolean {
-  return typeof model === "string" && model.trim().startsWith("litellm/");
+  return parseModelProvider(model) === "litellm";
 }
 
 function defaultOpenCodeAuthPaths(homeDir: string): string[] {

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+const {
+  runChildProcessMock,
+  ensureOpenCodeAgentConfiguredAndAvailableMock,
+  ensureOpenCodeModelConfiguredAndAvailableMock,
+  resolveConfiguredOpenCodeAgentModelMock,
+  hydrateLiteLlmApiKeyMock,
+} = vi.hoisted(() => ({
+  runChildProcessMock: vi.fn(),
+  ensureOpenCodeAgentConfiguredAndAvailableMock: vi.fn(),
+  ensureOpenCodeModelConfiguredAndAvailableMock: vi.fn(),
+  resolveConfiguredOpenCodeAgentModelMock: vi.fn(async (): Promise<string | null> => null),
+  hydrateLiteLlmApiKeyMock: vi.fn(async (env: Record<string, string>) => ({
+    env,
+    source: "existing_litellm_env" as const,
+  })),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureAbsoluteDirectory: vi.fn().mockResolvedValue(undefined),
+    ensureCommandResolvable: vi.fn().mockResolvedValue(undefined),
+    runChildProcess: runChildProcessMock,
+  };
+});
+
+vi.mock("./models.js", () => ({
+  ensureOpenCodeAgentConfiguredAndAvailable: ensureOpenCodeAgentConfiguredAndAvailableMock,
+  ensureOpenCodeModelConfiguredAndAvailable: ensureOpenCodeModelConfiguredAndAvailableMock,
+  resolveConfiguredOpenCodeAgentModel: resolveConfiguredOpenCodeAgentModelMock,
+  resolveOpenCodeCommand: vi.fn((input: unknown) =>
+    typeof input === "string" && input.trim().length > 0 ? input.trim() : "opencode"
+  ),
+}));
+
+vi.mock("./auth.js", async () => {
+  const actual = await vi.importActual<typeof import("./auth.js")>("./auth.js");
+  return {
+    ...actual,
+    hydrateLiteLlmApiKey: hydrateLiteLlmApiKeyMock,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildStdout(sessionId: string) {
+  return [
+    JSON.stringify({
+      type: "text",
+      sessionID: sessionId,
+      part: { text: "completed task" },
+    }),
+    JSON.stringify({
+      type: "step_finish",
+      sessionID: sessionId,
+      part: {
+        cost: 0,
+        tokens: {
+          input: 12,
+          output: 4,
+          reasoning: 0,
+          cache: { read: 0 },
+        },
+      },
+    }),
+  ].join("\n");
+}
+
+describe("execute", () => {
+  let tempRoot: string;
+  let instructionsPath: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-execute-"));
+    instructionsPath = path.join(tempRoot, "AGENTS.md");
+    await fs.writeFile(instructionsPath, "# Test Agent\n\nFollow the task.\n", "utf8");
+    vi.spyOn(os, "homedir").mockReturnValue(tempRoot);
+    runChildProcessMock.mockReset();
+    ensureOpenCodeAgentConfiguredAndAvailableMock.mockReset();
+    ensureOpenCodeModelConfiguredAndAvailableMock.mockReset();
+    resolveConfiguredOpenCodeAgentModelMock.mockReset();
+    hydrateLiteLlmApiKeyMock.mockClear();
+    ensureOpenCodeAgentConfiguredAndAvailableMock.mockResolvedValue(undefined);
+    ensureOpenCodeModelConfiguredAndAvailableMock.mockResolvedValue(undefined);
+    resolveConfiguredOpenCodeAgentModelMock.mockResolvedValue(null);
+    runChildProcessMock.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: buildStdout("ses_fresh"),
+      stderr: "",
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  function createContext(
+    overrides: Partial<AdapterExecutionContext> = {},
+  ): AdapterExecutionContext {
+    return {
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        cwd: tempRoot,
+        model: "litellm/devstral-small-2-24b",
+        instructionsFilePath: instructionsPath,
+      },
+      context: {},
+      onLog: vi.fn(async () => {}),
+      onMeta: vi.fn(async () => {}),
+      authToken: "paperclip-token",
+      ...overrides,
+    };
+  }
+
+  it("passes the Paperclip prompt via stdin", async () => {
+    const ctx = createContext();
+
+    const result = await execute(ctx);
+
+    expect(runChildProcessMock).toHaveBeenCalledTimes(1);
+    const [, , args, options] = runChildProcessMock.mock.calls[0];
+    expect(args.slice(0, 5)).toEqual([
+      "run",
+      "--format",
+      "json",
+      "--model",
+      "litellm/devstral-small-2-24b",
+    ]);
+    expect(options.stdin).toContain("Continue your Paperclip work.");
+    expect(options.stdin).toContain("The above agent instructions were loaded from");
+    expect(result.sessionParams).toMatchObject({
+      sessionId: "ses_fresh",
+      cwd: tempRoot,
+    });
+  });
+
+  it("does not resume sessions saved for a different cwd", async () => {
+    const onLog = vi.fn(async () => {});
+    const ctx = createContext({
+      runtime: {
+        sessionId: "ses_other",
+        sessionParams: {
+          sessionId: "ses_other",
+          cwd: path.join(tempRoot, "other"),
+        },
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      onLog,
+    });
+
+    await execute(ctx);
+
+    const [, , args] = runChildProcessMock.mock.calls[0];
+    expect(args).not.toContain("--session");
+    expect(onLog).toHaveBeenCalledWith(
+      "stderr",
+      expect.stringContaining("will not be resumed"),
+    );
+  });
+
+  it("resumes compatible sessions that already use run_message_v1", async () => {
+    const ctx = createContext({
+      runtime: {
+        sessionId: "ses_saved",
+        sessionParams: {
+          sessionId: "ses_saved",
+          cwd: tempRoot,
+        },
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+    });
+
+    await execute(ctx);
+
+    const [, , args] = runChildProcessMock.mock.calls[0];
+    expect(args).toContain("--session");
+    expect(args).toContain("ses_saved");
+  });
+
+  it("passes an OpenCode agent profile when configured without requiring an explicit model", async () => {
+    resolveConfiguredOpenCodeAgentModelMock.mockResolvedValue(
+      "litellm/devstral-small-2-24b",
+    );
+    const ctx = createContext({
+      config: {
+        command: "opencode",
+        cwd: tempRoot,
+        agent: "plan",
+        instructionsFilePath: instructionsPath,
+      },
+    });
+
+    await execute(ctx);
+
+    const [, , args] = runChildProcessMock.mock.calls[0];
+    expect(args.slice(0, 5)).toEqual([
+      "run",
+      "--format",
+      "json",
+      "--agent",
+      "plan",
+    ]);
+    expect(args).not.toContain("--model");
+    expect(ensureOpenCodeAgentConfiguredAndAvailableMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "plan",
+        command: "opencode",
+        cwd: tempRoot,
+      }),
+    );
+    expect(ensureOpenCodeModelConfiguredAndAvailableMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredOpenCodeAgentModelMock).toHaveBeenCalledWith({
+      agent: "plan",
+    });
+    expect(hydrateLiteLlmApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -36,13 +36,6 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
-function parseModelProvider(model: string | null): string | null {
-  if (!model) return null;
-  const trimmed = model.trim();
-  if (!trimmed.includes("/")) return null;
-  return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
-}
-
 function resolveOpenCodeBiller(env: Record<string, string>, provider: string | null): string {
   return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
 }

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -19,7 +19,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
-import { hydrateLiteLlmApiKey } from "./auth.js";
+import { hydrateLiteLlmApiKey, isLiteLlmModel } from "./auth.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_SKILLS_CANDIDATES = [
@@ -46,7 +46,6 @@ function parseModelProvider(model: string | null): string | null {
 function resolveOpenCodeBiller(env: Record<string, string>, provider: string | null): string {
   return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
 }
-
 function claudeSkillsHome(): string {
   return path.join(os.homedir(), ".claude", "skills");
 }
@@ -171,8 +170,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
-  const modelProvider = parseModelProvider(model);
-  if (modelProvider === "litellm") {
+  if (isLiteLlmModel(model)) {
     const hydrated = await hydrateLiteLlmApiKey(runtimeEnv);
     runtimeEnv = hydrated.env;
     if (hydrated.source === "openai_env" || hydrated.source === "opencode_auth") {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -18,7 +18,12 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
-import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
+import {
+  ensureOpenCodeAgentConfiguredAndAvailable,
+  ensureOpenCodeModelConfiguredAndAvailable,
+  resolveConfiguredOpenCodeAgentModel,
+  resolveOpenCodeCommand,
+} from "./models.js";
 import { hydrateLiteLlmApiKey, isLiteLlmModel, parseModelProvider } from "./auth.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -87,7 +92,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
-  const command = asString(config.command, "opencode");
+  const command = resolveOpenCodeCommand(config.command);
+  const agentProfile = asString(config.agent, "").trim();
   const model = asString(config.model, "").trim();
   const variant = asString(config.variant, "").trim();
 
@@ -113,6 +119,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const configuredAgentModel = agentProfile
+    ? await resolveConfiguredOpenCodeAgentModel({ agent: agentProfile })
+    : null;
+  const effectiveModelId = model || configuredAgentModel || "";
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
@@ -163,7 +173,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
-  if (isLiteLlmModel(model)) {
+  if (isLiteLlmModel(effectiveModelId)) {
     const hydrated = await hydrateLiteLlmApiKey(runtimeEnv);
     runtimeEnv = hydrated.env;
     if (hydrated.source === "openai_env" || hydrated.source === "opencode_auth") {
@@ -175,12 +185,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   await ensureCommandResolvable(command, cwd, runtimeEnv);
 
-  await ensureOpenCodeModelConfiguredAndAvailable({
-    model,
-    command,
-    cwd,
-    env: runtimeEnv,
-  });
+  if (!model && !agentProfile) {
+    throw new Error("OpenCode requires `adapterConfig.model` or `adapterConfig.agent`.");
+  }
+  if (model) {
+    await ensureOpenCodeModelConfiguredAndAvailable({
+      model,
+      command,
+      cwd,
+      env: runtimeEnv,
+    });
+  }
+  if (agentProfile) {
+    await ensureOpenCodeAgentConfiguredAndAvailable({
+      agent: agentProfile,
+      command,
+      cwd,
+      env: runtimeEnv,
+    });
+  }
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
@@ -276,6 +299,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const buildArgs = (resumeSessionId: string | null) => {
     const args = ["run", "--format", "json"];
     if (resumeSessionId) args.push("--session", resumeSessionId);
+    if (agentProfile) args.push("--agent", agentProfile);
     if (model) args.push("--model", model);
     if (variant) args.push("--variant", variant);
     if (extraArgs.length > 0) args.push(...extraArgs);
@@ -352,7 +376,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       parsedError ||
       stderrLine ||
       `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
-    const modelId = model || null;
+    const modelId = effectiveModelId || null;
 
     return {
       exitCode: synthesizedExitCode,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -19,7 +19,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
-import { hydrateLiteLlmApiKey, isLiteLlmModel } from "./auth.js";
+import { hydrateLiteLlmApiKey, isLiteLlmModel, parseModelProvider } from "./auth.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_SKILLS_CANDIDATES = [

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -19,6 +19,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
+import { hydrateLiteLlmApiKey } from "./auth.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_SKILLS_CANDIDATES = [
@@ -165,11 +166,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (!hasExplicitApiKey && authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }
-  const runtimeEnv = Object.fromEntries(
+  let runtimeEnv = Object.fromEntries(
     Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
+  const modelProvider = parseModelProvider(model);
+  if (modelProvider === "litellm") {
+    const hydrated = await hydrateLiteLlmApiKey(runtimeEnv);
+    runtimeEnv = hydrated.env;
+    if (hydrated.source === "openai_env" || hydrated.source === "opencode_auth") {
+      await onLog(
+        "stderr",
+        `[paperclip] Prepared LITELLM_API_KEY for OpenCode (${hydrated.source === "openai_env" ? "from OPENAI_API_KEY" : `from ${hydrated.detail}`}).\n`,
+      );
+    }
+  }
   await ensureCommandResolvable(command, cwd, runtimeEnv);
 
   await ensureOpenCodeModelConfiguredAndAvailable({

--- a/packages/adapters/opencode-local/src/server/index.ts
+++ b/packages/adapters/opencode-local/src/server/index.ts
@@ -64,8 +64,13 @@ export { execute } from "./execute.js";
 export { testEnvironment } from "./test.js";
 export {
   listOpenCodeModels,
+  listOpenCodeAgents,
   discoverOpenCodeModels,
+  discoverOpenCodeAgents,
   ensureOpenCodeModelConfiguredAndAvailable,
+  ensureOpenCodeAgentConfiguredAndAvailable,
+  resolveConfiguredOpenCodeAgentModel,
+  resolveOpenCodeCommand,
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
 export { parseOpenCodeJsonl, isOpenCodeUnknownSessionError } from "./parse.js";

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,9 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  discoverOpenCodeModels,
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
+
+async function withMockOpenCodeCommand(
+  stdout: string,
+  run: (commandPath: string, cwd: string) => Promise<void>,
+) {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-models-"));
+  const commandPath = path.join(cwd, "opencode-mock.sh");
+  await fs.writeFile(
+    commandPath,
+    [
+      "#!/usr/bin/env bash",
+      "if [ \"$1\" = \"models\" ]; then",
+      "cat <<'__OPENCODE_MODELS__'",
+      stdout,
+      "__OPENCODE_MODELS__",
+      "exit 0",
+      "fi",
+      "echo \"unexpected args: $*\" >&2",
+      "exit 1",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.chmod(commandPath, 0o755);
+
+  try {
+    await run(commandPath, cwd);
+  } finally {
+    await fs.rm(cwd, { recursive: true, force: true });
+  }
+}
 
 describe("openCode models", () => {
   afterEach(() => {
@@ -29,5 +64,40 @@ describe("openCode models", () => {
         model: "openai/gpt-5",
       }),
     ).rejects.toThrow("Failed to start command");
+  });
+
+  it("parses plain model ids from `opencode models` output", async () => {
+    await withMockOpenCodeCommand(
+      [
+        "Available models",
+        "qwen3-coder-next",
+        "gemma-3-27b-it",
+      ].join("\n"),
+      async (commandPath, cwd) => {
+        const models = await discoverOpenCodeModels({ command: commandPath, cwd });
+        expect(models).toEqual([
+          { id: "gemma-3-27b-it", label: "gemma-3-27b-it" },
+          { id: "qwen3-coder-next", label: "qwen3-coder-next" },
+        ]);
+      },
+    );
+  });
+
+  it("parses table-style output that mixes provider/model and plain ids", async () => {
+    await withMockOpenCodeCommand(
+      [
+        "| Model | Provider |",
+        "| --- | --- |",
+        "| litellm/qwen3-coder-next | litellm |",
+        "| o3-mini | openai |",
+      ].join("\n"),
+      async (commandPath, cwd) => {
+        const models = await discoverOpenCodeModels({ command: commandPath, cwd });
+        expect(models).toEqual([
+          { id: "litellm/qwen3-coder-next", label: "litellm/qwen3-coder-next" },
+          { id: "o3-mini", label: "o3-mini" },
+        ]);
+      },
+    );
   });
 });

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,11 +1,15 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  discoverOpenCodeAgents,
   discoverOpenCodeModels,
+  ensureOpenCodeAgentConfiguredAndAvailable,
   ensureOpenCodeModelConfiguredAndAvailable,
+  listOpenCodeAgents,
   listOpenCodeModels,
+  resolveConfiguredOpenCodeAgentModel,
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
 
@@ -41,14 +45,199 @@ async function withMockOpenCodeCommand(
 }
 
 describe("openCode models", () => {
-  afterEach(() => {
-    delete process.env.PAPERCLIP_OPENCODE_COMMAND;
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-models-home-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+    vi.spyOn(os, "userInfo").mockReturnValue({
+      uid: 1000,
+      gid: 1000,
+      username: "paperclip-test",
+      homedir: tempHome,
+      shell: "/bin/sh",
+    });
     resetOpenCodeModelsCacheForTests();
+    delete process.env.PAPERCLIP_OPENCODE_COMMAND;
   });
 
-  it("returns an empty list when discovery command is unavailable", async () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.PAPERCLIP_OPENCODE_COMMAND;
+    resetOpenCodeModelsCacheForTests();
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  async function writeGlobalConfig(filename: "opencode.json" | "opencode.jsonc", contents: string) {
+    const configPath = path.join(tempHome, ".config", "opencode", filename);
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, contents, "utf8");
+    return configPath;
+  }
+
+  it("returns an empty list when discovery command is unavailable and no config models exist", async () => {
     process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
     await expect(listOpenCodeModels()).resolves.toEqual([]);
+  });
+
+  it("falls back to ~/.config/opencode/opencode.jsonc when discovery command is unavailable", async () => {
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    await writeGlobalConfig(
+      "opencode.jsonc",
+      [
+        "{",
+        "  // Global OpenCode config",
+        "  \"provider\": {",
+        "    \"litellm\": {",
+        "      \"models\": {",
+        "        \"omnicoder-9b\": {},",
+        "        \"qwen3.5-122b-a10b\": {},",
+        "      },",
+        "    },",
+        "  },",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    await expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "litellm/omnicoder-9b", label: "litellm/omnicoder-9b" },
+      { id: "litellm/qwen3.5-122b-a10b", label: "litellm/qwen3.5-122b-a10b" },
+    ]);
+  });
+
+  it("falls back to ~/.config/opencode/opencode.jsonc for agent profiles when agent list is unavailable", async () => {
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    await writeGlobalConfig(
+      "opencode.jsonc",
+      [
+        "{",
+        "  \"default_agent\": \"plan\",",
+        "  \"agent\": {",
+        "    \"plan\": {},",
+        "    \"code-reviewer\": {",
+        "      \"model\": \"anthropic/claude-sonnet-4-5\"",
+        "    }",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    await expect(listOpenCodeAgents()).resolves.toEqual([
+      { id: "code-reviewer", label: "code-reviewer" },
+      { id: "plan", label: "plan" },
+    ]);
+  });
+
+  it("auto-detects the default ~/.opencode/bin/opencode install", async () => {
+    const binDir = path.join(tempHome, ".opencode", "bin");
+    const opencodePath = path.join(binDir, "opencode");
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.writeFile(
+      opencodePath,
+      [
+        "#!/bin/sh",
+        "echo 'litellm/qwen3.5-122b-a10b'",
+        "echo 'litellm/omnicoder-9b'",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.chmod(opencodePath, 0o755);
+
+    await expect(discoverOpenCodeModels({ cwd: tempHome })).resolves.toEqual([
+      { id: "litellm/omnicoder-9b", label: "litellm/omnicoder-9b" },
+      { id: "litellm/qwen3.5-122b-a10b", label: "litellm/qwen3.5-122b-a10b" },
+    ]);
+  });
+
+  it("parses `opencode agent list` output", async () => {
+    const binDir = path.join(tempHome, ".opencode", "bin");
+    const opencodePath = path.join(binDir, "opencode");
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.writeFile(
+      opencodePath,
+      [
+        "#!/bin/sh",
+        "if [ \"$1\" = \"agent\" ] && [ \"$2\" = \"list\" ]; then",
+        "  echo 'Available Agents:'",
+        "  echo '- default (Default agent)'",
+        "  echo '- code-reviewer (Agent with custom prompt)'",
+        "  exit 0",
+        "fi",
+        "exit 1",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.chmod(opencodePath, 0o755);
+
+    await expect(discoverOpenCodeAgents({ cwd: tempHome })).resolves.toEqual([
+      { id: "code-reviewer", label: "code-reviewer" },
+      { id: "default", label: "default" },
+    ]);
+  });
+
+  it("accepts configured models from the global OpenCode config fallback", async () => {
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    await writeGlobalConfig(
+      "opencode.json",
+      JSON.stringify({
+        provider: {
+          litellm: {
+            models: {
+              "omnicoder-9b": {},
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(
+      ensureOpenCodeModelConfiguredAndAvailable({ model: "litellm/omnicoder-9b" }),
+    ).resolves.toEqual([
+      { id: "litellm/omnicoder-9b", label: "litellm/omnicoder-9b" },
+    ]);
+  });
+
+  it("accepts configured agent profiles from the global OpenCode config fallback", async () => {
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    await writeGlobalConfig(
+      "opencode.json",
+      JSON.stringify({
+        default_agent: "plan",
+        agent: {
+          plan: {},
+          reviewer: {},
+        },
+      }),
+    );
+
+    await expect(
+      ensureOpenCodeAgentConfiguredAndAvailable({ agent: "reviewer" }),
+    ).resolves.toEqual([
+      { id: "plan", label: "plan" },
+      { id: "reviewer", label: "reviewer" },
+    ]);
+  });
+
+  it("resolves an agent profile model from OpenCode config", async () => {
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    await writeGlobalConfig(
+      "opencode.json",
+      JSON.stringify({
+        agent: {
+          plan: {
+            model: "litellm/omnicoder-9b",
+          },
+        },
+      }),
+    );
+
+    await expect(resolveConfiguredOpenCodeAgentModel({ agent: "plan" })).resolves.toBe(
+      "litellm/omnicoder-9b",
+    );
   });
 
   it("rejects when model is missing", async () => {
@@ -57,13 +246,10 @@ describe("openCode models", () => {
     ).rejects.toThrow("OpenCode requires `adapterConfig.model`");
   });
 
-  it("rejects when discovery cannot run for configured model", async () => {
-    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+  it("rejects when agent profile is missing", async () => {
     await expect(
-      ensureOpenCodeModelConfiguredAndAvailable({
-        model: "openai/gpt-5",
-      }),
-    ).rejects.toThrow("Failed to start command");
+      ensureOpenCodeAgentConfiguredAndAvailable({ agent: "" }),
+    ).rejects.toThrow("OpenCode requires `adapterConfig.agent`");
   });
 
   it("parses plain model ids from `opencode models` output", async () => {

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -9,6 +9,21 @@ import {
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const ANSI_ESCAPE_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const TABLE_SEPARATOR_PATTERN = /^[\s|:-]+$/;
+const PLAIN_MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:+-]*$/;
+const NON_MODEL_TOKENS = new Set([
+  "model",
+  "models",
+  "id",
+  "name",
+  "provider",
+  "providers",
+  "description",
+  "status",
+  "default",
+  "available",
+]);
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =
@@ -50,17 +65,58 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function normalizeModelToken(value: string): string {
+  return value
+    .trim()
+    .replace(/^[*\-•]+\s*/, "")
+    .replace(/^[`'"]+/, "")
+    .replace(/[`'"]+$/, "")
+    .replace(/[,:;]+$/, "")
+    .trim();
+}
+
+function parseModelIdFromToken(token: string): string | null {
+  const value = normalizeModelToken(token);
+  if (!value) return null;
+  if (TABLE_SEPARATOR_PATTERN.test(value)) return null;
+
+  if (value.includes("/")) {
+    const provider = value.slice(0, value.indexOf("/")).trim();
+    const model = value.slice(value.indexOf("/") + 1).trim();
+    if (!provider || !model) return null;
+    return `${provider}/${model}`;
+  }
+
+  if (!PLAIN_MODEL_ID_PATTERN.test(value)) return null;
+  if (NON_MODEL_TOKENS.has(value.toLowerCase())) return null;
+  return value;
+}
+
+function parseModelIdFromLine(line: string): string | null {
+  const cleanLine = stripAnsi(line).trim();
+  if (!cleanLine) return null;
+
+  if (cleanLine.includes("|")) {
+    for (const cell of cleanLine.split("|")) {
+      const modelId = parseModelIdFromToken(cell);
+      if (modelId) return modelId;
+    }
+  }
+
+  const firstToken = cleanLine.split(/\s+/)[0]?.trim() ?? "";
+  return parseModelIdFromToken(firstToken);
+}
+
 function parseModelsOutput(stdout: string): AdapterModel[] {
   const parsed: AdapterModel[] = [];
   for (const raw of stdout.split(/\r?\n/)) {
-    const line = raw.trim();
-    if (!line) continue;
-    const firstToken = line.split(/\s+/)[0]?.trim() ?? "";
-    if (!firstToken.includes("/")) continue;
-    const provider = firstToken.slice(0, firstToken.indexOf("/")).trim();
-    const model = firstToken.slice(firstToken.indexOf("/") + 1).trim();
-    if (!provider || !model) continue;
-    parsed.push({ id: `${provider}/${model}`, label: `${provider}/${model}` });
+    const modelId = parseModelIdFromLine(raw);
+    if (!modelId) continue;
+    parsed.push({ id: modelId, label: modelId });
   }
   return dedupeModels(parsed);
 }
@@ -173,7 +229,7 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
 }): Promise<AdapterModel[]> {
   const model = asString(input.model, "").trim();
   if (!model) {
-    throw new Error("OpenCode requires `adapterConfig.model` in provider/model format.");
+    throw new Error("OpenCode requires `adapterConfig.model`.");
   }
 
   const models = await discoverOpenCodeModelsCached({

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -1,17 +1,23 @@
 import { createHash } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
+import path from "node:path";
 import type { AdapterModel } from "@paperclipai/adapter-utils";
 import {
   asString,
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
+import { hydrateLiteLlmApiKey } from "./auth.js";
 
+const DEFAULT_OPENCODE_COMMAND = "opencode";
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
-const ANSI_ESCAPE_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const OPENCODE_CONFIG_FILENAMES = ["opencode.json", "opencode.jsonc"] as const;
+const ANSI_ESCAPE_RE = /\u001B(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
 const TABLE_SEPARATOR_PATTERN = /^[\s|:-]+$/;
-const PLAIN_MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:+-]*$/;
+const PLAIN_MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:+/-]*$/;
 const NON_MODEL_TOKENS = new Set([
   "model",
   "models",
@@ -24,36 +30,97 @@ const NON_MODEL_TOKENS = new Set([
   "default",
   "available",
 ]);
+type OpenCodeNamedItem = { id: string; label: string };
+export type OpenCodeAgentProfile = OpenCodeNamedItem;
 
-function resolveOpenCodeCommand(input: unknown): string {
-  const envOverride =
-    typeof process.env.PAPERCLIP_OPENCODE_COMMAND === "string" &&
+function resolveRuntimeHomeDir(): string {
+  try {
+    const homedir = os.userInfo().homedir;
+    if (typeof homedir === "string" && homedir.trim().length > 0) {
+      return homedir.trim();
+    }
+  } catch {
+    // Fall back to os.homedir() when passwd lookup is unavailable.
+  }
+  return os.homedir();
+}
+
+function defaultOpenCodeCommandOverride(): string {
+  return typeof process.env.PAPERCLIP_OPENCODE_COMMAND === "string" &&
     process.env.PAPERCLIP_OPENCODE_COMMAND.trim().length > 0
-      ? process.env.PAPERCLIP_OPENCODE_COMMAND.trim()
-      : "opencode";
-  return asString(input, envOverride);
+    ? process.env.PAPERCLIP_OPENCODE_COMMAND.trim()
+    : DEFAULT_OPENCODE_COMMAND;
+}
+
+function isExecutableFile(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultOpenCodeCommandCandidates(homeDir: string): string[] {
+  return [
+    path.join(homeDir, ".opencode", "bin", "opencode"),
+    path.join(homeDir, ".local", "bin", "opencode"),
+    path.join(homeDir, ".bun", "bin", "opencode"),
+    path.join(homeDir, ".config", "opencode", "node_modules", ".bin", "opencode"),
+  ];
+}
+
+export function resolveOpenCodeCommand(
+  input: unknown,
+  options?: { homeDir?: string },
+): string {
+  const configured = asString(input, defaultOpenCodeCommandOverride()).trim() || DEFAULT_OPENCODE_COMMAND;
+  if (configured !== DEFAULT_OPENCODE_COMMAND) return configured;
+
+  const homeDir = options?.homeDir ?? resolveRuntimeHomeDir();
+  for (const candidate of defaultOpenCodeCommandCandidates(homeDir)) {
+    if (isExecutableFile(candidate)) return candidate;
+  }
+  return configured;
 }
 
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+const agentDiscoveryCache = new Map<string, { expiresAt: number; agents: OpenCodeAgentProfile[] }>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
 
-function dedupeModels(models: AdapterModel[]): AdapterModel[] {
+function dedupeNamedItems<T extends OpenCodeNamedItem>(items: T[]): T[] {
   const seen = new Set<string>();
-  const deduped: AdapterModel[] = [];
-  for (const model of models) {
-    const id = model.id.trim();
+  const deduped: T[] = [];
+  for (const item of items) {
+    const id = item.id.trim();
     if (!id || seen.has(id)) continue;
     seen.add(id);
-    deduped.push({ id, label: model.label.trim() || id });
+    deduped.push({ ...item, id, label: item.label.trim() || id });
   }
   return deduped;
 }
 
-function sortModels(models: AdapterModel[]): AdapterModel[] {
-  return [...models].sort((a, b) =>
+function sortNamedItems<T extends OpenCodeNamedItem>(items: T[]): T[] {
+  return [...items].sort((a, b) =>
     a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }),
   );
+}
+
+function dedupeModels(models: AdapterModel[]): AdapterModel[] {
+  return dedupeNamedItems(models);
+}
+
+function sortModels(models: AdapterModel[]): AdapterModel[] {
+  return sortNamedItems(models);
+}
+
+function dedupeAgents(agents: OpenCodeAgentProfile[]): OpenCodeAgentProfile[] {
+  return dedupeNamedItems(agents);
+}
+
+function sortAgents(agents: OpenCodeAgentProfile[]): OpenCodeAgentProfile[] {
+  return sortNamedItems(agents);
 }
 
 function firstNonEmptyLine(text: string): string {
@@ -66,7 +133,7 @@ function firstNonEmptyLine(text: string): string {
 }
 
 function stripAnsi(text: string): string {
-  return text.replace(ANSI_ESCAPE_PATTERN, "");
+  return text.replace(ANSI_ESCAPE_RE, "");
 }
 
 function normalizeModelToken(value: string): string {
@@ -83,42 +150,44 @@ function parseModelIdFromToken(token: string): string | null {
   const value = normalizeModelToken(token);
   if (!value) return null;
   if (TABLE_SEPARATOR_PATTERN.test(value)) return null;
-
-  if (value.includes("/")) {
-    const provider = value.slice(0, value.indexOf("/")).trim();
-    const model = value.slice(value.indexOf("/") + 1).trim();
-    if (!provider || !model) return null;
-    return `${provider}/${model}`;
-  }
-
   if (!PLAIN_MODEL_ID_PATTERN.test(value)) return null;
   if (NON_MODEL_TOKENS.has(value.toLowerCase())) return null;
   return value;
 }
 
-function parseModelIdFromLine(line: string): string | null {
-  const cleanLine = stripAnsi(line).trim();
-  if (!cleanLine) return null;
-
-  if (cleanLine.includes("|")) {
-    for (const cell of cleanLine.split("|")) {
-      const modelId = parseModelIdFromToken(cell);
-      if (modelId) return modelId;
-    }
-  }
-
-  const firstToken = cleanLine.split(/\s+/)[0]?.trim() ?? "";
-  return parseModelIdFromToken(firstToken);
-}
-
 function parseModelsOutput(stdout: string): AdapterModel[] {
   const parsed: AdapterModel[] = [];
   for (const raw of stdout.split(/\r?\n/)) {
-    const modelId = parseModelIdFromLine(raw);
+    const line = stripAnsi(raw).trim();
+    if (!line) continue;
+    if (line.includes("|")) {
+      for (const cell of line.split("|")) {
+        const modelId = parseModelIdFromToken(cell);
+        if (!modelId) continue;
+        parsed.push({ id: modelId, label: modelId });
+        break;
+      }
+      continue;
+    }
+    const firstToken = line.split(/\s+/)[0]?.trim() ?? "";
+    const modelId = parseModelIdFromToken(firstToken);
     if (!modelId) continue;
     parsed.push({ id: modelId, label: modelId });
   }
   return dedupeModels(parsed);
+}
+
+function parseAgentListOutput(stdout: string): OpenCodeAgentProfile[] {
+  const parsed: OpenCodeAgentProfile[] = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = stripAnsi(raw).trim();
+    if (!line.startsWith("-")) continue;
+    const match = /^-\s+(.+?)(?:\s+\(|$)/.exec(line);
+    const id = match?.[1]?.trim() ?? "";
+    if (!id) continue;
+    parsed.push({ id, label: id });
+  }
+  return dedupeAgents(parsed);
 }
 
 function normalizeEnv(input: unknown): Record<string, string> {
@@ -132,6 +201,208 @@ function normalizeEnv(input: unknown): Record<string, string> {
   return env;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stripJsonComments(input: string): string {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    const next = input[i + 1] ?? "";
+
+    if (lineComment) {
+      if (char === "\n") {
+        lineComment = false;
+        output += char;
+      }
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+        continue;
+      }
+      if (char === "\n") output += char;
+      continue;
+    }
+
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+function stripTrailingCommas(input: string): string {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === ",") {
+      let cursor = i + 1;
+      while (cursor < input.length && /\s/.test(input[cursor] ?? "")) cursor += 1;
+      const next = input[cursor] ?? "";
+      if (next === "}" || next === "]") continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+function parseJsonLikeObject(input: string): Record<string, unknown> | null {
+  const candidates = [
+    input,
+    stripTrailingCommas(stripJsonComments(input)),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      return asRecord(parsed);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function defaultOpenCodeConfigPaths(homeDir: string): string[] {
+  return OPENCODE_CONFIG_FILENAMES.map((filename) =>
+    path.join(homeDir, ".config", "opencode", filename),
+  );
+}
+
+function resolveOpenCodeConfigPaths(input: {
+  configPaths?: string[];
+  homeDir?: string;
+}): string[] {
+  const homeDir = input.homeDir ?? os.homedir();
+  const candidates = input.configPaths?.length
+    ? input.configPaths
+    : defaultOpenCodeConfigPaths(homeDir);
+  return Array.from(new Set(candidates.map((entry) => path.resolve(entry))));
+}
+
+async function loadOpenCodeConfigIndex(configPaths: string[]): Promise<{
+  models: AdapterModel[];
+  agents: OpenCodeAgentProfile[];
+  agentModels: Record<string, string>;
+}> {
+  const parsed: AdapterModel[] = [];
+  const parsedAgents: OpenCodeAgentProfile[] = [];
+  const agentModels: Record<string, string> = {};
+
+  for (const configPath of configPaths) {
+    try {
+      const raw = await fsp.readFile(configPath, "utf8");
+      const config = parseJsonLikeObject(raw);
+      const providers = asRecord(config?.provider);
+      if (providers) {
+        for (const [providerId, providerConfig] of Object.entries(providers)) {
+          const models = asRecord(asRecord(providerConfig)?.models);
+          if (!models) continue;
+          for (const modelId of Object.keys(models)) {
+            const trimmedProviderId = providerId.trim();
+            const trimmedModelId = modelId.trim();
+            if (!trimmedProviderId || !trimmedModelId) continue;
+            const id = `${trimmedProviderId}/${trimmedModelId}`;
+            parsed.push({ id, label: id });
+          }
+        }
+      }
+
+      const agents = asRecord(config?.agent);
+      if (agents) {
+        for (const [agentId, agentConfig] of Object.entries(agents)) {
+          const trimmedAgentId = agentId.trim();
+          if (!trimmedAgentId) continue;
+          parsedAgents.push({ id: trimmedAgentId, label: trimmedAgentId });
+          const agentModel = asString(asRecord(agentConfig)?.model, "").trim();
+          if (agentModel) {
+            agentModels[trimmedAgentId] = agentModel;
+          }
+        }
+      }
+
+      const defaultAgent = asString(config?.default_agent, "").trim();
+      if (defaultAgent) {
+        parsedAgents.push({ id: defaultAgent, label: defaultAgent });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    models: sortModels(dedupeModels(parsed)),
+    agents: sortAgents(dedupeAgents(parsedAgents)),
+    agentModels,
+  };
+}
+
 function isVolatileEnvKey(key: string): boolean {
   if (VOLATILE_ENV_KEY_EXACT.has(key)) return true;
   return VOLATILE_ENV_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
@@ -141,18 +412,26 @@ function hashValue(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function discoveryCacheKey(command: string, cwd: string, env: Record<string, string>) {
+function discoveryCacheKey(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+  configPaths: string[],
+) {
   const envKey = Object.entries(env)
     .filter(([key]) => !isVolatileEnvKey(key))
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `${key}=${hashValue(value)}`)
     .join("\n");
-  return `${command}\n${cwd}\n${envKey}`;
+  return `${command}\n${cwd}\n${configPaths.join("\n")}\n${envKey}`;
 }
 
 function pruneExpiredDiscoveryCache(now: number) {
   for (const [key, value] of discoveryCache.entries()) {
     if (value.expiresAt <= now) discoveryCache.delete(key);
+  }
+  for (const [key, value] of agentDiscoveryCache.entries()) {
+    if (value.expiresAt <= now) agentDiscoveryCache.delete(key);
   }
 }
 
@@ -160,65 +439,166 @@ export async function discoverOpenCodeModels(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
 } = {}): Promise<AdapterModel[]> {
-  const command = resolveOpenCodeCommand(input.command);
+  const homeDir = input.homeDir ?? resolveRuntimeHomeDir();
+  const command = resolveOpenCodeCommand(input.command, { homeDir });
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
-  // Ensure HOME points to the actual running user's home directory.
-  // When the server is started via `runuser -u <user>`, HOME may still
-  // reflect the parent process (e.g. /root), causing OpenCode to miss
-  // provider auth credentials stored under the target user's home.
-  let resolvedHome: string | undefined;
+  let runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, HOME: homeDir }));
+  runtimeEnv = (await hydrateLiteLlmApiKey(runtimeEnv, { homeDir })).env;
+  const configPaths = resolveOpenCodeConfigPaths({
+    configPaths: input.configPaths,
+    homeDir,
+  });
+  const configured = await loadOpenCodeConfigIndex(configPaths);
+  const configuredModels = configured.models;
+
   try {
-    resolvedHome = os.userInfo().homedir || undefined;
-  } catch {
-    // os.userInfo() throws a SystemError when the current UID has no
-    // /etc/passwd entry (e.g. `docker run --user 1234` with a minimal
-    // image). Fall back to process.env.HOME.
-  }
-  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}) }));
+    const result = await runChildProcess(
+      `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command,
+      ["models"],
+      {
+        cwd,
+        env: runtimeEnv,
+        timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
+        graceSec: 3,
+        onLog: async () => {},
+      },
+    );
 
-  const result = await runChildProcess(
-    `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-    command,
-    ["models"],
-    {
-      cwd,
-      env: runtimeEnv,
-      timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
-      graceSec: 3,
-      onLog: async () => {},
-    },
-  );
+    if (result.timedOut) {
+      throw new Error(`\`opencode models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    }
+    if ((result.exitCode ?? 1) !== 0) {
+      const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
+      throw new Error(detail ? `\`opencode models\` failed: ${detail}` : "`opencode models` failed.");
+    }
 
-  if (result.timedOut) {
-    throw new Error(`\`opencode models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    const discovered = parseModelsOutput(result.stdout);
+    return sortModels(dedupeModels([...discovered, ...configuredModels]));
+  } catch (error) {
+    if (configuredModels.length > 0) return configuredModels;
+    throw error;
   }
-  if ((result.exitCode ?? 1) !== 0) {
-    const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
-    throw new Error(detail ? `\`opencode models\` failed: ${detail}` : "`opencode models` failed.");
-  }
+}
 
-  return sortModels(parseModelsOutput(result.stdout));
+export async function discoverOpenCodeAgents(input: {
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
+} = {}): Promise<OpenCodeAgentProfile[]> {
+  const homeDir = input.homeDir ?? resolveRuntimeHomeDir();
+  const command = resolveOpenCodeCommand(input.command, { homeDir });
+  const cwd = asString(input.cwd, process.cwd());
+  const env = normalizeEnv(input.env);
+  let runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, HOME: homeDir }));
+  runtimeEnv = (await hydrateLiteLlmApiKey(runtimeEnv, { homeDir })).env;
+  const configPaths = resolveOpenCodeConfigPaths({
+    configPaths: input.configPaths,
+    homeDir,
+  });
+  const configured = await loadOpenCodeConfigIndex(configPaths);
+  const configuredAgents = configured.agents;
+
+  try {
+    const result = await runChildProcess(
+      `opencode-agents-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command,
+      ["agent", "list"],
+      {
+        cwd,
+        env: runtimeEnv,
+        timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
+        graceSec: 3,
+        onLog: async () => {},
+      },
+    );
+
+    if (result.timedOut) {
+      throw new Error(`\`opencode agent list\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    }
+    if ((result.exitCode ?? 1) !== 0) {
+      const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
+      throw new Error(
+        detail ? `\`opencode agent list\` failed: ${detail}` : "`opencode agent list` failed.",
+      );
+    }
+
+    const discovered = parseAgentListOutput(result.stdout);
+    return sortAgents(dedupeAgents([...discovered, ...configuredAgents]));
+  } catch (error) {
+    if (configuredAgents.length > 0) return configuredAgents;
+    throw error;
+  }
 }
 
 export async function discoverOpenCodeModelsCached(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
 } = {}): Promise<AdapterModel[]> {
-  const command = resolveOpenCodeCommand(input.command);
+  const homeDir = input.homeDir ?? resolveRuntimeHomeDir();
+  const command = resolveOpenCodeCommand(input.command, { homeDir });
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
-  const key = discoveryCacheKey(command, cwd, env);
+  const configPaths = resolveOpenCodeConfigPaths({
+    configPaths: input.configPaths,
+    homeDir,
+  });
+  const key = discoveryCacheKey(command, cwd, env, configPaths);
   const now = Date.now();
   pruneExpiredDiscoveryCache(now);
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
 
-  const models = await discoverOpenCodeModels({ command, cwd, env });
+  const models = await discoverOpenCodeModels({
+    command,
+    cwd,
+    env,
+    configPaths,
+    homeDir,
+  });
   discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
   return models;
+}
+
+export async function discoverOpenCodeAgentsCached(input: {
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
+} = {}): Promise<OpenCodeAgentProfile[]> {
+  const homeDir = input.homeDir ?? resolveRuntimeHomeDir();
+  const command = resolveOpenCodeCommand(input.command, { homeDir });
+  const cwd = asString(input.cwd, process.cwd());
+  const env = normalizeEnv(input.env);
+  const configPaths = resolveOpenCodeConfigPaths({
+    configPaths: input.configPaths,
+    homeDir,
+  });
+  const key = discoveryCacheKey(`agent-list:${command}`, cwd, env, configPaths);
+  const now = Date.now();
+  pruneExpiredDiscoveryCache(now);
+  const cached = agentDiscoveryCache.get(key);
+  if (cached && cached.expiresAt > now) return cached.agents;
+
+  const agents = await discoverOpenCodeAgents({
+    command,
+    cwd,
+    env,
+    configPaths,
+    homeDir,
+  });
+  agentDiscoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, agents });
+  return agents;
 }
 
 export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
@@ -226,16 +606,20 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
 }): Promise<AdapterModel[]> {
   const model = asString(input.model, "").trim();
   if (!model) {
-    throw new Error("OpenCode requires `adapterConfig.model`.");
+    throw new Error("OpenCode requires `adapterConfig.model` in provider/model format.");
   }
 
   const models = await discoverOpenCodeModelsCached({
     command: input.command,
     cwd: input.cwd,
     env: input.env,
+    configPaths: input.configPaths,
+    homeDir: input.homeDir,
   });
 
   if (models.length === 0) {
@@ -252,6 +636,58 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   return models;
 }
 
+export async function ensureOpenCodeAgentConfiguredAndAvailable(input: {
+  agent?: unknown;
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
+}): Promise<OpenCodeAgentProfile[]> {
+  const agent = asString(input.agent, "").trim();
+  if (!agent) {
+    throw new Error("OpenCode requires `adapterConfig.agent` to match an available agent profile.");
+  }
+
+  const agents = await discoverOpenCodeAgentsCached({
+    command: input.command,
+    cwd: input.cwd,
+    env: input.env,
+    configPaths: input.configPaths,
+    homeDir: input.homeDir,
+  });
+
+  if (agents.length === 0) {
+    throw new Error("OpenCode returned no agents. Run `opencode agent list` and verify agent config.");
+  }
+
+  if (!agents.some((entry) => entry.id === agent)) {
+    const sample = agents.slice(0, 12).map((entry) => entry.id).join(", ");
+    throw new Error(
+      `Configured OpenCode agent is unavailable: ${agent}. Available agents: ${sample}${agents.length > 12 ? ", ..." : ""}`,
+    );
+  }
+
+  return agents;
+}
+
+export async function resolveConfiguredOpenCodeAgentModel(input: {
+  agent?: unknown;
+  configPaths?: string[];
+  homeDir?: string;
+}): Promise<string | null> {
+  const agent = asString(input.agent, "").trim();
+  if (!agent) return null;
+  const homeDir = input.homeDir ?? resolveRuntimeHomeDir();
+  const configPaths = resolveOpenCodeConfigPaths({
+    configPaths: input.configPaths,
+    homeDir,
+  });
+  const configured = await loadOpenCodeConfigIndex(configPaths);
+  const model = configured.agentModels[agent];
+  return typeof model === "string" && model.trim().length > 0 ? model.trim() : null;
+}
+
 export async function listOpenCodeModels(): Promise<AdapterModel[]> {
   try {
     return await discoverOpenCodeModelsCached();
@@ -260,6 +696,15 @@ export async function listOpenCodeModels(): Promise<AdapterModel[]> {
   }
 }
 
+export async function listOpenCodeAgents(): Promise<OpenCodeAgentProfile[]> {
+  try {
+    return await discoverOpenCodeAgentsCached();
+  } catch {
+    return [];
+  }
+}
+
 export function resetOpenCodeModelsCacheForTests() {
   discoveryCache.clear();
+  agentDiscoveryCache.clear();
 }

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -14,6 +14,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { parseOpenCodeJsonl } from "./parse.js";
+import { hydrateLiteLlmApiKey } from "./auth.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -86,11 +87,45 @@ export async function testEnvironment(
       code: "opencode_openai_api_key_missing",
       level: "warn",
       message: "OPENAI_API_KEY override is empty.",
-      hint: "The OPENAI_API_KEY override is empty. Set a valid key or remove the override.",
+      hint: "The OPENAI_API_KEY override is empty. Set a valid key, set LITELLM_API_KEY, or remove the override.",
+    });
+  }
+  const litellmKeyOverride = "LITELLM_API_KEY" in envConfig ? asString(envConfig.LITELLM_API_KEY, "") : null;
+  if (litellmKeyOverride !== null && litellmKeyOverride.trim() === "") {
+    checks.push({
+      code: "opencode_litellm_api_key_missing",
+      level: "warn",
+      message: "LITELLM_API_KEY override is empty.",
+      hint: "The LITELLM_API_KEY override is empty. Set a valid key or remove the override.",
     });
   }
 
-  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
+  let runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
+  const configuredModel = asString(config.model, "").trim();
+  if (configuredModel.startsWith("litellm/")) {
+    const hydrated = await hydrateLiteLlmApiKey(runtimeEnv);
+    runtimeEnv = hydrated.env;
+    if (hydrated.source === "openai_env") {
+      checks.push({
+        code: "opencode_litellm_api_key_from_openai_env",
+        level: "info",
+        message: "Prepared LITELLM_API_KEY from OPENAI_API_KEY for the OpenCode litellm provider.",
+      });
+    } else if (hydrated.source === "opencode_auth") {
+      checks.push({
+        code: "opencode_litellm_api_key_from_auth_store",
+        level: "info",
+        message: "Prepared LITELLM_API_KEY from the existing OpenCode auth store.",
+      });
+    } else if (hydrated.source === "missing") {
+      checks.push({
+        code: "opencode_litellm_api_key_unavailable",
+        level: "warn",
+        message: "No LITELLM_API_KEY was available for the OpenCode litellm provider.",
+        hint: "Set LITELLM_API_KEY, set OPENAI_API_KEY, or run `opencode auth login` so Paperclip can reuse OpenCode auth.",
+      });
+    }
+  }
 
   const cwdInvalid = checks.some((check) => check.code === "opencode_cwd_invalid");
   if (cwdInvalid) {
@@ -122,7 +157,6 @@ export async function testEnvironment(
     checks.every((check) => check.code !== "opencode_cwd_invalid" && check.code !== "opencode_command_unresolvable");
 
   let modelValidationPassed = false;
-  const configuredModel = asString(config.model, "").trim();
 
   if (canRunProbe && configuredModel) {
     try {

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -14,7 +14,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { parseOpenCodeJsonl } from "./parse.js";
-import { hydrateLiteLlmApiKey } from "./auth.js";
+import { hydrateLiteLlmApiKey, isLiteLlmModel } from "./auth.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -102,7 +102,7 @@ export async function testEnvironment(
 
   let runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
   const configuredModel = asString(config.model, "").trim();
-  if (configuredModel.startsWith("litellm/")) {
+  if (isLiteLlmModel(configuredModel)) {
     const hydrated = await hydrateLiteLlmApiKey(runtimeEnv);
     runtimeEnv = hydrated.env;
     if (hydrated.source === "openai_env") {

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -12,7 +12,14 @@ import {
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
-import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
+import {
+  discoverOpenCodeAgents,
+  ensureOpenCodeAgentConfiguredAndAvailable,
+  discoverOpenCodeModels,
+  ensureOpenCodeModelConfiguredAndAvailable,
+  resolveConfiguredOpenCodeAgentModel,
+  resolveOpenCodeCommand,
+} from "./models.js";
 import { parseOpenCodeJsonl } from "./parse.js";
 import { hydrateLiteLlmApiKey, isLiteLlmModel } from "./auth.js";
 
@@ -56,7 +63,7 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const command = asString(config.command, "opencode");
+  const command = resolveOpenCodeCommand(config.command);
   const cwd = asString(config.cwd, process.cwd());
 
   try {
@@ -101,8 +108,13 @@ export async function testEnvironment(
   }
 
   let runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
+  const configuredAgent = asString(config.agent, "").trim();
   const configuredModel = asString(config.model, "").trim();
-  if (isLiteLlmModel(configuredModel)) {
+  const configuredAgentModel = configuredAgent
+    ? await resolveConfiguredOpenCodeAgentModel({ agent: configuredAgent })
+    : null;
+  const effectiveModelId = configuredModel || configuredAgentModel || "";
+  if (isLiteLlmModel(effectiveModelId)) {
     const hydrated = await hydrateLiteLlmApiKey(runtimeEnv);
     runtimeEnv = hydrated.env;
     if (hydrated.source === "openai_env") {
@@ -157,6 +169,7 @@ export async function testEnvironment(
     checks.every((check) => check.code !== "opencode_cwd_invalid" && check.code !== "opencode_command_unresolvable");
 
   let modelValidationPassed = false;
+  let agentValidationPassed = false;
 
   if (canRunProbe && configuredModel) {
     try {
@@ -252,7 +265,60 @@ export async function testEnvironment(
     }
   }
 
-  if (canRunProbe && modelValidationPassed) {
+  if (canRunProbe && configuredAgent) {
+    try {
+      const discoveredAgents = await discoverOpenCodeAgents({ command, cwd, env: runtimeEnv });
+      if (discoveredAgents.length > 0) {
+        checks.push({
+          code: "opencode_agents_discovered",
+          level: "info",
+          message: `Discovered ${discoveredAgents.length} agent profile(s) from OpenCode.`,
+        });
+      } else {
+        checks.push({
+          code: "opencode_agents_empty",
+          level: "warn",
+          message: "OpenCode returned no agent profiles.",
+          hint: "Run `opencode agent list` and verify your opencode agent config.",
+        });
+      }
+    } catch (err) {
+      checks.push({
+        code: "opencode_agents_discovery_failed",
+        level: "warn",
+        message: err instanceof Error ? err.message : "OpenCode agent discovery failed.",
+        hint: "Run `opencode agent list` manually to verify agent config.",
+      });
+    }
+
+    try {
+      await ensureOpenCodeAgentConfiguredAndAvailable({
+        agent: configuredAgent,
+        command,
+        cwd,
+        env: runtimeEnv,
+      });
+      checks.push({
+        code: "opencode_agent_configured",
+        level: "info",
+        message: `Configured agent profile: ${configuredAgent}`,
+      });
+      agentValidationPassed = true;
+    } catch (err) {
+      checks.push({
+        code: "opencode_agent_invalid",
+        level: "error",
+        message: err instanceof Error ? err.message : "Configured OpenCode agent profile is unavailable.",
+        hint: "Run `opencode agent list` and choose an available OpenCode agent profile.",
+      });
+    }
+  }
+
+  const hasInvocationTarget = configuredModel.length > 0 || configuredAgent.length > 0;
+  const targetsValidated =
+    (!configuredModel || modelValidationPassed) && (!configuredAgent || agentValidationPassed);
+
+  if (canRunProbe && hasInvocationTarget && targetsValidated) {
     const extraArgs = (() => {
       const fromExtraArgs = asStringArray(config.extraArgs);
       if (fromExtraArgs.length > 0) return fromExtraArgs;
@@ -262,7 +328,8 @@ export async function testEnvironment(
     const probeModel = configuredModel;
 
     const args = ["run", "--format", "json"];
-    args.push("--model", probeModel);
+    if (configuredAgent) args.push("--agent", configuredAgent);
+    if (probeModel) args.push("--model", probeModel);
     if (variant) args.push("--variant", variant);
     if (extraArgs.length > 0) args.push(...extraArgs);
 

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -53,6 +53,7 @@ function parseEnvBindings(bindings: unknown): Record<string, unknown> {
 export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
   if (v.cwd) ac.cwd = v.cwd;
+  if (v.agent?.trim()) ac.agent = v.agent.trim();
   if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
 import { resetOpenCodeModelsCacheForTests } from "@paperclipai/adapter-opencode-local/server";
@@ -7,14 +10,23 @@ import { resetCodexModelsCacheForTests } from "../adapters/codex-models.js";
 import { resetCursorModelsCacheForTests, setCursorModelsRunnerForTests } from "../adapters/cursor-models.js";
 
 describe("adapter model listing", () => {
-  beforeEach(() => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-adapter-models-home-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
     delete process.env.OPENAI_API_KEY;
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
     resetCodexModelsCacheForTests();
     resetCursorModelsCacheForTests();
     setCursorModelsRunnerForTests(null);
     resetOpenCodeModelsCacheForTests();
+  });
+
+  afterEach(async () => {
     vi.restoreAllMocks();
+    await fs.rm(tempHome, { recursive: true, force: true });
   });
 
   it("returns an empty list for unknown adapters", async () => {

--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -3,14 +3,12 @@ import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 
 describe("agent local JWT", () => {
   const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
-  const betterAuthSecretEnv = "BETTER_AUTH_SECRET";
   const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
   const issuerEnv = "PAPERCLIP_AGENT_JWT_ISSUER";
   const audienceEnv = "PAPERCLIP_AGENT_JWT_AUDIENCE";
 
   const originalEnv = {
     secret: process.env[secretEnv],
-    betterAuthSecret: process.env[betterAuthSecretEnv],
     ttl: process.env[ttlEnv],
     issuer: process.env[issuerEnv],
     audience: process.env[audienceEnv],
@@ -18,7 +16,6 @@ describe("agent local JWT", () => {
 
   beforeEach(() => {
     process.env[secretEnv] = "test-secret";
-    delete process.env[betterAuthSecretEnv];
     process.env[ttlEnv] = "3600";
     delete process.env[issuerEnv];
     delete process.env[audienceEnv];
@@ -29,8 +26,6 @@ describe("agent local JWT", () => {
     vi.useRealTimers();
     if (originalEnv.secret === undefined) delete process.env[secretEnv];
     else process.env[secretEnv] = originalEnv.secret;
-    if (originalEnv.betterAuthSecret === undefined) delete process.env[betterAuthSecretEnv];
-    else process.env[betterAuthSecretEnv] = originalEnv.betterAuthSecret;
     if (originalEnv.ttl === undefined) delete process.env[ttlEnv];
     else process.env[ttlEnv] = originalEnv.ttl;
     if (originalEnv.issuer === undefined) delete process.env[issuerEnv];
@@ -80,21 +75,5 @@ describe("agent local JWT", () => {
     process.env[issuerEnv] = "paperclip";
     process.env[audienceEnv] = "paperclip-api";
     expect(verifyLocalAgentJwt(token!)).toBeNull();
-  });
-
-  it("falls back to BETTER_AUTH_SECRET when PAPERCLIP_AGENT_JWT_SECRET is missing", () => {
-    delete process.env[secretEnv];
-    process.env[betterAuthSecretEnv] = "better-auth-secret";
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-
-    const token = createLocalAgentJwt("agent-1", "company-1", "codex_local", "run-1");
-
-    expect(typeof token).toBe("string");
-    expect(verifyLocalAgentJwt(token!)).toMatchObject({
-      sub: "agent-1",
-      company_id: "company-1",
-      adapter_type: "codex_local",
-      run_id: "run-1",
-    });
   });
 });

--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -3,12 +3,14 @@ import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 
 describe("agent local JWT", () => {
   const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
+  const betterAuthSecretEnv = "BETTER_AUTH_SECRET";
   const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
   const issuerEnv = "PAPERCLIP_AGENT_JWT_ISSUER";
   const audienceEnv = "PAPERCLIP_AGENT_JWT_AUDIENCE";
 
   const originalEnv = {
     secret: process.env[secretEnv],
+    betterAuthSecret: process.env[betterAuthSecretEnv],
     ttl: process.env[ttlEnv],
     issuer: process.env[issuerEnv],
     audience: process.env[audienceEnv],
@@ -16,6 +18,7 @@ describe("agent local JWT", () => {
 
   beforeEach(() => {
     process.env[secretEnv] = "test-secret";
+    delete process.env[betterAuthSecretEnv];
     process.env[ttlEnv] = "3600";
     delete process.env[issuerEnv];
     delete process.env[audienceEnv];
@@ -26,6 +29,8 @@ describe("agent local JWT", () => {
     vi.useRealTimers();
     if (originalEnv.secret === undefined) delete process.env[secretEnv];
     else process.env[secretEnv] = originalEnv.secret;
+    if (originalEnv.betterAuthSecret === undefined) delete process.env[betterAuthSecretEnv];
+    else process.env[betterAuthSecretEnv] = originalEnv.betterAuthSecret;
     if (originalEnv.ttl === undefined) delete process.env[ttlEnv];
     else process.env[ttlEnv] = originalEnv.ttl;
     if (originalEnv.issuer === undefined) delete process.env[issuerEnv];
@@ -75,5 +80,21 @@ describe("agent local JWT", () => {
     process.env[issuerEnv] = "paperclip";
     process.env[audienceEnv] = "paperclip-api";
     expect(verifyLocalAgentJwt(token!)).toBeNull();
+  });
+
+  it("falls back to BETTER_AUTH_SECRET when PAPERCLIP_AGENT_JWT_SECRET is missing", () => {
+    delete process.env[secretEnv];
+    process.env[betterAuthSecretEnv] = "better-auth-secret";
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const token = createLocalAgentJwt("agent-1", "company-1", "codex_local", "run-1");
+
+    expect(typeof token).toBe("string");
+    expect(verifyLocalAgentJwt(token!)).toMatchObject({
+      sub: "agent-1",
+      company_id: "company-1",
+      adapter_type: "codex_local",
+      run_id: "run-1",
+    });
   });
 });

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -65,8 +65,15 @@ describe("opencode_local environment diagnostics", () => {
     const fakeOpencode = path.join(binDir, "opencode");
     const script = [
       "#!/bin/sh",
-      "echo 'ProviderModelNotFoundError: ProviderModelNotFoundError' 1>&2",
-      "echo 'data: { providerID: \"openai\", modelID: \"gpt-5.3-codex\", suggestions: [] }' 1>&2",
+      "if [ \"$1\" = \"models\" ]; then",
+      "  echo 'openai/gpt-5.3-codex'",
+      "  exit 0",
+      "fi",
+      "if [ \"$1\" = \"run\" ]; then",
+      "  echo 'ProviderModelNotFoundError: ProviderModelNotFoundError' 1>&2",
+      "  echo 'data: { providerID: \"openai\", modelID: \"gpt-5.3-codex\", suggestions: [] }' 1>&2",
+      "  exit 1",
+      "fi",
       "exit 1",
       "",
     ].join("\n");
@@ -81,6 +88,7 @@ describe("opencode_local environment diagnostics", () => {
         config: {
           command: fakeOpencode,
           cwd,
+          model: "openai/gpt-5.3-codex",
         },
       });
 
@@ -88,6 +96,65 @@ describe("opencode_local environment diagnostics", () => {
       expect(modelCheck).toBeTruthy();
       expect(modelCheck?.level).toBe("warn");
       expect(result.status).toBe("warn");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+      await fs.rm(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("validates configured OpenCode agent profiles and probes with --agent", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-agent-cwd-"));
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-agent-bin-"));
+    const fakeOpencode = path.join(binDir, "opencode");
+    const script = [
+      "#!/bin/sh",
+      "if [ \"$1\" = \"agent\" ] && [ \"$2\" = \"list\" ]; then",
+      "  echo 'Available Agents:'",
+      "  echo '- plan (Planning agent)'",
+      "  exit 0",
+      "fi",
+      "if [ \"$1\" = \"models\" ]; then",
+      "  echo 'litellm/qwen3.5-35b-a3b'",
+      "  exit 0",
+      "fi",
+      "if [ \"$1\" = \"run\" ]; then",
+      "  agent_flag=''",
+      "  while [ $# -gt 0 ]; do",
+      "    if [ \"$1\" = \"--agent\" ]; then",
+      "      shift",
+      "      agent_flag=\"$1\"",
+      "    fi",
+      "    shift",
+      "  done",
+      "  if [ \"$agent_flag\" != 'plan' ]; then",
+      "    echo 'missing expected --agent plan' 1>&2",
+      "    exit 1",
+      "  fi",
+      "  printf '%s\n' '{\"type\":\"text\",\"sessionID\":\"ses_agent\",\"part\":{\"text\":\"hello\"}}'",
+      "  printf '%s\n' '{\"type\":\"step_finish\",\"sessionID\":\"ses_agent\",\"part\":{\"cost\":0,\"tokens\":{\"input\":1,\"output\":1,\"reasoning\":0,\"cache\":{\"read\":0}}}}'",
+      "  exit 0",
+      "fi",
+      "exit 1",
+      "",
+    ].join("\n");
+
+    try {
+      await fs.writeFile(fakeOpencode, script, "utf8");
+      await fs.chmod(fakeOpencode, 0o755);
+
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "opencode_local",
+        config: {
+          command: fakeOpencode,
+          cwd,
+          agent: "plan",
+        },
+      });
+
+      expect(result.checks.some((check) => check.code === "opencode_agent_configured")).toBe(true);
+      expect(result.checks.some((check) => check.code === "opencode_hello_probe_passed")).toBe(true);
+      expect(result.status).toBe("pass");
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
       await fs.rm(binDir, { recursive: true, force: true });

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -26,7 +26,7 @@ function parseNumber(value: string | undefined, fallback: number) {
 }
 
 function jwtConfig() {
-  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
   if (!secret) return null;
 
   return {

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -26,7 +26,7 @@ function parseNumber(value: string | undefined, fallback: number) {
 }
 
 function jwtConfig() {
-  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
+  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
   if (!secret) return null;
 
   return {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -43,7 +43,10 @@ import {
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
-import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
+import {
+  ensureOpenCodeAgentConfiguredAndAvailable,
+  ensureOpenCodeModelConfiguredAndAvailable,
+} from "@paperclipai/adapter-opencode-local/server";
 
 export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
@@ -260,7 +263,7 @@ export function agentRoutes(db: Db) {
       next.model = DEFAULT_GEMINI_LOCAL_MODEL;
       return ensureGatewayDeviceKey(adapterType, next);
     }
-    // OpenCode requires explicit model selection — no default
+    // OpenCode has no Paperclip-side default target — configure either model or agent.
     if (adapterType === "cursor" && !asNonEmptyString(next.model)) {
       next.model = DEFAULT_CURSOR_LOCAL_MODEL;
     }
@@ -275,13 +278,30 @@ export function agentRoutes(db: Db) {
     if (adapterType !== "opencode_local") return;
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(companyId, adapterConfig);
     const runtimeEnv = asRecord(runtimeConfig.env) ?? {};
+    const configuredModel = asNonEmptyString(runtimeConfig.model);
+    const configuredAgent = asNonEmptyString(runtimeConfig.agent);
+    if (!configuredModel && !configuredAgent) {
+      throw unprocessable(
+        "Invalid opencode_local adapterConfig: OpenCode requires adapterConfig.model or adapterConfig.agent",
+      );
+    }
     try {
-      await ensureOpenCodeModelConfiguredAndAvailable({
-        model: runtimeConfig.model,
-        command: runtimeConfig.command,
-        cwd: runtimeConfig.cwd,
-        env: runtimeEnv,
-      });
+      if (configuredModel) {
+        await ensureOpenCodeModelConfiguredAndAvailable({
+          model: configuredModel,
+          command: runtimeConfig.command,
+          cwd: runtimeConfig.cwd,
+          env: runtimeEnv,
+        });
+      }
+      if (configuredAgent) {
+        await ensureOpenCodeAgentConfiguredAndAvailable({
+          agent: configuredAgent,
+          command: runtimeConfig.command,
+          cwd: runtimeConfig.cwd,
+          env: runtimeEnv,
+        });
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);

--- a/ui/src/adapters/opencode-local/config-fields.tsx
+++ b/ui/src/adapters/opencode-local/config-fields.tsx
@@ -7,6 +7,8 @@ import { ChoosePathButton } from "../../components/PathInstructionsModal";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const agentProfileHint =
+  "Optional OpenCode agent profile name from agent.<name> in opencode.json. Paperclip passes it as `opencode run --agent <name>`. Use this when OpenCode owns model selection via agent/harness config.";
 const instructionsFileHint =
   "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime.";
 
@@ -19,29 +21,48 @@ export function OpenCodeLocalConfigFields({
   mark,
 }: AdapterConfigFieldsProps) {
   return (
-    <Field label="Agent instructions file" hint={instructionsFileHint}>
-      <div className="flex items-center gap-2">
+    <>
+      <Field label="OpenCode agent profile" hint={agentProfileHint}>
         <DraftInput
           value={
             isCreate
-              ? values!.instructionsFilePath ?? ""
-              : eff(
-                  "adapterConfig",
-                  "instructionsFilePath",
-                  String(config.instructionsFilePath ?? ""),
-                )
+              ? values!.agent ?? ""
+              : eff("adapterConfig", "agent", String(config.agent ?? ""))
           }
           onCommit={(v) =>
             isCreate
-              ? set!({ instructionsFilePath: v })
-              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              ? set!({ agent: v })
+              : mark("adapterConfig", "agent", v || undefined)
           }
           immediate
           className={inputClass}
-          placeholder="/absolute/path/to/AGENTS.md"
+          placeholder="plan"
         />
-        <ChoosePathButton />
-      </div>
-    </Field>
+      </Field>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+    </>
   );
 }

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -349,6 +349,14 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const currentModelId = isCreate
     ? val!.model
     : eff("adapterConfig", "model", String(config.model ?? ""));
+  const currentOpenCodeAgent =
+    adapterType === "opencode_local"
+      ? (
+          isCreate
+            ? val!.agent ?? ""
+            : eff("adapterConfig", "agent", String(config.agent ?? ""))
+        ).trim()
+      : "";
 
   const thinkingEffortKey =
     adapterType === "codex_local"
@@ -526,6 +534,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   } else if (t === "cursor") {
                     nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
                   } else if (t === "opencode_local") {
+                    nextValues.agent = "";
                     nextValues.model = "";
                   }
                   set!(nextValues);
@@ -544,6 +553,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                           : t === "cursor"
                             ? DEFAULT_CURSOR_LOCAL_MODEL
                           : "",
+                      agent: "",
                       effort: "",
                       modelReasoningEffort: "",
                       variant: "",
@@ -672,8 +682,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 }
                 open={modelOpen}
                 onOpenChange={setModelOpen}
-                allowDefault={adapterType !== "opencode_local"}
-                required={adapterType === "opencode_local"}
+                allowDefault={adapterType !== "opencode_local" || Boolean(currentOpenCodeAgent)}
+                required={adapterType === "opencode_local" && !currentOpenCodeAgent}
                 groupByProvider={adapterType === "opencode_local"}
               />
               {fetchedModelsError && (

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1084,7 +1084,9 @@ export function OnboardingWizard() {
                                   ? "CURSOR_API_KEY"
                                   : adapterType === "gemini_local"
                                     ? "GEMINI_API_KEY"
-                                    : "OPENAI_API_KEY"}
+                                    : adapterType === "opencode_local"
+                                      ? "LITELLM_API_KEY"
+                                      : "OPENAI_API_KEY"}
                               </span>{" "}
                               in env or run{" "}
                               <span className="font-mono">

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -114,6 +114,7 @@ export function OnboardingWizard() {
   const [agentName, setAgentName] = useState("CEO");
   const [adapterType, setAdapterType] = useState<AdapterType>("claude_local");
   const [cwd, setCwd] = useState("");
+  const [openCodeAgent, setOpenCodeAgent] = useState("");
   const [model, setModel] = useState("");
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
@@ -217,7 +218,7 @@ export function OnboardingWizard() {
     if (step !== 2) return;
     setAdapterEnvResult(null);
     setAdapterEnvError(null);
-  }, [step, adapterType, cwd, model, command, args, url]);
+  }, [step, adapterType, cwd, openCodeAgent, model, command, args, url]);
 
   const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
   const hasAnthropicApiKeyOverrideCheck =
@@ -274,6 +275,7 @@ export function OnboardingWizard() {
     setAgentName("CEO");
     setAdapterType("claude_local");
     setCwd("");
+    setOpenCodeAgent("");
     setModel("");
     setCommand("");
     setArgs("");
@@ -302,6 +304,7 @@ export function OnboardingWizard() {
       ...defaultCreateValues,
       adapterType,
       cwd,
+      agent: adapterType === "opencode_local" ? openCodeAgent : "",
       model:
         adapterType === "codex_local"
           ? model || DEFAULT_CODEX_LOCAL_MODEL
@@ -402,35 +405,36 @@ export function OnboardingWizard() {
     setError(null);
     try {
       if (adapterType === "opencode_local") {
+        const selectedAgentProfile = openCodeAgent.trim();
         const selectedModelId = model.trim();
-        if (!selectedModelId) {
-          setError(
-            "OpenCode requires an explicit model in provider/model format."
-          );
+        if (!selectedModelId && !selectedAgentProfile) {
+          setError("OpenCode requires either a model or an agent profile.");
           return;
         }
-        if (adapterModelsError) {
-          setError(
-            adapterModelsError instanceof Error
-              ? adapterModelsError.message
-              : "Failed to load OpenCode models."
-          );
-          return;
-        }
-        if (adapterModelsLoading || adapterModelsFetching) {
-          setError(
-            "OpenCode models are still loading. Please wait and try again."
-          );
-          return;
-        }
-        const discoveredModels = adapterModels ?? [];
-        if (!discoveredModels.some((entry) => entry.id === selectedModelId)) {
-          setError(
-            discoveredModels.length === 0
-              ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
-              : `Configured OpenCode model is unavailable: ${selectedModelId}`
-          );
-          return;
+        if (selectedModelId) {
+          if (adapterModelsError) {
+            setError(
+              adapterModelsError instanceof Error
+                ? adapterModelsError.message
+                : "Failed to load OpenCode models."
+            );
+            return;
+          }
+          if (adapterModelsLoading || adapterModelsFetching) {
+            setError(
+              "OpenCode models are still loading. Please wait and try again."
+            );
+            return;
+          }
+          const discoveredModels = adapterModels ?? [];
+          if (!discoveredModels.some((entry) => entry.id === selectedModelId)) {
+            setError(
+              discoveredModels.length === 0
+                ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
+                : `Configured OpenCode model is unavailable: ${selectedModelId}`
+            );
+            return;
+          }
         }
       }
 
@@ -743,6 +747,7 @@ export function OnboardingWizard() {
                           onClick={() => {
                             const nextType = opt.value as AdapterType;
                             setAdapterType(nextType);
+                            setOpenCodeAgent("");
                             if (nextType === "codex_local" && !model) {
                               setModel(DEFAULT_CODEX_LOCAL_MODEL);
                             }
@@ -835,6 +840,7 @@ export function OnboardingWizard() {
                               if (opt.comingSoon) return;
                               const nextType = opt.value as AdapterType;
                               setAdapterType(nextType);
+                              setOpenCodeAgent("");
                               if (nextType === "gemini_local" && !model) {
                                 setModel(DEFAULT_GEMINI_LOCAL_MODEL);
                                 return;
@@ -892,6 +898,22 @@ export function OnboardingWizard() {
                           <ChoosePathButton />
                         </div>
                       </div>
+                      {adapterType === "opencode_local" && (
+                        <div>
+                          <div className="flex items-center gap-1.5 mb-1">
+                            <label className="text-xs text-muted-foreground">
+                              OpenCode agent profile
+                            </label>
+                            <HintIcon text="Optional OpenCode agent profile name from agent.<name> in opencode.json. Paperclip passes --agent <name>. Use this when OpenCode handles model selection via agent/harness config." />
+                          </div>
+                          <input
+                            className="w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/50"
+                            placeholder="plan"
+                            value={openCodeAgent}
+                            onChange={(e) => setOpenCodeAgent(e.target.value)}
+                          />
+                        </div>
+                      )}
                       <div>
                         <label className="text-xs text-muted-foreground mb-1 block">
                           Model
@@ -914,7 +936,9 @@ export function OnboardingWizard() {
                                   ? selectedModel.label
                                   : model ||
                                     (adapterType === "opencode_local"
-                                      ? "Select model (required)"
+                                      ? openCodeAgent.trim()
+                                        ? "Default from agent profile"
+                                        : "Select model (or use agent profile)"
                                       : "Default")}
                               </span>
                               <ChevronDown className="h-3 w-3 text-muted-foreground" />
@@ -983,7 +1007,10 @@ export function OnboardingWizard() {
                             </div>
                             {filteredModels.length === 0 && (
                               <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                                No models discovered.
+                                {adapterType === "opencode_local" &&
+                                openCodeAgent.trim()
+                                  ? "No models discovered. You can still continue if the agent profile resolves a model in OpenCode."
+                                  : "No models discovered."}
                               </p>
                             )}
                           </PopoverContent>
@@ -1066,7 +1093,7 @@ export function OnboardingWizard() {
                               : adapterType === "gemini_local"
                                 ? `${effectiveAdapterCommand} --output-format json "Respond with hello."`
                               : adapterType === "opencode_local"
-                                ? `${effectiveAdapterCommand} run --format json "Respond with hello."`
+                                ? `${effectiveAdapterCommand} run --format json${openCodeAgent.trim() ? ` --agent ${openCodeAgent.trim()}` : ""}${model.trim() ? ` --model ${model.trim()}` : ""} "Respond with hello."`
                               : `${effectiveAdapterCommand} --print - --output-format stream-json --verbose`}
                           </p>
                           <p className="text-muted-foreground">

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -3,6 +3,7 @@ import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 export const defaultCreateValues: CreateConfigValues = {
   adapterType: "claude_local",
   cwd: "",
+  agent: "",
   instructionsFilePath: "",
   promptTemplate: "",
   model: "",

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -27,7 +27,7 @@ export const help: Record<string, string> = {
   adapterType: "How this agent runs: local CLI (Claude/Codex/OpenCode), OpenClaw Gateway, spawned process, or generic HTTP webhook.",
   cwd: "Default working directory fallback for local adapters. Use an absolute path on the machine running Paperclip.",
   promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Use it for current-task framing, not large static instructions. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} and other template variables.",
-  model: "Override the default model used by the adapter.",
+  model: "Override the default model used by the adapter. For OpenCode, this becomes optional when an agent profile is configured.",
   thinkingEffort: "Control model reasoning depth. Supported values vary by adapter/model.",
   chrome: "Enable Claude's Chrome integration by passing --chrome.",
   dangerouslySkipPermissions: "Run Claude without permission prompts. Required for unattended operation.",

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -50,6 +50,7 @@ function createValuesForAdapterType(
   } else if (adapterType === "cursor") {
     nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
   } else if (adapterType === "opencode_local") {
+    nextValues.agent = "";
     nextValues.model = "";
   }
   return nextValues;
@@ -142,31 +143,34 @@ export function NewAgent() {
     if (!selectedCompanyId || !name.trim()) return;
     setFormError(null);
     if (configValues.adapterType === "opencode_local") {
+      const selectedAgent = (configValues.agent ?? "").trim();
       const selectedModel = configValues.model.trim();
-      if (!selectedModel) {
-        setFormError("OpenCode requires an explicit model in provider/model format.");
+      if (!selectedModel && !selectedAgent) {
+        setFormError("OpenCode requires either a model or an agent profile.");
         return;
       }
-      if (adapterModelsError) {
-        setFormError(
-          adapterModelsError instanceof Error
-            ? adapterModelsError.message
-            : "Failed to load OpenCode models.",
-        );
-        return;
-      }
-      if (adapterModelsLoading || adapterModelsFetching) {
-        setFormError("OpenCode models are still loading. Please wait and try again.");
-        return;
-      }
-      const discovered = adapterModels ?? [];
-      if (!discovered.some((entry) => entry.id === selectedModel)) {
-        setFormError(
-          discovered.length === 0
-            ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
-            : `Configured OpenCode model is unavailable: ${selectedModel}`,
-        );
-        return;
+      if (selectedModel) {
+        if (adapterModelsError) {
+          setFormError(
+            adapterModelsError instanceof Error
+              ? adapterModelsError.message
+              : "Failed to load OpenCode models.",
+          );
+          return;
+        }
+        if (adapterModelsLoading || adapterModelsFetching) {
+          setFormError("OpenCode models are still loading. Please wait and try again.");
+          return;
+        }
+        const discovered = adapterModels ?? [];
+        if (!discovered.some((entry) => entry.id === selectedModel)) {
+          setFormError(
+            discovered.length === 0
+              ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
+              : `Configured OpenCode model is unavailable: ${selectedModel}`,
+          );
+          return;
+        }
       }
     }
     createAgent.mutate({


### PR DESCRIPTION
## Summary
- hydrate `LITELLM_API_KEY` for `litellm/*` OpenCode models by reusing an existing `LITELLM_API_KEY`, copying `OPENAI_API_KEY`, or reading the OpenCode auth store
- surface the LiteLLM fallback behavior in opencode-local environment diagnostics and onboarding copy
- add test coverage for the LiteLLM auth fallback paths, including the `missing` case
- centralize litellm provider detection so execution and diagnostics use the same check

## Why
`opencode-local` currently depends on auth defaults that are easy to miss in local setups. This change makes local configuration more forgiving by reusing credentials users often already have, and it updates the onboarding hint to point to the variable the adapter actually uses.

## Testing
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`

## Manual verification
- verified the adapter can prepare `LITELLM_API_KEY` from `OPENAI_API_KEY`
- verified the adapter can reuse the existing OpenCode auth store when env vars are absent
- verified the adapter reports the `missing` path cleanly when no LiteLLM credential source is available

## Notes
- UI impact is limited to onboarding helper text, so I did not attach screenshots
