### PR TITLE
Fix Documentation link to open external URL in new tab

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -230,7 +230,7 @@ export function Layout() {
           <div className="border-t border-r border-border px-3 py-2 bg-background">
             <div className="flex items-center gap-1">
               <SidebarNavItem
-                to="/docs"
+                href="https://paperclip.ing/docs"
                 label="Documentation"
                 icon={BookOpen}
                 className="flex-1 min-w-0"
@@ -265,7 +265,7 @@ export function Layout() {
           <div className="border-t border-r border-border px-3 py-2">
             <div className="flex items-center gap-1">
               <SidebarNavItem
-                to="/docs"
+                href="https://paperclip.ing/docs"
                 label="Documentation"
                 icon={BookOpen}
                 className="flex-1 min-w-0"

--- a/ui/src/components/SidebarNavItem.tsx
+++ b/ui/src/components/SidebarNavItem.tsx
@@ -4,7 +4,8 @@ import { useSidebar } from "../context/SidebarContext";
 import type { LucideIcon } from "lucide-react";
 
 interface SidebarNavItemProps {
-  to: string;
+  to?: string;
+  href?: string;
   label: string;
   icon: LucideIcon;
   end?: boolean;
@@ -17,6 +18,7 @@ interface SidebarNavItemProps {
 
 export function SidebarNavItem({
   to,
+  href,
   label,
   icon: Icon,
   end,
@@ -28,21 +30,13 @@ export function SidebarNavItem({
 }: SidebarNavItemProps) {
   const { isMobile, setSidebarOpen } = useSidebar();
 
-  return (
-    <NavLink
-      to={to}
-      end={end}
-      onClick={() => { if (isMobile) setSidebarOpen(false); }}
-      className={({ isActive }) =>
-        cn(
-          "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors",
-          isActive
-            ? "bg-accent text-foreground"
-            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
-          className,
-        )
-      }
-    >
+  const linkClassName = cn(
+    "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+    className,
+  );
+
+  const content = (
+    <>
       <span className="relative shrink-0">
         <Icon className="h-4 w-4" />
         {alert && (
@@ -71,6 +65,36 @@ export function SidebarNavItem({
           {badge}
         </span>
       )}
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={() => { if (isMobile) setSidebarOpen(false); }}
+        className={linkClassName}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <NavLink
+      to={to!}
+      end={end}
+      onClick={() => { if (isMobile) setSidebarOpen(false); }}
+      className={({ isActive }) =>
+        cn(
+          linkClassName,
+          isActive && "bg-accent text-foreground",
+        )
+      }
+    >
+      {content}
     </NavLink>
   );
 }


### PR DESCRIPTION
**Summary**

Fixed the Documentation link in the dashboard sidebar to open the external docs URL (`https://paperclip.ing/docs`) instead of navigating to a non-existent internal `/docs` route
Added href prop to SidebarNavItem component to support external links
External links open in a new tab with proper security attributes (`target="_blank", rel="noreferrer"`)

**Changes**

- `ui/src/components/SidebarNavItem.tsx` - Added optional `href` prop; when provided, renders `<a>` tag instead of `<NavLink>`
- `ui/src/components/Layout.tsx` - Updated both mobile and desktop Documentation links to use `href="https://paperclip.ing/docs"`

**Testing**

1. Click the Documentation link in the sidebar
2. Verify it opens `https://paperclip.ing/docs` in a new browser tab
3. Verify the original page remains unchanged

Fixes #579