### PR TITLE
feat(heartbeat): auto-requeue agent on transient failures

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -977,11 +977,12 @@ export function heartbeatService(db: Db) {
         and(
           eq(heartbeatRuns.agentId, agentId),
           inArray(heartbeatRuns.status, ["failed", "timed_out"]),
+          inArray(heartbeatRuns.errorCode, [...TRANSIENT_ERROR_CODES]),
           gte(heartbeatRuns.finishedAt, cutoff),
         ),
       );
 
-    return recentFailures.length < AUTO_REQUEUE_MAX_RETRIES;
+    return recentFailures.length <= AUTO_REQUEUE_MAX_RETRIES;
   }
 
   async function autoRequeueOnTransientFailure(agentId: string, errorCode: string | null) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The heartbeat service handles run lifecycle - including failures
> - Transient failures (adapter crashes, timeouts, lost processes) are recoverable but currently require manual intervention
> - No automatic retry logic existed, so agents stayed down until a human noticed
> - Adds auto-requeue for transient failure types with a 3-retry / 10-minute safety window to prevent infinite loops
> - Agents self-heal from temporary infrastructure issues without human intervention

## Summary
- Adds auto-requeue logic for transient failure types (`adapter_failed`, `timeout`, `process_lost`) in the heartbeat service's run completion handler
- Safety-limited to 3 retries within a 10-minute sliding window to prevent infinite retry loops
- Permanent failures (auth errors, budget exceeded, etc.) are not retried
- Uses `enqueueWakeup` with `source: "automation"` and `triggerDetail: "system"` for requeued runs

## Test plan
- [ ] Verify agent auto-requeues after `adapter_failed` error
- [ ] Verify agent auto-requeues after `timeout` error
- [ ] Verify agent does NOT auto-requeue after 3 failures within 10 minutes
- [ ] Verify permanent failures (non-transient error codes) do not trigger requeue

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)