### PR TITLE
fix: embed uploaded images inline in comments via paperclip button

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -340,8 +340,9 @@ export function CommentThread({
     try {
       if (imageUploadHandler) {
         const url = await imageUploadHandler(file);
-        const markdown = `![${file.name}](${url})`;
-        setBody((prev) => prev ? `${prev}\n${markdown}` : markdown);
+        const safeName = file.name.replace(/[[\]]/g, "\\$&");
+        const markdown = `![${safeName}](${url})`;
+        setBody((prev) => prev ? `${prev}\n\n${markdown}` : markdown);
       } else if (onAttachImage) {
         await onAttachImage(file);
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Humans and agents collaborate on issues through threaded comments with file attachments
> - When a user clicks the paperclip button to attach an image, it should appear inline in the comment
> - The button was only adding images to the issue-level Attachments section with no visible link in the comment body
> - This changes the upload handler to insert a markdown image reference inline so images render in the comment
> - Attached images are now immediately visible in context, not buried in a separate section

## Summary

- The paperclip button in the comment section now inserts an inline markdown image (`![filename](url)`) into the comment body after upload
- Previously it only added the file to the issue-level Attachments section without any visible link in the comment
- The button now shows when either `imageUploadHandler` or `onAttachImage` is available

Fixes #272

## Approach

Changed `handleAttachFile` in `CommentThread.tsx` to prefer `imageUploadHandler` (which uploads the file AND returns the content URL) over `onAttachImage` (which only uploads). After getting the URL, it appends a markdown image reference to the comment body. Since `body` is controlled state passed as `value` to the MarkdownEditor, the editor syncs automatically.

## Test plan

- [ ] Open an issue, go to Comments tab
- [ ] Click the paperclip button and select an image
- [ ] Image should appear inline in the comment editor as `![filename](url)`
- [ ] Submit the comment - image renders in the posted comment
- [ ] Drag-and-drop / paste image into editor still works as before
- [ ] All CI checks pass (typecheck, tests, build)

This contribution was developed with AI assistance (Claude Code).
