### PR TITLE
feat: reset password

### DIFF
--- a/server/src/__tests__/password-reset.test.ts
+++ b/server/src/__tests__/password-reset.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildResetPasswordLogLines,
+  deriveAuthTrustedOrigins,
+} from "../auth/better-auth.js";
+import type { Config } from "../config.js";
+
+// Minimal config stub with only the fields deriveAuthTrustedOrigins needs.
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    deploymentMode: "authenticated",
+    deploymentExposure: "private",
+    authBaseUrlMode: "auto",
+    authPublicBaseUrl: undefined,
+    authDisableSignUp: false,
+    allowedHostnames: [],
+    host: "127.0.0.1",
+    port: 3100,
+    databaseMode: "embedded-postgres",
+    databaseUrl: undefined,
+    embeddedPostgresDataDir: "/tmp/test-pg",
+    embeddedPostgresPort: 54329,
+    databaseBackupEnabled: false,
+    databaseBackupIntervalMinutes: 60,
+    databaseBackupRetentionDays: 30,
+    databaseBackupDir: "/tmp/test-backups",
+    serveUi: false,
+    uiDevMiddleware: false,
+    secretsProvider: "local_encrypted",
+    secretsStrictMode: false,
+    secretsMasterKeyFilePath: "/tmp/test-master.key",
+    storageProvider: "local_disk",
+    storageLocalDiskBaseDir: "/tmp/test-storage",
+    storageS3Bucket: "paperclip",
+    storageS3Region: "us-east-1",
+    storageS3Endpoint: undefined,
+    storageS3Prefix: "",
+    storageS3ForcePathStyle: false,
+    heartbeatSchedulerEnabled: false,
+    heartbeatSchedulerIntervalMs: 30000,
+    companyDeletionEnabled: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildResetPasswordLogLines
+// ---------------------------------------------------------------------------
+
+describe("buildResetPasswordLogLines", () => {
+  it("includes the user email", () => {
+    const lines = buildResetPasswordLogLines(
+      { email: "admin@example.com" },
+      "http://localhost:3100/api/auth/reset-password/abc123?callbackURL=%2Freset-password",
+    );
+    const joined = lines.join("\n");
+    expect(joined).toContain("admin@example.com");
+  });
+
+  it("includes the reset URL", () => {
+    const url = "http://localhost:3100/api/auth/reset-password/abc123?callbackURL=%2Freset-password";
+    const lines = buildResetPasswordLogLines({ email: "user@test.com" }, url);
+    const joined = lines.join("\n");
+    expect(joined).toContain(url);
+  });
+
+  it("includes the tailscale hostname hint", () => {
+    const lines = buildResetPasswordLogLines(
+      { email: "user@test.com" },
+      "http://localhost:3100/api/auth/reset-password/tok",
+    );
+    const joined = lines.join("\n");
+    expect(joined).toContain("Tailscale");
+  });
+
+  it("returns an array of strings", () => {
+    const lines = buildResetPasswordLogLines({ email: "a@b.com" }, "http://localhost/reset");
+    expect(Array.isArray(lines)).toBe(true);
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(typeof line).toBe("string");
+    }
+  });
+
+  it("logs all lines to console when joined", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const user = { email: "console@test.com" };
+    const url = "http://localhost:3100/api/auth/reset-password/xyz";
+
+    const lines = buildResetPasswordLogLines(user, url);
+    console.log(lines.join("\n"));
+
+    expect(spy).toHaveBeenCalledOnce();
+    const logged = spy.mock.calls[0]?.[0] as string;
+    expect(logged).toContain(user.email);
+    expect(logged).toContain(url);
+
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveAuthTrustedOrigins
+// ---------------------------------------------------------------------------
+
+describe("deriveAuthTrustedOrigins", () => {
+  it("returns empty array when no public URL and no allowed hostnames", () => {
+    const origins = deriveAuthTrustedOrigins(makeConfig());
+    expect(origins).toEqual([]);
+  });
+
+  it("includes the origin of an explicit authPublicBaseUrl", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        authBaseUrlMode: "explicit",
+        authPublicBaseUrl: "https://paperclip.example.com",
+      }),
+    );
+    expect(origins).toContain("https://paperclip.example.com");
+  });
+
+  it("does not include authPublicBaseUrl origin when mode is auto", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        authBaseUrlMode: "auto",
+        authPublicBaseUrl: "https://paperclip.example.com",
+      }),
+    );
+    // auto mode ignores the public URL for trusted origins
+    expect(origins).not.toContain("https://paperclip.example.com");
+  });
+
+  it("adds both http and https variants for each allowed hostname in authenticated mode", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        deploymentMode: "authenticated",
+        allowedHostnames: ["my-host.internal"],
+      }),
+    );
+    expect(origins).toContain("https://my-host.internal");
+    expect(origins).toContain("http://my-host.internal");
+  });
+
+  it("does not add hostname variants in local_trusted mode", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        deploymentMode: "local_trusted",
+        allowedHostnames: ["my-host.internal"],
+      }),
+    );
+    expect(origins).not.toContain("https://my-host.internal");
+    expect(origins).not.toContain("http://my-host.internal");
+  });
+
+  it("deduplicates origins", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        deploymentMode: "authenticated",
+        authBaseUrlMode: "explicit",
+        authPublicBaseUrl: "https://my-host.internal",
+        allowedHostnames: ["my-host.internal"],
+      }),
+    );
+    const httpsCount = origins.filter((o) => o === "https://my-host.internal").length;
+    expect(httpsCount).toBe(1);
+  });
+
+  it("handles multiple allowed hostnames", () => {
+    const origins = deriveAuthTrustedOrigins(
+      makeConfig({
+        deploymentMode: "authenticated",
+        allowedHostnames: ["host-a.example", "host-b.example"],
+      }),
+    );
+    expect(origins).toContain("https://host-a.example");
+    expect(origins).toContain("https://host-b.example");
+  });
+});

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -65,6 +65,19 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
   return Array.from(trustedOrigins);
 }
 
