### PR TITLE
UI: support non-image file uploads with server-side validation

### DIFF
--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -1,14 +1,13 @@
 /**
  * Shared attachment content-type configuration.
  *
- * By default only image types are allowed.  Set the
+ * By default a broad set of common file types are allowed.  Set the
  * `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES` environment variable to a
- * comma-separated list of MIME types or wildcard patterns to expand the
- * allowed set.
+ * comma-separated list of MIME types or wildcard patterns to override.
  *
  * Examples:
  *   PAPERCLIP_ALLOWED_ATTACHMENT_TYPES=image/*,application/pdf
- *   PAPERCLIP_ALLOWED_ATTACHMENT_TYPES=image/*,application/pdf,text/*
+ *   PAPERCLIP_ALLOWED_ATTACHMENT_TYPES=*
  *
  * Supported pattern syntax:
  *   - Exact types:   "application/pdf"
@@ -16,11 +15,21 @@
  */
 
 export const DEFAULT_ALLOWED_TYPES: readonly string[] = [
-  "image/png",
-  "image/jpeg",
-  "image/jpg",
-  "image/webp",
-  "image/gif",
+  // Images
+  "image/*",
+  // Documents
+  "application/pdf",
+  "text/*",
+  // Office (docx, xlsx, pptx)
+  "application/vnd.openxmlformats-officedocument.*",
+  "application/msword",
+  "application/vnd.ms-excel",
+  "application/vnd.ms-powerpoint",
+  // Data & config
+  "application/json",
+  "application/xml",
+  "application/zip",
+  "application/gzip",
 ];
 
 /**

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { Link, useLocation } from "react-router-dom";
 import type { IssueComment, Agent } from "@paperclipai/shared";
+import { useToast } from "../context/ToastContext";
 import { Button } from "@/components/ui/button";
 import { Check, Copy, Paperclip } from "lucide-react";
 import { Identity } from "./Identity";
@@ -228,6 +229,7 @@ export function CommentThread({
   currentAssigneeValue = "",
   mentions: providedMentions,
 }: CommentThreadProps) {
+  const { pushToast } = useToast();
   const [body, setBody] = useState("");
   const [reopen, setReopen] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -334,11 +336,19 @@ export function CommentThread({
   }
 
   async function handleAttachFile(evt: ChangeEvent<HTMLInputElement>) {
-    const file = evt.target.files?.[0];
-    if (!file || !onAttachImage) return;
+    const files = evt.target.files;
+    if (!files || files.length === 0 || !onAttachImage) return;
     setAttaching(true);
     try {
-      await onAttachImage(file);
+      for (const file of Array.from(files)) {
+        await onAttachImage(file);
+      }
+    } catch (err) {
+      pushToast({
+        title: "Upload failed",
+        body: err instanceof Error ? err.message : "Could not upload file",
+        tone: "error",
+      });
     } finally {
       setAttaching(false);
       if (attachInputRef.current) attachInputRef.current.value = "";
@@ -372,7 +382,7 @@ export function CommentThread({
               <input
                 ref={attachInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif"
+                multiple
                 className="hidden"
                 onChange={handleAttachFile}
               />
@@ -381,7 +391,7 @@ export function CommentThread({
                 size="icon-sm"
                 onClick={() => attachInputRef.current?.click()}
                 disabled={attaching}
-                title="Attach image"
+                title="Attach file"
               >
                 <Paperclip className="h-4 w-4" />
               </Button>

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -473,7 +473,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     return Array.from(evt.dataTransfer?.types ?? []).includes("Files");
   }
 
-  const canDropImage = Boolean(imageUploadHandler);
+  const canDrop = Boolean(imageUploadHandler);
 
   return (
     <div
@@ -533,23 +533,56 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         }
       }}
       onDragEnter={(evt) => {
-        if (!canDropImage || !hasFilePayload(evt)) return;
+        if (!canDrop || !hasFilePayload(evt)) return;
         dragDepthRef.current += 1;
         setIsDragOver(true);
       }}
       onDragOver={(evt) => {
-        if (!canDropImage || !hasFilePayload(evt)) return;
+        if (!canDrop || !hasFilePayload(evt)) return;
         evt.preventDefault();
         evt.dataTransfer.dropEffect = "copy";
       }}
       onDragLeave={() => {
-        if (!canDropImage) return;
+        if (!canDrop) return;
         dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
         if (dragDepthRef.current === 0) setIsDragOver(false);
       }}
-      onDrop={() => {
+      onDrop={async (evt) => {
         dragDepthRef.current = 0;
         setIsDragOver(false);
+
+        const handler = imageUploadHandlerRef.current;
+        if (!handler) return;
+
+        const files = evt.dataTransfer?.files;
+        if (!files || files.length === 0) return;
+
+        // Non-image files are ignored by MDXEditor's imagePlugin,
+        // so we handle them here by uploading and inserting a link.
+        const nonImageFiles = Array.from(files).filter(
+          (f) => !f.type.startsWith("image/"),
+        );
+        if (nonImageFiles.length === 0) return; // all images — imagePlugin handles them
+
+        evt.preventDefault();
+        for (const file of nonImageFiles) {
+          try {
+            const url = await handler(file);
+            const name = file.name || "file";
+            const md = `[${name}](${url})`;
+            const next = latestValueRef.current
+              ? `${latestValueRef.current}\n\n${md}`
+              : md;
+            latestValueRef.current = next;
+            ref.current?.setMarkdown(next);
+            onChange(next);
+            setUploadError(null);
+          } catch (err) {
+            const message =
+              err instanceof Error ? err.message : "Upload failed";
+            setUploadError(message);
+          }
+        }
       }}
     >
       <MDXEditor
@@ -608,14 +641,14 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         </div>
       )}
 
-      {isDragOver && canDropImage && (
+      {isDragOver && canDrop && (
         <div
           className={cn(
             "pointer-events-none absolute inset-1 z-40 flex items-center justify-center rounded-md border border-dashed border-primary/80 bg-primary/10 text-xs font-medium text-primary",
             !bordered && "inset-0 rounded-sm",
           )}
         >
-          Drop image to upload
+          Drop files to upload
         </div>
       )}
       {uploadError && (

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDialog } from "../context/DialogContext";
+import { useToast } from "../context/ToastContext";
 import { useCompany } from "../context/CompanyContext";
 import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
@@ -166,6 +167,7 @@ const priorities = [
 
 export function NewIssueDialog() {
   const { newIssueOpen, newIssueDefaults, closeNewIssue } = useDialog();
+  const { pushToast } = useToast();
   const { companies, selectedCompanyId, selectedCompany } = useCompany();
   const queryClient = useQueryClient();
   const [title, setTitle] = useState("");
@@ -457,14 +459,25 @@ export function NewIssueDialog() {
   }
 
   async function handleAttachImage(evt: ChangeEvent<HTMLInputElement>) {
-    const file = evt.target.files?.[0];
-    if (!file) return;
+    const files = evt.target.files;
+    if (!files || files.length === 0) return;
     try {
-      const asset = await uploadDescriptionImage.mutateAsync(file);
-      const name = file.name || "image";
-      setDescription((prev) => {
-        const suffix = `![${name}](${asset.contentPath})`;
-        return prev ? `${prev}\n\n${suffix}` : suffix;
+      for (const file of Array.from(files)) {
+        const asset = await uploadDescriptionImage.mutateAsync(file);
+        const name = file.name || "file";
+        const isImage = file.type.startsWith("image/");
+        setDescription((prev) => {
+          const suffix = isImage
+            ? `![${name}](${asset.contentPath})`
+            : `[${name}](${asset.contentPath})`;
+          return prev ? `${prev}\n\n${suffix}` : suffix;
+        });
+      }
+    } catch (err) {
+      pushToast({
+        title: "Upload failed",
+        body: err instanceof Error ? err.message : "Could not upload file",
+        tone: "error",
       });
     } finally {
       if (attachInputRef.current) attachInputRef.current.value = "";
@@ -954,11 +967,11 @@ export function NewIssueDialog() {
             Labels
           </button>
 
-          {/* Attach image chip */}
+          {/* Attach file chip */}
           <input
             ref={attachInputRef}
             type="file"
