### PR TITLE
feat: subscription pool for Claude Max accounts

### DIFF
--- a/scripts/setup-subscription-slot.sh
+++ b/scripts/setup-subscription-slot.sh
@@ -15,6 +15,11 @@ if [ -z "$SLOT_NAME" ]; then
   exit 1
 fi
 
+if [[ "$SLOT_NAME" == *"/"* || "$SLOT_NAME" == *".."* ]]; then
+  echo "Error: slot name must not contain '/' or '..'"
+  exit 1
+fi
+
 SLOT_DIR="$HOME/.paperclip/subscription-slots/$SLOT_NAME"
 
 if [ -f "$SLOT_DIR/.credentials.json" ]; then

--- a/scripts/setup-subscription-slot.sh
+++ b/scripts/setup-subscription-slot.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Setup a Claude Max subscription slot for Paperclip agent pool.
+# Usage: ./setup-subscription-slot.sh <slot-name>
+#
+# Creates a credential directory and launches Claude login for that slot.
+# Claude CLI resolves: $CLAUDE_CONFIG_DIR/.credentials.json
+# After setup, assign to agents via runtimeConfig.subscriptionConfigDir.
+
+set -euo pipefail
+
+SLOT_NAME="${1:-}"
+if [ -z "$SLOT_NAME" ]; then
+  echo "Usage: $0 <slot-name>"
+  echo "Example: $0 slot-1"
+  exit 1
+fi
+
+SLOT_DIR="$HOME/.paperclip/subscription-slots/$SLOT_NAME"
+
+if [ -f "$SLOT_DIR/.credentials.json" ]; then
+  echo "Slot '$SLOT_NAME' already exists. Re-authenticating will invalidate the previous session."
+  read -rp "Continue? [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+mkdir -p "$SLOT_DIR"
+chmod 700 "$SLOT_DIR"
+
+echo "=== Setting up subscription slot: $SLOT_NAME ==="
+echo "Config dir: $SLOT_DIR"
+echo ""
+echo "Logging in..."
+CLAUDE_CONFIG_DIR="$SLOT_DIR" claude auth login
+
+echo ""
+echo "Verifying..."
+CLAUDE_CONFIG_DIR="$SLOT_DIR" claude auth status
+
+echo ""
+echo "Done. Assign to agents with:"
+echo "  PATCH /agents/:id"
+echo "  runtimeConfig.subscriptionConfigDir: \"$SLOT_DIR\""

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -1446,10 +1446,12 @@ export function heartbeatService(db: Db) {
             throw new Error("resolved path escapes allowed prefix");
           }
           return canonicalResolved;
