### PR TITLE
feat(heartbeat): auto-restart agents after process_lost

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1222,11 +1222,11 @@ export function heartbeatService(db: Db) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
 
-    // Find all runs in "queued" or "running" state
+    // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
     const activeRuns = await db
       .select()
       .from(heartbeatRuns)
-      .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+      .where(eq(heartbeatRuns.status, "running"));
 
     const reaped: string[] = [];
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The heartbeat system monitors agent health and detects when processes die unexpectedly
> - When an agent's process is lost, it enters error status and requires manual intervention to resume
> - Manual recovery can take up to 15 minutes (next timer heartbeat) or requires clicking "Resume" in the UI
> - This auto-enqueues a recovery wakeup after process_lost, with a safety cap of 3 restarts per 10 minutes
> - Agents self-heal from transient crashes without human intervention, improving uptime for zero-human operations

## Summary

- After the orphan reaper marks a run as `process_lost`, automatically enqueues a recovery wakeup for the agent
- Safety limit: max 3 `process_lost` failures within 10 minutes prevents infinite restart loops
- Respects agent status (paused/terminated agents are not restarted) and heartbeat policy (disabled heartbeats skip auto-restart)
- Logs auto-restart events with consecutive failure count for observability
- Incorporates the reaper query fix from #903 (narrow to `running` state only, skip `queued` runs handled by `resumeQueuedRuns`)

Previously, agents would enter `error` status after process_lost and require manual intervention (clicking "Resume" in UI or waiting for the next timer heartbeat up to 15 min).

Fixes #458

## Test plan

- [ ] Verify orphan reaper no longer marks queued runs as process_lost after server restart
- [ ] Verify agents auto-restart after process_lost (check logs for `auto-restarted agent after process_lost`)
- [ ] Verify restart loop protection: agent enters error after 3 process_lost in 10 min window
- [ ] Verify paused/terminated agents are not auto-restarted

This contribution was developed with AI assistance (Claude Code).
