### PR TITLE
fix: clear stale sessions after failed runs to prevent incorrect context reuse

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1139,9 +1139,16 @@ export function heartbeatService(db: Db) {
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;
+    // Determine if we should reset the session for this wake
     const resetTaskSession = shouldResetTaskSessionForWake(context);
-    const sessionResetReason = describeSessionResetReason(context);
-    const taskSessionForRun = resetTaskSession ? null : taskSession;
+    // Also reset if the previous run failed (lastError is set)
+    // A failed run's session state is unreliable and should not be resumed
+    const resetDueToPreviousFailure = taskSession?.lastError != null && taskSession.lastError.length > 0;
+    const shouldReset = resetTaskSession || resetDueToPreviousFailure;
+    const sessionResetReason = resetDueToPreviousFailure
+      ? "previous run ended with an error"
+      : describeSessionResetReason(context);
+    const taskSessionForRun = shouldReset ? null : taskSession;
     const previousSessionParams = normalizeSessionParams(
       sessionCodec.deserialize(taskSessionForRun?.sessionParamsJson ?? null),
     );


### PR DESCRIPTION
## 📋 Summary

Fixes #635

When a run fails mid-execution (rate limit, process_lost, encoding error, etc.), the session ID was still saved in `agent_task_sessions`. Subsequent runs for the same issue would resume that session, inheriting stale/incorrect context from the failed run.

This caused agents to act on outdated beliefs — for example, believing an issue was reassigned when it wasn't — with no self-recovery mechanism.

## Root Cause

The session reset logic (`shouldResetTaskSessionForWake`) only considered the wake reason (issue_assigned, timer, manual), but **did not check whether the previous run succeeded or failed**. Failed runs left behind "tainted" sessions that would be resumed on the next wake.

## 🔄 Changes

Added a check for `lastError` field in the task session:
- If `lastError` is set (previous run failed), the session is not resumed
- A fresh session starts for the new run
- Successful runs continue to properly resume their sessions

## ✅ Behavior

**Before fix:**
1. Run starts on issue OCT-57
2. Run fails mid-way (rate limit)
3. Session ID saved in `agent_task_sessions`
4. Next run resumes the session → agent has stale context
5. Agent reports "no assignments" or "issue was reassigned" (incorrect)

**After fix:**
1. Run starts on issue OCT-57
2. Run fails mid-way
3. Session ID saved with `lastError` set
4. Next run checks `lastError`, sees the failure, starts fresh session
5. Agent has correct context about the issue

## Manual Workaround (No Longer Needed)

Previously users had to manually delete stale sessions:
```sql
DELETE FROM agent_task_sessions 
WHERE agent_id = '<agent-id>' AND task_key = '<issue-id>';
```

This is now handled automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)