### PR TITLE
fix(heartbeat): skip queued runs in orphan reaper

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -977,20 +977,21 @@ export function heartbeatService(db: Db) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
 
-    // Find all runs in "queued" or "running" state
+    // Only reap "running" runs — queued runs are legitimately waiting for
+    // a concurrency slot and have no child process yet by design.
+    // NOTE: if a queued run becomes permanently stuck (e.g. the preceding
+    // run finalizes via a path that fails to call startNextQueuedRunForAgent),
+    // it will not be reaped. A long-staleness safety net could be added as
+    // a follow-up if this proves to be a problem in practice.
     const activeRuns = await db
       .select()
       .from(heartbeatRuns)
-      .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+      .where(eq(heartbeatRuns.status, "running"));
 
     const reaped: string[] = [];
 
     for (const run of activeRuns) {
       if (runningProcesses.has(run.id)) continue;
-
-      // Queued runs are legitimately waiting for a concurrency slot —
-      // they have no process yet, so they should not be reaped.
-      if (run.status === "queued") continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {


### PR DESCRIPTION
## Summary

- Queued runs waiting for a concurrency slot are incorrectly reaped as `process_lost` by the orphan reaper
- Added a `status === "queued"` check to skip them — they have no child process yet by design

## Problem

When a comment/wake triggers a follow-up run while an agent already has a run in-flight, the coalescing logic creates a new **queued** run. Since `maxConcurrentRuns` slots are full, `startNextQueuedRunForAgent` correctly defers it. However, the orphan reaper sees a run not in `runningProcesses` and reaps it after 5 minutes — before the in-flight run finishes (which can take 10-15+ minutes).

```
4c5ece4d | running | 17:59 → 18:13  (13 min, succeeded)
3b9862c7 | queued  | 18:00 → reaped at 18:05 as process_lost ❌
```

## Fix

One-line guard in `reapOrphanedRuns`: skip runs with `status === "queued"`. These runs are legitimately waiting for a slot, not orphaned processes. They will be started by `startNextQueuedRunForAgent` when the preceding run completes.

## Test plan

- [ ] Agent with `maxConcurrentRuns=1` receives a comment while a run is in-flight
- [ ] Follow-up run stays queued until the in-flight run finishes
- [ ] Queued run is NOT reaped after 5 minutes
- [ ] Queued run is started when the slot becomes available
- [ ] Startup reap still correctly cleans up orphaned `running` runs

Fixes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)