### PR TITLE
fix: remove Cmd+1..9 company-switch shortcut

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -104,23 +104,12 @@ export function Layout() {
 
   const togglePanel = togglePanelVisible;
 
-  // Cmd+1..9 to switch companies
-  const switchCompany = useCallback(
-    (index: number) => {
-      if (index < companies.length) {
-        setSelectedCompanyId(companies[index]!.id);
-      }
-    },
-    [companies, setSelectedCompanyId],
-  );
-
   useCompanyPageMemory();
 
   useKeyboardShortcuts({
     onNewIssue: () => openNewIssue(),
     onToggleSidebar: toggleSidebar,
     onTogglePanel: togglePanel,
-    onSwitchCompany: switchCompany,
   });
 
   useEffect(() => {

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -4,22 +4,14 @@ interface ShortcutHandlers {
   onNewIssue?: () => void;
   onToggleSidebar?: () => void;
   onTogglePanel?: () => void;
-  onSwitchCompany?: (index: number) => void;
 }
 
-export function useKeyboardShortcuts({ onNewIssue, onToggleSidebar, onTogglePanel, onSwitchCompany }: ShortcutHandlers) {
+export function useKeyboardShortcuts({ onNewIssue, onToggleSidebar, onTogglePanel }: ShortcutHandlers) {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       // Don't fire shortcuts when typing in inputs
       const target = e.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
-        return;
-      }
-
-      // Cmd+1..9 → Switch company
-      if ((e.metaKey || e.ctrlKey) && e.key >= "1" && e.key <= "9") {
-        e.preventDefault();
-        onSwitchCompany?.(parseInt(e.key, 10) - 1);
         return;
       }
 
@@ -44,5 +36,5 @@ export function useKeyboardShortcuts({ onNewIssue, onToggleSidebar, onTogglePane
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onNewIssue, onToggleSidebar, onTogglePanel, onSwitchCompany]);
+  }, [onNewIssue, onToggleSidebar, onTogglePanel]);
 }

--- a/ui/src/pages/DesignGuide.tsx
+++ b/ui/src/pages/DesignGuide.tsx
@@ -1313,7 +1313,7 @@ export function DesignGuide() {
             ["C", "New Issue (outside inputs)"],
             ["[", "Toggle Sidebar"],
             ["]", "Toggle Properties Panel"],
-            ["Cmd+1..9 / Ctrl+1..9", "Switch Company (by rail order)"],
+
             ["Cmd+Enter / Ctrl+Enter", "Submit markdown comment"],
           ].map(([key, desc]) => (
             <div key={key} className="flex items-center justify-between px-4 py-2">


### PR DESCRIPTION
## Summary
- Removed the `Cmd+1..9 / Ctrl+1..9` keyboard shortcut that attempted to switch companies by rail order
- The shortcut was broken (showed a black screen) and interfered with browser tab-switching controls
- Removed handler from `useKeyboardShortcuts.ts`, callback from `Layout.tsx`, and documentation from `DesignGuide.tsx`

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No remaining references to `onSwitchCompany` or `switchCompany`
- [ ] Verify Cmd+1..9 now correctly switches browser tabs instead of being intercepted

Closes RUS-56

🤖 Generated with [Claude Code](https://claude.com/claude-code)