### PR TITLE
feat(LAS-140): add Create sub-issue button with card styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Paperclip Development — Agent Rules
+
+## Branch & Worktree Discipline
+
+**Never commit directly to `master`.** All work goes on feature branches.
+
+### Parallel Work
+- Use `git worktree` or the `EnterWorktree` tool to isolate your work from other agents.
+- Never assume you own the shared working directory at `/home/openclaw/paperclip`. Other agents may be using it.
+- If you must work in the main checkout, check `git status` first and never discard uncommitted changes that aren't yours.
+
+### Branch Naming
+- Features: `feat/<ISSUE-ID>-short-description`
+- Fixes: `fix/<ISSUE-ID>-short-description`
+- Always include the Paperclip issue identifier (e.g., `LAS-142`).
+
+### Commits
+- Commit early and often. Uncommitted changes are invisible to other agents and will be lost on branch switches.
+- Never leave work as uncommitted modifications overnight. If the work is incomplete, commit to a WIP branch.
+- Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`.
+
+### PRs and Merging
+- Push feature branches to the `fork` remote (`https://github.com/lazmo88/paperclip.git`).
+- Open PRs against `origin/master` (`https://github.com/paperclipai/paperclip.git`).
+- After a PR is merged upstream, the local master must be updated: `git pull origin master`.
+- Delete merged feature branches locally to reduce clutter.
+
+## Dev Service
+
+The `paperclip.service` systemd unit runs from the main checkout on `master`. To pick up merged PRs:
+
+```bash
+cd /home/openclaw/paperclip && git pull origin master && systemctl --user restart paperclip.service
+```
+
+Never switch the service checkout to a feature branch. If you need to test a feature branch, use a separate worktree or run the dev server manually in that worktree.
+
+## Patches to Upstream Code
+
+If you need to patch a file that will be overwritten by `pnpm install` or upstream merges, use `pnpm patch`:
+
+```bash
+pnpm patch <package-name>
+# edit files in the temp directory
+pnpm patch-commit <temp-dir>
+```
+
+This creates entries in `package.json` under `pnpm.patchedDependencies` and a `patches/` directory that survives installs.
+
+For patches to Paperclip's own source (not node_modules), always commit to a branch. Never leave patches as uncommitted edits.

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1188,12 +1188,33 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         null;
       const summary = summaryFromEvents || summaryFromPayload || null;
 
-      const meta = asRecord(asRecord(acceptedPayload?.result)?.meta) ?? asRecord(acceptedPayload?.meta);
-      const agentMeta = asRecord(meta?.agentMeta);
+      // Check latestResultPayload (agent.wait response) first, then acceptedPayload (initial agent response)
+      const waitMeta = asRecord(asRecord(latestResultPayload)?.meta);
+      const waitAgentMeta = asRecord(waitMeta?.agentMeta);
+      const acceptMeta = asRecord(asRecord(acceptedPayload?.result)?.meta) ?? asRecord(acceptedPayload?.meta);
+      const acceptAgentMeta = asRecord(acceptMeta?.agentMeta);
+      const agentMeta = waitAgentMeta ?? acceptAgentMeta;
+      const meta = waitMeta ?? acceptMeta;
       const usage = parseUsage(agentMeta?.usage ?? meta?.usage);
       const provider = nonEmpty(agentMeta?.provider) ?? nonEmpty(meta?.provider) ?? "openclaw";
       const model = nonEmpty(agentMeta?.model) ?? nonEmpty(meta?.model) ?? null;
