### PR TITLE
fix: harden heartbeat reaper against process_lost race conditions

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -513,8 +513,13 @@ export async function startServer(): Promise<StartedServer> {
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any);
   
-    // Reap orphaned runs at startup (no threshold -- runningProcesses is empty)
-    void heartbeat.reapOrphanedRuns().catch((err) => {
+    // Reap orphaned runs at startup.  Use the same staleness threshold as the
+    // periodic reaper so that recently-active runs survive a server restart.
+    // Their child processes may still be alive as OS-level orphans, and our
+    // periodic updatedAt touch (every 60 s) keeps them fresh.
+    // Without this threshold the startup reap would massacre every in-flight
+    // run because runningProcesses is empty right after boot.
+    void heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 }).catch((err) => {
       logger.error({ err }, "startup reap of orphaned heartbeat runs failed");
     });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1309,6 +1309,7 @@ export function heartbeatService(db: Db) {
     let handle: RunLogHandle | null = null;
     let stdoutExcerpt = "";
     let stderrExcerpt = "";
+    let heartbeatTouchInterval: ReturnType<typeof setInterval> | undefined;
     try {
       const startedAt = run.startedAt ?? new Date();
       const runningWithSession = await db
@@ -1373,7 +1374,7 @@ export function heartbeatService(db: Db) {
       // is finalised.  Using setInterval (not onLog) ensures the touch fires
       // even when the agent is silent (e.g. waiting on a slow API call).
       const HEARTBEAT_TOUCH_INTERVAL_MS = 60_000;
-      const heartbeatTouchInterval = setInterval(async () => {
+      heartbeatTouchInterval = setInterval(async () => {
         try {
           await db
             .update(heartbeatRuns)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -967,25 +967,63 @@ export function heartbeatService(db: Db) {
         if (now.getTime() - refTime < staleThresholdMs) continue;
       }
 
-      await setRunStatus(run.id, "failed", {
-        error: "Process lost -- server may have restarted",
-        errorCode: "process_lost",
-        finishedAt: now,
+      // Use a conditional UPDATE to avoid overwriting a status that was
+      // already finalised by the normal executeRun flow between our SELECT
+      // and this point (race between reaper and adapter teardown).
+      const [conditionallyReaped] = await db
+        .update(heartbeatRuns)
+        .set({
+          status: "failed",
+          error: "Process lost -- server may have restarted",
+          errorCode: "process_lost",
+          finishedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(heartbeatRuns.id, run.id),
+            inArray(heartbeatRuns.status, ["queued", "running"]),
+          ),
+        )
+        .returning();
+
+      if (!conditionallyReaped) {
+        // Run was already finalised by the normal flow — skip.
+        continue;
+      }
+
+      // Publish the status event that setRunStatus would normally emit.
+      publishLiveEvent({
+        companyId: conditionallyReaped.companyId,
+        type: "heartbeat.run.status",
+        payload: {
+          runId: conditionallyReaped.id,
+          agentId: conditionallyReaped.agentId,
+          status: conditionallyReaped.status,
+          invocationSource: conditionallyReaped.invocationSource,
+          triggerDetail: conditionallyReaped.triggerDetail,
+          error: conditionallyReaped.error ?? null,
+          errorCode: conditionallyReaped.errorCode ?? null,
+          startedAt: conditionallyReaped.startedAt
+            ? new Date(conditionallyReaped.startedAt).toISOString()
+            : null,
+          finishedAt: conditionallyReaped.finishedAt
+            ? new Date(conditionallyReaped.finishedAt).toISOString()
+            : null,
+        },
       });
+
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
         error: "Process lost -- server may have restarted",
       });
-      const updatedRun = await getRun(run.id);
-      if (updatedRun) {
-        await appendRunEvent(updatedRun, 1, {
-          eventType: "lifecycle",
-          stream: "system",
-          level: "error",
-          message: "Process lost -- server may have restarted",
-        });
-        await releaseIssueExecutionAndPromote(updatedRun);
-      }
+      await appendRunEvent(conditionallyReaped, 1, {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "error",
+        message: "Process lost -- server may have restarted",
+      });
+      await releaseIssueExecutionAndPromote(conditionallyReaped);
       await finalizeAgentStatus(run.agentId, "failed");
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
@@ -1328,6 +1366,24 @@ export function heartbeatService(db: Db) {
         })
         .where(eq(heartbeatRuns.id, runId));
 
+      // Periodically touch updatedAt so the reaper's staleness threshold
+      // stays effective for long-running processes.  Without this, a process
+      // that runs >5 min makes the row look stale and vulnerable to reaping
+      // during the brief window after the child exits but before DB status
+      // is finalised.  Using setInterval (not onLog) ensures the touch fires
+      // even when the agent is silent (e.g. waiting on a slow API call).
+      const HEARTBEAT_TOUCH_INTERVAL_MS = 60_000;
+      const heartbeatTouchInterval = setInterval(async () => {
+        try {
+          await db
+            .update(heartbeatRuns)
+            .set({ updatedAt: new Date() })
+            .where(eq(heartbeatRuns.id, run.id));
+        } catch {
+          // Best-effort — don't crash the run if the touch fails.
+        }
+      }, HEARTBEAT_TOUCH_INTERVAL_MS);
+
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
         const sanitizedChunk = redactCurrentUserText(chunk);
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
@@ -1451,6 +1507,20 @@ export function heartbeatService(db: Db) {
         onMeta: onAdapterMeta,
         authToken: authToken ?? undefined,
       });
+
+      // The child process has exited and runChildProcess has already removed
+      // the entry from runningProcesses.  Re-insert a lightweight sentinel so
+      // the reaper's `runningProcesses.has(run.id)` check still returns true
+      // while we finalize the DB state below.  The sentinel's `child` is a
+      // no-op stub so that cancelRun / cancelActiveForAgent won't crash if
+      // they happen to run concurrently.
+      if (!runningProcesses.has(run.id)) {
+        runningProcesses.set(run.id, {
+          child: { kill: () => false, killed: true } as any,
+          graceSec: 1,
+        });
+      }
+
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,
@@ -1677,6 +1747,10 @@ export function heartbeatService(db: Db) {
 
       await finalizeAgentStatus(agent.id, "failed");
     } finally {
+      clearInterval(heartbeatTouchInterval);
+      // Clean up the sentinel (or real entry) we may have kept alive during
+      // DB finalization — see the comment after adapter.execute() above.
+      runningProcesses.delete(run.id);
       await releaseRuntimeServicesForRun(run.id);
       await startNextQueuedRunForAgent(agent.id);
     }


### PR DESCRIPTION
## Summary

Follow-up to #645 (UTF-8 encoding fix, now merged). This PR contains the **reaper hardening** from the original #643, rebased cleanly on master with no encoding overlap.

On Windows with multiple concurrent agents, the heartbeat reaper incorrectly marks running processes as `process_lost` — all agents die at the exact same second with no exit code and no signal. This is a server-side race condition, not individual agent crashes.

**Evidence from production runs:**
```
2026-03-11T16:26:17 QA       status=failed exit=None signal= err=process_lost
2026-03-11T16:26:17 Frontend status=failed exit=None signal= err=process_lost
2026-03-11T16:26:17 Backend  status=failed exit=None signal= err=process_lost
```

## Changes (2 files: `heartbeat.ts`, `index.ts`)

### 1. Conditional UPDATE in `reapOrphanedRuns`
The reaper was blindly calling `setRunStatus("failed")` which could overwrite a run that was legitimately finalised between the SELECT and UPDATE. Now uses a conditional UPDATE with `WHERE status IN ('queued', 'running')` — if the run was already finalised, it skips it.

### 2. Sentinel entry in `runningProcesses` after `adapter.execute()`
After the child process exits, `runChildProcess` removes it from `runningProcesses`. But DB finalisation (status update, runtime state, session persistence) takes time. During that gap, the reaper's `runningProcesses.has(run.id)` check returns false and marks it as lost. The sentinel keeps it "visible" until the finally block cleans up.

### 3. Independent `setInterval` heartbeat touch (every 60s)
The reaper uses `updatedAt` staleness to decide if a process is dead. Without a periodic touch, agents that are silent for >5 minutes (waiting on slow API calls, compilations) look stale and get reaped. This was flagged in the Greptile review of #643 — using `setInterval` instead of `onLog` ensures the touch fires even for silent agents.

### 4. Startup reap staleness threshold (5 minutes)
On server restart, `runningProcesses` is empty so the reaper would immediately kill ALL in-flight runs. Now passes `staleThresholdMs: 5 * 60 * 1000` to the startup reap, matching the periodic reaper's threshold. Runs that were active within the last 5 minutes survive a restart.

## Test plan
- [x] Tested on Windows 10 with 5 concurrent `claude_local` agents
- [x] Before fix: agents die every 5-15 min with simultaneous `process_lost`
- [x] After fix: runs complete successfully, no false `process_lost` events
- [ ] Verify silent agents (no stdout for >5 min) are not incorrectly reaped
- [ ] Verify server restart does not kill recently-active runs

## Related
- Follows #645 (UTF-8 encoding fix — merged)
- Replaces reaper portion of #643 (closed per reviewer recommendation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)