### PR TITLE
feat: add Hermes Paperclip adapters

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,8 @@
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-hermes-gateway": "workspace:*",
+    "@paperclipai/adapter-hermes-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/cli/src/__tests__/adapter-registry.test.ts
+++ b/cli/src/__tests__/adapter-registry.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getCLIAdapter } from "../adapters/registry.js";
+
+describe("CLI adapter registry", () => {
+  it("registers hermes_local with a stdout formatter", () => {
+    const adapter = getCLIAdapter("hermes_local");
+
+    expect(adapter.type).toBe("hermes_local");
+    expect(typeof adapter.formatStdoutEvent).toBe("function");
+  });
+
+  it("registers hermes_gateway with a stdout formatter", () => {
+    const adapter = getCLIAdapter("hermes_gateway");
+
+    expect(adapter.type).toBe("hermes_gateway");
+    expect(typeof adapter.formatStdoutEvent).toBe("function");
+  });
+});

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -2,6 +2,8 @@ import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
+import { printHermesGatewayStreamEvent } from "@paperclipai/adapter-hermes-gateway/cli";
+import { printHermesLocalStreamEvent } from "@paperclipai/adapter-hermes-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
@@ -16,6 +18,16 @@ const claudeLocalCLIAdapter: CLIAdapterModule = {
 const codexLocalCLIAdapter: CLIAdapterModule = {
   type: "codex_local",
   formatStdoutEvent: printCodexStreamEvent,
+};
+
+const hermesLocalCLIAdapter: CLIAdapterModule = {
+  type: "hermes_local",
+  formatStdoutEvent: printHermesLocalStreamEvent,
+};
+
+const hermesGatewayCLIAdapter: CLIAdapterModule = {
+  type: "hermes_gateway",
+  formatStdoutEvent: printHermesGatewayStreamEvent,
 };
 
 const openCodeLocalCLIAdapter: CLIAdapterModule = {
@@ -42,6 +54,8 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
     codexLocalCLIAdapter,
+    hermesGatewayCLIAdapter,
+    hermesLocalCLIAdapter,
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,

--- a/packages/adapters/hermes-gateway/package.json
+++ b/packages/adapters/hermes-gateway/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@paperclipai/adapter-hermes-gateway",
+  "version": "0.3.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/hermes-gateway/src/cli/format-event.ts
+++ b/packages/adapters/hermes-gateway/src/cli/format-event.ts
@@ -1,0 +1,15 @@
+import pc from "picocolors";
+
+export function printHermesGatewayStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+  if (!debug) {
+    console.log(line);
+    return;
+  }
+  if (line.startsWith("[hermes-gateway]")) {
+    console.log(pc.magenta(line));
+    return;
+  }
+  console.log(pc.gray(line));
+}

--- a/packages/adapters/hermes-gateway/src/cli/index.ts
+++ b/packages/adapters/hermes-gateway/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printHermesGatewayStreamEvent } from "./format-event.js";

--- a/packages/adapters/hermes-gateway/src/index.ts
+++ b/packages/adapters/hermes-gateway/src/index.ts
@@ -1,0 +1,28 @@
+export const type = "hermes_gateway";
+export const label = "Hermes Gateway";
+
+export const models: Array<{ id: string; label: string }> = [];
+
+export const agentConfigurationDoc = `# hermes_gateway agent configuration
+
+Adapter: hermes_gateway
+
+Use when:
+- You want Paperclip to invoke Hermes over a persistent gateway/runtime connection.
+- You want Hermes to control Paperclip agents directly instead of spawning hermes CLI locally.
+
+Core fields:
+- url (string, required): Hermes gateway WebSocket URL (ws:// or wss://)
+- sessionKeyStrategy (string, optional): fixed (default), issue, or run
+- sessionKey (string, optional): fixed session key override when strategy=fixed
+- model (string, optional): model override advertised to Hermes
+- toolsets (string|string[], optional): requested Hermes toolsets
+- maxTurnsPerRun (number, optional): requested turn limit
+- gatewayAuthToken (string, optional): shared token for the Hermes gateway transport
+- paperclipApiUrl (string, optional): Paperclip API base URL override sent to Hermes
+
+Notes:
+- Paperclip resolves instructions locally and sends final system text to Hermes.
+- Paperclip auth is passed as a per-run agent JWT.
+- Session isolation is per Paperclip agent identity.
+`;

--- a/packages/adapters/hermes-gateway/src/server/execute.ts
+++ b/packages/adapters/hermes-gateway/src/server/execute.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "node:crypto";
+import { WebSocket } from "ws";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { asNumber, asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import type {
+  HermesGatewayClientHello,
+  HermesGatewayServerFrame,
+  HermesGatewayWakeRun,
+} from "../shared/stream.js";
+
+function nonEmpty(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === "string").map((entry) => entry.trim()).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function resolveSessionKey(input: {
+  strategy: "fixed" | "issue" | "run";
+  sessionKey: string | null;
+  agentId: string;
+  issueId: string | null;
+  runId: string;
+}): string {
+  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
+  if (input.strategy === "issue" && input.issueId) {
+    return `paperclip:agent:${input.agentId}:issue:${input.issueId}`;
+  }
+  return input.sessionKey ?? `paperclip:agent:${input.agentId}`;
+}
+
+function resolveAgentRole(ctx: AdapterExecutionContext): string {
+  const configured = parseObject(ctx.config);
+  const contextualAgent = parseObject(ctx.context.agent);
+  return asString(contextualAgent.role ?? configured.role, "agent");
+}
+
+function buildSystemPrompt(ctx: AdapterExecutionContext): string {
+  const configured = parseObject(ctx.config);
+  const promptTemplate = asString(
+    configured.promptTemplate,
+    "You are {{agent.name}}, acting as a Paperclip agent. Continue your assigned work.",
+  );
+  return promptTemplate
+    .replaceAll("{{agent.name}}", ctx.agent.name)
+    .replaceAll("{{agent.role}}", resolveAgentRole(ctx))
+    .replaceAll("{{agent.id}}", ctx.agent.id)
+    .replaceAll("{{company.id}}", ctx.agent.companyId);
+}
+
+function resultBase(partial?: Partial<AdapterExecutionResult>): AdapterExecutionResult {
+  return {
+    exitCode: null,
+    signal: null,
+    timedOut: false,
+    sessionParams: null,
+    sessionDisplayId: null,
+    summary: null,
+    ...partial,
+  };
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const url = nonEmpty(ctx.config.url);
+  if (!url) {
+    return resultBase({
+      exitCode: 1,
+      summary: "Hermes gateway URL is missing.",
+      errorCode: "hermes_gateway_url_missing",
+    });
+  }
+
+  if (!ctx.authToken) {
+    return resultBase({
+      exitCode: 1,
+      summary: "Paperclip auth token missing for Hermes gateway run.",
+      errorCode: "paperclip_auth_missing",
+    });
+  }
+
+  const strategyRaw = asString(ctx.config.sessionKeyStrategy, "fixed").trim().toLowerCase();
+  const strategy: "fixed" | "issue" | "run" =
+    strategyRaw === "issue" || strategyRaw === "run" ? strategyRaw : "fixed";
+
+  const issueId = nonEmpty(ctx.context.issueId) ?? nonEmpty(ctx.context.taskId) ?? null;
+  const sessionKey = resolveSessionKey({
+    strategy,
+    sessionKey: nonEmpty(ctx.config.sessionKey),
+    agentId: ctx.agent.id,
+    issueId,
+    runId: ctx.runId,
+  });
+
+  const paperclipApiUrl =
+    nonEmpty(ctx.config.paperclipApiUrl) ??
+    nonEmpty(process.env.PAPERCLIP_API_URL) ??
+    "http://localhost:3100/api";
+
+  const requestId = randomUUID();
+  const timeoutMs = Math.max(1_000, asNumber(ctx.config.waitTimeoutMs, 120_000));
+
+  const wake: HermesGatewayWakeRun = {
+    type: "wake.run",
+    requestId,
+    idempotencyKey: `paperclip-run:${ctx.runId}`,
+    session: {
+      key: sessionKey,
+      strategy,
+    },
+    paperclip: {
+      apiUrl: paperclipApiUrl,
+      authToken: ctx.authToken,
+    },
+    agent: {
+      id: ctx.agent.id,
+      companyId: ctx.agent.companyId,
+      name: ctx.agent.name,
+      role: resolveAgentRole(ctx),
+    },
+    context: {
+      runId: ctx.runId,
+      issueId: nonEmpty(ctx.context.issueId),
+      taskId: nonEmpty(ctx.context.taskId),
+      wakeReason: nonEmpty(ctx.context.wakeReason),
+      actionHint: nonEmpty(ctx.context.actionHint) ?? undefined,
+      followupIssue: parseObject(ctx.context.followupIssue),
+      issueIds: Array.isArray(ctx.context.issueIds)
+        ? ctx.context.issueIds.filter((value): value is string => typeof value === "string")
+        : [],
+      governance: parseObject(ctx.context.governance),
+    },
+    prompt: {
+      system: buildSystemPrompt(ctx),
+      user: [
+        `Paperclip wake for ${ctx.agent.name}.`,
+        `runId=${ctx.runId}`,
+        `issueId=${nonEmpty(ctx.context.issueId) ?? 'none'}`,
+        `wakeReason=${nonEmpty(ctx.context.wakeReason) ?? 'none'}`,
+        "Use the paperclip tool when you need to inspect or act on issues.",
+        "If issueId is present, call paperclip(action=list_issue_comments) and paperclip(action=get_issue) before replying.",
+        "If the wakeReason asks for planning or follow-up work, you may use paperclip(action=create_issue) to open a concrete follow-up issue.",
+        "You must inspect the issue via the paperclip tool before replying.",
+        "Reply with a brief status update and the next immediate action, then stop.",
+      ].join(" "),
+    },
+    runtime: {
+      model: nonEmpty(ctx.config.model) ?? undefined,
+      toolsets: toStringArray(ctx.config.toolsets),
+      maxTurns: asNumber(ctx.config.maxTurnsPerRun, 0) || undefined,
+    },
+  };
+
+  return await new Promise<AdapterExecutionResult>((resolve) => {
+    const headers: Record<string, string> = {};
+    const gatewayAuthToken = nonEmpty(ctx.config.gatewayAuthToken);
+    if (gatewayAuthToken) headers.authorization = `Bearer ${gatewayAuthToken}`;
+
+    const ws = new WebSocket(url, { headers });
+    let done = false;
+    let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      if (done) return;
+      done = true;
+      try {
+        ws.close();
+      } catch {}
+      resolve(
+        resultBase({
+          exitCode: 1,
+          timedOut: true,
+          summary: "Timed out waiting for Hermes gateway final response.",
+          errorCode: "hermes_gateway_timeout",
+        }),
+      );
+    }, timeoutMs);
+
+    const finish = (result: AdapterExecutionResult) => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {}
+      resolve(resultBase(result));
+    };
+
+    ws.on("open", () => {
+      const hello: HermesGatewayClientHello = {
+        type: "hello",
+        protocolVersion: 1,
+        client: { name: "paperclip", version: "0.3.0" },
+      };
+      ws.send(JSON.stringify(hello));
+      ws.send(JSON.stringify(wake));
+    });
+
+    ws.on("message", async (raw) => {
+      let frame: HermesGatewayServerFrame;
+      try {
+        frame = JSON.parse(String(raw)) as HermesGatewayServerFrame;
+      } catch {
+        return;
+      }
+
+      if (frame.type === "event.log" && frame.requestId === requestId) {
+        await ctx.onLog(frame.stream, frame.text);
+        return;
+      }
+
+      if (frame.type === "final" && frame.requestId === requestId) {
+        finish({
+          exitCode: frame.ok ? 0 : 1,
+          signal: null,
+          timedOut: false,
+          summary:
+            frame.summary ||
+            (frame.ok ? "Hermes gateway run completed." : "Hermes gateway run failed."),
+          errorCode: frame.ok ? null : frame.errorCode ?? "internal_error",
+          sessionParams: frame.session?.id ? { sessionId: frame.session.id } : { sessionId: sessionKey },
+          sessionDisplayId: frame.session?.id ?? sessionKey,
+        });
+      }
+    });
+
+    ws.on("error", (err) => {
+      finish({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        summary: err instanceof Error ? err.message : "Failed to connect to Hermes gateway.",
+        errorCode: "hermes_gateway_connect_failed",
+      });
+    });
+
+    ws.on("close", () => {
+      if (!done) {
+        finish({
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          summary: "Hermes gateway connection closed before final response.",
+          errorCode: "hermes_gateway_protocol_error",
+        });
+      }
+    });
+  });
+}

