### PR TITLE
ui: point Documentation sidebar link to docs.paperclip.ing

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -5,7 +5,6 @@ import { Link, Outlet, useLocation, useNavigate, useParams } from "@/lib/router"
 import { CompanyRail } from "./CompanyRail";
 import { Sidebar } from "./Sidebar";
 import { InstanceSidebar } from "./InstanceSidebar";
-import { SidebarNavItem } from "./SidebarNavItem";
 import { BreadcrumbBar } from "./BreadcrumbBar";
 import { PropertiesPanel } from "./PropertiesPanel";
 import { CommandPalette } from "./CommandPalette";
@@ -248,12 +247,15 @@ export function Layout() {
           </div>
           <div className="border-t border-r border-border px-3 py-2 bg-background">
             <div className="flex items-center gap-1">
-              <SidebarNavItem
-                to="/docs"
-                label="Documentation"
-                icon={BookOpen}
-                className="flex-1 min-w-0"
-              />
+              <a
+                href="https://docs.paperclip.ing/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
+              >
+                <BookOpen className="h-4 w-4 shrink-0" />
+                <span className="truncate">Documentation</span>
+              </a>
               <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                 <Link
                   to="/instance/settings"
@@ -295,12 +297,15 @@ export function Layout() {
           </div>
           <div className="border-t border-r border-border px-3 py-2">
             <div className="flex items-center gap-1">
-              <SidebarNavItem
-                to="/docs"
-                label="Documentation"
-                icon={BookOpen}
-                className="flex-1 min-w-0"
-              />
+              <a
+                href="https://docs.paperclip.ing/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
+              >
+                <BookOpen className="h-4 w-4 shrink-0" />
+                <span className="truncate">Documentation</span>
+              </a>
               <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                 <Link
                   to="/instance/settings"


### PR DESCRIPTION
## Summary
- update the desktop and mobile sidebar Documentation links to open `https://docs.paperclip.ing/`
- stop routing that navigation item to the internal `/docs` route
- keep this change isolated from the agent skill-resolution fixes

## Testing
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`