### PR TITLE
feat: enforce company-level budget limits and add budget management UI

### DIFF
--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -33,4 +33,5 @@ export interface CostByAgent {
   subscriptionRunCount: number;
   subscriptionInputTokens: number;
   subscriptionOutputTokens: number;
+  budgetMonthlyCents: number;
 }

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -63,6 +63,28 @@ export function costService(db: Db) {
           .where(eq(agents.id, updatedAgent.id));
       }
 
+      const updatedCompany = await db
+        .select()
+        .from(companies)
+        .where(eq(companies.id, companyId))
+        .then((rows) => rows[0] ?? null);
+
+      if (
+        updatedCompany &&
+        updatedCompany.budgetMonthlyCents > 0 &&
+        updatedCompany.spentMonthlyCents >= updatedCompany.budgetMonthlyCents
+      ) {
+        await db
+          .update(agents)
+          .set({ status: "paused", updatedAt: new Date() })
+          .where(
+            and(
+              eq(agents.companyId, companyId),
+              eq(agents.status, "idle"),
+            ),
+          );
+      }
+
       return event;
     },
 
@@ -113,6 +135,7 @@ export function costService(db: Db) {
           costCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
           inputTokens: sql<number>`coalesce(sum(${costEvents.inputTokens}), 0)::int`,
           outputTokens: sql<number>`coalesce(sum(${costEvents.outputTokens}), 0)::int`,
+          budgetMonthlyCents: sql<number>`coalesce(max(${agents.budgetMonthlyCents}), 0)::int`,
         })
         .from(costEvents)
         .leftJoin(agents, eq(costEvents.agentId, agents.id))

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7,6 +7,7 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  companies,
   heartbeatRunEvents,
   heartbeatRuns,
   costEvents,
@@ -1045,6 +1046,63 @@ export function heartbeatService(db: Db) {
           updatedAt: new Date(),
         })
         .where(eq(agents.id, agent.id));
+
+      await db
+        .update(companies)
+        .set({
+          spentMonthlyCents: sql`${companies.spentMonthlyCents} + ${additionalCostCents}`,
+          updatedAt: new Date(),
+        })
+        .where(eq(companies.id, agent.companyId));
+
+      const updatedAgent = await db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, agent.id))
+        .then((rows) => rows[0] ?? null);
+
+      if (
+        updatedAgent &&
+        updatedAgent.budgetMonthlyCents > 0 &&
+        updatedAgent.spentMonthlyCents >= updatedAgent.budgetMonthlyCents &&
+        updatedAgent.status !== "paused" &&
+        updatedAgent.status !== "terminated"
+      ) {
+        logger.info(
+          { agentId: agent.id, spent: updatedAgent.spentMonthlyCents, budget: updatedAgent.budgetMonthlyCents },
+          "agent over budget, pausing",
+        );
+        await db
+          .update(agents)
+          .set({ status: "paused", updatedAt: new Date() })
+          .where(eq(agents.id, updatedAgent.id));
+      }
+
+      const updatedCompany = await db
+        .select()
+        .from(companies)
+        .where(eq(companies.id, agent.companyId))
+        .then((rows) => rows[0] ?? null);
+
+      if (
+        updatedCompany &&
+        updatedCompany.budgetMonthlyCents > 0 &&
+        updatedCompany.spentMonthlyCents >= updatedCompany.budgetMonthlyCents
+      ) {
+        logger.info(
+          { companyId: agent.companyId, spent: updatedCompany.spentMonthlyCents, budget: updatedCompany.budgetMonthlyCents },
+          "company over budget, pausing all active agents",
+        );
+        await db
+          .update(agents)
+          .set({ status: "paused", updatedAt: new Date() })
+          .where(
+            and(
+              eq(agents.companyId, agent.companyId),
+              eq(agents.status, "idle"),
+            ),
+          );
+      }
     }
   }
 
@@ -1868,6 +1926,38 @@ export function heartbeatService(db: Db) {
       throw conflict("Agent is not invokable in its current state", { status: agent.status });
     }
 
