### PR TITLE
feat(heartbeat): add circuit breaker for token waste prevention

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1016,7 +1016,7 @@ export function heartbeatService(db: Db) {
     }
 
     const cbConfig = parseObject(parseObject(agent.runtimeConfig).circuitBreaker);
-    const cbMaxInputTokens = asNumber(cbConfig.maxInputTokensPerRun, 500_000);
+    const cbMaxInputTokens = Math.max(asNumber(cbConfig.maxInputTokensPerRun, 500_000), 1000);
     if (inputTokens > cbMaxInputTokens) {
       logger.warn(
         { agentId: agent.id, runId: run.id, inputTokens, limit: cbMaxInputTokens },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The heartbeat service monitors every agent run in real-time
> - Runaway token consumption burns budget silently if unchecked
> - No mechanism existed to halt an agent mid-run when token usage spikes
> - Adds a circuit breaker in `updateRuntimeState` that pauses an agent when input tokens exceed a configurable per-run threshold (default 500k)
> - Prevents token waste from stuck or looping agents before they drain the monthly budget

## Summary
- Adds a lightweight circuit breaker in `updateRuntimeState` that pauses an agent when a single run's input token usage exceeds a configurable threshold
- Default limit is 500,000 input tokens per run, configurable via `runtimeConfig.circuitBreaker.maxInputTokensPerRun`
- Logs a warning and emits a live event when the circuit breaker trips, following the same pattern as `budgetMonthlyCents`

## Test plan
- [ ] Verify typecheck passes (`pnpm -r typecheck`)
- [ ] Set `runtimeConfig.circuitBreaker.maxInputTokensPerRun` to a low value and confirm agent pauses after a run exceeds it
- [ ] Confirm default behavior (no circuitBreaker config) uses 500k token limit
- [ ] Verify live event is published with `circuit_breaker_tripped` outcome

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)