### PR TITLE
fix(ui): preserve env var editor rows while editing

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1026,14 +1026,54 @@ function EnvVarEditor({
     return [...entries, { key: "", source: "plain", plainValue: "", secretId: "" }];
   }
 
+  function normalizeEnvRecord(rec: Record<string, EnvBinding> | null | undefined): string {
+    if (!rec || typeof rec !== "object") return "{}";
+    const normalized = Object.entries(rec)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, binding]) => {
+        if (typeof binding === "string") {
+          return [key, { type: "plain", value: binding }];
+        }
+        if (typeof binding === "object" && binding !== null) {
+          if ((binding as { type?: unknown }).type === "secret_ref") {
+            return [key, {
+              type: "secret_ref",
+              secretId: typeof (binding as { secretId?: unknown }).secretId === "string"
+                ? (binding as { secretId: string }).secretId
+                : "",
+              version: typeof (binding as { version?: unknown }).version === "string"
+                ? (binding as { version: string }).version
+                : "latest",
+            }];
+          }
+          if ((binding as { type?: unknown }).type === "plain") {
+            return [key, {
+              type: "plain",
+              value: typeof (binding as { value?: unknown }).value === "string"
+                ? (binding as { value: string }).value
+                : "",
+            }];
+          }
+        }
+        return [key, { type: "plain", value: "" }];
+      });
+    return JSON.stringify(normalized);
+  }
+
   const [rows, setRows] = useState<Row[]>(() => toRows(value));
   const [sealError, setSealError] = useState<string | null>(null);
-  const valueRef = useRef(value);
+  const lastExternalValueRef = useRef(normalizeEnvRecord(value));
+  const lastEmittedValueRef = useRef<string | null>(null);
 
-  // Sync when value identity changes (overlay reset after save)
+  // Sync only for true external updates (save/reset/server refresh), not our own in-progress edits.
   useEffect(() => {
-    if (value !== valueRef.current) {
-      valueRef.current = value;
+    const normalizedValue = normalizeEnvRecord(value);
+    if (normalizedValue === lastEmittedValueRef.current) {
+      lastExternalValueRef.current = normalizedValue;
+      return;
+    }
+    if (normalizedValue !== lastExternalValueRef.current) {
+      lastExternalValueRef.current = normalizedValue;
       setRows(toRows(value));
     }
   }, [value]);
@@ -1050,7 +1090,9 @@ function EnvVarEditor({
         rec[k] = { type: "plain", value: row.plainValue };
       }
     }
-    onChange(Object.keys(rec).length > 0 ? rec : undefined);
+    const emitted = Object.keys(rec).length > 0 ? rec : undefined;
+    lastEmittedValueRef.current = normalizeEnvRecord(emitted);
+    onChange(emitted);
   }
 
   function updateRow(i: number, patch: Partial<Row>) {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -975,7 +975,7 @@ function EnvVarEditor({
     secretId: string;
   };
 
-  function toRows(rec: Record<string, EnvBinding> | null | undefined): Row[] {
+  const toRows = useCallback((rec: Record<string, EnvBinding> | null | undefined): Row[] => {
     if (!rec || typeof rec !== "object") {
       return [{ key: "", source: "plain", plainValue: "", secretId: "" }];
     }
@@ -1024,10 +1024,10 @@ function EnvVarEditor({
       };
     });
     return [...entries, { key: "", source: "plain", plainValue: "", secretId: "" }];
-  }
+  }, []);
 
-  function normalizeEnvRecord(rec: Record<string, EnvBinding> | null | undefined): string {
-    if (!rec || typeof rec !== "object") return "{}";
+  const normalizeEnvRecord = useCallback((rec: Record<string, EnvBinding> | null | undefined): string => {
+    if (!rec || typeof rec !== "object" || Object.keys(rec).length === 0) return "{}";
     const normalized = Object.entries(rec)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([key, binding]) => {
@@ -1058,7 +1058,7 @@ function EnvVarEditor({
         return [key, { type: "plain", value: "" }];
       });
     return JSON.stringify(normalized);
-  }
+  }, []);
 
   const [rows, setRows] = useState<Row[]>(() => toRows(value));
   const [sealError, setSealError] = useState<string | null>(null);
@@ -1076,7 +1076,7 @@ function EnvVarEditor({
       lastExternalValueRef.current = normalizedValue;
       setRows(toRows(value));
     }
-  }, [value]);
+  }, [value, normalizeEnvRecord, toRows]);
 
   function emit(nextRows: Row[]) {
     const rec: Record<string, EnvBinding> = {};


### PR DESCRIPTION
## Summary
- prevent the environment variable editor from resetting in-progress rows on local edits
- preserve previously entered rows while switching between plain values and secret references
- only resync editor rows when the incoming env value changes externally (for example after save/reset/server refresh)

## Root cause
`EnvVarEditor` mirrored `value` into local `rows` state with an effect that reacted to parent updates too aggressively. Because the editor emits `onChange` on each row edit, the parent re-render fed a new `value` back into the component and the effect treated that as an external update, overwriting in-progress local row state.

That made the configuration UX unstable:
- the first env var row could disappear while editing another row
- switching a row to `Secret` could block entering the key/value in a predictable order
- selecting a second variable/source could wipe the first row unexpectedly

## Fix
- normalize env bindings before comparing them
- track the last value emitted by the editor itself
- skip local row resync when the new prop value matches the editor's own last emitted value
- continue resyncing when the prop value actually changes from an external source

## Validation
- rebuilt the Paperclip UI/server Docker image successfully
- verified the patched code is present in the running container used for local reproduction
- confirmed the issue was UI-state related rather than a backend/API failure during `/agents/{agentId}/configuration`

## Notes
I also tried a targeted `tsc -p ui/tsconfig.json --noEmit` check in a clean upstream worktree, but that worktree currently fails due to unrelated existing type-resolution issues outside this change.
