### PR TITLE
test: add company-scope regressions for approval/activity/access routes

### DIFF
--- a/server/src/__tests__/access-company-scope.test.ts
+++ b/server/src/__tests__/access-company-scope.test.ts
@@ -1,0 +1,98 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { accessRoutes } from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockAccessService = vi.hoisted(() => ({
+  hasPermission: vi.fn(),
+  canUser: vi.fn(),
+  isInstanceAdmin: vi.fn(),
+  getMembership: vi.fn(),
+  ensureMembership: vi.fn(),
+  listMembers: vi.fn(),
+  setMemberPermissions: vi.fn(),
+  promoteInstanceAdmin: vi.fn(),
+  demoteInstanceAdmin: vi.fn(),
+  listUserCompanyAccess: vi.fn(),
+  setUserCompanyAccess: vi.fn(),
+  setPrincipalGrants: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  deduplicateAgentName: vi.fn(),
+  logActivity: vi.fn(),
+  notifyHireApproved: vi.fn(),
+}));
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes({} as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("access routes company scope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockResolvedValue(true);
+  });
+
+  it("rejects cross-company members view requests before permission/service checks", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app).get("/api/companies/company-2/members");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("User does not have access to this company");
+    expect(mockAccessService.canUser).not.toHaveBeenCalled();
+    expect(mockAccessService.listMembers).not.toHaveBeenCalled();
+  });
+
+  it("allows in-scope members view requests", async () => {
+    mockAccessService.listMembers.mockResolvedValue([{ id: "membership-1" }]);
+    const app = createApp({
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app).get("/api/companies/company-1/members");
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.canUser).toHaveBeenCalledWith(
+      "company-1",
+      "user-1",
+      "users:manage_permissions",
+    );
+    expect(mockAccessService.listMembers).toHaveBeenCalledWith("company-1");
+    expect(res.body).toEqual([{ id: "membership-1" }]);
+  });
+});

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -48,6 +48,16 @@ describe("activity routes", () => {
     vi.clearAllMocks();
   });
 
+  it("rejects cross-company activity listing before hitting the service", async () => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const res = await request(createApp()).get("/api/companies/company-2/activity");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("User does not have access to this company");
+    expect(mockActivityService.list).not.toHaveBeenCalled();
+  });
+
   it("resolves issue identifiers before loading runs", async () => {
     mockIssueService.getByIdentifier.mockResolvedValue({
       id: "issue-uuid-1",
@@ -66,5 +76,18 @@ describe("activity routes", () => {
     expect(mockIssueService.getById).not.toHaveBeenCalled();
     expect(mockActivityService.runsForIssue).toHaveBeenCalledWith("company-1", "issue-uuid-1");
     expect(res.body).toEqual([{ runId: "run-1" }]);
+  });
+
+  it("rejects issue run lookup when the resolved issue belongs to another company", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValue({
+      id: "issue-uuid-2",
+      companyId: "company-2",
+    });
+
+    const res = await request(createApp()).get("/api/issues/PAP-999/runs");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("User does not have access to this company");
+    expect(mockActivityService.runsForIssue).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -65,6 +65,31 @@ describe("approval routes idempotent retries", () => {
     mockLogActivity.mockResolvedValue(undefined);
   });
 
+  it("rejects cross-company approval list requests before service execution", async () => {
+    mockApprovalService.list.mockResolvedValue([]);
+
+    const res = await request(createApp()).get("/api/companies/company-2/approvals");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("User does not have access to this company");
+    expect(mockApprovalService.list).not.toHaveBeenCalled();
+  });
+
+  it("rejects approval detail access when the approval belongs to another company", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-1",
+      companyId: "company-2",
+      type: "hire_agent",
+      status: "pending",
+      payload: {},
+    });
+
+    const res = await request(createApp()).get("/api/approvals/approval-1");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("User does not have access to this company");
+  });
+
   it("does not emit duplicate approval side effects when approve is already resolved", async () => {
     mockApprovalService.approve.mockResolvedValue({
       approval: {


### PR DESCRIPTION
## Problem
Company-scoped route regressions in approval/activity/access views can leak cross-company data if boundary checks are accidentally bypassed.

## Why now
These routes aggregate sensitive cross-cutting records and need explicit fail-closed regression coverage for tenant isolation.

## What changed
- Added cross-company deny-path tests for:
  - `GET /companies/:companyId/approvals`
  - `GET /approvals/:id` when approval belongs to another company
  - `GET /companies/:companyId/activity`
  - `GET /issues/:id/runs` when issue resolves to another company
  - `GET /companies/:companyId/members`
- Added assertions that downstream service calls are not executed on denied company scope.

## Validation
- `pnpm vitest server/src/__tests__/approval-routes-idempotency.test.ts server/src/__tests__/activity-routes.test.ts server/src/__tests__/access-company-scope.test.ts --run`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm -r typecheck`

Refs #709
