### PR TITLE
fix: prevent appendWithCap from splitting surrogate pairs

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { appendWithCap } from "./server-utils.js";
+
+describe("appendWithCap", () => {
+  it("returns combined string when under cap", () => {
+    expect(appendWithCap("hello", " world", 100)).toBe("hello world");
+  });
+
+  it("returns combined string at exactly cap", () => {
+    expect(appendWithCap("ab", "cd", 4)).toBe("abcd");
+  });
+
+  it("truncates from the beginning when over cap", () => {
+    expect(appendWithCap("abcde", "fgh", 5)).toBe("defgh");
+  });
+
+  it("handles empty prev", () => {
+    expect(appendWithCap("", "hello", 100)).toBe("hello");
+  });
+
+  it("handles empty chunk", () => {
+    expect(appendWithCap("hello", "", 100)).toBe("hello");
+  });
+
+  it("drops lone low surrogate at start after slicing", () => {
+    // U+1F600 (😀) = \uD83D\uDE00 in UTF-16 (2 code units)
+    // "x😀yz" indices: 0=x, 1=\uD83D, 2=\uDE00, 3=y, 4=z (length 5)
+    // cap=3 → slice(2) → "\uDE00yz" — lone low surrogate at start → dropped
+    const prev = "x\uD83D\uDE00";
+    const chunk = "yz";
+    const result = appendWithCap(prev, chunk, 3);
+    expect(result).toBe("yz");
+  });
+
+  it("drops lone high surrogate at end after slicing", () => {
+    // Chunk ends with a lone high surrogate (simulating a partial write)
+    // "abcde\uD83D" indices: 0=a,1=b,2=c,3=d,4=e,5=\uD83D (length 6)
+    // cap=4 → slice(2) → "de\uD83D" — trailing high surrogate → dropped
+    const result = appendWithCap("ab", "cde\uD83D", 4);
+    expect(result).toBe("cde");
+  });
+
+  it("handles string that is entirely surrogate pairs", () => {
+    const emoji = "\uD83D\uDE00";
+    const text = emoji.repeat(5); // 5 emojis, length 10
+    expect(appendWithCap("", text, 10)).toBe(text);
+  });
+
+  it("handles cap of 1 with surrogate pair", () => {
+    // "\uD83D\uDE00" length 2, cap=1 → slice(1) → "\uDE00" → dropped → ""
+    expect(appendWithCap("", "\uD83D\uDE00", 1)).toBe("");
+  });
+
+  it("uses MAX_CAPTURE_BYTES as default cap", () => {
+    expect(appendWithCap("", "abc")).toBe("abc");
+  });
+
+  it("preserves valid surrogate pairs when slice boundary is clean", () => {
+    // "a😀b" indices: 0=a, 1=\uD83D, 2=\uDE00, 3=b (length 4)
+    // cap=3 → slice(1) → "\uD83D\uDE00b" = "😀b" — pair intact
+    const text = "a\uD83D\uDE00b";
+    expect(appendWithCap("", text, 3)).toBe("\uD83D\uDE00b");
+  });
+
+  it("handles consecutive surrogate pairs at boundary", () => {
+    const a = "\uD83D\uDE00"; // 😀
+    const b = "\uD83D\uDE01"; // 😁
+    // "x😀😁y" indices: 0=x, 1=\uD83D, 2=\uDE00, 3=\uD83D, 4=\uDE01, 5=y (length 6)
+    // cap=5 → slice(1) → pair a intact + pair b + y
+    expect(appendWithCap("", "x" + a + b + "y", 5)).toBe(a + b + "y");
+    // cap=4 → slice(2) → "\uDE00😁y" → lone low surrogate dropped → "😁y"
+    expect(appendWithCap("", "x" + a + b + "y", 4)).not.toMatch(/[\uDC00-\uDFFF](?![\s\S])/);
+    // cap=2 → slice(4) → "\uDE01y" → lone low surrogate dropped → "y"
+    expect(appendWithCap("", "x" + a + b + "y", 2)).toBe("y");
+  });
+});

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -66,7 +66,13 @@ export function parseJson(value: string): Record<string, unknown> | null {
 
 export function appendWithCap(prev: string, chunk: string, cap = MAX_CAPTURE_BYTES) {
   const combined = prev + chunk;
-  return combined.length > cap ? combined.slice(combined.length - cap) : combined;
+  if (combined.length <= cap) return combined;
+  let result = combined.slice(combined.length - cap);
+  // If slice cut through a surrogate pair, drop the leading lone surrogate
+  if (result.length > 0 && result.charCodeAt(0) >= 0xdc00 && result.charCodeAt(0) <= 0xdfff) {
+    result = result.slice(1);
+  }
+  return result;
 }
 
 export function resolvePathValue(obj: Record<string, unknown>, dottedPath: string) {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -68,9 +68,13 @@ export function appendWithCap(prev: string, chunk: string, cap = MAX_CAPTURE_BYT
   const combined = prev + chunk;
   if (combined.length <= cap) return combined;
   let result = combined.slice(combined.length - cap);
-  // If slice cut through a surrogate pair, drop the leading lone surrogate
+  // If slice cut through a surrogate pair, drop the lone surrogate
   if (result.length > 0 && result.charCodeAt(0) >= 0xdc00 && result.charCodeAt(0) <= 0xdfff) {
     result = result.slice(1);
+  }
+  const last = result.length - 1;
+  if (last >= 0 && result.charCodeAt(last) >= 0xd800 && result.charCodeAt(last) <= 0xdbff) {
+    result = result.slice(0, last);
   }
   return result;
 }

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/db", "packages/adapters/opencode-local", "server", "ui", "cli"],
+    projects: ["packages/adapter-utils", "packages/db", "packages/adapters/opencode-local", "server", "ui", "cli"],
   },
 });


### PR DESCRIPTION
## Summary

- Fix `appendWithCap()` in `packages/adapter-utils/src/server-utils.ts` to not produce invalid UTF-8 when truncating strings containing emoji or supplementary Unicode characters
- `string.slice()` operates on UTF-16 code units and can split a surrogate pair, producing a lone surrogate that becomes an invalid UTF-8 byte sequence when stored in PostgreSQL
- After slicing, drop a leading lone low surrogate (U+DC00–U+DFFF) and a trailing lone high surrogate (U+D800–U+DBFF) so the result is always valid Unicode

## Changes

1. **`packages/adapter-utils/src/server-utils.ts`** — after `slice()`, strip lone low surrogate at start and lone high surrogate at end
2. **`packages/adapter-utils/src/server-utils.test.ts`** — 12 unit tests covering surrogate pair handling
3. **`packages/adapter-utils/vitest.config.ts`** + **`vitest.config.ts`** — register `adapter-utils` in the vitest project list

## Test plan

- [x] Unit tests pass (`npx vitest run packages/adapter-utils/src/server-utils.test.ts` — 12/12)
  - Basic truncation (under cap, at cap, over cap)
  - Empty prev / empty chunk
  - Lone low surrogate at start after slicing → dropped
  - Lone high surrogate at end (partial write) → dropped
  - Cap of 1 with surrogate pair → empty string
  - Valid pairs preserved when boundary is clean
  - Consecutive surrogate pairs at various boundaries
  - Default cap (MAX_CAPTURE_BYTES)
- [ ] Verify heartbeat-runs list endpoint no longer returns 500 when agent output contains emoji near the truncation boundary

Fixes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)