### PR TITLE
Install dependencies after creating worktree

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -753,6 +753,19 @@ export async function worktreeMakeCommand(nameArg: string, opts: WorktreeMakeOpt
     throw new Error(extractExecSyncErrorMessage(error) ?? String(error));
   }
 
+  const installSpinner = p.spinner();
+  installSpinner.start("Installing dependencies...");
+  try {
+    execFileSync("pnpm", ["install"], {
+      cwd: targetPath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    installSpinner.stop("Installed dependencies.");
+  } catch (error) {
+    installSpinner.stop(pc.yellow("Failed to install dependencies (continuing anyway)."));
+    p.log.warning(extractExecSyncErrorMessage(error) ?? String(error));
+  }
+
   const originalCwd = process.cwd();
   try {
     process.chdir(targetPath);


### PR DESCRIPTION
## Summary
- Adds a `pnpm install` step in `worktree:make` after creating the git worktree, ensuring dependencies are installed before the Paperclip instance init runs
- Gracefully handles install failures with a warning so the workflow continues

## Test plan
- [ ] Run `worktree:make` and verify `pnpm install` executes in the new worktree
- [ ] Simulate install failure (e.g. no network) and confirm the command continues with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)