+    if (agent.budgetMonthlyCents > 0 && agent.spentMonthlyCents >= agent.budgetMonthlyCents) {
+      logger.info(
+        { agentId, spent: agent.spentMonthlyCents, budget: agent.budgetMonthlyCents },
+        "agent over budget, blocking run",
+      );
+      throw conflict("Agent has exceeded its monthly budget", {
+        spent: agent.spentMonthlyCents,
+        budget: agent.budgetMonthlyCents,
+      });
+    }
+
+    const company = await db
+      .select()
+      .from(companies)
+      .where(eq(companies.id, agent.companyId))
+      .then((rows) => rows[0] ?? null);
+
+    if (
+      company &&
+      company.budgetMonthlyCents > 0 &&
+      company.spentMonthlyCents >= company.budgetMonthlyCents
+    ) {
+      logger.info(
+        { companyId: agent.companyId, spent: company.spentMonthlyCents, budget: company.budgetMonthlyCents },
+        "company over budget, blocking run",
+      );
+      throw conflict("Company has exceeded its monthly budget", {
+        spent: company.spentMonthlyCents,
+        budget: company.budgetMonthlyCents,
+      });
+    }
+
     const policy = parseHeartbeatPolicy(agent);
     const writeSkippedRequest = async (reason: string) => {
       await db.insert(agentWakeupRequests).values({
@@ -2433,10 +2523,31 @@ export function heartbeatService(db: Db) {
       let enqueued = 0;
       let skipped = 0;
 
+      const companyBudgetCache = new Map<string, { budgetMonthlyCents: number; spentMonthlyCents: number }>();
+
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
+
+        if (agent.budgetMonthlyCents > 0 && agent.spentMonthlyCents >= agent.budgetMonthlyCents) {
+          skipped += 1;
+          continue;
+        }
+
+        if (!companyBudgetCache.has(agent.companyId)) {
+          const co = await db
+            .select({ budgetMonthlyCents: companies.budgetMonthlyCents, spentMonthlyCents: companies.spentMonthlyCents })
+            .from(companies)
+            .where(eq(companies.id, agent.companyId))
+            .then((rows) => rows[0] ?? null);
+          if (co) companyBudgetCache.set(agent.companyId, co);
+        }
+        const coBudget = companyBudgetCache.get(agent.companyId);
+        if (coBudget && coBudget.budgetMonthlyCents > 0 && coBudget.spentMonthlyCents >= coBudget.budgetMonthlyCents) {
+          skipped += 1;
+          continue;
+        }
 
         checked += 1;
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();

--- a/ui/src/api/costs.ts
+++ b/ui/src/api/costs.ts
@@ -24,4 +24,8 @@ export const costsApi = {
     api.get<CostByAgent[]>(`/companies/${companyId}/costs/by-agent${dateParams(from, to)}`),
   byProject: (companyId: string, from?: string, to?: string) =>
     api.get<CostByProject[]>(`/companies/${companyId}/costs/by-project${dateParams(from, to)}`),
+  updateCompanyBudget: (companyId: string, budgetMonthlyCents: number) =>
+    api.patch<Record<string, unknown>>(`/companies/${companyId}/budgets`, { budgetMonthlyCents }),
+  updateAgentBudget: (agentId: string, budgetMonthlyCents: number) =>
+    api.patch<Record<string, unknown>>(`/agents/${agentId}/budgets`, { budgetMonthlyCents }),
 };

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -5,6 +5,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { companiesApi } from "../api/companies";
 import { accessApi } from "../api/access";
 import { queryKeys } from "../lib/queryKeys";
+import { formatCents } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Settings, Check } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
@@ -34,6 +35,7 @@ export function CompanySettings() {
   const [companyName, setCompanyName] = useState("");
   const [description, setDescription] = useState("");
   const [brandColor, setBrandColor] = useState("");
+  const [budgetDollars, setBudgetDollars] = useState("");
 
   // Sync local state from selected company
   useEffect(() => {
@@ -41,6 +43,11 @@ export function CompanySettings() {
     setCompanyName(selectedCompany.name);
     setDescription(selectedCompany.description ?? "");
     setBrandColor(selectedCompany.brandColor ?? "");
+    setBudgetDollars(
+      selectedCompany.budgetMonthlyCents > 0
+        ? (selectedCompany.budgetMonthlyCents / 100).toFixed(2)
+        : "",
+    );
   }, [selectedCompany]);
 
   const [inviteError, setInviteError] = useState<string | null>(null);
@@ -74,6 +81,24 @@ export function CompanySettings() {
       queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
     }
   });
+
+  const budgetMutation = useMutation({
+    mutationFn: (cents: number) =>
+      companiesApi.update(selectedCompanyId!, { budgetMonthlyCents: cents }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
+
+  const budgetDirty =
+    !!selectedCompany &&
+    (() => {
+      const currentCents = selectedCompany.budgetMonthlyCents;
+      const editedCents = budgetDollars
+        ? Math.round(parseFloat(budgetDollars) * 100)
+        : 0;
+      return currentCents !== editedCents;
+    })();
 
   const inviteMutation = useMutation({
     mutationFn: () =>
@@ -304,6 +329,65 @@ export function CompanySettings() {
             checked={!!selectedCompany.requireBoardApprovalForNewAgents}
             onChange={(v) => settingsMutation.mutate(v)}
           />
+        </div>
+      </div>
+
+      {/* Budget */}
+      <div className="space-y-4">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Monthly Budget
+        </div>
+        <div className="space-y-3 rounded-md border border-border px-4 py-4">
+          <Field
+            label="Company monthly budget"
+            hint="Maximum monthly spend across all agents. Set to 0 or leave empty for unlimited."
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">$</span>
+              <input
+                className="w-32 rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none text-right font-mono"
+                type="number"
+                min="0"
+                step="0.01"
+                value={budgetDollars}
+                placeholder="0.00 (unlimited)"
+                onChange={(e) => setBudgetDollars(e.target.value)}
+              />
+              <span className="text-sm text-muted-foreground">/ month</span>
+            </div>
+          </Field>
+          {selectedCompany.budgetMonthlyCents > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Current budget: {formatCents(selectedCompany.budgetMonthlyCents)}/mo
+              {" · "}Spent: {formatCents(selectedCompany.spentMonthlyCents ?? 0)}
+            </p>
+          )}
+          {budgetDirty && (
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() => {
+                  const cents = budgetDollars
+                    ? Math.round(parseFloat(budgetDollars) * 100)
+                    : 0;
+                  budgetMutation.mutate(isNaN(cents) ? 0 : cents);
+                }}
+                disabled={budgetMutation.isPending}
+              >
+                {budgetMutation.isPending ? "Saving..." : "Save budget"}
+              </Button>
+              {budgetMutation.isSuccess && (
+                <span className="text-xs text-muted-foreground">Saved</span>
+              )}
+              {budgetMutation.isError && (
+                <span className="text-xs text-destructive">
+                  {budgetMutation.error instanceof Error
+                    ? budgetMutation.error.message
+                    : "Failed to save budget"}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { costsApi } from "../api/costs";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -11,7 +11,7 @@ import { Identity } from "../components/Identity";
 import { StatusBadge } from "../components/StatusBadge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { DollarSign } from "lucide-react";
+import { DollarSign, Pencil, Check, X } from "lucide-react";
 
 type DatePreset = "mtd" | "7d" | "30d" | "ytd" | "all" | "custom";
 
@@ -51,9 +51,88 @@ function computeRange(preset: DatePreset): { from: string; to: string } {
   }
 }
 
+function BudgetEditor({
+  currentCents,
+  onSave,
+  isPending,
+  label,
+}: {
+  currentCents: number;
+  onSave: (cents: number) => void;
+  isPending: boolean;
+  label?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(() =>
+    currentCents > 0 ? (currentCents / 100).toFixed(2) : "",
+  );
+
+  useEffect(() => {
+    setValue(currentCents > 0 ? (currentCents / 100).toFixed(2) : "");
+  }, [currentCents]);
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+        title={label ?? "Edit budget"}
+      >
+        <Pencil className="h-3 w-3" />
+      </button>
+    );
+  }
+
+  function handleSave() {
+    const dollars = parseFloat(value);
+    const cents = !value || isNaN(dollars) ? 0 : Math.round(dollars * 100);
+    onSave(cents);
+    setEditing(false);
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-sm text-muted-foreground">$</span>
+      <input
+        type="number"
+        min="0"
+        step="0.01"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="0.00"
+        className="w-20 h-6 rounded border border-border bg-transparent px-1.5 text-sm outline-none text-right"
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSave();
+          if (e.key === "Escape") setEditing(false);
+        }}
+      />
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={isPending}
+        className="text-green-600 hover:text-green-700 disabled:opacity-50"
+        title="Save"
+      >
+        <Check className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => setEditing(false)}
+        className="text-muted-foreground hover:text-foreground"
+        title="Cancel"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  );
+}
+
 export function Costs() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
 
   const [preset, setPreset] = useState<DatePreset>("mtd");
   const [customFrom, setCustomFrom] = useState("");
@@ -84,6 +163,23 @@ export function Costs() {
       return { summary, byAgent, byProject };
     },
     enabled: !!selectedCompanyId,
+  });
+
+  const companyBudgetMutation = useMutation({
+    mutationFn: (cents: number) =>
+      costsApi.updateCompanyBudget(selectedCompanyId!, cents),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.costs(selectedCompanyId!, from || undefined, to || undefined) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
+
+  const agentBudgetMutation = useMutation({
+    mutationFn: ({ agentId, cents }: { agentId: string; cents: number }) =>
+      costsApi.updateAgentBudget(agentId, cents),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.costs(selectedCompanyId!, from || undefined, to || undefined) });
+    },
   });
 
   if (!selectedCompanyId) {
@@ -149,7 +245,13 @@ export function Costs() {
                 <span className="text-base font-normal text-muted-foreground">
                   {data.summary.budgetCents > 0
                     ? `/ ${formatCents(data.summary.budgetCents)}`
-                    : "Unlimited budget"}
+                    : "No budget limit"}{" "}
+                  <BudgetEditor
+                    currentCents={data.summary.budgetCents}
+                    onSave={(cents) => companyBudgetMutation.mutate(cents)}
+                    isPending={companyBudgetMutation.isPending}
+                    label="Edit company monthly budget"
+                  />
                 </span>
               </p>
               {data.summary.budgetCents > 0 && (
@@ -177,33 +279,51 @@ export function Costs() {
                 {data.byAgent.length === 0 ? (
                   <p className="text-sm text-muted-foreground">No cost events yet.</p>
                 ) : (
-                  <div className="space-y-2">
+                  <div className="space-y-3">
                     {data.byAgent.map((row) => (
                       <div
                         key={row.agentId}
-                        className="flex items-start justify-between text-sm"
+                        className="space-y-1"
                       >
-                        <div className="flex items-center gap-2 min-w-0">
-                          <Identity
-                            name={row.agentName ?? row.agentId}
-                            size="sm"
-                          />
-                          {row.agentStatus === "terminated" && (
-                            <StatusBadge status="terminated" />
-                          )}
-                        </div>
-                        <div className="text-right shrink-0 ml-2 tabular-nums">
-                          <span className="font-medium block">{formatCents(row.costCents)}</span>
-                          <span className="text-xs text-muted-foreground block">
-                            in {formatTokens(row.inputTokens)} / out {formatTokens(row.outputTokens)} tok
-                          </span>
-                          {(row.apiRunCount > 0 || row.subscriptionRunCount > 0) && (
+                        <div className="flex items-start justify-between text-sm">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <Identity
+                              name={row.agentName ?? row.agentId}
+                              size="sm"
+                            />
+                            {row.agentStatus === "terminated" && (
+                              <StatusBadge status="terminated" />
+                            )}
+                          </div>
+                          <div className="text-right shrink-0 ml-2">
+                            <span className="font-medium block">{formatCents(row.costCents)}</span>
                             <span className="text-xs text-muted-foreground block">
-                              {row.apiRunCount > 0 ? `api runs: ${row.apiRunCount}` : null}
-                              {row.apiRunCount > 0 && row.subscriptionRunCount > 0 ? " | " : null}
-                              {row.subscriptionRunCount > 0
-                                ? `subscription runs: ${row.subscriptionRunCount} (${formatTokens(row.subscriptionInputTokens)} in / ${formatTokens(row.subscriptionOutputTokens)} out tok)`
-                                : null}
+                              in {formatTokens(row.inputTokens)} / out {formatTokens(row.outputTokens)} tok
+                            </span>
+                            {(row.apiRunCount > 0 || row.subscriptionRunCount > 0) && (
+                              <span className="text-xs text-muted-foreground block">
+                                {row.apiRunCount > 0 ? `api runs: ${row.apiRunCount}` : null}
+                                {row.apiRunCount > 0 && row.subscriptionRunCount > 0 ? " | " : null}
+                                {row.subscriptionRunCount > 0
+                                  ? `subscription runs: ${row.subscriptionRunCount} (${formatTokens(row.subscriptionInputTokens)} in / ${formatTokens(row.subscriptionOutputTokens)} out tok)`
+                                  : null}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground pl-7">
+                          <span>
+                            Budget: {row.budgetMonthlyCents > 0 ? `${formatCents(row.budgetMonthlyCents)}/mo` : "Unlimited"}
+                          </span>
+                          <BudgetEditor
+                            currentCents={row.budgetMonthlyCents}
+                            onSave={(cents) => agentBudgetMutation.mutate({ agentId: row.agentId, cents })}
+                            isPending={agentBudgetMutation.isPending}
+                            label={`Edit budget for ${row.agentName ?? "agent"}`}
+                          />
+                          {row.budgetMonthlyCents > 0 && (
+                            <span className="text-muted-foreground">
+                              ({Math.min(100, Math.round((row.costCents / row.budgetMonthlyCents) * 100))}% used)
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
## Summary

- **Company-level budget enforcement**: when company monthly spend exceeds its budget, all idle agents are automatically paused (previously only agent-level enforcement existed)
- **Pre-execution budget checks**: heartbeat service blocks runs before they start if the agent or company budget is exhausted, preventing any wasted tokens
- **Scheduler-level budget skipping**: over-budget agents/companies are skipped during scheduled heartbeat ticks, with a per-company cache to avoid redundant DB queries
- **Company spending counter updates**: the heartbeat post-run flow now increments `companies.spentMonthlyCents` alongside the agent counter
- **Budget editing UI**: inline `BudgetEditor` component on the Costs page for both company-wide and per-agent monthly budgets
- **Company Settings budget section**: dedicated budget management panel with current spend display
- **`budgetMonthlyCents` in by-agent query**: surfaces per-agent budget in the cost breakdown view

## Motivation

Without company-level enforcement, individual agent budgets could be set but there was no global safety net. A single company could rack up unbounded costs if per-agent budgets weren't configured. This PR adds defense-in-depth: budgets are enforced at the agent level, company level, pre-execution, and at the scheduler.

## Test plan

- [ ] Set a company monthly budget via Company Settings and verify it persists
- [ ] Set per-agent budgets via the Costs page inline editor
- [ ] Trigger a heartbeat run and verify `companies.spentMonthlyCents` increments
- [ ] Exceed an agent budget and confirm the agent is auto-paused
- [ ] Exceed a company budget and confirm all idle agents are paused
- [ ] Attempt to start a run on an over-budget agent and confirm it's blocked with a conflict error
- [ ] Verify scheduled heartbeats skip over-budget agents/companies

🤖 Generated with [Claude Code](https://claude.com/claude-code)