### PR TITLE
fix: createdAt type mismatch breaks Docker build (TS2322)

### DIFF
--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -32,7 +32,7 @@ export interface HeartbeatRun {
   errorCode: string | null;
   externalRunId: string | null;
   contextSnapshot: Record<string, unknown> | null;
-  createdAt: Date;
+  createdAt: string | Date;
   updatedAt: Date;
 }
 
@@ -48,7 +48,7 @@ export interface HeartbeatRunEvent {
   color: string | null;
   message: string | null;
   payload: Record<string, unknown> | null;
-  createdAt: Date;
+  createdAt: string | Date;
 }
 
 export interface AgentRuntimeState {
@@ -66,7 +66,7 @@ export interface AgentRuntimeState {
   totalCachedInputTokens: number;
   totalCostCents: number;
   lastError: string | null;
-  createdAt: Date;
+  createdAt: string | Date;
   updatedAt: Date;
 }
 
@@ -80,7 +80,7 @@ export interface AgentTaskSession {
   sessionDisplayId: string | null;
   lastRunId: string | null;
   lastError: string | null;
-  createdAt: Date;
+  createdAt: string | Date;
   updatedAt: Date;
 }
 
@@ -102,6 +102,6 @@ export interface AgentWakeupRequest {
   claimedAt: Date | null;
   finishedAt: Date | null;
   error: string | null;
-  createdAt: Date;
+  createdAt: string | Date;
   updatedAt: Date;
 }

--- a/ui/src/components/ActivityCharts.tsx
+++ b/ui/src/components/ActivityCharts.tsx
@@ -113,7 +113,7 @@ const priorityColors: Record<string, string> = {
 
 const priorityOrder = ["critical", "high", "medium", "low"] as const;
 
-export function PriorityChart({ issues }: { issues: { priority: string; createdAt: Date }[] }) {
+export function PriorityChart({ issues }: { issues: { priority: string; createdAt: string | Date }[] }) {
   const days = getLast14Days();
   const grouped = new Map<string, Record<string, number>>();
   for (const day of days) grouped.set(day, { critical: 0, high: 0, medium: 0, low: 0 });
@@ -177,7 +177,7 @@ const statusLabels: Record<string, string> = {
   backlog: "Backlog",
 };
 
-export function IssueStatusChart({ issues }: { issues: { status: string; createdAt: Date }[] }) {
+export function IssueStatusChart({ issues }: { issues: { status: string; createdAt: string | Date }[] }) {
   const days = getLast14Days();
   const allStatuses = new Set<string>();
   const grouped = new Map<string, Record<string, number>>();

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -772,7 +772,7 @@ function AgentOverview({
 }: {
   agent: Agent;
   runs: HeartbeatRun[];
-  assignedIssues: { id: string; title: string; status: string; priority: string; identifier?: string | null; createdAt: Date }[];
+  assignedIssues: { id: string; title: string; status: string; priority: string; identifier?: string | null; createdAt: string | Date }[];
   runtimeState?: AgentRuntimeState;
   agentId: string;
   agentRouteId: string;
@@ -1985,7 +1985,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           color: asNonEmptyString(payload.color),
           message: asNonEmptyString(payload.message),
           payload: asRecord(payload.payload),
-          createdAt: new Date(event.createdAt),
+          createdAt: event.createdAt,
         };
 
         setEvents((prev) => {


### PR DESCRIPTION
## Problem

Docker image build from `master` fails at `pnpm --filter @paperclipai/ui build` with multiple TS2322 errors.

After the SQLite port, the DB driver returns `createdAt` as ISO strings instead of `Date` objects. Three component prop signatures still expect `Date`, causing `tsc` to fail:

```
src/components/ActivityCharts.tsx(116): error TS2322 — PriorityChart props
src/components/ActivityCharts.tsx(180): error TS2322 — IssueStatusChart props  
src/pages/AgentDetail.tsx(775): error TS2322 — AgentOverview assignedIssues
src/pages/AgentDetail.tsx(1988): error TS2322 — LogViewer new Date() wrapper
```

## Fix

- Changed `createdAt: Date` → `createdAt: string | Date` in prop types
- Removed unnecessary `new Date(event.createdAt)` conversion in LogViewer

## Testing

- `docker compose build` now completes successfully
- UI renders correctly with string timestamps

Found during WiseChef dogfooding deployment.