### PR TITLE
fix(heartbeat): auto-post agent run output as issue comment

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1584,16 +1584,25 @@ export function heartbeatService(db: Db) {
         await releaseIssueExecutionAndPromote(finalizedRun);
       }
 
-      // Auto-post agent's text output as an issue comment when the run
-      // succeeds and has an associated issue.  This ensures the agent's
-      // response is visible in the issue thread even when the agent
-      // itself did not call the comment API (e.g. --print mode).
-      if (outcome === "succeeded" && issueId && stdoutExcerpt.trim()) {
+      // Auto-post agent's text output as an issue comment when a
+      // claude_local run succeeds with an associated issue.  This
+      // ensures the agent's response is visible in the issue thread
+      // even when the agent itself did not call the comment API
+      // (e.g. --print mode).  Other adapter types may produce
+      // machine-readable output (JSON, XML) that should not be posted.
+      if (
+        outcome === "succeeded" &&
+        agent.adapterType === "claude_local" &&
+        issueId &&
+        stdoutExcerpt.trim()
+      ) {
         try {
-          // Check if the agent already posted a comment during this run
-          // to avoid duplicating the output.
+          // Check if the agent already posted a substantive comment
+          // during this run to avoid duplicating the output.  Exclude
+          // system-generated workspace-ready comments (they start with
+          // "## Workspace Ready") since those are not agent output.
           const existingComments = await db
-            .select({ id: issueComments.id })
+            .select({ id: issueComments.id, body: issueComments.body })
             .from(issueComments)
             .where(
               and(
@@ -1601,10 +1610,17 @@ export function heartbeatService(db: Db) {
                 eq(issueComments.authorAgentId, agent.id),
                 gt(issueComments.createdAt, run.startedAt ?? run.createdAt),
               ),
-            )
-            .limit(1);
-          if (existingComments.length === 0) {
-            await issuesSvc.addComment(issueId, stdoutExcerpt.trim(), {
+            );
+          const hasAgentComment = existingComments.some(
+            (c) => !c.body.startsWith("## Workspace Ready"),
+          );
+          if (!hasAgentComment) {
+            const trimmed = stdoutExcerpt.trim();
+            const body =
+              trimmed.length >= MAX_EXCERPT_BYTES
+                ? `_(output truncated to last 32 KB)_\n\n${trimmed}`
+                : trimmed;
+            await issuesSvc.addComment(issueId, body, {
               agentId: agent.id,
             });
           }


### PR DESCRIPTION
## Summary

- When a `claude_local` adapter run succeeds with stdout output, automatically post it as a comment on the associated issue
- Adds deduplication guard: skips posting if the agent already commented on the issue after the run started (e.g., the agent posted its own summary during execution)
- Logs a warning instead of throwing if the auto-post fails, so it never disrupts the heartbeat lifecycle

## Details

Currently, when an agent completes a run via the `claude_local` adapter, the output (`stdoutExcerpt`) is captured and stored on the heartbeat run but never surfaced back to the issue. Users have to manually navigate to the agent's run page to see what happened.

This change adds a lightweight auto-post step in `finalizeRun()` that posts the agent's stdout as an issue comment when:
1. The run outcome is `"succeeded"`
2. There is a non-empty `stdoutExcerpt`
3. There is an associated `issueId`
4. The agent hasn't already posted a comment on the issue since the run started

Fixes #629

This contribution was developed with AI assistance (Claude Code).