### PR TITLE
UI: multi-file upload, dynamic accept filter & non-image drag-and-drop

### DIFF
--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { and, count, eq, gt, isNull, sql } from "drizzle-orm";
 import { instanceUserRoles, invites } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+import { parseAllowedTypes } from "../attachment-types.js";
 
 export function healthRoutes(
   db?: Db,
@@ -64,6 +65,9 @@ export function healthRoutes(
       features: {
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },
+      allowedAttachmentTypes: parseAllowedTypes(
+        process.env.PAPERCLIP_ALLOWED_ATTACHMENT_TYPES,
+      ),
     });
   });
 

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -8,6 +8,7 @@ export type HealthStatus = {
   features?: {
     companyDeletionEnabled?: boolean;
   };
+  allowedAttachmentTypes?: string[];
 };
 
 export const healthApi = {

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -10,6 +10,7 @@ import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./Ma
 import { StatusBadge } from "./StatusBadge";
 import { AgentIcon } from "./AgentIconPicker";
 import { formatDateTime } from "../lib/utils";
+import { useAttachmentConfig } from "../hooks/useAttachmentConfig";
 
 interface CommentWithRunMeta extends IssueComment {
   runId?: string | null;
@@ -233,6 +234,7 @@ export function CommentThread({
   const [submitting, setSubmitting] = useState(false);
   const [attaching, setAttaching] = useState(false);
   const [reassignTarget, setReassignTarget] = useState(currentAssigneeValue);
+  const { accept: attachAccept } = useAttachmentConfig();
   const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
   const editorRef = useRef<MarkdownEditorRef>(null);
   const attachInputRef = useRef<HTMLInputElement | null>(null);
@@ -334,11 +336,13 @@ export function CommentThread({
   }
 
   async function handleAttachFile(evt: ChangeEvent<HTMLInputElement>) {
-    const file = evt.target.files?.[0];
-    if (!file || !onAttachImage) return;
+    const files = evt.target.files;
+    if (!files || files.length === 0 || !onAttachImage) return;
     setAttaching(true);
     try {
-      await onAttachImage(file);
+      for (const file of Array.from(files)) {
+        await onAttachImage(file);
+      }
     } finally {
       setAttaching(false);
       if (attachInputRef.current) attachInputRef.current.value = "";
@@ -372,7 +376,8 @@ export function CommentThread({
               <input
                 ref={attachInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif"
+                accept={attachAccept}
+                multiple
                 className="hidden"
                 onChange={handleAttachFile}
               />
@@ -381,7 +386,7 @@ export function CommentThread({
                 size="icon-sm"
                 onClick={() => attachInputRef.current?.click()}
                 disabled={attaching}
-                title="Attach image"
+                title="Attach file"
               >
                 <Paperclip className="h-4 w-4" />
               </Button>

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -473,7 +473,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     return Array.from(evt.dataTransfer?.types ?? []).includes("Files");
   }
 
-  const canDropImage = Boolean(imageUploadHandler);
+  const canDrop = Boolean(imageUploadHandler);
 
   return (
     <div
@@ -533,23 +533,56 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         }
       }}
       onDragEnter={(evt) => {
-        if (!canDropImage || !hasFilePayload(evt)) return;
+        if (!canDrop || !hasFilePayload(evt)) return;
         dragDepthRef.current += 1;
         setIsDragOver(true);
       }}
       onDragOver={(evt) => {
-        if (!canDropImage || !hasFilePayload(evt)) return;
+        if (!canDrop || !hasFilePayload(evt)) return;
         evt.preventDefault();
         evt.dataTransfer.dropEffect = "copy";
       }}
       onDragLeave={() => {
-        if (!canDropImage) return;
+        if (!canDrop) return;
         dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
         if (dragDepthRef.current === 0) setIsDragOver(false);
       }}
-      onDrop={() => {
+      onDrop={async (evt) => {
         dragDepthRef.current = 0;
         setIsDragOver(false);
+
+        const handler = imageUploadHandlerRef.current;
+        if (!handler) return;
+
+        const files = evt.dataTransfer?.files;
+        if (!files || files.length === 0) return;
+
+        // Non-image files are ignored by MDXEditor's imagePlugin,
+        // so we handle them here by uploading and inserting a link.
+        const nonImageFiles = Array.from(files).filter(
+          (f) => !f.type.startsWith("image/"),
+        );
+        if (nonImageFiles.length === 0) return; // all images — imagePlugin handles them
+
+        evt.preventDefault();
+        for (const file of nonImageFiles) {
+          try {
+            const url = await handler(file);
+            const name = file.name || "file";
+            const md = `[${name}](${url})`;
+            const next = latestValueRef.current
+              ? `${latestValueRef.current}\n\n${md}`
+              : md;
+            latestValueRef.current = next;
+            ref.current?.setMarkdown(next);
+            onChange(next);
+            setUploadError(null);
+          } catch (err) {
+            const message =
+              err instanceof Error ? err.message : "Upload failed";
+            setUploadError(message);
+          }
+        }
       }}
     >
       <MDXEditor
@@ -608,14 +641,14 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         </div>
       )}
 
-      {isDragOver && canDropImage && (
+      {isDragOver && canDrop && (
         <div
           className={cn(
             "pointer-events-none absolute inset-1 z-40 flex items-center justify-center rounded-md border border-dashed border-primary/80 bg-primary/10 text-xs font-medium text-primary",
             !bordered && "inset-0 rounded-sm",
           )}
         >
-          Drop image to upload
+          Drop files to upload
         </div>
       )}
       {uploadError && (

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -9,6 +9,7 @@ import { authApi } from "../api/auth";
 import { assetsApi } from "../api/assets";
 import { queryKeys } from "../lib/queryKeys";
 import { useProjectOrder } from "../hooks/useProjectOrder";
+import { useAttachmentConfig } from "../hooks/useAttachmentConfig";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
 import {
   Dialog,
@@ -169,6 +170,7 @@ const priorities = [
 export function NewIssueDialog() {
   const { newIssueOpen, newIssueDefaults, closeNewIssue } = useDialog();
   const { companies, selectedCompanyId, selectedCompany } = useCompany();
+  const { accept: attachAccept } = useAttachmentConfig();
   const queryClient = useQueryClient();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -448,15 +450,20 @@ export function NewIssueDialog() {
   }
 
   async function handleAttachImage(evt: ChangeEvent<HTMLInputElement>) {
-    const file = evt.target.files?.[0];
-    if (!file) return;
+    const files = evt.target.files;
+    if (!files || files.length === 0) return;
     try {
-      const asset = await uploadDescriptionImage.mutateAsync(file);
-      const name = file.name || "image";
-      setDescription((prev) => {
-        const suffix = `![${name}](${asset.contentPath})`;
-        return prev ? `${prev}\n\n${suffix}` : suffix;
-      });
+      for (const file of Array.from(files)) {
+        const asset = await uploadDescriptionImage.mutateAsync(file);
+        const name = file.name || "file";
+        const isImage = file.type.startsWith("image/");
+        setDescription((prev) => {
+          const suffix = isImage
+            ? `![${name}](${asset.contentPath})`
+            : `[${name}](${asset.contentPath})`;
+          return prev ? `${prev}\n\n${suffix}` : suffix;
+        });
+      }
     } finally {
       if (attachInputRef.current) attachInputRef.current.value = "";
     }
@@ -906,11 +913,12 @@ export function NewIssueDialog() {
             Labels
           </button>
 
-          {/* Attach image chip */}
+          {/* Attach file chip */}
           <input
             ref={attachInputRef}
             type="file"
-            accept="image/png,image/jpeg,image/webp,image/gif"
+            accept={attachAccept}
+            multiple
             className="hidden"
             onChange={handleAttachImage}
           />
@@ -920,7 +928,7 @@ export function NewIssueDialog() {
             disabled={uploadDescriptionImage.isPending}
           >
             <Paperclip className="h-3 w-3" />
-            {uploadDescriptionImage.isPending ? "Uploading..." : "Image"}
+            {uploadDescriptionImage.isPending ? "Uploading..." : "Attach"}
           </button>
 
           {/* More (dates) */}

--- a/ui/src/hooks/useAttachmentConfig.ts
+++ b/ui/src/hooks/useAttachmentConfig.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { healthApi } from "../api/health";
+import { queryKeys } from "../lib/queryKeys";
+
+const DEFAULT_ACCEPT = "image/png,image/jpeg,image/webp,image/gif";
+
+/**
+ * Returns the `accept` attribute value for file inputs,
+ * derived from the server's allowed attachment types configuration.
+ */
+export function useAttachmentConfig() {
+  const { data } = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+    staleTime: Infinity, // already fetched at app boot
+  });
+
+  const types = data?.allowedAttachmentTypes;
+  const accept = types && types.length > 0 ? types.join(",") : DEFAULT_ACCEPT;
+
+  return { accept };
+}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -12,6 +12,7 @@ import { usePanel } from "../context/PanelContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { useProjectOrder } from "../hooks/useProjectOrder";
+import { useAttachmentConfig } from "../hooks/useAttachmentConfig";
 import { relativeTime, cn, formatTokens } from "../lib/utils";
 import { InlineEditor } from "../components/InlineEditor";
 import { CommentThread } from "../components/CommentThread";
@@ -158,6 +159,7 @@ export function IssueDetail() {
     cost: false,
   });
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const { accept: attachAccept } = useAttachmentConfig();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const lastMarkedReadIssueIdRef = useRef<string | null>(null);
 
@@ -504,9 +506,11 @@ export function IssueDetail() {
   const ancestors = issue.ancestors ?? [];
 
   const handleFilePicked = async (evt: ChangeEvent<HTMLInputElement>) => {
-    const file = evt.target.files?.[0];
-    if (!file) return;
-    await uploadAttachment.mutateAsync(file);
+    const files = evt.target.files;
+    if (!files || files.length === 0) return;
+    for (const file of Array.from(files)) {
+      await uploadAttachment.mutateAsync(file);
+    }
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -679,7 +683,8 @@ export function IssueDetail() {
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/png,image/jpeg,image/webp,image/gif"
+              accept={attachAccept}
+              multiple
               className="hidden"
               onChange={handleFilePicked}
             />
@@ -690,7 +695,7 @@ export function IssueDetail() {
               disabled={uploadAttachment.isPending}
             >
               <Paperclip className="h-3.5 w-3.5 mr-1.5" />
-              {uploadAttachment.isPending ? "Uploading..." : "Upload image"}
+              {uploadAttachment.isPending ? "Uploading..." : "Upload file"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Follow-up to #495 (configurable attachment types). The server-side validation was in place but the UI had three issues:

- **File picker only showed images** — hardcoded `accept="image/png,..."` in 3 UI files
- - **No multi-file selection** — file inputs lacked the `multiple` attribute
- - **Non-image drag-and-drop didn't work** — MarkdownEditor only handled image drops via MDXEditor's imagePlugin
### Changes

**Server (1 file)**
- Expose `allowedAttachmentTypes` array in `/api/health` response so the UI can derive the `accept` attribute dynamically
**UI (6 files)**
- New `useAttachmentConfig` hook — reads allowed types from health endpoint, builds the `accept` string
- - `IssueDetail.tsx` — dynamic `accept`, `multiple`, multi-file handler, label "Upload file"
- - `NewIssueDialog.tsx` — dynamic `accept`, `multiple`, multi-file handler with link-vs-image markdown fix (PDFs use `[name](url)` not `![name](url)`), label "Attach"
- - `CommentThread.tsx` — dynamic `accept`, `multiple`, multi-file handler, title "Attach file"
- - `MarkdownEditor.tsx` — handle non-image file drops (upload + insert as link), "Drop files to upload"
## Test plan

- [ ] Set `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES="image/*,application/pdf,text/*"` and verify file picker shows images, PDFs, and text files
- [ ] - [ ] Verify multi-file selection works (Cmd/Ctrl+click)
- [ ] - [ ] Upload a PDF via the Attach button in New Issue — should appear as a link, not a broken image
- [ ] - [ ] Drag-and-drop a PDF onto the markdown editor — should upload and insert as `[filename](url)`
- [ ] - [ ] Drag-and-drop an image — should still work as before (inserted at cursor via imagePlugin)
- [ ] - [ ] Without the env var set, verify only image types are selectable (default behavior unchanged)