### PR TITLE
fix: ignore invalid run IDs in activity logging

### DIFF
--- a/server/src/__tests__/activity-log-invalid-run-id.test.ts
+++ b/server/src/__tests__/activity-log-invalid-run-id.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logActivity } from "../services/activity-log.js";
+
+const mockPublishLiveEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/live-events.js", () => ({
+  publishLiveEvent: mockPublishLiveEvent,
+}));
+
+function createDbStub(runExists: boolean) {
+  const inserted: unknown[] = [];
+
+  // Chain for select().from().where().then()
+  const thenFn = vi.fn((cb: (rows: unknown[]) => unknown) =>
+    Promise.resolve(cb(runExists ? [{ id: "run-1" }] : [])),
+  );
+  const where = vi.fn(() => ({ then: thenFn }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+
+  // Chain for insert().values()
+  const values = vi.fn(async (row: unknown) => {
+    inserted.push(row);
+  });
+  const insert = vi.fn(() => ({ values }));
+
+  return { db: { select, insert } as any, inserted, values };
+}
+
+describe("logActivity run_id validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("nulls out a runId that does not exist in heartbeat_runs", async () => {
+    const { db, values } = createDbStub(false);
+
+    await logActivity(db, {
+      companyId: "company-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: "issue-1",
+      runId: "nonexistent-run-id",
+    });
+
+    const inserted = (values.mock.calls[0] as any)[0];
+    expect(inserted.runId).toBeNull();
+  });
+
+  it("preserves a runId that exists in heartbeat_runs", async () => {
+    const { db, values } = createDbStub(true);
+
+    await logActivity(db, {
+      companyId: "company-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: "issue-1",
+      runId: "run-1",
+    });
+
+    const inserted = (values.mock.calls[0] as any)[0];
+    expect(inserted.runId).toBe("run-1");
+  });
+
+  it("passes null through without querying heartbeat_runs", async () => {
+    const { db, values } = createDbStub(false);
+
+    await logActivity(db, {
+      companyId: "company-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: "issue-1",
+      runId: null,
+    });
+
+    const inserted = (values.mock.calls[0] as any)[0];
+    expect(inserted.runId).toBeNull();
+    // select should not have been called since runId was null
+    expect((db.select as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/activity-log-invalid-run-id.test.ts
+++ b/server/src/__tests__/activity-log-invalid-run-id.test.ts
@@ -1,3 +1,10 @@
+/**
+ * runId validation was moved from logActivity into actorMiddleware.
+ * See actor-middleware-run-id.test.ts for the validation tests.
+ *
+ * This file verifies that logActivity itself is simple: it writes whatever
+ * runId it receives directly, without performing any DB lookup.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { logActivity } from "../services/activity-log.js";
 
@@ -7,33 +14,23 @@ vi.mock("../services/live-events.js", () => ({
   publishLiveEvent: mockPublishLiveEvent,
 }));
 
-function createDbStub(runExists: boolean) {
+function makeDb() {
   const inserted: unknown[] = [];
-
-  // Chain for select().from().where().then()
-  const thenFn = vi.fn((cb: (rows: unknown[]) => unknown) =>
-    Promise.resolve(cb(runExists ? [{ id: "run-1" }] : [])),
-  );
-  const where = vi.fn(() => ({ then: thenFn }));
-  const from = vi.fn(() => ({ where }));
-  const select = vi.fn(() => ({ from }));
-
-  // Chain for insert().values()
   const values = vi.fn(async (row: unknown) => {
     inserted.push(row);
   });
   const insert = vi.fn(() => ({ values }));
-
-  return { db: { select, insert } as any, inserted, values };
+  const select = vi.fn(); // should not be called
+  return { db: { insert, select } as any, inserted, values, select };
 }
 
-describe("logActivity run_id validation", () => {
+describe("logActivity — simple pass-through (no run lookup)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("nulls out a runId that does not exist in heartbeat_runs", async () => {
-    const { db, values } = createDbStub(false);
+  it("writes the provided runId directly without querying heartbeat_runs", async () => {
+    const { db, values, select } = makeDb();
 
     await logActivity(db, {
       companyId: "company-1",
@@ -42,32 +39,16 @@ describe("logActivity run_id validation", () => {
       action: "issue.updated",
       entityType: "issue",
       entityId: "issue-1",
-      runId: "nonexistent-run-id",
+      runId: "run-abc",
     });
 
     const inserted = (values.mock.calls[0] as any)[0];
-    expect(inserted.runId).toBeNull();
+    expect(inserted.runId).toBe("run-abc");
+    expect((select as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
   });
 
-  it("preserves a runId that exists in heartbeat_runs", async () => {
-    const { db, values } = createDbStub(true);
-
-    await logActivity(db, {
-      companyId: "company-1",
-      actorType: "agent",
-      actorId: "agent-1",
-      action: "issue.updated",
-      entityType: "issue",
-      entityId: "issue-1",
-      runId: "run-1",
-    });
-
-    const inserted = (values.mock.calls[0] as any)[0];
-    expect(inserted.runId).toBe("run-1");
-  });
-
-  it("passes null through without querying heartbeat_runs", async () => {
-    const { db, values } = createDbStub(false);
+  it("writes null when runId is null, without querying heartbeat_runs", async () => {
+    const { db, values, select } = makeDb();
 
     await logActivity(db, {
       companyId: "company-1",
@@ -81,7 +62,6 @@ describe("logActivity run_id validation", () => {
 
     const inserted = (values.mock.calls[0] as any)[0];
     expect(inserted.runId).toBeNull();
-    // select should not have been called since runId was null
-    expect((db.select as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    expect((select as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
   });
 });

--- a/server/src/__tests__/actor-middleware-run-id.test.ts
+++ b/server/src/__tests__/actor-middleware-run-id.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { actorMiddleware } from "../middleware/auth.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import { agentApiKeys, agents, heartbeatRuns } from "@paperclipai/db";
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: { warn: vi.fn(), info: vi.fn() },
+}));
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const COMPANY_ID = "00000000-0000-0000-0000-000000000002";
+const RUN_ID = "00000000-0000-0000-0000-000000000003";
+
+const AGENT_RECORD = {
+  id: AGENT_ID,
+  companyId: COMPANY_ID,
+  status: "active",
+};
+
+/**
+ * Builds a minimal DB stub for the actor middleware.
+ * All select() calls are differentiating by table reference.
+ * update() for agentApiKeys.lastUsedAt is a no-op.
+ */
+function makeDb(opts: {
+  apiKey?: { id: string; agentId: string; companyId: string; keyHash: string; revokedAt: null } | null;
+  agentRecord?: typeof AGENT_RECORD | null;
+  runRecord?: { id: string } | null;
+  throwOnRunLookup?: boolean;
+}) {
+  const select = vi.fn().mockImplementation(() => {
+    let queriedTable: unknown;
+    const then = vi.fn().mockImplementation((cb: (rows: unknown[]) => unknown) => {
+      if (queriedTable === agentApiKeys) {
+        return Promise.resolve(cb(opts.apiKey ? [opts.apiKey] : []));
+      }
+      if (queriedTable === agents) {
+        return Promise.resolve(cb(opts.agentRecord ? [opts.agentRecord] : []));
+      }
+      if (queriedTable === heartbeatRuns) {
+        if (opts.throwOnRunLookup) return Promise.reject(new Error("simulated DB error"));
+        return Promise.resolve(cb(opts.runRecord ? [opts.runRecord] : []));
+      }
+      // instanceUserRoles, companyMemberships, etc.
+      return Promise.resolve(cb([]));
+    });
+    const where = vi.fn().mockReturnValue({ then });
+    const from = vi.fn().mockImplementation((table: unknown) => {
+      queriedTable = table;
+      return { where };
+    });
+    return { from };
+  });
+
+  const update = vi.fn().mockReturnValue({
+    set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+  });
+
+  return { select, update } as any;
+}
+
+function makeApp(db: ReturnType<typeof makeDb>, deploymentMode: "authenticated" | "local_trusted" = "authenticated") {
+  const app = express();
+  app.use(actorMiddleware(db, { deploymentMode }));
+  app.get("/me", (req, res) => {
+    res.json({ actor: req.actor });
+  });
+  return app;
+}
+
+describe("actor middleware — runId validation", () => {
+  const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
+
+  beforeEach(() => {
+    process.env[secretEnv] = "test-secret";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env[secretEnv];
+    vi.clearAllMocks();
+  });
+
+  describe("agent JWT actor", () => {
+    it("preserves runId when the run exists for the same agent and company", async () => {
+      const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, "claude_local", RUN_ID)!;
+      const db = makeDb({
+        agentRecord: AGENT_RECORD,
+        runRecord: { id: RUN_ID },
+      });
+
+      const res = await request(makeApp(db)).get("/me").set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.actor.runId).toBe(RUN_ID);
+    });
+
+    it("nulls runId when the run does not exist in heartbeat_runs", async () => {
+      const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, "claude_local", RUN_ID)!;
+      const db = makeDb({
+        agentRecord: AGENT_RECORD,
+        runRecord: null,
+      });
+
+      const res = await request(makeApp(db)).get("/me").set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.actor.runId).toBeUndefined();
+    });
+
+    it("falls back to undefined (not error) when heartbeat_runs lookup throws", async () => {
+      const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, "claude_local", RUN_ID)!;
+      const db = makeDb({
+        agentRecord: AGENT_RECORD,
+        throwOnRunLookup: true,
+      });
+
+      const res = await request(makeApp(db)).get("/me").set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.actor.runId).toBeUndefined();
+    });
+
+    it("header runId overrides JWT claim run_id and is validated", async () => {
+      const tokenRunId = "00000000-0000-0000-0000-000000000099";
+      const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, "claude_local", tokenRunId)!;
+      const db = makeDb({
+        agentRecord: AGENT_RECORD,
+        runRecord: { id: RUN_ID },
+      });
+
+      const res = await request(makeApp(db))
+        .get("/me")
+        .set("Authorization", `Bearer ${token}`)
+        .set("x-paperclip-run-id", RUN_ID);
+      expect(res.status).toBe(200);
+      // header wins; that run exists → preserved
+      expect(res.body.actor.runId).toBe(RUN_ID);
+    });
+  });
+
+  describe("board actor", () => {
+    it("never carries runId even when x-paperclip-run-id header is present (local_trusted)", async () => {
+      const db = makeDb({});
+
+      const res = await request(makeApp(db, "local_trusted"))
+        .get("/me")
+        .set("x-paperclip-run-id", RUN_ID);
+      expect(res.status).toBe(200);
+      expect(res.body.actor.type).toBe("board");
+      expect(res.body.actor.runId).toBeUndefined();
+    });
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import type { Request, RequestHandler } from "express";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agentApiKeys, agents, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import { agentApiKeys, agents, companyMemberships, heartbeatRuns, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
@@ -10,6 +10,25 @@ import { logger } from "./logger.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
+}
+
+async function resolveAgentRunId(
+  db: Db,
+  runId: string | null | undefined,
+  agentId: string,
+  companyId: string,
+): Promise<string | undefined> {
+  if (!runId) return undefined;
+  try {
+    const row = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.companyId, companyId)))
+      .then((rows) => rows[0] ?? null);
+    return row ? runId : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 interface ActorMiddlewareOptions {
@@ -62,14 +81,13 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
             userId,
             companyIds: memberships.map((row) => row.companyId),
             isInstanceAdmin: Boolean(roleRow),
-            runId: runIdHeader ?? undefined,
             source: "session",
           };
           next();
           return;
         }
       }