-            accept="image/png,image/jpeg,image/webp,image/gif"
+            multiple
             className="hidden"
             onChange={handleAttachImage}
           />
@@ -968,7 +981,7 @@ export function NewIssueDialog() {
             disabled={uploadDescriptionImage.isPending}
           >
             <Paperclip className="h-3 w-3" />
-            {uploadDescriptionImage.isPending ? "Uploading..." : "Image"}
+            {uploadDescriptionImage.isPending ? "Uploading..." : "Attach"}
           </button>
 
           {/* More (dates) */}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -10,6 +10,7 @@ import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
 import { usePanel } from "../context/PanelContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { useProjectOrder } from "../hooks/useProjectOrder";
 import { relativeTime, cn, formatTokens } from "../lib/utils";
@@ -148,6 +149,7 @@ export function IssueDetail() {
   const { selectedCompanyId } = useCompany();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { pushToast } = useToast();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [moreOpen, setMoreOpen] = useState(false);
@@ -449,7 +451,9 @@ export function IssueDetail() {
       invalidateIssue();
     },
     onError: (err) => {
-      setAttachmentError(err instanceof Error ? err.message : "Upload failed");
+      const msg = err instanceof Error ? err.message : "Upload failed";
+      setAttachmentError(msg);
+      pushToast({ title: "Upload failed", body: msg, tone: "error" });
     },
   });
 
