### PR TITLE
fix(adapter): prevent nested Claude Code session error in spawned agents

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -204,7 +204,16 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_API_KEY = authToken;
   }
 
+  // Build the full runtime environment by merging process.env with Paperclip
+  // variables. We must return this merged env (not just the Paperclip vars)
+  // because runChildProcess() also merges with process.env — if we only return
+  // the Paperclip vars, any nesting-detection env vars from the parent process
+  // get re-introduced by that second merge.
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  // Remove nesting-detection variables so the spawned Claude CLI doesn't think
+  // it's running inside another Claude Code session.
+  delete runtimeEnv.CLAUDECODE;
+  delete runtimeEnv.CLAUDE_CODE_ENTRYPOINT;
   await ensureCommandResolvable(command, cwd, runtimeEnv);
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
@@ -221,7 +230,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     workspaceId,
     workspaceRepoUrl,
     workspaceRepoRef,
-    env,
+    env: runtimeEnv,
     timeoutSec,
     graceSec,
     extraArgs,


### PR DESCRIPTION
## Summary

- Fixes agents failing with `Claude Code cannot be launched inside another Claude Code session` when the Paperclip server itself runs inside Claude Code
- `buildClaudeRuntimeConfig()` was returning only Paperclip-specific env vars, so `runChildProcess()` re-introduced `CLAUDECODE` from `process.env` during its own merge
- Now returns the full merged `runtimeEnv` with `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` deleted, preventing the second merge from reintroducing them

## Root cause

```
buildClaudeRuntimeConfig():
  runtimeEnv = { ...process.env, ...env }  // CLAUDECODE present from parent
  // runtimeEnv used only for ensureCommandResolvable()
  return { env }                           // ← returns Paperclip vars only

runChildProcess():
  mergedEnv = { ...process.env, ...opts.env }  // CLAUDECODE re-introduced!
  spawn(command, args, { env: mergedEnv })     // Claude CLI detects nesting → exits
```

## Test plan

- [ ] Start Paperclip server inside a Claude Code session
- [ ] Trigger an agent heartbeat run
- [ ] Confirm agent spawns successfully without nested session error
- [ ] Confirm agent runs work normally when server is NOT inside Claude Code (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)