### PR TITLE
fix: remove VOLUME instruction from Dockerfiles for Railway compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private
 
-VOLUME ["/paperclip"]
 EXPOSE 3100
 
 USER node

--- a/Dockerfile.onboard-smoke
+++ b/Dockerfile.onboard-smoke
@@ -32,7 +32,6 @@ RUN apt-get update \
   && chown -R paperclip:paperclip /paperclip /home/paperclip \
   && rm -rf /var/lib/apt/lists/*
 
-VOLUME ["/paperclip"]
 WORKDIR /home/paperclip/workspace
 EXPOSE 3100
 USER paperclip


### PR DESCRIPTION
## Summary
- Removes the `VOLUME ["/paperclip"]` instruction from `Dockerfile` and `Dockerfile.onboard-smoke`
- Railway bans the `VOLUME` keyword in Dockerfiles — deployment fails during build with: *"The `VOLUME` keyword is banned in Dockerfiles. Use Railway volumes instead."*
- For persistent storage on Railway, use [Railway Volumes](https://docs.railway.com/reference/volumes) instead

## Test plan
- [ ] Verify Railway deployment succeeds after merging
- [ ] Confirm the application starts and functions correctly
- [ ] Verify `/paperclip` directory is still created and writable (it is — `mkdir -p /paperclip` in the Dockerfile still runs)

Made with [Cursor](https://cursor.com)