### PR TITLE
fix: remove paperclip property from OpenClaw Gateway agent params

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1069,7 +1069,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
-    paperclip: paperclipPayload,
     message,
     sessionKey,
     idempotencyKey: ctx.runId,

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -456,33 +456,6 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("wake now");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
-      expect(payload?.paperclip).toEqual(
-        expect.objectContaining({
-          runId: "run-123",
-          companyId: "company-123",
-          agentId: "agent-123",
-          taskId: "task-123",
-          issueId: "issue-123",
-          workspace: expect.objectContaining({
-            cwd: "/tmp/worktrees/pap-123",
-            strategy: "git_worktree",
-          }),
-          workspaces: [
-            expect.objectContaining({
-              id: "workspace-1",
-              cwd: "/tmp/project",
-            }),
-          ],
-          workspaceRuntime: expect.objectContaining({
-            services: [
-              expect.objectContaining({
-                name: "preview",
-                lifecycle: "ephemeral",
-              }),
-            ],
-          }),
-        }),
-      );
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {


### PR DESCRIPTION
## Summary
- Fixed the `openclaw_gateway_request_failed` error caused by sending an invalid `paperclip` property in agent parameters
- The OpenClaw Gateway's agent method has strict parameter validation that rejects unknown properties
- Paperclip metadata is already included in the message field via wakeText, so the separate property was redundant

## Test plan
- [x] All existing tests pass (`pnpm test openclaw-gateway-adapter.test.ts`)
- [x] Type checks pass
- [x] Removed test expectations for the invalid `paperclip` property

## Root cause
The OpenClaw Gateway's `agent` method uses `validateAgentParams` which has strict schema validation (`additionalProperties: false`). The adapter was sending a `paperclip` property at the root level of agentParams, which is not in the allowed schema.

Fixes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)