### PR TITLE
fix(server): clear execution lock fields on release and checkout drop

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -83,6 +83,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -17,6 +17,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -751,12 +751,18 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {
@@ -1021,6 +1027,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Problem

When an issue is released or its assignee/status transitions away from `in_progress`, the checkout ownership fields (`assigneeAgentId`, `checkoutRunId`) were cleared but the execution lock fields (`executionRunId`, `executionAgentNameKey`, `executionLockedAt`) were left behind as stale artifacts.

This causes run-ownership conflicts when agents restart or crash and `activeRun` is null — the stale execution lock makes the issue appear still checked out.

## Fix

Two places in `server/src/services/issues.ts`:

1. **`release()`** — clear `executionRunId`, `executionAgentNameKey`, `executionLockedAt` alongside `assigneeAgentId` and `checkoutRunId`

2. **`update()`** — clear execution lock fields when:
   - status transitions away from `in_progress`
   - assignee changes (checkout ownership drops)

## Testing

1. Check out an issue with an agent
2. Kill the agent process (simulating crash)
3. Release the issue via API
4. Verify `executionRunId`, `executionAgentNameKey`, `executionLockedAt` are all null on the returned issue

Fixes #725