-      const costUsd = asNumber(agentMeta?.costUsd ?? meta?.costUsd, 0);
+      let costUsd = asNumber(agentMeta?.costUsd ?? meta?.costUsd, 0);
+
+      // If no costUsd reported but we have token usage, estimate from model pricing
+      if (costUsd <= 0 && usage) {
+        const m = (model ?? "").toLowerCase();
+        let inputPer1M = 3, outputPer1M = 15, cachePer1M = 0.30; // default: sonnet-class
+        if (m.includes("opus")) {
+          inputPer1M = 15; outputPer1M = 75; cachePer1M = 1.50;
+        } else if (m.includes("haiku")) {
+          inputPer1M = 0.80; outputPer1M = 4; cachePer1M = 0.08;
+        }
+        const uncachedInput = Math.max(0, (usage.inputTokens ?? 0) - (usage.cachedInputTokens ?? 0));
+        costUsd =
+          (uncachedInput / 1_000_000) * inputPer1M +
+          ((usage.cachedInputTokens ?? 0) / 1_000_000) * cachePer1M +
+          ((usage.outputTokens ?? 0) / 1_000_000) * outputPer1M;
+      }
 
       await ctx.onLog(
         "stdout",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -321,6 +324,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
@@ -988,6 +994,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -3423,6 +3432,11 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -6741,6 +6755,8 @@ snapshots:
   '@embedded-postgres/windows-x64@18.1.0-beta.16':
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -9254,6 +9270,11 @@ snapshots:
       layout-base: 2.0.1
 
   crelt@1.0.6: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -47,7 +47,7 @@ function applyStatusSideEffects(
 }
 
 export interface IssueFilters {
-  status?: string;
+  status?: string | string[];
   assigneeAgentId?: string;
   assigneeUserId?: string;
   touchedByUserId?: string;
@@ -443,7 +443,7 @@ export function issueService(db: Db) {
         )
       `;
       if (filters?.status) {
-        const statuses = filters.status.split(",").map((s) => s.trim());
+        const statuses = (Array.isArray(filters.status) ? filters.status : filters.status.split(",")).map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
       if (filters?.assigneeAgentId) {

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -72,8 +72,8 @@ If subtasks exist, they define the work breakdown. You MUST work through subtask
   - **Assigned to you** → work on it (checkout, execute, mark done).
   - **Unassigned** (`assigneeAgentId` is null) → you may pick it up. Checkout the subtask to claim it, then work on it.
 - **Delegate to specialists when available:** If a subtask requires skills outside your role (e.g., design, frontend, security) and a specialist agent exists in the company, assign the subtask to them (`PATCH` with `assigneeAgentId`) and add a comment explaining the ask. Use `GET /api/companies/{companyId}/agents` to find available agents and match by role/capabilities. Do NOT delegate if you can reasonably do the work yourself.
-- Work on actionable subtasks (`todo`, `in_progress`, or `backlog` status) in priority order (critical → high → medium → low).
-- For each subtask you complete, checkout that subtask, do the work, and mark it `done` with a comment.
+- Work on actionable subtasks (`todo` or `in_progress` status) in priority order (critical → high → medium → low). Skip `backlog` subtasks — they have not been triaged for work yet.
+- For each subtask, checkout it first. When checking out a subtask that is already `in_progress` (resumed from a prior heartbeat), include `"in_progress"` in `expectedStatuses`. Then do the work and mark it `done` with a comment.
 - If you can only complete some subtasks in this heartbeat, mark those done and leave the parent as `in_progress`.
 - Do NOT mark the parent as `done` while any subtasks are still open (`todo`, `in_progress`, `in_review`, `backlog`, `blocked`).
 - Only mark the parent `done` when all subtasks are `done` (or `cancelled`).

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -72,7 +72,7 @@ If subtasks exist, they define the work breakdown. You MUST work through subtask
   - **Assigned to you** → work on it (checkout, execute, mark done).
   - **Unassigned** (`assigneeAgentId` is null) → you may pick it up. Checkout the subtask to claim it, then work on it.
 - **Delegate to specialists when available:** If a subtask requires skills outside your role (e.g., design, frontend, security) and a specialist agent exists in the company, assign the subtask to them (`PATCH` with `assigneeAgentId`) and add a comment explaining the ask. Use `GET /api/companies/{companyId}/agents` to find available agents and match by role/capabilities. Do NOT delegate if you can reasonably do the work yourself.
-- Work on actionable subtasks (`todo` or `backlog` status) in priority order (critical → high → medium → low).
+- Work on actionable subtasks (`todo`, `in_progress`, or `backlog` status) in priority order (critical → high → medium → low).
 - For each subtask you complete, checkout that subtask, do the work, and mark it `done` with a comment.
 - If you can only complete some subtasks in this heartbeat, mark those done and leave the parent as `in_progress`.
 - Do NOT mark the parent as `done` while any subtasks are still open (`todo`, `in_progress`, `in_review`, `backlog`, `blocked`).

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -1,5 +1,3 @@
-<!-- PAPERCLIP_API_URL: https://paperclip.lasse.dev -->
-
 ---
 name: paperclip
 description: >
@@ -77,7 +75,7 @@ If subtasks exist, they define the work breakdown. You MUST work through subtask
 - Work on actionable subtasks (`todo` or `backlog` status) in priority order (critical → high → medium → low).
 - For each subtask you complete, checkout that subtask, do the work, and mark it `done` with a comment.
 - If you can only complete some subtasks in this heartbeat, mark those done and leave the parent as `in_progress`.
-- Do NOT mark the parent as `done` while any subtasks are still open (`todo`, `in_progress`, `backlog`, `blocked`).
+- Do NOT mark the parent as `done` while any subtasks are still open (`todo`, `in_progress`, `in_review`, `backlog`, `blocked`).
 - Only mark the parent `done` when all subtasks are `done` (or `cancelled`).
 
 If the issue has NO subtasks, proceed normally with Step 7.
@@ -99,7 +97,7 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`.
 
-**Subtask completion rule:** When marking a parent issue done, first verify all subtasks are done: `GET /api/companies/{companyId}/issues?parentId={issueId}&status=todo,in_progress,backlog,blocked`. If any are returned, do NOT mark the parent done — leave it `in_progress` and comment which subtasks remain.
+**Subtask completion rule:** When marking a parent issue done, first verify all subtasks are done: `GET /api/companies/{companyId}/issues?parentId={issueId}&status=todo,in_progress,in_review,backlog,blocked`. If any are returned, do NOT mark the parent done — leave it `in_progress` and comment which subtasks remain.
 
 **Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. Set `billingCode` for cross-team work.
 
@@ -144,7 +142,7 @@ Access control:
 
 - **Always checkout** before working. Never PATCH to `in_progress` manually.
 - **Never retry a 409.** The task belongs to someone else.
-- **Never look for unassigned work.**
+- **Never look for unassigned work.** Exception: unassigned subtasks of a parent issue you have checked out may be claimed (see Step 6b).
 - **Self-assign only for explicit @-mention handoff.** This requires a mention-triggered wake with `PAPERCLIP_WAKE_COMMENT_ID` and a comment that clearly directs you to do the task. Use checkout (never direct assignee patch). Otherwise, no assignments = exit.
 - **Honor "send it back to me" requests from board users.** If a board/user asks for review handoff (e.g. "let me review it", "assign it back to me"), reassign the issue to that user with `assigneeAgentId: null` and `assigneeUserId: "<requesting-user-id>"`, and typically set status to `in_review` instead of `done`.
   Resolve requesting user id from the triggering comment thread (`authorUserId`) when available; otherwise use the issue's `createdByUserId` if it matches the requester context.
@@ -255,7 +253,7 @@ PATCH /api/agents/{agentId}/instructions-path
 | Update task          | `PATCH /api/issues/:issueId` (optional `comment` field)                                    |
 | Add comment          | `POST /api/issues/:issueId/comments`                                                       |
 | List subtasks        | `GET /api/companies/:companyId/issues?parentId=:issueId`                                   |
-| List open subtasks   | `GET /api/companies/:companyId/issues?parentId=:issueId&status=todo,in_progress,backlog,blocked` |
+| List open subtasks   | `GET /api/companies/:companyId/issues?parentId=:issueId&status=todo,in_progress,in_review,backlog,blocked` |
 | Create subtask       | `POST /api/companies/:companyId/issues`                                                    |
 | Generate OpenClaw invite prompt (CEO) | `POST /api/companies/:companyId/openclaw/invite-prompt`                   |
 | Create project       | `POST /api/companies/:companyId/projects`                                                  |

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -1,3 +1,5 @@
+<!-- PAPERCLIP_API_URL: https://paperclip.lasse.dev -->
+
 ---
 name: paperclip
 description: >
@@ -59,7 +61,28 @@ If already checked out by you, returns normally. If owned by another agent: `409
 **Step 6 — Understand context.** `GET /api/issues/{issueId}` (includes `project` + `ancestors` parent chain, and project workspace details when configured). `GET /api/issues/{issueId}/comments`. Read ancestors to understand _why_ this task exists.
 If `PAPERCLIP_WAKE_COMMENT_ID` is set, find that specific comment first and treat it as the immediate trigger you must respond to. Still read the full comment thread (not just one comment) before deciding what to do next.
 
-**Step 7 — Do the work.** Use your tools and capabilities.
+**Step 6b — Check for subtasks.** After reading the issue, check if it has subtasks:
+
+```
+GET /api/companies/{companyId}/issues?parentId={issueId}
+```
+
+If subtasks exist, they define the work breakdown. You MUST work through subtasks individually rather than doing all the work on the parent:
+
+- **Triage subtasks by assignment:**
+  - **Assigned to another agent** → skip it. That agent owns it and will handle it in their own heartbeat.
+  - **Assigned to you** → work on it (checkout, execute, mark done).
+  - **Unassigned** (`assigneeAgentId` is null) → you may pick it up. Checkout the subtask to claim it, then work on it.
+- **Delegate to specialists when available:** If a subtask requires skills outside your role (e.g., design, frontend, security) and a specialist agent exists in the company, assign the subtask to them (`PATCH` with `assigneeAgentId`) and add a comment explaining the ask. Use `GET /api/companies/{companyId}/agents` to find available agents and match by role/capabilities. Do NOT delegate if you can reasonably do the work yourself.
+- Work on actionable subtasks (`todo` or `backlog` status) in priority order (critical → high → medium → low).
+- For each subtask you complete, checkout that subtask, do the work, and mark it `done` with a comment.
+- If you can only complete some subtasks in this heartbeat, mark those done and leave the parent as `in_progress`.
+- Do NOT mark the parent as `done` while any subtasks are still open (`todo`, `in_progress`, `backlog`, `blocked`).
+- Only mark the parent `done` when all subtasks are `done` (or `cancelled`).
+
+If the issue has NO subtasks, proceed normally with Step 7.
+
+**Step 7 — Do the work.** Use your tools and capabilities. When working on an issue with subtasks, focus on one subtask at a time — checkout, execute, mark done, then move to the next.
 
 **Step 8 — Update status and communicate.** Always include the run ID header.
 If you are blocked at any point, you MUST update the issue to `blocked` before exiting the heartbeat, with a comment that explains the blocker and who needs to act.
@@ -75,6 +98,8 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 ```
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`.
+
+**Subtask completion rule:** When marking a parent issue done, first verify all subtasks are done: `GET /api/companies/{companyId}/issues?parentId={issueId}&status=todo,in_progress,backlog,blocked`. If any are returned, do NOT mark the parent done — leave it `in_progress` and comment which subtasks remain.
 
 **Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. Set `billingCode` for cross-team work.
 
@@ -229,6 +254,8 @@ PATCH /api/agents/{agentId}/instructions-path
 | Get specific comment | `GET /api/issues/:issueId/comments/:commentId`                                              |
 | Update task          | `PATCH /api/issues/:issueId` (optional `comment` field)                                    |
 | Add comment          | `POST /api/issues/:issueId/comments`                                                       |
+| List subtasks        | `GET /api/companies/:companyId/issues?parentId=:issueId`                                   |
+| List open subtasks   | `GET /api/companies/:companyId/issues?parentId=:issueId&status=todo,in_progress,backlog,blocked` |
 | Create subtask       | `POST /api/companies/:companyId/issues`                                                    |
 | Generate OpenClaw invite prompt (CEO) | `POST /api/companies/:companyId/openclaw/invite-prompt`                   |
 | Create project       | `POST /api/companies/:companyId/projects`                                                  |

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -22,6 +22,84 @@ import { CircleDot, Plus, Filter, ArrowUpDown, Layers, Check, X, ChevronRight, L
 import { KanbanBoard } from "./KanbanBoard";
 import type { Issue } from "@paperclipai/shared";
 
+/* ── Subtask count helpers ── */
+
+export interface SubtaskCounts {
+  total: number;
+  done: number;
+}
+
+export function buildSubtaskCountMap(issues: Issue[]): Map<string, SubtaskCounts> {
+  const map = new Map<string, SubtaskCounts>();
+  for (const issue of issues) {
+    if (!issue.parentId) continue;
+    const existing = map.get(issue.parentId) ?? { total: 0, done: 0 };
+    existing.total += 1;
+    if (issue.status === "done" || issue.status === "cancelled") {
+      existing.done += 1;
+    }
+    map.set(issue.parentId, existing);
+  }
+  return map;
+}
+
+export function SubtaskBadge({ counts }: { counts: SubtaskCounts }) {
+  if (counts.total === 0) return null;
+  const allDone = counts.done === counts.total;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+        allDone
+          ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
+          : "border-border text-muted-foreground bg-muted/40"
+      }`}
+      title={`${counts.done} of ${counts.total} subtasks done`}
+    >
+      <span className="leading-none">⊞</span>
+      <span>{counts.done}/{counts.total}</span>
+    </span>
+  );
+}
+
+/* ── Inline subtask list (collapsed by default, shown under parent row) ── */
+
+export function SubtaskList({
+  subtasks,
+  highlightIds,
+}: {
+  subtasks: Issue[];
+  highlightIds?: Set<string>;
+}) {
+  if (subtasks.length === 0) return null;
+  return (
+    <div className="ml-6 border-l border-border pl-3 py-1 space-y-0.5">
+      {subtasks.map((sub) => (
+        <Link
+          key={sub.id}
+          to={`/issues/${sub.identifier ?? sub.id}`}
+          className={`flex items-center gap-2 py-1 pr-2 text-xs rounded hover:bg-accent/50 no-underline text-inherit transition-colors ${
+            highlightIds?.has(sub.id) ? "ring-1 ring-blue-500/50 bg-blue-500/5" : ""
+          }`}
+        >
+          <StatusIcon status={sub.status} />
+          <span
+            className={`flex-1 truncate ${
+              sub.status === "done" || sub.status === "cancelled"
+                ? "line-through text-muted-foreground"
+                : ""
+            }`}
+          >
+            {sub.title}
+          </span>
+          <span className="text-muted-foreground font-mono shrink-0">
+            {sub.identifier ?? sub.id.slice(0, 8)}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 /* ── Helpers ── */
 
 const statusOrder = ["in_progress", "todo", "backlog", "in_review", "blocked", "done", "cancelled"];
@@ -94,6 +172,58 @@ function applyFilters(issues: Issue[], state: IssueViewState): Issue[] {
   if (state.assignees.length > 0) result = result.filter((i) => i.assigneeAgentId != null && state.assignees.includes(i.assigneeAgentId));
   if (state.labels.length > 0) result = result.filter((i) => (i.labelIds ?? []).some((id) => state.labels.includes(id)));
   return result;
+}
+
+// Returns { rootIssues, subtaskMap } where rootIssues are parents/top-level and
+// subtaskMap groups subtasks by parentId. When filters are active, a parent is
+// included if it matches OR if any of its subtasks match (filter-through logic).
+function buildRootAndSubtaskMap(
+  allIssues: Issue[],
+  filteredIssues: Issue[],
+): { rootIssues: Issue[]; subtaskMap: Map<string, Issue[]> } {
+  const filteredIds = new Set(filteredIssues.map((i) => i.id));
+
+  // Build subtask map from ALL issues (unfiltered) so subtasks appear under parent
+  const subtaskMap = new Map<string, Issue[]>();
+  const subtaskIds = new Set<string>();
+
+  for (const issue of allIssues) {
+    if (issue.parentId) {
+      subtaskIds.add(issue.id);
+      const list = subtaskMap.get(issue.parentId) ?? [];
+      list.push(issue);
+      subtaskMap.set(issue.parentId, list);
+    }
+  }
+
+  // Root issues: filtered issues that are NOT subtasks themselves
+  // Plus: parents of filtered subtasks (filter-through: subtask matches, include parent)
+  const rootSet = new Set<Issue>();
+  const rootById = new Map<string, Issue>();
+  for (const issue of allIssues) {
+    if (!issue.parentId) rootById.set(issue.id, issue);
+  }
+
+  for (const issue of filteredIssues) {
+    if (!subtaskIds.has(issue.id)) {
+      // It's a root issue that matched filter
+      rootSet.add(issue);
+    } else if (issue.parentId) {
+      // It's a subtask that matched filter — include its parent if available
+      const parent = rootById.get(issue.parentId);
+      if (parent) rootSet.add(parent);
+    }
+  }
+
+  // If no filters applied (filteredIssues === allIssues for root), just use all roots
+  // We detect this by checking if filteredIds covers all non-subtask issues
+  const allRootIssues = [...rootById.values()];
+  const allRootsFiltered = allRootIssues.every((r) => filteredIds.has(r.id));
+  const rootIssues = allRootsFiltered
+    ? allRootIssues // no filtering needed
+    : [...rootSet]; // filtered with filter-through
+
+  return { rootIssues, subtaskMap };
 }
 
 function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
@@ -226,6 +356,31 @@ export function IssuesList({
     return sortIssues(filteredByControls, viewState);
   }, [issues, searchedIssues, viewState, normalizedIssueSearch]);
 
+  // Separate root issues from subtasks; apply filter-through for subtask matches.
+  const { rootIssues, subtaskMap } = useMemo(
+    () => buildRootAndSubtaskMap(issues, filtered),
+    [issues, filtered]
+  );
+
+  // Track which subtask IDs matched the filter (for highlighting when expanded).
+  const highlightedSubtaskIds = useMemo(() => {
+    const hasFilter =
+      viewState.statuses.length > 0 ||
+      viewState.priorities.length > 0 ||
+      viewState.assignees.length > 0 ||
+      viewState.labels.length > 0 ||
+      normalizedIssueSearch.length > 0;
+    if (!hasFilter) return new Set<string>();
+    const filteredIds = new Set(filtered.map((i) => i.id));
+    const result = new Set<string>();
+    for (const id of filteredIds) {
+      // If it's a subtask (has a parent in subtaskMap values), add to highlight set
+      const issue = issues.find((i) => i.id === id);
+      if (issue?.parentId) result.add(id);
+    }
+    return result;
+  }, [filtered, issues, viewState, normalizedIssueSearch]);
+
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(selectedCompanyId!),
     queryFn: () => issuesApi.listLabels(selectedCompanyId!),
@@ -234,30 +389,46 @@ export function IssuesList({
 
   const activeFilterCount = countActiveFilters(viewState);
 
+  // Build subtask count map from the full (unfiltered) issues list so parent tasks
+  // show counts even when children are filtered out.
+  const subtaskCountMap = useMemo(() => buildSubtaskCountMap(issues), [issues]);
+
+  // Collapse state per parent issue (for the subtask expand/collapse toggle)
+  const [expandedSubtasks, setExpandedSubtasks] = useState<Set<string>>(new Set());
+
+  const toggleSubtasks = useCallback((issueId: string) => {
+    setExpandedSubtasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(issueId)) next.delete(issueId);
+      else next.add(issueId);
+      return next;
+    });
+  }, []);
+
   const groupedContent = useMemo(() => {
     if (viewState.groupBy === "none") {
-      return [{ key: "__all", label: null as string | null, items: filtered }];
+      return [{ key: "__all", label: null as string | null, items: rootIssues }];
     }
     if (viewState.groupBy === "status") {
-      const groups = groupBy(filtered, (i) => i.status);
+      const groups = groupBy(rootIssues, (i) => i.status);
       return statusOrder
         .filter((s) => groups[s]?.length)
         .map((s) => ({ key: s, label: statusLabel(s), items: groups[s]! }));
     }
     if (viewState.groupBy === "priority") {
-      const groups = groupBy(filtered, (i) => i.priority);
+      const groups = groupBy(rootIssues, (i) => i.priority);
       return priorityOrder
         .filter((p) => groups[p]?.length)
         .map((p) => ({ key: p, label: statusLabel(p), items: groups[p]! }));
     }
     // assignee
-    const groups = groupBy(filtered, (i) => i.assigneeAgentId ?? "__unassigned");
+    const groups = groupBy(rootIssues, (i) => i.assigneeAgentId ?? "__unassigned");
     return Object.keys(groups).map((key) => ({
       key,
       label: key === "__unassigned" ? "Unassigned" : (agentName(key) ?? key.slice(0, 8)),
       items: groups[key]!,
     }));
-  }, [filtered, viewState.groupBy, agents]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rootIssues, viewState.groupBy, agents]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const newIssueDefaults = (groupKey?: string) => {
     const defaults: Record<string, string> = {};
@@ -539,7 +710,7 @@ export function IssuesList({
       {isLoading && <PageSkeleton variant="issues-list" />}
       {error && <p className="text-sm text-destructive">{error.message}</p>}
 
-      {!isLoading && filtered.length === 0 && viewState.viewMode === "list" && (
+      {!isLoading && rootIssues.length === 0 && viewState.viewMode === "list" && (
         <EmptyState
           icon={CircleDot}
           message="No issues match the current filters or search."
@@ -550,9 +721,12 @@ export function IssuesList({
 
       {viewState.viewMode === "board" ? (
         <KanbanBoard
-          issues={filtered}
+          issues={rootIssues}
+          allIssues={issues}
           agents={agents}
           liveIssueIds={liveIssueIds}
+          subtaskCountMap={subtaskCountMap}
+          subtaskMap={subtaskMap}
           onUpdateIssue={onUpdateIssue}
         />
       ) : (
@@ -587,11 +761,15 @@ export function IssuesList({
               </div>
             )}
             <CollapsibleContent>
-              {group.items.map((issue) => (
+              {group.items.map((issue) => {
+                const issueSubtasks = subtaskMap.get(issue.id) ?? [];
+                const hasSubtasks = issueSubtasks.length > 0;
+                const isExpanded = expandedSubtasks.has(issue.id);
+                return (
+                <div key={issue.id} className="border-b border-border last:border-b-0">
                 <Link
-                  key={issue.id}
                   to={`/issues/${issue.identifier ?? issue.id}`}
-                  className="flex items-start gap-2 py-2.5 pl-2 pr-3 text-sm border-b border-border last:border-b-0 cursor-pointer hover:bg-accent/50 transition-colors no-underline text-inherit sm:items-center sm:py-2 sm:pl-1"
+                  className="flex items-start gap-2 py-2.5 pl-2 pr-3 text-sm cursor-pointer hover:bg-accent/50 transition-colors no-underline text-inherit sm:items-center sm:py-2 sm:pl-1"
                 >
                   {/* Status icon - left column on mobile, inline on desktop */}
                   <span className="shrink-0 pt-px sm:hidden" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
@@ -622,6 +800,10 @@ export function IssuesList({
                       <span className="text-xs text-muted-foreground font-mono shrink-0">
                         {issue.identifier ?? issue.id.slice(0, 8)}
                       </span>
+                      {(() => {
+                        const counts = subtaskCountMap.get(issue.id);
+                        return counts ? <SubtaskBadge counts={counts} /> : null;
+                      })()}
                       {liveIssueIds?.has(issue.id) && (
                         <span className="inline-flex items-center gap-1 sm:gap-1.5 px-1.5 sm:px-2 py-0.5 rounded-full bg-blue-500/10">
                           <span className="relative flex h-2 w-2">
@@ -743,7 +925,26 @@ export function IssuesList({
                     </span>
                   </span>
                 </Link>
-              ))}
+                {hasSubtasks && (
+                  <div>
+                    <button
+                      className="flex items-center gap-1 px-3 py-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                      onClick={() => toggleSubtasks(issue.id)}
+                    >
+                      <span>{isExpanded ? "⬆️" : "⬇️"}</span>
+                      <span>Subtasks ({issueSubtasks.length})</span>
+                    </button>
+                    {isExpanded && (
+                      <SubtaskList
+                        subtasks={issueSubtasks}
+                        highlightIds={highlightedSubtaskIds}
+                      />
+                    )}
+                  </div>
+                )}
+                </div>
+                );
+              })}
             </CollapsibleContent>
           </Collapsible>
         ))

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -21,84 +21,8 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/component
 import { CircleDot, Plus, Filter, ArrowUpDown, Layers, Check, X, ChevronRight, List, Columns3, User, Search } from "lucide-react";
 import { KanbanBoard } from "./KanbanBoard";
 import type { Issue } from "@paperclipai/shared";
-
-/* ── Subtask count helpers ── */
-
-export interface SubtaskCounts {
-  total: number;
-  done: number;
-}
-
-export function buildSubtaskCountMap(issues: Issue[]): Map<string, SubtaskCounts> {
-  const map = new Map<string, SubtaskCounts>();
-  for (const issue of issues) {
-    if (!issue.parentId) continue;
-    const existing = map.get(issue.parentId) ?? { total: 0, done: 0 };
-    existing.total += 1;
-    if (issue.status === "done" || issue.status === "cancelled") {
-      existing.done += 1;
-    }
-    map.set(issue.parentId, existing);
-  }
-  return map;
-}
-
-export function SubtaskBadge({ counts }: { counts: SubtaskCounts }) {
-  if (counts.total === 0) return null;
-  const allDone = counts.done === counts.total;
-  return (
-    <span
-      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
-        allDone
-          ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
-          : "border-border text-muted-foreground bg-muted/40"
-      }`}
-      title={`${counts.done} of ${counts.total} subtasks done`}
-    >
-      <span className="leading-none">⊞</span>
-      <span>{counts.done}/{counts.total}</span>
-    </span>
-  );
-}
-
-/* ── Inline subtask list (collapsed by default, shown under parent row) ── */
-
-export function SubtaskList({
-  subtasks,
-  highlightIds,
-}: {
-  subtasks: Issue[];
-  highlightIds?: Set<string>;
-}) {
-  if (subtasks.length === 0) return null;
-  return (
-    <div className="ml-6 border-l border-border pl-3 py-1 space-y-0.5">
-      {subtasks.map((sub) => (
-        <Link
-          key={sub.id}
-          to={`/issues/${sub.identifier ?? sub.id}`}
-          className={`flex items-center gap-2 py-1 pr-2 text-xs rounded hover:bg-accent/50 no-underline text-inherit transition-colors ${
-            highlightIds?.has(sub.id) ? "ring-1 ring-blue-500/50 bg-blue-500/5" : ""
-          }`}
-        >
-          <StatusIcon status={sub.status} />
-          <span
-            className={`flex-1 truncate ${
-              sub.status === "done" || sub.status === "cancelled"
-                ? "line-through text-muted-foreground"
-                : ""
-            }`}
-          >
-            {sub.title}
-          </span>
-          <span className="text-muted-foreground font-mono shrink-0">
-            {sub.identifier ?? sub.id.slice(0, 8)}
-          </span>
-        </Link>
-      ))}
-    </div>
-  );
-}
+import { SubtaskBadge, SubtaskList, buildSubtaskCountMap } from "./subtask-utils";
+import type { SubtaskCounts } from "./subtask-utils";
 
 /* ── Helpers ── */
 
@@ -357,9 +281,12 @@ export function IssuesList({
   }, [issues, searchedIssues, viewState, normalizedIssueSearch]);
 
   // Separate root issues from subtasks; apply filter-through for subtask matches.
+  // Use the same source that produced `filtered` as allIssues, so that
+  // search results whose parents aren't yet in the local cache are handled correctly.
+  const sourceIssues = normalizedIssueSearch.length > 0 ? searchedIssues : issues;
   const { rootIssues, subtaskMap } = useMemo(
-    () => buildRootAndSubtaskMap(issues, filtered),
-    [issues, filtered]
+    () => buildRootAndSubtaskMap(sourceIssues, filtered),
+    [sourceIssues, filtered]
   );
 
   // Track which subtask IDs matched the filter (for highlighting when expanded).
@@ -371,15 +298,14 @@ export function IssuesList({
       viewState.labels.length > 0 ||
       normalizedIssueSearch.length > 0;
     if (!hasFilter) return new Set<string>();
-    const filteredIds = new Set(filtered.map((i) => i.id));
+    // Build O(1) lookup map to avoid O(n²) scan
+    const issueById = new Map(sourceIssues.map((i) => [i.id, i]));
     const result = new Set<string>();
-    for (const id of filteredIds) {
-      // If it's a subtask (has a parent in subtaskMap values), add to highlight set
-      const issue = issues.find((i) => i.id === id);
-      if (issue?.parentId) result.add(id);
+    for (const issue of filtered) {
+      if (issueById.get(issue.id)?.parentId) result.add(issue.id);
     }
     return result;
-  }, [filtered, issues, viewState, normalizedIssueSearch]);
+  }, [filtered, sourceIssues, viewState, normalizedIssueSearch]);
 
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(selectedCompanyId!),

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -928,11 +928,12 @@ export function IssuesList({
                 {hasSubtasks && (
                   <div>
                     <button
-                      className="flex items-center gap-1 px-3 py-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors w-full text-left rounded-b-sm"
                       onClick={() => toggleSubtasks(issue.id)}
                     >
-                      <span>{isExpanded ? "⬆️" : "⬇️"}</span>
-                      <span>Subtasks ({issueSubtasks.length})</span>
+                      <ChevronRight className={`h-3 w-3 shrink-0 transition-transform duration-150 ${isExpanded ? "rotate-90" : ""}`} />
+                      <span className="font-medium">{isExpanded ? "Hide subtasks" : `Show subtasks`}</span>
+                      <span className="text-muted-foreground/60">({issueSubtasks.length})</span>
                     </button>
                     {isExpanded && (
                       <SubtaskList

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { Link } from "@/lib/router";
 import {
   DndContext,
@@ -20,6 +20,7 @@ import {
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
+import { SubtaskBadge, SubtaskList, type SubtaskCounts } from "./IssuesList";
 import type { Issue } from "@paperclipai/shared";
 
 const boardStatuses = [
@@ -43,8 +44,11 @@ interface Agent {
 
 interface KanbanBoardProps {
   issues: Issue[];
+  allIssues?: Issue[];
   agents?: Agent[];
   liveIssueIds?: Set<string>;
+  subtaskCountMap?: Map<string, SubtaskCounts>;
+  subtaskMap?: Map<string, Issue[]>;
   onUpdateIssue: (id: string, data: Record<string, unknown>) => void;
 }
 
@@ -55,11 +59,19 @@ function KanbanColumn({
   issues,
   agents,
   liveIssueIds,
+  subtaskCountMap,
+  subtaskMap,
+  expandedSubtasks,
+  onToggleSubtasks,
 }: {
   status: string;
   issues: Issue[];
   agents?: Agent[];
   liveIssueIds?: Set<string>;
+  subtaskCountMap?: Map<string, SubtaskCounts>;
+  subtaskMap?: Map<string, Issue[]>;
+  expandedSubtasks: Set<string>;
+  onToggleSubtasks: (id: string) => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
 
@@ -90,6 +102,10 @@ function KanbanColumn({
               issue={issue}
               agents={agents}
               isLive={liveIssueIds?.has(issue.id)}
+              subtaskCounts={subtaskCountMap?.get(issue.id)}
+              subtasks={subtaskMap?.get(issue.id)}
+              isExpanded={expandedSubtasks.has(issue.id)}
+              onToggleSubtasks={onToggleSubtasks}
             />
           ))}
         </SortableContext>
@@ -105,11 +121,19 @@ function KanbanCard({
   agents,
   isLive,
   isOverlay,
+  subtaskCounts,
+  subtasks,
+  isExpanded,
+  onToggleSubtasks,
 }: {
   issue: Issue;
   agents?: Agent[];
   isLive?: boolean;
   isOverlay?: boolean;
+  subtaskCounts?: SubtaskCounts;
+  subtasks?: Issue[];
+  isExpanded?: boolean;
+  onToggleSubtasks?: (id: string) => void;
 }) {
   const {
     attributes,
@@ -160,7 +184,7 @@ function KanbanCard({
           )}
         </div>
         <p className="text-sm leading-snug line-clamp-2 mb-2">{issue.title}</p>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <PriorityIcon priority={issue.priority} />
           {issue.assigneeAgentId && (() => {
             const name = agentName(issue.assigneeAgentId);
@@ -172,8 +196,28 @@ function KanbanCard({
               </span>
             );
           })()}
+          {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
         </div>
       </Link>
+      {subtasks && subtasks.length > 0 && onToggleSubtasks && (
+        <div>
+          <button
+            className="flex items-center gap-1 px-2 pt-1.5 pb-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSubtasks(issue.id);
+            }}
+          >
+            <span>{isExpanded ? "⬆️" : "⬇️"}</span>
+            <span>Subtasks ({subtasks.length})</span>
+          </button>
+          {isExpanded && (
+            <div className="px-1 pb-1.5">
+              <SubtaskList subtasks={subtasks} />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -184,9 +228,21 @@ export function KanbanBoard({
   issues,
   agents,
   liveIssueIds,
+  subtaskCountMap,
+  subtaskMap,
   onUpdateIssue,
 }: KanbanBoardProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [expandedSubtasks, setExpandedSubtasks] = useState<Set<string>>(new Set());
+
+  const toggleSubtasks = useCallback((id: string) => {
+    setExpandedSubtasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -261,6 +317,10 @@ export function KanbanBoard({
             issues={columnIssues[status] ?? []}
             agents={agents}
             liveIssueIds={liveIssueIds}
+            subtaskCountMap={subtaskCountMap}
+            subtaskMap={subtaskMap}
+            expandedSubtasks={expandedSubtasks}
+            onToggleSubtasks={toggleSubtasks}
           />
         ))}
       </div>

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -17,6 +17,7 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import { ChevronRight } from "lucide-react";
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
@@ -202,14 +203,15 @@ function KanbanCard({
       {subtasks && subtasks.length > 0 && onToggleSubtasks && (
         <div>
           <button
-            className="flex items-center gap-1 px-2 pt-1.5 pb-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+            className="flex items-center gap-1.5 px-2 pt-2 pb-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left border-t border-border/50 mt-1"
             onClick={(e) => {
               e.stopPropagation();
               onToggleSubtasks(issue.id);
             }}
           >
-            <span>{isExpanded ? "⬆️" : "⬇️"}</span>
-            <span>Subtasks ({subtasks.length})</span>
+            <ChevronRight className={`h-3 w-3 shrink-0 transition-transform duration-150 ${isExpanded ? "rotate-90" : ""}`} />
+            <span className="font-medium">{isExpanded ? "Hide subtasks" : "Show subtasks"}</span>
+            <span className="text-muted-foreground/60">({subtasks.length})</span>
           </button>
           {isExpanded && (
             <div className="px-1 pb-1.5">

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -21,7 +21,8 @@ import { ChevronRight } from "lucide-react";
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
-import { SubtaskBadge, SubtaskList, type SubtaskCounts } from "./IssuesList";
+import { SubtaskBadge, SubtaskList } from "./subtask-utils";
+import type { SubtaskCounts } from "./subtask-utils";
 import type { Issue } from "@paperclipai/shared";
 
 const boardStatuses = [

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -181,6 +181,8 @@ export function NewIssueDialog() {
   const [assigneeThinkingEffort, setAssigneeThinkingEffort] = useState("");
   const [assigneeChrome, setAssigneeChrome] = useState(false);
   const [assigneeUseProjectWorkspace, setAssigneeUseProjectWorkspace] = useState(true);
+  const [parentId, setParentId] = useState("");
+  const [goalId, setGoalId] = useState("");
   const [expanded, setExpanded] = useState(false);
   const [dialogCompanyId, setDialogCompanyId] = useState<string | null>(null);
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -323,6 +325,9 @@ export function NewIssueDialog() {
     setDialogCompanyId(selectedCompanyId);
 
     const draft = loadDraft();
+    // parentId/goalId are ephemeral — never restored from draft
+    setParentId(newIssueDefaults.parentId ?? "");
+    setGoalId(newIssueDefaults.goalId ?? "");
     if (newIssueDefaults.title) {
       setTitle(newIssueDefaults.title);
       setDescription(newIssueDefaults.description ?? "");
@@ -334,7 +339,7 @@ export function NewIssueDialog() {
       setAssigneeThinkingEffort("");
       setAssigneeChrome(false);
       setAssigneeUseProjectWorkspace(true);
-    } else if (draft && draft.title.trim()) {
+    } else if (draft && draft.title.trim() && !newIssueDefaults.parentId) {
       setTitle(draft.title);
       setDescription(draft.description);
       setStatus(draft.status || "todo");
@@ -346,6 +351,8 @@ export function NewIssueDialog() {
       setAssigneeChrome(draft.assigneeChrome ?? false);
       setAssigneeUseProjectWorkspace(draft.assigneeUseProjectWorkspace ?? true);
     } else {
+      setTitle("");
+      setDescription("");
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
       setProjectId(newIssueDefaults.projectId ?? "");
@@ -392,6 +399,8 @@ export function NewIssueDialog() {
     setPriority("");
     setAssigneeId("");
     setProjectId("");
+    setParentId("");
+    setGoalId("");
     setAssigneeOptionsOpen(false);
     setAssigneeModelOverride("");
     setAssigneeThinkingEffort("");
@@ -436,6 +445,8 @@ export function NewIssueDialog() {
       priority: priority || "medium",
       ...(assigneeId ? { assigneeAgentId: assigneeId } : {}),
       ...(projectId ? { projectId } : {}),
+      ...(parentId ? { parentId } : {}),
+      ...(goalId ? { goalId } : {}),
       ...(assigneeAdapterOverrides ? { assigneeAdapterOverrides } : {}),
     });
   }
@@ -609,7 +620,7 @@ export function NewIssueDialog() {
               </PopoverContent>
             </Popover>
             <span className="text-muted-foreground/60">&rsaquo;</span>
-            <span>New issue</span>
+            <span>{parentId ? "New sub-issue" : "New issue"}</span>
           </div>
           <div className="flex items-center gap-1">
             <Button
@@ -672,7 +683,11 @@ export function NewIssueDialog() {
                 emptyMessage="No assignees found."
                 onChange={(id) => { if (id) trackRecentAssignee(id); setAssigneeId(id); }}
                 onConfirm={() => {
-                  projectSelectorRef.current?.focus();
+                  if (parentId) {
+                    descriptionEditorRef.current?.focus();
+                  } else {
+                    projectSelectorRef.current?.focus();
+                  }
                 }}
                 renderTriggerValue={(option) =>
                   option && currentAssignee ? (
@@ -695,47 +710,51 @@ export function NewIssueDialog() {
                   );
                 }}
               />
-              <span>in</span>
-              <InlineEntitySelector
-                ref={projectSelectorRef}
-                value={projectId}
-                options={projectOptions}
-                placeholder="Project"
-                disablePortal
-                noneLabel="No project"
-                searchPlaceholder="Search projects..."
-                emptyMessage="No projects found."
-                onChange={setProjectId}
-                onConfirm={() => {
-                  descriptionEditorRef.current?.focus();
-                }}
-                renderTriggerValue={(option) =>
-                  option && currentProject ? (
-                    <>
-                      <span
-                        className="h-3.5 w-3.5 shrink-0 rounded-sm"
-                        style={{ backgroundColor: currentProject.color ?? "#6366f1" }}
-                      />
-                      <span className="truncate">{option.label}</span>
-                    </>
-                  ) : (
-                    <span className="text-muted-foreground">Project</span>
-                  )
-                }
-                renderOption={(option) => {
-                  if (!option.id) return <span className="truncate">{option.label}</span>;
-                  const project = orderedProjects.find((item) => item.id === option.id);
-                  return (
-                    <>
-                      <span
-                        className="h-3.5 w-3.5 shrink-0 rounded-sm"
-                        style={{ backgroundColor: project?.color ?? "#6366f1" }}
-                      />
-                      <span className="truncate">{option.label}</span>
-                    </>
-                  );
-                }}
-              />
+              {!parentId && (
+                <>
+                  <span>in</span>
+                  <InlineEntitySelector
+                    ref={projectSelectorRef}
+                    value={projectId}
+                    options={projectOptions}
+                    placeholder="Project"
+                    disablePortal
+                    noneLabel="No project"
+                    searchPlaceholder="Search projects..."
+                    emptyMessage="No projects found."
+                    onChange={setProjectId}
+                    onConfirm={() => {
+                      descriptionEditorRef.current?.focus();
+                    }}
+                    renderTriggerValue={(option) =>
+                      option && currentProject ? (
+                        <>
+                          <span
+                            className="h-3.5 w-3.5 shrink-0 rounded-sm"
+                            style={{ backgroundColor: currentProject.color ?? "#6366f1" }}
+                          />
+                          <span className="truncate">{option.label}</span>
+                        </>
+                      ) : (
+                        <span className="text-muted-foreground">Project</span>
+                      )
+                    }
+                    renderOption={(option) => {
+                      if (!option.id) return <span className="truncate">{option.label}</span>;
+                      const project = orderedProjects.find((item) => item.id === option.id);
+                      return (
+                        <>
+                          <span
+                            className="h-3.5 w-3.5 shrink-0 rounded-sm"
+                            style={{ backgroundColor: project?.color ?? "#6366f1" }}
+                          />
+                          <span className="truncate">{option.label}</span>
+                        </>
+                      );
+                    }}
+                  />
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/ui/src/components/subtask-utils.tsx
+++ b/ui/src/components/subtask-utils.tsx
@@ -1,0 +1,81 @@
+import { Link } from "@/lib/router";
+import { StatusIcon } from "./StatusIcon";
+import type { Issue } from "@paperclipai/shared";
+
+/* ── Subtask count helpers ── */
+
+export interface SubtaskCounts {
+  total: number;
+  done: number;
+}
+
+export function buildSubtaskCountMap(issues: Issue[]): Map<string, SubtaskCounts> {
+  const map = new Map<string, SubtaskCounts>();
+  for (const issue of issues) {
+    if (!issue.parentId) continue;
+    const existing = map.get(issue.parentId) ?? { total: 0, done: 0 };
+    existing.total += 1;
+    if (issue.status === "done" || issue.status === "cancelled") {
+      existing.done += 1;
+    }
+    map.set(issue.parentId, existing);
+  }
+  return map;
+}
+
+export function SubtaskBadge({ counts }: { counts: SubtaskCounts }) {
+  if (counts.total === 0) return null;
+  const allDone = counts.done === counts.total;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+        allDone
+          ? "border-green-500/40 text-green-600 dark:text-green-400 bg-green-500/10"
+          : "border-border text-muted-foreground bg-muted/40"
+      }`}
+      title={`${counts.done} of ${counts.total} subtasks done`}
+    >
+      <span className="leading-none">⊞</span>
+      <span>{counts.done}/{counts.total}</span>
+    </span>
+  );
+}
+
+/* ── Inline subtask list (collapsed by default, shown under parent row) ── */
+
+export function SubtaskList({
+  subtasks,
+  highlightIds,
+}: {
+  subtasks: Issue[];
+  highlightIds?: Set<string>;
+}) {
+  if (subtasks.length === 0) return null;
+  return (
+    <div className="ml-6 border-l border-border pl-3 py-1 space-y-0.5">
+      {subtasks.map((sub) => (
+        <Link
+          key={sub.id}
+          to={`/issues/${sub.identifier ?? sub.id}`}
+          className={`flex items-center gap-2 py-1 pr-2 text-xs rounded hover:bg-accent/50 no-underline text-inherit transition-colors ${
+            highlightIds?.has(sub.id) ? "ring-1 ring-blue-500/50 bg-blue-500/5" : ""
+          }`}
+        >
+          <StatusIcon status={sub.status} />
+          <span
+            className={`flex-1 truncate ${
+              sub.status === "done" || sub.status === "cancelled"
+                ? "line-through text-muted-foreground"
+                : ""
+            }`}
+          >
+            {sub.title}
+          </span>
+          <span className="text-muted-foreground font-mono shrink-0">
+            {sub.identifier ?? sub.id.slice(0, 8)}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/context/DialogContext.tsx
+++ b/ui/src/context/DialogContext.tsx
@@ -4,6 +4,8 @@ interface NewIssueDefaults {
   status?: string;
   priority?: string;
   projectId?: string;
+  goalId?: string;
+  parentId?: string;
   assigneeAgentId?: string;
   title?: string;
   description?: string;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -178,6 +178,14 @@
   background: oklch(0.5 0 0);
 }
 
+/* Completely hidden scrollbar (scrollable via touch/keyboard, no visible bar) */
+.scrollbar-none {
+  scrollbar-width: none; /* Firefox */
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Edge */
+}
+
 /* Auto-hide scrollbar: transparent by default, visible on container hover */
 .scrollbar-auto-hide::-webkit-scrollbar-thumb {
   background: transparent !important;

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -857,27 +857,29 @@ export function IssueDetail() {
                     </div>
                   </div>
                 )}
-                <div className="border border-border rounded-lg divide-y divide-border">
+                <div className="space-y-1.5">
                   {childIssues.map((child) => (
                     <Link
                       key={child.id}
                       to={`/issues/${child.identifier ?? child.id}`}
-                      className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
+                      className="block rounded-md border bg-card p-2.5 hover:shadow-sm transition-shadow no-underline text-inherit"
                     >
-                      <div className="flex items-center gap-2 min-w-0">
-                        <StatusIcon status={child.status} />
-                        <PriorityIcon priority={child.priority} />
-                        <span className="font-mono text-muted-foreground shrink-0">
+                      <div className="flex items-center gap-1.5 mb-1.5">
+                        <span className="text-xs text-muted-foreground font-mono shrink-0">
                           {child.identifier ?? child.id.slice(0, 8)}
                         </span>
-                        <span className="truncate">{child.title}</span>
                       </div>
-                      {child.assigneeAgentId && (() => {
-                        const name = agentMap.get(child.assigneeAgentId)?.name;
-                        return name
-                          ? <Identity name={name} size="sm" />
-                          : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
-                      })()}
+                      <p className="text-sm leading-snug line-clamp-2 mb-2">{child.title}</p>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <StatusIcon status={child.status} />
+                        <PriorityIcon priority={child.priority} />
+                        {child.assigneeAgentId && (() => {
+                          const name = agentMap.get(child.assigneeAgentId)?.name;
+                          return name
+                            ? <Identity name={name} size="xs" />
+                            : <span className="text-xs text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
+                        })()}
+                      </div>
                     </Link>
                   ))}
                 </div>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -154,6 +154,8 @@ export function IssueDetail() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
+  const [isDescriptionOverflowing, setIsDescriptionOverflowing] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement>(null);
   const [detailTab, setDetailTab] = useState("comments");
   const [secondaryOpen, setSecondaryOpen] = useState({
     approvals: false,
@@ -504,6 +506,17 @@ export function IssueDetail() {
     return () => closePanel();
   }, [issue]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Reset description expanded state when navigating between issues
+  useEffect(() => {
+    setIsDescriptionExpanded(false);
+  }, [issueId]);
+
+  // Detect whether description actually overflows the collapsed height
+  useEffect(() => {
+    const el = descriptionRef.current;
+    if (el) setIsDescriptionOverflowing(el.scrollHeight > el.clientHeight);
+  }, [issue?.description]);
+
   if (isLoading) return <p className="text-sm text-muted-foreground">Loading...</p>;
   if (error) return <p className="text-sm text-destructive">{error.message}</p>;
   if (!issue) return null;
@@ -665,13 +678,12 @@ export function IssueDetail() {
           className="text-xl font-bold"
         />
 
-        <div className="space-y-1">
+        <Collapsible open={isDescriptionExpanded} onOpenChange={setIsDescriptionExpanded}>
           <div
+            ref={descriptionRef}
             className={cn(
               "overflow-hidden transition-all duration-200",
-              isDescriptionExpanded
-                ? "max-h-screen overflow-y-auto"
-                : "max-h-32",
+              isDescriptionExpanded ? "max-h-screen overflow-y-auto" : "max-h-32",
             )}
           >
             <InlineEditor
@@ -688,12 +700,8 @@ export function IssueDetail() {
               }}
             />
           </div>
-          {(issue.description ?? "").length > 0 && (
-            <button
-              type="button"
-              onClick={() => setIsDescriptionExpanded((prev) => !prev)}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
+          {isDescriptionOverflowing && (
+            <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mt-1">
               <ChevronDown
                 className={cn(
                   "h-3.5 w-3.5 transition-transform duration-200",
@@ -701,9 +709,9 @@ export function IssueDetail() {
                 )}
               />
               {isDescriptionExpanded ? "Hide description" : "Show description"}
-            </button>
+            </CollapsibleTrigger>
           )}
-        </div>
+        </Collapsible>
       </div>
 
       <div className="space-y-3">
@@ -869,6 +877,23 @@ export function IssueDetail() {
                 </Link>
               ))}
             </div>
+            {!issue.parentId && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full text-muted-foreground"
+                onClick={() =>
+                  openNewIssue({
+                    parentId: issue.id,
+                    ...(issue.projectId ? { projectId: issue.projectId } : {}),
+                    ...(issue.goalId ? { goalId: issue.goalId } : {}),
+                  })
+                }
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Create sub-issue
+              </Button>
+            )}
             </div>
           )}
         </TabsContent>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -798,11 +798,13 @@ export function IssueDetail() {
               <MessageSquare className="h-3.5 w-3.5" />
               Comments
             </TabsTrigger>
-            <TabsTrigger value="subissues" className="gap-1.5 shrink-0">
-              <ListTree className="h-3.5 w-3.5" />
-              Sub-issues
-              {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
-            </TabsTrigger>
+            {!issue.parentId && (
+              <TabsTrigger value="subissues" className="gap-1.5 shrink-0">
+                <ListTree className="h-3.5 w-3.5" />
+                Sub-issues
+                {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
+              </TabsTrigger>
+            )}
             <TabsTrigger value="activity" className="gap-1.5 shrink-0">
               <ActivityIcon className="h-3.5 w-3.5" />
               Activity
@@ -839,7 +841,7 @@ export function IssueDetail() {
           />
         </TabsContent>
 
-        <TabsContent value="subissues">
+        {!issue.parentId && <TabsContent value="subissues">
           <div className="space-y-2">
             {childIssues.length === 0 ? (
               <p className="text-xs text-muted-foreground">No sub-issues.</p>
@@ -901,7 +903,7 @@ export function IssueDetail() {
               Create sub-issue
             </Button>
           </div>
-        </TabsContent>
+        </TabsContent>}
 
         <TabsContent value="activity">
           {!activity || activity.length === 0 ? (

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -789,7 +789,7 @@ export function IssueDetail() {
       <Separator />
 
       <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <div className="overflow-x-auto scrollbar-none pb-[5px] mb-[-5px]">
+        <div className="overflow-x-auto [overflow-y:clip] [overflow-clip-margin:6px] scrollbar-none">
           <TabsList variant="line" className="w-max min-w-full justify-start gap-1 flex-nowrap">
             <TabsTrigger value="comments" className="gap-1.5 shrink-0">
               <MessageSquare className="h-3.5 w-3.5" />

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -8,6 +8,7 @@ import { agentsApi } from "../api/agents";
 import { authApi } from "../api/auth";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
+import { useDialog } from "../context/DialogContext";
 import { usePanel } from "../context/PanelContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
@@ -41,6 +42,7 @@ import {
   MessageSquare,
   MoreHorizontal,
   Paperclip,
+  Plus,
   SlidersHorizontal,
   Trash2,
 } from "lucide-react";
@@ -149,6 +151,7 @@ export function IssueDetail() {
   const { selectedCompanyId } = useCompany();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { openNewIssue } = useDialog();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [moreOpen, setMoreOpen] = useState(false);
@@ -837,65 +840,65 @@ export function IssueDetail() {
         </TabsContent>
 
         <TabsContent value="subissues">
-          {childIssues.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No sub-issues.</p>
-          ) : (
-            <div className="space-y-2">
-            {subtaskCounts && (
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <SubtaskBadge counts={subtaskCounts} />
-                <span>{subtaskCounts.done} of {subtaskCounts.total} completed</span>
-                <div className="flex-1 h-1 rounded-full bg-muted overflow-hidden">
-                  <div
-                    className={`h-full rounded-full transition-all ${subtaskCounts.done === subtaskCounts.total ? "bg-green-500" : "bg-primary"}`}
-                    style={{ width: `${(subtaskCounts.done / subtaskCounts.total) * 100}%` }}
-                  />
-                </div>
-              </div>
-            )}
-            <div className="border border-border rounded-lg divide-y divide-border">
-              {childIssues.map((child) => (
-                <Link
-                  key={child.id}
-                  to={`/issues/${child.identifier ?? child.id}`}
-                  className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <StatusIcon status={child.status} />
-                    <PriorityIcon priority={child.priority} />
-                    <span className="font-mono text-muted-foreground shrink-0">
-                      {child.identifier ?? child.id.slice(0, 8)}
-                    </span>
-                    <span className="truncate">{child.title}</span>
+          <div className="space-y-2">
+            {childIssues.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No sub-issues.</p>
+            ) : (
+              <>
+                {subtaskCounts && (
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <SubtaskBadge counts={subtaskCounts} />
+                    <span>{subtaskCounts.done} of {subtaskCounts.total} completed</span>
+                    <div className="flex-1 h-1 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all ${subtaskCounts.done === subtaskCounts.total ? "bg-green-500" : "bg-primary"}`}
+                        style={{ width: `${(subtaskCounts.done / subtaskCounts.total) * 100}%` }}
+                      />
+                    </div>
                   </div>
-                  {child.assigneeAgentId && (() => {
-                    const name = agentMap.get(child.assigneeAgentId)?.name;
-                    return name
-                      ? <Identity name={name} size="sm" />
-                      : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
-                  })()}
-                </Link>
-              ))}
-            </div>
-            {!issue.parentId && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="w-full text-muted-foreground"
-                onClick={() =>
-                  openNewIssue({
-                    parentId: issue.id,
-                    ...(issue.projectId ? { projectId: issue.projectId } : {}),
-                    ...(issue.goalId ? { goalId: issue.goalId } : {}),
-                  })
-                }
-              >
-                <Plus className="h-3.5 w-3.5 mr-1.5" />
-                Create sub-issue
-              </Button>
+                )}
+                <div className="border border-border rounded-lg divide-y divide-border">
+                  {childIssues.map((child) => (
+                    <Link
+                      key={child.id}
+                      to={`/issues/${child.identifier ?? child.id}`}
+                      className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <StatusIcon status={child.status} />
+                        <PriorityIcon priority={child.priority} />
+                        <span className="font-mono text-muted-foreground shrink-0">
+                          {child.identifier ?? child.id.slice(0, 8)}
+                        </span>
+                        <span className="truncate">{child.title}</span>
+                      </div>
+                      {child.assigneeAgentId && (() => {
+                        const name = agentMap.get(child.assigneeAgentId)?.name;
+                        return name
+                          ? <Identity name={name} size="sm" />
+                          : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
+                      })()}
+                    </Link>
+                  ))}
+                </div>
+              </>
             )}
-            </div>
-          )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full text-muted-foreground"
+              onClick={() =>
+                openNewIssue({
+                  parentId: issue.id,
+                  ...(issue.projectId ? { projectId: issue.projectId } : {}),
+                  ...(issue.goalId ? { goalId: issue.goalId } : {}),
+                })
+              }
+            >
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              Create sub-issue
+            </Button>
+          </div>
         </TabsContent>
 
         <TabsContent value="activity">

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -16,7 +16,7 @@ import { relativeTime, cn, formatTokens } from "../lib/utils";
 import { InlineEditor } from "../components/InlineEditor";
 import { CommentThread } from "../components/CommentThread";
 import { IssueProperties } from "../components/IssueProperties";
-import { buildSubtaskCountMap, SubtaskBadge } from "../components/IssuesList";
+import { buildSubtaskCountMap, SubtaskBadge } from "../components/subtask-utils";
 import { LiveRunWidget } from "../components/LiveRunWidget";
 import type { MentionOption } from "../components/MarkdownEditor";
 import { ScrollToBottom } from "../components/ScrollToBottom";

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -16,6 +16,7 @@ import { relativeTime, cn, formatTokens } from "../lib/utils";
 import { InlineEditor } from "../components/InlineEditor";
 import { CommentThread } from "../components/CommentThread";
 import { IssueProperties } from "../components/IssueProperties";
+import { buildSubtaskCountMap, SubtaskBadge } from "../components/IssuesList";
 import { LiveRunWidget } from "../components/LiveRunWidget";
 import type { MentionOption } from "../components/MarkdownEditor";
 import { ScrollToBottom } from "../components/ScrollToBottom";
@@ -152,6 +153,7 @@ export function IssueDetail() {
   const navigate = useNavigate();
   const [moreOpen, setMoreOpen] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [detailTab, setDetailTab] = useState("comments");
   const [secondaryOpen, setSecondaryOpen] = useState({
     approvals: false,
@@ -288,6 +290,12 @@ export function IssueDetail() {
       .filter((i) => i.parentId === issue.id)
       .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
   }, [allIssues, issue]);
+
+  const subtaskCounts = useMemo(() => {
+    if (!issue || childIssues.length === 0) return null;
+    const map = buildSubtaskCountMap(childIssues.map((c) => ({ ...c, parentId: issue.id })));
+    return map.get(issue.id) ?? null;
+  }, [childIssues, issue]);
 
   const commentReassignOptions = useMemo(() => {
     const options: Array<{ id: string; label: string; searchText?: string }> = [];
@@ -657,19 +665,45 @@ export function IssueDetail() {
           className="text-xl font-bold"
         />
 
-        <InlineEditor
-          value={issue.description ?? ""}
-          onSave={(description) => updateIssue.mutate({ description })}
-          as="p"
-          className="text-sm text-muted-foreground"
-          placeholder="Add a description..."
-          multiline
-          mentions={mentionOptions}
-          imageUploadHandler={async (file) => {
-            const attachment = await uploadAttachment.mutateAsync(file);
-            return attachment.contentPath;
-          }}
-        />
+        <div className="space-y-1">
+          <div
+            className={cn(
+              "overflow-hidden transition-all duration-200",
+              isDescriptionExpanded
+                ? "max-h-screen overflow-y-auto"
+                : "max-h-32",
+            )}
+          >
+            <InlineEditor
+              value={issue.description ?? ""}
+              onSave={(description) => updateIssue.mutate({ description })}
+              as="p"
+              className="text-sm text-muted-foreground"
+              placeholder="Add a description..."
+              multiline
+              mentions={mentionOptions}
+              imageUploadHandler={async (file) => {
+                const attachment = await uploadAttachment.mutateAsync(file);
+                return attachment.contentPath;
+              }}
+            />
+          </div>
+          {(issue.description ?? "").length > 0 && (
+            <button
+              type="button"
+              onClick={() => setIsDescriptionExpanded((prev) => !prev)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ChevronDown
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  isDescriptionExpanded && "rotate-180",
+                )}
+              />
+              {isDescriptionExpanded ? "Hide description" : "Show description"}
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="space-y-3">
@@ -755,6 +789,7 @@ export function IssueDetail() {
           <TabsTrigger value="subissues" className="gap-1.5">
             <ListTree className="h-3.5 w-3.5" />
             Sub-issues
+            {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
           </TabsTrigger>
           <TabsTrigger value="activity" className="gap-1.5">
             <ActivityIcon className="h-3.5 w-3.5" />
@@ -795,6 +830,19 @@ export function IssueDetail() {
           {childIssues.length === 0 ? (
             <p className="text-xs text-muted-foreground">No sub-issues.</p>
           ) : (
+            <div className="space-y-2">
+            {subtaskCounts && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <SubtaskBadge counts={subtaskCounts} />
+                <span>{subtaskCounts.done} of {subtaskCounts.total} completed</span>
+                <div className="flex-1 h-1 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all ${subtaskCounts.done === subtaskCounts.total ? "bg-green-500" : "bg-primary"}`}
+                    style={{ width: `${(subtaskCounts.done / subtaskCounts.total) * 100}%` }}
+                  />
+                </div>
+              </div>
+            )}
             <div className="border border-border rounded-lg divide-y divide-border">
               {childIssues.map((child) => (
                 <Link
@@ -818,6 +866,7 @@ export function IssueDetail() {
                   })()}
                 </Link>
               ))}
+            </div>
             </div>
           )}
         </TabsContent>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -789,7 +789,7 @@ export function IssueDetail() {
       <Separator />
 
       <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <div className="overflow-x-auto scrollbar-none">
+        <div className="overflow-x-auto scrollbar-none pb-[5px] mb-[-5px]">
           <TabsList variant="line" className="w-max min-w-full justify-start gap-1 flex-nowrap">
             <TabsTrigger value="comments" className="gap-1.5 shrink-0">
               <MessageSquare className="h-3.5 w-3.5" />

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -781,21 +781,23 @@ export function IssueDetail() {
       <Separator />
 
       <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <TabsList variant="line" className="w-full justify-start gap-1">
-          <TabsTrigger value="comments" className="gap-1.5">
-            <MessageSquare className="h-3.5 w-3.5" />
-            Comments
-          </TabsTrigger>
-          <TabsTrigger value="subissues" className="gap-1.5">
-            <ListTree className="h-3.5 w-3.5" />
-            Sub-issues
-            {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
-          </TabsTrigger>
-          <TabsTrigger value="activity" className="gap-1.5">
-            <ActivityIcon className="h-3.5 w-3.5" />
-            Activity
-          </TabsTrigger>
-        </TabsList>
+        <div className="overflow-x-auto scrollbar-none">
+          <TabsList variant="line" className="w-max min-w-full justify-start gap-1 flex-nowrap">
+            <TabsTrigger value="comments" className="gap-1.5 shrink-0">
+              <MessageSquare className="h-3.5 w-3.5" />
+              Comments
+            </TabsTrigger>
+            <TabsTrigger value="subissues" className="gap-1.5 shrink-0">
+              <ListTree className="h-3.5 w-3.5" />
+              Sub-issues
+              {subtaskCounts && <SubtaskBadge counts={subtaskCounts} />}
+            </TabsTrigger>
+            <TabsTrigger value="activity" className="gap-1.5 shrink-0">
+              <ActivityIcon className="h-3.5 w-3.5" />
+              Activity
+            </TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="comments">
           <CommentThread


### PR DESCRIPTION
## Summary

- Add **Create sub-issue** button to the Sub-issues tab in `IssueDetail`
- Opens `NewIssueDialog` with `parentId`, `projectId`, and `goalId` pre-filled from parent
- Dialog shows **"New sub-issue"** header when `parentId` is set; draft restore is skipped
- Replace slim `divide-y` row list with kanban-style cards for sub-issues
  - Each card: `rounded-md border bg-card p-2.5` (matches KanbanCard)
  - Title: `text-sm leading-snug line-clamp-2` in its own row
  - Footer row: `StatusIcon` + `PriorityIcon` + `Identity size="xs"`
- Hide Sub-issues tab when viewing a sub-issue (`!issue.parentId`)
- Show count badge on Sub-issues tab trigger

Ref: [LAS-140](/LAS/issues/LAS-140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)