### PR TITLE
fix(codex-local): resolve OPENAI_API_KEY auth failure by explicit env inheritance

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -315,9 +315,41 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (!hasExplicitApiKey && authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }
+
+  // Explicitly inherit OPENAI_API_KEY from the server's process.env when not
+  // configured in adapter config.  runChildProcess() merges process.env into
+  // the child env, but making this explicit lets us validate the key early and
+  // report the auth source in logs so that 401 errors are easier to diagnose.
+  const openaiKeySource: "adapter_config" | "server_env" | "missing" = (() => {
+    if (hasNonEmptyEnvValue(env, "OPENAI_API_KEY")) return "adapter_config";
+    // Remove any whitespace-only or empty value that leaked from adapter config
+    // so it doesn't override a valid key (or confuse Codex) via runChildProcess.
+    if (typeof env.OPENAI_API_KEY === "string") delete env.OPENAI_API_KEY;
+    const fromProcess = process.env.OPENAI_API_KEY;
+    if (typeof fromProcess === "string" && fromProcess.trim().length > 0) {
+      env.OPENAI_API_KEY = fromProcess;
+      return "server_env";
+    }
+    return "missing";
+  })();
+
   const billingType = resolveCodexBillingType(env);
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  if (openaiKeySource === "missing") {
+    await onLog(
+      "stderr",
+      "[paperclip] Warning: OPENAI_API_KEY is not set in adapter config or server environment. " +
+        "Codex will fall back to local login auth (codex login). " +
+        "If you see a 401 error, set OPENAI_API_KEY in adapter env or export it in the shell that runs Paperclip.\n",
+    );
+  } else {
+    await onLog(
+      "stderr",
+      `[paperclip] Codex auth: OPENAI_API_KEY sourced from ${openaiKeySource === "adapter_config" ? "adapter config" : "server environment"} (billing: ${billingType}).\n`,
+    );
+  }
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -56,6 +56,32 @@ function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean 
   return typeof raw === "string" && raw.trim().length > 0;
 }
 
+export type OpenaiKeySource = "adapter_config" | "server_env" | "missing";
+
+/**
+ * Resolve the source of OPENAI_API_KEY for the Codex adapter.
+ *
+ * Mutates `env`: removes empty/whitespace-only values and, when the key is
+ * only available in `serverProcessEnv`, copies it into `env` so that
+ * downstream consumers (resolveCodexBillingType, runChildProcess) see a
+ * consistent snapshot.
+ */
+export function resolveOpenaiKeySource(
+  env: Record<string, string>,
+  serverProcessEnv: Record<string, string | undefined>,
+): OpenaiKeySource {
+  if (hasNonEmptyEnvValue(env, "OPENAI_API_KEY")) return "adapter_config";
+  // Remove any whitespace-only or empty value that leaked from adapter config
+  // so it doesn't override a valid key (or confuse Codex) via runChildProcess.
+  if (typeof env.OPENAI_API_KEY === "string") delete env.OPENAI_API_KEY;
+  const fromProcess = serverProcessEnv.OPENAI_API_KEY;
+  if (typeof fromProcess === "string" && fromProcess.trim().length > 0) {
+    env.OPENAI_API_KEY = fromProcess;
+    return "server_env";
+  }
+  return "missing";
+}
+
 function resolveCodexBillingType(env: Record<string, string>): "api" | "subscription" {
   // Codex uses API-key auth when OPENAI_API_KEY is present; otherwise rely on local login/session auth.
   return hasNonEmptyEnvValue(env, "OPENAI_API_KEY") ? "api" : "subscription";
@@ -316,22 +342,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     env.PAPERCLIP_API_KEY = authToken;
   }
 
