### PR TITLE
feat(server): add GET /api/tasks/:id for agent context lookup

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -322,6 +322,39 @@ export function issueRoutes(db: Db, storage: StorageService) {
     });
   });
 
+  // Agents receive PAPERCLIP_TASK_ID (which is an issue ID) as an env var but have no
+  // endpoint to fetch the task/issue body. GET /api/tasks/:id provides that context.
+  router.get("/tasks/:id", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Task not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const [ancestors, project, goal, mentionedProjectIds] = await Promise.all([
+      svc.getAncestors(issue.id),
+      issue.projectId ? projectsSvc.getById(issue.projectId) : null,
+      issue.goalId
+        ? goalsSvc.getById(issue.goalId)
+        : !issue.projectId
+          ? goalsSvc.getDefaultCompanyGoal(issue.companyId)
+          : null,
+      svc.findMentionedProjectIds(issue.id),
+    ]);
+    const mentionedProjects = mentionedProjectIds.length > 0
+      ? await projectsSvc.listByIds(issue.companyId, mentionedProjectIds)
+      : [];
+    res.json({
+      ...issue,
+      goalId: goal?.id ?? issue.goalId,
+      ancestors,
+      project: project ?? null,
+      goal: goal ?? null,
+      mentionedProjects,
+    });
+  });
+
   router.get("/issues/:id/heartbeat-context", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);


### PR DESCRIPTION
## Problem

Agents wake with `PAPERCLIP_TASK_ID` injected as an environment variable, but calling `GET /api/tasks/:id` returns a 404 — the route does not exist. This leaves agents unable to fetch the issue title, body, or goal context they need to act on an assigned task.

As reported in #683, agents try endpoints like:
- `GET $PAPERCLIP_API_URL/api/tasks/$PAPERCLIP_TASK_ID` → `{"error":"API route not found"}`

And are forced to either fail silently or ask the user to paste the task content manually.

## Solution

Add `GET /api/tasks/:id` as an alias that resolves the issue by ID and returns its full context — title, body, status, project, goal, and ancestors.

Uses the same `assertCompanyAccess` guard as the existing `GET /api/issues/:id` route, so agent JWT auth works out of the box with no additional auth changes needed.

## Changes

- `server/src/routes/issues.ts` — add `GET /tasks/:id` route

## Testing

With a running Paperclip instance and an agent that has `PAPERCLIP_TASK_ID` set:

```bash
curl -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
  $PAPERCLIP_API_URL/api/tasks/$PAPERCLIP_TASK_ID
```

Should return the full issue object instead of 404.

Fixes #683