### PR TITLE
fix(types): add initdbFlags to EmbeddedPostgresCtor in db, server, and cli

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -83,6 +83,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -17,6 +17,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;


### PR DESCRIPTION
## Summary
PR #645 added `initdbFlags` to all three `EmbeddedPostgres` instantiation sites but did not update the local `EmbeddedPostgresCtor` type definitions, causing `TS2353` typecheck failures across the repo.

Fixes the type in all three affected files:
- `packages/db/src/migration-runtime.ts`
- `server/src/index.ts`
- `cli/src/commands/worktree.ts`

## Test plan
- [x] `pnpm -r typecheck` passes with no errors