### PR TITLE
fix: resolve comment-mention agent shortnames in heartbeat wake triggers

### DIFF
--- a/server/src/__tests__/issues-mentions.test.ts
+++ b/server/src/__tests__/issues-mentions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { findMentionedAgentIds } from "../services/issues.ts";
+
+describe("findMentionedAgentIds", () => {
+  const agents = [
+    { id: "agent-qa", name: "QA Engineer" },
+    { id: "agent-fe", name: "Frontend Eng" },
+    { id: "agent-custom", name: "Ops", urlKey: "custom-handle" },
+  ];
+
+  it("matches normalized agent names from mention tokens", () => {
+    expect(findMentionedAgentIds("ping @qa-engineer and @QA_Engineer", agents)).toEqual(["agent-qa"]);
+  });
+
+  it("matches explicit url keys when present", () => {
+    expect(findMentionedAgentIds("check with @custom-handle", agents)).toEqual(["agent-custom"]);
+  });
+
+  it("ignores unknown mentions", () => {
+    expect(findMentionedAgentIds("hello @nobody", agents)).toEqual([]);
+  });
+});

--- a/server/src/__tests__/issues-mentions.test.ts
+++ b/server/src/__tests__/issues-mentions.test.ts
@@ -5,18 +5,30 @@ describe("findMentionedAgentIds", () => {
   const agents = [
     { id: "agent-qa", name: "QA Engineer" },
     { id: "agent-fe", name: "Frontend Eng" },
-    { id: "agent-custom", name: "Ops", urlKey: "custom-handle" },
   ];
 
   it("matches normalized agent names from mention tokens", () => {
-    expect(findMentionedAgentIds("ping @qa-engineer and @QA_Engineer", agents)).toEqual(["agent-qa"]);
+    expect(findMentionedAgentIds("ping @qa-engineer", agents)).toEqual(["agent-qa"]);
   });
 
-  it("matches explicit url keys when present", () => {
-    expect(findMentionedAgentIds("check with @custom-handle", agents)).toEqual(["agent-custom"]);
+  it("deduplicates when multiple tokens resolve to the same agent", () => {
+    const result = findMentionedAgentIds("ping @qa-engineer and @QA_Engineer", agents);
+    expect(result).toEqual(["agent-qa"]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("matches multiple distinct agents", () => {
+    expect(findMentionedAgentIds("cc @qa-engineer @frontend-eng", agents)).toEqual([
+      "agent-qa",
+      "agent-fe",
+    ]);
   });
 
   it("ignores unknown mentions", () => {
     expect(findMentionedAgentIds("hello @nobody", agents)).toEqual([]);
+  });
+
+  it("returns empty array when body has no mentions", () => {
+    expect(findMentionedAgentIds("just a normal comment", agents)).toEqual([]);
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -68,7 +68,6 @@ export interface IssueFilters {
 interface MentionableAgentRow {
   id: string;
   name: string;
-  urlKey?: string | null;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -131,11 +130,7 @@ export function findMentionedAgentIds(
   return rows
     .filter((agent) => {
       const normalizedName = normalizeAgentUrlKey(agent.name);
-      const normalizedUrlKey = normalizeAgentUrlKey(agent.urlKey);
-      return (
-        (normalizedName && tokens.has(normalizedName)) ||
-        (normalizedUrlKey && tokens.has(normalizedUrlKey))
-      );
+      return normalizedName != null && tokens.has(normalizedName);
     })
     .map((agent) => agent.id);
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -16,7 +16,7 @@ import {
   projectWorkspaces,
   projects,
 } from "@paperclipai/db";
-import { extractProjectMentionIds } from "@paperclipai/shared";
+import { extractProjectMentionIds, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -65,6 +65,12 @@ export interface IssueFilters {
   q?: string;
 }
 
+interface MentionableAgentRow {
+  id: string;
+  name: string;
+  urlKey?: string | null;
+}
+
 type IssueRow = typeof issues.$inferSelect;
 type IssueLabelRow = typeof labels.$inferSelect;
 type IssueActiveRunRow = {
@@ -107,6 +113,31 @@ const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancell
 
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
+}
+
+export function findMentionedAgentIds(
+  body: string,
+  rows: MentionableAgentRow[],
+): string[] {
+  const re = /\B@([^\s@,!?.]+)/g;
+  const tokens = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body)) !== null) {
+    const normalized = normalizeAgentUrlKey(match[1]);
+    if (normalized) tokens.add(normalized);
+  }
+  if (tokens.size === 0) return [];
+
+  return rows
+    .filter((agent) => {
+      const normalizedName = normalizeAgentUrlKey(agent.name);
+      const normalizedUrlKey = normalizeAgentUrlKey(agent.urlKey);
+      return (
+        (normalizedName && tokens.has(normalizedName)) ||
+        (normalizedUrlKey && tokens.has(normalizedUrlKey))
+      );
+    })
+    .map((agent) => agent.id);
 }
 
 function touchedByUserCondition(companyId: string, userId: string) {
@@ -1265,14 +1296,9 @@ export function issueService(db: Db) {
       }),
 
     findMentionedAgents: async (companyId: string, body: string) => {
-      const re = /\B@([^\s@,!?.]+)/g;
-      const tokens = new Set<string>();
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(body)) !== null) tokens.add(m[1].toLowerCase());
-      if (tokens.size === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      return rows.filter(a => tokens.has(a.name.toLowerCase())).map(a => a.id);
+      return findMentionedAgentIds(body, rows);
     },
 
     findMentionedProjectIds: async (issueId: string) => {


### PR DESCRIPTION
## Summary

Fixes agent shortname resolution in comment-mention wakeup triggers so that `@AgentName` mentions in issue comments correctly trigger heartbeats for the target agent.

## Changes

- Resolve agent shortnames (e.g. `@0agent`) to agent IDs when processing comment mentions
- Ensures heartbeat wake triggers fire for the correct agent

## Context

Opened by 0agent.

Related: AGE-55, AGE-57, AGE-75