### PR TITLE
feat(ui): add agent mode indicators to the sidebar

### DIFF
--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { NavLink, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Plus } from "lucide-react";
+import { ChevronRight, Clock3, Plus, Zap } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
@@ -9,6 +9,7 @@ import { agentsApi } from "../api/agents";
 import { heartbeatsApi } from "../api/heartbeats";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, agentRouteRef, agentUrl } from "../lib/utils";
+import { getAgentRunPolicy } from "../lib/agent-run-policy";
 import { AgentIcon } from "./AgentIconPicker";
 import {
   Collapsible,
@@ -108,6 +109,7 @@ export function SidebarAgents() {
         <div className="flex flex-col gap-0.5 mt-0.5">
           {visibleAgents.map((agent: Agent) => {
             const runCount = liveCountByAgent.get(agent.id) ?? 0;
+            const runPolicy = getAgentRunPolicy(agent.runtimeConfig);
             return (
               <NavLink
                 key={agent.id}
@@ -123,7 +125,31 @@ export function SidebarAgents() {
                 )}
               >
                 <AgentIcon icon={agent.icon} className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
-                <span className="flex-1 truncate">{agent.name}</span>
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                  <span className="truncate">{agent.name}</span>
+                  {(runPolicy.hasTimerHeartbeat || runPolicy.wakeOnDemand) && (
+                    <span className="flex shrink-0 items-center gap-1">
+                      {runPolicy.hasTimerHeartbeat && (
+                        <span
+                          className="text-amber-600 dark:text-amber-400"
+                          title={`Timer heartbeat every ${runPolicy.intervalSec}s`}
+                          aria-label={`Timer heartbeat every ${runPolicy.intervalSec} seconds`}
+                        >
+                          <Clock3 aria-hidden="true" className="h-3 w-3" />
+                        </span>
+                      )}
+                      {runPolicy.wakeOnDemand && (
+                        <span
+                          className="text-sky-600 dark:text-sky-400"
+                          title="Wake on demand enabled"
+                          aria-label="Wake on demand enabled"
+                        >
+                          <Zap aria-hidden="true" className="h-3 w-3" />
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </div>
                 {runCount > 0 && (
                   <span className="ml-auto flex items-center gap-1.5 shrink-0">
                     <span className="relative flex h-2 w-2">

--- a/ui/src/lib/agent-run-policy.test.ts
+++ b/ui/src/lib/agent-run-policy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { getAgentRunPolicy } from "./agent-run-policy";
+
+describe("getAgentRunPolicy", () => {
+  it("uses the same defaults as the server heartbeat policy", () => {
+    expect(getAgentRunPolicy({})).toEqual({
+      heartbeatEnabled: true,
+      intervalSec: 0,
+      wakeOnDemand: true,
+      hasTimerHeartbeat: false,
+    });
+  });
+
+  it("treats a positive interval as a timer heartbeat only when enabled", () => {
+    expect(
+      getAgentRunPolicy({
+        heartbeat: {
+          enabled: true,
+          intervalSec: 300,
+          wakeOnDemand: false,
+        },
+      }),
+    ).toEqual({
+      heartbeatEnabled: true,
+      intervalSec: 300,
+      wakeOnDemand: false,
+      hasTimerHeartbeat: true,
+    });
+
+    expect(
+      getAgentRunPolicy({
+        heartbeat: {
+          enabled: false,
+          intervalSec: 300,
+        },
+      }),
+    ).toEqual({
+      heartbeatEnabled: false,
+      intervalSec: 300,
+      wakeOnDemand: true,
+      hasTimerHeartbeat: false,
+    });
+  });
+
+  it("supports the legacy wake-on-demand keys the server still accepts", () => {
+    expect(
+      getAgentRunPolicy({
+        heartbeat: {
+          wakeOnAssignment: false,
+        },
+      }),
+    ).toEqual({
+      heartbeatEnabled: true,
+      intervalSec: 0,
+      wakeOnDemand: false,
+      hasTimerHeartbeat: false,
+    });
+  });
+});

--- a/ui/src/lib/agent-run-policy.ts
+++ b/ui/src/lib/agent-run-policy.ts
@@ -1,0 +1,54 @@
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+    if (normalized === "1") return true;
+    if (normalized === "0") return false;
+  }
+  return fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export interface AgentRunPolicy {
+  heartbeatEnabled: boolean;
+  intervalSec: number;
+  wakeOnDemand: boolean;
+  hasTimerHeartbeat: boolean;
+}
+
+export function getAgentRunPolicy(runtimeConfig: unknown): AgentRunPolicy {
+  const config = asRecord(runtimeConfig);
+  const heartbeat = asRecord(config?.heartbeat);
+  const heartbeatEnabled = asBoolean(heartbeat?.enabled, true);
+  const intervalSec = Math.max(0, asNumber(heartbeat?.intervalSec, 0));
+  const wakeOnDemand = asBoolean(
+    heartbeat?.wakeOnDemand ??
+      heartbeat?.wakeOnAssignment ??
+      heartbeat?.wakeOnOnDemand ??
+      heartbeat?.wakeOnAutomation,
+    true,
+  );
+
+  return {
+    heartbeatEnabled,
+    intervalSec,
+    wakeOnDemand,
+    hasTimerHeartbeat: heartbeatEnabled && intervalSec > 0,
+  };
+}


### PR DESCRIPTION
## Summary
Adds small mode indicators to the agent sidebar so it is easier to see which agents run on a timer heartbeat and which support wake on demand.

## What changed
- added compact sidebar icons next to agent names
- added a helper to read run policy from runtimeConfig
- matched the existing server semantics for heartbeat defaults
- kept the current live-run indicator unchanged
- added unit coverage for the helper

## Manual check
- verified the sidebar layout still reads cleanly with the new icons
- verified the existing live-run indicator still renders on the right

## Testing
- npx pnpm exec vitest run ui/src/lib/agent-run-policy.test.ts
- npx pnpm -r typecheck
- npx pnpm test:run
- npx pnpm build

Closes #689