-  // Explicitly inherit OPENAI_API_KEY from the server's process.env when not
-  // configured in adapter config.  runChildProcess() merges process.env into
-  // the child env, but making this explicit lets us validate the key early and
-  // report the auth source in logs so that 401 errors are easier to diagnose.
-  const openaiKeySource: "adapter_config" | "server_env" | "missing" = (() => {
-    if (hasNonEmptyEnvValue(env, "OPENAI_API_KEY")) return "adapter_config";
-    // Remove any whitespace-only or empty value that leaked from adapter config
-    // so it doesn't override a valid key (or confuse Codex) via runChildProcess.
-    if (typeof env.OPENAI_API_KEY === "string") delete env.OPENAI_API_KEY;
-    const fromProcess = process.env.OPENAI_API_KEY;
-    if (typeof fromProcess === "string" && fromProcess.trim().length > 0) {
-      env.OPENAI_API_KEY = fromProcess;
-      return "server_env";
-    }
-    return "missing";
-  })();
+  const openaiKeySource = resolveOpenaiKeySource(env, process.env);
 
   const billingType = resolveCodexBillingType(env);
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,4 +1,4 @@
-export { execute, ensureCodexSkillsInjected } from "./execute.js";
+export { execute, ensureCodexSkillsInjected, resolveOpenaiKeySource, type OpenaiKeySource } from "./execute.js";
 export { testEnvironment } from "./test.js";
 export { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -15,15 +15,12 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
 import { parseCodexJsonl } from "./parse.js";
+import { resolveOpenaiKeySource } from "./execute.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
   if (checks.some((check) => check.level === "warn")) return "warn";
   return "pass";
-}
-
-function isNonEmpty(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 function firstNonEmptyLine(text: string): string {
@@ -97,20 +94,13 @@ export async function testEnvironment(
     });
   }
 
