### PR TITLE
Fix reaper incorrectly killing queued runs (#634)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -950,11 +950,12 @@ export function heartbeatService(db: Db) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
 
-    // Find all runs in "queued" or "running" state
+    // Only reap "running" runs — queued runs are legitimately waiting
+    // for a concurrency slot and have no child process yet.
     const activeRuns = await db
       .select()
       .from(heartbeatRuns)
-      .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+      .where(eq(heartbeatRuns.status, "running"));
 
     const reaped: string[] = [];
 


### PR DESCRIPTION
## Summary
- Excludes `queued` status runs from the orphan heartbeat reaper
- Queued runs have no heartbeat yet and no child process — reaping them was incorrect
- Only `running` runs are now checked for staleness

Fixes #634

## Test plan
- [x] Queued runs survive reaper cycles
- [x] Truly orphaned running runs still get reaped
- [x] Existing tests pass