### PR TITLE
Add ACPX sidecar adapter for isolated runtime containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
+COPY packages/adapters/acpx-sidecar/package.json packages/adapters/acpx-sidecar/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/

--- a/docs/adapters/acpx-sidecar.md
+++ b/docs/adapters/acpx-sidecar.md
@@ -1,0 +1,93 @@
+---
+title: ACPX Sidecar
+summary: Run Paperclip agents through dedicated external sidecar containers that shell out to acpx and official CLIs
+---
+
+The `acpx_sidecar` adapter lets Paperclip orchestrate an external runtime container instead of executing CLIs inside the main Paperclip process.
+
+Use this adapter when:
+
+- you want official CLIs (`codex`, `claude`, `gemini`, `openclaw`, `opencode`, `pi`) isolated in dedicated containers
+- you want the sidecar container, not Paperclip, to own `acpx` session state
+- you want provider-specific auth and network policy separated from the Paperclip API/UI container
+
+How it works:
+
+1. Paperclip renders the prompt and optional instructions file.
+2. Paperclip calls `POST /run` on the sidecar.
+3. The sidecar runs:
+   - `acpx <agent> sessions ensure --name <session>`
+   - optional `acpx <agent> set model <model>`
+   - `acpx <agent> prompt -s <session> --file -`
+4. The sidecar returns raw ACP JSON output.
+5. Paperclip parses the ACP stream and stores the run summary.
+
+## Required sidecar HTTP contract
+
+`GET /health`
+
+Returns a simple health payload.
+
+`GET /status`
+
+Returns sidecar rate-limit and active-run status.
+
+`POST /run`
+
+Request body:
+
+```json
+{
+  "agent": "katya",
+  "args": ["--cwd", "/home/node/workspaces/katya", "--format", "json", "--json-strict", "gemini", "prompt", "-s", "paperclip-katya", "--file", "-"],
+  "cwd": "/home/node/workspaces/katya",
+  "stdin": "Prompt text goes here",
+  "timeout": 300
+}
+```
+
+Response body:
+
+```json
+{
+  "ok": true,
+  "provider": "gemini",
+  "agent": "katya",
+  "command": ["acpx", "--cwd", "/home/node/workspaces/katya", "..."],
+  "cwd": "/home/node/workspaces/katya",
+  "exit_code": 0,
+  "stdout": "{\"jsonrpc\":\"2.0\",...}",
+  "stderr": "",
+  "status": {}
+}
+```
+
+## Adapter configuration
+
+Core fields:
+
+- `url`: sidecar base URL
+- `agentCommand`: acpx runtime name such as `gemini`, `claude`, `codex`, `openclaw`, `opencode`, `pi`
+- `cwd`: sidecar-local working directory
+- `instructionsFilePath`: optional instructions markdown file
+- `promptTemplate`: run prompt template
+- `model`: optional `acpx set model ...` value
+- `sessionNameTemplate`: optional session name template
+- `extraArgs`: optional extra acpx flags
+- `timeoutSec`: prompt timeout
+
+Example:
+
+```json
+{
+  "adapterType": "acpx_sidecar",
+  "adapterConfig": {
+    "url": "http://sidecar-gemini-shared:8730",
+    "agentCommand": "gemini",
+    "cwd": "/home/node/workspaces/katya",
+    "model": "gemini-3.1-pro",
+    "instructionsFilePath": "/home/node/workspaces/katya/AGENTS.md",
+    "promptTemplate": "You are {{agent.name}}. Continue your Paperclip work."
+  }
+}
+```

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -24,6 +24,7 @@ When a heartbeat fires, Paperclip:
 | OpenClaw | `openclaw` | Sends wake payloads to an OpenClaw webhook |
 | [Process](/adapters/process) | `process` | Executes arbitrary shell commands |
 | [HTTP](/adapters/http) | `http` | Sends webhooks to external agents |
+| [ACPX Sidecar](/adapters/acpx-sidecar) | `acpx_sidecar` | Calls a dedicated sidecar service that runs acpx + official CLIs |
 
 ## Adapter Architecture
 

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -38,6 +38,7 @@ Common choices:
 - `codex_local`: runs your local `codex` CLI
 - `process`: generic shell command adapter
 - `http`: calls an external HTTP endpoint
+- `acpx_sidecar`: calls a dedicated runtime sidecar that shells out to `acpx`
 
 For `claude_local` and `codex_local`, Paperclip assumes the CLI is already installed and authenticated on the host machine.
 

--- a/docs/examples/acpx-sidecars/README.md
+++ b/docs/examples/acpx-sidecars/README.md
@@ -1,0 +1,5 @@
+# ACPX sidecar runtime image templates
+
+These templates are minimal base images for ACPX-compatible runtime sidecars.
+
+They are intended to be paired with your own small `/run` sidecar wrapper that executes `acpx` commands on behalf of Paperclip.

--- a/docs/examples/acpx-sidecars/claude.Dockerfile
+++ b/docs/examples/acpx-sidecars/claude.Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update -qq &&     apt-get install -y -qq --no-install-recommends python3 ca-certificates curl git &&     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g acpx @anthropic-ai/claude-code
+
+ENV HOME=/home/node
+RUN useradd -m -d /home/node -s /bin/bash node 2>/dev/null || true
+USER node
+WORKDIR /home/node