@@ -504,9 +508,11 @@ export function IssueDetail() {
   const ancestors = issue.ancestors ?? [];
 
   const handleFilePicked = async (evt: ChangeEvent<HTMLInputElement>) => {
-    const file = evt.target.files?.[0];
-    if (!file) return;
-    await uploadAttachment.mutateAsync(file);
+    const files = evt.target.files;
+    if (!files || files.length === 0) return;
+    for (const file of Array.from(files)) {
+      await uploadAttachment.mutateAsync(file);
+    }
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -679,7 +685,7 @@ export function IssueDetail() {
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/png,image/jpeg,image/webp,image/gif"
+              multiple
               className="hidden"
               onChange={handleFilePicked}
             />
@@ -690,7 +696,7 @@ export function IssueDetail() {
               disabled={uploadAttachment.isPending}
             >
               <Paperclip className="h-3.5 w-3.5 mr-1.5" />
-              {uploadAttachment.isPending ? "Uploading..." : "Upload image"}
+              {uploadAttachment.isPending ? "Uploading..." : "Upload file"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Follow-up to #495 (configurable attachment types). The UI was still hardcoded to only accept images — this PR fixes that so users can upload any supported file type.

### What changed (5 files)

**Server (1 file)**
- `attachment-types.ts` — Expand `DEFAULT_ALLOWED_TYPES` to include PDFs, text, Office docs (docx/xlsx/pptx), JSON, XML, and archives (zip/gzip) out of the box. The `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES` env var override from #495 still works.

**UI (4 files)**
- `IssueDetail.tsx`, `NewIssueDialog.tsx`, `CommentThread.tsx` — Remove hardcoded `accept="image/png,image/jpeg,..."` so users can select any file. Add `multiple` for multi-file selection. Show **toast errors** when the server rejects an unsupported type (422).
- `MarkdownEditor.tsx` — Handle non-image drag-and-drop. MDXEditor's `imagePlugin` only processes image drops; non-image files were silently ignored. Now they're uploaded and inserted as markdown links `[name](url)` instead of broken image syntax `![name](url)`.

### Why this approach over dynamic `accept` filtering

We initially explored an approach where the server exposed `allowedAttachmentTypes` via `/api/health`, and the UI dynamically built the `accept` attribute from that list (PR #523). We moved away from that because:

1. **Simpler** — No new API surface, no new hook (`useAttachmentConfig`), no health endpoint changes. 5 files instead of 7.
2. **Better UX** — Dynamic `accept` causes the OS file picker to grey out unsupported files, which is confusing ("why can't I select this?"). Accepting all files and showing a clear toast error is more transparent.
3. **Server is already the source of truth** — #495 added server-side validation with `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES`. Duplicating that logic in the UI adds coupling without real benefit.
4. **Aligns with @cryppadotta's suggestion** in #495 to expand the default allowed types rather than adding UI complexity.

Supersedes #523.

## Test plan

- [ ] Upload a PDF, DOCX, or ZIP via the file picker — should succeed
- [ ] Upload an unsupported file (e.g. `.exe`) — should show a toast error
- [ ] Select multiple files at once — all should upload
- [ ] Drag and drop a non-image file onto the markdown editor — should upload and insert as a link
- [ ] Drag and drop an image — should still insert inline as before
- [ ] Set `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES` env var to a restricted list — server should reject types not in the list