### PR TITLE
fix(cli): add restart hint after allowed-hostname change

### DIFF
--- a/cli/src/commands/allowed-hostname.ts
+++ b/cli/src/commands/allowed-hostname.ts
@@ -26,6 +26,9 @@ export async function addAllowedHostname(host: string, opts: { config?: string }
     p.log.info(`Hostname ${pc.cyan(normalized)} is already allowed.`);
   } else {
     p.log.success(`Added allowed hostname: ${pc.cyan(normalized)}`);
+    p.log.message(
+      pc.dim("Restart the Paperclip server for this change to take effect."),
+    );
   }
 
   if (!(config.server.deploymentMode === "authenticated" && config.server.exposure === "private")) {


### PR DESCRIPTION
## Summary

- After `paperclipai allowed-hostname <host>` adds a new hostname, display a message: "Restart the Paperclip server for this change to take effect."
- Only shown when a hostname is newly added (not when it already exists)

Fixes #538

## Root cause

The server builds its `allowSet` in the `privateHostnameGuard` middleware closure at startup. The `allowed-hostname` CLI command writes to the config file, but the running server never reloads it. Users (especially in K8s deployments) weren't aware they needed to restart.

## Test plan

- [ ] Run `paperclipai allowed-hostname example.com` - should show restart hint
- [ ] Run the same command again - should show "already allowed" (no restart hint)
- [ ] All CI checks pass (typecheck, tests, build)

This contribution was developed with AI assistance (Claude Code).