### PR TITLE
feat(adapters): add git audit trail for agent commits

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -127,6 +127,10 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string; name?:
   vars.GIT_AUTHOR_NAME = gitName;
   vars.GIT_COMMITTER_NAME = gitName;
 
+  const gitEmail = `agent-${agent.id}@paperclip.local`;
+  vars.GIT_AUTHOR_EMAIL = gitEmail;
+  vars.GIT_COMMITTER_EMAIL = gitEmail;
+
   return vars;
 }
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -86,10 +86,10 @@ Example commit message:
 ```
 fix(auth): handle expired token refresh
 
-Paperclip-Run-Id: run_abc123
+Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 ```
 
-Your `GIT_AUTHOR_NAME` and `GIT_COMMITTER_NAME` are automatically set by the adapter to identify you as a Paperclip agent. Do not override them.
+Your `GIT_AUTHOR_NAME`, `GIT_COMMITTER_NAME`, `GIT_AUTHOR_EMAIL`, and `GIT_COMMITTER_EMAIL` are automatically set by the adapter to identify you as a Paperclip agent. Do not override them.
 
 ## Project Setup Workflow (CEO/Manager Common Path)
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents produce git commits autonomously through adapter processes
> - When something goes wrong, operators need to trace a commit back to the agent and run that created it
> - No attribution metadata existed on agent-produced commits - they were anonymous
> - Sets `GIT_AUTHOR_NAME` to the agent identity in `buildPaperclipEnv()` and instructs agents to include a `Paperclip-Run-Id` trailer
> - Every agent commit is now traceable to the specific agent and heartbeat run that produced it

## Summary
- Sets `GIT_AUTHOR_NAME` and `GIT_COMMITTER_NAME` in `buildPaperclipEnv()` (adapter-utils) so all agent git commits are attributed to `AgentName [paperclip-agent/agent-id]`
- Updates `skills/paperclip/SKILL.md` to instruct agents to include a `Paperclip-Run-Id: $PAPERCLIP_RUN_ID` trailer in every commit message

This enables tracing any git commit back to the specific agent and heartbeat run that produced it.

## Test plan
- [ ] Verify `GIT_AUTHOR_NAME` and `GIT_COMMITTER_NAME` appear in the env passed to child processes for each adapter (claude-local, codex-local, cursor-local, opencode-local, pi-local, openclaw-gateway)
- [ ] Verify an agent-produced commit shows the agent name in `git log --format="%an"`
- [ ] Verify the SKILL.md change is picked up by agents and they include `Paperclip-Run-Id` trailers

Fixes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)