### PR TITLE
fix(openclaw-gateway): use dynamic agentId in session key instead of hardcoded "paperclip"

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1080,8 +1080,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
   delete agentParams.text;
 
-  if (resolvedAgentId && !nonEmpty(agentParams.agentId)) {
-    agentParams.agentId = resolvedAgentId;
+  const effectiveAgentId = resolvedAgentId ?? "main";
+  if (!nonEmpty(agentParams.agentId)) {
+    agentParams.agentId = effectiveAgentId;
   }
 
   if (typeof agentParams.timeout !== "number") {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -129,12 +129,14 @@ function normalizeSessionKeyStrategy(value: unknown): SessionKeyStrategy {
 function resolveSessionKey(input: {
   strategy: SessionKeyStrategy;
   configuredSessionKey: string | null;
+  agentId: string | null;
   runId: string;
   issueId: string | null;
 }): string {
-  const fallback = input.configuredSessionKey ?? "paperclip";
-  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
-  if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
+  const agentSlug = input.agentId ?? "main";
+  const fallback = input.configuredSessionKey ?? agentSlug;
+  if (input.strategy === "run") return `agent:${agentSlug}:run:${input.runId}`;
+  if (input.strategy === "issue" && input.issueId) return `agent:${agentSlug}:issue:${input.issueId}`;
   return fallback;
 }
 
@@ -1056,9 +1058,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
+  const configuredAgentId = nonEmpty(ctx.config.agentId);
+  const resolvedAgentId = nonEmpty(payloadTemplate.agentId) ?? configuredAgentId;
   const sessionKey = resolveSessionKey({
     strategy: sessionKeyStrategy,
     configuredSessionKey,
+    agentId: resolvedAgentId,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
   });
@@ -1075,9 +1080,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
   delete agentParams.text;
 
-  const configuredAgentId = nonEmpty(ctx.config.agentId);
-  if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
-    agentParams.agentId = configuredAgentId;
+  if (resolvedAgentId && !nonEmpty(agentParams.agentId)) {
+    agentParams.agentId = resolvedAgentId;
   }
 
   if (typeof agentParams.timeout !== "number") {


### PR DESCRIPTION
## Summary

Session keys generated by the OpenClaw gateway adapter were using an incorrect format. The adapter was producing keys like `paperclip:run:<runId>` and `paperclip:issue:<issueId>`, which do not match the format expected by OpenClaw's session key parser. This causes issues when using OpenClaw's multiple agent feature, as sessions cannot be correctly routed to the target agent.

## Bug

The old `resolveSessionKey` was hardcoding `"paperclip"` as prefix:

```typescript
// Before (broken)
if (input.strategy === "run") return `paperclip:run:${input.runId}`;
if (input.strategy === "issue") return `paperclip:issue:${input.issueId}`;
```

This produces keys like `paperclip:issue:57205fcb-...` which OpenClaw's parser splits by `:` and expects:
1. Part 1 = `"agent"` — got `"paperclip"` → **parse fails, returns `null`**
2. Fallback to `"main"` agent regardless of configuration

Result: in a multi-agent OpenClaw setup, the session key resolves to agent `"main"` while `agentParams.agentId` is set to `"paperclip"`, causing a mismatch error:

```
[openclaw-gateway] request failed: invalid agent params: agent "paperclip" does not match session key agent "main"
```

## Context from OpenClaw

Per OpenClaw's [`session-key-utils.ts#L19-L30`](https://github.com/openclaw/openclaw/blob/main/src/sessions/session-key-utils.ts#L19-L30), session keys must follow this format:

```
agent:<agentId>:<rest>
```

Parser rules:
- Must have at least 3 parts separated by `:`
- First part must be `"agent"`
- Second part is the `agentId`
- Remaining parts form the session identifier

Valid examples:
- `agent:main:main` — default session
- `agent:paperclip:issue:57205fcb-...` — custom session
- `agent:main:telegram:direct:12345` — DM session
- `agent:main:discord:group:98765` — group session
- `agent:main:cron:daily:run:abc` — cron session

## Changes

- `resolveSessionKey` now generates keys in the correct `agent:<agentId>:<rest>` format
- AgentId is resolved with a consistent priority chain: `payloadTemplate.agentId` > `config.agentId` > `"main"` (default)
- Both `sessionKey` and `agentParams.agentId` use the same `resolvedAgentId`, ensuring they always match