--- a/packages/adapters/hermes-gateway/src/server/index.ts
+++ b/packages/adapters/hermes-gateway/src/server/index.ts
@@ -1,0 +1,2 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/hermes-gateway/src/server/test.ts
+++ b/packages/adapters/hermes-gateway/src/server/test.ts
@@ -1,0 +1,40 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const url = typeof ctx.config.url === "string" ? ctx.config.url.trim() : "";
+  const checks: AdapterEnvironmentCheck[] = [];
+
+  if (!url) {
+    checks.push({
+      code: "hermes_gateway_url_missing",
+      level: "error",
+      message: "Hermes gateway URL is required.",
+    });
+  } else if (!/^wss?:\/\//i.test(url)) {
+    checks.push({
+      code: "hermes_gateway_url_invalid",
+      level: "error",
+      message: "Hermes gateway URL must start with ws:// or wss://",
+      detail: url,
+    });
+  } else {
+    checks.push({
+      code: "hermes_gateway_url_valid",
+      level: "info",
+      message: `Hermes gateway URL looks valid: ${url}`,
+    });
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: checks.some((check) => check.level === "error") ? "fail" : "pass",
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/hermes-gateway/src/shared/stream.ts
+++ b/packages/adapters/hermes-gateway/src/shared/stream.ts
@@ -1,0 +1,89 @@
+export type HermesGatewayClientHello = {
+  type: "hello";
+  protocolVersion: 1;
+  client: {
+    name: string;
+    version: string;
+  };
+};
+
+export type HermesGatewayWakeRun = {
+  type: "wake.run";
+  requestId: string;
+  idempotencyKey: string;
+  session: {
+    key: string;
+    strategy: "fixed" | "issue" | "run";
+  };
+  paperclip: {
+    apiUrl: string;
+    authToken: string;
+  };
+  agent: {
+    id: string;
+    companyId: string;
+    name: string;
+    role: string;
+  };
+  context: {
+    runId: string;
+    issueId: string | null;
+    taskId: string | null;
+    wakeReason: string | null;
+    actionHint?: string;
+    followupIssue?: Record<string, unknown>;
+    issueIds: string[];
+    governance?: Record<string, unknown>;
+  };
+  prompt: {
+    system: string;
+    user?: string;
+  };
+  runtime: {
+    model?: string;
+    toolsets?: string[];
+    maxTurns?: number | null;
+  };
+};
+
+export type HermesGatewayServerAck = {
+  type: "ack";
+  requestId: string;
+  accepted: boolean;
+  session?: {
+    id: string;
+    resumed: boolean;
+  };
+};
+
+export type HermesGatewayServerLog = {
+  type: "event.log";
+  requestId: string;
+  stream: "stdout" | "stderr";
+  text: string;
+};
+
+export type HermesGatewayServerState = {
+  type: "event.state";
+  requestId: string;
+  state: "queued" | "running" | "waiting_on_tool" | "waiting_on_paperclip" | "completed" | "failed";
+};
+
+export type HermesGatewayServerFinal = {
+  type: "final";
+  requestId: string;
+  ok: boolean;
+  summary: string;
+  errorCode?: string;
+  session?: {
+    id: string;
+    resumed: boolean;
+  };
+  usage?: Record<string, number>;
+};
+
+export type HermesGatewayServerFrame =
+  | HermesGatewayServerAck
+  | HermesGatewayServerLog
+  | HermesGatewayServerState
+  | HermesGatewayServerFinal;

--- a/packages/adapters/hermes-gateway/src/ui/build-config.ts
+++ b/packages/adapters/hermes-gateway/src/ui/build-config.ts
@@ -1,0 +1,17 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaList(value: string): string[] {
+  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+export function buildHermesGatewayConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.url) ac.url = v.url;
+  if (v.model) ac.model = v.model;
+  if (v.extraArgs) ac.toolsets = parseCommaList(v.extraArgs);
+  ac.timeoutSec = 120;
+  ac.waitTimeoutMs = 120000;
+  ac.sessionKeyStrategy = "fixed";
+  ac.maxTurnsPerRun = v.maxTurnsPerRun || 80;
+  return ac;
+}

--- a/packages/adapters/hermes-gateway/src/ui/index.ts
+++ b/packages/adapters/hermes-gateway/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseHermesGatewayStdoutLine } from "./parse-stdout.js";
+export { buildHermesGatewayConfig } from "./build-config.js";

