### PR TITLE
feat(LAS-133): collapsible task descriptions

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -22,6 +22,84 @@ import { CircleDot, Plus, Filter, ArrowUpDown, Layers, Check, X, ChevronRight, L
 import { KanbanBoard } from "./KanbanBoard";
 import type { Issue } from "@paperclipai/shared";
 
+/* ── Subtask count helpers ── */
+
+export interface SubtaskCounts {
+  total: number;
+  done: number;
+}
+
+export function buildSubtaskCountMap(issues: Issue[]): Map<string, SubtaskCounts> {
+  const map = new Map<string, SubtaskCounts>();
+  for (const issue of issues) {
+    if (!issue.parentId) continue;
+    const existing = map.get(issue.parentId) ?? { total: 0, done: 0 };
+    existing.total += 1;
+    if (issue.status === "done" || issue.status === "cancelled") {
+      existing.done += 1;
+    }
+    map.set(issue.parentId, existing);
+  }
+  return map;
+}
+
+export function SubtaskBadge({ counts }: { counts: SubtaskCounts }) {
+  if (counts.total === 0) return null;
+  const allDone = counts.done === counts.total;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+        allDone
+          ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
+          : "border-border text-muted-foreground bg-muted/40"
+      }`}
+      title={`${counts.done} of ${counts.total} subtasks done`}
+    >
+      <span className="leading-none">⊞</span>
+      <span>{counts.done}/{counts.total}</span>
+    </span>
+  );
+}
+
+/* ── Inline subtask list (collapsed by default, shown under parent row) ── */
+
+export function SubtaskList({
+  subtasks,
+  highlightIds,
+}: {
+  subtasks: Issue[];
+  highlightIds?: Set<string>;
+}) {
+  if (subtasks.length === 0) return null;
+  return (
+    <div className="ml-6 border-l border-border pl-3 py-1 space-y-0.5">
+      {subtasks.map((sub) => (
+        <Link
+          key={sub.id}
+          to={`/issues/${sub.identifier ?? sub.id}`}
+          className={`flex items-center gap-2 py-1 pr-2 text-xs rounded hover:bg-accent/50 no-underline text-inherit transition-colors ${
+            highlightIds?.has(sub.id) ? "ring-1 ring-blue-500/50 bg-blue-500/5" : ""
+          }`}
+        >
+          <StatusIcon status={sub.status} />
+          <span
+            className={`flex-1 truncate ${
+              sub.status === "done" || sub.status === "cancelled"
+                ? "line-through text-muted-foreground"
+                : ""
+            }`}
+          >
+            {sub.title}
+          </span>
+          <span className="text-muted-foreground font-mono shrink-0">
+            {sub.identifier ?? sub.id.slice(0, 8)}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 /* ── Helpers ── */
 
 const statusOrder = ["in_progress", "todo", "backlog", "in_review", "blocked", "done", "cancelled"];
@@ -94,6 +172,58 @@ function applyFilters(issues: Issue[], state: IssueViewState): Issue[] {
   if (state.assignees.length > 0) result = result.filter((i) => i.assigneeAgentId != null && state.assignees.includes(i.assigneeAgentId));
   if (state.labels.length > 0) result = result.filter((i) => (i.labelIds ?? []).some((id) => state.labels.includes(id)));
   return result;
+}
+
+// Returns { rootIssues, subtaskMap } where rootIssues are parents/top-level and
+// subtaskMap groups subtasks by parentId. When filters are active, a parent is
+// included if it matches OR if any of its subtasks match (filter-through logic).
+function buildRootAndSubtaskMap(
+  allIssues: Issue[],
+  filteredIssues: Issue[],
+): { rootIssues: Issue[]; subtaskMap: Map<string, Issue[]> } {
+  const filteredIds = new Set(filteredIssues.map((i) => i.id));
+
+  // Build subtask map from ALL issues (unfiltered) so subtasks appear under parent
+  const subtaskMap = new Map<string, Issue[]>();
+  const subtaskIds = new Set<string>();
+
+  for (const issue of allIssues) {
+    if (issue.parentId) {
+      subtaskIds.add(issue.id);
+      const list = subtaskMap.get(issue.parentId) ?? [];
+      list.push(issue);
+      subtaskMap.set(issue.parentId, list);
+    }
+  }
+
+  // Root issues: filtered issues that are NOT subtasks themselves
+  // Plus: parents of filtered subtasks (filter-through: subtask matches, include parent)
+  const rootSet = new Set<Issue>();
+  const rootById = new Map<string, Issue>();
+  for (const issue of allIssues) {
+    if (!issue.parentId) rootById.set(issue.id, issue);
+  }
+
+  for (const issue of filteredIssues) {
+    if (!subtaskIds.has(issue.id)) {
+      // It's a root issue that matched filter
+      rootSet.add(issue);
+    } else if (issue.parentId) {
+      // It's a subtask that matched filter — include its parent if available
+      const parent = rootById.get(issue.parentId);
+      if (parent) rootSet.add(parent);
+    }
+  }
+
+  // If no filters applied (filteredIssues === allIssues for root), just use all roots
+  // We detect this by checking if filteredIds covers all non-subtask issues
+  const allRootIssues = [...rootById.values()];
+  const allRootsFiltered = allRootIssues.every((r) => filteredIds.has(r.id));
+  const rootIssues = allRootsFiltered
+    ? allRootIssues // no filtering needed
+    : [...rootSet]; // filtered with filter-through
+
+  return { rootIssues, subtaskMap };
 }
 
 function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
@@ -226,6 +356,31 @@ export function IssuesList({
     return sortIssues(filteredByControls, viewState);
   }, [issues, searchedIssues, viewState, normalizedIssueSearch]);
 
+  // Separate root issues from subtasks; apply filter-through for subtask matches.
+  const { rootIssues, subtaskMap } = useMemo(
+    () => buildRootAndSubtaskMap(issues, filtered),
+    [issues, filtered]
+  );
+
+  // Track which subtask IDs matched the filter (for highlighting when expanded).
+  const highlightedSubtaskIds = useMemo(() => {
+    const hasFilter =
+      viewState.statuses.length > 0 ||
+      viewState.priorities.length > 0 ||
+      viewState.assignees.length > 0 ||
+      viewState.labels.length > 0 ||
+      normalizedIssueSearch.length > 0;
+    if (!hasFilter) return new Set<string>();
+    const filteredIds = new Set(filtered.map((i) => i.id));
+    const result = new Set<string>();
+    for (const id of filteredIds) {
+      // If it's a subtask (has a parent in subtaskMap values), add to highlight set
+      const issue = issues.find((i) => i.id === id);
+      if (issue?.parentId) result.add(id);
+    }
+    return result;
+  }, [filtered, issues, viewState, normalizedIssueSearch]);
+
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(selectedCompanyId!),
     queryFn: () => issuesApi.listLabels(selectedCompanyId!),
@@ -234,30 +389,46 @@ export function IssuesList({
 
   const activeFilterCount = countActiveFilters(viewState);
 
+  // Build subtask count map from the full (unfiltered) issues list so parent tasks
+  // show counts even when children are filtered out.
+  const subtaskCountMap = useMemo(() => buildSubtaskCountMap(issues), [issues]);
+
+  // Collapse state per parent issue (for the subtask expand/collapse toggle)
+  const [expandedSubtasks, setExpandedSubtasks] = useState<Set<string>>(new Set());
+
+  const toggleSubtasks = useCallback((issueId: string) => {
+    setExpandedSubtasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(issueId)) next.delete(issueId);
+      else next.add(issueId);
+      return next;
+    });
+  }, []);
+
   const groupedContent = useMemo(() => {
     if (viewState.groupBy === "none") {
-      return [{ key: "__all", label: null as string | null, items: filtered }];
+      return [{ key: "__all", label: null as string | null, items: rootIssues }];
     }
     if (viewState.groupBy === "status") {
-      const groups = groupBy(filtered, (i) => i.status);
+      const groups = groupBy(rootIssues, (i) => i.status);
       return statusOrder
         .filter((s) => groups[s]?.length)
         .map((s) => ({ key: s, label: statusLabel(s), items: groups[s]! }));
     }
     if (viewState.groupBy === "priority") {
-      const groups = groupBy(filtered, (i) => i.priority);
+      const groups = groupBy(rootIssues, (i) => i.priority);
       return priorityOrder
         .filter((p) => groups[p]?.length)
         .map((p) => ({ key: p, label: statusLabel(p), items: groups[p]! }));
     }
     // assignee
-    const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? "__unassigned");
+    const groups = groupBy(rootIssues, (i) => i.assigneeAgentId ?? "__unassigned");
     return Object.keys(groups).map((key) => ({
       key,
       label: key === "__unassigned" ? "Unassigned" : (agentName(key) ?? key.slice(0, 8)),
       items: groups[key]!,
     }));
-  }, [filtered, viewState.groupBy, agents]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rootIssues, viewState.groupBy, agents]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const newIssueDefaults = (groupKey?: string) => {
     const defaults: Record<string, string> = {};
@@ -539,7 +710,7 @@ export function IssuesList({
       {isLoading && <PageSkeleton variant="issues-list" />}
       {error && <p className="text-sm text-destructive">{error.message}</p>}
 
-      {!isLoading && filtered.length === 0 && viewState.viewMode === "list" && (
+      {!isLoading && rootIssues.length === 0 && viewState.viewMode === "list" && (
         <EmptyState
           icon={CircleDot}
           message="No issues match the current filters or search."
@@ -550,9 +721,12 @@ export function IssuesList({
 
       {viewState.viewMode === "board" ? (
         <KanbanBoard
-          issues={filtered}
+          issues={rootIssues}
+          allIssues={issues}
           agents={agents}
           liveIssueIds={liveIssueIds}
+          subtaskCountMap={subtaskCountMap}
+          subtaskMap={subtaskMap}
           onUpdateIssue={onUpdateIssue}
         />
       ) : (
@@ -587,11 +761,15 @@ export function IssuesList({
               </div>
             )}
             <CollapsibleContent>
-              {group.items.map((issue) => (
+              {group.items.map((issue) => {
+                const issueSubtasks = subtaskMap.get(issue.id) ?? [];
+                const hasSubtasks = issueSubtasks.length > 0;
+                const isExpanded = expandedSubtasks.has(issue.id);
+                return (
+                <div key={issue.id} className="border-b border-border last:border-b-0">
                 <Link
-                  key={issue.id}
                   to={`/issues/${issue.identifier ?? issue.id}`}
-                  className="flex items-start gap-2 py-2.5 pl-2 pr-3 text-sm border-b border-border last:border-b-0 cursor-pointer hover:bg-accent/50 transition-colors no-underline text-inherit sm:items-center sm:py-2 sm:pl-1"
+                  className="flex items-start gap-2 py-2.5 pl-2 pr-3 text-sm cursor-pointer hover:bg-accent/50 transition-colors no-underline text-inherit sm:items-center sm:py-2 sm:pl-1"
                 >
                   {/* Status icon - left column on mobile, inline on desktop */}
                   <span className="shrink-0 pt-px sm:hidden" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
@@ -622,6 +800,10 @@ export function IssuesList({
                       <span className="text-xs text-muted-foreground font-mono shrink-0">
                         {issue.identifier ?? issue.id.slice(0, 8)}
                       </span>
+                      {(() => {
+                        const counts = subtaskCountMap.get(issue.id);
+                        return counts ? <SubtaskBadge counts={counts} /> : null;
+                      })()}
                       {liveIssueIds?.has(issue.id) && (
                         <span className="inline-flex items-center gap-1 sm:gap-1.5 px-1.5 sm:px-2 py-0.5 rounded-full bg-blue-500/10">
                           <span className="relative flex h-2 w-2">
@@ -743,7 +925,26 @@ export function IssuesList({
                     </span>
                   </span>
                 </Link>
-              ))}
+                {hasSubtasks && (
+                  <div>
+                    <button
+                      className="flex items-center gap-1 px-3 py-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                      onClick={() => toggleSubtasks(issue.id)}
+                    >
+                      <span>{isExpanded ? "⬆️" : "⬇️"}</span>
+                      <span>Subtasks ({issueSubtasks.length})</span>
+                    </button>
+                    {isExpanded && (
+                      <SubtaskList
+                        subtasks={issueSubtasks}
+                        highlightIds={highlightedSubtaskIds}
+                      />
+                    )}
+                  </div>
+                )}
+                </div>
+                );
+              })}
             </CollapsibleContent>
           </Collapsible>
         ))

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -928,11 +928,12 @@ export function IssuesList({
                 {hasSubtasks && (
                   <div>
                     <button
-                      className="flex items-center gap-1 px-3 py-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors w-full text-left rounded-b-sm"
                       onClick={() => toggleSubtasks(issue.id)}
                     >
-                      <span>{isExpanded ? "⬆️" : "⬇️"}</span>
-                      <span>Subtasks ({issueSubtasks.length})</span>
+                      <ChevronRight className={`h-3 w-3 shrink-0 transition-transform duration-150 ${isExpanded ? "rotate-90" : ""}`} />
+                      <span className="font-medium">{isExpanded ? "Hide subtasks" : `Show subtasks`}</span>
+                      <span className="text-muted-foreground/60">({issueSubtasks.length})</span>
                     </button>
                     {isExpanded && (
                       <SubtaskList

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { Link } from "@/lib/router";
 import {
   DndContext,
@@ -20,6 +20,7 @@ import {
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
+import { SubtaskBadge, SubtaskList, type SubtaskCounts } from "./IssuesList";
 import type { Issue } from "@paperclipai/shared";
 
 const boardStatuses = [
@@ -43,8 +44,11 @@ interface Agent {
 
 interface KanbanBoardProps {
   issues: Issue[];
+  allIssues?: Issue[];
   agents?: Agent[];
   liveIssueIds?: Set<string>;
+  subtaskCountMap?: Map<string, SubtaskCounts>;
+  subtaskMap?: Map<string, Issue[]>;
   onUpdateIssue: (id: string, data: Record<string, unknown>) => void;
 }
 
@@ -55,11 +59,19 @@ function KanbanColumn({
   issues,
   agents,
   liveIssueIds,
+  subtaskCountMap,
+  subtaskMap,
+  expandedSubtasks,
+  onToggleSubtasks,
 }: {
   status: string;
   issues: Issue[];
   agents?: Agent[];
   liveIssueIds?: Set<string>;
+  subtaskCountMap?: Map<string, SubtaskCounts>;
+  subtaskMap?: Map<string, Issue[]>;
+  expandedSubtasks: Set<string>;
+  onToggleSubtasks: (id: string) => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
 
@@ -90,6 +102,10 @@ function KanbanColumn({
               issue={issue}
               agents={agents}
               isLive={liveIssueIds?.has(issue.id)}
+              subtaskCounts={subtaskCountMap?.get(issue.id)}
+              subtasks={subtaskMap?.get(issue.id)}
+              isExpanded={expandedSubtasks.has(issue.id)}
+              onToggleSubtasks={onToggleSubtasks}
             />
           ))}
         </SortableContext>
@@ -105,11 +121,19 @@ function KanbanCard({
   agents,
   isLive,
   isOverlay,
+  subtaskCounts,
+  subtasks,
+  isExpanded,
+  onToggleSubtasks,
 }: {
   issue: Issue;
   agents?: Agent[];
   isLive?: boolean;
   isOverlay?: boolean;
+  subtaskCounts?: SubtaskCounts;
+  subtasks?: Issue[];
+  isExpanded?: boolean;
+  onToggleSubtasks?: (id: string) => void;
 }) {
   const {
     attributes,
@@ -160,7 +184,7 @@ function KanbanCard({
           )}
         </div>
         <p className="text-sm leading-snug line-clamp-2 mb-2">{issue.title}</p>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <PriorityIcon priority={issue.priority} />
           {issue.assigneeAgentId && (() => {
             const name = agentName(issue.assigneeAgentId);
@@ -172,8 +196,28 @@ function KanbanCard({
               </span>
             );
           })()}
+          {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
         </div>
       </Link>
+      {subtasks && subtasks.length > 0 && onToggleSubtasks && (
+        <div>
+          <button
+            className="flex items-center gap-1 px-2 pt-1.5 pb-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSubtasks(issue.id);
+            }}
+          >
+            <span>{isExpanded ? "⬆️" : "⬇️"}</span>
+            <span>Subtasks ({subtasks.length})</span>
+          </button>
+          {isExpanded && (
+            <div className="px-1 pb-1.5">
+              <SubtaskList subtasks={subtasks} />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -184,9 +228,21 @@ export function KanbanBoard({
   issues,
   agents,
   liveIssueIds,
+  subtaskCountMap,
+  subtaskMap,
   onUpdateIssue,
 }: KanbanBoardProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [expandedSubtasks, setExpandedSubtasks] = useState<Set<string>>(new Set());
+
+  const toggleSubtasks = useCallback((id: string) => {
+    setExpandedSubtasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -261,6 +317,10 @@ export function KanbanBoard({
             issues={columnIssues[status] ?? []}
             agents={agents}
             liveIssueIds={liveIssueIds}
+            subtaskCountMap={subtaskCountMap}
+            subtaskMap={subtaskMap}
+            expandedSubtasks={expandedSubtasks}
+            onToggleSubtasks={toggleSubtasks}
           />
         ))}
       </div>

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -17,6 +17,7 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { ChevronRight } from "lucide-react";
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
@@ -202,14 +203,15 @@ function KanbanCard({
       {subtasks && subtasks.length > 0 && onToggleSubtasks && (
         <div>
           <button
-            className="flex items-center gap-1 px-2 pt-1.5 pb-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+            className="flex items-center gap-1.5 px-2 pt-2 pb-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left border-t border-border/50 mt-1"
             onClick={(e) => {
               e.stopPropagation();
               onToggleSubtasks(issue.id);
             }}
           >
-            <span>{isExpanded ? "⬆️" : "⬇️"}</span>
-            <span>Subtasks ({subtasks.length})</span>
+            <ChevronRight className={`h-3 w-3 shrink-0 transition-transform duration-150 ${isExpanded ? "rotate-90" : ""}`} />
+            <span className="font-medium">{isExpanded ? "Hide subtasks" : "Show subtasks"}</span>
+            <span className="text-muted-foreground/60">({subtasks.length})</span>
           </button>
           {isExpanded && (
             <div className="px-1 pb-1.5">

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -178,6 +178,14 @@
   background: oklch(0.5 0 0);
 }
 
+/* Completely hidden scrollbar (scrollable via touch/keyboard, no visible bar) */
+.scrollbar-none {
+  scrollbar-width: none; /* Firefox */
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Edge */
+}
+
 /* Auto-hide scrollbar: transparent by default, visible on container hover */
 .scrollbar-auto-hide::-webkit-scrollbar-thumb {
   background: transparent !important;

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -10,6 +10,7 @@ import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
 import { usePanel } from "../context/PanelContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useDialog } from "../context/DialogContext";
 import { queryKeys } from "../lib/queryKeys";
 import { useProjectOrder } from "../hooks/useProjectOrder";
 import { relativeTime, cn, formatTokens } from "../lib/utils";
@@ -40,6 +41,7 @@ import {
   MessageSquare,
   MoreHorizontal,
   Paperclip,
+  Plus,
   SlidersHorizontal,
   Trash2,
 } from "lucide-react";
@@ -148,6 +150,7 @@ export function IssueDetail() {
   const { selectedCompanyId } = useCompany();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { openNewIssue } = useDialog();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [moreOpen, setMoreOpen] = useState(false);
@@ -289,6 +292,14 @@ export function IssueDetail() {
       .filter((i) => i.parentId === issue.id)
       .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
   }, [allIssues, issue]);
+
+  const childIssueCounts = useMemo(() => {
+    if (childIssues.length === 0) return null;
+    const done = childIssues.filter(
+      (c) => c.status === "done" || c.status === "cancelled"
+    ).length;
+    return { total: childIssues.length, done };
+  }, [childIssues]);
 
   const commentReassignOptions = useMemo(() => {
     const options: Array<{ id: string; label: string; searchText?: string }> = [];
@@ -782,6 +793,18 @@ export function IssueDetail() {
           <TabsTrigger value="subissues" className="gap-1.5">
             <ListTree className="h-3.5 w-3.5" />
             Sub-issues
+            {childIssueCounts && (
+              <span
+                className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+                  childIssueCounts.done === childIssueCounts.total
+                    ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
+                    : "border-border text-muted-foreground bg-muted/40"
+                }`}
+                title={`${childIssueCounts.done} of ${childIssueCounts.total} sub-issues done`}
+              >
+                ⊞ {childIssueCounts.done}/{childIssueCounts.total}
+              </span>
+            )}
           </TabsTrigger>
           <TabsTrigger value="activity" className="gap-1.5">
             <ActivityIcon className="h-3.5 w-3.5" />
