### PR TITLE
Filter [paperclip] stderr in transcript nice mode (#716)

### DIFF
--- a/ui/src/components/transcript/RunTranscriptView.test.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.test.tsx
@@ -58,12 +58,27 @@ describe("RunTranscriptView", () => {
     expect(html).toContain("<li>second</li>");
   });
 
-  it("hides saved-session resume skip stderr from nice mode normalization", () => {
+  it("hides all informational [paperclip] stderr from nice mode normalization", () => {
     const entries: TranscriptEntry[] = [
       {
         kind: "stderr",
         ts: "2026-03-12T00:00:00.000Z",
         text: "[paperclip] Skipping saved session resume for task \"PAP-485\" because wake reason is issue_assigned.",
+      },
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.100Z",
+        text: "[paperclip] No project or prior session workspace was available. Using fallback workspace /tmp/ws",
+      },
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.200Z",
+        text: "[paperclip] Injected Codex skill from /home/user/.paperclip/skills/codex.md",
+      },
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.300Z",
+        text: "[paperclip] Loaded agent instructions file agents/coder/AGENTS.md",
       },
       {
         kind: "assistant",
@@ -80,5 +95,45 @@ describe("RunTranscriptView", () => {
       role: "assistant",
       text: "Working on the task.",
     });
+  });
+
+  it("keeps [paperclip] stderr containing error keywords visible", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "[paperclip] Fatal error: adapter crashed during execution",
+      },
+      {
+        kind: "assistant",
+        ts: "2026-03-12T00:00:01.000Z",
+        text: "Something went wrong.",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    const stderrBlock = blocks.find((b) => b.type === "event" && "label" in b && b.label === "stderr");
+    expect(stderrBlock).toBeDefined();
+  });
+
+  it("keeps non-paperclip stderr visible in nice mode", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "npm ERR! code ENOENT",
+      },
+      {
+        kind: "assistant",
+        ts: "2026-03-12T00:00:01.000Z",
+        text: "Investigating the error.",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    const stderrBlock = blocks.find((b) => b.type === "event" && "label" in b && b.label === "stderr");
+    expect(stderrBlock).toBeDefined();
   });
 });

--- a/ui/src/components/transcript/RunTranscriptView.test.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.test.tsx
@@ -58,7 +58,7 @@ describe("RunTranscriptView", () => {
     expect(html).toContain("<li>second</li>");
   });
 
-  it("hides all informational [paperclip] stderr from nice mode normalization", () => {
+  it("hides all informational [paperclip] stderr during normalization", () => {
     const entries: TranscriptEntry[] = [
       {
         kind: "stderr",
@@ -117,7 +117,7 @@ describe("RunTranscriptView", () => {
     expect(stderrBlock).toBeDefined();
   });
 
-  it("keeps non-paperclip stderr visible in nice mode", () => {
+  it("keeps non-paperclip stderr visible during normalization", () => {
     const entries: TranscriptEntry[] = [
       {
         kind: "stderr",
@@ -135,5 +135,49 @@ describe("RunTranscriptView", () => {
 
     const stderrBlock = blocks.find((b) => b.type === "event" && "label" in b && b.label === "stderr");
     expect(stderrBlock).toBeDefined();
+  });
+
+  it("keeps [paperclip] stderr containing warning keyword visible", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "[paperclip] Warning: adapter memory usage is high",
+      },
+      {
+        kind: "assistant",
+        ts: "2026-03-12T00:00:01.000Z",
+        text: "Continuing.",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    const stderrBlock = blocks.find((b) => b.type === "event" && "label" in b && b.label === "stderr");
+    expect(stderrBlock).toBeDefined();
+  });
+
+  it("hides [paperclip] stderr whose file path contains an error keyword but message is informational", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: "[paperclip] Loaded skill from /home/user/error-handler/codex.md",
+      },
+      {
+        kind: "assistant",
+        ts: "2026-03-12T00:00:01.000Z",
+        text: "Working on the task.",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "Working on the task.",
+    });
   });
 });

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -278,7 +278,10 @@ function parseSystemActivity(text: string): { activityId?: string; name: string;
 
 function shouldHideNiceModeStderr(text: string): boolean {
   const normalized = compactWhitespace(text).toLowerCase();
-  return normalized.startsWith("[paperclip] skipping saved session resume");
+  if (!normalized.startsWith("[paperclip]")) return false;
+  // Keep actual errors visible
+  if (/\b(error|fatal|panic|exception)\b/.test(normalized)) return false;
+  return true;
 }
 
 function groupCommandBlocks(blocks: TranscriptBlock[]): TranscriptBlock[] {

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -279,8 +279,10 @@ function parseSystemActivity(text: string): { activityId?: string; name: string;
 function shouldHideNiceModeStderr(text: string): boolean {
   const normalized = compactWhitespace(text).toLowerCase();
   if (!normalized.startsWith("[paperclip]")) return false;
-  // Keep actual errors visible
-  if (/\b(error|fatal|panic|exception)\b/.test(normalized)) return false;
+  // Keep actual errors/warnings visible; only check the portion before any file path
+  // to avoid false positives from keywords in path segments (e.g. /error-handler/).
+  const beforePath = normalized.split("/")[0];
+  if (/\b(error|fatal|panic|exception|warning)\b/.test(beforePath)) return false;
   return true;
 }
 

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -279,10 +279,10 @@ function parseSystemActivity(text: string): { activityId?: string; name: string;
 function shouldHideNiceModeStderr(text: string): boolean {
   const normalized = compactWhitespace(text).toLowerCase();
   if (!normalized.startsWith("[paperclip]")) return false;
-  // Keep actual errors/warnings visible; only check the portion before any file path
-  // to avoid false positives from keywords in path segments (e.g. /error-handler/).
-  const beforePath = normalized.split("/")[0];
-  if (/\b(error|fatal|panic|exception|warning)\b/.test(beforePath)) return false;
+  // Keep actual errors/warnings visible; strip file paths before checking for error
+  // keywords to avoid false positives from keywords in path segments (e.g. /error-handler/).
+  const withoutPaths = normalized.replace(/\/\S+/g, '');
+  if (/\b(error|fatal|panic|exception|warning)\b/.test(withoutPaths)) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Expands `shouldHideNiceModeStderr()` to filter all `[paperclip]` informational stderr messages in nice mode
- These are status messages (skill injection, workspace setup, session resume info) — not errors
- Actual errors (containing error/fatal/panic/exception) remain visible
- Adds test coverage for informational filtering, error preservation, and non-paperclip stderr

Fixes #716

## Test plan
- [x] `[paperclip]` informational messages hidden in nice mode
- [x] Non-paperclip stderr still displays
- [x] Actual paperclip errors/warnings remain visible
- [x] 3 new test cases pass
- [x] Existing tests pass