### PR TITLE
feat: enable sort controls in kanban board view

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -457,8 +457,8 @@ export function IssuesList({
             </PopoverContent>
           </Popover>
 
-          {/* Sort (list view only) */}
-          {viewState.viewMode === "list" && (
+          {/* Sort */}
+          {(
             <Popover>
               <PopoverTrigger asChild>
                 <Button variant="ghost" size="sm" className="text-xs">
@@ -474,7 +474,9 @@ export function IssuesList({
                     ["title", "Title"],
                     ["created", "Created"],
                     ["updated", "Updated"],
-                  ] as const).map(([field, label]) => (
+                  ] as const)
+                  .filter(([field]) => viewState.viewMode === "board" ? field !== "status" : true)
+                  .map(([field, label]) => (
                     <button
                       key={field}
                       className={`flex items-center justify-between w-full px-2 py-1.5 text-sm rounded-sm ${


### PR DESCRIPTION
## Problem

The kanban board has no sort controls — the Sort dropdown is explicitly gated to list view only (`viewState.viewMode === 'list'`). This makes the Done column (and others) feel scrambled since issues appear in arbitrary order. (#509)

## Fix

- Remove the list-view-only guard on the Sort dropdown — now visible in both list and board views
- Filter out the 'Status' sort option when in board view (kanban already groups by status, so sorting by status within a column is meaningless)
- Issues in each kanban column now respect the selected sort field and direction (priority, title, created, updated)

## How it works

The `filtered` memo in `IssuesList.tsx` already applies `sortIssues()` before passing issues to `KanbanBoard`. The kanban `columnIssues` grouping preserves this order. So the only change needed was exposing the sort UI — no changes to KanbanBoard.tsx required.

## Changes

- `ui/src/components/IssuesList.tsx`: 5 lines changed — removed view mode guard, added status filter for board mode

Closes #509