### PR TITLE
fix(ui): prevent IME composition Enter from moving focus in new issue title

### DIFF
--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -681,7 +681,12 @@ export function NewIssueDialog() {
               e.target.style.height = `${e.target.scrollHeight}px`;
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
+              if (
+                e.key === "Enter" &&
+                !e.metaKey &&
+                !e.ctrlKey &&
+                !e.nativeEvent.isComposing
+              ) {
                 e.preventDefault();
                 descriptionEditorRef.current?.focus();
               }


### PR DESCRIPTION
 ## Summary

  Fix IME composition Enter key moving focus from title to description in NewIssueDialog

  When typing Japanese (or other IME languages) in the issue title, pressing Enter to confirm the composition would incorrectly move focus to the description field and
  duplicate the composing text into description.

  ## Approach

  Added `e.nativeEvent.isComposing` check to the title textarea's `onKeyDown` handler. This skips the focus-move behavior while the IME is actively composing, so Enter
  only confirms the composition. Plain Enter (without active composition) still moves focus to description as before.

  ## Test plan

  - [ ] Type Japanese in issue title, confirm with Enter - focus stays in title, text is committed correctly
  - [ ] Press Enter without IME - focus moves to description as before
  - [ ] Cmd/Ctrl+Enter still submits the issue
  - [ ] Tab still moves focus to assignee selector
  - [ ] All CI checks pass (typecheck, tests, build)

  This contribution was developed with AI assistance (Claude Code).