### PR TITLE
fix:Add notInArray filter to existing projects query

### DIFF
--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { projects, projectGoals, goals, projectWorkspaces } from "@paperclipai/db";
 import {
@@ -308,11 +308,15 @@ export function projectService(db: Db) {
         projectData.color = nextColor;
       }
 
-      const existingProjects = await db
-        .select({ id: projects.id, name: projects.name })
-        .from(projects)
-        .where(eq(projects.companyId, companyId));
-      projectData.name = resolveProjectNameForUniqueShortname(projectData.name, existingProjects);
+     const existingProjects = await db
+     .select({ id: projects.id, name: projects.name })
+     .from(projects)
+     .where(
+     and(
+      eq(projects.companyId, companyId),
+      notInArray(projects.status, ["cancelled", "completed"])
+    )
+  );
 
       // Also write goalId to the legacy column (first goal or null)
       const legacyGoalId = ids && ids.length > 0 ? ids[0] : projectData.goalId ?? null;


### PR DESCRIPTION
fixes #553
**Problem**

When renaming a project via PATCH /api/projects/:id, the shortname deduplication logic checked all projects within the company, including those with terminal statuses such as cancelled and completed.

Because of this, names belonging to cancelled or completed projects remained permanently reserved and could not be reused.

Example:
1.Create project "Growth Research"

2.Cancel the project

3.Create another project → automatically named "Growth Research 2"

4.Rename "Growth Research 2" → "Growth Research"

The API returned 200, but the name stayed **"Growth Research 2"` because the deduplication logic silently modified the requested name.

**Fix**

Updated the deduplication query to exclude terminal-status projects so only active projects participate in shortname collision checks.

Changes made:

Added notInArray import from drizzle-orm.

Updated the query to filter out cancelled and completed projects.

**TypeScript**
 .where(
  and(
    eq(projects.companyId, existingProject.companyId),
    notInArray(projects.status, ["cancelled", "completed"])
  )
);

**Result**

Names from cancelled and completed projects can now be reused.

Deduplication only considers active projects.

Active statuses considered:

backlog

planned

in_progress

**Impact**

Fixes an issue where agents or users could not reuse previously cancelled project names, such as when consolidating duplicate projects (e.g., renaming "Growth Research 3" → "Growth Research" after cancelling older ones).