### PR TITLE
fix(auth): resolve agent identity from run ID in local_trusted mode

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -34,17 +34,28 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         const run = await db
           .select({ agentId: heartbeatRuns.agentId, companyId: heartbeatRuns.companyId })
           .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.id, runIdHeader))
+          .where(and(eq(heartbeatRuns.id, runIdHeader), isNull(heartbeatRuns.finishedAt)))
           .then((rows) => rows[0] ?? null);
 
         if (run) {
+          const agentRecord = await db
+            .select()
+            .from(agents)
+            .where(eq(agents.id, run.agentId))
+            .then((rows) => rows[0] ?? null);
+
+          if (!agentRecord || agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
+            next();
+            return;
+          }
+
           req.actor = {
             type: "agent",
             agentId: run.agentId,
             companyId: run.companyId,
             keyId: undefined,
             runId: runIdHeader,
-            source: "agent_jwt",
+            source: "run_id",
           };
           next();
           return;

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -12,7 +12,7 @@ declare global {
         isInstanceAdmin?: boolean;
         keyId?: string;
         runId?: string;
-        source?: "local_implicit" | "session" | "agent_key" | "agent_jwt" | "none";
+        source?: "local_implicit" | "session" | "agent_key" | "agent_jwt" | "run_id" | "none";
       };
     }
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Activity logs must attribute each action to the correct agent for accountability
> - In local_trusted mode, agents making API calls without a Bearer token fall back to "Board" identity
> - Heartbeat-spawned agents use curl with `X-Paperclip-Run-Id` but not always an auth token, so their actions appear as "Board"
> - This resolves agent identity from the run ID header when no Bearer token is present
> - Activity feeds now correctly show which agent performed each action, even in local_trusted mode

## Summary

- In `local_trusted` mode, when an agent makes API calls (via curl) without a Bearer token but with `X-Paperclip-Run-Id` header, resolves the agent identity from the heartbeat run
- This ensures activity logs attribute actions to the correct agent instead of falling back to "board"/"local-board"
- Falls through to default board identity if run ID is invalid or lookup fails

The root cause: in `local_trusted` mode, all unauthenticated requests default to board identity. Agents spawned during heartbeats use curl with `X-Paperclip-Run-Id` but not always `Authorization: Bearer`, causing their actions to appear as "Board" in the activity feed.

Fixes #337

This contribution was developed with AI assistance (Claude Code).
