### PR TITLE
fix: improve Windows .CMD/.BAT file detection in ensureCommandResolvable

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -247,7 +247,21 @@ export async function ensureAbsoluteDirectory(
 
 export async function ensureCommandResolvable(command: string, cwd: string, env: NodeJS.ProcessEnv) {
   const resolved = await resolveCommandPath(command, cwd, env);
-  if (resolved) return;
+  if (resolved) {
+    // On Windows, .CMD and .BAT files must be executed through cmd.exe
+    // Verify that cmd.exe is available for these file types
+    if (process.platform === "win32" && /\.(cmd|bat)$/i.test(resolved)) {
+      const shell = env.ComSpec || process.env.ComSpec || "cmd.exe";
+      const shellPath = await resolveCommandPath(shell, cwd, env);
+      if (!shellPath) {
+        throw new Error(
+          `Windows requires cmd.exe to execute .CMD/.BAT files, but cmd.exe was not found in PATH. ` +
+          `Command "${command}" resolved to "${resolved}", but cannot be executed without cmd.exe.`
+        );
+      }
+    }
+    return;
+  }
   if (command.includes("/") || command.includes("\\")) {
     const absolute = path.isAbsolute(command) ? command : path.resolve(cwd, command);
     throw new Error(`Command is not executable: "${command}" (resolved: "${absolute}")`);


### PR DESCRIPTION
## Summary
- Fixed Windows .CMD/.BAT file detection in `ensureCommandResolvable`
- Added validation that cmd.exe is available before marking .CMD/.BAT files as resolvable
- Provides clearer error messages when cmd.exe is missing from PATH

## Test plan
- [x] Type checks pass
- [x] All tests pass (249 passed, 1 skipped)
- [x] Follows existing error handling patterns in the codebase

## Root cause
On Windows, .CMD and .BAT files must be executed through cmd.exe and cannot be spawned directly. The previous implementation of `ensureCommandResolvable` only checked if the file exists, but did not verify that cmd.exe is available to execute these file types.

When a .CMD file was found but cmd.exe was unavailable, the error would occur later during execution with a cryptic ENOENT error, making it difficult to diagnose the actual problem.

## Changes
- Added a check for .CMD/.BAT files on Windows in `ensureCommandResolvable`
- Verifies that cmd.exe is available in PATH before considering the command resolvable
- Provides a clear error message explaining that cmd.exe is required and missing

Fixes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)