### PR TITLE
feat(openclaw-gateway): improve claimed API key guidance in wake flow

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -36,6 +36,7 @@ Request behavior fields:
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
+- claimedApiKeyPath (string, optional): path hint for the claimed Paperclip API key JSON used in wake instructions
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -335,8 +335,17 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+function resolveClaimedApiKeyPath(value: unknown): string {
+  const raw = nonEmpty(value);
+  if (!raw) return "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  return raw;
+}
+
+function buildWakeText(
+  payload: WakePayload,
+  paperclipEnv: Record<string, string>,
+  claimedApiKeyPath: string,
+): string {
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -370,6 +379,10 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
     "",
     `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    "Preflight key checks (must pass before API calls):",
+    `- test -f ${claimedApiKeyPath}`,
+    `- parse token from ${claimedApiKeyPath} JSON: {\"token\":\"pcp_...\"}`,
+    "- export PAPERCLIP_API_KEY to run context and verify non-empty",
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,
@@ -1052,7 +1065,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
-  const wakeText = buildWakeText(wakePayload, paperclipEnv);
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
+  const wakeText = buildWakeText(wakePayload, paperclipEnv, claimedApiKeyPath);
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -336,9 +336,16 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
 }
 
 function resolveClaimedApiKeyPath(value: unknown): string {
+  const fallback = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const raw = nonEmpty(value);
-  if (!raw) return "~/.openclaw/workspace/paperclip-claimed-api-key.json";
-  return raw;
+  if (!raw) return fallback;
+  // Keep path hints shell-safe for instruction text rendered to remote agents.
+  const safePath = /^[~./A-Za-z0-9_\- ]+$/.test(raw);
+  return safePath ? raw : fallback;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 function buildWakeText(
@@ -368,6 +375,7 @@ function buildWakeText(
 
   const issueIdHint = payload.taskId ?? payload.issueId ?? "";
   const apiBaseHint = paperclipEnv.PAPERCLIP_API_URL ?? "<set PAPERCLIP_API_URL>";
+  const quotedClaimedApiKeyPath = shellQuote(claimedApiKeyPath);
 
   const lines = [
     "Paperclip wake event for a cloud adapter.",
@@ -380,8 +388,8 @@ function buildWakeText(
     "",
     `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
     "Preflight key checks (must pass before API calls):",
-    `- test -f ${claimedApiKeyPath}`,
-    `- parse token from ${claimedApiKeyPath} JSON: {\"token\":\"pcp_...\"}`,
+    `- test -f ${quotedClaimedApiKeyPath}`,
+    `- parse token from ${quotedClaimedApiKeyPath} JSON: {\"token\":\"pcp_...\"}`,
     "- export PAPERCLIP_API_KEY to run context and verify non-empty",
     "",
     `api_base=${apiBaseHint}`,

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -150,6 +150,22 @@ export function OpenClawGatewayConfigFields({
             />
           </Field>
 
+          <Field label="Claimed API key path hint">
+            <DraftInput
+              value={
+                eff(
+                  "adapterConfig",
+                  "claimedApiKeyPath",
+                  String(config.claimedApiKeyPath ?? ""),
+                )
+              }
+              onCommit={(v) => mark("adapterConfig", "claimedApiKeyPath", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="~/.openclaw/workspace/paperclip-claimed-api-key.json"
+            />
+          </Field>
+
           <Field label="Session strategy">
             <select
               value={sessionStrategy}


### PR DESCRIPTION
## Summary
Improves OpenClaw gateway wake instructions by making claimed Paperclip API key handling explicit and configurable.

## Changes
- Added optional adapter config hint:
  - `claimedApiKeyPath` (string)
- Wake instructions now include explicit preflight checks for key file handling:
  - key file existence
  - expected JSON schema (`{"token":"pcp_..."}`)
  - export and non-empty verification of `PAPERCLIP_API_KEY`
- UI adapter config form now exposes **Claimed API key path hint**.
- Adapter docs updated to include the new config field.

## Why
A recurring failure mode was missing or malformed `paperclip-claimed-api-key.json` during wake execution. This change makes setup expectations explicit inside runtime instructions and allows non-default key file locations.

## Validation
- `pnpm -C packages/adapters/openclaw-gateway typecheck`
- `pnpm -C ui typecheck`
