### PR TITLE
fix(adapters): auto-enable permission bypass for headless heartbeat runs

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -309,8 +309,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = (() => {
-    const explicit = asBoolean(config.dangerouslySkipPermissions, false);
-    if (explicit) return true;
+    if (typeof config.dangerouslySkipPermissions === "boolean") {
+      return config.dangerouslySkipPermissions;
+    }
     // Heartbeat runs always use --print (non-interactive). Without --dangerously-skip-permissions,
     // Claude will stall on permission prompts with no user to approve, causing the agent to loop
     // and waste tokens. Auto-enable for headless execution. See: #447

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -119,11 +119,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const search = asBoolean(config.search, false);
   const bypass = (() => {
-    const explicit = asBoolean(
-      config.dangerouslyBypassApprovalsAndSandbox,
-      asBoolean(config.dangerouslyBypassSandbox, false),
-    );
-    if (explicit) return true;
+    if (typeof config.dangerouslyBypassApprovalsAndSandbox === "boolean") {
+      return config.dangerouslyBypassApprovalsAndSandbox;
+    }
+    if (typeof config.dangerouslyBypassSandbox === "boolean") {
+      return config.dangerouslyBypassSandbox;
+    }
     // Heartbeat runs are non-interactive. Without bypass, Codex will stall on
     // approval prompts with no user to approve, causing the agent to loop
     // and waste tokens. Auto-enable for headless execution. See: #447


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Adapters like claude_local and codex_local run agents in headless (non-interactive) mode
> - Headless agents cannot answer permission prompts, so they stall and loop indefinitely
> - Agents created via API or with manual config may not have the permission bypass enabled
> - This auto-enables the permission bypass flag when running in headless heartbeat mode, with a warning log
> - Agents no longer waste tokens looping on unanswerable prompts during headless runs

## Summary

- Auto-enables `--dangerously-skip-permissions` (claude_local) and `--dangerously-bypass-approvals-and-sandbox` (codex_local) when running in headless heartbeat mode
- Logs a warning so users know the bypass was auto-applied
- Prevents agents from looping indefinitely on permission prompts that can never be answered in `--print` mode

Heartbeat runs always use `--print` (non-interactive). Without the bypass, Claude/Codex stalls on permission prompts with no user to approve, causing the agent to loop and waste tokens trying different approaches.

The onboarding wizard already defaults `dangerouslySkipPermissions: true` for `claude_local`, but agents created via API or with the setting manually toggled off still hit this issue.

Fixes #447

This contribution was developed with AI assistance (Claude Code).
