### PR TITLE
feat(doctor): detect and repair stale runtime run lock

### DIFF
--- a/cli/src/__tests__/runtime-lock-check.test.ts
+++ b/cli/src/__tests__/runtime-lock-check.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runtimeLockCheck } from "../checks/runtime-lock-check.js";
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const p of cleanup.splice(0)) {
+    fs.rmSync(p, { recursive: true, force: true });
+  }
+  delete process.env.PAPERCLIP_HOME;
+  delete process.env.PAPERCLIP_INSTANCE_ID;
+});
+
+function setupHome(instanceId = "default"): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "pc-home-"));
+  cleanup.push(home);
+  process.env.PAPERCLIP_HOME = home;
+  process.env.PAPERCLIP_INSTANCE_ID = instanceId;
+  fs.mkdirSync(path.join(home, "instances", instanceId), { recursive: true });
+  return home;
+}
+
+describe("runtimeLockCheck", () => {
+  it("passes when no lock file", () => {
+    setupHome();
+    const r = runtimeLockCheck();
+    expect(r.status).toBe("pass");
+  });
+
+  it("warns and repair removes stale lock", async () => {
+    const home = setupHome();
+    const lock = path.join(home, "instances", "default", "run.lock.json");
+    fs.writeFileSync(lock, JSON.stringify({ pid: 999999, startedAt: new Date().toISOString() }), "utf8");
+
+    const r = runtimeLockCheck();
+    expect(r.status).toBe("warn");
+    expect(typeof r.repair).toBe("function");
+    await r.repair?.();
+    expect(fs.existsSync(lock)).toBe(false);
+  });
+
+  it("warns on live lock", () => {
+    const home = setupHome();
+    const lock = path.join(home, "instances", "default", "run.lock.json");
+    fs.writeFileSync(lock, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }), "utf8");
+
+    const r = runtimeLockCheck();
+    expect(r.status).toBe("warn");
+    expect(r.message).toContain("active");
+  });
+});

--- a/cli/src/__tests__/runtime-lock-check.test.ts
+++ b/cli/src/__tests__/runtime-lock-check.test.ts
@@ -1,12 +1,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runtimeLockCheck } from "../checks/runtime-lock-check.js";
 
 const cleanup: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const p of cleanup.splice(0)) {
     fs.rmSync(p, { recursive: true, force: true });
   }
@@ -31,9 +33,15 @@ describe("runtimeLockCheck", () => {
   });
 
   it("warns and repair removes stale lock", async () => {
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 10)"]);
+    const deadPid = child.pid ?? -1;
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
+
     const home = setupHome();
     const lock = path.join(home, "instances", "default", "run.lock.json");
-    fs.writeFileSync(lock, JSON.stringify({ pid: 999999, startedAt: new Date().toISOString() }), "utf8");
+    fs.writeFileSync(lock, JSON.stringify({ pid: deadPid, startedAt: new Date().toISOString() }), "utf8");
 
     const r = runtimeLockCheck();
     expect(r.status).toBe("warn");
@@ -50,5 +58,34 @@ describe("runtimeLockCheck", () => {
     const r = runtimeLockCheck();
     expect(r.status).toBe("warn");
     expect(r.message).toContain("active");
+  });
+
+  it("treats EPERM as live process", () => {
+    const home = setupHome();
+    const lock = path.join(home, "instances", "default", "run.lock.json");
+    fs.writeFileSync(lock, JSON.stringify({ pid: 12345, startedAt: new Date().toISOString() }), "utf8");
+
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("not permitted") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+
+    const r = runtimeLockCheck();
+    expect(r.status).toBe("warn");
+    expect(r.canRepair).toBe(false);
+    expect(r.message).toContain("active");
+  });
+
+  it("warns and repairs corrupt lock file", async () => {
+    const home = setupHome();
+    const lock = path.join(home, "instances", "default", "run.lock.json");
+    fs.writeFileSync(lock, "not-json", "utf8");
+
+    const r = runtimeLockCheck();
+    expect(r.status).toBe("warn");
+    expect(r.canRepair).toBe(true);
+    await r.repair?.();
+    expect(fs.existsSync(lock)).toBe(false);
   });
 });

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -16,3 +16,4 @@ export { logCheck } from "./log-check.js";
 export { portCheck } from "./port-check.js";
 export { secretsCheck } from "./secrets-check.js";
 export { storageCheck } from "./storage-check.js";
