### PR TITLE
fix(ui): classify paperclip transcript stderr

### DIFF
--- a/ui/src/components/transcript/RunTranscriptView.test.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.test.tsx
@@ -81,4 +81,64 @@ describe("RunTranscriptView", () => {
       text: "Working on the task.",
     });
   });
+
+  it("renders informational paperclip stderr as a neutral paperclip event", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "[paperclip] Loaded agent instructions file: /workspace/agents/ceo/AGENTS.md",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "event",
+      label: "paperclip",
+      tone: "neutral",
+      text: "[paperclip] Loaded agent instructions file: /workspace/agents/ceo/AGENTS.md",
+    });
+  });
+
+  it("keeps actionable paperclip stderr visible as warnings", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "[paperclip] Warning: could not read agent instructions file \"/workspace/agents/ceo/AGENTS.md\": ENOENT",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "event",
+      label: "paperclip",
+      tone: "warn",
+      text: "[paperclip] Warning: could not read agent instructions file \"/workspace/agents/ceo/AGENTS.md\": ENOENT",
+    });
+  });
+
+  it("keeps non-paperclip stderr as an error event", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "ERROR mcp:transport:worker transport channel closed",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "event",
+      label: "stderr",
+      tone: "error",
+      text: "ERROR mcp:transport:worker transport channel closed",
+    });
+  });
 });

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -276,9 +276,30 @@ function parseSystemActivity(text: string): { activityId?: string; name: string;
   };
 }
 
-function shouldHideNiceModeStderr(text: string): boolean {
+type NiceModeStderrHandling =
+  | { hidden: true }
+  | {
+      hidden: false;
+      label: string;
+      tone: Extract<TranscriptBlock, { type: "event" }>["tone"];
+    };
+
+function classifyNiceModeStderr(text: string): NiceModeStderrHandling {
   const normalized = compactWhitespace(text).toLowerCase();
-  return normalized.startsWith("[paperclip] skipping saved session resume");
+  if (normalized.startsWith("[paperclip] skipping saved session resume")) {
+    return { hidden: true };
+  }
+  if (!normalized.startsWith("[paperclip]")) {
+    return { hidden: false, label: "stderr", tone: "error" };
+  }
+  if (
+    normalized.includes("[paperclip] failed to ")
+    || normalized.includes("[paperclip] warning:")
+    || normalized.includes(" could not ")
+  ) {
+    return { hidden: false, label: "paperclip", tone: "warn" };
+  }
+  return { hidden: false, label: "paperclip", tone: "neutral" };
 }
 
 function groupCommandBlocks(blocks: TranscriptBlock[]): TranscriptBlock[] {
@@ -434,14 +455,15 @@ export function normalizeTranscript(entries: TranscriptEntry[], streaming: boole
     }
 
     if (entry.kind === "stderr") {
-      if (shouldHideNiceModeStderr(entry.text)) {
+      const handling = classifyNiceModeStderr(entry.text);
+      if (handling.hidden) {
         continue;
       }
       blocks.push({
         type: "event",
         ts: entry.ts,
-        label: "stderr",
-        tone: "error",
+        label: handling.label,
+        tone: handling.tone,
         text: entry.text,
       });
       continue;


### PR DESCRIPTION
## Summary

Classifies internal `[paperclip]` stderr lines in the nice transcript view so successful Codex runs do not look broken by default.

## What changed

- replaced the one-off saved-session stderr hide rule with a small stderr classifier
- renders informational `[paperclip]` stderr as neutral `paperclip` events
- keeps actionable Paperclip warnings visible as warnings
- leaves non-Paperclip stderr as hard errors
- added transcript coverage for info, warning, and external stderr cases

## Testing

- `npx pnpm exec vitest run ui/src/components/transcript/RunTranscriptView.test.tsx`
- `npx pnpm -r typecheck`
- `npx pnpm test:run`
- `npx pnpm build`

Closes #716
