### PR TITLE
fix(openclaw-gateway): handle challengePromise rejection to prevent crash

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -605,6 +605,7 @@ class GatewayWsClient {
       this.resolveChallenge = resolve;
       this.rejectChallenge = reject;
     });
+    this.challengePromise.catch(() => {});
   }
 
   async connect(


### PR DESCRIPTION
Fixes #727.

The `challengePromise` created in the `GatewayWsClient` constructor rejects on WebSocket close. If this rejection occurs before the promise is awaited (or if it's never awaited), Node.js triggers an UnhandledPromiseRejection, crashing the entire process. Adding a `.catch(() => {})` to the promise prevents this crash.