### PR TITLE
fix: point Documentation sidebar link to external docs

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -215,12 +215,15 @@ export function Layout() {
           </div>
           <div className="border-t border-r border-border px-3 py-2 bg-background">
             <div className="flex items-center gap-1">
-              <SidebarNavItem
-                to="/docs"
-                label="Documentation"
-                icon={BookOpen}
-                className="flex-1 min-w-0"
-              />
+              <a
+                href="https://github.com/paperclipai/paperclip#readme"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
+              >
+                <BookOpen className="h-4 w-4 shrink-0" />
+                <span className="flex-1 truncate">Documentation</span>
+              </a>
               <Button
                 type="button"
                 variant="ghost"
@@ -250,12 +253,15 @@ export function Layout() {
           </div>
           <div className="border-t border-r border-border px-3 py-2">
             <div className="flex items-center gap-1">
-              <SidebarNavItem
-                to="/docs"
-                label="Documentation"
-                icon={BookOpen}
-                className="flex-1 min-w-0"
-              />
+              <a
+                href="https://github.com/paperclipai/paperclip#readme"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
+              >
+                <BookOpen className="h-4 w-4 shrink-0" />
+                <span className="flex-1 truncate">Documentation</span>
+              </a>
               <Button
                 type="button"
                 variant="ghost"

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -4,7 +4,6 @@ import { BookOpen, Moon, Sun } from "lucide-react";
 import { Outlet, useLocation, useNavigate, useParams } from "@/lib/router";
 import { CompanyRail } from "./CompanyRail";
 import { Sidebar } from "./Sidebar";
-import { SidebarNavItem } from "./SidebarNavItem";
 import { BreadcrumbBar } from "./BreadcrumbBar";
 import { PropertiesPanel } from "./PropertiesPanel";
 import { CommandPalette } from "./CommandPalette";
@@ -219,6 +218,7 @@ export function Layout() {
                 href="https://github.com/paperclipai/paperclip#readme"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => setSidebarOpen(false)}
                 className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
               >
                 <BookOpen className="h-4 w-4 shrink-0" />


### PR DESCRIPTION
## Problem

The "Documentation" link in the sidebar navigates to `/docs`, but no `/docs` route exists. The app falls through to the dashboard, making it look like the link does nothing.

## Fix

Replace the internal `SidebarNavItem` (React Router `NavLink`) with a plain `<a>` tag pointing to `https://github.com/paperclipai/paperclip#readme`. Opens in a new tab.

Applied to both desktop and mobile sidebar instances.

When a proper docs site exists, this can be updated to point there instead.

## Changes

- `ui/src/components/Layout.tsx`: Replace 2 `SidebarNavItem` instances with external `<a>` tags