### PR TITLE
fix(runtime): enforce single-instance run + deterministic readiness

### DIFF
--- a/cli/src/__tests__/run-runtime-guard.test.ts
+++ b/cli/src/__tests__/run-runtime-guard.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawn } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
 import { acquireRunLock, isPidAlive, waitForReadiness } from "../commands/run-runtime-guard.js";
 
@@ -34,12 +35,18 @@ describe("run-runtime-guard", () => {
     lockA.release();
   });
 
-  it("replaces stale lock", () => {
+  it("replaces stale lock", async () => {
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 10)"]);
+    const deadPid = child.pid ?? -1;
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
+
     const dir = mkTempDir();
     const lockPath = path.join(dir, "run.lock.json");
     fs.writeFileSync(
       lockPath,
-      JSON.stringify({ pid: 999999, startedAt: new Date().toISOString(), command: "x", instanceId: "default" }),
+      JSON.stringify({ pid: deadPid, startedAt: new Date().toISOString(), command: "x", instanceId: "default" }),
       "utf8",
     );
     const lock = acquireRunLock(dir, "default");
@@ -84,6 +91,22 @@ describe("run-runtime-guard", () => {
     expect(result.ok).toBe(false);
     expect(result.apiOk).toBe(true);
     expect(result.uiOk).toBe(false);
+  });
+
+  it("waitForReadiness passes in api-only mode when api is ok", async () => {
+    const fetcher = async (): Promise<Response> => new Response("ok", { status: 200 });
+
+    const result = await waitForReadiness({
+      baseUrl: "http://127.0.0.1:3100",
+      mode: "api-only",
+      timeoutMs: 100,
+      intervalMs: 10,
+      fetcher: fetcher as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.apiOk).toBe(true);
+    expect(result.uiOk).toBe(true);
   });
 
   it("isPidAlive works for current process", () => {

--- a/cli/src/__tests__/run-runtime-guard.test.ts
+++ b/cli/src/__tests__/run-runtime-guard.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireRunLock, isPidAlive, waitForReadiness } from "../commands/run-runtime-guard.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function mkTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pc-run-guard-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe("run-runtime-guard", () => {
+  it("acquires and releases run lock", () => {
+    const dir = mkTempDir();
+    const lock = acquireRunLock(dir, "default");
+    expect(fs.existsSync(lock.lockPath)).toBe(true);
+    lock.release();
+    expect(fs.existsSync(lock.lockPath)).toBe(false);
+  });
+
+  it("blocks when existing live lock owner exists", () => {
+    const dir = mkTempDir();
+    const lockA = acquireRunLock(dir, "default");
+    expect(() => acquireRunLock(dir, "default")).toThrow(/Another paperclipai run appears active/);
+    lockA.release();
+  });
+
+  it("replaces stale lock", () => {
+    const dir = mkTempDir();
+    const lockPath = path.join(dir, "run.lock.json");
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 999999, startedAt: new Date().toISOString(), command: "x", instanceId: "default" }),
+      "utf8",
+    );
+    const lock = acquireRunLock(dir, "default");
+    const payload = JSON.parse(fs.readFileSync(lockPath, "utf8")) as { pid: number };
+    expect(payload.pid).toBe(process.pid);
+    lock.release();
+  });
+
+  it("waitForReadiness passes in full mode when api and ui are ok", async () => {
+    const fetcher = async (url: string | URL | Request): Promise<Response> => {
+      const u = String(url);
+      return new Response("ok", { status: u.endsWith("/api/health") || u.endsWith("/") ? 200 : 404 });
+    };
+
+    const result = await waitForReadiness({
+      baseUrl: "http://127.0.0.1:3100",
+      mode: "full",
+      timeoutMs: 100,
+      intervalMs: 10,
+      fetcher: fetcher as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.apiOk).toBe(true);
+    expect(result.uiOk).toBe(true);
+  });
+
+  it("waitForReadiness fails in full mode if ui never becomes available", async () => {
+    const fetcher = async (url: string | URL | Request): Promise<Response> => {
+      const u = String(url);
+      return new Response("x", { status: u.endsWith("/api/health") ? 200 : 404 });
+    };
+
+    const result = await waitForReadiness({
+      baseUrl: "http://127.0.0.1:3100",
+      mode: "full",
+      timeoutMs: 60,
+      intervalMs: 10,
+      fetcher: fetcher as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.apiOk).toBe(true);
+    expect(result.uiOk).toBe(false);
+  });
+
+  it("isPidAlive works for current process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+});

--- a/cli/src/commands/run-runtime-guard.ts
+++ b/cli/src/commands/run-runtime-guard.ts
@@ -19,7 +19,9 @@ export function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") return true;
     return false;
   }
 }
@@ -53,8 +55,20 @@ export function acquireRunLock(instanceRoot: string, instanceId: string): RunLoc
         `Another paperclipai run appears active for instance '${instanceId}' (pid=${existing.pid}, startedAt=${existing.startedAt}).`,
       );
     }
-    // stale/corrupt lock: replace
-    fs.writeFileSync(lockPath, JSON.stringify(state, null, 2), { encoding: "utf8" });
+
+    // stale/corrupt lock: attempt atomic re-acquire first
+    try {
+      fs.rmSync(lockPath, { force: true });
+      fs.writeFileSync(lockPath, JSON.stringify(state, null, 2), { encoding: "utf8", flag: "wx" });
+    } catch {
+      const contested = readLock(lockPath);
+      if (contested && isPidAlive(contested.pid)) {
+        throw new Error(
+          `Another paperclipai run appears active for instance '${instanceId}' (pid=${contested.pid}, startedAt=${contested.startedAt}).`,
+        );
+      }
+      throw new Error(`Failed to acquire run lock for instance '${instanceId}'. Retry startup.`);
+    }
   }
 
   let released = false;