-      if (runIdHeader) req.actor.runId = runIdHeader;
+      // Board and unauthenticated actors do not carry a run ID
       next();
       return;
     }
@@ -110,12 +128,13 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         return;
       }
 
+      const jwtRunId = runIdHeader || claims.run_id || undefined;
       req.actor = {
         type: "agent",
         agentId: claims.sub,
         companyId: claims.company_id,
         keyId: undefined,
-        runId: runIdHeader || claims.run_id || undefined,
+        runId: await resolveAgentRunId(db, jwtRunId, claims.sub, claims.company_id),
         source: "agent_jwt",
       };
       next();
@@ -143,7 +162,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       agentId: key.agentId,
       companyId: key.companyId,
       keyId: key.id,
-      runId: runIdHeader || undefined,
+      runId: await resolveAgentRunId(db, runIdHeader, key.agentId, key.companyId),
       source: "agent_key",
     };
 

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,5 +1,6 @@
 import type { Db } from "@paperclipai/db";
-import { activityLog } from "@paperclipai/db";
+import { activityLog, heartbeatRuns } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
 import { publishLiveEvent } from "./live-events.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { sanitizeRecord } from "../redaction.js";
@@ -16,9 +17,20 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+async function resolveRunId(db: Db, runId: string | null | undefined): Promise<string | null> {
+  if (!runId) return null;
+  const row = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+  return row ? runId : null;
+}
+
 export async function logActivity(db: Db, input: LogActivityInput) {
   const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
   const redactedDetails = sanitizedDetails ? redactCurrentUserValue(sanitizedDetails) : null;
+  const resolvedRunId = await resolveRunId(db, input.runId);
   await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -27,7 +39,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId: resolvedRunId,
     details: redactedDetails,
   });
 
