### PR TITLE
feat(openclaw-gateway): add claimedApiKeyPath + validation-first wake guidance

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -36,6 +36,7 @@ Request behavior fields:
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
+- claimedApiKeyPath (string, optional): path to JSON file containing \`{ "token": "..." }\` used by OpenClaw runs for \`PAPERCLIP_API_KEY\`
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -335,8 +335,17 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+function resolveClaimedApiKeyPath(raw: unknown): string {
+  const value = nonEmpty(raw);
+  if (!value) return "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  return value;
+}
+
+function buildWakeText(
+  payload: WakePayload,
+  paperclipEnv: Record<string, string>,
+  claimedApiKeyPath: string,
+): string {
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -369,7 +378,16 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     ...envLines,
     `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
     "",
-    `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    `Before any API call, validate and load PAPERCLIP_API_KEY from ${claimedApiKeyPath}:`,
+    "- File must exist and be valid JSON.",
+    "- JSON must contain non-empty string field: token.",
+    `- If missing/invalid, stop and report blocker with exact path ${claimedApiKeyPath}.`,
+    "",
+    "Reference shell snippet:",
+    `- test -f ${claimedApiKeyPath}`,
+    `- TOKEN=$(jq -r '.token // empty' ${claimedApiKeyPath})`,
+    "- test -n \"$TOKEN\"",
+    "- export PAPERCLIP_API_KEY=\"$TOKEN\"",
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,
@@ -1052,7 +1070,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
-  const wakeText = buildWakeText(wakePayload, paperclipEnv);
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
+  const wakeText = buildWakeText(wakePayload, paperclipEnv, claimedApiKeyPath);
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -150,6 +150,22 @@ export function OpenClawGatewayConfigFields({
             />
           </Field>
 
+          <Field label="Claimed API key file path">
+            <DraftInput
+              value={
+                eff(
+                  "adapterConfig",
+                  "claimedApiKeyPath",
+                  String(config.claimedApiKeyPath ?? ""),
+                )
+              }
+              onCommit={(v) => mark("adapterConfig", "claimedApiKeyPath", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="~/.openclaw/workspace/paperclip-claimed-api-key.json"
+            />
+          </Field>
+
           <Field label="Session strategy">
             <select
               value={sessionStrategy}


### PR DESCRIPTION
## Summary
Improve OpenClaw Gateway wake guidance by making claimed API key handling explicit, configurable, and validation-first.

## Why
A recurring failure mode was missing/invalid `paperclip-claimed-api-key.json`, discovered only after a run had already started. This change makes the dependency explicit in adapter config and in wake instructions.

## What changed
- Added configurable adapter field:
  - `claimedApiKeyPath` (optional)
  - default remains `~/.openclaw/workspace/paperclip-claimed-api-key.json`

- Updated wake-text generation to:
  - include path-specific validation instructions
  - require file existence + JSON validity + non-empty `token`
  - provide concrete shell snippet (`test -f`, `jq`, export token)
  - instruct run to stop and report blocker if invalid/missing

- Exposed the field in adapter UI config panel:
  - "Claimed API key file path"

- Updated adapter documentation string in `src/index.ts`.

## Validation
- `packages/adapters/openclaw-gateway`: `pnpm typecheck` ✅
- `ui`: `pnpm typecheck` ✅

## Notes
This PR is intentionally scoped to guidance + config surface. It does not yet add a full `paperclipai keys ...` command lifecycle (planned follow-up).
