### PR TITLE
fix: improve Windows command launching for local adapters

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -131,7 +131,7 @@ export function defaultPathForPlatform() {
 }
 
 function windowsPathExts(env: NodeJS.ProcessEnv): string[] {
-  return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
+  return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM;.PS1").split(";").filter(Boolean);
 }
 
 async function pathExists(candidate: string) {
@@ -295,7 +295,7 @@ export async function runChildProcess(
         const child = spawn(target.command, target.args, {
           cwd: opts.cwd,
           env: mergedEnv,
-          shell: false,
+          shell: process.platform === "win32",
           stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
         }) as ChildProcessWithEvents;
 


### PR DESCRIPTION
## Summary
- include .PS1 in Windows command resolution so local adapter commands can be discovered correctly
- run spawned child commands through the Windows shell to match how local agent CLIs are typically invoked
- keep this PR scoped to shared process execution utilities

## Context
This is split out from #308 so the Windows command-launching fix can be reviewed independently.

This contribution was developed with AI assistance (Multiple Models).