### PR TITLE
fix: prevent NewProjectDialog from extending beyond viewport

### DIFF
--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -214,11 +214,16 @@ export function NewProjectDialog() {
     >
       <DialogContent
         showCloseButton={false}
-        className={cn("p-0 gap-0", expanded ? "sm:max-w-2xl" : "sm:max-w-lg")}
+        className={cn(
+          "p-0 gap-0 flex flex-col max-h-[calc(100dvh-2rem)]",
+          expanded
+            ? "sm:max-w-2xl h-[calc(100dvh-2rem)]"
+            : "sm:max-w-lg"
+        )}
         onKeyDown={handleKeyDown}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border shrink-0">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             {selectedCompany && (
               <span className="bg-muted px-1.5 py-0.5 rounded text-xs font-medium">
@@ -266,7 +271,7 @@ export function NewProjectDialog() {
         </div>
 
         {/* Description */}
-        <div className="px-4 pb-2">
+        <div className={cn("px-4 pb-2 overflow-y-auto min-h-0 border-t border-border/60 pt-3", expanded ? "flex-1" : "")}>
           <MarkdownEditor
             ref={descriptionEditorRef}
             value={description}
@@ -281,7 +286,7 @@ export function NewProjectDialog() {
           />
         </div>
 
-        <div className="px-4 pb-3 space-y-3 border-t border-border">
+        <div className="px-4 pb-3 space-y-3 border-t border-border shrink-0">
           <div className="pt-3">
             <p className="text-sm font-medium">Where will work be done on this project?</p>
             <p className="text-xs text-muted-foreground">Add local folder and/or GitHub repo workspace hints.</p>
@@ -362,7 +367,7 @@ export function NewProjectDialog() {
         </div>
 
         {/* Property chips */}
-        <div className="flex items-center gap-1.5 px-4 py-2 border-t border-border flex-wrap">
+        <div className="flex items-center gap-1.5 px-4 py-2 border-t border-border flex-wrap shrink-0">
           {/* Status */}
           <Popover open={statusOpen} onOpenChange={setStatusOpen}>
             <PopoverTrigger asChild>
@@ -457,7 +462,7 @@ export function NewProjectDialog() {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-4 py-2.5 border-t border-border">
+        <div className="flex items-center justify-between px-4 py-2.5 border-t border-border shrink-0">
           {createProject.isError ? (
             <p className="text-xs text-destructive">Failed to create project.</p>
           ) : (


### PR DESCRIPTION
## Summary
- Fixed the NewProjectDialog modal overflow issue where long descriptions pushed the submit button beyond the viewport
- Added max-height constraint and flexbox layout to enable internal scrolling
- Header and footer now remain visible while the content scrolls

## Test plan
- [x] Type checks pass
- [x] Follows the same pattern as NewIssueDialog which already handles this correctly

## Root cause
The NewProjectDialog was missing:
1. A max-height constraint on the DialogContent
2. A flexbox layout (flex flex-col)
3. overflow-y-auto on the description section
4. shrink-0 classes on header and footer to prevent them from shrinking

The NewIssueDialog already has this fix, so this PR applies the same pattern to NewProjectDialog.

Fixes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)