### PR TITLE
fix: add null guards to dashboard.summary and tickTimers

### DIFF
--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -39,7 +39,8 @@ export function dashboardService(db: Db) {
         error: 0,
       };
       for (const row of agentRows) {
-        const count = Number(row.count);
+        if (!row?.status) continue;
+        const count = Number(row.count ?? 0);
         // "idle" agents are operational — count them as active
         const bucket = row.status === "idle" ? "active" : row.status;
         agentCounts[bucket] = (agentCounts[bucket] ?? 0) + count;
@@ -52,7 +53,8 @@ export function dashboardService(db: Db) {
         done: 0,
       };
       for (const row of taskRows) {
-        const count = Number(row.count);
+        if (!row?.status) continue;
+        const count = Number(row.count ?? 0);
         if (row.status === "in_progress") taskCounts.inProgress += count;
         if (row.status === "blocked") taskCounts.blocked += count;
         if (row.status === "done") taskCounts.done += count;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2462,7 +2462,7 @@ export function heartbeatService(db: Db) {
       let skipped = 0;
 
       for (const agent of allAgents) {
-        if (!agent?.status) continue;
+        if (!agent?.status) { skipped += 1; continue; }
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2462,6 +2462,7 @@ export function heartbeatService(db: Db) {
       let skipped = 0;
 
       for (const agent of allAgents) {
+        if (!agent?.status) continue;
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;


### PR DESCRIPTION
## Summary

- Add defensive null checks in `dashboard.ts` to guard `agentRows`/`taskRows` iteration against undefined rows
- Add defensive null check in `heartbeat.ts` `tickTimers()` to guard agent iteration
- These crashes are secondary symptoms of #636 (invalid UTF-8 corrupting the postgres.js connection pool), but the guards prevent a single bad query from cascading into unrelated endpoint failures

## Test plan

- [ ] Verify `GET /api/companies/:id/sidebar-badges` no longer crashes when connection pool is in degraded state
- [ ] Verify `tickTimers()` skips undefined agents instead of crashing
- [ ] Verify normal operation is unaffected (counts remain accurate)

Fixes #637
Fixes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)