+export { runtimeLockCheck } from "./runtime-lock-check.js";

--- a/cli/src/checks/runtime-lock-check.ts
+++ b/cli/src/checks/runtime-lock-check.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { CheckResult } from "./index.js";
+import { describeLocalInstancePaths, resolvePaperclipInstanceId } from "../config/home.js";
+
+type LockPayload = {
+  pid?: number;
+  startedAt?: string;
+  instanceId?: string;
+};
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function runtimeLockCheck(instance?: string): CheckResult {
+  const instanceId = resolvePaperclipInstanceId(instance);
+  const paths = describeLocalInstancePaths(instanceId);
+  const lockPath = path.join(paths.instanceRoot, "run.lock.json");
+
+  if (!fs.existsSync(lockPath)) {
+    return {
+      name: "Runtime lock",
+      status: "pass",
+      message: "No active run lock detected",
+      canRepair: false,
+    };
+  }
+
+  let payload: LockPayload = {};
+  try {
+    payload = JSON.parse(fs.readFileSync(lockPath, "utf8")) as LockPayload;
+  } catch {
+    return {
+      name: "Runtime lock",
+      status: "warn",
+      message: `Lock file exists but is unreadable: ${lockPath}`,
+      canRepair: true,
+      repairHint: "Remove stale/corrupt lock file and retry",
+      repair: () => {
+        fs.rmSync(lockPath, { force: true });
+      },
+    };
+  }
+
+  const pid = typeof payload.pid === "number" ? payload.pid : -1;
+  if (isPidAlive(pid)) {
+    return {
+      name: "Runtime lock",
+      status: "warn",
+      message: `Another paperclipai run appears active (pid=${pid}, lock=${lockPath})`,
+      canRepair: false,
+      repairHint: "Stop active run before starting another instance",
+    };
+  }
+
+  return {
+    name: "Runtime lock",
+    status: "warn",
+    message: `Stale run lock detected (pid=${pid}, lock=${lockPath})`,
+    canRepair: true,
+    repairHint: "Remove stale lock and retry",
+    repair: () => {
+      fs.rmSync(lockPath, { force: true });
+    },
+  };
+}

--- a/cli/src/checks/runtime-lock-check.ts
+++ b/cli/src/checks/runtime-lock-check.ts
@@ -14,7 +14,9 @@ function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") return true;
     return false;
   }
 }

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -12,6 +12,7 @@ import {
   portCheck,
   secretsCheck,
   storageCheck,
+  runtimeLockCheck,
   type CheckResult,
 } from "../checks/index.js";
 import { loadPaperclipEnvFile } from "../config/env.js";
@@ -115,7 +116,16 @@ export async function doctor(opts: {
     }),
   );
 
-  // 9. Port check
+  // 9. Runtime lock check
+  results.push(
+    await runRepairableCheck({
+      run: () => runtimeLockCheck(),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 10. Port check
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);


### PR DESCRIPTION
## Summary
Add a doctor check that inspects runtime run-lock state and helps recover from stale locks.

## Why
A recurring reliability issue is stale or conflicting `run.lock.json` state, which causes confusing startup behavior on reruns.

## What changed
- New check: `runtimeLockCheck`
  - inspects `<instanceRoot>/run.lock.json`
  - pass: no lock
  - warn: active lock owner PID appears alive
  - warn + repairable: stale lock PID appears dead
  - warn + repairable: unreadable/corrupt lock file
- Wired into `paperclipai doctor` flow before port check.
- Added tests for no lock, stale lock repair, and live lock warning.

## Validation
- `cd cli && pnpm exec vitest run src/__tests__/runtime-lock-check.test.ts` ✅