+export function buildResetPasswordLogLines(user: { email: string }, url: string): string[] {
+  const cyan = "\x1b[36m";
+  const bold = "\x1b[1m";
+  const reset = "\x1b[0m";
+  return [
+    `\n${bold}${cyan}  PASSWORD RESET REQUESTED  ${reset}`,
+    `${cyan}User: ${user.email}${reset}`,
+    `${cyan}Open this URL to set a new password (expires in 1 hour):${reset}`,
+    `${cyan}${url}${reset}`,
+    `${cyan}If connecting over Tailscale or a custom hostname, replace the host in the URL above.${reset}\n`,
+  ];
+}
+
 export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET ?? "paperclip-dev-secret";
@@ -90,6 +103,9 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
       enabled: true,
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
+      sendResetPassword: async ({ user, url }: { user: { email: string }; url: string }) => {
+        console.log(buildResetPasswordLogLines(user, url).join("\n"));
+      },
     },
     ...(isHttpOnly ? { advanced: { useSecureCookies: false } } : {}),
   };

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -26,6 +26,7 @@ import { DesignGuide } from "./pages/DesignGuide";
 import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
+import { ResetPasswordPage } from "./pages/ResetPassword";
 import { BoardClaimPage } from "./pages/BoardClaim";
 import { InviteLandingPage } from "./pages/InviteLanding";
 import { NotFoundPage } from "./pages/NotFound";