-        } catch {
-          logger.warn(
-            { agentId: agent.id, subscriptionConfigDir: resolved },
-            "subscriptionConfigDir does not exist or is not a valid directory; ignoring",
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          const level = code === "ENOENT" || code === "ENOTDIR" ? "warn" : "error";
+          logger[level](
+            { agentId: agent.id, subscriptionConfigDir: resolved, err },
+            "subscriptionConfigDir validation failed; ignoring",
           );
           return null;
         }
@@ -1467,11 +1469,11 @@ export function heartbeatService(db: Db) {
           const strategy = typeof rc.subscriptionStrategy === "string" ? rc.subscriptionStrategy : "round-robin";
 
           if (slotNames.length > 0) {
-            // Single query: get last run's slot and status for rotation decisions
+            // Get previous run's slot and status (exclude current run which has null usageJson)
             const [lastRun] = await db
               .select({ status: heartbeatRuns.status, usageJson: heartbeatRuns.usageJson })
               .from(heartbeatRuns)
-              .where(eq(heartbeatRuns.agentId, agent.id))
+              .where(and(eq(heartbeatRuns.agentId, agent.id), ne(heartbeatRuns.id, run.id)))
               .orderBy(desc(heartbeatRuns.createdAt))
               .limit(1);
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
@@ -1412,11 +1413,112 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+      // Subscription pool: inject CLAUDE_CONFIG_DIR so the agent process uses
+      // credentials from a specific subscription slot directory.
+      // Claude CLI resolves its config dir as: $CLAUDE_CONFIG_DIR ?? ~/.claude
+      // Credentials live at $CLAUDE_CONFIG_DIR/.credentials.json
+      // Data flow: resolvedConfig.env → adapter.execute(config) → claude-local
+      // execute.ts merges config.env into the spawned process environment.
+      //
+      // Supports two modes:
+      //   1. subscriptionConfigDir (string) — fixed slot assignment
+      //   2. subscriptionSlots (string[]) + subscriptionStrategy — pool rotation
+      //      Strategies: "round-robin" (default) alternates each run,
+      //                  "failover" uses first slot until a run fails then advances.
+      const SUBSCRIPTION_SLOTS_ROOT = path.resolve(os.homedir(), ".paperclip/subscription-slots");
+
+      async function validateSlotDir(slotPath: string): Promise<string | null> {
+        const resolved = path.resolve(slotPath);
+        if (!resolved.startsWith(SUBSCRIPTION_SLOTS_ROOT + path.sep)) {
+          logger.warn(
+            { agentId: agent.id, subscriptionConfigDir: resolved },
+            "subscriptionConfigDir outside allowed prefix; ignoring",
+          );
+          return null;
+        }
+        try {
+          const stat = await fs.lstat(resolved);
+          if (stat.isSymbolicLink()) throw new Error("symlink not allowed");
+          if (!stat.isDirectory()) throw new Error("not a directory");
+          const canonicalRoot = await fs.realpath(SUBSCRIPTION_SLOTS_ROOT);
+          const canonicalResolved = await fs.realpath(resolved);
+          if (!canonicalResolved.startsWith(canonicalRoot + path.sep)) {
+            throw new Error("resolved path escapes allowed prefix");
+          }
+          return canonicalResolved;
+        } catch {
+          logger.warn(
+            { agentId: agent.id, subscriptionConfigDir: resolved },
+            "subscriptionConfigDir does not exist or is not a valid directory; ignoring",
+          );
+          return null;
+        }
+      }
+
+      let subConfigDir: string | undefined;
+      if (agent.adapterType === "claude_local") {
+        const rc = parseObject(agent.runtimeConfig);
+        const singleSlot = rc.subscriptionConfigDir;
+        const poolSlots = rc.subscriptionSlots;
+
+        if (Array.isArray(poolSlots) && poolSlots.length > 0) {
+          // Pool mode: resolve slot names to full paths under SUBSCRIPTION_SLOTS_ROOT
+          const slotNames = poolSlots.filter((s): s is string => typeof s === "string");
+          const strategy = typeof rc.subscriptionStrategy === "string" ? rc.subscriptionStrategy : "round-robin";
+
+          if (slotNames.length > 0) {
+            // Single query: get last run's slot and status for rotation decisions
+            const [lastRun] = await db
+              .select({ status: heartbeatRuns.status, usageJson: heartbeatRuns.usageJson })
+              .from(heartbeatRuns)
+              .where(eq(heartbeatRuns.agentId, agent.id))
+              .orderBy(desc(heartbeatRuns.createdAt))
+              .limit(1);
+
+            const lastSlot = lastRun?.usageJson
+              ? (parseObject(lastRun.usageJson) as Record<string, unknown>).subscriptionSlot as string | undefined
+              : undefined;
+
+            let selectedName: string;
+            if (strategy === "failover") {
+              // Stick with current slot; advance to next only if last run failed
+              if (lastRun?.status === "failed" && lastSlot) {
+                const lastIdx = slotNames.indexOf(lastSlot);
+                selectedName = slotNames[(lastIdx + 1) % slotNames.length];
+              } else {
+                selectedName = lastSlot && slotNames.includes(lastSlot) ? lastSlot : slotNames[0];
+              }
+            } else {
+              // round-robin: advance to next slot after each run
+              if (lastSlot && slotNames.includes(lastSlot)) {
+                const lastIdx = slotNames.indexOf(lastSlot);
+                selectedName = slotNames[(lastIdx + 1) % slotNames.length];
+              } else {
+                selectedName = slotNames[0];
+              }
+            }
+
+            const validated = await validateSlotDir(path.join(SUBSCRIPTION_SLOTS_ROOT, selectedName));
+            if (validated) subConfigDir = validated;
+          }
+        } else if (singleSlot && typeof singleSlot === "string") {
+          // Single slot mode (explicit assignment)
+          subConfigDir = await validateSlotDir(singleSlot) ?? undefined;
+        }
+      }
+
+      const configForAdapter = subConfigDir
+        ? {
+            ...resolvedConfig,
+            env: { ...(parseObject(resolvedConfig.env) as Record<string, string>), CLAUDE_CONFIG_DIR: subConfigDir },
+          }
+        : resolvedConfig;
+
       const adapterResult = await adapter.execute({
         runId: run.id,
         agent,
         runtime: runtimeForAdapter,
-        config: resolvedConfig,
+        config: configForAdapter,
         context,
         onLog,
         onMeta: onAdapterMeta,
@@ -1504,12 +1606,14 @@ export function heartbeatService(db: Db) {
               ? "timed_out"
               : "failed";
 
+      const subscriptionSlot = subConfigDir ? path.basename(subConfigDir) : undefined;
       const usageJson =
-        adapterResult.usage || adapterResult.costUsd != null
+        adapterResult.usage || adapterResult.costUsd != null || subscriptionSlot
           ? ({
               ...(adapterResult.usage ?? {}),
               ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
               ...(adapterResult.billingType ? { billingType: adapterResult.billingType } : {}),
+              ...(subscriptionSlot ? { subscriptionSlot } : {}),
             } as Record<string, unknown>)
           : null;
 


### PR DESCRIPTION
## Summary

- Distributes agent runs across multiple Claude Max subscription credentials, solving rate-limit bottlenecks when many agents share one account
- Injects `CLAUDE_CONFIG_DIR` into spawned Claude processes to isolate credential lookup per-run
- Supports three modes: fixed slot assignment, round-robin rotation, and failover (advance on failure)
- Zero new DB tables/columns/migrations — uses existing `runtimeConfig` JSONB and `usageJson` fields

## How it works

Each subscription gets its own credential directory:
```
~/.paperclip/subscription-slots/
├── slot-1/.credentials.json   ← Claude Max account A
└── slot-2/.credentials.json   ← Claude Max account B
```

Configure agents via `runtimeConfig`:
```jsonc
// Fixed assignment
{ "subscriptionConfigDir": "/home/user/.paperclip/subscription-slots/slot-1" }

// Round-robin (alternates each run)
{ "subscriptionSlots": ["slot-1", "slot-2"] }

// Failover (uses first until a run fails, then advances)
{ "subscriptionSlots": ["slot-1", "slot-2"], "subscriptionStrategy": "failover" }
```

`scripts/setup-subscription-slot.sh` is a convenience script to create slots and authenticate.

## Security

- Path must be under `~/.paperclip/subscription-slots/` (prefix validation)
- Symlinks rejected (`fs.lstat` check)
- Canonical path validated via `fs.realpath` to prevent traversal
- Only slot name (not full path) stored in `usageJson`

## Files changed

- `server/src/services/heartbeat.ts` — ~106 lines (pool resolution + tracking)
- `scripts/setup-subscription-slot.sh` — new convenience script

## Test plan

- [x] Set up two slots with different Claude Max credentials
- [x] Verified `CLAUDE_CONFIG_DIR` is injected into spawned process (`/proc/<pid>/environ`)
- [x] Fixed slot: agent ran successfully, `usageJson.subscriptionSlot` recorded
- [x] Round-robin: agent alternated from slot-2 → slot-1 across consecutive runs
- [x] Backward compatibility: agents without pool config use default credentials
- [x] TypeScript compiles clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)