@@ -819,34 +842,72 @@ export function IssueDetail() {
         </TabsContent>
 
         <TabsContent value="subissues">
-          {childIssues.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No sub-issues.</p>
-          ) : (
-            <div className="border border-border rounded-lg divide-y divide-border">
-              {childIssues.map((child) => (
-                <Link
-                  key={child.id}
-                  to={`/issues/${child.identifier ?? child.id}`}
-                  className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <StatusIcon status={child.status} />
-                    <PriorityIcon priority={child.priority} />
-                    <span className="font-mono text-muted-foreground shrink-0">
-                      {child.identifier ?? child.id.slice(0, 8)}
+          <div className="space-y-2">
+            {childIssues.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No sub-issues.</p>
+            ) : (
+              <div className="space-y-2">
+                {childIssueCounts && (
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span className="shrink-0">
+                      {childIssueCounts.done} of {childIssueCounts.total} completed
                     </span>
-                    <span className="truncate">{child.title}</span>
+                    <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all ${
+                          childIssueCounts.done === childIssueCounts.total
+                            ? "bg-green-500"
+                            : "bg-primary"
+                        }`}
+                        style={{
+                          width: `${(childIssueCounts.done / childIssueCounts.total) * 100}%`,
+                        }}
+                      />
+                    </div>
                   </div>
-                  {child.assigneeAgentId && (() => {
-                    const name = agentMap.get(child.assigneeAgentId)?.name;
-                    return name
-                      ? <Identity name={name} size="sm" />
-                      : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
-                  })()}
-                </Link>
-              ))}
-            </div>
-          )}
+                )}
+                <div className="border border-border rounded-lg divide-y divide-border">
+                  {childIssues.map((child) => (
+                    <Link
+                      key={child.id}
+                      to={`/issues/${child.identifier ?? child.id}`}
+                      className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <StatusIcon status={child.status} />
+                        <PriorityIcon priority={child.priority} />
+                        <span className="font-mono text-muted-foreground shrink-0">
+                          {child.identifier ?? child.id.slice(0, 8)}
+                        </span>
+                        <span className="truncate">{child.title}</span>
+                      </div>
+                      {child.assigneeAgentId && (() => {
+                        const name = agentMap.get(child.assigneeAgentId)?.name;
+                        return name
+                          ? <Identity name={name} size="sm" />
+                          : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
+                      })()}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full text-muted-foreground"
+              onClick={() =>
+                openNewIssue({
+                  parentId: issue.id,
+                  ...(issue.projectId ? { projectId: issue.projectId } : {}),
+                  ...(issue.goalId ? { goalId: issue.goalId } : {}),
+                })
+              }
+            >
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              Create sub-issue
+            </Button>
+          </div>
         </TabsContent>
 
         <TabsContent value="activity">

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -793,7 +793,7 @@ export function IssueDetail() {
       <Separator />
 
       <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <div className="overflow-x-auto scrollbar-none pb-[5px] mb-[-5px]">
+        <div className="overflow-x-auto [overflow-y:clip] [overflow-clip-margin:6px] scrollbar-none">
           <TabsList variant="line" className="w-max min-w-full justify-start gap-1 flex-nowrap">
             <TabsTrigger value="comments" className="gap-1.5 shrink-0">
               <MessageSquare className="h-3.5 w-3.5" />

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -793,28 +793,30 @@ export function IssueDetail() {
       <Separator />
 
       <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <div className="overflow-x-auto scrollbar-none">
+        <div className="overflow-x-auto scrollbar-none pb-[5px] mb-[-5px]">
           <TabsList variant="line" className="w-max min-w-full justify-start gap-1 flex-nowrap">
             <TabsTrigger value="comments" className="gap-1.5 shrink-0">
               <MessageSquare className="h-3.5 w-3.5" />
               Comments
             </TabsTrigger>
-            <TabsTrigger value="subissues" className="gap-1.5 shrink-0">
-              <ListTree className="h-3.5 w-3.5" />
-              Sub-issues
-              {childIssueCounts && (
-                <span
-                  className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
-                    childIssueCounts.done === childIssueCounts.total
-                      ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
-                      : "border-border text-muted-foreground bg-muted/40"
-                  }`}
-                  title={`${childIssueCounts.done} of ${childIssueCounts.total} sub-issues done`}
-                >
-                  ⊞ {childIssueCounts.done}/{childIssueCounts.total}
-                </span>
-              )}
-            </TabsTrigger>
+            {!issue.parentId && (
+              <TabsTrigger value="subissues" className="gap-1.5 shrink-0">
+                <ListTree className="h-3.5 w-3.5" />
+                Sub-issues
+                {childIssueCounts && (
+                  <span
+                    className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+                      childIssueCounts.done === childIssueCounts.total
+                        ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
+                        : "border-border text-muted-foreground bg-muted/40"
+                    }`}
+                    title={`${childIssueCounts.done} of ${childIssueCounts.total} sub-issues done`}
+                  >
+                    ⊞ {childIssueCounts.done}/{childIssueCounts.total}
+                  </span>
+                )}
+              </TabsTrigger>
+            )}
             <TabsTrigger value="activity" className="gap-1.5 shrink-0">
               <ActivityIcon className="h-3.5 w-3.5" />
               Activity
@@ -851,7 +853,7 @@ export function IssueDetail() {
           />
         </TabsContent>
 
-        <TabsContent value="subissues">
+        {!issue.parentId && <TabsContent value="subissues">
           <div className="space-y-2">
             {childIssues.length === 0 ? (
               <p className="text-xs text-muted-foreground">No sub-issues.</p>
@@ -876,51 +878,51 @@ export function IssueDetail() {
                     </div>
                   </div>
                 )}
-                <div className="border border-border rounded-lg divide-y divide-border">
+                <div className="space-y-1.5">
                   {childIssues.map((child) => (
                     <Link
                       key={child.id}
                       to={`/issues/${child.identifier ?? child.id}`}
-                      className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
+                      className="block rounded-md border bg-card p-2.5 hover:shadow-sm transition-shadow no-underline text-inherit"
                     >
-                      <div className="flex items-center gap-2 min-w-0">
-                        <StatusIcon status={child.status} />
-                        <PriorityIcon priority={child.priority} />
-                        <span className="font-mono text-muted-foreground shrink-0">
+                      <div className="flex items-center gap-1.5 mb-1.5">
+                        <span className="text-xs text-muted-foreground font-mono shrink-0">
                           {child.identifier ?? child.id.slice(0, 8)}
                         </span>
-                        <span className="truncate">{child.title}</span>
                       </div>
-                      {child.assigneeAgentId && (() => {
-                        const name = agentMap.get(child.assigneeAgentId)?.name;
-                        return name
-                          ? <Identity name={name} size="sm" />
-                          : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
-                      })()}
+                      <p className="text-sm leading-snug line-clamp-2 mb-2">{child.title}</p>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <StatusIcon status={child.status} />
+                        <PriorityIcon priority={child.priority} />
+                        {child.assigneeAgentId && (() => {
+                          const name = agentMap.get(child.assigneeAgentId)?.name;
+                          return name
+                            ? <Identity name={name} size="xs" />
+                            : <span className="text-xs text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
+                        })()}
+                      </div>
                     </Link>
                   ))}
                 </div>
               </div>
             )}
-            {!issue.parentId && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="w-full text-muted-foreground"
-                onClick={() =>
-                  openNewIssue({
-                    parentId: issue.id,
-                    ...(issue.projectId ? { projectId: issue.projectId } : {}),
-                    ...(issue.goalId ? { goalId: issue.goalId } : {}),
-                  })
-                }
-              >
-                <Plus className="h-3.5 w-3.5 mr-1.5" />
-                Create sub-issue
-              </Button>
-            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full text-muted-foreground"
+              onClick={() =>
+                openNewIssue({
+                  parentId: issue.id,
+                  ...(issue.projectId ? { projectId: issue.projectId } : {}),
+                  ...(issue.goalId ? { goalId: issue.goalId } : {}),
+                })
+              }
+            >
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              Create sub-issue
+            </Button>
           </div>
-        </TabsContent>
+        </TabsContent>}
 
         <TabsContent value="activity">
           {!activity || activity.length === 0 ? (

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -152,6 +152,7 @@ export function IssueDetail() {
   const navigate = useNavigate();
   const [moreOpen, setMoreOpen] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [detailTab, setDetailTab] = useState("comments");
   const [secondaryOpen, setSecondaryOpen] = useState({
     approvals: false,
@@ -657,19 +658,45 @@ export function IssueDetail() {
           className="text-xl font-bold"
         />
 
-        <InlineEditor
-          value={issue.description ?? ""}
-          onSave={(description) => updateIssue.mutate({ description })}
-          as="p"
-          className="text-sm text-muted-foreground"
-          placeholder="Add a description..."
-          multiline
-          mentions={mentionOptions}
-          imageUploadHandler={async (file) => {
-            const attachment = await uploadAttachment.mutateAsync(file);
-            return attachment.contentPath;
-          }}
-        />
+        <div className="space-y-1">
+          <div
+            className={cn(
+              "overflow-hidden transition-all duration-200",
+              isDescriptionExpanded
+                ? "max-h-screen overflow-y-auto"
+                : "max-h-32",
+            )}
+          >
+            <InlineEditor
+              value={issue.description ?? ""}
+              onSave={(description) => updateIssue.mutate({ description })}
+              as="p"
+              className="text-sm text-muted-foreground"
+              placeholder="Add a description..."
+              multiline
+              mentions={mentionOptions}
+              imageUploadHandler={async (file) => {
+                const attachment = await uploadAttachment.mutateAsync(file);
+                return attachment.contentPath;
+              }}
+            />
+          </div>
+          {(issue.description ?? "").length > 0 && (
+            <button
+              type="button"
+              onClick={() => setIsDescriptionExpanded((prev) => !prev)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ChevronDown
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  isDescriptionExpanded && "rotate-180",
+                )}
+              />
+              {isDescriptionExpanded ? "Hide description" : "Show description"}
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="space-y-3">

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -156,6 +156,8 @@ export function IssueDetail() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
+  const [isDescriptionOverflowing, setIsDescriptionOverflowing] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement>(null);
   const [detailTab, setDetailTab] = useState("comments");
   const [secondaryOpen, setSecondaryOpen] = useState({
     approvals: false,
@@ -508,6 +510,17 @@ export function IssueDetail() {
     return () => closePanel();
   }, [issue]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Reset description expanded state when navigating between issues
+  useEffect(() => {
+    setIsDescriptionExpanded(false);
+  }, [issueId]);
+
+  // Detect whether description actually overflows the collapsed height
+  useEffect(() => {
+    const el = descriptionRef.current;
+    if (el) setIsDescriptionOverflowing(el.scrollHeight > el.clientHeight);
+  }, [issue?.description]);
+
   if (isLoading) return <p className="text-sm text-muted-foreground">Loading...</p>;
   if (error) return <p className="text-sm text-destructive">{error.message}</p>;
   if (!issue) return null;
@@ -669,13 +682,12 @@ export function IssueDetail() {
           className="text-xl font-bold"
         />
 
-        <div className="space-y-1">
+        <Collapsible open={isDescriptionExpanded} onOpenChange={setIsDescriptionExpanded}>
           <div
+            ref={descriptionRef}
             className={cn(
               "overflow-hidden transition-all duration-200",
-              isDescriptionExpanded
-                ? "max-h-screen overflow-y-auto"
-                : "max-h-32",
+              isDescriptionExpanded ? "max-h-screen overflow-y-auto" : "max-h-32",
             )}
           >
             <InlineEditor
@@ -692,12 +704,8 @@ export function IssueDetail() {
               }}
             />
           </div>
-          {(issue.description ?? "").length > 0 && (
-            <button
-              type="button"
-              onClick={() => setIsDescriptionExpanded((prev) => !prev)}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
+          {isDescriptionOverflowing && (
+            <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mt-1">
               <ChevronDown
                 className={cn(
                   "h-3.5 w-3.5 transition-transform duration-200",
@@ -705,9 +713,9 @@ export function IssueDetail() {
                 )}
               />
               {isDescriptionExpanded ? "Hide description" : "Show description"}
-            </button>
+            </CollapsibleTrigger>
           )}
-        </div>
+        </Collapsible>
       </div>
 
       <div className="space-y-3">
@@ -894,21 +902,23 @@ export function IssueDetail() {
                 </div>
               </div>
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full text-muted-foreground"
-              onClick={() =>
-                openNewIssue({
-                  parentId: issue.id,
-                  ...(issue.projectId ? { projectId: issue.projectId } : {}),
-                  ...(issue.goalId ? { goalId: issue.goalId } : {}),
-                })
-              }
-            >
-              <Plus className="h-3.5 w-3.5 mr-1.5" />
-              Create sub-issue
-            </Button>
+            {!issue.parentId && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full text-muted-foreground"
+                onClick={() =>
+                  openNewIssue({
+                    parentId: issue.id,
+                    ...(issue.projectId ? { projectId: issue.projectId } : {}),
+                    ...(issue.goalId ? { goalId: issue.goalId } : {}),
+                  })
+                }
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Create sub-issue
+              </Button>
+            )}
           </div>
         </TabsContent>
 

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -785,32 +785,34 @@ export function IssueDetail() {
       <Separator />
 
       <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <TabsList variant="line" className="w-full justify-start gap-1">
-          <TabsTrigger value="comments" className="gap-1.5">
-            <MessageSquare className="h-3.5 w-3.5" />
-            Comments
-          </TabsTrigger>
-          <TabsTrigger value="subissues" className="gap-1.5">
-            <ListTree className="h-3.5 w-3.5" />
-            Sub-issues
-            {childIssueCounts && (
-              <span
-                className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
-                  childIssueCounts.done === childIssueCounts.total
-                    ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
-                    : "border-border text-muted-foreground bg-muted/40"
-                }`}
-                title={`${childIssueCounts.done} of ${childIssueCounts.total} sub-issues done`}
-              >
-                ⊞ {childIssueCounts.done}/{childIssueCounts.total}
-              </span>
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="activity" className="gap-1.5">
-            <ActivityIcon className="h-3.5 w-3.5" />
-            Activity
-          </TabsTrigger>
-        </TabsList>
+        <div className="overflow-x-auto scrollbar-none">
+          <TabsList variant="line" className="w-max min-w-full justify-start gap-1 flex-nowrap">
+            <TabsTrigger value="comments" className="gap-1.5 shrink-0">
+              <MessageSquare className="h-3.5 w-3.5" />
+              Comments
+            </TabsTrigger>
+            <TabsTrigger value="subissues" className="gap-1.5 shrink-0">
+              <ListTree className="h-3.5 w-3.5" />
+              Sub-issues
+              {childIssueCounts && (
+                <span
+                  className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+                    childIssueCounts.done === childIssueCounts.total
+                      ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
+                      : "border-border text-muted-foreground bg-muted/40"
+                  }`}
+                  title={`${childIssueCounts.done} of ${childIssueCounts.total} sub-issues done`}
+                >
+                  ⊞ {childIssueCounts.done}/{childIssueCounts.total}
+                </span>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="activity" className="gap-1.5 shrink-0">
+              <ActivityIcon className="h-3.5 w-3.5" />
+              Activity
+            </TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="comments">
           <CommentThread


### PR DESCRIPTION
## Summary

Fixes long descriptions requiring excessive scrolling to reach task controls, especially on mobile.

- Description is **collapsed by default** (max-h-32, ~5 lines visible)
- A **chevron toggle** ("Show description" / "Hide description") appears below when description is non-empty
- Expanding sets `max-h-screen` with `overflow-y-auto` for full scrollable content
- Smooth CSS transition (`duration-200`) for collapse/expand animation
- Works on all screen sizes (mobile-first intent per issue)

## Changes

- `ui/src/pages/IssueDetail.tsx` — wrap `InlineEditor` in collapsible container with toggle button

Closes LAS-133