--- a/packages/adapters/hermes-gateway/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes-gateway/src/ui/parse-stdout.ts
@@ -1,0 +1,10 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+export function parseHermesGatewayStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[hermes-gateway]")) {
+    return [{ kind: "system", ts, text: trimmed.replace(/^\[hermes-gateway\]\s*/, "") }];
+  }
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/hermes-gateway/tsconfig.json
+++ b/packages/adapters/hermes-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/hermes-local/package.json
+++ b/packages/adapters/hermes-local/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@paperclipai/adapter-hermes-local",
+  "version": "0.3.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/hermes-local/src/cli/format-event.ts
+++ b/packages/adapters/hermes-local/src/cli/format-event.ts
@@ -1,0 +1,3 @@
+export function printHermesLocalStreamEvent(line: string): void {
+  process.stdout.write(`${line}\n`);
+}

--- a/packages/adapters/hermes-local/src/cli/index.ts
+++ b/packages/adapters/hermes-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printHermesLocalStreamEvent } from "./format-event.js";

--- a/packages/adapters/hermes-local/src/index.ts
+++ b/packages/adapters/hermes-local/src/index.ts
@@ -1,0 +1,38 @@
+export const type = "hermes_local";
+export const label = "Hermes (local)";
+export const DEFAULT_HERMES_LOCAL_MODEL = "gpt-5.4";
+
+export const models = [
+  { id: DEFAULT_HERMES_LOCAL_MODEL, label: DEFAULT_HERMES_LOCAL_MODEL },
+];
+
+export const agentConfigurationDoc = `# hermes_local agent configuration
+
+Adapter: hermes_local
+
+Use when:
+- You want Paperclip to invoke the local Hermes CLI as an agent runtime.
+- You want a Paperclip-managed Hermes employee on the same machine.
+
+Core fields:
+- cwd (string, optional): absolute working directory fallback for the Hermes process
+- instructionsFilePath (string, optional): absolute path to markdown instructions prepended to the query prompt at runtime
+- model (string, optional): Hermes chat model id (passed as -m)
+- provider (string, optional): Hermes provider override (passed as --provider)
+- promptTemplate (string, optional): run prompt template
+- toolsets (string|string[], optional): Hermes toolsets passed as -t (comma-separated if array)
+- command (string, optional): defaults to "hermes"
+- extraArgs (string[], optional): additional Hermes CLI args injected before -q
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+- verbose (boolean, optional): pass -v to Hermes
+
+Notes:
+- Paperclip auto-injects Paperclip skills into ~/.hermes/skills when missing.
+- Session resume uses \
+\`hermes --resume <sessionId>\` under the hood for long-lived agent continuity.
+- Paperclip run auth is passed via PAPERCLIP_* environment variables, including PAPERCLIP_API_KEY for local JWTs.
+`;

