### PR TITLE
fix(projects): ignore terminal projects in shortname dedup

### DIFF
--- a/server/src/__tests__/project-shortname-resolution.test.ts
+++ b/server/src/__tests__/project-shortname-resolution.test.ts
@@ -36,6 +36,24 @@ describe("resolveProjectNameForUniqueShortname", () => {
     expect(resolved).toBe("Growth Team");
   });
 
+  it("ignores completed and cancelled projects when deduplicating", () => {
+    const resolved = resolveProjectNameForUniqueShortname("Growth Team", [
+      { id: "p1", name: "growth-team", status: "completed" },
+      { id: "p2", name: "growth-team-2", status: "cancelled" },
+    ]);
+    expect(resolved).toBe("Growth Team");
+  });
+
+  it("reuses suffixes occupied only by terminal projects while respecting active ones", () => {
+    const resolved = resolveProjectNameForUniqueShortname("Growth Team", [
+      { id: "p1", name: "growth-team", status: "in_progress" },
+      { id: "p2", name: "growth-team-2", status: "cancelled" },
+    ]);
+    // The active project still blocks "Growth Team", but the cancelled
+    // project should no longer reserve the "Growth Team 2" suffix.
+    expect(resolved).toBe("Growth Team 2");
+  });
+
   it("keeps non-normalizable names unchanged", () => {
     const resolved = resolveProjectNameForUniqueShortname("!!!", [
       { id: "p1", name: "growth" },

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, notInArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { projects, projectGoals, goals, projectWorkspaces, workspaceRuntimeServices } from "@paperclipai/db";
 import {
@@ -377,12 +377,7 @@ export function projectService(db: Db) {
       const existingProjects = await db
         .select({ id: projects.id, name: projects.name, status: projects.status })
         .from(projects)
-        .where(
-          and(
-            eq(projects.companyId, companyId),
-            notInArray(projects.status, ["completed", "cancelled"]),
-          ),
-        );
+        .where(eq(projects.companyId, companyId));
       projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects);
 
       // Also write goalId to the legacy column (first goal or null)
@@ -423,12 +418,7 @@ export function projectService(db: Db) {
           const existingProjects = await db
             .select({ id: projects.id, name: projects.name, status: projects.status })
             .from(projects)
-            .where(
-              and(
-                eq(projects.companyId, existingProject.companyId),
-                notInArray(projects.status, ["completed", "cancelled"]),
-              ),
-            );
+            .where(eq(projects.companyId, existingProject.companyId));
           projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects, {
             excludeProjectId: id,
           });

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { projects, projectGoals, goals, projectWorkspaces, workspaceRuntimeServices } from "@paperclipai/db";
 import {
@@ -40,11 +40,14 @@ interface ProjectWithGoals extends Omit<ProjectRow, "executionWorkspacePolicy"> 
 interface ProjectShortnameRow {
   id: string;
   name: string;
+  status?: string | null;
 }
 
 interface ResolveProjectNameOptions {
   excludeProjectId?: string | null;
 }
+
+const TERMINAL_PROJECT_STATUSES = new Set(["completed", "cancelled"]);
 
 /** Batch-load goal refs for a set of projects. */
 async function attachGoals(db: Db, rows: ProjectRow[]): Promise<ProjectWithGoals[]> {
@@ -274,6 +277,7 @@ export function resolveProjectNameForUniqueShortname(
   const usedShortnames = new Set(
     existingProjects
       .filter((project) => !(options?.excludeProjectId && project.id === options.excludeProjectId))
+      .filter((project) => !project.status || !TERMINAL_PROJECT_STATUSES.has(project.status))
       .map((project) => normalizeProjectUrlKey(project.name))
       .filter((value): value is string => value !== null),
   );
@@ -371,9 +375,14 @@ export function projectService(db: Db) {
       }
 
       const existingProjects = await db
-        .select({ id: projects.id, name: projects.name })
+        .select({ id: projects.id, name: projects.name, status: projects.status })
         .from(projects)
-        .where(eq(projects.companyId, companyId));
+        .where(
+          and(
+            eq(projects.companyId, companyId),
+            notInArray(projects.status, ["completed", "cancelled"]),
+          ),
+        );
       projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects);
 
       // Also write goalId to the legacy column (first goal or null)
@@ -412,9 +421,14 @@ export function projectService(db: Db) {
         const nextShortname = normalizeProjectUrlKey(projectData.name);
         if (existingShortname !== nextShortname) {
           const existingProjects = await db
-            .select({ id: projects.id, name: projects.name })
+            .select({ id: projects.id, name: projects.name, status: projects.status })
             .from(projects)
-            .where(eq(projects.companyId, existingProject.companyId));
+            .where(
+              and(
+                eq(projects.companyId, existingProject.companyId),
+                notInArray(projects.status, ["completed", "cancelled"]),
+              ),
+            );
           projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects, {
             excludeProjectId: id,
           });


### PR DESCRIPTION
## Summary
- ignore completed and cancelled projects when resolving project shortname collisions
- keep active projects participating in deduplication for both create and rename flows
- add regression coverage for terminal-vs-active project status handling

## Testing
- pnpm vitest run src/__tests__/project-shortname-resolution.test.ts
- pnpm typecheck

Fixes #553