### PR TITLE
chore(ci): deploy docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
   packages: write
 
+jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -34,6 +35,8 @@ permissions:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}


### PR DESCRIPTION
Deploy docker image to the github registry

close: #519 
duplicate: #674

alternative: #795 (published to Docker registry)