--- a/docs/examples/acpx-sidecars/codex.Dockerfile
+++ b/docs/examples/acpx-sidecars/codex.Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update -qq &&     apt-get install -y -qq --no-install-recommends python3 ca-certificates curl git &&     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g acpx @openai/codex
+
+ENV HOME=/home/node
+RUN useradd -m -d /home/node -s /bin/bash node 2>/dev/null || true
+USER node
+WORKDIR /home/node

--- a/docs/examples/acpx-sidecars/gemini.Dockerfile
+++ b/docs/examples/acpx-sidecars/gemini.Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update -qq &&     apt-get install -y -qq --no-install-recommends python3 ca-certificates curl git &&     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g acpx @google/gemini-cli
+
+ENV HOME=/home/node
+RUN useradd -m -d /home/node -s /bin/bash node 2>/dev/null || true
+USER node
+WORKDIR /home/node

--- a/docs/examples/acpx-sidecars/hermes.Dockerfile
+++ b/docs/examples/acpx-sidecars/hermes.Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update -qq &&     apt-get install -y -qq --no-install-recommends python3 python3-pip python3-venv ca-certificates curl git &&     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g acpx
+
+WORKDIR /app
+RUN git clone --depth=1 https://github.com/NousResearch/hermes-agent.git /app/hermes-agent
+RUN python3 -m pip install --break-system-packages --no-cache-dir /app/hermes-agent
+
+ENV HOME=/home/node
+RUN useradd -m -d /home/node -s /bin/bash node 2>/dev/null || true
+USER node
+WORKDIR /home/node

--- a/docs/guides/board-operator/managing-agents.md
+++ b/docs/guides/board-operator/managing-agents.md
@@ -29,6 +29,9 @@ Create agents from the Agents page. Each agent requires:
 
 Common adapter choices:
 - `claude_local` / `codex_local` / `opencode_local` for local coding agents
+- `acpx_sidecar` for dedicated runtime sidecars that keep official CLIs out of the main Paperclip container
+- `claude_local` / `codex_local` / `gemini_local` / `opencode_local` for local coding agents
+- `acpx_sidecar` for dedicated runtime sidecars that keep official CLIs out of the main Paperclip container
 - `openclaw` / `http` for webhook-based external agents
 - `process` for generic local command execution
 

--- a/docs/guides/deploy/acpx-sidecars.md
+++ b/docs/guides/deploy/acpx-sidecars.md
@@ -1,0 +1,58 @@
+---
+title: ACPX sidecars with Docker Compose
+summary: Generic ACPX sidecar patterns for Codex, Claude, Gemini, and Hermes runtimes
+---
+
+This guide shows how to run dedicated runtime containers for the `acpx_sidecar` adapter.
+
+The working, upstream-facing pattern is:
+
+- Paperclip uses `adapterType: "acpx_sidecar"`
+- Paperclip talks to a small HTTP sidecar exposing `/health`, `/status`, and `/run`
+- that sidecar shells out to `acpx`
+- `acpx` then runs the target runtime
+
+This guide intentionally documents only the currently working runtime families:
+
+- Codex
+- Claude Code
+- Gemini CLI
+- Hermes Agent
+
+## Adapter config shape
+
+```json
+{
+  "adapterType": "acpx_sidecar",
+  "adapterConfig": {
+    "url": "http://runtime-sidecar:8710",
+    "agentCommand": "codex",
+    "cwd": "/home/node/workspaces/agent-name",
+    "timeoutSec": 600,
+    "model": "gpt-5.4"
+  }
+}
+```
+
+Use `customAgentCommand` when the runtime is not a built-in ACPX agent command.
+
+## Runtime image templates
+
+The following templates are provided as starting points:
+
+- [`codex.Dockerfile`](/docs/examples/acpx-sidecars/codex.Dockerfile)
+- [`claude.Dockerfile`](/docs/examples/acpx-sidecars/claude.Dockerfile)
+- [`gemini.Dockerfile`](/docs/examples/acpx-sidecars/gemini.Dockerfile)
+- [`hermes.Dockerfile`](/docs/examples/acpx-sidecars/hermes.Dockerfile)
+
+These templates are intentionally minimal:
+
+- install `acpx`
+- install the target runtime
+- provide a writable `HOME`
+
+They do not prescribe your HTTP `/run` wrapper implementation. That wrapper is deployment-specific and can live outside the Paperclip core repo.
+
+## Why this pattern exists
+
+This keeps provider CLIs and runtime dependencies out of the main Paperclip API container while still letting Paperclip orchestrate them through one generic adapter.

--- a/docs/start/architecture.md
+++ b/docs/start/architecture.md
@@ -87,7 +87,8 @@ Adapters are the bridge between Paperclip and agent runtimes. Each adapter is a 
 - **UI module** — stdout parser for the run viewer, config form fields for agent creation
 - **CLI module** — terminal formatter for `paperclipai run --watch`
 
