### PR TITLE
issues: fail closed stale checkout adoption on lock mismatch

### DIFF
--- a/server/src/__tests__/issues-checkout-adoption.test.ts
+++ b/server/src/__tests__/issues-checkout-adoption.test.ts
@@ -31,4 +31,94 @@ describe("shouldAttemptStaleCheckoutAdoption", () => {
       }),
     ).toBe(false);
   });
+
+  it("allows adoption when execution lock is unset", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-new",
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: "run-old",
+          executionRunId: null,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks adoption without an actor run id", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: null,
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: "run-old",
+          executionRunId: "run-old",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks adoption when issue is not in progress", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-new",
+        current: {
+          status: "blocked",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: "run-old",
+          executionRunId: "run-old",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks adoption when assignee does not match actor", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-new",
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-2",
+          checkoutRunId: "run-old",
+          executionRunId: "run-old",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks adoption when checkout lock is missing", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-new",
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: null,
+          executionRunId: null,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks adoption when checkout lock is already owned by the actor run", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-same",
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: "run-same",
+          executionRunId: "run-same",
+        },
+      }),
+    ).toBe(false);
+  });
 });

--- a/server/src/__tests__/issues-checkout-adoption.test.ts
+++ b/server/src/__tests__/issues-checkout-adoption.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldAttemptStaleCheckoutAdoption } from "../services/issues-checkout-adoption.js";
+
+describe("shouldAttemptStaleCheckoutAdoption", () => {
+  it("allows adoption when stale checkout lock is present for same assignee", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-new",
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: "run-old",
+          executionRunId: "run-old",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks adoption when execution lock points to a different run", () => {
+    expect(
+      shouldAttemptStaleCheckoutAdoption({
+        actorAgentId: "agent-1",
+        actorRunId: "run-new",
+        current: {
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          checkoutRunId: "run-old",
+          executionRunId: "run-foreign",
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/issues-checkout-adoption.ts
+++ b/server/src/services/issues-checkout-adoption.ts
@@ -1,0 +1,27 @@
+type StaleCheckoutState = {
+  status: string;
+  assigneeAgentId: string | null;
+  checkoutRunId: string | null;
+  executionRunId: string | null;
+};
+
+type StaleCheckoutAdoptionInput = {
+  actorAgentId: string;
+  actorRunId: string | null;
+  current: StaleCheckoutState;
+};
+
+export function shouldAttemptStaleCheckoutAdoption(input: StaleCheckoutAdoptionInput): boolean {
+  if (!input.actorRunId) return false;
+  if (input.current.status !== "in_progress") return false;
+  if (input.current.assigneeAgentId !== input.actorAgentId) return false;
+  if (!input.current.checkoutRunId) return false;
+  if (input.current.checkoutRunId === input.actorRunId) return false;
+
+  // Fail closed when the execution lock does not align with the stale checkout lock.
+  // This prevents cross-run lock adoption when run ownership is ambiguous.
+  return (
+    input.current.executionRunId == null ||
+    input.current.executionRunId === input.current.checkoutRunId
+  );
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -887,8 +887,8 @@ export function issueService(db: Db) {
         const adopted = await adoptStaleCheckoutRun({
           issueId: id,
           actorAgentId: agentId,
-          actorRunId: checkoutRunId,
-          expectedCheckoutRunId: current.checkoutRunId,
+          actorRunId: checkoutRunId!,
+          expectedCheckoutRunId: current.checkoutRunId!,
         });
         if (adopted) {
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
@@ -924,6 +924,7 @@ export function issueService(db: Db) {
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, id))
@@ -940,17 +941,22 @@ export function issueService(db: Db) {
       }
 
       if (
-        actorRunId &&
-        current.status === "in_progress" &&
-        current.assigneeAgentId === actorAgentId &&
-        current.checkoutRunId &&
-        current.checkoutRunId !== actorRunId
+        shouldAttemptStaleCheckoutAdoption({
+          actorAgentId,
+          actorRunId,
+          current: {
+            status: current.status,
+            assigneeAgentId: current.assigneeAgentId,
+            checkoutRunId: current.checkoutRunId,
+            executionRunId: current.executionRunId,
+          },
+        })
       ) {
         const adopted = await adoptStaleCheckoutRun({
           issueId: id,
           actorAgentId,
-          actorRunId,
-          expectedCheckoutRunId: current.checkoutRunId,
+          actorRunId: actorRunId!,
+          expectedCheckoutRunId: current.checkoutRunId!,
         });
 
         if (adopted) {
@@ -966,6 +972,7 @@ export function issueService(db: Db) {
         status: current.status,
         assigneeAgentId: current.assigneeAgentId,
         checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
         actorAgentId,
         actorRunId,
       });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -22,6 +22,7 @@ import {
   defaultIssueExecutionWorkspaceSettingsForProject,
   parseProjectExecutionWorkspacePolicy,
 } from "./execution-workspace-policy.js";
+import { shouldAttemptStaleCheckoutAdoption } from "./issues-checkout-adoption.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 
@@ -872,11 +873,16 @@ export function issueService(db: Db) {
       }
 
       if (
-        checkoutRunId &&
-        current.assigneeAgentId === agentId &&
-        current.status === "in_progress" &&
-        current.checkoutRunId &&
-        current.checkoutRunId !== checkoutRunId
+        shouldAttemptStaleCheckoutAdoption({
+          actorAgentId: agentId,
+          actorRunId: checkoutRunId,
+          current: {
+            status: current.status,
+            assigneeAgentId: current.assigneeAgentId,
+            checkoutRunId: current.checkoutRunId,
+            executionRunId: current.executionRunId,
+          },
+        })
       ) {
         const adopted = await adoptStaleCheckoutRun({
           issueId: id,


### PR DESCRIPTION
## Problem
Stale checkout lock adoption could proceed when checkout/execution lock ownership diverged, and one adoption call path (`assertCheckoutOwner`) still bypassed the new fail-closed guard.

## Why now
Checkout and execution locks are governance-critical ownership signals. Ambiguous lock state should fail closed across all adoption paths.

## What changed
- Reused `shouldAttemptStaleCheckoutAdoption` in both `checkout()` and `assertCheckoutOwner()`.
- Added `executionRunId` to owner-assertion selection so stale adoption eligibility checks can enforce lock alignment.
- Added guard-coverage tests for all helper branches, including nil execution lock allow-path and all deny paths.

## Validation
- `pnpm vitest server/src/__tests__/issues-checkout-adoption.test.ts --run`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm -r typecheck`

Refs #611
