### PR TITLE
fix: open Documentation link in new tab instead of navigating to /docs

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -247,7 +247,7 @@ export function Layout() {
           <div className="border-t border-r border-border px-3 py-2 bg-background">
             <div className="flex items-center gap-1">
               <SidebarNavItem
-                to="/docs"
+                href="https://paperclip.ing/docs"
                 label="Documentation"
                 icon={BookOpen}
                 className="flex-1 min-w-0"
@@ -282,7 +282,7 @@ export function Layout() {
           <div className="border-t border-r border-border px-3 py-2">
             <div className="flex items-center gap-1">
               <SidebarNavItem
-                to="/docs"
+                href="https://paperclip.ing/docs"
                 label="Documentation"
                 icon={BookOpen}
                 className="flex-1 min-w-0"

--- a/ui/src/components/SidebarNavItem.tsx
+++ b/ui/src/components/SidebarNavItem.tsx
@@ -4,7 +4,8 @@ import { useSidebar } from "../context/SidebarContext";
 import type { LucideIcon } from "lucide-react";
 
 interface SidebarNavItemProps {
-  to: string;
+  to?: string;
+  href?: string;
   label: string;
   icon: LucideIcon;
   end?: boolean;
@@ -17,6 +18,7 @@ interface SidebarNavItemProps {
 
 export function SidebarNavItem({
   to,
+  href,
   label,
   icon: Icon,
   end,
@@ -28,6 +30,40 @@ export function SidebarNavItem({
 }: SidebarNavItemProps) {
   const { isMobile, setSidebarOpen } = useSidebar();
 
+  // External link - use <a> tag
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors",
+          "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+          className,
+        )}
+      >
+        <span className="relative shrink-0">
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="flex-1 truncate">{label}</span>
+        {badge != null && badge > 0 && (
+          <span
+            className={cn(
+              "ml-auto rounded-full px-1.5 py-0.5 text-xs leading-none",
+              badgeTone === "danger"
+                ? "bg-red-600/90 text-red-50"
+                : "bg-primary text-primary-foreground",
+            )}
+          >
+            {badge}
+          </span>
+        )}
+      </a>
+    );
+  }
+
+  // Internal link - use NavLink
   return (
     <NavLink
       to={to}


### PR DESCRIPTION
## 📋 Summary

Fixes #579

The Documentation link in the sidebar was using `to="/docs"` which attempted to navigate to an internal route that doesn't exist. This caused the dashboard to refresh instead of opening the documentation website.

## 🔄 Changes

1. **SidebarNavItem component** - Added `href` prop support for external links
   - When `href` is provided, renders an `<a>` tag with `target="_blank"` and `rel="noopener noreferrer"`
   - When `to` is provided, uses the existing `NavLink` for internal routing

2. **Layout component** - Updated Documentation links to use external URL
   - Changed from `to="/docs"` to `href="https://paperclip.ing/docs"`
   - Applied to both mobile and desktop sidebar layouts

## ✅ Verification

Click the Documentation link in the sidebar:
- **Before**: Dashboard refreshes (route /docs doesn't exist)
- **After**: Opens https://paperclip.ing/docs in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)