### PR TITLE
fix: add initdbFlags to EmbeddedPostgres constructor typings

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -83,6 +83,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -17,6 +17,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;


### PR DESCRIPTION
## Summary
- Add `initdbFlags?: string[]` to `EmbeddedPostgresCtor` option types in:
  - `server/src/index.ts`
  - `packages/db/src/migration-runtime.ts`
  - `cli/src/commands/worktree.ts`

This aligns constructor typings with existing callsites that pass `initdbFlags` to enforce UTF-8/locale initialization.

## Why
`pnpm --filter @paperclipai/server build` was failing with `TS2353` during Docker builds because `initdbFlags` was being passed to `new EmbeddedPostgres(...)` but was missing from the local constructor type definitions.

Fixes #737