### PR TITLE
chore: add Makefile for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: install onboard dev bootstrap-ceo setup
+
+APP_PORT = 3100
+
+-include .env
+export
+
+## Create .env for local development (no external DB needed)
+.env:
+	@echo "BETTER_AUTH_SECRET=$$(openssl rand -hex 32)" > .env
+	@echo "PAPERCLIP_PUBLIC_URL=http://localhost:$(APP_PORT)" >> .env
+	@echo "PORT=$(APP_PORT)" >> .env
+	@echo "SERVE_UI=true" >> .env
+	@echo ".env created."
+
+## Install dependencies
+install:
+	pnpm install
+
+## Run onboard (first-time config, skips prompts)
+onboard:
+	pnpm paperclipai onboard --yes
+
+## Generate the first admin invite URL
+bootstrap-ceo:
+	pnpm paperclipai auth bootstrap-ceo
+
+## Start dev server with hot reload
+dev:
+	pnpm dev
+
+## Full first-time setup: .env + install + onboard
+setup: .env install onboard
+	@echo ""
+	@echo "Setup complete. Run 'make dev' to start, then 'make bootstrap-ceo' to create the first admin."

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-.PHONY: install onboard dev bootstrap-ceo setup
+.PHONY: help install onboard dev bootstrap-ceo setup
 
 APP_PORT = 3100
 
--include .env
-export
+## Show available targets
+help:
+	@echo "Usage:"
+	@echo "  make setup          First-time setup (.env + install + onboard)"
+	@echo "  make dev            Start dev server with hot reload"
+	@echo "  make bootstrap-ceo  Generate the first admin invite URL"
 
 ## Create .env for local development (no external DB needed)
 .env:
@@ -26,7 +30,7 @@ bootstrap-ceo:
 	pnpm paperclipai auth bootstrap-ceo
 
 ## Start dev server with hot reload
-dev:
+dev: .env
 	pnpm dev
 
 ## Full first-time setup: .env + install + onboard


### PR DESCRIPTION
Adds a Makefile to simplify local development setup without Docker or an external PostgreSQL — uses the app's built-in embedded postgres.                                                                    
                                                                                                                                                                                                                 
- make setup for first-time setup, 
- make dev to start, 
- make bootstrap-ceo for the first admin invite.