-Built-in adapters: `claude_local`, `codex_local`, `process`, `http`. You can create custom adapters for any runtime.
+Built-in adapters: `claude_local`, `codex_local`, `acpx_sidecar`, `process`, `http`. You can create custom adapters for any runtime.
+Built-in adapters: `claude_local`, `codex_local`, `gemini_local`, `acpx_sidecar`, `process`, `http`. You can create custom adapters for any runtime.
 
 ## Key Design Decisions
 

--- a/packages/adapters/acpx-sidecar/package.json
+++ b/packages/adapters/acpx-sidecar/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@paperclipai/adapter-acpx-sidecar",
+  "version": "0.2.7",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/acpx-sidecar/src/cli/format-event.ts
+++ b/packages/adapters/acpx-sidecar/src/cli/format-event.ts
@@ -1,0 +1,39 @@
+import pc from "picocolors";
+
+export function printAcpxSidecarStreamEvent(raw: string): void {
+  const line = raw.trim();
+  if (!line) return;
+  try {
+    const event = JSON.parse(line) as Record<string, unknown>;
+    const method = typeof event.method === "string" ? event.method : "";
+    if (method === "session/update") {
+      const params =
+        typeof event.params === "object" && event.params && !Array.isArray(event.params)
+          ? (event.params as Record<string, unknown>)
+          : {};
+      const updateType = typeof params.sessionUpdate === "string" ? params.sessionUpdate : "";
+      const content =
+        typeof params.content === "object" && params.content && !Array.isArray(params.content)
+          ? (params.content as Record<string, unknown>)
+          : {};
+      if (updateType === "agent_message_chunk" && content.type === "text") {
+        console.log(pc.green(String(content.text ?? "")));
+        return;
+      }
+      if (updateType === "agent_thought_chunk" && content.type === "text") {
+        console.log(pc.gray(`[thinking] ${String(content.text ?? "")}`));
+        return;
+      }
+    }
+    if (event.result && typeof event.result === "object") {
+      const stopReason = (event.result as Record<string, unknown>).stopReason;
+      if (typeof stopReason === "string") {
+        console.log(pc.gray(`[done] ${stopReason}`));
+        return;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  console.log(line);
+}

--- a/packages/adapters/acpx-sidecar/src/cli/index.ts
+++ b/packages/adapters/acpx-sidecar/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAcpxSidecarStreamEvent } from "./format-event.js";

--- a/packages/adapters/acpx-sidecar/src/index.ts
+++ b/packages/adapters/acpx-sidecar/src/index.ts
@@ -1,0 +1,37 @@
+export const type = "acpx_sidecar";
+export const label = "ACPX Sidecar";
+
+export const models = [
+  { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro" },
+  { id: "gemini-3.1-pro-high", label: "Gemini 3.1 Pro High" },
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "gpt-4", label: "GPT-4" },
+];
+
+export const agentConfigurationDoc = `# acpx_sidecar agent configuration
+
+Adapter: acpx_sidecar
+
+This adapter sends Paperclip heartbeats to an external sidecar service that shells out to \`acpx\`.
+The sidecar, not the main Paperclip container, owns the official CLI runtime and session state.
+
+Core fields:
+- url (string, required): sidecar base URL (for example http://sidecar-gemini-shared:8730)
+- agentCommand (string, optional): ACPX runtime name (for example gemini, claude, codex, openclaw)
+- customAgentCommand (string, optional): raw ACP server command passed via \`acpx --agent\`; use this for custom ACP shims such as DeerFlow
+- cwd (string, optional): sidecar-local working directory for session scoping
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- promptTemplate (string, optional): run prompt template
+- model (string, optional): model/config value applied with \`acpx <agent> set model <value>\`
+- sessionNameTemplate (string, optional): template for ACPX session name, defaults to paperclip-{{agent.id}}-{{runtime.taskKey}}
+- headers (object, optional): extra HTTP headers sent to the sidecar
+- extraArgs (string[], optional): additional ACPX flags inserted before the runtime command
+- timeoutSec (number, optional): prompt timeout in seconds
+
+Notes:
+- Paperclip keeps only lightweight adapter session metadata; ACPX keeps runtime sessions in the sidecar container.
+- The sidecar should expose \`GET /health\`, \`GET /status\`, and \`POST /run\`.
+- \`POST /run\` should support JSON with \`args\`, optional \`stdin\`, optional \`cwd\`, and optional \`timeout\`.
+- When \`customAgentCommand\` is set, the adapter invokes \`acpx --agent "<command>" ...\` and does not require \`agentCommand\`.
+- This is intended for dedicated runtime containers so official CLIs do not run in the main Paperclip container.`;

--- a/packages/adapters/acpx-sidecar/src/server/execute.ts
+++ b/packages/adapters/acpx-sidecar/src/server/execute.ts
@@ -1,0 +1,257 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  renderTemplate,
+  redactEnvForLogs,
+} from "@paperclipai/adapter-utils/server-utils";
+import { parseAcpxJson } from "./parse.js";
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseHeaders(raw: unknown): Record<string, string> {
+  const record = parseObject(raw);
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (typeof value === "string" && value.trim().length > 0) headers[key] = value;
+  }
+  return headers;
+}
+
+function buildAcpxCommandArgs(input: {
+  cwd: string;
+  extraArgs: string[];
+  agentCommand: string | null;
+  customAgentCommand: string | null;
+  operation: "sessions" | "set" | "prompt";
+  sessionName: string;
+  model?: string | null;
+}): string[] {
+  const prefix = ["--cwd", input.cwd];
+  const target = input.customAgentCommand
+    ? [...input.extraArgs, "--agent", input.customAgentCommand]
+    : [...input.extraArgs, ...(input.agentCommand ? [input.agentCommand] : [])];
+
+  if (input.operation === "sessions") {
+    return [...prefix, "--format", "json", "--json-strict", ...target, "sessions", "ensure", "--name", input.sessionName];
+  }
+  if (input.operation === "set") {
+    return [...prefix, ...target, "set", "model", input.model ?? "", "-s", input.sessionName];
+  }
+  return [...prefix, "--format", "json", "--json-strict", ...target, "prompt", "-s", input.sessionName, "--file", "-"];
+}
+
+async function sidecarRun(input: {
+  url: string;
+  headers: Record<string, string>;
+  agentId: string;
+  args: string[];
+  timeout: number;
+  cwd?: string;
+  stdin?: string;
+}) {
+  const response = await fetch(`${input.url.replace(/\/+$/, "")}/run`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...input.headers,
+    },
+    body: JSON.stringify({
+      agent: input.agentId,
+      args: input.args,
+      timeout: input.timeout,
+      ...(input.cwd ? { cwd: input.cwd } : {}),
+      ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+    }),
+  });
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!response.ok) {
+    throw new Error(`sidecar_run_failed:${response.status}:${JSON.stringify(payload)}`);
+  }
+  return payload;
+}
+
+function buildSessionName(ctx: AdapterExecutionContext, template: string | null): string {
+  if (template) {
+    return renderTemplate(template, {
+      agent: ctx.agent,
+      runId: ctx.runId,
+      context: ctx.context,
+      runtime: ctx.runtime,
+    }).replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 120);
+  }
+  return `paperclip-${ctx.agent.id}${ctx.runtime.taskKey ? `-${ctx.runtime.taskKey}` : ""}`
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .slice(0, 120);
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, config, context, runtime, onLog, onMeta, authToken } = ctx;
+  const url = asString(config.url, "").trim();
+  if (!url) throw new Error("acpx_sidecar missing url");
+
+  const agentCommand = asString(config.agentCommand, "").trim() || asString(config.command, "").trim();
+  const customAgentCommand = asString(config.customAgentCommand, "").trim();
+  if (!agentCommand && !customAgentCommand) throw new Error("acpx_sidecar missing agentCommand or customAgentCommand");
+
+  const timeoutSec = asNumber(config.timeoutSec, 300);
+  const model = asString(config.model, "").trim();
+  const cwd =
+    nonEmptyString(config.cwd) ||
+    nonEmptyString(parseObject(context.paperclipWorkspace).cwd) ||
+    `/home/node/workspaces/${agent.id}`;
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+  const sessionName = buildSessionName(ctx, nonEmptyString(config.sessionNameTemplate));
+  const headers = parseHeaders(config.headers);
+  if (authToken && !headers.authorization) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
+  const env = redactEnvForLogs(buildPaperclipEnv(agent));
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  let instructionsPrefix = "";
+  if (instructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. Resolve relative paths from ${path.dirname(instructionsFilePath)}/.\n\n`;
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not read acpx_sidecar instructions file "${instructionsFilePath}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  const prompt = instructionsPrefix + renderTemplate(promptTemplate, {
+    agent,
+    runId,
+    context,
+    runtime,
+  });
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "acpx_sidecar",
+      command: "sidecar:/run",
+      cwd,
+      commandArgs: customAgentCommand
+        ? ["acpx", "--agent", customAgentCommand, "sessions", "ensure", "set", "prompt"]
+        : ["acpx", agentCommand, "sessions", "ensure", "set", "prompt"],
+      env,
+      prompt,
+      context,
+      commandNotes: [`External ACPX sidecar at ${url}`],
+    });
+  }
+
+  const ensurePayload = await sidecarRun({
+    url,
+    headers,
+    agentId: agent.id,
+    timeout: Math.max(timeoutSec, 60),
+    cwd,
+    args: buildAcpxCommandArgs({
+      cwd,
+      extraArgs,
+      agentCommand: agentCommand || null,
+      customAgentCommand: customAgentCommand || null,
+      operation: "sessions",
+      sessionName,
+    }),
+  });
+  const ensureStdout = asString(ensurePayload.stdout, "");
+  const ensureLines = ensureStdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const ensureLast = ensureLines.at(-1);
+  let sessionId: string | null = null;
+  if (ensureLast) {
+    try {
+      const parsed = JSON.parse(ensureLast) as Record<string, unknown>;
+      sessionId = nonEmptyString(parsed.sessionId) ?? nonEmptyString(parsed.id);
+    } catch {
+      sessionId = null;
+    }
+  }
+
+  if (model) {
+    const setPayload = await sidecarRun({
+      url,
+      headers,
+      agentId: agent.id,
+      timeout: 30,
+      cwd,
+      args: buildAcpxCommandArgs({
+        cwd,
+        extraArgs,
+        agentCommand: agentCommand || null,
+        customAgentCommand: customAgentCommand || null,
+        operation: "set",
+        sessionName,
+        model,
+      }),
+    });
+    const setExit = asNumber(setPayload.exit_code, 0);
+    if (setExit !== 0) {
+      await onLog("stderr", `[paperclip] Warning: failed to set model via acpx sidecar: ${asString(setPayload.stderr, "").trim() || asString(setPayload.stdout, "").trim()}\n`);
+    }
+  }
+
+  const promptPayload = await sidecarRun({
+    url,
+    headers,
+    agentId: agent.id,
+    timeout: timeoutSec,
+    cwd,
+    stdin: prompt,
+    args: buildAcpxCommandArgs({
+      cwd,
+      extraArgs,
+      agentCommand: agentCommand || null,
+      customAgentCommand: customAgentCommand || null,
+      operation: "prompt",
+      sessionName,
+    }),
+  });
+
+  const stdout = asString(promptPayload.stdout, "");
+  const stderr = asString(promptPayload.stderr, "");
+  if (stdout) await onLog("stdout", stdout);
+  if (stderr) await onLog("stderr", stderr);
+
+  const parsed = parseAcpxJson(stdout);
+  const exitCode = asNumber(promptPayload.exit_code, 1);
+  const ok = promptPayload.ok === true && exitCode === 0;
+  const errorMessage = ok ? null : parsed.errorMessage || stderr.trim() || stdout.trim() || "acpx_sidecar_failed";
+
+  return {
+    exitCode,
+    signal: null,
+    timedOut: false,
+    errorMessage,
+    errorCode: ok ? null : "acpx_sidecar_error",
+    summary: parsed.summary,
+    sessionId,
+    sessionDisplayId: sessionName,
+    sessionParams: { sessionId, sessionName, cwd },
+    provider: `${(customAgentCommand || agentCommand || "acpx")}-sidecar`,
+    model: model || null,
+    billingType: "subscription",
+    resultJson: parsed.stopReason ? { stopReason: parsed.stopReason } : null,
+  };
+}

--- a/packages/adapters/acpx-sidecar/src/server/index.ts
+++ b/packages/adapters/acpx-sidecar/src/server/index.ts
@@ -1,0 +1,41 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionName = readNonEmptyString(record.sessionName) ?? readNonEmptyString(record.session_name);
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    const cwd = readNonEmptyString(record.cwd);
+    return sessionName || sessionId
+      ? {
+          ...(sessionName ? { sessionName } : {}),
+          ...(sessionId ? { sessionId } : {}),
+          ...(cwd ? { cwd } : {}),
+        }
+      : null;
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionName = readNonEmptyString(params.sessionName) ?? readNonEmptyString(params.session_name);
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    const cwd = readNonEmptyString(params.cwd);
+    return sessionName || sessionId
+      ? {
+          ...(sessionName ? { sessionName } : {}),
+          ...(sessionId ? { sessionId } : {}),
+          ...(cwd ? { cwd } : {}),
+        }
+      : null;
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionName) ?? readNonEmptyString(params.sessionId) ?? null;
+  },
+};

--- a/packages/adapters/acpx-sidecar/src/server/parse.ts
+++ b/packages/adapters/acpx-sidecar/src/server/parse.ts
@@ -1,0 +1,60 @@
+import { asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+function extractTextContent(content: unknown): string {
+  const record = parseObject(content);
+  if (!record) return "";
+  if (asString(record.type, "") !== "text") return "";
+  return asString(record.text, "");
+}
+
+export function parseAcpxJson(stdout: string) {
+  const assistant: string[] = [];
+  const thoughts: string[] = [];
+  let errorMessage: string | null = null;
+  let stopReason: string | null = null;
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) continue;
+
+    const method = asString((event as Record<string, unknown>).method, "");
+    if (method === "session/update") {
+      const params = parseObject((event as Record<string, unknown>).params);
+      const updateType = asString(params?.sessionUpdate, "");
+      if (updateType === "agent_message_chunk") {
+        const text = extractTextContent(params?.content);
+        if (text) assistant.push(text);
+        continue;
+      }
+      if (updateType === "agent_thought_chunk") {
+        const text = extractTextContent(params?.content);
+        if (text) thoughts.push(text);
+        continue;
+      }
+      continue;
+    }
+
+    const error = parseObject((event as Record<string, unknown>).error);
+    if (error) {
+      const message = asString(error.message, "").trim();
+      if (message) errorMessage = message;
+      continue;
+    }
+
+    const result = parseObject((event as Record<string, unknown>).result);
+    if (result) {
+      const maybeStopReason = asString(result.stopReason, "").trim();
+      if (maybeStopReason) stopReason = maybeStopReason;
+      continue;
+    }
+  }
+
+  return {
+    summary: assistant.join("").trim(),
+    thought: thoughts.join("").trim(),
+    errorMessage,
+    stopReason,
+  };
+}

--- a/packages/adapters/acpx-sidecar/src/server/test.ts
+++ b/packages/adapters/acpx-sidecar/src/server/test.ts
@@ -1,0 +1,107 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const urlValue = asString(config.url, "").trim();
+  const agentCommand = asString(config.agentCommand, asString(config.command, "")).trim();
+  const customAgentCommand = asString(config.customAgentCommand, "").trim();
+
+  if (!urlValue) {
+    checks.push({
+      code: "acpx_sidecar_url_missing",
+      level: "error",
+      message: "ACPX sidecar adapter requires a sidecar URL.",
+      hint: "Set adapterConfig.url to an absolute http(s) endpoint.",
+    });
+  } else {
+    try {
+      const url = new URL(urlValue);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        checks.push({
+          code: "acpx_sidecar_url_protocol_invalid",
+          level: "error",
+          message: `Unsupported URL protocol: ${url.protocol}`,
+        });
+      } else {
+        checks.push({
+          code: "acpx_sidecar_url_valid",
+          level: "info",
+          message: `Configured sidecar endpoint: ${url.toString()}`,
+        });
+      }
+    } catch {
+      checks.push({
+        code: "acpx_sidecar_url_invalid",
+        level: "error",
+        message: `Invalid URL: ${urlValue}`,
+      });
+    }
+  }
+
+  if (!agentCommand && !customAgentCommand) {
+    checks.push({
+      code: "acpx_sidecar_agent_command_missing",
+      level: "error",
+      message: "ACPX sidecar adapter requires agentCommand or customAgentCommand.",
+      hint: "Set adapterConfig.agentCommand to a valid acpx runtime or adapterConfig.customAgentCommand to a raw ACP server command.",
+    });
+  } else if (customAgentCommand) {
+    checks.push({
+      code: "acpx_sidecar_custom_agent_command_configured",
+      level: "info",
+      message: `Configured custom ACP server: ${customAgentCommand}`,
+    });
+  } else {
+    checks.push({
+      code: "acpx_sidecar_agent_command_configured",
+      level: "info",
+      message: `Configured ACPX runtime: ${agentCommand}`,
+    });
+  }
+
+  if (urlValue) {
+    try {
+      const response = await fetch(`${urlValue.replace(/\/+$/, "")}/health`, { method: "GET" });
+      if (response.ok) {
+        checks.push({
+          code: "acpx_sidecar_health_ok",
+          level: "info",
+          message: "ACPX sidecar health endpoint responded.",
+        });
+      } else {
+        checks.push({
+          code: "acpx_sidecar_health_unexpected_status",
+          level: "warn",
+          message: `ACPX sidecar health endpoint returned HTTP ${response.status}.`,
+        });
+      }
+    } catch (err) {
+      checks.push({
+        code: "acpx_sidecar_health_failed",
+        level: "warn",
+        message: err instanceof Error ? err.message : "ACPX sidecar probe failed",
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/acpx-sidecar/src/ui/build-config.ts
+++ b/packages/adapters/acpx-sidecar/src/ui/build-config.ts
@@ -1,0 +1,21 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function buildAcpxSidecarConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.url) ac.url = v.url;
+  if (v.command) ac.agentCommand = v.command;
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.model) ac.model = v.model;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  ac.timeoutSec = 300;
+  return ac;
+}

--- a/packages/adapters/acpx-sidecar/src/ui/index.ts
+++ b/packages/adapters/acpx-sidecar/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseAcpxSidecarStdoutLine } from "./parse-stdout.js";
+export { buildAcpxSidecarConfig } from "./build-config.js";

--- a/packages/adapters/acpx-sidecar/src/ui/parse-stdout.ts
+++ b/packages/adapters/acpx-sidecar/src/ui/parse-stdout.ts
@@ -1,0 +1,67 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function parseAcpxSidecarStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = safeJsonParse(line.trim());
+  const event = asRecord(parsed);
+  if (!event) return line.trim() ? [{ kind: "stdout", ts, text: line.trim() }] : [];
+
+  const method = asString(event.method);
+  if (method === "session/update") {
+    const params = asRecord(event.params);
+    const updateType = asString(params?.sessionUpdate);
+    const content = asRecord(params?.content);
+    if (updateType === "agent_message_chunk" && asString(content?.type) === "text") {
+      const text = asString(content?.text).trim();
+      return text ? [{ kind: "assistant", ts, text, delta: true }] : [];
+    }
+    if (updateType === "agent_thought_chunk" && asString(content?.type) === "text") {
+      const text = asString(content?.text).trim();
+      return text ? [{ kind: "thinking", ts, text, delta: true }] : [];
+    }
+    return [];
+  }
+
+  const result = asRecord(event.result);
+  if (result) {
+    const stopReason = asString(result.stopReason).trim();
+    return stopReason
+      ? [{
+          kind: "result",
+          ts,
+          text: stopReason,
+          inputTokens: 0,
+          outputTokens: 0,
+          cachedTokens: 0,
+          costUsd: 0,
+          subtype: stopReason,
+          isError: false,
+          errors: [],
+        }]
+      : [];
+  }
+
+  const error = asRecord(event.error);
+  if (error) {
+    const text = asString(error.message).trim();
+    return text ? [{ kind: "stderr", ts, text }] : [];
+  }
+
+  return [];
+}

--- a/packages/adapters/acpx-sidecar/tsconfig.json
+++ b/packages/adapters/acpx-sidecar/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -24,6 +24,7 @@ export type AgentStatus = (typeof AGENT_STATUSES)[number];
 export const AGENT_ADAPTER_TYPES = [
   "process",
   "http",
+  "acpx_sidecar",
   "claude_local",
   "codex_local",
   "opencode_local",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/acpx-sidecar:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/claude-local:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -236,6 +252,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.994.0
+      '@paperclipai/adapter-acpx-sidecar':
+        specifier: workspace:*
+        version: link:../packages/adapters/acpx-sidecar
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -351,6 +370,9 @@ importers:
       '@mdxeditor/editor':
         specifier: ^3.52.4
         version: 3.52.4(@codemirror/language@6.12.1)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.29)
+      '@paperclipai/adapter-acpx-sidecar':
+        specifier: workspace:*
+        version: link:../packages/adapters/acpx-sidecar
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
+    "@paperclipai/adapter-acpx-sidecar": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -1,5 +1,11 @@
 import type { ServerAdapterModule } from "./types.js";
 import {
+  execute as acpxSidecarExecute,
+  testEnvironment as acpxSidecarTestEnvironment,
+  sessionCodec as acpxSidecarSessionCodec,
+} from "@paperclipai/adapter-acpx-sidecar/server";
+import { agentConfigurationDoc as acpxSidecarAgentConfigurationDoc, models as acpxSidecarModels } from "@paperclipai/adapter-acpx-sidecar";
+import {
   execute as claudeExecute,
   testEnvironment as claudeTestEnvironment,
   sessionCodec as claudeSessionCodec,
@@ -58,6 +64,16 @@ const claudeLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: claudeAgentConfigurationDoc,
 };
 
+const acpxSidecarAdapter: ServerAdapterModule = {
+  type: "acpx_sidecar",
+  execute: acpxSidecarExecute,
+  testEnvironment: acpxSidecarTestEnvironment,
+  sessionCodec: acpxSidecarSessionCodec,
+  models: acpxSidecarModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: acpxSidecarAgentConfigurationDoc,
+};
+
 const codexLocalAdapter: ServerAdapterModule = {
   type: "codex_local",
   execute: codexExecute,
@@ -114,6 +130,7 @@ const piLocalAdapter: ServerAdapterModule = {
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
+    acpxSidecarAdapter,
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -41,6 +41,7 @@ import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-
 
 export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
+    acpx_sidecar: "instructionsFilePath",
     claude_local: "instructionsFilePath",
     codex_local: "instructionsFilePath",
     opencode_local: "instructionsFilePath",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@mdxeditor/editor": "^3.52.4",
     "@paperclipai/adapter-claude-local": "workspace:*",
+    "@paperclipai/adapter-acpx-sidecar": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/ui/src/adapters/acpx-sidecar/config-fields.tsx
+++ b/ui/src/adapters/acpx-sidecar/config-fields.tsx
@@ -1,0 +1,62 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput } from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+export function AcpxSidecarConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="Sidecar URL" hint="HTTP base URL for the external acpx sidecar service.">
+        <DraftInput
+          value={isCreate ? values!.url : eff("adapterConfig", "url", String(config.url ?? ""))}
+          onCommit={(v) => (isCreate ? set!({ url: v }) : mark("adapterConfig", "url", v || undefined))}
+          immediate
+          className={inputClass}
+          placeholder="http://sidecar-gemini-shared:8730"
+        />
+      </Field>
+      <Field label="ACPX runtime" hint="Runtime name passed to acpx (for example gemini, claude, codex, openclaw).">
+        <DraftInput
+          value={isCreate ? values!.command : eff("adapterConfig", "agentCommand", String(config.agentCommand ?? config.command ?? ""))}
+          onCommit={(v) => (isCreate ? set!({ command: v }) : mark("adapterConfig", "agentCommand", v || undefined))}
+          immediate
+          className={inputClass}
+          placeholder="gemini"
+        />
+      </Field>
+      <Field label="Sidecar working directory" hint="Per-agent working directory inside the sidecar container.">
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={isCreate ? values!.cwd : eff("adapterConfig", "cwd", String(config.cwd ?? ""))}
+            onCommit={(v) => (isCreate ? set!({ cwd: v }) : mark("adapterConfig", "cwd", v || undefined))}
+            immediate
+            className={inputClass}
+            placeholder="/home/node/workspaces/agent"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+      <Field label="Agent instructions file" hint="Absolute path to a markdown instructions file prepended to the prompt.">
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={isCreate ? values!.instructionsFilePath ?? "" : eff("adapterConfig", "instructionsFilePath", String(config.instructionsFilePath ?? ""))}
+            onCommit={(v) => (isCreate ? set!({ instructionsFilePath: v }) : mark("adapterConfig", "instructionsFilePath", v || undefined))}
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/acpx-sidecar/index.ts
+++ b/ui/src/adapters/acpx-sidecar/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { parseAcpxSidecarStdoutLine, buildAcpxSidecarConfig } from "@paperclipai/adapter-acpx-sidecar/ui";
+import { AcpxSidecarConfigFields } from "./config-fields";
+
+export const acpxSidecarUIAdapter: UIAdapterModule = {
+  type: "acpx_sidecar",
+  label: "ACPX Sidecar",
+  parseStdoutLine: parseAcpxSidecarStdoutLine,
+  ConfigFields: AcpxSidecarConfigFields,
+  buildAdapterConfig: buildAcpxSidecarConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -1,4 +1,5 @@
 import type { UIAdapterModule } from "./types";
+import { acpxSidecarUIAdapter } from "./acpx-sidecar";
 import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
@@ -10,6 +11,7 @@ import { httpUIAdapter } from "./http";
 
 const adaptersByType = new Map<string, UIAdapterModule>(
   [
+    acpxSidecarUIAdapter,
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     openCodeLocalUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -891,7 +891,8 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["acpx_sidecar", "claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["acpx_sidecar", "claude_local", "codex_local", "gemini_local", "opencode_local", "cursor"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -15,6 +15,7 @@ interface AgentPropertiesProps {
 }
 
 const adapterLabels: Record<string, string> = {
+  acpx_sidecar: "ACPX Sidecar",
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   opencode_local: "OpenCode (local)",

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -22,6 +22,7 @@ import { cn } from "@/lib/utils";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 
 type AdvancedAdapterType =
+  | "acpx_sidecar"
   | "claude_local"
   | "codex_local"
   | "opencode_local"
@@ -36,6 +37,13 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
   icon: ComponentType<{ className?: string }>;
   recommended?: boolean;
 }> = [
+  {
+    value: "acpx_sidecar",
+    label: "ACPX Sidecar",
+    icon: Bot,
+    desc: "External sidecar via acpx",
+    recommended: true,
+  },
   {
     value: "claude_local",
     label: "Claude Code",

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -51,6 +51,7 @@ export const help: Record<string, string> = {
 };
 
 export const adapterLabels: Record<string, string> = {
+  acpx_sidecar: "ACPX Sidecar",
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   opencode_local: "OpenCode (local)",

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -21,6 +21,7 @@ import { Bot, Plus, List, GitBranch, SlidersHorizontal } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
 
 const adapterLabels: Record<string, string> = {
+  acpx_sidecar: "ACPX Sidecar",
   claude_local: "Claude",
   codex_local: "Codex",
   opencode_local: "OpenCode",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -13,6 +13,7 @@ type JoinType = "human" | "agent";
 const joinAdapterOptions: AgentAdapterType[] = [...AGENT_ADAPTER_TYPES];
 
 const adapterLabels: Record<string, string> = {
+  acpx_sidecar: "ACPX Sidecar",
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   opencode_local: "OpenCode (local)",
@@ -22,7 +23,8 @@ const adapterLabels: Record<string, string> = {
   http: "HTTP",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["acpx_sidecar", "claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["acpx_sidecar", "claude_local", "codex_local", "gemini_local", "opencode_local", "cursor"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -26,6 +26,7 @@ import {
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 
 const SUPPORTED_ADVANCED_ADAPTER_TYPES = new Set<CreateConfigValues["adapterType"]>([
+  "acpx_sidecar",
   "claude_local",
   "codex_local",
   "opencode_local",
@@ -39,7 +40,9 @@ function createValuesForAdapterType(
 ): CreateConfigValues {
   const { adapterType: _discard, ...defaults } = defaultCreateValues;
   const nextValues: CreateConfigValues = { ...defaults, adapterType };
-  if (adapterType === "codex_local") {
+  if (adapterType === "acpx_sidecar") {
+    nextValues.command = "gemini";
+  } else if (adapterType === "codex_local") {
     nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
     nextValues.dangerouslyBypassSandbox =
       DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -116,6 +116,7 @@ function collectEdges(nodes: LayoutNode[]): Array<{ parent: LayoutNode; child: L
 // ── Status dot colors (raw hex for SVG) ─────────────────────────────────
 
 const adapterLabels: Record<string, string> = {
+  acpx_sidecar: "ACPX Sidecar",
   claude_local: "Claude",
   codex_local: "Codex",
   opencode_local: "OpenCode",


### PR DESCRIPTION
## Summary
This PR adds a new `acpx_sidecar` adapter that lets a Paperclip agent run through an external ACPX-compatible runtime instead of executing inside the main Paperclip server container.

The adapter supports two execution styles:
- built-in ACPX runtimes such as Codex, Claude Code, and Gemini
- a custom ACP agent command for runtimes that need a thin shim, such as Hermes

The PR also includes example runtime container templates for:
- Codex
- Claude Code
- Gemini
- Hermes

## Why this is useful
Today, Paperclip’s local adapters run inside the main Paperclip container. That is simple, but it couples runtime state, auth state, dependencies, and execution environment to the server itself.

This change makes it possible to run each agent runtime in its own container while still keeping the Paperclip integration small and generic.

That gives a few practical benefits:
- one runtime sandbox per agent or provider
- cleaner separation of auth and local runtime state
- fewer provider-specific dependencies inside the main Paperclip image
- a consistent path for integrating official CLIs and other ACP-compatible runtimes

## What is included
- generic `acpx_sidecar` adapter support
- support for built-in ACPX runtimes
- support for a custom ACP agent command
- example Dockerfiles for isolated Codex, Claude Code, Gemini, and Hermes runtime containers
- deployment docs showing how to connect those containers back to Paperclip

## Intended outcome
With this adapter in place, Paperclip can orchestrate agents that still use the existing local-style runtime model, but now those runtimes can live in distinct external containers instead of the main server process.