### PR TITLE
fix: 6 small bug fixes and code quality improvements

### DIFF
--- a/cli/src/client/context.ts
+++ b/cli/src/client/context.ts
@@ -80,7 +80,7 @@ function normalizeContext(raw: unknown): ClientContext {
   }
 
   const record = raw as Record<string, unknown>;
-  const version = record.version === 1 ? 1 : 1;
+  const version = 1;
   const currentProfile = toStringOrUndefined(record.currentProfile) ?? DEFAULT_PROFILE;
 
   const rawProfiles = record.profiles;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -551,6 +551,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
   } finally {
-    fs.rm(skillsDir, { recursive: true, force: true }).catch(() => {});
+    fs.rm(skillsDir, { recursive: true, force: true }).catch((err) => {
+      onLog("stderr", `[paperclip] Failed to clean up skills dir: ${err instanceof Error ? err.message : String(err)}\n`).catch(() => {});
+    });
   }
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -25,6 +25,7 @@ import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { applyUiBranding } from "./ui-branding.js";
+import { logger } from "./middleware/logger.js";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 
 type UiMode = "none" | "static" | "vite-dev";
@@ -142,7 +143,7 @@ export async function createApp(
         res.status(200).set("Content-Type", "text/html").end(indexHtml);
       });
     } else {
-      console.warn("[paperclip] UI dist not found; running in API-only mode");
+      logger.warn("[paperclip] UI dist not found; running in API-only mode");
     }
   }
 

--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -3,7 +3,11 @@ import type { ZodSchema } from "zod";
 
 export function validate(schema: ZodSchema) {
   return (req: Request, _res: Response, next: NextFunction) => {
-    req.body = schema.parse(req.body);
-    next();
+    try {
+      req.body = schema.parse(req.body);
+      next();
+    } catch (err) {
+      next(err);
+    }
   };
 }

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -22,50 +22,52 @@ export function costService(db: Db) {
         throw unprocessable("Agent does not belong to company");
       }
 
-      const event = await db
-        .insert(costEvents)
-        .values({ ...data, companyId })
-        .returning()
-        .then((rows) => rows[0] ?? null);
+      return db.transaction(async (tx) => {
+        const event = await tx
+          .insert(costEvents)
+          .values({ ...data, companyId })
+          .returning()
+          .then((rows) => rows[0] ?? null);
 
-      if (!event) throw new Error("Failed to insert cost event");
+        if (!event) throw new Error("Failed to insert cost event");
 
-      await db
-        .update(agents)
-        .set({
-          spentMonthlyCents: sql`${agents.spentMonthlyCents} + ${event.costCents}`,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, event.agentId));
-
-      await db
-        .update(companies)
-        .set({
-          spentMonthlyCents: sql`${companies.spentMonthlyCents} + ${event.costCents}`,
-          updatedAt: new Date(),
-        })
-        .where(eq(companies.id, companyId));
-
-      const updatedAgent = await db
-        .select()
-        .from(agents)
-        .where(eq(agents.id, event.agentId))
-        .then((rows) => rows[0] ?? null);
-
-      if (
-        updatedAgent &&
-        updatedAgent.budgetMonthlyCents > 0 &&
-        updatedAgent.spentMonthlyCents >= updatedAgent.budgetMonthlyCents &&
-        updatedAgent.status !== "paused" &&
-        updatedAgent.status !== "terminated"
-      ) {
-        await db
+        await tx
           .update(agents)
-          .set({ status: "paused", updatedAt: new Date() })
-          .where(eq(agents.id, updatedAgent.id));
-      }
+          .set({
+            spentMonthlyCents: sql`${agents.spentMonthlyCents} + ${event.costCents}`,
+            updatedAt: new Date(),
+          })
+          .where(eq(agents.id, event.agentId));
 
-      return event;
+        await tx
+          .update(companies)
+          .set({
+            spentMonthlyCents: sql`${companies.spentMonthlyCents} + ${event.costCents}`,
+            updatedAt: new Date(),
+          })
+          .where(eq(companies.id, companyId));
+
+        const updatedAgent = await tx
+          .select()
+          .from(agents)
+          .where(eq(agents.id, event.agentId))
+          .then((rows) => rows[0] ?? null);
+
+        if (
+          updatedAgent &&
+          updatedAgent.budgetMonthlyCents > 0 &&
+          updatedAgent.spentMonthlyCents >= updatedAgent.budgetMonthlyCents &&
+          updatedAgent.status !== "paused" &&
+          updatedAgent.status !== "terminated"
+        ) {
+          await tx
+            .update(agents)
+            .set({ status: "paused", updatedAt: new Date() })
+            .where(eq(agents.id, updatedAgent.id));
+        }
+
+        return event;
+      });
     },
 
     summary: async (companyId: string, range?: CostDateRange) => {

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -26,7 +26,9 @@ export function costService(db: Db) {
         .insert(costEvents)
         .values({ ...data, companyId })
         .returning()
-        .then((rows) => rows[0]);
+        .then((rows) => rows[0] ?? null);
+
+      if (!event) throw new Error("Failed to insert cost event");
 
       await db
         .update(agents)


### PR DESCRIPTION
## Summary

Six targeted fixes found by automated code review across server, CLI, and adapters:

- **Remove redundant ternary** in `cli/src/client/context.ts` — `version === 1 ? 1 : 1` simplified to `1`
- **Add null guard after cost event insert** in `server/src/services/costs.ts` — prevents null dereference
- **Wrap cost event creation in a database transaction** — fixes a race condition in budget enforcement where concurrent cost events could exceed the agent budget before the pause check runs
- **Catch Zod parse errors in validate middleware** — without this, validation errors bypass the Express error handler
- **Replace `console.warn` with structured `logger.warn`** in `server/src/app.ts` — consistent logging
- **Log cleanup errors in claude-local adapter** — instead of silently swallowing `fs.rm` failures

## Test plan

- [x] `pnpm build` passes with all changes
- [ ] Verify validate middleware returns 422 on malformed request body
- [ ] Verify cost events are rolled back if budget update fails mid-transaction

🤖 Generated with [Paperclip](https://github.com/paperclipai/paperclip) agents