### PR TITLE
fix: prevent text overflow on issue detail page

### DIFF
--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -54,9 +54,9 @@ export function BreadcrumbBar() {
             return (
               <Fragment key={i}>
                 {i > 0 && <BreadcrumbSeparator />}
-                <BreadcrumbItem className={isLast ? "min-w-0" : "shrink-0"}>
+                <BreadcrumbItem className={isLast ? "min-w-0 overflow-hidden" : "shrink-0"}>
                   {isLast || !crumb.href ? (
-                    <BreadcrumbPage className="truncate">{crumb.label}</BreadcrumbPage>
+                    <BreadcrumbPage className="truncate block">{crumb.label}</BreadcrumbPage>
                   ) : (
                     <BreadcrumbLink asChild>
                       <Link to={crumb.href}>{crumb.label}</Link>

--- a/ui/src/components/InlineEditor.tsx
+++ b/ui/src/components/InlineEditor.tsx
@@ -132,7 +132,7 @@ export function InlineEditor({
   return (
     <DisplayTag
       className={cn(
-        "cursor-pointer rounded hover:bg-accent/50 transition-colors",
+        "cursor-pointer rounded hover:bg-accent/50 transition-colors break-words",
         pad,
         !value && "text-muted-foreground italic",
         className

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -117,7 +117,7 @@ export function MarkdownBody({ children, className }: MarkdownBodyProps) {
   return (
     <div
       className={cn(
-        "prose prose-sm max-w-none prose-p:my-2 prose-p:leading-[1.4] prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-li:leading-[1.4] prose-pre:my-2 prose-pre:whitespace-pre-wrap prose-pre:break-words prose-headings:my-2 prose-headings:text-sm prose-blockquote:leading-[1.4] prose-table:my-2 prose-th:px-3 prose-th:py-1.5 prose-td:px-3 prose-td:py-1.5 prose-code:break-all [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:list-item",
+        "prose prose-sm max-w-none break-words prose-p:my-2 prose-p:leading-[1.4] prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-li:leading-[1.4] prose-pre:my-2 prose-pre:whitespace-pre-wrap prose-pre:break-words prose-headings:my-2 prose-headings:text-sm prose-blockquote:leading-[1.4] prose-table:my-2 prose-th:px-3 prose-th:py-1.5 prose-td:px-3 prose-td:py-1.5 prose-code:break-all [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:list-item",
         theme === "dark" && "prose-invert",
         className,
       )}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -514,7 +514,7 @@ export function IssueDetail() {
   const isImageAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("image/");
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-2xl space-y-6 overflow-hidden">
       {/* Parent chain breadcrumb */}
       {ancestors.length > 0 && (
         <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">
@@ -703,13 +703,13 @@ export function IssueDetail() {
         ) : (
           <div className="space-y-2">
             {attachments.map((attachment) => (
-              <div key={attachment.id} className="border border-border rounded-md p-2">
-                <div className="flex items-center justify-between gap-2">
+              <div key={attachment.id} className="border border-border rounded-md p-2 overflow-hidden">
+                <div className="flex items-center justify-between gap-2 min-w-0">
                   <a
                     href={attachment.contentPath}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-xs hover:underline truncate"
+                    className="text-xs hover:underline truncate min-w-0"
                     title={attachment.originalFilename ?? attachment.id}
                   >
                     {attachment.originalFilename ?? attachment.id}


### PR DESCRIPTION
 ## Summary
  - Fix text overflow when issue title/description contains long strings without spaces
  - Fix breadcrumb truncation not working for long issue titles
  - Add proper overflow containment to attachment filenames

  ## Changes

  | File | Change |
  |------|--------|
  | `IssueDetail.tsx` | Add `overflow-hidden` to root container and attachment cards, `min-w-0` to flex containers |
  | `BreadcrumbBar.tsx` | Add `overflow-hidden` to last breadcrumb item, `block` to enable truncation |
  | `InlineEditor.tsx` | Add `break-words` for long unspaced text wrapping |
  | `MarkdownBody.tsx` | Add `break-words` for description content |

  ## Test plan
  - [x] Navigate to an issue with a very long title without spaces
  - [x] Verify title wraps within container instead of overflowing
  - [x] Verify breadcrumb truncates with ellipsis
  - [x] Verify description with long words wraps correctly
  - [x] Check attachment filenames truncate properly

<img width="1178" height="724" alt="CleanShot 2026-03-11 at 15 04 58" src="https://github.com/user-attachments/assets/65cf5f03-a185-47ef-812c-5e74cd9c8232" />

## Fix

<img width="827" height="740" alt="CleanShot 2026-03-11 at 14 51 43" src="https://github.com/user-attachments/assets/79762be8-0bc9-4abb-a083-2b6422ab4615" />