--- a/cli/src/commands/run-runtime-guard.ts
+++ b/cli/src/commands/run-runtime-guard.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type RunLockState = {
+  pid: number;
+  startedAt: string;
+  command: string;
+  instanceId: string;
+};
+
+export type RunLockHandle = {
+  lockPath: string;
+  state: RunLockState;
+  release: () => void;
+};
+
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readLock(lockPath: string): RunLockState | null {
+  try {
+    const raw = fs.readFileSync(lockPath, "utf8");
+    return JSON.parse(raw) as RunLockState;
+  } catch {
+    return null;
+  }
+}
+
+export function acquireRunLock(instanceRoot: string, instanceId: string): RunLockHandle {
+  fs.mkdirSync(instanceRoot, { recursive: true });
+  const lockPath = path.join(instanceRoot, "run.lock.json");
+
+  const state: RunLockState = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    command: process.argv.join(" "),
+    instanceId,
+  };
+
+  try {
+    fs.writeFileSync(lockPath, JSON.stringify(state, null, 2), { encoding: "utf8", flag: "wx" });
+  } catch {
+    const existing = readLock(lockPath);
+    if (existing && isPidAlive(existing.pid)) {
+      throw new Error(
+        `Another paperclipai run appears active for instance '${instanceId}' (pid=${existing.pid}, startedAt=${existing.startedAt}).`,
+      );
+    }
+    // stale/corrupt lock: replace
+    fs.writeFileSync(lockPath, JSON.stringify(state, null, 2), { encoding: "utf8" });
+  }
+
+  let released = false;
+  return {
+    lockPath,
+    state,
+    release: () => {
+      if (released) return;
+      released = true;
+      try {
+        const latest = readLock(lockPath);
+        if (!latest || latest.pid === process.pid) {
+          fs.rmSync(lockPath, { force: true });
+        }
+      } catch {
+        // best effort cleanup only
+      }
+    },
+  };
+}
+
+export type ReadinessMode = "full" | "api-only";
+
+export type ReadinessResult = {
+  ok: boolean;
+  apiOk: boolean;
+  uiOk: boolean;
+  checks: number;
+  mode: ReadinessMode;
+};
+
+export async function waitForReadiness(opts: {
+  baseUrl: string;
+  mode: ReadinessMode;
+  timeoutMs?: number;
+  intervalMs?: number;
+  fetcher?: typeof fetch;
+}): Promise<ReadinessResult> {
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const intervalMs = opts.intervalMs ?? 1_500;
+  const fetcher = opts.fetcher ?? fetch;
+  const deadline = Date.now() + timeoutMs;
+
+  let checks = 0;
+  let apiOk = false;
+  let uiOk = opts.mode === "api-only";
+
+  while (Date.now() < deadline) {
+    checks += 1;
+    apiOk = await probe(`${opts.baseUrl.replace(/\/$/, "")}/api/health`, fetcher);
+    if (opts.mode === "full") {
+      uiOk = await probe(`${opts.baseUrl.replace(/\/$/, "")}/`, fetcher);
+    }
+
+    if (apiOk && uiOk) {
+      return { ok: true, apiOk, uiOk, checks, mode: opts.mode };
+    }
+
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  return { ok: false, apiOk, uiOk, checks, mode: opts.mode };
+}
+
+async function probe(url: string, fetcher: typeof fetch): Promise<boolean> {
+  try {
+    const res = await fetcher(url, { method: "GET" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -51,8 +51,18 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   }
 
   const cleanup = () => lock.release();
-  process.once("SIGINT", cleanup);
-  process.once("SIGTERM", cleanup);
+  const onSigint = () => {
+    cleanup();
+    process.removeListener("SIGINT", onSigint);
+    process.kill(process.pid, "SIGINT");
+  };
+  const onSigterm = () => {
+    cleanup();
+    process.removeListener("SIGTERM", onSigterm);
+    process.kill(process.pid, "SIGTERM");
+  };
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
   process.once("exit", cleanup);
 
   const configPath = resolveConfigPath(opts.config);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -15,6 +15,7 @@ import {
   resolvePaperclipHomeDir,
   resolvePaperclipInstanceId,
 } from "../config/home.js";
+import { acquireRunLock, waitForReadiness, type ReadinessMode, type RunLockHandle } from "./run-runtime-guard.js";
 
 interface RunOptions {
   config?: string;
@@ -40,6 +41,20 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const paths = describeLocalInstancePaths(instanceId);
   fs.mkdirSync(paths.instanceRoot, { recursive: true });
 
+  let lock: RunLockHandle;
+  try {
+    lock = acquireRunLock(paths.instanceRoot, instanceId);
+  } catch (err) {
+    p.log.error(formatError(err));
+    p.log.message("If this is stale, stop the old process or remove the stale run lock and retry.");
+    process.exit(1);
+  }
+
+  const cleanup = () => lock.release();
+  process.once("SIGINT", cleanup);
+  process.once("SIGTERM", cleanup);
+  process.once("exit", cleanup);
+
   const configPath = resolveConfigPath(opts.config);
   process.env.PAPERCLIP_CONFIG = configPath;
   loadPaperclipEnvFile(configPath);
@@ -48,6 +63,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   p.log.message(pc.dim(`Home: ${paths.homeDir}`));
   p.log.message(pc.dim(`Instance: ${paths.instanceId}`));
   p.log.message(pc.dim(`Config: ${configPath}`));
+  p.log.message(pc.dim(`Lock: ${lock.lockPath} (pid ${lock.state.pid})`));
 
   if (!configExists(configPath)) {
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
@@ -80,6 +96,23 @@ export async function runCommand(opts: RunOptions): Promise<void> {
 
   p.log.step("Starting Paperclip server...");
   const startedServer = await importServerEntry();
+
+  const openHost = startedServer.host === "0.0.0.0" || startedServer.host === "::" ? "127.0.0.1" : startedServer.host;
+  const baseUrl = `http://${openHost}:${startedServer.listenPort}`;
+  const readinessMode: ReadinessMode = config.server.serveUi || process.env.PAPERCLIP_UI_DEV_MIDDLEWARE === "true"
+    ? "full"
+    : "api-only";
+
+  p.log.step(`Waiting for readiness (${readinessMode})...`);
+  const readiness = await waitForReadiness({ baseUrl, mode: readinessMode, timeoutMs: 90_000, intervalMs: 1_500 });
+  if (!readiness.ok) {
+    p.log.error(
+      `Startup readiness failed after ${readiness.checks} checks (apiOk=${readiness.apiOk}, uiOk=${readiness.uiOk}, mode=${readiness.mode}).`,
+    );
+    p.log.message(`Check logs and status at ${pc.cyan(baseUrl)} and ${pc.cyan(`${baseUrl}/api/health`)}`);
+    process.exit(1);
+  }
+  p.log.success(`Readiness passed (apiOk=${readiness.apiOk}, uiOk=${readiness.uiOk}, mode=${readiness.mode})`);
 
   if (shouldGenerateBootstrapInviteAfterStart(config)) {
     p.log.step("Generating bootstrap CEO invite");


### PR DESCRIPTION
## Summary
This PR hardens `paperclipai run` startup reliability by enforcing single-instance ownership and adding deterministic readiness gating.

## Why
During OpenClaw + Paperclip setup/recovery runs, we hit repeated split-runtime failures:
- multiple `paperclipai run` processes active at the same time
- API endpoint healthy while UI route behavior was inconsistent
- false-positive "running" state from an operator perspective

## What changed
- Added runtime lock support:
  - new file: `cli/src/commands/run-runtime-guard.ts`
  - lock file: `<instanceRoot>/run.lock.json`
  - blocks concurrent `paperclipai run` for same instance
  - stale lock replacement when previous PID is dead
  - lock cleanup on `SIGINT` / `SIGTERM` / process exit

- Added readiness gating in `run` command:
  - `full` mode (default): requires both API and UI probes to pass
  - `api-only` mode: requires API probe only
  - startup exits non-zero with diagnostics when readiness times out

- Improved startup logs:
  - lock path + owner pid
  - readiness mode and final readiness result

## Tests
Added: `cli/src/__tests__/run-runtime-guard.test.ts`
- lock acquire + release
- conflict on second live owner
- stale lock replacement
- readiness pass/fail behavior
- PID liveness helper

Run command used:
```bash
cd cli && pnpm exec vitest run src/__tests__/run-runtime-guard.test.ts
```

## Notes
`pnpm typecheck` currently reports existing unrelated errors in the repo (e.g. `initdbFlags` typing in other files). This PR does not touch those code paths.

## Follow-ups
- PR #2: explicit claim-key lifecycle validation
- PR #3: `doctor --openclaw` integration checks
