### PR TITLE
fix(ui): route docs link to documentation

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,7 +49,7 @@ function DocsRedirectPage() {
         </p>
         <div className="mt-4 flex gap-2">
           <Button asChild>
-            <a href={PAPERCLIP_DOCS_URL} rel="noreferrer">
+            <a href={PAPERCLIP_DOCS_URL} target="_blank" rel="noreferrer noopener">
               Open docs
             </a>
           </Button>


### PR DESCRIPTION
## Summary
- add a real global `/docs` route instead of letting the sidebar link fall through to the app router
- redirect that route to the Paperclip documentation landing page
- show a small fallback card with manual links in case the redirect is blocked

## Testing
- cd ui && pnpm typecheck

Fixes #579