### PR TITLE
fix: align embedded postgres ctor types with initdbFlags usage

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -83,6 +83,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -17,6 +17,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;


### PR DESCRIPTION
## Summary
- add `initdbFlags` to the local `EmbeddedPostgresCtor` typings in the DB migration runtime and CLI worktree helper
- keep those local constructor types consistent with the actual embedded-postgres usage already present in the repo
- fix the TypeScript failure that blocked repo-wide typecheck

## Reproduction
Before this change, these commands failed with `TS2353` because `initdbFlags` was missing from the local constructor type:
- `pnpm --filter @paperclipai/db typecheck`
- `pnpm --dir cli typecheck`

## Testing
- `pnpm --filter @paperclipai/db typecheck`
- `pnpm --dir cli typecheck`
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`