### PR TITLE
fix(ui): detect mentions at editor start

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -28,6 +28,7 @@ import {
   type RealmPlugin,
 } from "@mdxeditor/editor";
 import { buildProjectMentionHref, parseProjectMentionHref } from "@paperclipai/shared";
+import { detectMention, type MentionState } from "./markdownMentionUtils";
 import { cn } from "../lib/utils";
 
 /* ---- Mention types ---- */
@@ -63,15 +64,6 @@ export interface MarkdownEditorRef {
 
 /* ---- Mention detection helpers ---- */
 
-interface MentionState {
-  query: string;
-  top: number;
-  left: number;
-  textNode: Text;
-  atPos: number;
-  endPos: number;
-}
-
 const CODE_BLOCK_LANGUAGES: Record<string, string> = {
   txt: "Text",
   md: "Markdown",
@@ -99,52 +91,6 @@ const FALLBACK_CODE_BLOCK_DESCRIPTOR: CodeBlockEditorDescriptor = {
   match: () => true,
   Editor: CodeMirrorEditor,
 };
-
-function detectMention(container: HTMLElement): MentionState | null {
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) return null;
-
-  const range = sel.getRangeAt(0);
-  const textNode = range.startContainer;
-  if (textNode.nodeType !== Node.TEXT_NODE) return null;
-  if (!container.contains(textNode)) return null;
-
-  const text = textNode.textContent ?? "";
-  const offset = range.startOffset;
-
-  // Walk backwards from cursor to find @
-  let atPos = -1;
-  for (let i = offset - 1; i >= 0; i--) {
-    const ch = text[i];
-    if (ch === "@") {
-      if (i === 0 || /\s/.test(text[i - 1])) {
-        atPos = i;
-      }
-      break;
-    }
-    if (/\s/.test(ch)) break;
-  }
-
-  if (atPos === -1) return null;
-
-  const query = text.slice(atPos + 1, offset);
-
-  // Get position relative to container
-  const tempRange = document.createRange();
-  tempRange.setStart(textNode, atPos);
-  tempRange.setEnd(textNode, atPos + 1);
-  const rect = tempRange.getBoundingClientRect();
-  const containerRect = container.getBoundingClientRect();
-
-  return {
-    query,
-    top: rect.bottom - containerRect.top,
-    left: rect.left - containerRect.left,
-    textNode: textNode as Text,
-    atPos,
-    endPos: offset,
-  };
-}
 
 function mentionMarkdown(option: MentionOption): string {
   if (option.kind === "project" && option.projectId) {
@@ -397,10 +343,20 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       // lands after the inserted text. Lexical picks up the change through
       // its normal input-event handling.
       const sel = window.getSelection();
-      if (sel && state.textNode.isConnected) {
+      if (
+        sel
+        && state.textNode
+        && state.atPos !== null
+        && state.endPos !== null
+        && state.textNode.isConnected
+      ) {
+        const textNode = state.textNode;
+        const atPos = state.atPos;
+        const endPos = state.endPos;
+
         const range = document.createRange();
-        range.setStart(state.textNode, state.atPos);
-        range.setEnd(state.textNode, state.endPos);
+        range.setStart(textNode, atPos);
+        range.setEnd(textNode, endPos);
         sel.removeAllRanges();
         sel.addRange(range);
         document.execCommand("insertText", false, replacement);
@@ -408,16 +364,16 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         // After Lexical reconciles the DOM, the cursor position set by
         // execCommand may be lost. Explicitly reposition it after the
         // inserted mention text.
-        const cursorTarget = state.atPos + replacement.length;
+        const cursorTarget = atPos + replacement.length;
         requestAnimationFrame(() => {
           const newSel = window.getSelection();
           if (!newSel) return;
           // Try the original text node first (it may still be valid)
-          if (state.textNode.isConnected) {
-            const len = state.textNode.textContent?.length ?? 0;
+          if (textNode.isConnected) {
+            const len = textNode.textContent?.length ?? 0;
             if (cursorTarget <= len) {
               const r = document.createRange();
-              r.setStart(state.textNode, cursorTarget);
+              r.setStart(textNode, cursorTarget);
               r.collapse(true);
               newSel.removeAllRanges();
               newSel.addRange(r);

--- a/ui/src/components/markdownMentionUtils.test.ts
+++ b/ui/src/components/markdownMentionUtils.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { detectMention } from "./markdownMentionUtils";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  window.getSelection()?.removeAllRanges();
+});
 
 describe("detectMention", () => {
   it("detects mentions when the caret is inside a text node", () => {
@@ -45,6 +50,27 @@ describe("detectMention", () => {
     expect(state?.textNode).toBeNull();
     expect(state?.atPos).toBeNull();
     expect(state?.endPos).toBeNull();
+  });
+
+  it("does not leak mentions from earlier blocks for text-node carets", () => {
+    const container = document.createElement("div");
+    container.contentEditable = "true";
+    const first = document.createElement("p");
+    first.appendChild(document.createTextNode("@alice"));
+    const second = document.createElement("p");
+    const secondText = document.createTextNode("hello world");
+    second.appendChild(secondText);
+    container.append(first, second);
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.setStart(secondText, secondText.textContent!.length);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    expect(detectMention(container)).toBeNull();
   });
 
   it("returns null when there is no active mention", () => {

--- a/ui/src/components/markdownMentionUtils.test.ts
+++ b/ui/src/components/markdownMentionUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { detectMention } from "./markdownMentionUtils";
+
+describe("detectMention", () => {
+  it("detects mentions when the caret is inside a text node", () => {
+    const container = document.createElement("div");
+    container.contentEditable = "true";
+    const textNode = document.createTextNode("@alice");
+    container.appendChild(textNode);
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.setStart(textNode, 6);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const state = detectMention(container);
+    expect(state).not.toBeNull();
+    expect(state?.query).toBe("alice");
+    expect(state?.textNode).toBe(textNode);
+    expect(state?.atPos).toBe(0);
+    expect(state?.endPos).toBe(6);
+  });
+
+  it("detects mentions when the caret is anchored on an element node at editor start", () => {
+    const container = document.createElement("div");
+    container.contentEditable = "true";
+    const paragraph = document.createElement("p");
+    paragraph.appendChild(document.createTextNode("@alice"));
+    container.appendChild(paragraph);
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.setStart(paragraph, 1);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const state = detectMention(container);
+    expect(state).not.toBeNull();
+    expect(state?.query).toBe("alice");
+    expect(state?.textNode).toBeNull();
+    expect(state?.atPos).toBeNull();
+    expect(state?.endPos).toBeNull();
+  });
+
+  it("returns null when there is no active mention", () => {
+    const container = document.createElement("div");
+    container.contentEditable = "true";
+    const textNode = document.createTextNode("hello world");
+    container.appendChild(textNode);
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.setStart(textNode, textNode.textContent!.length);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    expect(detectMention(container)).toBeNull();
+  });
+});

--- a/ui/src/components/markdownMentionUtils.ts
+++ b/ui/src/components/markdownMentionUtils.ts
@@ -50,12 +50,12 @@ export function detectMention(container: HTMLElement): MentionState | null {
   const range = sel.getRangeAt(0);
   if (!container.contains(range.startContainer)) return null;
 
-  const inlineState =
-    range.startContainer.nodeType === Node.TEXT_NODE
-      ? extractInlineMentionState(range.startContainer as Text, range.startOffset)
-      : null;
+  const isTextNodeCaret = range.startContainer.nodeType === Node.TEXT_NODE;
+  const inlineState = isTextNodeCaret
+    ? extractInlineMentionState(range.startContainer as Text, range.startOffset)
+    : null;
 
-  const query = inlineState?.query ?? extractMentionQuery(container, range);
+  const query = isTextNodeCaret ? inlineState?.query ?? null : extractMentionQuery(container, range);
   if (query == null) return null;
 
   const rect = typeof range.getBoundingClientRect === "function"

--- a/ui/src/components/markdownMentionUtils.ts
+++ b/ui/src/components/markdownMentionUtils.ts
@@ -1,0 +1,74 @@
+export interface MentionState {
+  query: string;
+  top: number;
+  left: number;
+  textNode: Text | null;
+  atPos: number | null;
+  endPos: number | null;
+}
+
+function extractInlineMentionState(textNode: Text | null, offset: number): Pick<MentionState, "query" | "textNode" | "atPos" | "endPos"> | null {
+  if (!textNode) return null;
+
+  const text = textNode.textContent ?? "";
+
+  let atPos = -1;
+  for (let i = offset - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === "@") {
+      if (i === 0 || /\s/.test(text[i - 1])) {
+        atPos = i;
+      }
+      break;
+    }
+    if (/\s/.test(ch)) break;
+  }
+
+  if (atPos === -1) return null;
+
+  return {
+    query: text.slice(atPos + 1, offset),
+    textNode,
+    atPos,
+    endPos: offset,
+  };
+}
+
+function extractMentionQuery(container: HTMLElement, range: Range): string | null {
+  const beforeCaret = range.cloneRange();
+  beforeCaret.selectNodeContents(container);
+  beforeCaret.setEnd(range.startContainer, range.startOffset);
+
+  const match = /(?:^|\s)@([^\s@]*)$/.exec(beforeCaret.toString());
+  return match ? match[1] ?? "" : null;
+}
+
+export function detectMention(container: HTMLElement): MentionState | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) return null;
+
+  const range = sel.getRangeAt(0);
+  if (!container.contains(range.startContainer)) return null;
+
+  const inlineState =
+    range.startContainer.nodeType === Node.TEXT_NODE
+      ? extractInlineMentionState(range.startContainer as Text, range.startOffset)
+      : null;
+
+  const query = inlineState?.query ?? extractMentionQuery(container, range);
+  if (query == null) return null;
+
+  const rect = typeof range.getBoundingClientRect === "function"
+    ? range.getBoundingClientRect()
+    : ({ top: 0, left: 0, bottom: 0 } as DOMRect);
+  const containerRect = container.getBoundingClientRect();
+
+  return {
+    query,
+    top: rect.bottom - containerRect.top,
+    left: rect.left - containerRect.left,
+    textNode: inlineState?.textNode ?? null,
+    atPos: inlineState?.atPos ?? null,
+    endPos: inlineState?.endPos ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- extract mention detection into a small utility so it can be tested directly
- detect active mentions even when the caret is anchored on an element node at the start of the editor
- keep the existing DOM replacement path when a text node is available and fall back cleanly otherwise
- add regression coverage for both text-node and element-node caret cases

## Testing
- cd ui && pnpm vitest run src/components/markdownMentionUtils.test.ts
- cd ui && pnpm typecheck

Fixes #515