@@ -227,6 +228,7 @@ export function App() {
     <>
       <Routes>
         <Route path="auth" element={<AuthPage />} />
+        <Route path="reset-password" element={<ResetPasswordPage />} />
         <Route path="board-claim/:token" element={<BoardClaimPage />} />
         <Route path="invite/:token" element={<InviteLandingPage />} />
 

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -71,4 +71,15 @@ export const authApi = {
   signOut: async () => {
     await authPost("/sign-out", {});
   },
+
+  requestPasswordReset: async (email: string) => {
+    await authPost("/request-password-reset", {
+      email,
+      redirectTo: `${window.location.origin}/reset-password`,
+    });
+  },
+
+  resetPassword: async (token: string, newPassword: string) => {
+    await authPost("/reset-password", { token, newPassword });
+  },
 };

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
 import { Sparkles } from "lucide-react";
 
-type AuthMode = "sign_in" | "sign_up";
+type AuthMode = "sign_in" | "sign_up" | "forgot_password";
 
 export function AuthPage() {
   const queryClient = useQueryClient();
@@ -18,6 +18,7 @@ export function AuthPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [resetRequested, setResetRequested] = useState(false);
 
   const nextPath = useMemo(() => searchParams.get("next") || "/", [searchParams]);
   const { data: session, isLoading: isSessionLoading } = useQuery({
@@ -34,6 +35,10 @@ export function AuthPage() {
 
   const mutation = useMutation({
     mutationFn: async () => {
+      if (mode === "forgot_password") {
+        await authApi.requestPasswordReset(email.trim());
+        return;
+      }
       if (mode === "sign_in") {
         await authApi.signInEmail({ email: email.trim(), password });
         return;
@@ -46,6 +51,10 @@ export function AuthPage() {
     },
     onSuccess: async () => {
       setError(null);
+      if (mode === "forgot_password") {
+        setResetRequested(true);
+        return;
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
       await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       navigate(nextPath, { replace: true });
@@ -57,8 +66,8 @@ export function AuthPage() {
 
   const canSubmit =
     email.trim().length > 0 &&
-    password.trim().length >= 8 &&
-    (mode === "sign_in" || name.trim().length > 0);
+    (mode === "forgot_password" ||
+      (password.trim().length >= 8 && (mode === "sign_in" || name.trim().length > 0)));
 
   if (isSessionLoading) {
     return (
@@ -79,77 +88,141 @@ export function AuthPage() {
           </div>
 
           <h1 className="text-xl font-semibold">
-            {mode === "sign_in" ? "Sign in to Paperclip" : "Create your Paperclip account"}
+            {mode === "sign_in"
+              ? "Sign in to Paperclip"
+              : mode === "sign_up"
+                ? "Create your Paperclip account"
+                : "Reset your password"}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             {mode === "sign_in"
               ? "Use your email and password to access this instance."
-              : "Create an account for this instance. Email confirmation is not required in v1."}
+              : mode === "sign_up"
+                ? "Create an account for this instance. Email confirmation is not required in v1."
+                : "Enter your email and a reset link will be printed to the server logs."}
           </p>
 
-          <form
-            className="mt-6 space-y-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              mutation.mutate();
-            }}
-          >
-            {mode === "sign_up" && (
-              <div>
-                <label className="text-xs text-muted-foreground mb-1 block">Name</label>
-                <input
-                  className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  autoComplete="name"
-                  autoFocus
-                />
-              </div>
-            )}
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Email</label>
-              <input
-                className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                type="email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                autoComplete="email"
-                autoFocus={mode === "sign_in"}
-              />
+          {mode === "forgot_password" && resetRequested ? (
+            <div className="mt-6 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">Check your server logs</p>
+              <p className="mt-1">A password reset URL has been printed to the Paperclip server console. Open that URL to set a new password.</p>
+              <button
+                type="button"
+                className="mt-4 font-medium text-foreground underline underline-offset-2 text-sm"
+                onClick={() => {
+                  setResetRequested(false);
+                  setError(null);
+                  setMode("sign_in");
+                }}
+              >
+                Back to sign in
+              </button>
             </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Password</label>
-              <input
-                className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                type="password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                autoComplete={mode === "sign_in" ? "current-password" : "new-password"}
-              />
-            </div>
-            {error && <p className="text-xs text-destructive">{error}</p>}
-            <Button type="submit" disabled={!canSubmit || mutation.isPending} className="w-full">
-              {mutation.isPending
-                ? "Working…"
-                : mode === "sign_in"
-                  ? "Sign In"
-                  : "Create Account"}
-            </Button>
-          </form>
+          ) : (
+            <>
+              <form
+                className="mt-6 space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  mutation.mutate();
+                }}
+              >
+                {mode === "sign_up" && (
+                  <div>
+                    <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+                    <input
+                      className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                      value={name}
+                      onChange={(event) => setName(event.target.value)}
+                      autoComplete="name"
+                      autoFocus
+                    />
+                  </div>
+                )}
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Email</label>
+                  <input
+                    className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    autoComplete="email"
+                    autoFocus={mode === "sign_in" || mode === "forgot_password"}
+                  />
+                </div>
+                {mode !== "forgot_password" && (
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="text-xs text-muted-foreground">Password</label>
+                      {mode === "sign_in" && (
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+                          onClick={() => {
+                            setError(null);
+                            setResetRequested(false);
+                            setMode("forgot_password");
+                          }}
+                        >
+                          Forgot password?
+                        </button>
+                      )}
+                    </div>
+                    <input
+                      className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                      type="password"
+                      value={password}
+                      onChange={(event) => setPassword(event.target.value)}
+                      autoComplete={mode === "sign_in" ? "current-password" : "new-password"}
+                    />
+                  </div>
+                )}
+                {error && <p className="text-xs text-destructive">{error}</p>}
+                <Button type="submit" disabled={!canSubmit || mutation.isPending} className="w-full">
+                  {mutation.isPending
+                    ? "Working…"
+                    : mode === "sign_in"
+                      ? "Sign In"
+                      : mode === "sign_up"
+                        ? "Create Account"
+                        : "Send Reset Link"}
+                </Button>
+              </form>
 
-          <div className="mt-5 text-sm text-muted-foreground">
-            {mode === "sign_in" ? "Need an account?" : "Already have an account?"}{" "}
-            <button
-              type="button"
-              className="font-medium text-foreground underline underline-offset-2"
-              onClick={() => {
-                setError(null);
-                setMode(mode === "sign_in" ? "sign_up" : "sign_in");
-              }}
-            >
-              {mode === "sign_in" ? "Create one" : "Sign in"}
-            </button>
-          </div>
+              <div className="mt-5 text-sm text-muted-foreground">
+                {mode === "forgot_password" ? (
+                  <>
+                    Remember your password?{" "}
+                    <button
+                      type="button"
+                      className="font-medium text-foreground underline underline-offset-2"
+                      onClick={() => {
+                        setError(null);
+                        setResetRequested(false);
+                        setMode("sign_in");
+                      }}
+                    >
+                      Sign in
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    {mode === "sign_in" ? "Need an account?" : "Already have an account?"}{" "}
+                    <button
+                      type="button"
+                      className="font-medium text-foreground underline underline-offset-2"
+                      onClick={() => {
+                        setError(null);
+                        setMode(mode === "sign_in" ? "sign_up" : "sign_in");
+                      }}
+                    >
+                      {mode === "sign_in" ? "Create one" : "Sign in"}
+                    </button>
+                  </>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/ui/src/pages/ResetPassword.tsx
+++ b/ui/src/pages/ResetPassword.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate, useSearchParams } from "@/lib/router";
+import { authApi } from "../api/auth";
+import { Button } from "@/components/ui/button";
+import { Sparkles } from "lucide-react";
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: () => authApi.resetPassword(token, newPassword),
+    onSuccess: () => {
+      setError(null);
+      setDone(true);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "Failed to reset password");
+    },
+  });
+
+  const canSubmit =
+    token.length > 0 &&
+    newPassword.length >= 8 &&
+    newPassword === confirmPassword;
+
+  if (!token) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-background">
+        <div className="w-full max-w-md px-8">
+          <div className="rounded-lg border border-border bg-card p-6">
+            <h1 className="text-lg font-semibold">Invalid reset link</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              This password reset link is missing a token. Request a new one from the sign-in page.
+            </p>
+            <Button className="mt-4" onClick={() => navigate("/auth")}>
+              Back to sign in
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 flex bg-background">
+      <div className="w-full md:w-1/2 flex flex-col overflow-y-auto">
+        <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
+          <div className="flex items-center gap-2 mb-8">
+            <Sparkles className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Paperclip</span>
+          </div>
+
+          <h1 className="text-xl font-semibold">Set a new password</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Choose a new password for your account.
+          </p>
+
+          {done ? (
+            <div className="mt-6 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">Password updated</p>
+              <p className="mt-1">Your password has been reset. You can now sign in with your new password.</p>
+              <Button className="mt-4" onClick={() => navigate("/auth")}>
+                Sign in
+              </Button>
+            </div>
+          ) : (
+            <form
+              className="mt-6 space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                mutation.mutate();
+              }}
+            >
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">New password</label>
+                <input
+                  className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                  type="password"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                  autoComplete="new-password"
+                  autoFocus
+                  minLength={8}
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Confirm password</label>
+                <input
+                  className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(event) => setConfirmPassword(event.target.value)}
+                  autoComplete="new-password"
+                />
+                {confirmPassword.length > 0 && newPassword !== confirmPassword && (
+                  <p className="mt-1 text-xs text-destructive">Passwords do not match</p>
+                )}
+              </div>
+              {error && <p className="text-xs text-destructive">{error}</p>}
+              <Button type="submit" disabled={!canSubmit || mutation.isPending} className="w-full">
+                {mutation.isPending ? "Updating…" : "Set new password"}
+              </Button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Problem

I didn't remember what password I used when creating my account when using an authenticated deployment. Rather than manually updating the database, wanted a solution taking advantage of Better Auth.

### Solution

Add forgot/reset password flow for authenticated mode

 Adds a self-hosted-friendly password reset flow that requires no email
 infrastructure. When a user requests a reset, the server prints a one-time
 reset URL to the console (mirroring the board-claim pattern). The user opens
 the URL, which redirects to a new /reset-password page where they set a new
 password.

 Changes:
 - Server logs reset URL to console via Better Auth's sendResetPassword callback
 - Auth page gains a "Forgot password?" link and email-submission form
 - New /reset-password route handles the token and new-password form
 - 12 new tests covering log output and trusted origin derivation


### Screenshots

<img width="478" height="425" alt="Screenshot 2026-03-11 at 1 18 51 PM" src="https://github.com/user-attachments/assets/7607db8e-1361-4de4-b990-17895c751e49" />

<img width="446" height="350" alt="Screenshot 2026-03-11 at 1 18 57 PM" src="https://github.com/user-attachments/assets/5363bf21-8901-41bf-9665-ab47f58bb542" />

<img width="944" height="120" alt="Screenshot 2026-03-11 at 1 23 43 PM" src="https://github.com/user-attachments/assets/7b3e0c9e-a824-4dcd-8d1f-8f9ba54669df" />

<img width="881" height="26" alt="Screenshot 2026-03-11 at 1 24 24 PM" src="https://github.com/user-attachments/assets/2b1905df-e2b2-4b18-91d2-7bac077256e8" />