-  const configOpenAiKey = env.OPENAI_API_KEY;
-  const hostOpenAiKey = process.env.OPENAI_API_KEY;
-  if (isNonEmpty(configOpenAiKey) || isNonEmpty(hostOpenAiKey)) {
-    const source = isNonEmpty(configOpenAiKey) ? "adapter config env" : "server environment";
-    // Explicitly inherit from process.env when not in adapter config, so the
-    // hello probe (and later execute runs) use a consistent env snapshot.
-    if (!isNonEmpty(configOpenAiKey) && isNonEmpty(hostOpenAiKey)) {
-      env.OPENAI_API_KEY = hostOpenAiKey;
-    }
+  const openaiKeySource = resolveOpenaiKeySource(env, process.env);
+  if (openaiKeySource !== "missing") {
     checks.push({
       code: "codex_openai_api_key_present",
       level: "info",
       message: "OPENAI_API_KEY is set for Codex authentication.",
-      detail: `Detected in ${source}.`,
+      detail: `Detected in ${openaiKeySource === "adapter_config" ? "adapter config env" : "server environment"}.`,
     });
   } else {
     checks.push({

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -101,6 +101,11 @@ export async function testEnvironment(
   const hostOpenAiKey = process.env.OPENAI_API_KEY;
   if (isNonEmpty(configOpenAiKey) || isNonEmpty(hostOpenAiKey)) {
     const source = isNonEmpty(configOpenAiKey) ? "adapter config env" : "server environment";
+    // Explicitly inherit from process.env when not in adapter config, so the
+    // hello probe (and later execute runs) use a consistent env snapshot.
+    if (!isNonEmpty(configOpenAiKey) && isNonEmpty(hostOpenAiKey)) {
+      env.OPENAI_API_KEY = hostOpenAiKey;
+    }
     checks.push({
       code: "codex_openai_api_key_present",
       level: "info",

--- a/server/src/__tests__/openai-key-resolution.test.ts
+++ b/server/src/__tests__/openai-key-resolution.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
 
 /**
  * End-to-end test for the OPENAI_API_KEY resolution fix (#497).
  *
- * These tests spawn real child processes (using `env` command) with the same
- * merge logic used by runChildProcess: `{ ...process.env, ...adapterEnv }`.
+ * These tests spawn real child processes with the same merge logic used by
+ * runChildProcess: `{ ...process.env, ...adapterEnv }`.
  * They verify the key the child process actually receives — not a simulation.
  */
 
@@ -34,17 +34,21 @@ function applyOpenaiKeyFix(
 
 /**
  * Spawn a real child process with the given env, read its OPENAI_API_KEY.
- * Uses `printenv OPENAI_API_KEY` which outputs the value or exits 1 if unset.
+ * Uses `node -e` to print the env var, which works cross-platform (unlike printenv).
  */
 function readKeyFromChildProcess(
   mergedEnv: Record<string, string | undefined>,
 ): Promise<{ value: string | null; exitCode: number }> {
   return new Promise((resolve) => {
-    const child = spawn("printenv", ["OPENAI_API_KEY"], {
-      env: mergedEnv as NodeJS.ProcessEnv,
-      shell: false,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawn(
+      process.execPath,
+      ["-e", "process.stdout.write(process.env.OPENAI_API_KEY ?? '')"],
+      {
+        env: mergedEnv as NodeJS.ProcessEnv,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     let stdout = "";
     child.stdout.on("data", (chunk) => (stdout += String(chunk)));
     child.on("close", (code) => {
@@ -73,7 +77,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
 
       const result = await readKeyFromChildProcess(mergedEnv);
       // BUG: child gets empty string, NOT the valid key
-      expect(result.value).toBeNull(); // printenv exits 1 for empty
+      expect(result.value).toBeNull();
       expect(result.value).not.toBe(VALID_KEY);
     });
 

--- a/server/src/__tests__/openai-key-resolution.test.ts
+++ b/server/src/__tests__/openai-key-resolution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
+import { resolveOpenaiKeySource } from "@paperclipai/adapter-codex-local/server";
 
 /**
  * End-to-end test for the OPENAI_API_KEY resolution fix (#497).
@@ -7,30 +8,10 @@ import { spawn } from "node:child_process";
  * These tests spawn real child processes with the same merge logic used by
  * runChildProcess: `{ ...process.env, ...adapterEnv }`.
  * They verify the key the child process actually receives — not a simulation.
+ *
+ * `resolveOpenaiKeySource` is imported from the production code so that these
+ * tests break if the production logic is accidentally changed.
  */
-
-function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
-  const raw = env[key];
-  return typeof raw === "string" && raw.trim().length > 0;
-}
-
-/**
- * The fix from execute.ts lines 250-261: resolves the OPENAI_API_KEY source
- * and cleans up empty/whitespace values.
- */
-function applyOpenaiKeyFix(
-  env: Record<string, string>,
-  processEnv: Record<string, string | undefined>,
-): "adapter_config" | "server_env" | "missing" {
-  if (hasNonEmptyEnvValue(env, "OPENAI_API_KEY")) return "adapter_config";
-  if (typeof env.OPENAI_API_KEY === "string") delete env.OPENAI_API_KEY;
-  const fromProcess = processEnv.OPENAI_API_KEY;
-  if (typeof fromProcess === "string" && fromProcess.trim().length > 0) {
-    env.OPENAI_API_KEY = fromProcess;
-    return "server_env";
-  }
-  return "missing";
-}
 
 /**
  * Spawn a real child process with the given env, read its OPENAI_API_KEY.
@@ -94,7 +75,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
   describe("FIX VERIFICATION: with fix applied, child gets the correct key", () => {
     it("Scenario C: empty config value → fix inherits from process.env", async () => {
       const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "" };
-      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const source = resolveOpenaiKeySource(adapterEnv, FAKE_PROCESS_ENV);
       const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
 
       expect(source).toBe("server_env");
@@ -104,7 +85,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
 
     it("Scenario D: whitespace config value → fix inherits from process.env", async () => {
       const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "   " };
-      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const source = resolveOpenaiKeySource(adapterEnv, FAKE_PROCESS_ENV);
       const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
 
       expect(source).toBe("server_env");
@@ -114,7 +95,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
 
     it("Scenario A: key only in shell → fix copies from process.env", async () => {
       const adapterEnv: Record<string, string> = {};
-      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const source = resolveOpenaiKeySource(adapterEnv, FAKE_PROCESS_ENV);
       const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
 
       expect(source).toBe("server_env");
@@ -125,7 +106,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
     it("Scenario B: valid key in adapter config → fix preserves it", async () => {
       const CONFIG_KEY = "sk-from-adapter-config";
       const adapterEnv: Record<string, string> = { OPENAI_API_KEY: CONFIG_KEY };
-      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const source = resolveOpenaiKeySource(adapterEnv, FAKE_PROCESS_ENV);
       const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
 
       expect(source).toBe("adapter_config");
@@ -136,7 +117,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
     it("Scenario E: empty config, no shell key → fix reports missing", async () => {
       const NO_KEY_PROCESS_ENV = { PATH: process.env.PATH, HOME: process.env.HOME };
       const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "" };
-      const source = applyOpenaiKeyFix(adapterEnv, NO_KEY_PROCESS_ENV);
+      const source = resolveOpenaiKeySource(adapterEnv, NO_KEY_PROCESS_ENV);
       const mergedEnv = { ...NO_KEY_PROCESS_ENV, ...adapterEnv };
 
       expect(source).toBe("missing");
@@ -149,7 +130,7 @@ describe("OPENAI_API_KEY resolution (#497)", () => {
     it("Scenario F: no key anywhere → fix reports missing", async () => {
       const NO_KEY_PROCESS_ENV = { PATH: process.env.PATH, HOME: process.env.HOME };
       const adapterEnv: Record<string, string> = {};
-      const source = applyOpenaiKeyFix(adapterEnv, NO_KEY_PROCESS_ENV);
+      const source = resolveOpenaiKeySource(adapterEnv, NO_KEY_PROCESS_ENV);
       const mergedEnv = { ...NO_KEY_PROCESS_ENV, ...adapterEnv };
 
       expect(source).toBe("missing");

--- a/server/src/__tests__/openai-key-resolution.test.ts
+++ b/server/src/__tests__/openai-key-resolution.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+
+/**
+ * End-to-end test for the OPENAI_API_KEY resolution fix (#497).
+ *
+ * These tests spawn real child processes (using `env` command) with the same
+ * merge logic used by runChildProcess: `{ ...process.env, ...adapterEnv }`.
+ * They verify the key the child process actually receives — not a simulation.
+ */
+
+function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+  const raw = env[key];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+/**
+ * The fix from execute.ts lines 250-261: resolves the OPENAI_API_KEY source
+ * and cleans up empty/whitespace values.
+ */
+function applyOpenaiKeyFix(
+  env: Record<string, string>,
+  processEnv: Record<string, string | undefined>,
+): "adapter_config" | "server_env" | "missing" {
+  if (hasNonEmptyEnvValue(env, "OPENAI_API_KEY")) return "adapter_config";
+  if (typeof env.OPENAI_API_KEY === "string") delete env.OPENAI_API_KEY;
+  const fromProcess = processEnv.OPENAI_API_KEY;
+  if (typeof fromProcess === "string" && fromProcess.trim().length > 0) {
+    env.OPENAI_API_KEY = fromProcess;
+    return "server_env";
+  }
+  return "missing";
+}
+
+/**
+ * Spawn a real child process with the given env, read its OPENAI_API_KEY.
+ * Uses `printenv OPENAI_API_KEY` which outputs the value or exits 1 if unset.
+ */
+function readKeyFromChildProcess(
+  mergedEnv: Record<string, string | undefined>,
+): Promise<{ value: string | null; exitCode: number }> {
+  return new Promise((resolve) => {
+    const child = spawn("printenv", ["OPENAI_API_KEY"], {
+      env: mergedEnv as NodeJS.ProcessEnv,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => (stdout += String(chunk)));
+    child.on("close", (code) => {
+      resolve({
+        value: stdout.trim() || null,
+        exitCode: code ?? 1,
+      });
+    });
+  });
+}
+
+describe("OPENAI_API_KEY resolution (#497)", () => {
+  const VALID_KEY = "sk-test-valid-key-for-497";
+  const FAKE_PROCESS_ENV: Record<string, string | undefined> = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    OPENAI_API_KEY: VALID_KEY,
+  };
+
+  describe("BUG REPRODUCTION: without fix, empty config value overrides valid shell key", () => {
+    it("empty string in adapter env overrides valid process.env key", async () => {
+      // Simulate old code: adapter sets OPENAI_API_KEY="" from config
+      const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "" };
+      // runChildProcess merge: { ...process.env, ...opts.env }
+      const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
+
+      const result = await readKeyFromChildProcess(mergedEnv);
+      // BUG: child gets empty string, NOT the valid key
+      expect(result.value).toBeNull(); // printenv exits 1 for empty
+      expect(result.value).not.toBe(VALID_KEY);
+    });
+
+    it("whitespace-only in adapter env overrides valid process.env key", async () => {
+      const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "   " };
+      const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
+
+      const result = await readKeyFromChildProcess(mergedEnv);
+      // BUG: child gets whitespace, NOT the valid key
+      expect(result.value).not.toBe(VALID_KEY);
+    });
+  });
+
+  describe("FIX VERIFICATION: with fix applied, child gets the correct key", () => {
+    it("Scenario C: empty config value → fix inherits from process.env", async () => {
+      const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "" };
+      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
+
+      expect(source).toBe("server_env");
+      const result = await readKeyFromChildProcess(mergedEnv);
+      expect(result.value).toBe(VALID_KEY);
+    });
+
+    it("Scenario D: whitespace config value → fix inherits from process.env", async () => {
+      const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "   " };
+      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
+
+      expect(source).toBe("server_env");
+      const result = await readKeyFromChildProcess(mergedEnv);
+      expect(result.value).toBe(VALID_KEY);
+    });
+
+    it("Scenario A: key only in shell → fix copies from process.env", async () => {
+      const adapterEnv: Record<string, string> = {};
+      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
+
+      expect(source).toBe("server_env");
+      const result = await readKeyFromChildProcess(mergedEnv);
+      expect(result.value).toBe(VALID_KEY);
+    });
+
+    it("Scenario B: valid key in adapter config → fix preserves it", async () => {
+      const CONFIG_KEY = "sk-from-adapter-config";
+      const adapterEnv: Record<string, string> = { OPENAI_API_KEY: CONFIG_KEY };
+      const source = applyOpenaiKeyFix(adapterEnv, FAKE_PROCESS_ENV);
+      const mergedEnv = { ...FAKE_PROCESS_ENV, ...adapterEnv };
+
+      expect(source).toBe("adapter_config");
+      const result = await readKeyFromChildProcess(mergedEnv);
+      expect(result.value).toBe(CONFIG_KEY);
+    });
+
+    it("Scenario E: empty config, no shell key → fix reports missing", async () => {
+      const NO_KEY_PROCESS_ENV = { PATH: process.env.PATH, HOME: process.env.HOME };
+      const adapterEnv: Record<string, string> = { OPENAI_API_KEY: "" };
+      const source = applyOpenaiKeyFix(adapterEnv, NO_KEY_PROCESS_ENV);
+      const mergedEnv = { ...NO_KEY_PROCESS_ENV, ...adapterEnv };
+
+      expect(source).toBe("missing");
+      // empty string was deleted, so child shouldn't have the key at all
+      expect(adapterEnv.OPENAI_API_KEY).toBeUndefined();
+      const result = await readKeyFromChildProcess(mergedEnv);
+      expect(result.value).toBeNull();
+    });
+
+    it("Scenario F: no key anywhere → fix reports missing", async () => {
+      const NO_KEY_PROCESS_ENV = { PATH: process.env.PATH, HOME: process.env.HOME };
+      const adapterEnv: Record<string, string> = {};
+      const source = applyOpenaiKeyFix(adapterEnv, NO_KEY_PROCESS_ENV);
+      const mergedEnv = { ...NO_KEY_PROCESS_ENV, ...adapterEnv };
+
+      expect(source).toBe("missing");
+      const result = await readKeyFromChildProcess(mergedEnv);
+      expect(result.value).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Explicitly inherit `OPENAI_API_KEY` from `process.env` into the adapter's filtered env when absent or empty in adapter config
- Fix a bug where an empty or whitespace-only `OPENAI_API_KEY` in adapter config silently overrides the valid key from `process.env`, causing 401 errors — empty/whitespace values are now deleted from the adapter env before falling through to `process.env`
- Log the auth source (adapter config vs server environment) and billing type on each run for debuggability
- Warn clearly when `OPENAI_API_KEY` is missing from both adapter config and server environment
- Fix `resolveCodexBillingType()` to correctly report `"api"` when the key comes from `process.env` (previously it only checked the adapter's filtered env and would report `"subscription"`)
- Apply the same explicit inheritance in the test/probe path for consistency

## Problem

When a user exports `OPENAI_API_KEY` in the shell that runs Paperclip, the key is available in `process.env` and is implicitly passed to the Codex child process via `runChildProcess()` (which merges `{ ...process.env, ...opts.env }`). This implicit inheritance has two failure modes:

1. **Empty-value override**: If a user adds `OPENAI_API_KEY` to adapter config but the value resolves to an empty string (e.g., misconfigured secret reference, typo), the empty value is set in the adapter's env (`env.OPENAI_API_KEY = ""`). When `runChildProcess` merges `{ ...process.env, ...opts.env }`, the adapter's empty string overrides the valid key from `process.env`, causing a 401. The key still shows as `***REDACTED***` in logs (because `redactEnvForLogs` matches the key name, not its value), making the issue nearly impossible to diagnose.

2. **Missing diagnostics**: The adapter never validates or logs the auth source, so when a 401 occurs, users have no way to determine whether the key was missing, came from the wrong source, or was empty.

Additionally, `resolveCodexBillingType()` only checks the adapter's filtered env (not `process.env`), incorrectly reporting `"subscription"` when the key comes solely from the server environment.

## Changes

### `packages/adapters/codex-local/src/server/execute.ts`
- After merging `config.env` into the adapter's env, determine the `OPENAI_API_KEY` source: `"adapter_config"`, `"server_env"`, or `"missing"`
- When not in adapter config but present in `process.env`, explicitly copy it into the adapter's env; empty/whitespace-only values are deleted so they don't override valid keys in the `runChildProcess` merge
- Log the auth source and billing type at the start of each run
- Warn clearly when no API key is found

### `packages/adapters/codex-local/src/server/test.ts`
- Apply the same explicit inheritance in the hello probe path, so the probe env matches what `execute()` would use

### `server/src/__tests__/openai-key-resolution.test.ts`
- End-to-end tests that spawn real child processes (`printenv`) to verify the fix
- Reproduces the bug (empty/whitespace config values override valid shell keys)
- Verifies all 6 scenarios: shell-only, adapter config, empty override, whitespace override, no key anywhere

## Testing

- `pnpm --filter @paperclipai/adapter-codex-local run typecheck` — passes
- `pnpm --filter @paperclipai/server run typecheck` — passes
- `npx vitest run server/src/__tests__/openai-key-resolution.test.ts` — 8/8 tests pass

## Notes

- The `claude-local` and `gemini-local` adapters have the same latent `billingType` bug (only checking filtered env). Those can be fixed in a follow-up PR.

Fixes #497