--- a/packages/adapters/hermes-local/src/server/execute.ts
+++ b/packages/adapters/hermes-local/src/server/execute.ts
@@ -1,0 +1,326 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const PAPERCLIP_SKILLS_CANDIDATES = [
+  path.resolve(__moduleDir, "../../../../../skills"),
+  path.resolve(__moduleDir, "../../../../../../skills"),
+];
+const ANSI_RE = /\x1B\[[0-9;?]*[ -/]*[@-~]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function readNonEmptyString(value: unknown): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : "";
+}
+
+function hermesHomeDir(): string {
+  const fromEnv = process.env.HERMES_HOME;
+  if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return fromEnv.trim();
+  return path.join(os.homedir(), ".hermes");
+}
+
+async function resolvePaperclipSkillsDir(): Promise<string | null> {
+  for (const candidate of PAPERCLIP_SKILLS_CANDIDATES) {
+    const isDir = await fs.stat(candidate).then((s) => s.isDirectory()).catch(() => false);
+    if (isDir) return candidate;
+  }
+  return null;
+}
+
+async function ensureHermesSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
+  const skillsDir = await resolvePaperclipSkillsDir();
+  if (!skillsDir) return;
+
+  const skillsHome = path.join(hermesHomeDir(), "skills");
+  await fs.mkdir(skillsHome, { recursive: true });
+  for (const name of ["paperclip", "paperclip-create-agent"]) {
+    const source = path.join(skillsDir, name);
+    const sourceExists = await fs.stat(source).then((s) => s.isDirectory()).catch(() => false);
+    if (!sourceExists) continue;
+    const target = path.join(skillsHome, name);
+    const existing = await fs.lstat(target).catch(() => null);
+    if (existing) continue;
+    try {
+      await fs.symlink(source, target);
+      await onLog("stderr", `[paperclip] Injected Hermes skill \"${name}\" into ${skillsHome}\n`);
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to inject Hermes skill \"${name}\" into ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Use the Paperclip skills directly instead of improvising the API.",
+    "",
+    "",
+  ].join("\n");
+}
+
+function renderTaskFirstPromptNote(input: {
+  env: Record<string, string>;
+  context: Record<string, unknown>;
+  runtimeTaskKey: string | null;
+}): string {
+  const taskId = readNonEmptyString(input.env.PAPERCLIP_TASK_ID);
+  const contextTaskKey = readNonEmptyString(input.context.taskKey);
+  const runtimeTaskKey = readNonEmptyString(input.runtimeTaskKey);
+  const activeTaskKey = taskId || contextTaskKey || runtimeTaskKey;
+  const wakeReason = readNonEmptyString(input.env.PAPERCLIP_WAKE_REASON);
+  const isIssueWake = wakeReason === "issue_assigned" || wakeReason === "issue_checked_out";
+  if (!activeTaskKey && !isIssueWake) return "";
+
+  return [
+    "Paperclip task-first note:",
+    activeTaskKey
+      ? `This run has an active Paperclip issue/task context: ${activeTaskKey}.`
+      : "This run was woken for an active Paperclip issue/task.",
+    "Prioritize the active Paperclip issue now.",
+    "Do not spend this run on generic setup, banner chatter, or side quests.",
+    "This run must not exit without either completing the issue or blocking it with a real reason.",
+    "",
+    "",
+  ].join("\n");
+}
+
+export function extractHermesSessionId(output: string): string | null {
+  const clean = stripAnsi(output);
+  const match = clean.match(/^Session:\s+([^\s]+)$/m);
+  return match?.[1] ?? null;
+}
+
+export function extractHermesSummary(output: string): string | null {
+  const clean = stripAnsi(output).replace(/\r/g, "");
+  const blockRe = /╭─[^\n]*Hermes[^\n]*╮\n([\s\S]*?)\n╰─/g;
+  let lastMatch: RegExpExecArray | null = null;
+  while (true) {
+    const match = blockRe.exec(clean);
+    if (!match) break;
+    lastMatch = match;
+  }
+  if (lastMatch?.[1]) {
+    return lastMatch[1].trim();
+  }
+
+  const filtered = clean
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => {
+      if (!line) return false;
+      if (line.startsWith("Session:")) return false;
+      if (line.startsWith("Duration:")) return false;
+      if (line.startsWith("Messages:")) return false;
+      if (line.startsWith("Resume this session")) return false;
+      if (line.startsWith("Query:")) return false;
+      if (/^[╭╰│─]+/.test(line)) return false;
+      if (/ruminating/.test(line)) return false;
+      return true;
+    });
+
+  return filtered.length > 0 ? filtered.slice(-8).join("\n") : null;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const command = asString(config.command, "hermes");
+  const model = asString(config.model, "").trim();
+  const provider = asString(config.provider, "").trim();
+  const toolsets = config.toolsets;
+  const verbose = asBoolean(config.verbose, false);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const configuredCwd = asString(config.cwd, "");
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+  await ensureHermesSkillsInjected(onLog);
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
+
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const sessionId = readNonEmptyString(runtime.sessionParams?.sessionId ?? runtime.sessionId ?? "");
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const resolvedInstructionsFilePath = instructionsFilePath
+    ? path.resolve(cwd, instructionsFilePath)
+    : "";
+  let injectedInstructions = "";
+  if (resolvedInstructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(resolvedInstructionsFilePath, "utf8");
+      const instructionsDir = `${path.dirname(resolvedInstructionsFilePath)}/`;
+      injectedInstructions =
+        `${instructionsContents.trim()}\n\n` +
+        `The above agent instructions were loaded from ${resolvedInstructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+      await onLog("stderr", `[paperclip] Loaded agent instructions file: ${resolvedInstructionsFilePath}\n`);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not read agent instructions file "${resolvedInstructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+  const extraArgs = asStringArray(config.extraArgs)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const query = renderTemplate(promptTemplate, {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  });
+
+  const fullPrompt =
+    injectedInstructions +
+    renderPaperclipEnvNote(env) +
+    renderTaskFirstPromptNote({ env, context, runtimeTaskKey: runtime.taskKey }) +
+    query;
+
+  const args = ["chat"];
+  if (extraArgs.length > 0) args.push(...extraArgs);
+  if (model) args.push("-m", model);
+  if (provider) args.push("--provider", provider);
+  if (toolsets) {
+    const renderedToolsets = Array.isArray(toolsets) ? toolsets.join(",") : String(toolsets);
+    if (renderedToolsets.trim()) args.push("-t", renderedToolsets.trim());
+  }
+  if (verbose) args.push("-v");
+  if (sessionId) args.push("--resume", sessionId);
+  args.push("-q", fullPrompt);
+
+  await onMeta?.({
+    adapterType: "hermes_local",
+    command,
+    cwd,
+    commandArgs: args,
+    env: redactEnvForLogs(env),
+    prompt: fullPrompt,
+    context,
+  });
+
+  const proc = await runChildProcess(runId, command, args, {
+    cwd,
+    env,
+    timeoutSec,
+    graceSec,
+    onLog,
+  });
+
+  const summary = extractHermesSummary(proc.stdout);
+  const parsedSessionId = extractHermesSessionId(proc.stdout) ?? sessionId;
+
+  return {
+    exitCode: proc.exitCode,
+    signal: proc.signal,
+    timedOut: proc.timedOut,
+    summary,
+    sessionParams: parsedSessionId
+      ? {
+          sessionId: parsedSessionId,
+          cwd,
+        }
+      : null,
+    sessionDisplayId: parsedSessionId,
+    billingType: "subscription",
+    provider: provider || null,
+    model: model || null,
+    errorMessage:
+      proc.exitCode === 0 && !proc.timedOut
+        ? null
+        : firstNonEmptyLine(stripAnsi(proc.stderr)) || firstNonEmptyLine(stripAnsi(proc.stdout)) || null,
+  };
+}

--- a/packages/adapters/hermes-local/src/server/index.ts
+++ b/packages/adapters/hermes-local/src/server/index.ts
@@ -1,0 +1,35 @@
+export { execute, extractHermesSessionId, extractHermesSummary } from "./execute.js";
+export { testEnvironment } from "./test.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(record.cwd) ?? readNonEmptyString(record.workdir);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd) ?? readNonEmptyString(params.workdir);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};

--- a/packages/adapters/hermes-local/src/server/test.ts
+++ b/packages/adapters/hermes-local/src/server/test.ts
@@ -1,0 +1,132 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { extractHermesSummary } from "./execute.js";
+import path from "node:path";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "hermes");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({
+      code: "hermes_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "hermes_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "hermes_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "hermes_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "hermes_cwd_invalid" && check.code !== "hermes_command_unresolvable");
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "hermes")) {
+      checks.push({
+        code: "hermes_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `hermes`.",
+        detail: command,
+      });
+    } else {
+      const probe = await runChildProcess(
+        `hermes-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        ["chat", "-q", "Respond with exactly: hello"],
+        {
+          cwd,
+          env,
+          timeoutSec: 45,
+          graceSec: 5,
+          onLog: async () => {},
+        },
+      );
+
+      const summary = extractHermesSummary(probe.stdout)?.replace(/\s+/g, " ").trim() ?? "";
+      if (probe.timedOut) {
+        checks.push({
+          code: "hermes_hello_probe_timed_out",
+          level: "warn",
+          message: "Hermes hello probe timed out.",
+          hint: "Retry the probe. If this persists, run `hermes chat -q \"Respond with exactly: hello\"` manually.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0 && /\bhello\b/i.test(summary)) {
+        checks.push({
+          code: "hermes_hello_probe_passed",
+          level: "info",
+          message: "Hermes hello probe succeeded.",
+          detail: summary,
+        });
+      } else {
+        const detail = summary || probe.stderr.trim() || probe.stdout.trim();
+        checks.push({
+          code: "hermes_hello_probe_failed",
+          level: "error",
+          message: "Hermes hello probe failed.",
+          ...(detail ? { detail: detail.slice(0, 240) } : {}),
+          hint: "Run `hermes chat -q \"Respond with exactly: hello\"` manually to debug the local runtime.",
+        });
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/hermes-local/src/ui/build-config.ts
+++ b/packages/adapters/hermes-local/src/ui/build-config.ts
@@ -1,0 +1,71 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_HERMES_LOCAL_MODEL } from "../index.js";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest" ? { version: rec.version } : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildHermesLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  ac.model = v.model || DEFAULT_HERMES_LOCAL_MODEL;
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/hermes-local/src/ui/index.ts
+++ b/packages/adapters/hermes-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseHermesStdoutLine } from "./parse-stdout.js";
+export { buildHermesLocalConfig } from "./build-config.js";

--- a/packages/adapters/hermes-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes-local/src/ui/parse-stdout.ts
@@ -1,0 +1,16 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+const ANSI_RE = /\x1B\[[0-9;?]*[ -/]*[@-~]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+export function parseHermesStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const clean = stripAnsi(line);
+  const sessionMatch = clean.match(/^Session:\s+([^\s]+)$/);
+  if (sessionMatch) {
+    return [{ kind: "init", ts, model: "hermes", sessionId: sessionMatch[1] }];
+  }
+  return [{ kind: "stdout", ts, text: clean }];
+}

--- a/packages/adapters/hermes-local/tsconfig.json
+++ b/packages/adapters/hermes-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.test.ts
+++ b/packages/shared/src/constants.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_ADAPTER_TYPES } from "./constants.js";
+import { createAgentSchema } from "./validators/agent.js";
+
+describe("shared adapter registration", () => {
+  it("includes hermes_local and hermes_gateway in the allowed agent adapter types", () => {
+    expect(AGENT_ADAPTER_TYPES).toContain("hermes_local");
+    expect(AGENT_ADAPTER_TYPES).toContain("hermes_gateway");
+  });
+
+  it("accepts hermes_local and hermes_gateway when validating agent creation payloads", () => {
+    const localParsed = createAgentSchema.parse({
+      name: "Hermes Local",
+      adapterType: "hermes_local",
+    });
+    const gatewayParsed = createAgentSchema.parse({
+      name: "Hermes Gateway",
+      adapterType: "hermes_gateway",
+    });
+
+    expect(localParsed.adapterType).toBe("hermes_local");
+    expect(gatewayParsed.adapterType).toBe("hermes_gateway");
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -27,6 +27,8 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "opencode_local",
+  "hermes_local",
+  "hermes_gateway",
   "pi_local",
   "cursor",
   "openclaw_gateway",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -38,6 +41,12 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-hermes-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-gateway
+      '@paperclipai/adapter-hermes-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -68,6 +77,9 @@ importers:
       drizzle-orm:
         specifier: 0.38.4
         version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      embedded-postgres:
+        specifier: ^18.1.0-beta.16
+        version: 18.1.0-beta.16
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -124,6 +136,44 @@ importers:
         version: 5.9.3
 
   packages/adapters/cursor-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/hermes-gateway:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/hermes-local:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -245,6 +295,12 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-hermes-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-gateway
+      '@paperclipai/adapter-hermes-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -321,6 +377,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
@@ -360,6 +419,12 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-hermes-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-gateway
+      '@paperclipai/adapter-hermes-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -988,6 +1053,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -3423,6 +3491,11 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -6741,6 +6814,8 @@ snapshots:
   '@embedded-postgres/windows-x64@18.1.0-beta.16':
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -9254,6 +9329,11 @@ snapshots:
       layout-base: 2.0.1
 
   crelt@1.0.6: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,8 @@
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-hermes-gateway": "workspace:*",
+    "@paperclipai/adapter-hermes-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
+import { models as hermesFallbackModels } from "@paperclipai/adapter-hermes-local";
 import { resetOpenCodeModelsCacheForTests } from "@paperclipai/adapter-opencode-local/server";
 import { listAdapterModels } from "../adapters/index.js";
 import { resetCodexModelsCacheForTests } from "../adapters/codex-models.js";

--- a/server/src/__tests__/hermes-gateway-adapter.test.ts
+++ b/server/src/__tests__/hermes-gateway-adapter.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { createServer } from "node:http";
+import { WebSocketServer } from "ws";
+import { execute } from "@paperclipai/adapter-hermes-gateway/server";
+import { getServerAdapter } from "../adapters/index.js";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+function buildContext(config: Record<string, unknown>): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "Hermes",
+      adapterType: "hermes_gateway",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config,
+    context: {
+      taskId: "task-123",
+      issueId: "issue-123",
+      wakeReason: "issue_assigned",
+      issueIds: ["issue-123"],
+    },
+    onLog: async () => {},
+    authToken: "jwt-test-token",
+  };
+}
+
+describe("hermes_gateway registration", () => {
+  it("registers hermes_gateway in the server adapter registry", () => {
+    const adapter = getServerAdapter("hermes_gateway");
+
+    expect(adapter.type).toBe("hermes_gateway");
+    expect(adapter.supportsLocalAgentJwt).toBe(true);
+  });
+});
+
+describe("hermes_gateway execute", () => {
+  it("fails cleanly when url is missing", async () => {
+    const result = await execute(buildContext({}));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("hermes_gateway_url_missing");
+  });
+
+  it("streams logs and returns final summary from the gateway", async () => {
+    const server = createServer();
+    const wss = new WebSocketServer({ server });
+    const seenWakePayloads: Array<Record<string, unknown>> = [];
+
+    wss.on("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as Record<string, unknown>;
+        if (msg.type !== "wake.run") return;
+        seenWakePayloads.push(msg);
+        const requestId = String(msg.requestId);
+        socket.send(
+          JSON.stringify({
+            type: "ack",
+            requestId,
+            accepted: true,
+            session: { id: "paperclip:agent:agent-123", resumed: false },
+          }),
+        );
+        socket.send(
+          JSON.stringify({
+            type: "event.log",
+            requestId,
+            stream: "stdout",
+            text: "hello from hermes gateway\n",
+          }),
+        );
+        socket.send(
+          JSON.stringify({
+            type: "final",
+            requestId,
+            ok: true,
+            summary: "Hermes gateway completed the run.",
+            session: { id: "paperclip:agent:agent-123", resumed: false },
+          }),
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to resolve test server address");
+    }
+
+    const logs: string[] = [];
+    try {
+      const result = await execute({
+        ...buildContext({ url: `ws://127.0.0.1:${address.port}` }),
+        onLog: async (_stream, chunk) => {
+          logs.push(chunk);
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.summary).toBe("Hermes gateway completed the run.");
+      expect(result.sessionDisplayId).toBe("paperclip:agent:agent-123");
+      expect(logs.join("")).toContain("hello from hermes gateway");
+      expect(seenWakePayloads).toHaveLength(1);
+      expect((seenWakePayloads[0].prompt as Record<string, unknown>).user).toContain("paperclip");
+      expect((seenWakePayloads[0].prompt as Record<string, unknown>).user).toContain("get_issue");
+      expect((seenWakePayloads[0].prompt as Record<string, unknown>).user).toContain("status update");
+    } finally {
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("propagates actionHint and followupIssue context into the wake payload", async () => {
+    const server = createServer();
+    const wss = new WebSocketServer({ server });
+    const seenWakePayloads: Array<Record<string, unknown>> = [];
+
+    wss.on("connection", (socket) => {
+      socket.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as Record<string, unknown>;
+        if (msg.type !== "wake.run") return;
+        seenWakePayloads.push(msg);
+        const requestId = String(msg.requestId);
+        socket.send(
+          JSON.stringify({
+            type: "final",
+            requestId,
+            ok: true,
+            summary: "ok",
+            session: { id: "paperclip:agent:agent-123", resumed: false },
+          }),
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Failed to resolve test server address");
+
+    try {
+      await execute({
+        ...buildContext({ url: `ws://127.0.0.1:${address.port}` }),
+        context: {
+          taskId: "task-123",
+          issueId: "issue-123",
+          wakeReason: "follow-up",
+          issueIds: ["issue-123"],
+          actionHint: "create_followup_issue",
+          followupIssue: { title: "Hermes Gateway Follow-up Smoke", description: "create it" },
+        },
+      });
+
+      expect(seenWakePayloads).toHaveLength(1);
+      expect((seenWakePayloads[0].context as Record<string, unknown>).actionHint).toBe("create_followup_issue");
+      expect((seenWakePayloads[0].context as Record<string, unknown>).followupIssue).toEqual({
+        title: "Hermes Gateway Follow-up Smoke",
+        description: "create it",
+      });
+      expect((seenWakePayloads[0].prompt as Record<string, unknown>).user).toContain("create_issue");
+    } finally {
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/server/src/__tests__/hermes-local-adapter-environment.test.ts
+++ b/server/src/__tests__/hermes-local-adapter-environment.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { testEnvironment } from "@paperclipai/adapter-hermes-local/server";
+
+describe("hermes_local environment diagnostics", () => {
+  it("creates a missing working directory when cwd is absolute", async () => {
+    const cwd = path.join(
+      os.tmpdir(),
+      `paperclip-hermes-local-cwd-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      "workspace",
+    );
+
+    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "hermes_local",
+      config: {
+        command: process.execPath,
+        cwd,
+      },
+    });
+
+    expect(result.checks.some((check) => check.code === "hermes_cwd_valid")).toBe(true);
+    expect(result.checks.some((check) => check.level === "error")).toBe(false);
+    const stats = await fs.stat(cwd);
+    expect(stats.isDirectory()).toBe(true);
+    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+  });
+
+  it("runs the hello probe when Hermes is available on PATH", async () => {
+    const root = path.join(
+      os.tmpdir(),
+      `paperclip-hermes-local-probe-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    const binDir = path.join(root, "bin");
+    const cwd = path.join(root, "workspace");
+    const fakeHermes = path.join(binDir, "hermes");
+    const script = `#!/bin/sh
+printf '╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮\n'
+printf 'hello\n'
+printf '╰──────────────────────────────────────────────────────────────────────────────╯\n'
+printf 'Session:        20260310_000000_test\n'
+`;
+
+    try {
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.writeFile(fakeHermes, script, { encoding: "utf8", mode: 0o755 });
+
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "hermes_local",
+        config: {
+          command: "hermes",
+          cwd,
+          env: {
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.checks.some((check) => check.code === "hermes_hello_probe_passed")).toBe(true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/__tests__/hermes-local-execute.test.ts
+++ b/server/src/__tests__/hermes-local-execute.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-hermes-local/server";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+interface CapturePayload {
+  argv: string[];
+}
+
+function buildContext(
+  config: Record<string, unknown>,
+  overrides?: Partial<AdapterExecutionContext>,
+): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "Hermes Agent",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config,
+    context: {
+      taskId: "task-123",
+      issueId: "issue-123",
+      wakeReason: "issue_assigned",
+      issueIds: ["issue-123"],
+    },
+    onLog: async () => {},
+    ...overrides,
+  };
+}
+
+async function writeFakeHermesCommand(commandPath: string) {
+  const script = `#!/usr/bin/env node
+import fs from "node:fs";
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({ argv: process.argv.slice(2) }));
+}
+process.stdout.write("Hermes Agent banner noise\\n");
+process.stdout.write("╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮\\n");
+process.stdout.write("done and commented on the issue\\n\\nwith one extra line\\n");
+process.stdout.write("╰──────────────────────────────────────────────────────────────────────────────╯\\n");
+process.stdout.write("Session:        20260310_999999_test\\n");
+`;
+  await fs.writeFile(commandPath, script, { encoding: "utf8", mode: 0o755 });
+}
+
+describe("hermes_local execute", () => {
+  it("extracts assistant summary and session id from hermes CLI output", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-local-exec-"));
+    const cwd = path.join(root, "workspace");
+    const commandPath = path.join(root, "hermes");
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      await fs.mkdir(cwd, { recursive: true });
+      await writeFakeHermesCommand(commandPath);
+
+      const result = await execute(
+        buildContext({
+          command: commandPath,
+          cwd,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.summary).toContain("done and commented on the issue");
+      expect(result.sessionParams).toEqual({
+        sessionId: "20260310_999999_test",
+        cwd,
+      });
+      expect(result.sessionDisplayId).toBe("20260310_999999_test");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepends instructions file contents to the Hermes prompt and forwards extra args", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-local-prompt-"));
+    const cwd = path.join(root, "workspace");
+    const commandPath = path.join(root, "hermes");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsFilePath = path.join(root, "hermes-ceo.md");
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    let invocationPrompt = "";
+    try {
+      await fs.mkdir(cwd, { recursive: true });
+      await fs.writeFile(instructionsFilePath, "Run the company like you mean it.\nNo generic status fluff.");
+      await writeFakeHermesCommand(commandPath);
+
+      const result = await execute(
+        buildContext(
+          {
+            command: commandPath,
+            cwd,
+            instructionsFilePath,
+            extraArgs: ["--debug", "--emit-json"],
+            env: {
+              PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            },
+            promptTemplate: "Continue your assigned Paperclip work.",
+          },
+          {
+            onMeta: async (meta) => {
+              invocationPrompt = meta.prompt ?? "";
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.argv).toEqual(expect.arrayContaining(["chat", "--debug", "--emit-json", "-q"]));
+      const promptIndex = capture.argv.indexOf("-q");
+      expect(promptIndex).toBeGreaterThanOrEqual(0);
+      const promptArg = capture.argv[promptIndex + 1] ?? "";
+      expect(promptArg).toContain("Run the company like you mean it.");
+      expect(promptArg).toContain("No generic status fluff.");
+      expect(promptArg).toContain(`The above agent instructions were loaded from ${instructionsFilePath}.`);
+      expect(promptArg).toContain("Continue your assigned Paperclip work.");
+      expect(invocationPrompt).toContain("Run the company like you mean it.");
+      expect(invocationPrompt).toContain("No generic status fluff.");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -34,6 +34,23 @@ import {
   agentConfigurationDoc as openclawGatewayAgentConfigurationDoc,
   models as openclawGatewayModels,
 } from "@paperclipai/adapter-openclaw-gateway";
+import {
+  execute as hermesGatewayExecute,
+  testEnvironment as hermesGatewayTestEnvironment,
+} from "@paperclipai/adapter-hermes-gateway/server";
+import {
+  agentConfigurationDoc as hermesGatewayAgentConfigurationDoc,
+  models as hermesGatewayModels,
+} from "@paperclipai/adapter-hermes-gateway";
+import {
+  execute as hermesExecute,
+  testEnvironment as hermesTestEnvironment,
+  sessionCodec as hermesSessionCodec,
+} from "@paperclipai/adapter-hermes-local/server";
+import {
+  agentConfigurationDoc as hermesAgentConfigurationDoc,
+  models as hermesModels,
+} from "@paperclipai/adapter-hermes-local";
 import { listCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
@@ -89,6 +106,25 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,
 };
 
+const hermesGatewayAdapter: ServerAdapterModule = {
+  type: "hermes_gateway",
+  execute: hermesGatewayExecute,
+  testEnvironment: hermesGatewayTestEnvironment,
+  models: hermesGatewayModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: hermesGatewayAgentConfigurationDoc,
+};
+
+const hermesLocalAdapter: ServerAdapterModule = {
+  type: "hermes_local",
+  execute: hermesExecute,
+  testEnvironment: hermesTestEnvironment,
+  sessionCodec: hermesSessionCodec,
+  models: hermesModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: hermesAgentConfigurationDoc,
+};
+
 const openCodeLocalAdapter: ServerAdapterModule = {
   type: "opencode_local",
   execute: openCodeExecute,
@@ -115,6 +151,8 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
     codexLocalAdapter,
+    hermesGatewayAdapter,
+    hermesLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
     cursorLocalAdapter,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -43,6 +43,7 @@ export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
     claude_local: "instructionsFilePath",
     codex_local: "instructionsFilePath",
+    hermes_local: "instructionsFilePath",
     opencode_local: "instructionsFilePath",
     cursor: "instructionsFilePath",
   };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -261,6 +261,8 @@ function enrichWakeContextSnapshot(input: {
   const { contextSnapshot, reason, source, triggerDetail, payload } = input;
   const issueIdFromPayload = readNonEmptyString(payload?.["issueId"]);
   const commentIdFromPayload = readNonEmptyString(payload?.["commentId"]);
+  const actionHintFromPayload = readNonEmptyString(payload?.["actionHint"]);
+  const followupIssueFromPayload = parseObject(payload?.["followupIssue"]);
   const taskKey = deriveTaskKey(contextSnapshot, payload);
   const wakeCommentId = deriveCommentId(contextSnapshot, payload);
 
@@ -287,6 +289,15 @@ function enrichWakeContextSnapshot(input: {
   }
   if (!readNonEmptyString(contextSnapshot["wakeTriggerDetail"]) && triggerDetail) {
     contextSnapshot.wakeTriggerDetail = triggerDetail;
+  }
+  if (!readNonEmptyString(contextSnapshot["actionHint"]) && actionHintFromPayload) {
+    contextSnapshot.actionHint = actionHintFromPayload;
+  }
+  if (
+    Object.keys(parseObject(contextSnapshot["followupIssue"])).length === 0 &&
+    Object.keys(followupIssueFromPayload).length > 0
+  ) {
+    contextSnapshot.followupIssue = followupIssueFromPayload;
   }
 
   return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     { "path": "./packages/adapters/claude-local" },
     { "path": "./packages/adapters/codex-local" },
     { "path": "./packages/adapters/cursor-local" },
+    { "path": "./packages/adapters/hermes-gateway" },
+    { "path": "./packages/adapters/hermes-local" },
     { "path": "./packages/adapters/openclaw-gateway" },
     { "path": "./packages/adapters/opencode-local" },
     { "path": "./packages/adapters/pi-local" },

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,8 @@
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-hermes-gateway": "workspace:*",
+    "@paperclipai/adapter-hermes-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/ui/src/adapters/hermes-gateway/config-fields.tsx
+++ b/ui/src/adapters/hermes-gateway/config-fields.tsx
@@ -1,0 +1,88 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput } from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+export function HermesGatewayConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="Gateway URL">
+        <DraftInput
+          value={isCreate ? values!.url : eff("adapterConfig", "url", String(config.url ?? ""))}
+          onCommit={(v) =>
+            isCreate ? set!({ url: v }) : mark("adapterConfig", "url", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="ws://127.0.0.1:18791/paperclip"
+        />
+      </Field>
+
+      <Field label="Model override">
+        <DraftInput
+          value={isCreate ? values!.model : eff("adapterConfig", "model", String(config.model ?? ""))}
+          onCommit={(v) =>
+            isCreate ? set!({ model: v }) : mark("adapterConfig", "model", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="gpt-5.4"
+        />
+      </Field>
+
+      {!isCreate && (
+        <>
+          <Field label="Session strategy">
+            <select
+              value={eff("adapterConfig", "sessionKeyStrategy", String(config.sessionKeyStrategy ?? "fixed"))}
+              onChange={(e) => mark("adapterConfig", "sessionKeyStrategy", e.target.value)}
+              className={inputClass}
+            >
+              <option value="fixed">Fixed</option>
+              <option value="issue">Per issue</option>
+              <option value="run">Per run</option>
+            </select>
+          </Field>
+
+          <Field label="Session key">
+            <DraftInput
+              value={eff("adapterConfig", "sessionKey", String(config.sessionKey ?? ""))}
+              onCommit={(v) => mark("adapterConfig", "sessionKey", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="paperclip"
+            />
+          </Field>
+
+          <Field label="Paperclip API URL override">
+            <DraftInput
+              value={eff("adapterConfig", "paperclipApiUrl", String(config.paperclipApiUrl ?? ""))}
+              onCommit={(v) => mark("adapterConfig", "paperclipApiUrl", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="http://localhost:3100/api"
+            />
+          </Field>
+
+          <Field label="Gateway auth token">
+            <DraftInput
+              value={eff("adapterConfig", "gatewayAuthToken", String(config.gatewayAuthToken ?? ""))}
+              onCommit={(v) => mark("adapterConfig", "gatewayAuthToken", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="optional bearer token"
+            />
+          </Field>
+        </>
+      )}
+    </>
+  );
+}

--- a/ui/src/adapters/hermes-gateway/index.ts
+++ b/ui/src/adapters/hermes-gateway/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseHermesGatewayStdoutLine } from "@paperclipai/adapter-hermes-gateway/ui";
+import { buildHermesGatewayConfig } from "@paperclipai/adapter-hermes-gateway/ui";
+import { HermesGatewayConfigFields } from "./config-fields";
+
+export const hermesGatewayUIAdapter: UIAdapterModule = {
+  type: "hermes_gateway",
+  label: "Hermes Gateway",
+  parseStdoutLine: parseHermesGatewayStdoutLine,
+  ConfigFields: HermesGatewayConfigFields,
+  buildAdapterConfig: buildHermesGatewayConfig,
+};

--- a/ui/src/adapters/hermes-local/config-fields.tsx
+++ b/ui/src/adapters/hermes-local/config-fields.tsx
@@ -1,0 +1,46 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput } from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Prepended to the Hermes query prompt at runtime.";
+
+export function HermesLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/hermes-local/index.ts
+++ b/ui/src/adapters/hermes-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseHermesStdoutLine } from "@paperclipai/adapter-hermes-local/ui";
+import { HermesLocalConfigFields } from "./config-fields";
+import { buildHermesLocalConfig } from "@paperclipai/adapter-hermes-local/ui";
+
+export const hermesLocalUIAdapter: UIAdapterModule = {
+  type: "hermes_local",
+  label: "Hermes (local)",
+  parseStdoutLine: parseHermesStdoutLine,
+  ConfigFields: HermesLocalConfigFields,
+  buildAdapterConfig: buildHermesLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -2,6 +2,8 @@ import type { UIAdapterModule } from "./types";
 import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
+import { hermesGatewayUIAdapter } from "./hermes-gateway";
+import { hermesLocalUIAdapter } from "./hermes-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -12,6 +14,8 @@ const adaptersByType = new Map<string, UIAdapterModule>(
   [
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
+    hermesGatewayUIAdapter,
+    hermesLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -39,6 +39,7 @@ import {
 } from "./agent-config-primitives";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { getUIAdapter } from "../adapters";
+import { ENABLED_ADVANCED_ADAPTER_TYPES, isLocalCliAdapter } from "../lib/agent-adapters";
 import { ClaudeLocalAdvancedFields } from "../adapters/claude-local/config-fields";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { ChoosePathButton } from "./PathInstructionsModal";
@@ -272,11 +273,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const adapterType = isCreate
     ? props.values.adapterType
     : overlay.adapterType ?? props.agent.adapterType;
-  const isLocal =
-    adapterType === "claude_local" ||
-    adapterType === "codex_local" ||
-    adapterType === "opencode_local" ||
-    adapterType === "cursor";
+  const isLocal = isLocalCliAdapter(adapterType);
   const uiAdapter = useMemo(() => getUIAdapter(adapterType), [adapterType]);
 
   // Fetch adapter models for the effective adapter type
@@ -891,14 +888,12 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
-
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [
   ...AGENT_ADAPTER_TYPES.map((t) => ({
     value: t,
     label: adapterLabels[t] ?? t,
-    comingSoon: !ENABLED_ADAPTER_TYPES.has(t),
+    comingSoon: !ENABLED_ADVANCED_ADAPTER_TYPES.has(t),
   })),
 ];
 

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -4,6 +4,7 @@ import { AGENT_ROLE_LABELS, type Agent, type AgentRuntimeState } from "@papercli
 import { agentsApi } from "../api/agents";
 import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
+import { adapterLabels } from "../lib/agent-adapters";
 import { StatusBadge } from "./StatusBadge";
 import { Identity } from "./Identity";
 import { formatDate, agentUrl } from "../lib/utils";
@@ -13,16 +14,6 @@ interface AgentPropertiesProps {
   agent: Agent;
   runtimeState?: AgentRuntimeState;
 }
-
-const adapterLabels: Record<string, string> = {
-  claude_local: "Claude (local)",
-  codex_local: "Codex (local)",
-  opencode_local: "OpenCode (local)",
-  openclaw_gateway: "OpenClaw Gateway",
-  cursor: "Cursor (local)",
-  process: "Process",
-  http: "HTTP",
-};
 
 const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
 

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -25,6 +25,8 @@ type AdvancedAdapterType =
   | "claude_local"
   | "codex_local"
   | "opencode_local"
+  | "hermes_gateway"
+  | "hermes_local"
   | "pi_local"
   | "cursor"
   | "openclaw_gateway";
@@ -55,6 +57,18 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     label: "OpenCode",
     icon: OpenCodeLogoIcon,
     desc: "Local multi-provider agent",
+  },
+  {
+    value: "hermes_gateway",
+    label: "Hermes Gateway",
+    icon: Bot,
+    desc: "Persistent Hermes runtime over WebSocket",
+  },
+  {
+    value: "hermes_local",
+    label: "Hermes",
+    icon: Bot,
+    desc: "Local Hermes agent",
   },
   {
     value: "pi_local",

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -30,6 +30,11 @@ import { ChoosePathButton } from "./PathInstructionsModal";
 import { HintIcon } from "./agent-config-primitives";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 import {
+  getDefaultLocalAdapterCommand,
+  getLocalAdapterHelloProbeCommand,
+  isLocalCliAdapter,
+} from "../lib/agent-adapters";
+import {
   Building2,
   Bot,
   Code,
@@ -52,6 +57,8 @@ type AdapterType =
   | "claude_local"
   | "codex_local"
   | "opencode_local"
+  | "hermes_gateway"
+  | "hermes_local"
   | "pi_local"
   | "cursor"
   | "process"
@@ -164,17 +171,8 @@ export function OnboardingWizard() {
     queryFn: () => agentsApi.adapterModels(createdCompanyId!, adapterType),
     enabled: Boolean(createdCompanyId) && onboardingOpen && step === 2
   });
-  const isLocalAdapter =
-    adapterType === "claude_local" || adapterType === "codex_local" || adapterType === "opencode_local" || adapterType === "cursor";
-  const effectiveAdapterCommand =
-    command.trim() ||
-    (adapterType === "codex_local"
-      ? "codex"
-      : adapterType === "cursor"
-        ? "agent"
-        : adapterType === "opencode_local"
-          ? "opencode"
-          : "claude");
+  const isLocalAdapter = isLocalCliAdapter(adapterType);
+  const effectiveAdapterCommand = command.trim() || getDefaultLocalAdapterCommand(adapterType) || "";
 
   useEffect(() => {
     if (step !== 2) return;
@@ -662,6 +660,18 @@ export function OnboardingWizard() {
                           desc: "Local multi-provider agent"
                         },
                         {
+                          value: "hermes_gateway" as const,
+                          label: "Hermes Gateway",
+                          icon: Bot,
+                          desc: "Persistent Hermes runtime over WebSocket"
+                        },
+                        {
+                          value: "hermes_local" as const,
+                          label: "Hermes",
+                          icon: Bot,
+                          desc: "Local Hermes agent"
+                        },
+                        {
                           value: "pi_local" as const,
                           label: "Pi",
                           icon: Terminal,
@@ -733,6 +743,7 @@ export function OnboardingWizard() {
                   {(adapterType === "claude_local" ||
                     adapterType === "codex_local" ||
                     adapterType === "opencode_local" ||
+                    adapterType === "hermes_local" ||
                     adapterType === "pi_local" ||
                     adapterType === "cursor") && (
                     <div className="space-y-3">
@@ -900,13 +911,7 @@ export function OnboardingWizard() {
                       <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px] space-y-1.5">
                         <p className="font-medium">Manual debug</p>
                         <p className="text-muted-foreground font-mono break-all">
-                          {adapterType === "cursor"
-                            ? `${effectiveAdapterCommand} -p --mode ask --output-format json \"Respond with hello.\"`
-                            : adapterType === "codex_local"
-                            ? `${effectiveAdapterCommand} exec --json -`
-                            : adapterType === "opencode_local"
-                              ? `${effectiveAdapterCommand} run --format json "Respond with hello."`
-                            : `${effectiveAdapterCommand} --print - --output-format stream-json --verbose`}
+                          {getLocalAdapterHelloProbeCommand(adapterType, effectiveAdapterCommand) ?? "No probe available."}
                         </p>
                         <p className="text-muted-foreground">
                           Prompt:{" "}
@@ -966,14 +971,14 @@ export function OnboardingWizard() {
                     </div>
                   )}
 
-                  {(adapterType === "http" || adapterType === "openclaw_gateway") && (
+                  {(adapterType === "http" || adapterType === "openclaw_gateway" || adapterType === "hermes_gateway") && (
                     <div>
                       <label className="text-xs text-muted-foreground mb-1 block">
-                        {adapterType === "openclaw_gateway" ? "Gateway URL" : "Webhook URL"}
+                        {adapterType === "http" ? "Webhook URL" : "Gateway URL"}
                       </label>
                       <input
                         className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                        placeholder={adapterType === "openclaw_gateway" ? "ws://127.0.0.1:18789" : "https://..."}
+                        placeholder={adapterType === "http" ? "https://..." : "ws://127.0.0.1:18791/paperclip"}
                         value={url}
                         onChange={(e) => setUrl(e.target.value)}
                       />

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { HelpCircle, ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "../lib/utils";
 import { AGENT_ROLE_LABELS } from "@paperclipai/shared";
+export { adapterLabels } from "../lib/agent-adapters";
 
 /* ---- Help text for (?) tooltips ---- */
 export const help: Record<string, string> = {
@@ -55,16 +56,6 @@ export const help: Record<string, string> = {
   cooldownSec: "Minimum seconds between consecutive heartbeat runs.",
   maxConcurrentRuns: "Maximum number of heartbeat runs that can execute simultaneously for this agent.",
   budgetMonthlyCents: "Monthly spending limit in cents. 0 means no limit.",
-};
-
-export const adapterLabels: Record<string, string> = {
-  claude_local: "Claude (local)",
-  codex_local: "Codex (local)",
-  opencode_local: "OpenCode (local)",
-  openclaw_gateway: "OpenClaw Gateway",
-  cursor: "Cursor (local)",
-  process: "Process",
-  http: "HTTP",
 };
 
 export const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;

--- a/ui/src/lib/agent-adapters.test.ts
+++ b/ui/src/lib/agent-adapters.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  ENABLED_ADVANCED_ADAPTER_TYPES,
+  ENABLED_INVITE_ADAPTER_TYPES,
+  adapterLabels,
+  getDefaultLocalAdapterCommand,
+  isLocalCliAdapter,
+} from "./agent-adapters";
+
+describe("agent adapter helpers", () => {
+  it("treats Hermes as a first-class local CLI adapter", () => {
+    expect(adapterLabels.hermes_local).toBe("Hermes (local)");
+    expect(isLocalCliAdapter("hermes_local")).toBe(true);
+    expect(getDefaultLocalAdapterCommand("hermes_local")).toBe("hermes");
+  });
+
+  it("enables Hermes in invite and advanced creation flows", () => {
+    expect(ENABLED_INVITE_ADAPTER_TYPES.has("hermes_local")).toBe(true);
+    expect(ENABLED_ADVANCED_ADAPTER_TYPES.has("hermes_local")).toBe(true);
+  });
+
+  it("treats Hermes Gateway as an advanced remote adapter, not a local CLI adapter", () => {
+    expect(adapterLabels.hermes_gateway).toBe("Hermes Gateway");
+    expect(ENABLED_ADVANCED_ADAPTER_TYPES.has("hermes_gateway")).toBe(true);
+    expect(isLocalCliAdapter("hermes_gateway")).toBe(false);
+  });
+});

--- a/ui/src/lib/agent-adapters.ts
+++ b/ui/src/lib/agent-adapters.ts
@@ -1,0 +1,70 @@
+import type { AgentAdapterType } from "@paperclipai/shared";
+
+export const adapterLabels: Record<string, string> = {
+  claude_local: "Claude (local)",
+  codex_local: "Codex (local)",
+  opencode_local: "OpenCode (local)",
+  hermes_gateway: "Hermes Gateway",
+  hermes_local: "Hermes (local)",
+  pi_local: "Pi (local)",
+  cursor: "Cursor (local)",
+  openclaw_gateway: "OpenClaw Gateway",
+  process: "Process",
+  http: "HTTP",
+};
+
+const LOCAL_CLI_ADAPTER_COMMANDS: Record<string, string> = {
+  claude_local: "claude",
+  codex_local: "codex",
+  opencode_local: "opencode",
+  hermes_local: "hermes",
+  pi_local: "pi",
+  cursor: "agent",
+};
+
+export const ENABLED_ADVANCED_ADAPTER_TYPES = new Set<AgentAdapterType>([
+  "claude_local",
+  "codex_local",
+  "opencode_local",
+  "hermes_gateway",
+  "hermes_local",
+  "pi_local",
+  "cursor",
+]);
+
+export const ENABLED_INVITE_ADAPTER_TYPES = new Set<AgentAdapterType>([
+  "claude_local",
+  "codex_local",
+  "opencode_local",
+  "hermes_local",
+  "cursor",
+]);
+
+export function isLocalCliAdapter(type: string): boolean {
+  return Object.prototype.hasOwnProperty.call(LOCAL_CLI_ADAPTER_COMMANDS, type);
+}
+
+export function getDefaultLocalAdapterCommand(type: string): string | null {
+  return LOCAL_CLI_ADAPTER_COMMANDS[type] ?? null;
+}
+
+export function getLocalAdapterHelloProbeCommand(type: string, commandOverride?: string): string | null {
+  if (!isLocalCliAdapter(type)) return null;
+  const command = commandOverride?.trim() || getDefaultLocalAdapterCommand(type);
+  if (!command) return null;
+
+  switch (type) {
+    case "cursor":
+      return `${command} -p --mode ask --output-format json \"Respond with hello.\"`;
+    case "codex_local":
+      return `${command} exec --json -`;
+    case "opencode_local":
+      return `${command} run --format json \"Respond with hello.\"`;
+    case "hermes_local":
+      return `${command} chat -q \"Respond with exactly: hello\"`;
+    case "pi_local":
+      return `${command} -p \"Respond with hello.\" --mode json --tools read`;
+    default:
+      return `${command} --print - --output-format stream-json --verbose`;
+  }
+}

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -14,21 +14,12 @@ import { EntityRow } from "../components/EntityRow";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { relativeTime, cn, agentRouteRef, agentUrl } from "../lib/utils";
+import { adapterLabels } from "../lib/agent-adapters";
 import { PageTabBar } from "../components/PageTabBar";
 import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Bot, Plus, List, GitBranch, SlidersHorizontal } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
-
-const adapterLabels: Record<string, string> = {
-  claude_local: "Claude",
-  codex_local: "Codex",
-  opencode_local: "OpenCode",
-  cursor: "Cursor",
-  openclaw_gateway: "OpenClaw Gateway",
-  process: "Process",
-  http: "HTTP",
-};
 
 const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
 

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -8,21 +8,10 @@ import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
 import { AGENT_ADAPTER_TYPES } from "@paperclipai/shared";
 import type { AgentAdapterType, JoinRequest } from "@paperclipai/shared";
+import { ENABLED_INVITE_ADAPTER_TYPES, adapterLabels } from "../lib/agent-adapters";
 
 type JoinType = "human" | "agent";
 const joinAdapterOptions: AgentAdapterType[] = [...AGENT_ADAPTER_TYPES];
-
-const adapterLabels: Record<string, string> = {
-  claude_local: "Claude (local)",
-  codex_local: "Codex (local)",
-  opencode_local: "OpenCode (local)",
-  openclaw_gateway: "OpenClaw Gateway",
-  cursor: "Cursor (local)",
-  process: "Process",
-  http: "HTTP",
-};
-
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();
@@ -265,8 +254,8 @@ export function InviteLandingPage() {
                 onChange={(event) => setAdapterType(event.target.value as AgentAdapterType)}
               >
                 {joinAdapterOptions.map((type) => (
-                  <option key={type} value={type} disabled={!ENABLED_INVITE_ADAPTERS.has(type)}>
-                    {adapterLabels[type]}{!ENABLED_INVITE_ADAPTERS.has(type) ? " (Coming soon)" : ""}
+                  <option key={type} value={type} disabled={!ENABLED_INVITE_ADAPTER_TYPES.has(type)}>
+                    {adapterLabels[type]}{!ENABLED_INVITE_ADAPTER_TYPES.has(type) ? " (Coming soon)" : ""}
                   </option>
                 ))}
               </select>

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -29,6 +29,8 @@ const SUPPORTED_ADVANCED_ADAPTER_TYPES = new Set<CreateConfigValues["adapterType
   "claude_local",
   "codex_local",
   "opencode_local",
+  "hermes_gateway",
+  "hermes_local",
   "pi_local",
   "cursor",
   "openclaw_gateway",

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -9,6 +9,7 @@ import { agentUrl } from "../lib/utils";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
+import { adapterLabels } from "../lib/agent-adapters";
 import { Network } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
 
@@ -114,16 +115,6 @@ function collectEdges(nodes: LayoutNode[]): Array<{ parent: LayoutNode; child: L
 }
 
 // ── Status dot colors (raw hex for SVG) ─────────────────────────────────
-
-const adapterLabels: Record<string, string> = {
-  claude_local: "Claude",
-  codex_local: "Codex",
-  opencode_local: "OpenCode",
-  cursor: "Cursor",
-  openclaw_gateway: "OpenClaw Gateway",
-  process: "Process",
-  http: "HTTP",
-};
 
 const statusDotColor: Record<string, string> = {
   running: "#22d3ee",


### PR DESCRIPTION
## Summary

Adds first-class Hermes adapters to Paperclip for both gateway and local execution modes.

This wires Hermes into the adapter registry, server execution layer, CLI formatting, and UI config surfaces so Paperclip agents can run through a Hermes gateway or a local Hermes install. It also carries the wake payload auth/runtime fields Paperclip needs for the live follow-up issue flow.

## Changes

- add `@paperclipai/adapter-hermes-gateway`
- add `@paperclipai/adapter-hermes-local`
- register Hermes adapters across CLI, server, and UI adapter registries
- add execution plumbing for wake payload/auth handling and local Hermes environment setup
- add adapter-specific tests plus shared constant/UI coverage
- update `pnpm-lock.yaml` so the cherry-picked branch installs cleanly on current `master`

## Test Plan

- `pnpm test:run cli/src/__tests__/adapter-registry.test.ts packages/adapters/hermes-gateway/src/server/test.ts packages/adapters/hermes-local/src/server/test.ts packages/shared/src/constants.test.ts server/src/__tests__/adapter-models.test.ts server/src/__tests__/hermes-gateway-adapter.test.ts server/src/__tests__/hermes-local-adapter-environment.test.ts server/src/__tests__/hermes-local-execute.test.ts ui/src/lib/agent-adapters.test.ts`
- `pnpm -r typecheck`
- live smoke: Paperclip actionHint/create_followup_issue flow against Hermes gateway

## Notes

The original working branch had other unpublished local commits on top of `master`, so this PR branch was rebuilt cleanly from current `master` with only the Hermes adapter commit cherry-picked and its lockfile entry refreshed. Less garbage, fewer reviewer migraines.
