### PR TITLE
feat(ui): replace folder path instructions with native folder picker

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -24,6 +24,7 @@ import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { fsRoutes } from "./routes/fs.js";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 
 type UiMode = "none" | "static" | "vite-dev";
@@ -113,6 +114,7 @@ export async function createApp(
   api.use(activityRoutes(db));
   api.use(dashboardRoutes(db));
   api.use(sidebarBadgeRoutes(db));
+  api.use("/fs", fsRoutes());
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/fs.ts
+++ b/server/src/routes/fs.ts
@@ -1,0 +1,94 @@
+import { Router } from "express";
+import fsSync from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+export interface FsEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}
+
+export interface FsBrowseResult {
+  path: string;
+  parent: string | null;
+  entries: FsEntry[];
+}
+
+export function fsRoutes() {
+  const router = Router();
+
+  /**
+   * GET /fs/browse
+   * Browse the server filesystem.
+   * Query params:
+   *   path        — absolute path to browse (defaults to home directory)
+   *   showHidden  — "true" to include hidden files/folders (default: false)
+   */
+  router.get("/browse", (req, res) => {
+    const showHidden = req.query.showHidden === "true";
+    let rawPath = typeof req.query.path === "string" ? req.query.path : "~";
+
+    // Expand ~ to home directory
+    if (rawPath === "~" || rawPath.startsWith("~/")) {
+      rawPath = rawPath.replace(/^~/, os.homedir());
+    }
+
+    // Resolve and normalise
+    const dir = path.resolve(rawPath);
+
+    // Must be an absolute path
+    if (!path.isAbsolute(dir)) {
+      res.status(400).json({ error: "path must be absolute" });
+      return;
+    }
+
+    let stat: fsSync.Stats;
+    try {
+      stat = fsSync.statSync(dir);
+    } catch {
+      res.status(404).json({ error: "path not found" });
+      return;
+    }
+
+    if (!stat.isDirectory()) {
+      res.status(400).json({ error: "path is not a directory" });
+      return;
+    }
+
+    let names: string[];
+    try {
+      names = fsSync.readdirSync(dir);
+    } catch {
+      res.status(403).json({ error: "cannot read directory" });
+      return;
+    }
+
+    const entries: FsEntry[] = [];
+    for (const name of names) {
+      if (!showHidden && name.startsWith(".")) continue;
+      const fullPath = path.join(dir, name);
+      let isDirectory = false;
+      try {
+        isDirectory = fsSync.statSync(fullPath).isDirectory();
+      } catch {
+        // skip entries we can't stat (broken symlinks, permission errors)
+        continue;
+      }
+      entries.push({ name, path: fullPath, isDirectory });
+    }
+
+    // Directories first, then files — both sorted alphabetically
+    entries.sort((a, b) => {
+      if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    const parent = dir !== path.parse(dir).root ? path.dirname(dir) : null;
+
+    const result: FsBrowseResult = { path: dir, parent, entries };
+    res.json(result);
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -12,3 +12,4 @@ export { dashboardRoutes } from "./dashboard.js";
 export { sidebarBadgeRoutes } from "./sidebar-badges.js";
 export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
+export { fsRoutes } from "./fs.js";

--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -44,7 +44,18 @@ export function ClaudeLocalConfigFields({
           className={inputClass}
           placeholder="/absolute/path/to/AGENTS.md"
         />
-        <ChoosePathButton />
+        <ChoosePathButton
+          onSelect={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          currentPath={
+            isCreate
+              ? values!.instructionsFilePath || undefined
+              : String(config.instructionsFilePath ?? "") || undefined
+          }
+        />
       </div>
     </Field>
   );

--- a/ui/src/adapters/codex-local/config-fields.tsx
+++ b/ui/src/adapters/codex-local/config-fields.tsx
@@ -46,7 +46,18 @@ export function CodexLocalConfigFields({
             className={inputClass}
             placeholder="/absolute/path/to/AGENTS.md"
           />
-          <ChoosePathButton />
+          <ChoosePathButton
+            onSelect={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            currentPath={
+              isCreate
+                ? values!.instructionsFilePath || undefined
+                : String(config.instructionsFilePath ?? "") || undefined
+            }
+          />
         </div>
       </Field>
       <ToggleField

--- a/ui/src/adapters/cursor/config-fields.tsx
+++ b/ui/src/adapters/cursor/config-fields.tsx
@@ -40,7 +40,18 @@ export function CursorLocalConfigFields({
           className={inputClass}
           placeholder="/absolute/path/to/AGENTS.md"
         />
-        <ChoosePathButton />
+        <ChoosePathButton
+          onSelect={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          currentPath={
+            isCreate
+              ? values!.instructionsFilePath || undefined
+              : String(config.instructionsFilePath ?? "") || undefined
+          }
+        />
       </div>
     </Field>
   );

--- a/ui/src/adapters/opencode-local/config-fields.tsx
+++ b/ui/src/adapters/opencode-local/config-fields.tsx
@@ -40,7 +40,18 @@ export function OpenCodeLocalConfigFields({
           className={inputClass}
           placeholder="/absolute/path/to/AGENTS.md"
         />
-        <ChoosePathButton />
+        <ChoosePathButton
+          onSelect={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          currentPath={
+            isCreate
+              ? values!.instructionsFilePath || undefined
+              : String(config.instructionsFilePath ?? "") || undefined
+          }
+        />
       </div>
     </Field>
   );

--- a/ui/src/adapters/pi-local/config-fields.tsx
+++ b/ui/src/adapters/pi-local/config-fields.tsx
@@ -40,7 +40,18 @@ export function PiLocalConfigFields({
           className={inputClass}
           placeholder="/absolute/path/to/AGENTS.md"
         />
-        <ChoosePathButton />
+        <ChoosePathButton
+          onSelect={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          currentPath={
+            isCreate
+              ? values!.instructionsFilePath || undefined
+              : String(config.instructionsFilePath ?? "") || undefined
+          }
+        />
       </div>
     </Field>
   );

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -555,7 +555,18 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   className="w-full bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
                   placeholder="/path/to/project"
                 />
-                <ChoosePathButton />
+                <ChoosePathButton
+                  onSelect={(v) =>
+                    isCreate
+                      ? set!({ cwd: v })
+                      : mark("adapterConfig", "cwd", v || undefined)
+                  }
+                  currentPath={
+                    isCreate
+                      ? val!.cwd || undefined
+                      : String(config.cwd ?? "") || undefined
+                  }
+                />
               </div>
             </Field>
           )}

--- a/ui/src/components/FolderPickerDialog.tsx
+++ b/ui/src/components/FolderPickerDialog.tsx
@@ -1,0 +1,223 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Folder,
+  ChevronRight,
+  Home,
+  ArrowLeft,
+  Eye,
+  EyeOff,
+  Loader2,
+  FileText,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FsEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}
+
+interface FsBrowseResult {
+  path: string;
+  parent: string | null;
+  entries: FsEntry[];
+}
+
+export interface FolderPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (path: string) => void;
+  initialPath?: string;
+}
+
+async function browsePath(
+  dirPath: string,
+  showHidden: boolean,
+): Promise<FsBrowseResult> {
+  const params = new URLSearchParams({
+    path: dirPath,
+    showHidden: String(showHidden),
+  });
+  const res = await fetch(`/api/fs/browse?${params}`);
+  if (!res.ok) {
+    const { error } = await res
+      .json()
+      .catch(() => ({ error: "Unknown error" }));
+    throw new Error(error ?? "Failed to browse directory");
+  }
+  return res.json();
+}
+
+export function FolderPickerDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  initialPath,
+}: FolderPickerDialogProps) {
+  const [current, setCurrent] = useState<FsBrowseResult | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const navigate = useCallback(
+    async (toPath: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await browsePath(toPath, showHidden);
+        setCurrent(result);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to open folder");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [showHidden],
+  );
+
+  // Load initial path when dialog opens
+  useEffect(() => {
+    if (!open) return;
+    navigate(initialPath || "~");
+  }, [open, initialPath]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-browse when showHidden changes
+  useEffect(() => {
+    if (!open || !current) return;
+    navigate(current.path);
+  }, [showHidden]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleConfirm() {
+    if (current?.path) {
+      onSelect(current.path);
+      onOpenChange(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="text-base">Choose a folder</DialogTitle>
+        </DialogHeader>
+
+        {/* Toolbar */}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <button
+            type="button"
+            title="Go up"
+            disabled={!current?.parent || loading}
+            onClick={() => current?.parent && navigate(current.parent)}
+            className="inline-flex items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent/50 disabled:opacity-40 transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            title="Home directory"
+            disabled={loading}
+            onClick={() => navigate("~")}
+            className="inline-flex items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent/50 disabled:opacity-40 transition-colors"
+          >
+            <Home className="h-4 w-4" />
+          </button>
+
+          {/* Current path breadcrumb */}
+          <div className="flex-1 overflow-x-auto scrollbar-none rounded-md border border-border bg-muted/30 px-2 py-1 text-xs font-mono text-muted-foreground whitespace-nowrap">
+            {current?.path ?? "…"}
+          </div>
+
+          <button
+            type="button"
+            title={showHidden ? "Hide hidden folders" : "Show hidden folders"}
+            onClick={() => setShowHidden((v) => !v)}
+            className={cn(
+              "inline-flex items-center justify-center rounded p-1 transition-colors",
+              showHidden
+                ? "text-foreground bg-accent"
+                : "text-muted-foreground hover:bg-accent/50",
+            )}
+          >
+            {showHidden ? (
+              <Eye className="h-4 w-4" />
+            ) : (
+              <EyeOff className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+
+        {/* Directory listing */}
+        <div className="h-64 overflow-y-auto scrollbar-none rounded-md border border-border">
+          {loading && (
+            <div className="flex items-center justify-center h-full py-8 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </div>
+          )}
+
+          {error && !loading && (
+            <div className="flex items-center justify-center h-full py-8 text-sm text-destructive px-4 text-center">
+              {error}
+            </div>
+          )}
+
+          {!loading && !error && current && (
+            <div className="py-1">
+              {current.entries.length === 0 && (
+                <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+                  Empty folder
+                </p>
+              )}
+              {current.entries.map((entry) => (
+                <button
+                  key={entry.path}
+                  type="button"
+                  onClick={() => {
+                    if (entry.isDirectory) navigate(entry.path);
+                  }}
+                  disabled={!entry.isDirectory}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-3 py-1.5 text-sm transition-colors",
+                    entry.isDirectory
+                      ? "hover:bg-accent/50 cursor-pointer"
+                      : "opacity-40 cursor-default",
+                  )}
+                >
+                  {entry.isDirectory ? (
+                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="flex-1 truncate text-left">{entry.name}</span>
+                  {entry.isDirectory && (
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" disabled={!current?.path} onClick={handleConfirm}>
+            Select this folder
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -341,7 +341,10 @@ export function NewProjectDialog() {
                   onChange={(e) => setWorkspaceLocalPath(e.target.value)}
                   placeholder="/absolute/path/to/workspace"
                 />
-                <ChoosePathButton />
+                <ChoosePathButton
+                  onSelect={setWorkspaceLocalPath}
+                  currentPath={workspaceLocalPath || undefined}
+                />
               </div>
             </div>
           )}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -751,7 +751,10 @@ export function OnboardingWizard() {
                             value={cwd}
                             onChange={(e) => setCwd(e.target.value)}
                           />
-                          <ChoosePathButton />
+                          <ChoosePathButton
+                            onSelect={setCwd}
+                            currentPath={cwd || undefined}
+                          />
                         </div>
                       </div>
                       <div>

--- a/ui/src/components/PathInstructionsModal.tsx
+++ b/ui/src/components/PathInstructionsModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { FolderPickerDialog } from "./FolderPickerDialog";
 
 type Platform = "mac" | "windows" | "linux";
 
@@ -120,11 +121,23 @@ export function PathInstructionsModal({
 }
 
 /**
- * Small "Choose" button that opens the PathInstructionsModal.
- * Drop-in replacement for the old showDirectoryPicker buttons.
+ * "Choose" button that opens a folder picker dialog.
+ * When onSelect is provided, opens a browsable folder picker.
+ * Falls back to the PathInstructionsModal when onSelect is omitted.
  */
-export function ChoosePathButton({ className }: { className?: string }) {
+export function ChoosePathButton({
+  className,
+  onSelect,
+  currentPath,
+}: {
+  className?: string;
+  /** Called with the selected absolute path. When omitted, shows manual instructions instead. */
+  onSelect?: (path: string) => void;
+  /** Initial directory to open the picker at. */
+  currentPath?: string;
+}) {
   const [open, setOpen] = useState(false);
+
   return (
     <>
       <button
@@ -137,7 +150,17 @@ export function ChoosePathButton({ className }: { className?: string }) {
       >
         Choose
       </button>
-      <PathInstructionsModal open={open} onOpenChange={setOpen} />
+
+      {onSelect ? (
+        <FolderPickerDialog
+          open={open}
+          onOpenChange={setOpen}
+          onSelect={onSelect}
+          initialPath={currentPath}
+        />
+      ) : (
+        <PathInstructionsModal open={open} onOpenChange={setOpen} />
+      )}
     </>
   );
 }

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -444,7 +444,10 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
                   onChange={(e) => setWorkspaceCwd(e.target.value)}
                   placeholder="/absolute/path/to/workspace"
                 />
-                <ChoosePathButton />
+                <ChoosePathButton
+                  onSelect={setWorkspaceCwd}
+                  currentPath={workspaceCwd || undefined}
+                />
               </div>
               <div className="flex items-center gap-2">
                 <Button

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -498,3 +498,12 @@ a.paperclip-project-mention-chip {
 .paperclip-mdxeditor [class*="_toolbarNodeKindSelectContainer_"] {
   z-index: 81 !important;
 }
+
+/* Hide scrollbars while keeping scroll functionality */
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## Summary

Replaces the static 'how to copy a path' instructions modal with a real folder picker dialog that lets users browse and select a directory directly from the UI.

## What changed

- Added GET /api/fs/browse for directory browsing
- Created FolderPickerDialog with breadcrumb, back/home, and hidden-folder toggle
- Updated choose buttons to open the new dialog and wired it into every workspace/path field

Fixes the UX gap discussed in Discord where the ‘Choose’ button only showed instructions. This is a Path 1 change: server API + UI + hidden-folder toggle, no extra deps.
