### PR TITLE
feat(cli): add operator summary, workspace controls, and profile-aware reads

### DIFF
--- a/cli/src/__tests__/ops.test.ts
+++ b/cli/src/__tests__/ops.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import type { Agent, Company, DashboardSummary, Issue, Project } from "@paperclipai/shared";
+import { buildOpsSummary, renderOpsSummary } from "../commands/client/ops.js";
+
+const company: Company = {
+  id: "company-1",
+  name: "Rainwater",
+  description: null,
+  status: "active",
+  issuePrefix: "RAI",
+  issueCounter: 12,
+  budgetMonthlyCents: 50000,
+  spentMonthlyCents: 4900,
+  requireBoardApprovalForNewAgents: false,
+  brandColor: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const dashboard: DashboardSummary = {
+  companyId: "company-1",
+  agents: {
+    active: 1,
+    running: 1,
+    paused: 0,
+    error: 0,
+  },
+  tasks: {
+    open: 2,
+    inProgress: 1,
+    blocked: 1,
+    done: 4,
+  },
+  costs: {
+    monthSpendCents: 4900,
+    monthBudgetCents: 50000,
+    monthUtilizationPercent: 9.8,
+  },
+  pendingApprovals: 1,
+  staleTasks: 2,
+};
+
+const projects: Project[] = [
+  {
+    id: "project-1",
+    companyId: "company-1",
+    urlKey: "core-foundation",
+    goalId: null,
+    goalIds: [],
+    goals: [],
+    name: "Core Foundation",
+    description: null,
+    status: "in_progress",
+    leadAgentId: "agent-1",
+    targetDate: null,
+    color: null,
+    executionWorkspacePolicy: null,
+    workspaces: [],
+    primaryWorkspace: {
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: "project-1",
+      name: "rainwater",
+      cwd: "/Users/example/rainwater",
+      repoUrl: null,
+      repoRef: null,
+      metadata: null,
+      isPrimary: true,
+      runtimeServices: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "project-2",
+    companyId: "company-1",
+    urlKey: "ops-cadence",
+    goalId: null,
+    goalIds: [],
+    goals: [],
+    name: "Ops Cadence",
+    description: null,
+    status: "planned",
+    leadAgentId: null,
+    targetDate: null,
+    color: null,
+    executionWorkspacePolicy: null,
+    workspaces: [],
+    primaryWorkspace: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+const agents: Agent[] = [
+  {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "CEO",
+    urlKey: "ceo",
+    role: "ceo",
+    title: null,
+    icon: null,
+    status: "running",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "openclaw_gateway",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 25000,
+    spentMonthlyCents: 4900,
+    permissions: { canCreateAgents: true },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "agent-2",
+    companyId: "company-1",
+    name: "Ops",
+    urlKey: "ops",
+    role: "cto",
+    title: null,
+    icon: null,
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 10000,
+    spentMonthlyCents: 0,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+const issues: Issue[] = [
+  {
+    id: "issue-1",
+    companyId: "company-1",
+    projectId: "project-1",
+    goalId: null,
+    parentId: null,
+    title: "Ship operator summary",
+    description: null,
+    status: "blocked",
+    priority: "critical",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: 7,
+    identifier: "RAI-7",
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    project: projects[0],
+    goal: null,
+    mentionedProjects: [],
+    myLastTouchAt: null,
+    lastExternalCommentAt: null,
+    isUnreadForMe: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "issue-2",
+    companyId: "company-1",
+    projectId: "project-2",
+    goalId: null,
+    parentId: null,
+    title: "Tidy profile switching",
+    description: null,
+    status: "todo",
+    priority: "high",
+    assigneeAgentId: "agent-2",
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: 8,
+    identifier: "RAI-8",
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    project: projects[1],
+    goal: null,
+    mentionedProjects: [],
+    myLastTouchAt: null,
+    lastExternalCommentAt: null,
+    isUnreadForMe: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+describe("buildOpsSummary", () => {
+  it("builds compact counts and focus rows", () => {
+    const summary = buildOpsSummary({
+      profileName: "rainwater",
+      company,
+      dashboard,
+      projects,
+      agents,
+      activeIssues: issues,
+      limit: 2,
+    });
+
+    expect(summary.company.name).toBe("Rainwater");
+    expect(summary.projects.total).toBe(2);
+    expect(summary.projects.withPrimaryWorkspace).toBe(1);
+    expect(summary.projects.byStatus.in_progress).toBe(1);
+    expect(summary.projects.byStatus.planned).toBe(1);
+    expect(summary.tasks.focus[0]?.identifier).toBe("RAI-7");
+    expect(summary.agents.focus[0]?.status).toBe("running");
+  });
+});
+
+describe("renderOpsSummary", () => {
+  it("renders a readable operator summary", () => {
+    const summary = buildOpsSummary({
+      profileName: "rainwater",
+      company,
+      dashboard,
+      projects,
+      agents,
+      activeIssues: issues,
+      limit: 1,
+    });
+
+    const text = renderOpsSummary(summary);
+    expect(text).toContain("Company: Rainwater [active] prefix=RAI profile=rainwater");
+    expect(text).toContain("Focus projects:");
+    expect(text).toContain("core-foundation [in_progress]");
+    expect(text).toContain("RAI-7 [critical/blocked]");
+    expect(text).toContain("CEO [ceo/running]");
+  });
+});

--- a/cli/src/__tests__/project.test.ts
+++ b/cli/src/__tests__/project.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Project } from "@paperclipai/shared";
-import { filterProjectRows, resolveGoalIds } from "../commands/client/project.js";
+import { filterProjectRows, parseNullableCliValue, resolveGoalIds } from "../commands/client/project.js";
 
 function makeProject(overrides: Partial<Project>): Project {
   return {
@@ -41,6 +41,21 @@ describe("resolveGoalIds", () => {
 
   it("returns undefined when no goal flags are provided", () => {
     expect(resolveGoalIds({})).toBeUndefined();
+  });
+});
+
+describe("parseNullableCliValue", () => {
+  it("returns undefined when omitted", () => {
+    expect(parseNullableCliValue(undefined)).toBeUndefined();
+  });
+
+  it("maps literal null to null", () => {
+    expect(parseNullableCliValue("null")).toBeNull();
+    expect(parseNullableCliValue(" NULL ")).toBeNull();
+  });
+
+  it("preserves non-null strings", () => {
+    expect(parseNullableCliValue("main")).toBe("main");
   });
 });
 

--- a/cli/src/__tests__/project.test.ts
+++ b/cli/src/__tests__/project.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { Project } from "@paperclipai/shared";
+import { filterProjectRows, resolveGoalIds } from "../commands/client/project.js";
+
+function makeProject(overrides: Partial<Project>): Project {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    companyId: "company-1",
+    urlKey: "core-foundation",
+    goalId: null,
+    goalIds: [],
+    goals: [],
+    name: "Core Foundation",
+    description: "Primary workspace for Rainwater",
+    status: "in_progress",
+    leadAgentId: null,
+    targetDate: null,
+    color: "#8b5cf6",
+    executionWorkspacePolicy: null,
+    workspaces: [],
+    primaryWorkspace: null,
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("resolveGoalIds", () => {
+  it("prefers comma-separated goalIds when provided", () => {
+    expect(resolveGoalIds({ goalId: "old-goal", goalIds: "goal-a, goal-b" })).toEqual(["goal-a", "goal-b"]);
+  });
+
+  it("maps legacy single goalId to a one-item array", () => {
+    expect(resolveGoalIds({ goalId: "goal-a" })).toEqual(["goal-a"]);
+  });
+
+  it("returns empty array when legacy goalId is intentionally blank", () => {
+    expect(resolveGoalIds({ goalId: "   " })).toEqual([]);
+  });
+
+  it("returns undefined when no goal flags are provided", () => {
+    expect(resolveGoalIds({})).toBeUndefined();
+  });
+});
+
+describe("filterProjectRows", () => {
+  const rows: Project[] = [
+    makeProject({
+      id: "11111111-1111-1111-1111-111111111111",
+      urlKey: "core-foundation",
+      name: "Core Foundation",
+      status: "in_progress",
+      goalIds: ["goal-a"],
+      leadAgentId: "agent-1",
+      primaryWorkspace: {
+        id: "workspace-1",
+        companyId: "company-1",
+        projectId: "11111111-1111-1111-1111-111111111111",
+        name: "rainwater",
+        cwd: "/Users/example/rainwater",
+        repoUrl: null,
+        repoRef: null,
+        metadata: null,
+        isPrimary: true,
+        runtimeServices: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    }),
+    makeProject({
+      id: "22222222-2222-2222-2222-222222222222",
+      urlKey: "ops-cadence",
+      name: "Ops Cadence",
+      description: "Execution rhythm and review loops for Tomorrow Capital",
+      status: "planned",
+      goalIds: ["goal-b"],
+      leadAgentId: "agent-2",
+    }),
+  ];
+
+  it("filters by status", () => {
+    const result = filterProjectRows(rows, { status: "planned" });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("Ops Cadence");
+  });
+
+  it("filters by lead agent id", () => {
+    const result = filterProjectRows(rows, { leadAgentId: "agent-1" });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.urlKey).toBe("core-foundation");
+  });
+
+  it("filters by goal id", () => {
+    const result = filterProjectRows(rows, { goalId: "goal-b" });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("Ops Cadence");
+  });
+
+  it("matches against workspace paths and metadata text", () => {
+    const result = filterProjectRows(rows, { match: "rainwater" });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.urlKey).toBe("core-foundation");
+  });
+});

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -125,7 +125,6 @@ export function registerAgentCommands(program: Command): void {
     agent
       .command("list")
       .description("List agents for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
       .action(async (opts: AgentListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -158,7 +157,7 @@ export function registerAgentCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
-    { includeCompany: false },
+    { includeCompany: true },
   );
 
   addCommonClientOptions(

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -183,7 +183,6 @@ export function registerAgentCommands(program: Command): void {
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",
       )
       .argument("<agentRef>", "Agent ID or shortname/url-key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
       .option("--key-name <name>", "API key label", "local-cli")
       .option(
         "--no-install-skills",
@@ -271,6 +270,6 @@ export function registerAgentCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
-    { includeCompany: false },
+    { includeCompany: true },
   );
 }

--- a/cli/src/commands/client/dashboard.ts
+++ b/cli/src/commands/client/dashboard.ts
@@ -19,7 +19,6 @@ export function registerDashboardCommands(program: Command): void {
     dashboard
       .command("get")
       .description("Get dashboard summary for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
       .action(async (opts: DashboardGetOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -29,6 +28,6 @@ export function registerDashboardCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
-    { includeCompany: false },
+    { includeCompany: true },
   );
 }

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -68,7 +68,6 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("list")
       .description("List issues for a company")
-      .option("-C, --company-id <id>", "Company ID")
       .option("--status <csv>", "Comma-separated statuses")
       .option("--assignee-agent-id <id>", "Filter by assignee agent ID")
       .option("--project-id <id>", "Filter by project ID")
@@ -113,7 +112,7 @@ export function registerIssueCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
-    { includeCompany: false },
+    { includeCompany: true },
   );
 
   addCommonClientOptions(

--- a/cli/src/commands/client/ops.ts
+++ b/cli/src/commands/client/ops.ts
@@ -1,0 +1,309 @@
+import { Command } from "commander";
+import type { Agent, Company, DashboardSummary, Issue, Project } from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+const ACTIVE_ISSUE_STATUSES = ["blocked", "in_progress", "in_review", "todo", "backlog"] as const;
+const PROJECT_STATUS_RANK: Record<string, number> = {
+  in_progress: 0,
+  planned: 1,
+  backlog: 2,
+  completed: 3,
+  cancelled: 4,
+};
+const AGENT_STATUS_RANK: Record<string, number> = {
+  running: 0,
+  active: 1,
+  idle: 2,
+  pending_approval: 3,
+  paused: 4,
+  error: 5,
+  terminated: 6,
+};
+
+interface OpsSummaryOptions extends BaseClientOptions {
+  companyId?: string;
+  limit?: string;
+}
+
+interface OpsFocusProject {
+  id: string;
+  urlKey: string;
+  name: string;
+  status: string;
+  leadAgentId: string | null;
+  primaryWorkspace: string | null;
+}
+
+interface OpsFocusIssue {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  priority: string;
+  project: string | null;
+  assigneeAgentId: string | null;
+}
+
+interface OpsFocusAgent {
+  id: string;
+  urlKey: string;
+  name: string;
+  role: string;
+  status: string;
+  adapterType: string;
+  spentMonthlyCents: number;
+}
+
+export interface OpsSummary {
+  profileName: string;
+  company: {
+    id: string;
+    name: string;
+    status: string;
+    issuePrefix: string;
+  };
+  costs: {
+    monthSpendCents: number;
+    monthBudgetCents: number;
+    monthUtilizationPercent: number;
+  };
+  agents: {
+    counts: DashboardSummary["agents"];
+    focus: OpsFocusAgent[];
+  };
+  tasks: {
+    counts: DashboardSummary["tasks"];
+    pendingApprovals: number;
+    staleTasks: number;
+    focus: OpsFocusIssue[];
+  };
+  projects: {
+    total: number;
+    withPrimaryWorkspace: number;
+    byStatus: Record<string, number>;
+    focus: OpsFocusProject[];
+  };
+}
+
+function parseLimit(value: string | undefined): number {
+  if (!value?.trim()) return 3;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("--limit must be a positive number");
+  }
+  return Math.min(10, Math.floor(parsed));
+}
+
+function countByStatus<T extends { status: string }>(rows: T[]): Record<string, number> {
+  return rows.reduce<Record<string, number>>((acc, row) => {
+    acc[row.status] = (acc[row.status] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function primaryWorkspaceLabel(project: Project): string | null {
+  const workspace = project.primaryWorkspace;
+  if (!workspace) return null;
+  return workspace.cwd ?? workspace.repoUrl ?? workspace.name;
+}
+
+function compareByRankThenName(
+  left: { status: string; name?: string | null; title?: string | null },
+  right: { status: string; name?: string | null; title?: string | null },
+  rankMap: Record<string, number>,
+): number {
+  const rankDiff = (rankMap[left.status] ?? 99) - (rankMap[right.status] ?? 99);
+  if (rankDiff !== 0) return rankDiff;
+  const leftName = (left.name ?? left.title ?? "").toLowerCase();
+  const rightName = (right.name ?? right.title ?? "").toLowerCase();
+  return leftName.localeCompare(rightName);
+}
+
+function toMoney(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function buildOpsSummary(input: {
+  profileName: string;
+  company: Company;
+  dashboard: DashboardSummary;
+  projects: Project[];
+  agents: Agent[];
+  activeIssues: Issue[];
+  limit: number;
+}): OpsSummary {
+  const focusProjects = [...input.projects]
+    .sort((a, b) => compareByRankThenName(a, b, PROJECT_STATUS_RANK))
+    .slice(0, input.limit)
+    .map((project) => ({
+      id: project.id,
+      urlKey: project.urlKey,
+      name: project.name,
+      status: project.status,
+      leadAgentId: project.leadAgentId,
+      primaryWorkspace: primaryWorkspaceLabel(project),
+    }));
+
+  const focusIssues = [...input.activeIssues].slice(0, input.limit).map((issue) => ({
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    status: issue.status,
+    priority: issue.priority,
+    project: issue.project?.urlKey ?? issue.project?.name ?? issue.projectId,
+    assigneeAgentId: issue.assigneeAgentId,
+  }));
+
+  const focusAgents = [...input.agents]
+    .filter((agent) => agent.status !== "terminated")
+    .sort((a, b) => compareByRankThenName(a, b, AGENT_STATUS_RANK))
+    .slice(0, input.limit)
+    .map((agent) => ({
+      id: agent.id,
+      urlKey: agent.urlKey,
+      name: agent.name,
+      role: agent.role,
+      status: agent.status,
+      adapterType: agent.adapterType,
+      spentMonthlyCents: agent.spentMonthlyCents,
+    }));
+
+  return {
+    profileName: input.profileName,
+    company: {
+      id: input.company.id,
+      name: input.company.name,
+      status: input.company.status,
+      issuePrefix: input.company.issuePrefix,
+    },
+    costs: {
+      monthSpendCents: input.dashboard.costs.monthSpendCents,
+      monthBudgetCents: input.dashboard.costs.monthBudgetCents,
+      monthUtilizationPercent: input.dashboard.costs.monthUtilizationPercent,
+    },
+    agents: {
+      counts: input.dashboard.agents,
+      focus: focusAgents,
+    },
+    tasks: {
+      counts: input.dashboard.tasks,
+      pendingApprovals: input.dashboard.pendingApprovals,
+      staleTasks: input.dashboard.staleTasks,
+      focus: focusIssues,
+    },
+    projects: {
+      total: input.projects.length,
+      withPrimaryWorkspace: input.projects.filter((project) => Boolean(project.primaryWorkspace)).length,
+      byStatus: countByStatus(input.projects),
+      focus: focusProjects,
+    },
+  };
+}
+
+export function renderOpsSummary(summary: OpsSummary): string {
+  const lines = [
+    `Company: ${summary.company.name} [${summary.company.status}] prefix=${summary.company.issuePrefix} profile=${summary.profileName}`,
+    `Costs: ${toMoney(summary.costs.monthSpendCents)} / ${toMoney(summary.costs.monthBudgetCents)} (${summary.costs.monthUtilizationPercent.toFixed(1)}%)`,
+    `Agents: active=${summary.agents.counts.active} running=${summary.agents.counts.running} paused=${summary.agents.counts.paused} error=${summary.agents.counts.error}`,
+    `Tasks: open=${summary.tasks.counts.open} in_progress=${summary.tasks.counts.inProgress} blocked=${summary.tasks.counts.blocked} done=${summary.tasks.counts.done} pending_approvals=${summary.tasks.pendingApprovals} stale=${summary.tasks.staleTasks}`,
+    `Projects: total=${summary.projects.total} workspace_coverage=${summary.projects.withPrimaryWorkspace}/${summary.projects.total || 0}`,
+  ];
+
+  const statusParts = Object.entries(summary.projects.byStatus)
+    .sort(([left], [right]) => (PROJECT_STATUS_RANK[left] ?? 99) - (PROJECT_STATUS_RANK[right] ?? 99))
+    .map(([status, count]) => `${status}=${count}`);
+  if (statusParts.length > 0) {
+    lines.push(`Project status mix: ${statusParts.join(" ")}`);
+  }
+
+  lines.push("Focus projects:");
+  if (summary.projects.focus.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const project of summary.projects.focus) {
+      lines.push(
+        `- ${project.urlKey} [${project.status}] lead=${project.leadAgentId ?? "-"} workspace=${project.primaryWorkspace ?? "-"}`,
+      );
+    }
+  }
+
+  lines.push("Focus issues:");
+  if (summary.tasks.focus.length === 0) {
+    lines.push("- none active");
+  } else {
+    for (const issue of summary.tasks.focus) {
+      lines.push(
+        `- ${(issue.identifier ?? issue.id)} [${issue.priority}/${issue.status}] ${issue.title} project=${issue.project ?? "-"} assignee=${issue.assigneeAgentId ?? "-"}`,
+      );
+    }
+  }
+
+  lines.push("Focus agents:");
+  if (summary.agents.focus.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const agent of summary.agents.focus) {
+      lines.push(
+        `- ${agent.name} [${agent.role}/${agent.status}] adapter=${agent.adapterType} spend=${toMoney(agent.spentMonthlyCents)}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function registerOpsCommands(program: Command): void {
+  const ops = program.command("ops").description("Operator summary commands");
+
+  addCommonClientOptions(
+    ops
+      .command("summary")
+      .description("Compact one-company operator summary")
+      .option("--limit <count>", "Max number of focus rows to show per section", "3")
+      .action(async (opts: OpsSummaryOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const limit = parseLimit(opts.limit);
+          const issueParams = new URLSearchParams({ status: ACTIVE_ISSUE_STATUSES.join(",") });
+
+          const [company, dashboard, projects, agents, activeIssues] = await Promise.all([
+            ctx.api.get<Company>(`/api/companies/${ctx.companyId}`),
+            ctx.api.get<DashboardSummary>(`/api/companies/${ctx.companyId}/dashboard`),
+            ctx.api.get<Project[]>(`/api/companies/${ctx.companyId}/projects`),
+            ctx.api.get<Agent[]>(`/api/companies/${ctx.companyId}/agents`),
+            ctx.api.get<Issue[]>(`/api/companies/${ctx.companyId}/issues?${issueParams.toString()}`),
+          ]);
+
+          if (!company || !dashboard) {
+            throw new Error("Unable to load company summary data.");
+          }
+
+          const summary = buildOpsSummary({
+            profileName: ctx.profileName,
+            company,
+            dashboard,
+            projects: projects ?? [],
+            agents: agents ?? [],
+            activeIssues: activeIssues ?? [],
+            limit,
+          });
+
+          if (ctx.json) {
+            printOutput(summary, { json: true });
+            return;
+          }
+
+          console.log(renderOpsSummary(summary));
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+}

--- a/cli/src/commands/client/project.ts
+++ b/cli/src/commands/client/project.ts
@@ -1,8 +1,11 @@
 import { Command } from "commander";
 import {
   createProjectSchema,
+  createProjectWorkspaceSchema,
   updateProjectSchema,
+  updateProjectWorkspaceSchema,
   type Project,
+  type ProjectWorkspace,
 } from "@paperclipai/shared";
 import {
   addCommonClientOptions,
@@ -51,6 +54,29 @@ interface ProjectUpdateOptions extends BaseClientOptions {
   archivedAt?: string;
 }
 
+interface ProjectWorkspaceListOptions extends BaseClientOptions {
+  companyId?: string;
+}
+
+interface ProjectWorkspaceCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name?: string;
+  cwd?: string;
+  repoUrl?: string;
+  repoRef?: string;
+  primary?: boolean;
+}
+
+interface ProjectWorkspaceUpdateOptions extends BaseClientOptions {
+  companyId?: string;
+  name?: string;
+  cwd?: string;
+  repoUrl?: string;
+  repoRef?: string;
+  primary?: boolean;
+  notPrimary?: boolean;
+}
+
 function parseCsv(value: string | undefined): string[] {
   if (!value) return [];
   return value
@@ -66,15 +92,30 @@ export function resolveGoalIds(input: { goalId?: string; goalIds?: string }): st
   return single ? [single] : [];
 }
 
-function parseArchivedAt(value: string | undefined): string | null | undefined {
+export function parseNullableCliValue(value: string | undefined): string | null | undefined {
   if (value === undefined) return undefined;
   if (value.trim().toLowerCase() === "null") return null;
   return value;
 }
 
+function parseArchivedAt(value: string | undefined): string | null | undefined {
+  return parseNullableCliValue(value);
+}
+
+function buildReferenceQuery(companyId?: string): string {
+  return companyId?.trim() ? `?companyId=${encodeURIComponent(companyId.trim())}` : "";
+}
+
 function buildProjectPath(idOrRef: string, companyId?: string): string {
-  const query = companyId?.trim() ? `?companyId=${encodeURIComponent(companyId.trim())}` : "";
-  return `/api/projects/${encodeURIComponent(idOrRef)}${query}`;
+  return `/api/projects/${encodeURIComponent(idOrRef)}${buildReferenceQuery(companyId)}`;
+}
+
+function buildProjectWorkspacesPath(idOrRef: string, companyId?: string): string {
+  return `/api/projects/${encodeURIComponent(idOrRef)}/workspaces${buildReferenceQuery(companyId)}`;
+}
+
+function buildProjectWorkspacePath(idOrRef: string, workspaceId: string, companyId?: string): string {
+  return `/api/projects/${encodeURIComponent(idOrRef)}/workspaces/${encodeURIComponent(workspaceId)}${buildReferenceQuery(companyId)}`;
 }
 
 function buildWorkspaceInput(opts: ProjectCreateOptions) {
@@ -100,6 +141,19 @@ function primaryWorkspaceLabel(project: Project): string | null {
   const workspace = project.primaryWorkspace;
   if (!workspace) return null;
   return workspace.cwd ?? workspace.repoUrl ?? workspace.name;
+}
+
+function workspaceLabel(workspace: ProjectWorkspace): string {
+  return workspace.cwd ?? workspace.repoUrl ?? workspace.name;
+}
+
+function resolvePrimaryFlag(opts: { primary?: boolean; notPrimary?: boolean }): boolean | undefined {
+  if (opts.primary && opts.notPrimary) {
+    throw new Error("Choose either --primary or --not-primary, not both.");
+  }
+  if (opts.primary) return true;
+  if (opts.notPrimary) return false;
+  return undefined;
 }
 
 export function filterProjectRows(rows: Project[], opts: ProjectListOptions): Project[] {
@@ -148,12 +202,12 @@ export function filterProjectRows(rows: Project[], opts: ProjectListOptions): Pr
 
 export function registerProjectCommands(program: Command): void {
   const project = program.command("project").description("Project operations");
+  const workspace = project.command("workspace").description("Project workspace operations");
 
   addCommonClientOptions(
     project
       .command("list")
       .description("List projects for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
       .option("--status <csv>", "Comma-separated statuses")
       .option("--lead-agent-id <id>", "Filter by lead agent ID")
       .option("--goal-id <id>", "Filter by goal ID")
@@ -191,7 +245,7 @@ export function registerProjectCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
-    { includeCompany: false },
+    { includeCompany: true },
   );
 
   addCommonClientOptions(
@@ -215,7 +269,6 @@ export function registerProjectCommands(program: Command): void {
     project
       .command("create")
       .description("Create a project")
-      .requiredOption("-C, --company-id <id>", "Company ID")
       .requiredOption("--name <name>", "Project name")
       .option("--description <text>", "Project description")
       .option("--status <status>", "Project status")
@@ -249,7 +302,7 @@ export function registerProjectCommands(program: Command): void {
           handleCommandError(err);
         }
       }),
-    { includeCompany: false },
+    { includeCompany: true },
   );
 
   addCommonClientOptions(
@@ -285,6 +338,122 @@ export function registerProjectCommands(program: Command): void {
           }
 
           const updated = await ctx.api.patch<Project>(buildProjectPath(idOrReference, ctx.companyId), payload);
+          printOutput(updated, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    workspace
+      .command("list")
+      .description("List workspaces for a project")
+      .argument("<projectIdOrReference>", "Project ID or shortname/url-key")
+      .action(async (projectIdOrReference: string, opts: ProjectWorkspaceListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const rows = (await ctx.api.get<ProjectWorkspace[]>(
+            buildProjectWorkspacesPath(projectIdOrReference, ctx.companyId),
+          )) ?? [];
+
+          if (ctx.json) {
+            printOutput(rows, { json: true });
+            return;
+          }
+
+          if (rows.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of rows) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                name: row.name,
+                isPrimary: row.isPrimary,
+                workspace: workspaceLabel(row),
+                repoRef: row.repoRef,
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    workspace
+      .command("add")
+      .description("Add a workspace to a project")
+      .argument("<projectIdOrReference>", "Project ID or shortname/url-key")
+      .option("--name <name>", "Workspace display name")
+      .option("--cwd <path>", "Local workspace path")
+      .option("--repo-url <url>", "Repository URL")
+      .option("--repo-ref <ref>", "Repository ref or branch")
+      .option("--primary", "Mark this workspace as primary")
+      .action(async (projectIdOrReference: string, opts: ProjectWorkspaceCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = createProjectWorkspaceSchema.parse({
+            name: opts.name,
+            cwd: parseNullableCliValue(opts.cwd),
+            repoUrl: parseNullableCliValue(opts.repoUrl),
+            repoRef: parseNullableCliValue(opts.repoRef),
+            isPrimary: Boolean(opts.primary),
+          });
+
+          const created = await ctx.api.post<ProjectWorkspace>(
+            buildProjectWorkspacesPath(projectIdOrReference, ctx.companyId),
+            payload,
+          );
+          printOutput(created, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    workspace
+      .command("update")
+      .description("Update an existing project workspace")
+      .argument("<projectIdOrReference>", "Project ID or shortname/url-key")
+      .argument("<workspaceId>", "Workspace ID")
+      .option("--name <name>", "Workspace display name")
+      .option("--cwd <path|null>", "Set local workspace path or literal 'null' to clear")
+      .option("--repo-url <url|null>", "Set repo URL or literal 'null' to clear")
+      .option("--repo-ref <ref|null>", "Set repo ref or literal 'null' to clear")
+      .option("--primary", "Mark this workspace as primary")
+      .option("--not-primary", "Mark this workspace as not primary")
+      .action(async (
+        projectIdOrReference: string,
+        workspaceId: string,
+        opts: ProjectWorkspaceUpdateOptions,
+      ) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = updateProjectWorkspaceSchema.parse({
+            name: opts.name,
+            cwd: parseNullableCliValue(opts.cwd),
+            repoUrl: parseNullableCliValue(opts.repoUrl),
+            repoRef: parseNullableCliValue(opts.repoRef),
+            isPrimary: resolvePrimaryFlag(opts),
+          });
+
+          if (Object.keys(payload).length === 0) {
+            throw new Error("At least one field is required to update a project workspace.");
+          }
+
+          const updated = await ctx.api.patch<ProjectWorkspace>(
+            buildProjectWorkspacePath(projectIdOrReference, workspaceId, ctx.companyId),
+            payload,
+          );
           printOutput(updated, { json: ctx.json });
         } catch (err) {
           handleCommandError(err);

--- a/cli/src/commands/client/project.ts
+++ b/cli/src/commands/client/project.ts
@@ -1,0 +1,295 @@
+import { Command } from "commander";
+import {
+  createProjectSchema,
+  updateProjectSchema,
+  type Project,
+} from "@paperclipai/shared";
+import {
+  addCommonClientOptions,
+  formatInlineRecord,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface ProjectListOptions extends BaseClientOptions {
+  companyId?: string;
+  status?: string;
+  leadAgentId?: string;
+  goalId?: string;
+  match?: string;
+}
+
+interface ProjectCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  description?: string;
+  status?: string;
+  leadAgentId?: string;
+  targetDate?: string;
+  color?: string;
+  goalId?: string;
+  goalIds?: string;
+  workspaceName?: string;
+  workspaceCwd?: string;
+  workspaceRepoUrl?: string;
+  workspaceRepoRef?: string;
+  workspacePrimary?: boolean;
+}
+
+interface ProjectUpdateOptions extends BaseClientOptions {
+  companyId?: string;
+  name?: string;
+  description?: string;
+  status?: string;
+  leadAgentId?: string;
+  targetDate?: string;
+  color?: string;
+  goalId?: string;
+  goalIds?: string;
+  archivedAt?: string;
+}
+
+function parseCsv(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function resolveGoalIds(input: { goalId?: string; goalIds?: string }): string[] | undefined {
+  if (input.goalIds !== undefined) return parseCsv(input.goalIds);
+  if (input.goalId === undefined) return undefined;
+  const single = input.goalId.trim();
+  return single ? [single] : [];
+}
+
+function parseArchivedAt(value: string | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value.trim().toLowerCase() === "null") return null;
+  return value;
+}
+
+function buildProjectPath(idOrRef: string, companyId?: string): string {
+  const query = companyId?.trim() ? `?companyId=${encodeURIComponent(companyId.trim())}` : "";
+  return `/api/projects/${encodeURIComponent(idOrRef)}${query}`;
+}
+
+function buildWorkspaceInput(opts: ProjectCreateOptions) {
+  const hasWorkspaceInput = Boolean(
+    opts.workspaceName ||
+      opts.workspaceCwd ||
+      opts.workspaceRepoUrl ||
+      opts.workspaceRepoRef ||
+      opts.workspacePrimary,
+  );
+  if (!hasWorkspaceInput) return undefined;
+
+  return {
+    name: opts.workspaceName,
+    cwd: opts.workspaceCwd,
+    repoUrl: opts.workspaceRepoUrl,
+    repoRef: opts.workspaceRepoRef,
+    isPrimary: opts.workspacePrimary,
+  };
+}
+
+function primaryWorkspaceLabel(project: Project): string | null {
+  const workspace = project.primaryWorkspace;
+  if (!workspace) return null;
+  return workspace.cwd ?? workspace.repoUrl ?? workspace.name;
+}
+
+export function filterProjectRows(rows: Project[], opts: ProjectListOptions): Project[] {
+  const statusFilters = new Set(parseCsv(opts.status).map((value) => value.toLowerCase()));
+  const goalIdFilter = opts.goalId?.trim();
+  const leadAgentIdFilter = opts.leadAgentId?.trim();
+  const needle = opts.match?.trim().toLowerCase();
+
+  return rows.filter((row) => {
+    if (statusFilters.size > 0 && !statusFilters.has(row.status.toLowerCase())) {
+      return false;
+    }
+
+    if (leadAgentIdFilter && row.leadAgentId !== leadAgentIdFilter) {
+      return false;
+    }
+
+    if (goalIdFilter) {
+      const goalIds = row.goalIds ?? [];
+      const legacyGoalId = row.goalId ? [row.goalId] : [];
+      if (![...goalIds, ...legacyGoalId].includes(goalIdFilter)) {
+        return false;
+      }
+    }
+
+    if (!needle) return true;
+
+    const haystack = [
+      row.id,
+      row.urlKey,
+      row.name,
+      row.description,
+      row.status,
+      row.color,
+      row.primaryWorkspace?.name,
+      row.primaryWorkspace?.cwd,
+      row.primaryWorkspace?.repoUrl,
+    ]
+      .filter((part): part is string => Boolean(part))
+      .join("\n")
+      .toLowerCase();
+
+    return haystack.includes(needle);
+  });
+}
+
+export function registerProjectCommands(program: Command): void {
+  const project = program.command("project").description("Project operations");
+
+  addCommonClientOptions(
+    project
+      .command("list")
+      .description("List projects for a company")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--status <csv>", "Comma-separated statuses")
+      .option("--lead-agent-id <id>", "Filter by lead agent ID")
+      .option("--goal-id <id>", "Filter by goal ID")
+      .option("--match <text>", "Local text match on id/url-key/name/description/workspace")
+      .action(async (opts: ProjectListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const rows = (await ctx.api.get<Project[]>(`/api/companies/${ctx.companyId}/projects`)) ?? [];
+          const filtered = filterProjectRows(rows, opts);
+
+          if (ctx.json) {
+            printOutput(filtered, { json: true });
+            return;
+          }
+
+          if (filtered.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+
+          for (const row of filtered) {
+            console.log(
+              formatInlineRecord({
+                id: row.id,
+                urlKey: row.urlKey,
+                status: row.status,
+                name: row.name,
+                leadAgentId: row.leadAgentId,
+                goalCount: row.goalIds.length,
+                primaryWorkspace: primaryWorkspaceLabel(row),
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("get")
+      .description("Get a project by UUID or shortname/url-key")
+      .argument("<idOrReference>", "Project ID or shortname/url-key")
+      .action(async (idOrReference: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const row = await ctx.api.get<Project>(buildProjectPath(idOrReference, ctx.companyId));
+          printOutput(row, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("create")
+      .description("Create a project")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Project name")
+      .option("--description <text>", "Project description")
+      .option("--status <status>", "Project status")
+      .option("--lead-agent-id <id>", "Lead agent ID")
+      .option("--target-date <date>", "Target date")
+      .option("--color <color>", "Project color hex")
+      .option("--goal-id <id>", "Single goal ID (legacy shorthand)")
+      .option("--goal-ids <csv>", "Comma-separated goal IDs")
+      .option("--workspace-name <name>", "Optional primary workspace display name")
+      .option("--workspace-cwd <path>", "Optional primary workspace local path")
+      .option("--workspace-repo-url <url>", "Optional primary workspace repo URL")
+      .option("--workspace-repo-ref <ref>", "Optional primary workspace repo ref")
+      .option("--workspace-primary", "Mark the created workspace as primary")
+      .action(async (opts: ProjectCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload = createProjectSchema.parse({
+            name: opts.name,
+            description: opts.description,
+            status: opts.status,
+            leadAgentId: opts.leadAgentId,
+            targetDate: opts.targetDate,
+            color: opts.color,
+            goalIds: resolveGoalIds(opts),
+            workspace: buildWorkspaceInput(opts),
+          });
+
+          const created = await ctx.api.post<Project>(`/api/companies/${ctx.companyId}/projects`, payload);
+          printOutput(created, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    project
+      .command("update")
+      .description("Update a project")
+      .argument("<idOrReference>", "Project ID or shortname/url-key")
+      .option("--name <name>", "Project name")
+      .option("--description <text>", "Project description")
+      .option("--status <status>", "Project status")
+      .option("--lead-agent-id <id>", "Lead agent ID")
+      .option("--target-date <date>", "Target date")
+      .option("--color <color>", "Project color hex")
+      .option("--goal-id <id>", "Single goal ID (legacy shorthand)")
+      .option("--goal-ids <csv>", "Comma-separated goal IDs")
+      .option("--archived-at <iso8601|null>", "Set archivedAt timestamp or literal 'null'")
+      .action(async (idOrReference: string, opts: ProjectUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = updateProjectSchema.parse({
+            name: opts.name,
+            description: opts.description,
+            status: opts.status,
+            leadAgentId: opts.leadAgentId,
+            targetDate: opts.targetDate,
+            color: opts.color,
+            goalIds: resolveGoalIds(opts),
+            archivedAt: parseArchivedAt(opts.archivedAt),
+          });
+
+          if (Object.keys(payload).length === 0) {
+            throw new Error("At least one field is required to update a project.");
+          }
+
+          const updated = await ctx.api.patch<Project>(buildProjectPath(idOrReference, ctx.companyId), payload);
+          printOutput(updated, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+}

--- a/cli/src/commands/client/project.ts
+++ b/cli/src/commands/client/project.ts
@@ -77,6 +77,11 @@ interface ProjectWorkspaceUpdateOptions extends BaseClientOptions {
   notPrimary?: boolean;
 }
 
+interface ProjectWorkspaceDeleteOptions extends BaseClientOptions {
+  companyId?: string;
+  yes?: boolean;
+}
+
 function parseCsv(value: string | undefined): string[] {
   if (!value) return [];
   return value
@@ -455,6 +460,34 @@ export function registerProjectCommands(program: Command): void {
             payload,
           );
           printOutput(updated, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    workspace
+      .command("delete")
+      .description("Delete a project workspace")
+      .argument("<projectIdOrReference>", "Project ID or shortname/url-key")
+      .argument("<workspaceId>", "Workspace ID")
+      .option("--yes", "Required safety flag to confirm workspace deletion", false)
+      .action(async (
+        projectIdOrReference: string,
+        workspaceId: string,
+        opts: ProjectWorkspaceDeleteOptions,
+      ) => {
+        try {
+          if (!opts.yes) {
+            throw new Error("Workspace deletion requires --yes.");
+          }
+          const ctx = resolveCommandContext(opts);
+          const deleted = await ctx.api.delete<ProjectWorkspace>(
+            buildProjectWorkspacePath(projectIdOrReference, workspaceId, ctx.companyId),
+          );
+          printOutput(deleted, { json: ctx.json });
         } catch (err) {
           handleCommandError(err);
         }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,6 +16,7 @@ import { registerAgentCommands } from "./commands/client/agent.js";
 import { registerApprovalCommands } from "./commands/client/approval.js";
 import { registerActivityCommands } from "./commands/client/activity.js";
 import { registerDashboardCommands } from "./commands/client/dashboard.js";
+import { registerOpsCommands } from "./commands/client/ops.js";
 import { applyDataDirOverride, type DataDirOptionLike } from "./config/data-dir.js";
 import { loadPaperclipEnvFile } from "./config/env.js";
 import { registerWorktreeCommands } from "./commands/worktree.js";
@@ -137,6 +138,7 @@ registerAgentCommands(program);
 registerApprovalCommands(program);
 registerActivityCommands(program);
 registerDashboardCommands(program);
+registerOpsCommands(program);
 registerWorktreeCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { dbBackupCommand } from "./commands/db-backup.js";
 import { registerContextCommands } from "./commands/client/context.js";
 import { registerCompanyCommands } from "./commands/client/company.js";
 import { registerIssueCommands } from "./commands/client/issue.js";
+import { registerProjectCommands } from "./commands/client/project.js";
 import { registerAgentCommands } from "./commands/client/agent.js";
 import { registerApprovalCommands } from "./commands/client/approval.js";
 import { registerActivityCommands } from "./commands/client/activity.js";
@@ -130,6 +131,7 @@ heartbeat
 
 registerContextCommands(program);
 registerCompanyCommands(program);
+registerProjectCommands(program);
 registerIssueCommands(program);
 registerAgentCommands(program);
 registerApprovalCommands(program);


### PR DESCRIPTION
## Summary
- add first-class `project` CLI operations for list/get/create/update
- add nested `project workspace` CLI operations for list/add/update/delete
- add compact `ops summary` for one-company executive/operator review
- let profile-backed company context drive project, issue, agent, dashboard, and `agent local-cli` reads instead of forcing raw company IDs

## Why
This fills out the missing Paperclip operator chain for direct CLI oversight:

`company -> project -> workspace -> issue -> agent -> dashboard`

And it adds a compact one-company summary surface so an operator can quickly inspect execution health without manually hopping through multiple commands.

## Validation
- `pnpm --dir cli typecheck`
- `pnpm --dir cli exec vitest run src/__tests__/ops.test.ts src/__tests__/project.test.ts src/__tests__/context.test.ts src/__tests__/company-delete.test.ts`
- local smoke checks against a live Paperclip instance for:
  - `ops summary --profile rainwater`
  - `project workspace add/delete ... --profile rainwater`
  - `agent local-cli ceo --profile rainwater --no-install-skills --json` (temporary key created then revoked)

## Notes
- kept the scope to CLI/client surface only; no server route changes were needed because project/workspace APIs already exist
- used a clean PR branch so Rainwater-specific docs from the working branch were not included upstream
