### PR TITLE
fix: ensure embedded PostgreSQL databases use UTF-8 encoding

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -505,6 +505,7 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
     password: "paperclip",
     port,
     persistent: true,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
     onLog: () => {},
     onError: () => {},
   });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -730,7 +730,7 @@ export async function ensurePostgresDatabase(
     `;
     if (existing.length > 0) return "exists";
 
-    await sql.unsafe(`create database "${databaseName}"`);
+    await sql.unsafe(`create database "${databaseName}" encoding 'UTF8' lc_collate 'C' lc_ctype 'C' template template0`);
     return "created";
   } finally {
     await sql.end();

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -96,6 +96,7 @@ async function ensureEmbeddedPostgresConnection(
     password: "paperclip",
     port: preferredPort,
     persistent: true,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
     onLog: () => {},
     onError: () => {},
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -334,6 +334,7 @@ export async function startServer(): Promise<StartedServer> {
         password: "paperclip",
         port,
         persistent: true,
+        initdbFlags: ["--encoding=UTF8", "--locale=C"],
         onLog: appendEmbeddedPostgresLog,
         onError: appendEmbeddedPostgresLog,
       });


### PR DESCRIPTION
## Summary

On macOS, `initdb` defaults to **SQL_ASCII** encoding because it infers locale from the system environment. When `ensurePostgresDatabase()` creates a database without specifying encoding, the new database inherits SQL_ASCII from the cluster. This causes string functions like `left()` to operate on bytes instead of characters, producing **invalid UTF-8** when multi-byte characters (e.g. CJK, emoji, accented letters) are truncated mid-sequence.

## Changes

**Two-part fix:**

1. **`initdbFlags`** — Pass `--encoding=UTF8 --locale=C` to all three `EmbeddedPostgres` constructors (`server/src/index.ts`, `cli/src/commands/worktree.ts`, `packages/db/src/migration-runtime.ts`) so the cluster is initialized with UTF-8 encoding by default.

2. **`CREATE DATABASE`** — Explicitly set `encoding 'UTF8' lc_collate 'C' lc_ctype 'C' template template0` in `ensurePostgresDatabase()` (`packages/db/src/client.ts`). Using `template template0` is required because `template1` may already have a different encoding. The `C` locale is portable and works on all platforms.

## Migration note

Existing local databases created with SQL_ASCII are **not** automatically fixed. Users who encounter encoding issues should delete their local `data/db` directory and restart the server to re-initialize the cluster with UTF-8.

## Related

Relates to #636

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)