@@ -41,7 +53,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
+      runId: resolvedRunId,
       details: redactedDetails,
     },
   });

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,6 +1,5 @@
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns } from "@paperclipai/db";
-import { eq } from "drizzle-orm";
+import { activityLog } from "@paperclipai/db";
 import { publishLiveEvent } from "./live-events.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { sanitizeRecord } from "../redaction.js";
@@ -17,20 +16,10 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
-async function resolveRunId(db: Db, runId: string | null | undefined): Promise<string | null> {
-  if (!runId) return null;
-  const row = await db
-    .select({ id: heartbeatRuns.id })
-    .from(heartbeatRuns)
-    .where(eq(heartbeatRuns.id, runId))
-    .then((rows) => rows[0] ?? null);
-  return row ? runId : null;
-}
-
 export async function logActivity(db: Db, input: LogActivityInput) {
   const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
   const redactedDetails = sanitizedDetails ? redactCurrentUserValue(sanitizedDetails) : null;
-  const resolvedRunId = await resolveRunId(db, input.runId);
+  const runId = input.runId ?? null;
   await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -39,7 +28,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: resolvedRunId,
+    runId,
     details: redactedDetails,
   });
 
@@ -53,7 +42,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: resolvedRunId,
+      runId,
       details: redactedDetails,
     },
   });


### PR DESCRIPTION
## Summary
- validate claimed `runId` values in `actorMiddleware` before route code runs
- only keep `runId` on agent actors when it matches a real `heartbeat_runs` row for the same agent and company
- drop `runId` for board/session requests and degrade to `undefined` on lookup errors
- keep `logActivity` simple again and add focused tests around actor run-id handling

## Why
Some API requests were carrying stale or fabricated run IDs via `x-paperclip-run-id` or agent auth context. Those values flowed into `activity_log.run_id`, violated the FK to `heartbeat_runs`, and turned otherwise-successful mutations into 500 responses.

This version fixes the problem at the request-auth boundary instead of inside `logActivity`. That keeps invalid run IDs out of downstream route handling entirely, preserves valid run linkage, and avoids adding an extra lookup inside every `logActivity` call.