### PR TITLE
fix(claude-local): avoid phantom hyphen prompts in agent-home runs

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -41,27 +41,16 @@ async function resolvePaperclipSkillsDir(): Promise<string | null> {
   return null;
 }
 
-/**
- * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
- * the repo's `skills/` directory, so `--add-dir` makes Claude Code discover
- * them as proper registered skills.
- */
-async function buildSkillsDir(): Promise<string> {
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-skills-"));
-  const target = path.join(tmp, ".claude", "skills");
-  await fs.mkdir(target, { recursive: true });
+async function resolvePaperclipSkillFile(name: string): Promise<string | null> {
   const skillsDir = await resolvePaperclipSkillsDir();
-  if (!skillsDir) return tmp;
-  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      await fs.symlink(
-        path.join(skillsDir, entry.name),
-        path.join(target, entry.name),
-      );
-    }
-  }
-  return tmp;
+  if (!skillsDir) return null;
+  const candidate = path.join(skillsDir, name, "SKILL.md");
+  const isFile = await fs.stat(candidate).then((s) => s.isFile()).catch(() => false);
+  return isFile ? candidate : null;
+}
+
+async function buildRuntimeDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-"));
 }
 
 interface ClaudeExecutionInput {
@@ -75,6 +64,7 @@ interface ClaudeExecutionInput {
 interface ClaudeRuntimeConfig {
   command: string;
   cwd: string;
+  workspaceSource: string | null;
   workspaceId: string | null;
   workspaceRepoUrl: string | null;
   workspaceRepoRef: string | null;
@@ -250,6 +240,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   return {
     command,
     cwd,
+    workspaceSource: workspaceSource || null,
     workspaceId,
     workspaceRepoUrl,
     workspaceRepoRef,
@@ -258,6 +249,11 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     graceSec,
     extraArgs,
   };
+}
+
+function isPathInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative.length > 0 && !relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative);
 }
 
 export async function runClaudeLogin(input: {
@@ -327,6 +323,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const {
     command,
     cwd,
+    workspaceSource,
     workspaceId,
     workspaceRepoUrl,
     workspaceRepoRef,
@@ -336,31 +333,56 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     extraArgs,
   } = runtimeConfig;
   const billingType = resolveClaudeBillingType(env);
-  const skillsDir = await buildSkillsDir();
+  const runtimeDir = await buildRuntimeDir();
 
   // When instructionsFilePath is configured, create a combined temp file that
-  // includes both the file content and the path directive, so we only need
-  // --append-system-prompt-file (Claude CLI forbids using both flags together).
-  let effectiveInstructionsFilePath = instructionsFilePath;
+  // includes the Paperclip heartbeat skill plus any agent instructions, so we
+  // only need one --append-system-prompt-file.
+  let effectiveInstructionsFilePath = "";
+  const appendedPromptSections: string[] = [];
+  const paperclipSkillPath = await resolvePaperclipSkillFile("paperclip");
+  if (paperclipSkillPath) {
+    appendedPromptSections.push(await fs.readFile(paperclipSkillPath, "utf-8"));
+  }
   if (instructionsFilePath) {
     const instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
     const pathDirective = `\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsFileDir}.`;
-    const combinedPath = path.join(skillsDir, "agent-instructions.md");
-    await fs.writeFile(combinedPath, instructionsContent + pathDirective, "utf-8");
+    appendedPromptSections.push(instructionsContent + pathDirective);
+  }
+  if (appendedPromptSections.length > 0) {
+    const combinedPath = path.join(runtimeDir, "agent-instructions.md");
+    await fs.writeFile(combinedPath, appendedPromptSections.join("\n\n"), "utf-8");
     effectiveInstructionsFilePath = combinedPath;
   }
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeAgentHomeRun =
+    workspaceSource === "agent_home" &&
+    runtimeSessionCwd.length > 0 &&
+    isPathInside(path.resolve(cwd), path.resolve(runtimeSessionCwd));
   const canResumeSession =
     runtimeSessionId.length > 0 &&
-    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+    (runtimeSessionCwd.length === 0 ||
+      path.resolve(runtimeSessionCwd) === path.resolve(cwd) ||
+      canResumeAgentHomeRun);
   const sessionId = canResumeSession ? runtimeSessionId : null;
+  let effectiveCwd = cwd;
+  if (sessionId && runtimeSessionCwd.length > 0) {
+    effectiveCwd = runtimeSessionCwd;
+  } else if (workspaceSource === "agent_home" && !sessionId) {
+    effectiveCwd = path.join(cwd, ".paperclip-runs", runId);
+    await ensureAbsoluteDirectory(effectiveCwd, { createIfMissing: true });
+    await onLog(
+      "stderr",
+      `[paperclip] Using isolated agent-home run directory "${effectiveCwd}" to avoid Claude cwd session carry-over.\n`,
+    );
+  }
   if (runtimeSessionId && !canResumeSession) {
     await onLog(
       "stderr",
-      `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+      `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveCwd}".\n`,
     );
   }
   const prompt = renderTemplate(promptTemplate, {
@@ -374,7 +396,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
 
   const buildClaudeArgs = (resumeSessionId: string | null) => {
-    const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+    const args = ["--print", "--output-format", "stream-json", "--verbose"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (dangerouslySkipPermissions) args.push("--dangerously-skip-permissions");
     if (chrome) args.push("--chrome");
@@ -384,8 +406,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (effectiveInstructionsFilePath) {
       args.push("--append-system-prompt-file", effectiveInstructionsFilePath);
     }
-    args.push("--add-dir", skillsDir);
     if (extraArgs.length > 0) args.push(...extraArgs);
+    args.push(prompt);
     return args;
   };
 
@@ -411,7 +433,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       await onMeta({
         adapterType: "claude_local",
         command,
-        cwd,
+        cwd: effectiveCwd,
         commandArgs: args,
         commandNotes,
         env: redactEnvForLogs(env),
@@ -421,9 +443,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
 
     const proc = await runChildProcess(runId, command, args, {
-      cwd,
+      cwd: effectiveCwd,
       env,
-      stdin: prompt,
       timeoutSec,
       graceSec,
       onLog,
@@ -500,7 +521,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const resolvedSessionParams = resolvedSessionId
       ? ({
         sessionId: resolvedSessionId,
-        cwd,
+        cwd: effectiveCwd,
         ...(workspaceId ? { workspaceId } : {}),
         ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
         ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
@@ -551,6 +572,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
   } finally {
-    fs.rm(skillsDir, { recursive: true, force: true }).catch(() => {});
+    fs.rm(runtimeDir, { recursive: true, force: true }).catch(() => {});
   }
 }

--- a/server/src/__tests__/claude-local-command-args.test.ts
+++ b/server/src/__tests__/claude-local-command-args.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+
+  return {
+    ...actual,
+    ensureCommandResolvable: vi.fn().mockResolvedValue(undefined),
+    runChildProcess: vi.fn(),
+  };
+});
+
+const serverUtils = await import("@paperclipai/adapter-utils/server-utils");
+const { execute } = await import("@paperclipai/adapter-claude-local/server");
+
+const mockedRunChildProcess = vi.mocked(serverUtils.runChildProcess);
+
+function mockClaudeSuccess(summary: string) {
+  mockedRunChildProcess.mockResolvedValue({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "session_123",
+        model: "claude-opus-4-6",
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "session_123",
+        result: summary,
+        usage: {
+          input_tokens: 11,
+          cache_read_input_tokens: 0,
+          output_tokens: 7,
+        },
+      }),
+    ].join("\n"),
+    stderr: "",
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("claude_local argv handling", () => {
+  it("isolates fresh agent_home runs in a run-scoped cwd", async () => {
+    mockClaudeSuccess("ok");
+    const metaCalls: Array<{ commandArgs: string[]; prompt: string }> = [];
+    const agentHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-agent-home-"));
+
+    await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Polytope",
+      } as any,
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+      } as any,
+      config: {
+        command: "claude",
+        model: "claude-opus-4-6",
+        chrome: true,
+        dangerouslySkipPermissions: true,
+        extraArgs: ["--max-thinking-tokens", "8000"],
+        promptTemplate: "Respond with only {{agent.name}}.",
+      },
+      context: {
+        issueId: "issue-1",
+        wakeReason: "issue_assigned",
+        paperclipWorkspace: {
+          cwd: agentHome,
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async (meta) => {
+        metaCalls.push({
+          commandArgs: meta.commandArgs,
+          prompt: meta.prompt,
+        });
+      },
+    } as any);
+
+    expect(metaCalls).toHaveLength(1);
+    expect(metaCalls[0]?.commandArgs).toEqual(
+      expect.arrayContaining(["--print", "--output-format", "stream-json", "--verbose"]),
+    );
+    expect(metaCalls[0]?.commandArgs).not.toContain("-");
+    expect(metaCalls[0]?.commandArgs).not.toContain("--add-dir");
+    expect(metaCalls[0]?.commandArgs).toContain("--append-system-prompt-file");
+    expect(metaCalls[0]?.commandArgs.at(-1)).toBe("Respond with only Polytope.");
+    expect(mockedRunChildProcess).toHaveBeenCalledWith(
+      "run-1",
+      "claude",
+      expect.not.arrayContaining(["-"]),
+      expect.objectContaining({
+        cwd: path.join(agentHome, ".paperclip-runs", "run-1"),
+      }),
+    );
+    expect(mockedRunChildProcess.mock.calls[0]?.[3]?.stdin).toBeUndefined();
+  });
+
+  it("reuses the saved agent_home session cwd when resuming", async () => {
+    mockClaudeSuccess("ok");
+    const agentHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-agent-home-"));
+    const savedRunCwd = path.join(agentHome, ".paperclip-runs", "prior-run");
+    await fs.mkdir(savedRunCwd, { recursive: true });
+
+    await execute({
+      runId: "run-2",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Polytope",
+      } as any,
+      runtime: {
+        sessionId: "session-123",
+        sessionParams: {
+          sessionId: "session-123",
+          cwd: savedRunCwd,
+        },
+      } as any,
+      config: {
+        command: "claude",
+        model: "claude-opus-4-6",
+        promptTemplate: "Respond with only {{agent.name}}.",
+      },
+      context: {
+        issueId: "issue-1",
+        wakeReason: "heartbeat_timer",
+        paperclipWorkspace: {
+          cwd: agentHome,
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+    } as any);
+
+    expect(mockedRunChildProcess).toHaveBeenCalledWith(
+      "run-2",
+      "claude",
+      expect.arrayContaining(["--resume", "session-123"]),
+      expect.objectContaining({
+        cwd: savedRunCwd,
+      }),
+    );
+    const args = mockedRunChildProcess.mock.calls[0]?.[2] ?? [];
+    expect(args).not.toContain("-");
+    expect(args).not.toContain("--add-dir");
+    expect(args).toContain("--append-system-prompt-file");
+    expect(args.at(-1)).toBe("Respond with only Polytope.");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #684.

This changes the `claude_local` execution path to avoid the prompt shape that was causing fallback `agent_home` runs to behave as if the latest user message was the literal `"-"`.

- isolate fresh `agent_home` runs into `.paperclip-runs/<runId>` subdirectories
- replace repo skill registration via `--add-dir` with an appended Paperclip heartbeat skill file
- pass the rendered prompt as the final positional Claude argument instead of stdin / `-`
- add regression coverage for fresh and resumed `agent_home` runs

## Testing

- `pnpm test:run server/src/__tests__/claude-local-command-args.test.ts server/src/__tests__/claude-local-adapter.test.ts server/src/__tests__/claude-local-adapter-environment.test.ts`
- `pnpm -r typecheck`
