### PR TITLE
fix: stabilize embedded PostgreSQL startup on Windows locales

### DIFF
--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -32,6 +32,7 @@ if (process.env.npm_config_authenticated_private === "true") {
 const env = {
   ...process.env,
   PAPERCLIP_UI_DEV_MIDDLEWARE: "true",
+  LC_ALL: "C",
 };
 
 if (tailscaleAuth) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,8 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
+  postgresFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;
@@ -262,6 +264,9 @@ export async function startServer(): Promise<StartedServer> {
     const embeddedPostgresLogBuffer: string[] = [];
     const EMBEDDED_POSTGRES_LOG_BUFFER_LIMIT = 120;
     const verboseEmbeddedPostgresLogs = process.env.PAPERCLIP_EMBEDDED_POSTGRES_VERBOSE === "true";
+    const embeddedPostgresInitdbFlags =
+      process.platform === "win32" ? ["--locale=en-US", "--encoding=UTF8", "--lc-messages=C"] : [];
+    const embeddedPostgresPostgresFlags = process.platform === "win32" ? ["-c", "lc_messages=C"] : [];
     const appendEmbeddedPostgresLog = (message: unknown) => {
       const text = typeof message === "string" ? message : message instanceof Error ? message.message : String(message ?? "");
       for (const lineRaw of text.split(/\r?\n/)) {
@@ -334,6 +339,8 @@ export async function startServer(): Promise<StartedServer> {
         password: "paperclip",
         port,
         persistent: true,
+        initdbFlags: embeddedPostgresInitdbFlags,
+        postgresFlags: embeddedPostgresPostgresFlags,
         onLog: appendEmbeddedPostgresLog,
         onError: appendEmbeddedPostgresLog,
       });


### PR DESCRIPTION
## Summary
- set LC_ALL=C in the dev runner so embedded Postgres init avoids locale-dependent Windows failures
- pass Windows-specific initdb and postgres flags so startup uses ASCII-safe locale messaging
- keep this PR focused only on embedded Postgres startup behavior

## Context
This is split out from #308 so the Windows/Postgres locale fix can be reviewed independently.

This contribution was developed with AI assistance (Multiple Models).