### PR TITLE
feat: show agent names instead of IDs in failed runs

### DIFF
--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -9,6 +9,7 @@ export interface HeartbeatRun {
   id: string;
   companyId: string;
   agentId: string;
+  agentName?: string | null;
   invocationSource: HeartbeatInvocationSource;
   triggerDetail: WakeupTriggerDetail | null;
   status: HeartbeatRunStatus;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1286,7 +1286,49 @@ export function agentRoutes(db: Db) {
     const agentId = req.query.agentId as string | undefined;
     const limitParam = req.query.limit as string | undefined;
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
-    const runs = await heartbeat.list(companyId, agentId, limit);
+
+    const query = db
+      .select({
+        id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
+        agentName: agentsTable.name,
+        invocationSource: heartbeatRuns.invocationSource,
+        triggerDetail: heartbeatRuns.triggerDetail,
+        status: heartbeatRuns.status,
+        startedAt: heartbeatRuns.startedAt,
+        finishedAt: heartbeatRuns.finishedAt,
+        error: heartbeatRuns.error,
+        wakeupRequestId: heartbeatRuns.wakeupRequestId,
+        exitCode: heartbeatRuns.exitCode,
+        signal: heartbeatRuns.signal,
+        usageJson: heartbeatRuns.usageJson,
+        resultJson: heartbeatRuns.resultJson,
+        sessionIdBefore: heartbeatRuns.sessionIdBefore,
+        sessionIdAfter: heartbeatRuns.sessionIdAfter,
+        logStore: heartbeatRuns.logStore,
+        logRef: heartbeatRuns.logRef,
+        logBytes: heartbeatRuns.logBytes,
+        logSha256: heartbeatRuns.logSha256,
+        logCompressed: heartbeatRuns.logCompressed,
+        stdoutExcerpt: heartbeatRuns.stdoutExcerpt,
+        stderrExcerpt: heartbeatRuns.stderrExcerpt,
+        errorCode: heartbeatRuns.errorCode,
+        externalRunId: heartbeatRuns.externalRunId,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        createdAt: heartbeatRuns.createdAt,
+        updatedAt: heartbeatRuns.updatedAt,
+      })
+      .from(heartbeatRuns)
+      .leftJoin(agentsTable, eq(heartbeatRuns.agentId, agentsTable.id))
+      .where(
+        agentId
+          ? and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId))
+          : eq(heartbeatRuns.companyId, companyId),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt));
+
+    const runs = limit ? await query.limit(limit) : await query;
     res.json(runs);
   });
 

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
+import { activityLog, agents, heartbeatRuns, issues } from "@paperclipai/db";
 
 export interface ActivityFilters {
   companyId: string;
@@ -66,6 +66,7 @@ export function activityService(db: Db) {
           runId: heartbeatRuns.id,
           status: heartbeatRuns.status,
           agentId: heartbeatRuns.agentId,
+          agentName: agents.name,
           startedAt: heartbeatRuns.startedAt,
           finishedAt: heartbeatRuns.finishedAt,
           createdAt: heartbeatRuns.createdAt,
@@ -74,6 +75,7 @@ export function activityService(db: Db) {
           resultJson: heartbeatRuns.resultJson,
         })
         .from(heartbeatRuns)
+        .leftJoin(agents, eq(heartbeatRuns.agentId, agents.id))
         .where(
           and(
             eq(heartbeatRuns.companyId, companyId),

--- a/ui/src/api/activity.ts
+++ b/ui/src/api/activity.ts
@@ -5,6 +5,7 @@ export interface RunForIssue {
   runId: string;
   status: string;
   agentId: string;
+  agentName: string | null;
   startedAt: string | null;
   finishedAt: string | null;
   createdAt: string;

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -20,6 +20,7 @@ interface LinkedRunItem {
   runId: string;
   status: string;
   agentId: string;
+  agentName?: string | null;
   createdAt: Date | string;
   startedAt: Date | string | null;
 }
@@ -138,7 +139,7 @@ const TimelineList = memo(function TimelineList({
               <div className="flex items-center justify-between mb-2">
                 <Link to={`/agents/${run.agentId}`} className="hover:underline">
                   <Identity
-                    name={agentMap?.get(run.agentId)?.name ?? run.agentId.slice(0, 8)}
+                    name={agentMap?.get(run.agentId)?.name ?? run.agentName ?? run.agentId.slice(0, 8)}
                     size="sm"
                   />
                 </Link>

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -249,7 +249,7 @@ function FailedRunCard({
               {linkedAgentName ? (
                 <Identity name={linkedAgentName} size="sm" />
               ) : (
-                <span className="text-sm font-medium">Agent {run.agentId.slice(0, 8)}</span>
+                <span className="text-sm font-medium">{run.agentName ?? `Agent ${run.agentId.slice(0, 8)}`}</span>
               )}
               <StatusBadge status={run.status} />
             </div>


### PR DESCRIPTION
## Summary
- Join agents table in `/companies/:companyId/heartbeat-runs` and `/issues/:issueId/runs` API endpoints to include `agentName` in responses
- Add optional `agentName` field to shared `HeartbeatRun` type
- Update `FailedRunCard` (Inbox) and `CommentThread` UI components to display agent names instead of truncated UUIDs

## Test plan
- [ ] Verify Inbox page shows agent names on failed run cards instead of 8-char IDs
- [ ] Verify issue detail page CommentThread shows agent names on linked runs
- [ ] Verify TypeScript compiles cleanly (shared, server, ui)
- [ ] Verify existing agent name resolution still works as primary source

🤖 Generated with [Claude Code](https://claude.com/claude-code)