### PR TITLE
feat: pi-ai integration

### DIFF
--- a/doc/plans/2026-03-13-workspace-reporting-mismatch-investigation.md
+++ b/doc/plans/2026-03-13-workspace-reporting-mismatch-investigation.md
@@ -1,0 +1,138 @@
+# Investigation: Workspace reporting mismatch between heartbeat and local adapters
+
+## Summary
+Heartbeat and the local adapters are describing two different things. Heartbeat records and logs the **server-selected workspace** (`paperclipWorkspace.cwd`), while local adapters like Codex and Pi may intentionally execute in `adapterConfig.cwd` when `paperclipWorkspace.source === "agent_home"`. The result is a misleading warning, not usually a wrong execution cwd. The `issue_assigned` session-reset log is expected behavior, but its wording is too terse and compounds the confusion.
+
+## Symptoms
+- Heartbeat logs: `No project or prior session workspace was available. Using fallback workspace ".../.paperclip/..." for this run.`
+- Heartbeat logs: `Skipping saved session resume for task "..." because wake reason is issue_assigned.`
+- User observed Pi executing in the real project folder despite the fallback warning.
+- Codex and Pi share the same adapter-side `agent_home` override behavior.
+
+## Investigation Log
+
+### Phase 1 - Reset/session behavior
+**Hypothesis:** `issue_assigned` is intentionally treated as a fresh task-session boundary, so that log line is expected and separate from the workspace warning.
+
+**Findings:** Heartbeat deliberately resets task session reuse on assignment wakes.
+
+**Evidence:**
+- `server/src/services/heartbeat.ts:246-256`
+  - `shouldResetTaskSessionForWake()` returns `true` when `wakeReason === "issue_assigned"`.
+- `server/src/services/heartbeat.ts:259-272`
+  - `describeSessionResetReason()` maps that to the text `wake reason is issue_assigned`.
+- `server/src/services/heartbeat.ts:1231-1240`
+  - heartbeat appends `Skipping saved session resume for task "..." because ${sessionResetReason}.`
+- `server/src/routes/issues.ts:446-456`
+  - issue create wakes the assignee with `reason: "issue_assigned"`.
+- `server/src/routes/issues.ts:591-600`
+  - issue reassignment/update also wakes with `reason: "issue_assigned"`.
+
+**Conclusion:** Confirmed. The session-reset line is intentional and not the root bug, though the wording is not very explanatory.
+
+### Phase 2 - Heartbeat workspace resolution
+**Hypothesis:** Heartbeat logs the fallback workspace without considering that the adapter may execute elsewhere.
+
+**Findings:** `resolveWorkspaceForRun()` only reasons about project workspace rows, prior session cwd, and the fallback agent-home directory. It has no awareness of adapter `config.cwd`.
+
+**Evidence:**
+- `server/src/services/heartbeat.ts:530-669`
+  - `resolveWorkspaceForRun()` returns either:
+    - project workspace (`source: "project_primary"`),
+    - session workspace (`source: "task_session"`), or
+    - fallback agent-home workspace (`source: "agent_home"`).
+- `server/src/services/heartbeat.ts:651-658`
+  - when neither project workspace nor prior session workspace is usable, it emits:
+    - `Saved session workspace "..." is not available. Using fallback workspace "..." for this run.`
+    - `No project workspace directory is currently available for this issue. Using fallback workspace "..." for this run.`
+    - `No project or prior session workspace was available. Using fallback workspace "..." for this run.`
+- `server/src/services/heartbeat.ts:1241-1245`
+  - heartbeat writes `context.paperclipWorkspace = { cwd: executionWorkspace.cwd, source: executionWorkspace.source, ... }`, preserving the server-side workspace selection.
+
+**Conclusion:** Confirmed. Heartbeat is logging the server-selected workspace record, not the adapter's effective cwd.
+
+### Phase 3 - Local adapter execution behavior
+**Hypothesis:** Local adapters intentionally override fallback `agent_home` with `config.cwd`, causing the reporting mismatch.
+
+**Findings:** Codex and Pi both intentionally use `config.cwd` when the workspace source is `agent_home`, and they suppress `PAPERCLIP_WORKSPACE_CWD` in that case.
+
+**Evidence:**
+- `packages/adapters/codex-local/src/server/execute.ts:159-162`
+  - `useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0`
+  - `const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd()`
+- `packages/adapters/codex-local/src/server/execute.ts:211-215`
+  - only exports `PAPERCLIP_WORKSPACE_CWD` when `effectiveWorkspaceCwd` is non-empty.
+- `packages/adapters/pi-local/src/server/execute.ts:138-141`
+  - same `agent_home + configured cwd` override logic.
+- `packages/adapters/pi-local/src/server/execute.ts:187-193`
+  - same omission of `PAPERCLIP_WORKSPACE_CWD` when using configured cwd instead of `agent_home`.
+
+**Conclusion:** Confirmed. Adapter behavior is intentionally different from the raw heartbeat fallback workspace record.
+
+### Phase 4 - Cross-adapter contract and metadata
+**Hypothesis:** This override behavior is already part of the expected local-adapter contract, and there is already metadata to describe the real execution cwd.
+
+**Findings:** The local-adapter contract tests explicitly codify this override. Adapter invocation metadata already has `cwd` and `commandNotes`, and the UI already renders both.
+
+**Evidence:**
+- `packages/adapter-utils/src/local-execute-contract-test.ts:93-114`
+  - test name: `uses configured cwd instead of agent_home fallback without exporting fallback workspace cwd`
+  - asserts `runOpts.cwd === configuredCwd`
+  - asserts `runOpts.env.PAPERCLIP_WORKSPACE_SOURCE === "agent_home"`
+  - asserts `runOpts.env.PAPERCLIP_WORKSPACE_CWD === undefined`
+- `packages/adapter-utils/src/types.ts:94-101`
+  - `AdapterInvocationMeta` already supports:
+    - `cwd?: string`
+    - `commandNotes?: string[]`
+- `server/src/services/heartbeat.ts:1430-1441`
+  - heartbeat persists adapter metadata via `adapter.invoke` run events.
+- `ui/src/pages/AgentDetail.tsx:2058-2090`
+  - UI already displays invocation `Working dir` from `adapterInvokePayload.cwd`
+  - UI already displays `Command notes` from `adapterInvokePayload.commandNotes`
+
+**Conclusion:** Confirmed. The adapter-side effective cwd already has a proper reporting channel; the mismatch is that heartbeat warnings do not use it.
+
+## Root Cause
+The root cause is a **cross-layer reporting mismatch**:
+
+1. Heartbeat selects and records a server-side workspace in `paperclipWorkspace` (`server/src/services/heartbeat.ts:530-669`, `1241-1245`).
+2. For local adapters, `agent_home` is only a bookkeeping fallback when `config.cwd` exists; the adapter process intentionally runs in `config.cwd` instead (`packages/adapters/codex-local/src/server/execute.ts:159-162`, `packages/adapters/pi-local/src/server/execute.ts:138-141`).
+3. The shared local-adapter tests now explicitly encode that behavior as correct (`packages/adapter-utils/src/local-execute-contract-test.ts:93-114`).
+4. Heartbeat warnings still say `Using fallback workspace ...`, which is true about the server-selected workspace record but misleading about the actual process cwd.
+5. The `issue_assigned` reset message is expected, but the plain wording (`wake reason is issue_assigned`) makes the whole sequence read like a failure rather than intentional fresh-session behavior.
+
+## Eliminated Hypotheses
+- **"Pi alone is broken"** — eliminated. Codex and Pi share the same `agent_home + configured cwd` logic (`codex-local` and `pi-local` execute files cited above).
+- **"The issue_assigned reset line is the bug"** — eliminated. That reset is explicitly intended in heartbeat and triggered by issue routes (`heartbeat.ts:246-256`, `routes/issues.ts:446-456`, `591-600`).
+- **"paperclipWorkspace.cwd should always equal actual adapter cwd"** — eliminated as the current design. Existing adapter contract tests intentionally allow them to differ when `source === "agent_home"`.
+
+## Recommendations
+1. **Adopt a medium-risk reporting fix, not an execution change.**
+   - Keep current local-adapter cwd behavior.
+   - Do not change the semantics of `paperclipWorkspace.cwd` in this change.
+
+2. **Fix heartbeat warning text in `server/src/services/heartbeat.ts`.**
+   - When heartbeat falls back to `agent_home` and the local adapter has `config.cwd`, say that:
+     - fallback agent-home workspace was recorded, **but**
+     - the local adapter will execute in configured cwd `...`
+   - This should replace the current unconditional `Using fallback workspace ...` wording in the `agent_home` branch (`server/src/services/heartbeat.ts:651-658`).
+
+3. **Make session-reset wording explicit in `server/src/services/heartbeat.ts`.**
+   - Update `describeSessionResetReason()` (`server/src/services/heartbeat.ts:259-272`) so `issue_assigned` reads as an intentional fresh-task boundary, for example:
+     - `wake reason is "issue_assigned" (assignment wakes start a fresh task session)`
+   - This will make the existing `Skipping saved session resume ...` log (`server/src/services/heartbeat.ts:1235-1239`) clearer.
+
+4. **Use existing adapter metadata more deliberately.**
+   - Add `commandNotes` in each local adapter execute implementation when `config.cwd` overrides `agent_home`.
+   - Example note:
+     - `Using configured cwd "/path/to/repo" instead of fallback agent_home workspace "/Users/.../.paperclip/...".`
+   - This can be surfaced immediately because the UI already renders `commandNotes` and `cwd`.
+
+5. **Factor the local adapter cwd resolution into a shared helper.**
+   - Current logic is duplicated across local adapters.
+   - A shared helper in `packages/adapter-utils` would reduce drift and make the reporting note reusable.
+
+## Preventive Measures
+- Extend the shared local execute contract test to also assert `onMeta.cwd` and a `commandNotes` override explanation when `agent_home` is overridden by configured cwd.
+- Add heartbeat-focused tests for the fallback-warning formatter so the message stays aligned with actual local-adapter behavior.
+- Keep `paperclipWorkspace` as the server-selected workspace contract and `AdapterInvocationMeta.cwd` as the authoritative actual process cwd for local adapters.

--- a/packages/adapter-utils/src/local-execute-contract-test.ts
+++ b/packages/adapter-utils/src/local-execute-contract-test.ts
@@ -12,6 +12,7 @@ type RunOptions = {
 type MetaSummary = {
   cwd?: string;
   commandArgs?: string[];
+  commandNotes?: string[];
 };
 
 export function defineLocalAdapterExecuteContract(input: {
@@ -93,6 +94,7 @@ export function defineLocalAdapterExecuteContract(input: {
     it("uses configured cwd instead of agent_home fallback without exporting fallback workspace cwd", async () => {
       const configuredCwd = path.join(tempDir, "configured-workspace");
       await fs.mkdir(configuredCwd, { recursive: true });
+      const onMeta = vi.fn(async () => {});
 
       await input.execute(
         input.buildContext({
@@ -103,6 +105,7 @@ export function defineLocalAdapterExecuteContract(input: {
               source: "agent_home",
             },
           },
+          onMeta,
         }),
       );
 
@@ -110,6 +113,14 @@ export function defineLocalAdapterExecuteContract(input: {
       expect(runOpts.cwd).toBe(configuredCwd);
       expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("agent_home");
       expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBeUndefined();
+
+      const meta = input.getMeta?.(onMeta);
+      if (meta) {
+        expect(meta.cwd).toBe(configuredCwd);
+        expect(meta.commandNotes).toContain(
+          `Using configured cwd "${configuredCwd}" instead of fallback agent_home workspace "/Users/example/.paperclip/instances/default/workspaces/agent-123".`,
+        );
+      }
     });
   });
 }

--- a/packages/adapter-utils/src/local-execute-contract-test.ts
+++ b/packages/adapter-utils/src/local-execute-contract-test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "./types.js";
+
+type RunOptions = {
+  cwd: string;
+  env: Record<string, string | undefined>;
+};
+
+type MetaSummary = {
+  cwd?: string;
+  commandArgs?: string[];
+};
+
+export function defineLocalAdapterExecuteContract(input: {
+  label: string;
+  execute: (ctx: AdapterExecutionContext) => Promise<unknown>;
+  buildContext: (overrides?: Partial<AdapterExecutionContext>) => AdapterExecutionContext;
+  defaultConfig: Record<string, unknown>;
+  configuredCwdConfig: (configuredCwd: string) => Record<string, unknown>;
+  prepareMocks: (args: { tempDir: string }) => Promise<void> | void;
+  getRunOptions: () => RunOptions;
+  getMeta?: (onMeta: ReturnType<typeof vi.fn>) => MetaSummary | undefined;
+}) {
+  describe(`${input.label} execute contract`, () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `paperclip-${input.label}-execute-`));
+      await input.prepareMocks({ tempDir });
+    });
+
+    afterEach(async () => {
+      vi.clearAllMocks();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("passes project workspace metadata env fields", async () => {
+      const cwd = path.join(tempDir, "project");
+      await fs.mkdir(cwd, { recursive: true });
+      const onMeta = vi.fn(async () => {});
+
+      await input.execute(
+        input.buildContext({
+          config: input.defaultConfig,
+          context: {
+            issueId: "issue-123",
+            paperclipWorkspace: {
+              cwd,
+              source: "project_primary",
+              strategy: "git_worktree",
+              workspaceId: "workspace-123",
+              repoUrl: "https://github.com/acme/repo.git",
+              repoRef: "main",
+              branchName: "issue-123-fix",
+              worktreePath: "/tmp/worktree-path",
+            },
+            paperclipWorkspaces: [{ workspaceId: "workspace-123", cwd }],
+            paperclipRuntimeServiceIntents: [{ serviceName: "devserver" }],
+            paperclipRuntimeServices: [{ serviceName: "devserver", url: "http://127.0.0.1:4173" }],
+            paperclipRuntimePrimaryUrl: "http://127.0.0.1:4173",
+          },
+          onMeta,
+        }),
+      );
+
+      const runOpts = input.getRunOptions();
+      expect(runOpts.cwd).toBe(cwd);
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBe(cwd);
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("project_primary");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_STRATEGY).toBe("git_worktree");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_ID).toBe("workspace-123");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_REPO_URL).toBe("https://github.com/acme/repo.git");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_REPO_REF).toBe("main");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_BRANCH).toBe("issue-123-fix");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_WORKTREE_PATH).toBe("/tmp/worktree-path");
+      expect(runOpts.env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON).toBe(
+        JSON.stringify([{ serviceName: "devserver" }]),
+      );
+      expect(runOpts.env.PAPERCLIP_RUNTIME_SERVICES_JSON).toBe(
+        JSON.stringify([{ serviceName: "devserver", url: "http://127.0.0.1:4173" }]),
+      );
+      expect(runOpts.env.PAPERCLIP_RUNTIME_PRIMARY_URL).toBe("http://127.0.0.1:4173");
+
+      const meta = input.getMeta?.(onMeta);
+      if (meta) {
+        expect(meta.cwd).toBe(cwd);
+      }
+    });
+
+    it("uses configured cwd instead of agent_home fallback without exporting fallback workspace cwd", async () => {
+      const configuredCwd = path.join(tempDir, "configured-workspace");
+      await fs.mkdir(configuredCwd, { recursive: true });
+
+      await input.execute(
+        input.buildContext({
+          config: input.configuredCwdConfig(configuredCwd),
+          context: {
+            paperclipWorkspace: {
+              cwd: "/Users/example/.paperclip/instances/default/workspaces/agent-123",
+              source: "agent_home",
+            },
+          },
+        }),
+      );
+
+      const runOpts = input.getRunOptions();
+      expect(runOpts.cwd).toBe(configuredCwd);
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("agent_home");
+      expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBeUndefined();
+    });
+  });
+}

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -61,6 +61,43 @@ export function asString(value: unknown, fallback: string): string {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }
 
+export interface LocalAdapterExecutionCwdResolution {
+  workspaceSource: string;
+  workspaceCwd: string;
+  configuredCwd: string;
+  effectiveWorkspaceCwd: string;
+  effectiveCwd: string;
+  usedConfiguredCwdOverride: boolean;
+  commandNote: string | null;
+}
+
+export function resolveLocalAdapterExecutionCwd(
+  workspaceValue: unknown,
+  configuredCwdValue: unknown,
+  fallbackCwd = process.cwd(),
+): LocalAdapterExecutionCwdResolution {
+  const workspace = parseObject(workspaceValue);
+  const workspaceSource = asString(workspace.source, "");
+  const workspaceCwd = asString(workspace.cwd, "");
+  const configuredCwd = asString(configuredCwdValue, "").trim();
+  const usedConfiguredCwdOverride =
+    workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = usedConfiguredCwdOverride ? "" : workspaceCwd;
+  const effectiveCwd = effectiveWorkspaceCwd || configuredCwd || fallbackCwd;
+
+  return {
+    workspaceSource,
+    workspaceCwd,
+    configuredCwd,
+    effectiveWorkspaceCwd,
+    effectiveCwd,
+    usedConfiguredCwdOverride,
+    commandNote: usedConfiguredCwdOverride
+      ? `Using configured cwd "${effectiveCwd}" instead of fallback agent_home workspace "${workspaceCwd}".`
+      : null,
+  };
+}
+
 export function asNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }

--- a/packages/adapters/claude-local/src/server/execute.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.test.ts
@@ -1,0 +1,102 @@
+import { describe, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { defineLocalAdapterExecuteContract } from "@paperclipai/adapter-utils/local-execute-contract-test";
+
+const {
+  mockRunChildProcess,
+  mockEnsureCommandResolvable,
+} = vi.hoisted(() => ({
+  mockRunChildProcess: vi.fn(),
+  mockEnsureCommandResolvable: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess: mockRunChildProcess,
+    ensureCommandResolvable: mockEnsureCommandResolvable,
+  };
+});
+
+vi.mock("./parse.js", () => ({
+  parseClaudeStreamJson: () => ({
+    sessionId: "claude-session-123",
+    model: "sonnet",
+    costUsd: 0,
+    usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    summary: "hello",
+    resultJson: { subtype: "success", result: "hello", total_cost_usd: 0, usage: {} },
+  }),
+  describeClaudeFailure: () => "Claude failed",
+  detectClaudeLoginRequired: () => ({ loginRequired: false, loginUrl: null }),
+  isClaudeMaxTurnsResult: () => false,
+  isClaudeUnknownSessionError: () => false,
+}));
+
+import { execute } from "./execute.js";
+
+function buildContext(overrides: Partial<AdapterExecutionContext> = {}): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "CEO",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "claude",
+      model: "sonnet",
+    },
+    context: {},
+    onLog: async () => {},
+    onMeta: async () => {},
+    authToken: "pcp-test-token",
+    ...overrides,
+  };
+}
+
+describe("claude execute", () => {
+  defineLocalAdapterExecuteContract({
+    label: "claude",
+    execute,
+    buildContext,
+    defaultConfig: {
+      command: "claude",
+      model: "sonnet",
+    },
+    configuredCwdConfig: (configuredCwd) => ({
+      command: "claude",
+      model: "sonnet",
+      cwd: configuredCwd,
+    }),
+    prepareMocks: async () => {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+    },
+    getRunOptions: () => {
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      return runOpts;
+    },
+    getMeta: (onMeta) => {
+      const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+      return metaCalls[0]?.[0] as { cwd?: string } | undefined;
+    },
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -17,6 +17,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  resolveLocalAdapterExecutionCwd,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -76,6 +77,7 @@ interface ClaudeExecutionInput {
 interface ClaudeRuntimeConfig {
   command: string;
   cwd: string;
+  cwdCommandNote: string | null;
   workspaceId: string | null;
   workspaceRepoUrl: string | null;
   workspaceRepoRef: string | null;
@@ -138,10 +140,9 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
-  const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwdResolution = resolveLocalAdapterExecutionCwd(workspaceContext, config.cwd, process.cwd());
+  const effectiveWorkspaceCwd = cwdResolution.effectiveWorkspaceCwd;
+  const cwd = cwdResolution.effectiveCwd;
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
@@ -251,6 +252,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   return {
     command,
     cwd,
+    cwdCommandNote: cwdResolution.commandNote,
     workspaceId,
     workspaceRepoUrl,
     workspaceRepoRef,
@@ -312,11 +314,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, false);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
-  const commandNotes = instructionsFilePath
-    ? [
-        `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
-      ]
-    : [];
 
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
@@ -328,6 +325,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const {
     command,
     cwd,
+    cwdCommandNote,
     workspaceId,
     workspaceRepoUrl,
     workspaceRepoRef,
@@ -336,6 +334,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     graceSec,
     extraArgs,
   } = runtimeConfig;
+  const commandNotes = [
+    ...(cwdCommandNote ? [cwdCommandNote] : []),
+    ...(instructionsFilePath
+      ? [
+          `Injected agent instructions via --append-system-prompt-file ${instructionsFilePath} (with path directive appended)`,
+        ]
+      : []),
+  ];
   const billingType = resolveClaudeBillingType(env);
   const skillsDir = await buildSkillsDir();
 

--- a/packages/adapters/claude-local/vitest.config.ts
+++ b/packages/adapters/claude-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/codex-local/src/server/execute.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.test.ts
@@ -1,0 +1,109 @@
+import { describe, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { defineLocalAdapterExecuteContract } from "@paperclipai/adapter-utils/local-execute-contract-test";
+
+const {
+  mockRunChildProcess,
+  mockEnsureCommandResolvable,
+  mockListPaperclipSkillEntries,
+  mockRemoveMaintainerOnlySkillSymlinks,
+  mockEnsurePaperclipSkillSymlink,
+} = vi.hoisted(() => ({
+  mockRunChildProcess: vi.fn(),
+  mockEnsureCommandResolvable: vi.fn(),
+  mockListPaperclipSkillEntries: vi.fn(),
+  mockRemoveMaintainerOnlySkillSymlinks: vi.fn(),
+  mockEnsurePaperclipSkillSymlink: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess: mockRunChildProcess,
+    ensureCommandResolvable: mockEnsureCommandResolvable,
+    listPaperclipSkillEntries: mockListPaperclipSkillEntries,
+    removeMaintainerOnlySkillSymlinks: mockRemoveMaintainerOnlySkillSymlinks,
+    ensurePaperclipSkillSymlink: mockEnsurePaperclipSkillSymlink,
+  };
+});
+
+vi.mock("./parse.js", () => ({
+  parseCodexJsonl: () => ({
+    sessionId: "thread-123",
+    summary: "hello",
+    usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    errorMessage: null,
+  }),
+  isCodexUnknownSessionError: () => false,
+}));
+
+import { execute } from "./execute.js";
+
+function buildContext(overrides: Partial<AdapterExecutionContext> = {}): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "CEO",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "codex",
+      model: "gpt-5.4",
+    },
+    context: {},
+    onLog: async () => {},
+    onMeta: async () => {},
+    authToken: "pcp-test-token",
+    ...overrides,
+  };
+}
+
+describe("codex execute", () => {
+  defineLocalAdapterExecuteContract({
+    label: "codex",
+    execute,
+    buildContext,
+    defaultConfig: {
+      command: "codex",
+      model: "gpt-5.4",
+    },
+    configuredCwdConfig: (configuredCwd) => ({
+      command: "codex",
+      model: "gpt-5.4",
+      cwd: configuredCwd,
+    }),
+    prepareMocks: async () => {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockListPaperclipSkillEntries.mockResolvedValue([]);
+      mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+      mockEnsurePaperclipSkillSymlink.mockResolvedValue("created");
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+    },
+    getRunOptions: () => {
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      return runOpts;
+    },
+    getMeta: (onMeta) => {
+      const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+      return metaCalls[0]?.[0] as { cwd?: string } | undefined;
+    },
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -14,6 +14,7 @@ import {
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  resolveLocalAdapterExecutionCwd,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
@@ -204,10 +205,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
-  const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwdResolution = resolveLocalAdapterExecutionCwd(workspaceContext, config.cwd, process.cwd());
+  const effectiveWorkspaceCwd = cwdResolution.effectiveWorkspaceCwd;
+  const cwd = cwdResolution.effectiveCwd;
   const envConfig = parseObject(config.env);
   const configuredCodexHome =
     typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
@@ -361,16 +361,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    if (!instructionsFilePath) return [] as string[];
+    const notes: string[] = [];
+    if (cwdResolution.commandNote) {
+      notes.push(cwdResolution.commandNote);
+    }
+    if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {
-      return [
+      notes.push(
         `Loaded agent instructions from ${instructionsFilePath}`,
         `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
-      ];
+      );
+      return notes;
     }
-    return [
+    notes.push(
       `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-    ];
+    );
+    return notes;
   })();
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
   const templateData = {

--- a/packages/adapters/codex-local/vitest.config.ts
+++ b/packages/adapters/codex-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/cursor-local/src/server/execute.test.ts
+++ b/packages/adapters/cursor-local/src/server/execute.test.ts
@@ -1,0 +1,117 @@
+import { describe, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { defineLocalAdapterExecuteContract } from "@paperclipai/adapter-utils/local-execute-contract-test";
+
+const {
+  mockRunChildProcess,
+  mockEnsureCommandResolvable,
+  mockListPaperclipSkillEntries,
+  mockRemoveMaintainerOnlySkillSymlinks,
+  mockEnsurePaperclipSkillSymlink,
+  mockHasCursorTrustBypassArg,
+} = vi.hoisted(() => ({
+  mockRunChildProcess: vi.fn(),
+  mockEnsureCommandResolvable: vi.fn(),
+  mockListPaperclipSkillEntries: vi.fn(),
+  mockRemoveMaintainerOnlySkillSymlinks: vi.fn(),
+  mockEnsurePaperclipSkillSymlink: vi.fn(),
+  mockHasCursorTrustBypassArg: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess: mockRunChildProcess,
+    ensureCommandResolvable: mockEnsureCommandResolvable,
+    listPaperclipSkillEntries: mockListPaperclipSkillEntries,
+    removeMaintainerOnlySkillSymlinks: mockRemoveMaintainerOnlySkillSymlinks,
+    ensurePaperclipSkillSymlink: mockEnsurePaperclipSkillSymlink,
+  };
+});
+
+vi.mock("./parse.js", () => ({
+  parseCursorJsonl: () => ({
+    sessionId: "cursor-session-123",
+    summary: "hello",
+    usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    costUsd: 0,
+    errorMessage: null,
+  }),
+  isCursorUnknownSessionError: () => false,
+}));
+
+vi.mock("../shared/trust.js", () => ({
+  hasCursorTrustBypassArg: mockHasCursorTrustBypassArg,
+}));
+
+import { execute } from "./execute.js";
+
+function buildContext(overrides: Partial<AdapterExecutionContext> = {}): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "CEO",
+      adapterType: "cursor",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "agent",
+      model: "gpt-5.4",
+    },
+    context: {},
+    onLog: async () => {},
+    onMeta: async () => {},
+    authToken: "pcp-test-token",
+    ...overrides,
+  };
+}
+
+describe("cursor execute", () => {
+  defineLocalAdapterExecuteContract({
+    label: "cursor",
+    execute,
+    buildContext,
+    defaultConfig: {
+      command: "agent",
+      model: "gpt-5.4",
+    },
+    configuredCwdConfig: (configuredCwd) => ({
+      command: "agent",
+      model: "gpt-5.4",
+      cwd: configuredCwd,
+    }),
+    prepareMocks: async () => {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockListPaperclipSkillEntries.mockResolvedValue([]);
+      mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+      mockEnsurePaperclipSkillSymlink.mockResolvedValue("created");
+      mockHasCursorTrustBypassArg.mockReturnValue(false);
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+    },
+    getRunOptions: () => {
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      return runOpts;
+    },
+    getMeta: (onMeta) => {
+      const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+      return metaCalls[0]?.[0] as { cwd?: string } | undefined;
+    },
+  });
+});

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -154,14 +154,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
       )
     : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
@@ -221,6 +235,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   }
+  if (workspaceStrategy) {
+    env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
+  }
   if (workspaceId) {
     env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   }
@@ -230,8 +247,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceRepoRef) {
     env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
   }
+  if (workspaceBranch) {
+    env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  }
+  if (workspaceWorktreePath) {
+    env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
+  }
   if (workspaceHints.length > 0) {
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  }
+  if (runtimeServiceIntents.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  }
+  if (runtimeServices.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  }
+  if (runtimePrimaryUrl) {
+    env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
   }
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -14,6 +14,7 @@ import {
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  resolveLocalAdapterExecutionCwd,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
@@ -176,10 +177,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
-  const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwdResolution = resolveLocalAdapterExecutionCwd(workspaceContext, config.cwd, process.cwd());
+  const effectiveWorkspaceCwd = cwdResolution.effectiveWorkspaceCwd;
+  const cwd = cwdResolution.effectiveCwd;
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   await ensureCursorSkillsInjected(onLog);
 
@@ -324,6 +324,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   const commandNotes = (() => {
     const notes: string[] = [];
+    if (cwdResolution.commandNote) {
+      notes.push(cwdResolution.commandNote);
+    }
     if (autoTrustEnabled) {
       notes.push("Auto-added --yolo to bypass interactive prompts.");
     }

--- a/packages/adapters/cursor-local/vitest.config.ts
+++ b/packages/adapters/cursor-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/gemini-local/src/server/execute.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.test.ts
@@ -1,0 +1,115 @@
+import { describe, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { defineLocalAdapterExecuteContract } from "@paperclipai/adapter-utils/local-execute-contract-test";
+
+const {
+  mockRunChildProcess,
+  mockEnsureCommandResolvable,
+  mockListPaperclipSkillEntries,
+  mockRemoveMaintainerOnlySkillSymlinks,
+  mockEnsurePaperclipSkillSymlink,
+} = vi.hoisted(() => ({
+  mockRunChildProcess: vi.fn(),
+  mockEnsureCommandResolvable: vi.fn(),
+  mockListPaperclipSkillEntries: vi.fn(),
+  mockRemoveMaintainerOnlySkillSymlinks: vi.fn(),
+  mockEnsurePaperclipSkillSymlink: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess: mockRunChildProcess,
+    ensureCommandResolvable: mockEnsureCommandResolvable,
+    listPaperclipSkillEntries: mockListPaperclipSkillEntries,
+    removeMaintainerOnlySkillSymlinks: mockRemoveMaintainerOnlySkillSymlinks,
+    ensurePaperclipSkillSymlink: mockEnsurePaperclipSkillSymlink,
+  };
+});
+
+vi.mock("./parse.js", () => ({
+  parseGeminiJsonl: () => ({
+    sessionId: "gemini-session-123",
+    summary: "hello",
+    usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    costUsd: 0,
+    errorMessage: null,
+    resultJson: null,
+    question: null,
+  }),
+  detectGeminiAuthRequired: () => ({ authRequired: false, authUrl: null }),
+  isGeminiTurnLimitResult: () => false,
+  isGeminiUnknownSessionError: () => false,
+  describeGeminiFailure: () => "Gemini failed",
+}));
+
+import { execute } from "./execute.js";
+
+function buildContext(overrides: Partial<AdapterExecutionContext> = {}): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "CEO",
+      adapterType: "gemini_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "gemini",
+      model: "gemini-2.5-pro",
+    },
+    context: {},
+    onLog: async () => {},
+    onMeta: async () => {},
+    authToken: "pcp-test-token",
+    ...overrides,
+  };
+}
+
+describe("gemini execute", () => {
+  defineLocalAdapterExecuteContract({
+    label: "gemini",
+    execute,
+    buildContext,
+    defaultConfig: {
+      command: "gemini",
+      model: "gemini-2.5-pro",
+    },
+    configuredCwdConfig: (configuredCwd) => ({
+      command: "gemini",
+      model: "gemini-2.5-pro",
+      cwd: configuredCwd,
+    }),
+    prepareMocks: async () => {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockListPaperclipSkillEntries.mockResolvedValue([]);
+      mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+      mockEnsurePaperclipSkillSymlink.mockResolvedValue("created");
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+    },
+    getRunOptions: () => {
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      return runOpts;
+    },
+    getMeta: (onMeta) => {
+      const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+      return metaCalls[0]?.[0] as { cwd?: string } | undefined;
+    },
+  });
+});

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensurePaperclipSkillSymlink,
   joinPromptSections,
   ensurePathInEnv,
+  resolveLocalAdapterExecutionCwd,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
   parseObject,
@@ -164,10 +165,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
-  const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwdResolution = resolveLocalAdapterExecutionCwd(workspaceContext, config.cwd, process.cwd());
+  const effectiveWorkspaceCwd = cwdResolution.effectiveWorkspaceCwd;
+  const cwd = cwdResolution.effectiveCwd;
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   await ensureGeminiSkillsInjected(onLog);
 
@@ -279,7 +279,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini as the final positional argument."];
+    const notes: string[] = [];
+    if (cwdResolution.commandNote) {
+      notes.push(cwdResolution.commandNote);
+    }
+    notes.push("Prompt is passed to Gemini as the final positional argument.");
     notes.push("Added --approval-mode yolo for unattended execution.");
     if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -142,14 +142,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
       (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
     )
     : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+      (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+    )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+      (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+    )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
@@ -193,10 +207,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  if (runtimeServiceIntents.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  }
+  if (runtimeServices.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  }
+  if (runtimePrimaryUrl) {
+    env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
 
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;

--- a/packages/adapters/gemini-local/vitest.config.ts
+++ b/packages/adapters/gemini-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { defineLocalAdapterExecuteContract } from "@paperclipai/adapter-utils/local-execute-contract-test";
+
+const {
+  mockRunChildProcess,
+  mockEnsureCommandResolvable,
+  mockEnsureOpenCodeModelConfiguredAndAvailable,
+} = vi.hoisted(() => ({
+  mockRunChildProcess: vi.fn(),
+  mockEnsureCommandResolvable: vi.fn(),
+  mockEnsureOpenCodeModelConfiguredAndAvailable: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess: mockRunChildProcess,
+    ensureCommandResolvable: mockEnsureCommandResolvable,
+  };
+});
+
+vi.mock("./parse.js", () => ({
+  parseOpenCodeJsonl: () => ({
+    sessionId: "opencode-session-123",
+    summary: "hello",
+    usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    costUsd: 0,
+    errorMessage: null,
+  }),
+  isOpenCodeUnknownSessionError: () => false,
+}));
+
+vi.mock("./models.js", () => ({
+  ensureOpenCodeModelConfiguredAndAvailable: mockEnsureOpenCodeModelConfiguredAndAvailable,
+}));
+
+import { execute } from "./execute.js";
+
+function buildContext(overrides: Partial<AdapterExecutionContext> = {}): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "CEO",
+      adapterType: "opencode_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "opencode",
+      model: "openai/gpt-5.4",
+    },
+    context: {},
+    onLog: async () => {},
+    onMeta: async () => {},
+    authToken: "pcp-test-token",
+    ...overrides,
+  };
+}
+
+describe("opencode execute", () => {
+  defineLocalAdapterExecuteContract({
+    label: "opencode",
+    execute,
+    buildContext,
+    defaultConfig: {
+      command: "opencode",
+      model: "openai/gpt-5.4",
+    },
+    configuredCwdConfig: (configuredCwd) => ({
+      command: "opencode",
+      model: "openai/gpt-5.4",
+      cwd: configuredCwd,
+    }),
+    prepareMocks: async () => {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockEnsureOpenCodeModelConfiguredAndAvailable.mockResolvedValue([]);
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+    },
+    getRunOptions: () => {
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      return runOpts;
+    },
+    getMeta: (onMeta) => {
+      const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+      return metaCalls[0]?.[0] as { cwd?: string } | undefined;
+    },
+  });
+
+  it("resolves relative instructionsFilePath from cwd for backwards compatibility", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-relative-instructions-"));
+    try {
+      const instructionsPath = path.join(tempDir, "AGENTS.md");
+      await fs.writeFile(instructionsPath, "Follow the AGENTS instructions.", "utf8");
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockEnsureOpenCodeModelConfiguredAndAvailable.mockResolvedValue([]);
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+
+      await execute(
+        buildContext({
+          config: {
+            command: "opencode",
+            model: "openai/gpt-5.4",
+            cwd: tempDir,
+            instructionsFilePath: "AGENTS.md",
+          },
+        }),
+      );
+
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      expect(runOpts.stdin).toContain("Follow the AGENTS instructions.");
+      expect(runOpts.stdin).toContain(path.join(tempDir, "AGENTS.md"));
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -14,6 +14,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  resolveLocalAdapterExecutionCwd,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -119,10 +120,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
-  const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwdResolution = resolveLocalAdapterExecutionCwd(workspaceContext, config.cwd, process.cwd());
+  const effectiveWorkspaceCwd = cwdResolution.effectiveWorkspaceCwd;
+  const cwd = cwdResolution.effectiveCwd;
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   await ensureOpenCodeSkillsInjected(onLog);
 
@@ -248,16 +248,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
 
   const commandNotes = (() => {
-    if (!resolvedInstructionsFilePath) return [] as string[];
+    const notes: string[] = [];
+    if (cwdResolution.commandNote) {
+      notes.push(cwdResolution.commandNote);
+    }
+    if (!resolvedInstructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {
-      return [
+      notes.push(
         `Loaded agent instructions from ${resolvedInstructionsFilePath}`,
         `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
-      ];
+      );
+      return notes;
     }
-    return [
+    notes.push(
       `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-    ];
+    );
+    return notes;
   })();
 
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -97,14 +97,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
       )
     : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
@@ -148,10 +162,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  if (runtimeServiceIntents.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  }
+  if (runtimeServices.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  }
+  if (runtimePrimaryUrl) {
+    env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
 
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;

--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -34,7 +34,7 @@ Operational fields:
 Notes:
 - Pi supports multiple providers and models. Use \`pi --list-models\` to list available options.
 - Paperclip requires an explicit \`model\` value for \`pi_local\` agents.
-- Sessions are stored in ~/.pi/paperclips/ and resumed with --session.
+- Sessions are stored under the active workspace at .paperclip/pi/sessions/ and resumed with --session.
 - All tools (read, bash, edit, write, grep, find, ls) are enabled by default.
 - Agent instructions are appended to Pi's system prompt via --append-system-prompt, while the user task is sent via -p.
 `;

--- a/packages/adapters/pi-local/src/server/execute.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.test.ts
@@ -145,14 +145,60 @@ describe("pi execute", () => {
         }),
       );
 
-      const [, , args] = mockRunChildProcess.mock.calls[0];
+      const [, , args, runOptions] = mockRunChildProcess.mock.calls[0];
       const sessionFlagIndex = args.indexOf("--session");
       expect(sessionFlagIndex).toBeGreaterThanOrEqual(0);
       const sessionPath = args[sessionFlagIndex + 1] as string;
       expect(sessionPath.startsWith(path.join(cwd, ".paperclip", "pi", "sessions"))).toBe(true);
       expect(sessionPath.includes(`${path.sep}.pi${path.sep}paperclips${path.sep}`)).toBe(false);
+      expect(args).toContain("--mode");
+      expect(args).toContain("json");
+      const promptFlagIndex = args.indexOf("-p");
+      expect(promptFlagIndex).toBeGreaterThanOrEqual(0);
+      expect(args[promptFlagIndex + 1]).toContain("Continue your Paperclip work.");
+      expect(runOptions.stdin).toBeUndefined();
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("surfaces Pi logical errors even when the process exits with code 0", async () => {
+    mockEnsureCommandResolvable.mockResolvedValue(undefined);
+    mockListPaperclipSkillEntries.mockResolvedValue([]);
+    mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+    mockEnsurePiModelConfiguredAndAvailable.mockResolvedValue([]);
+    mockRunChildProcess.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        JSON.stringify({
+          type: "turn_end",
+          message: {
+            role: "assistant",
+            content: "",
+            stopReason: "error",
+            errorMessage: "Failed to extract accountId from token",
+          },
+        }),
+        JSON.stringify({
+          type: "agent_end",
+          messages: [
+            {
+              role: "assistant",
+              content: "",
+              stopReason: "error",
+              errorMessage: "Failed to extract accountId from token",
+            },
+          ],
+        }),
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const result = await execute(buildContext());
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toBe("Failed to extract accountId from token");
   });
 });

--- a/packages/adapters/pi-local/src/server/execute.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { defineLocalAdapterExecuteContract } from "@paperclipai/adapter-utils/local-execute-contract-test";
 
 const {
   mockRunChildProcess,
@@ -68,122 +68,91 @@ function buildContext(
 }
 
 describe("pi execute", () => {
-  let tempDir: string;
-
-  beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-execute-"));
-    mockEnsureCommandResolvable.mockResolvedValue(undefined);
-    mockListPaperclipSkillEntries.mockResolvedValue([]);
-    mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
-    mockEnsurePiModelConfiguredAndAvailable.mockResolvedValue([]);
-    mockRunChildProcess.mockResolvedValue({
-      exitCode: 0,
-      signal: null,
-      timedOut: false,
-      stdout: [
-        JSON.stringify({ type: "agent_start" }),
-        JSON.stringify({
-          type: "turn_end",
-          message: { role: "assistant", content: "hello" },
-        }),
-        JSON.stringify({ type: "agent_end", messages: [] }),
-      ].join("\n"),
-      stderr: "",
-    });
+  defineLocalAdapterExecuteContract({
+    label: "pi",
+    execute,
+    buildContext,
+    defaultConfig: {
+      command: "pi",
+      model: "openai-codex/gpt-5.4",
+    },
+    configuredCwdConfig: (configuredCwd) => ({
+      command: "pi",
+      model: "openai-codex/gpt-5.4",
+      cwd: configuredCwd,
+    }),
+    prepareMocks: async () => {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockListPaperclipSkillEntries.mockResolvedValue([]);
+      mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+      mockEnsurePiModelConfiguredAndAvailable.mockResolvedValue([]);
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          JSON.stringify({ type: "agent_start" }),
+          JSON.stringify({
+            type: "turn_end",
+            message: { role: "assistant", content: "hello" },
+          }),
+          JSON.stringify({ type: "agent_end", messages: [] }),
+        ].join("\n"),
+        stderr: "",
+      });
+    },
+    getRunOptions: () => {
+      const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+      return runOpts;
+    },
+    getMeta: (onMeta) => {
+      const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+      const meta = (metaCalls[0]?.[0] ?? undefined) as
+        | { cwd?: string; commandArgs?: string[] }
+        | undefined;
+      return meta;
+    },
   });
 
-  afterEach(async () => {
-    vi.clearAllMocks();
-    await fs.rm(tempDir, { recursive: true, force: true });
-  });
-
-  it("passes the same project workspace metadata env fields as other local adapters", async () => {
-    const cwd = path.join(tempDir, "project");
+  it("stores new session files under the active workspace instead of the home directory", async () => {
+    const cwd = path.join(process.cwd(), ".tmp-pi-session-test");
+    await fs.rm(cwd, { recursive: true, force: true });
     await fs.mkdir(cwd, { recursive: true });
+    try {
+      mockEnsureCommandResolvable.mockResolvedValue(undefined);
+      mockListPaperclipSkillEntries.mockResolvedValue([]);
+      mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+      mockEnsurePiModelConfiguredAndAvailable.mockResolvedValue([]);
+      mockRunChildProcess.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          JSON.stringify({ type: "agent_start" }),
+          JSON.stringify({ type: "turn_end", message: { role: "assistant", content: "hello" } }),
+          JSON.stringify({ type: "agent_end", messages: [] }),
+        ].join("\n"),
+        stderr: "",
+      });
 
-    const onMeta = vi.fn(async () => {});
-
-    await execute(
-      buildContext({
-        config: {
-          command: "pi",
-          model: "openai-codex/gpt-5.4",
-        },
-        context: {
-          issueId: "issue-123",
-          paperclipWorkspace: {
+      await execute(
+        buildContext({
+          config: {
+            command: "pi",
+            model: "openai-codex/gpt-5.4",
             cwd,
-            source: "project_primary",
-            strategy: "git_worktree",
-            workspaceId: "workspace-123",
-            repoUrl: "https://github.com/acme/repo.git",
-            repoRef: "main",
-            branchName: "issue-123-fix",
-            worktreePath: "/tmp/worktree-path",
           },
-          paperclipWorkspaces: [{ workspaceId: "workspace-123", cwd }],
-          paperclipRuntimeServiceIntents: [{ serviceName: "devserver" }],
-          paperclipRuntimeServices: [{ serviceName: "devserver", url: "http://127.0.0.1:4173" }],
-          paperclipRuntimePrimaryUrl: "http://127.0.0.1:4173",
-        },
-        onMeta,
-      }),
-    );
+        }),
+      );
 
-    expect(mockRunChildProcess).toHaveBeenCalledTimes(1);
-    const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
-    expect(runOpts.cwd).toBe(cwd);
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBe(cwd);
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("project_primary");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_STRATEGY).toBe("git_worktree");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_ID).toBe("workspace-123");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_REPO_URL).toBe("https://github.com/acme/repo.git");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_REPO_REF).toBe("main");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_BRANCH).toBe("issue-123-fix");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_WORKTREE_PATH).toBe("/tmp/worktree-path");
-    expect(runOpts.env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON).toBe(
-      JSON.stringify([{ serviceName: "devserver" }]),
-    );
-    expect(runOpts.env.PAPERCLIP_RUNTIME_SERVICES_JSON).toBe(
-      JSON.stringify([{ serviceName: "devserver", url: "http://127.0.0.1:4173" }]),
-    );
-    expect(runOpts.env.PAPERCLIP_RUNTIME_PRIMARY_URL).toBe("http://127.0.0.1:4173");
-
-    expect(onMeta).toHaveBeenCalledTimes(1);
-    const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
-    const meta = (metaCalls[0]?.[0] ?? undefined) as
-      | { cwd?: string; commandArgs?: string[] }
-      | undefined;
-    expect(meta).toBeDefined();
-    expect(meta?.cwd).toBe(cwd);
-    expect(meta?.commandArgs).toContain("--mode");
-    expect(meta?.commandArgs).toContain("rpc");
-  });
-
-  it("uses configured cwd instead of agent_home fallback without exporting fallback workspace cwd", async () => {
-    const configuredCwd = path.join(tempDir, "configured-workspace");
-    await fs.mkdir(configuredCwd, { recursive: true });
-
-    await execute(
-      buildContext({
-        config: {
-          command: "pi",
-          model: "openai-codex/gpt-5.4",
-          cwd: configuredCwd,
-        },
-        context: {
-          paperclipWorkspace: {
-            cwd: "/Users/example/.paperclip/instances/default/workspaces/agent-123",
-            source: "agent_home",
-          },
-        },
-      }),
-    );
-
-    expect(mockRunChildProcess).toHaveBeenCalledTimes(1);
-    const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
-    expect(runOpts.cwd).toBe(configuredCwd);
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("agent_home");
-    expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBeUndefined();
+      const [, , args] = mockRunChildProcess.mock.calls[0];
+      const sessionFlagIndex = args.indexOf("--session");
+      expect(sessionFlagIndex).toBeGreaterThanOrEqual(0);
+      const sessionPath = args[sessionFlagIndex + 1] as string;
+      expect(sessionPath.startsWith(path.join(cwd, ".paperclip", "pi", "sessions"))).toBe(true);
+      expect(sessionPath.includes(`${path.sep}.pi${path.sep}paperclips${path.sep}`)).toBe(false);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/adapters/pi-local/src/server/execute.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.test.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+const {
+  mockRunChildProcess,
+  mockEnsureCommandResolvable,
+  mockListPaperclipSkillEntries,
+  mockRemoveMaintainerOnlySkillSymlinks,
+  mockEnsurePiModelConfiguredAndAvailable,
+} = vi.hoisted(() => ({
+  mockRunChildProcess: vi.fn(),
+  mockEnsureCommandResolvable: vi.fn(),
+  mockListPaperclipSkillEntries: vi.fn(),
+  mockRemoveMaintainerOnlySkillSymlinks: vi.fn(),
+  mockEnsurePiModelConfiguredAndAvailable: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess: mockRunChildProcess,
+    ensureCommandResolvable: mockEnsureCommandResolvable,
+    listPaperclipSkillEntries: mockListPaperclipSkillEntries,
+    removeMaintainerOnlySkillSymlinks: mockRemoveMaintainerOnlySkillSymlinks,
+  };
+});
+
+vi.mock("./models.js", () => ({
+  ensurePiModelConfiguredAndAvailable: mockEnsurePiModelConfiguredAndAvailable,
+}));
+
+import { execute } from "./execute.js";
+
+function buildContext(
+  overrides: Partial<AdapterExecutionContext> = {},
+): AdapterExecutionContext {
+  return {
+    runId: "run-123",
+    agent: {
+      id: "agent-123",
+      companyId: "company-123",
+      name: "CEO",
+      adapterType: "pi_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "pi",
+      model: "openai-codex/gpt-5.4",
+    },
+    context: {},
+    onLog: async () => {},
+    onMeta: async () => {},
+    authToken: "pcp-test-token",
+    ...overrides,
+  };
+}
+
+describe("pi execute", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-execute-"));
+    mockEnsureCommandResolvable.mockResolvedValue(undefined);
+    mockListPaperclipSkillEntries.mockResolvedValue([]);
+    mockRemoveMaintainerOnlySkillSymlinks.mockResolvedValue([]);
+    mockEnsurePiModelConfiguredAndAvailable.mockResolvedValue([]);
+    mockRunChildProcess.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "agent_start" }),
+        JSON.stringify({
+          type: "turn_end",
+          message: { role: "assistant", content: "hello" },
+        }),
+        JSON.stringify({ type: "agent_end", messages: [] }),
+      ].join("\n"),
+      stderr: "",
+    });
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("passes the same project workspace metadata env fields as other local adapters", async () => {
+    const cwd = path.join(tempDir, "project");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const onMeta = vi.fn(async () => {});
+
+    await execute(
+      buildContext({
+        config: {
+          command: "pi",
+          model: "openai-codex/gpt-5.4",
+        },
+        context: {
+          issueId: "issue-123",
+          paperclipWorkspace: {
+            cwd,
+            source: "project_primary",
+            strategy: "git_worktree",
+            workspaceId: "workspace-123",
+            repoUrl: "https://github.com/acme/repo.git",
+            repoRef: "main",
+            branchName: "issue-123-fix",
+            worktreePath: "/tmp/worktree-path",
+          },
+          paperclipWorkspaces: [{ workspaceId: "workspace-123", cwd }],
+          paperclipRuntimeServiceIntents: [{ serviceName: "devserver" }],
+          paperclipRuntimeServices: [{ serviceName: "devserver", url: "http://127.0.0.1:4173" }],
+          paperclipRuntimePrimaryUrl: "http://127.0.0.1:4173",
+        },
+        onMeta,
+      }),
+    );
+
+    expect(mockRunChildProcess).toHaveBeenCalledTimes(1);
+    const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+    expect(runOpts.cwd).toBe(cwd);
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBe(cwd);
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("project_primary");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_STRATEGY).toBe("git_worktree");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_ID).toBe("workspace-123");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_REPO_URL).toBe("https://github.com/acme/repo.git");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_REPO_REF).toBe("main");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_BRANCH).toBe("issue-123-fix");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_WORKTREE_PATH).toBe("/tmp/worktree-path");
+    expect(runOpts.env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON).toBe(
+      JSON.stringify([{ serviceName: "devserver" }]),
+    );
+    expect(runOpts.env.PAPERCLIP_RUNTIME_SERVICES_JSON).toBe(
+      JSON.stringify([{ serviceName: "devserver", url: "http://127.0.0.1:4173" }]),
+    );
+    expect(runOpts.env.PAPERCLIP_RUNTIME_PRIMARY_URL).toBe("http://127.0.0.1:4173");
+
+    expect(onMeta).toHaveBeenCalledTimes(1);
+    const metaCalls = onMeta.mock.calls as unknown as Array<[unknown]>;
+    const meta = (metaCalls[0]?.[0] ?? undefined) as
+      | { cwd?: string; commandArgs?: string[] }
+      | undefined;
+    expect(meta).toBeDefined();
+    expect(meta?.cwd).toBe(cwd);
+    expect(meta?.commandArgs).toContain("--mode");
+    expect(meta?.commandArgs).toContain("rpc");
+  });
+
+  it("uses configured cwd instead of agent_home fallback without exporting fallback workspace cwd", async () => {
+    const configuredCwd = path.join(tempDir, "configured-workspace");
+    await fs.mkdir(configuredCwd, { recursive: true });
+
+    await execute(
+      buildContext({
+        config: {
+          command: "pi",
+          model: "openai-codex/gpt-5.4",
+          cwd: configuredCwd,
+        },
+        context: {
+          paperclipWorkspace: {
+            cwd: "/Users/example/.paperclip/instances/default/workspaces/agent-123",
+            source: "agent_home",
+          },
+        },
+      }),
+    );
+
+    expect(mockRunChildProcess).toHaveBeenCalledTimes(1);
+    const [, , , runOpts] = mockRunChildProcess.mock.calls[0];
+    expect(runOpts.cwd).toBe(configuredCwd);
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("agent_home");
+    expect(runOpts.env.PAPERCLIP_WORKSPACE_CWD).toBeUndefined();
+  });
+});

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -341,32 +341,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const buildArgs = (sessionFile: string): string[] => {
     const args: string[] = [];
-    
-    // Use RPC mode for proper lifecycle management (waits for agent completion)
-    args.push("--mode", "rpc");
-    
+
+    // Use Pi's single-shot JSON mode so the process exits after the task completes.
+    args.push("--mode", "json");
+
     // Use --append-system-prompt to extend Pi's default system prompt
     args.push("--append-system-prompt", renderedSystemPromptExtension);
-    
+
     if (provider) args.push("--provider", provider);
     if (modelId) args.push("--model", modelId);
     if (thinking) args.push("--thinking", thinking);
-    
+
     args.push("--tools", "read,bash,edit,write,grep,find,ls");
     args.push("--session", sessionFile);
-    
-    if (extraArgs.length > 0) args.push(...extraArgs);
-    
-    return args;
-  };
 
-  const buildRpcStdin = (): string => {
-    // Send the prompt as an RPC command
-    const promptCommand = {
-      type: "prompt",
-      message: userPrompt,
-    };
-    return JSON.stringify(promptCommand) + "\n";
+    if (extraArgs.length > 0) args.push(...extraArgs);
+
+    args.push("-p", userPrompt);
+
+    return args;
   };
 
   const runAttempt = async (sessionFile: string) => {
@@ -414,7 +407,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       timeoutSec,
       graceSec,
       onLog: bufferedOnLog,
-      stdin: buildRpcStdin(),
     });
     
     // Flush any remaining buffer content
@@ -453,14 +445,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
 
     const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const parsedError = attempt.parsed.errors[0]?.trim() || "";
     const rawExitCode = attempt.proc.exitCode;
-    const fallbackErrorMessage = stderrLine || `Pi exited with code ${rawExitCode ?? -1}`;
+    const effectiveExitCode = (rawExitCode ?? 0) === 0 && parsedError ? 1 : rawExitCode;
+    const fallbackErrorMessage = parsedError || stderrLine || `Pi exited with code ${effectiveExitCode ?? -1}`;
 
     return {
-      exitCode: rawExitCode,
+      exitCode: effectiveExitCode,
       signal: attempt.proc.signal,
       timedOut: false,
-      errorMessage: (rawExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+      errorMessage: (effectiveExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
       usage: {
         inputTokens: attempt.parsed.usage.inputTokens,
         outputTokens: attempt.parsed.usage.outputTokens,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  resolveLocalAdapterExecutionCwd,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
@@ -136,10 +137,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
-  const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwdResolution = resolveLocalAdapterExecutionCwd(workspaceContext, config.cwd, process.cwd());
+  const effectiveWorkspaceCwd = cwdResolution.effectiveWorkspaceCwd;
+  const cwd = cwdResolution.effectiveCwd;
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   
   // Ensure sessions directory exists inside the active workspace
@@ -327,16 +327,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const commandNotes = (() => {
-    if (!instructionsFilePath) return [] as string[];
-    if (instructionsReadFailed) {
-      return [
-        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-      ];
+    const notes: string[] = [];
+    if (cwdResolution.commandNote) {
+      notes.push(cwdResolution.commandNote);
     }
-    return [
-        `Loaded agent instructions from ${instructionsFilePath}`,
+    if (!instructionsFilePath) return notes;
+    if (instructionsReadFailed) {
+      notes.push(
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+      );
+      return notes;
+    }
+    notes.push(
+      `Loaded agent instructions from ${instructionsFilePath}`,
       `Appended instructions + path directive to system prompt (relative references from ${instructionsFileDir}).`,
-    ];
+    );
+    return notes;
   })();
 
   const buildArgs = (sessionFile: string): string[] => {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -114,14 +114,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
       )
     : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
@@ -171,12 +185,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
-  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
+  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  if (runtimeServiceIntents.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  }
+  if (runtimeServices.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  }
+  if (runtimePrimaryUrl) {
+    env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
 
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
@@ -238,31 +264,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   // Handle instructions file and build system prompt extension
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
-  const resolvedInstructionsFilePath = instructionsFilePath
-    ? path.resolve(cwd, instructionsFilePath)
-    : "";
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   
   let systemPromptExtension = "";
   let instructionsReadFailed = false;
-  if (resolvedInstructionsFilePath) {
+  if (instructionsFilePath) {
     try {
-      const instructionsContents = await fs.readFile(resolvedInstructionsFilePath, "utf8");
+      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
       systemPromptExtension =
         `${instructionsContents}\n\n` +
-        `The above agent instructions were loaded from ${resolvedInstructionsFilePath}. ` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsFileDir}.\n\n` +
         `You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.`;
       await onLog(
         "stderr",
-        `[paperclip] Loaded agent instructions file: ${resolvedInstructionsFilePath}\n`,
+        `[paperclip] Loaded agent instructions file: ${instructionsFilePath}\n`,
       );
     } catch (err) {
       instructionsReadFailed = true;
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
         "stderr",
-        `[paperclip] Warning: could not read agent instructions file "${resolvedInstructionsFilePath}": ${reason}\n`,
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
       );
       // Fall back to base prompt template
       systemPromptExtension = promptTemplate;
@@ -302,14 +325,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const commandNotes = (() => {
-    if (!resolvedInstructionsFilePath) return [] as string[];
+    if (!instructionsFilePath) return [] as string[];
     if (instructionsReadFailed) {
       return [
-        `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
       ];
     }
     return [
-      `Loaded agent instructions from ${resolvedInstructionsFilePath}`,
+        `Loaded agent instructions from ${instructionsFilePath}`,
       `Appended instructions + path directive to system prompt (relative references from ${instructionsFileDir}).`,
     ];
   })();

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -25,7 +25,6 @@ import { ensurePiModelConfiguredAndAvailable } from "./models.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
-const PAPERCLIP_SESSIONS_DIR = path.join(os.homedir(), ".pi", "paperclips");
 
 function firstNonEmptyLine(text: string): string {
   return (
@@ -86,14 +85,15 @@ async function ensurePiSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
   }
 }
 
-async function ensureSessionsDir(): Promise<string> {
-  await fs.mkdir(PAPERCLIP_SESSIONS_DIR, { recursive: true });
-  return PAPERCLIP_SESSIONS_DIR;
+async function ensureSessionsDir(cwd: string): Promise<string> {
+  const sessionsDir = path.join(cwd, ".paperclip", "pi", "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+  return sessionsDir;
 }
 
-function buildSessionPath(agentId: string, timestamp: string): string {
+function buildSessionPath(sessionsDir: string, agentId: string, timestamp: string): string {
   const safeTimestamp = timestamp.replace(/[:.]/g, "-");
-  return path.join(PAPERCLIP_SESSIONS_DIR, `${safeTimestamp}-${agentId}.jsonl`);
+  return path.join(sessionsDir, `${safeTimestamp}-${agentId}.jsonl`);
 }
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
@@ -142,8 +142,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   
-  // Ensure sessions directory exists
-  await ensureSessionsDir();
+  // Ensure sessions directory exists inside the active workspace
+  const sessionsDir = await ensureSessionsDir(cwd);
   
   // Inject skills
   await ensurePiSkillsInjected(onLog);
@@ -241,7 +241,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
-  const sessionPath = canResumeSession ? runtimeSessionId : buildSessionPath(agent.id, new Date().toISOString());
+  const sessionPath = canResumeSession
+    ? runtimeSessionId
+    : buildSessionPath(sessionsDir, agent.id, new Date().toISOString());
   
   if (runtimeSessionId && !canResumeSession) {
     await onLog(
@@ -493,7 +495,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       "stderr",
       `[paperclip] Pi session "${runtimeSessionId}" is unavailable; retrying with a fresh session.\n`,
     );
-    const newSessionPath = buildSessionPath(agent.id, new Date().toISOString());
+    const newSessionPath = buildSessionPath(sessionsDir, agent.id, new Date().toISOString());
     try {
       await fs.writeFile(newSessionPath, "", { flag: "wx" });
     } catch (err) {

--- a/packages/adapters/pi-local/src/server/parse.test.ts
+++ b/packages/adapters/pi-local/src/server/parse.test.ts
@@ -209,6 +209,34 @@ describe("parsePiJsonl", () => {
     expect(parsed.usage.cachedInputTokens).toBe(25);
     expect(parsed.usage.costUsd).toBe(0.003);
   });
+
+  it("captures logical agent errors even when Pi exits cleanly", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: "",
+          stopReason: "error",
+          errorMessage: "Failed to extract accountId from token",
+        },
+      }),
+      JSON.stringify({
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            stopReason: "error",
+            errorMessage: "Failed to extract accountId from token",
+          },
+        ],
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toContain("Failed to extract accountId from token");
+  });
 });
 
 describe("isPiUnknownSessionError", () => {

--- a/packages/adapters/pi-local/src/server/parse.ts
+++ b/packages/adapters/pi-local/src/server/parse.ts
@@ -71,6 +71,11 @@ export function parsePiJsonl(stdout: string): ParsedPiOutput {
         if (lastMessage?.role === "assistant") {
           const content = lastMessage.content as string | Array<{ type: string; text?: string }>;
           result.finalMessage = extractTextContent(content);
+          const stopReason = asString(lastMessage.stopReason, "").trim().toLowerCase();
+          const errorMessage = asString(lastMessage.errorMessage, "").trim();
+          if (stopReason === "error" && errorMessage) {
+            result.errors.push(errorMessage);
+          }
         }
       }
       continue;
@@ -89,6 +94,11 @@ export function parsePiJsonl(stdout: string): ParsedPiOutput {
         if (text) {
           result.finalMessage = text;
           result.messages.push(text);
+        }
+        const stopReason = asString(message.stopReason, "").trim().toLowerCase();
+        const errorMessage = asString(message.errorMessage, "").trim();
+        if (stopReason === "error" && errorMessage) {
+          result.errors.push(errorMessage);
         }
         
         // Extract usage and cost from assistant message

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  describeSessionResetReason,
+  formatFallbackWorkspaceWarning,
   resolveRuntimeSessionParamsForWorkspace,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -149,5 +151,54 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("describeSessionResetReason", () => {
+  it("explains assignment wakes as intentional fresh-session boundaries", () => {
+    expect(describeSessionResetReason({ wakeReason: "issue_assigned" })).toContain(
+      "assignment wakes start a fresh task session",
+    );
+  });
+});
+
+describe("formatFallbackWorkspaceWarning", () => {
+  it("mentions configured cwd when agent_home fallback is only a bookkeeping workspace", () => {
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir("agent-123");
+
+    expect(
+      formatFallbackWorkspaceWarning({
+        fallbackCwd,
+        resolvedProjectId: null,
+        sessionCwd: null,
+        configuredCwd: "/tmp/repo",
+      }),
+    ).toContain('Using configured cwd "/tmp/repo" instead of fallback agent_home workspace');
+  });
+
+  it("keeps the plain fallback message when no configured cwd is available", () => {
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir("agent-123");
+
+    expect(
+      formatFallbackWorkspaceWarning({
+        fallbackCwd,
+        resolvedProjectId: null,
+        sessionCwd: null,
+      }),
+    ).toBe(`No project or prior session workspace was available. Using fallback workspace "${fallbackCwd}" for this run.`);
+  });
+
+  it("does not claim no prior session was available when one was intentionally skipped", () => {
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir("agent-123");
+
+    expect(
+      formatFallbackWorkspaceWarning({
+        fallbackCwd,
+        resolvedProjectId: null,
+        sessionCwd: null,
+        skippedSessionCwd: "/tmp/old-session",
+        configuredCwd: "/tmp/repo",
+      }),
+    ).toContain('after intentionally skipping saved task session workspace "/tmp/old-session"');
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13,6 +13,7 @@ import {
   projects,
   projectWorkspaces,
 } from "@paperclipai/db";
+import { resolveLocalAdapterExecutionCwd } from "@paperclipai/adapter-utils/server-utils";
 import { conflict, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
@@ -363,14 +364,44 @@ export function shouldResetTaskSessionForWake(
   return false;
 }
 
-function describeSessionResetReason(
+export function describeSessionResetReason(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
   if (contextSnapshot?.forceFreshSession === true) return "forceFreshSession was requested";
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
-  if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
+  if (wakeReason === "issue_assigned") {
+    return 'wake reason is "issue_assigned" (assignment wakes start a fresh task session)';
+  }
   return null;
+}
+
+export function formatFallbackWorkspaceWarning(input: {
+  fallbackCwd: string;
+  resolvedProjectId: string | null;
+  sessionCwd: string | null;
+  skippedSessionCwd?: string | null;
+  configuredCwd?: string | null;
+}) {
+  const cwdResolution = resolveLocalAdapterExecutionCwd(
+    { cwd: input.fallbackCwd, source: "agent_home" },
+    input.configuredCwd,
+    input.fallbackCwd,
+  );
+  const target = cwdResolution.commandNote
+    ? `Paperclip recorded fallback workspace "${input.fallbackCwd}" for this run. ${cwdResolution.commandNote}`
+    : `Using fallback workspace "${input.fallbackCwd}" for this run.`;
+
+  if (input.sessionCwd) {
+    return `Saved session workspace "${input.sessionCwd}" is not available. ${target}`;
+  }
+  if (input.skippedSessionCwd) {
+    return `No reusable project workspace directory is currently available for this run after intentionally skipping saved task session workspace "${input.skippedSessionCwd}". ${target}`;
+  }
+  if (input.resolvedProjectId) {
+    return `No project workspace directory is currently available for this issue. ${target}`;
+  }
+  return `No project or prior session workspace was available. ${target}`;
 }
 
 function deriveCommentId(
@@ -802,7 +833,11 @@ export function heartbeatService(db: Db) {
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null },
+    opts?: {
+      useProjectWorkspace?: boolean | null;
+      configuredCwd?: string | null;
+      skippedSessionCwd?: string | null;
+    },
   ): Promise<ResolvedWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId);
     const contextProjectId = readNonEmptyString(context.projectId);
@@ -894,6 +929,7 @@ export function heartbeatService(db: Db) {
     }
 
     const sessionCwd = readNonEmptyString(previousSessionParams?.cwd);
+    const skippedSessionCwd = readNonEmptyString(opts?.skippedSessionCwd);
     if (sessionCwd) {
       const sessionCwdExists = await fs
         .stat(sessionCwd)
@@ -916,19 +952,15 @@ export function heartbeatService(db: Db) {
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
-    if (sessionCwd) {
-      warnings.push(
-        `Saved session workspace "${sessionCwd}" is not available. Using fallback workspace "${cwd}" for this run.`,
-      );
-    } else if (resolvedProjectId) {
-      warnings.push(
-        `No project workspace directory is currently available for this issue. Using fallback workspace "${cwd}" for this run.`,
-      );
-    } else {
-      warnings.push(
-        `No project or prior session workspace was available. Using fallback workspace "${cwd}" for this run.`,
-      );
-    }
+    warnings.push(
+      formatFallbackWorkspaceWarning({
+        fallbackCwd: cwd,
+        resolvedProjectId,
+        sessionCwd,
+        skippedSessionCwd,
+        configuredCwd: readNonEmptyString(opts?.configuredCwd),
+      }),
+    );
     return {
       cwd,
       source: "agent_home" as const,
@@ -1434,6 +1466,9 @@ export function heartbeatService(db: Db) {
     const resetTaskSession = shouldResetTaskSessionForWake(context);
     const sessionResetReason = describeSessionResetReason(context);
     const taskSessionForRun = resetTaskSession ? null : taskSession;
+    const taskSessionParams = normalizeSessionParams(
+      sessionCodec.deserialize(taskSession?.sessionParamsJson ?? null),
+    );
     const previousSessionParams = normalizeSessionParams(
       sessionCodec.deserialize(taskSessionForRun?.sessionParamsJson ?? null),
     );
@@ -1443,12 +1478,6 @@ export function heartbeatService(db: Db) {
       issueSettings: issueExecutionWorkspaceSettings,
       legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
     });
-    const resolvedWorkspace = await resolveWorkspaceForRun(
-      agent,
-      context,
-      previousSessionParams,
-      { useProjectWorkspace: executionWorkspaceMode !== "agent_default" },
-    );
     const workspaceManagedConfig = buildExecutionWorkspaceAdapterConfig({
       agentConfig: config,
       projectPolicy: projectExecutionWorkspacePolicy,
@@ -1459,6 +1488,18 @@ export function heartbeatService(db: Db) {
     const mergedConfig = issueAssigneeOverrides?.adapterConfig
       ? { ...workspaceManagedConfig, ...issueAssigneeOverrides.adapterConfig }
       : workspaceManagedConfig;
+    const configuredExecutionCwd = readNonEmptyString(mergedConfig.cwd);
+    const skippedSessionCwd = resetTaskSession ? readNonEmptyString(taskSessionParams?.cwd) : null;
+    const resolvedWorkspace = await resolveWorkspaceForRun(
+      agent,
+      context,
+      previousSessionParams,
+      {
+        useProjectWorkspace: executionWorkspaceMode !== "agent_default",
+        configuredCwd: configuredExecutionCwd,
+        skippedSessionCwd,
+      },
+    );
     const { config: resolvedConfig, secretKeys } = await secretsSvc.resolveAdapterConfigForRuntime(
       agent.companyId,
       mergedConfig,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,17 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/db", "packages/adapters/opencode-local", "server", "ui", "cli"],
+    projects: [
+      "packages/db",
+      "packages/adapters/claude-local",
+      "packages/adapters/codex-local",
+      "packages/adapters/cursor-local",
+      "packages/adapters/gemini-local",
+      "packages/adapters/opencode-local",
+      "packages/adapters/pi-local",
+      "server",
+      "ui",
+      "cli",
+    ],
   },
 });


### PR DESCRIPTION
This is a very, very basic implementation of pi's coding agent. 

- It now runs 'CREATE CEO HEARTBEAT.md' without issue on a variety of models using various service providers, which was a huge onboarding blocker.
- Hires and runs engineer agent without a problem
- Tests have been implemented to make sure we are matching existing patterns for other agentic clis like codex & claude code, and then making sure behavior across all tools is the same in the future.
- Pi exists when finished (was previously hanging)

Still to do:
- Assignable extension & skill stacks for individual agents (this is a must for anyone serious about agentic orchestration)
- Assignable models by agent

This PR is dedicated to the citizens of PI NATION. We will show the paperclip community why pi is the best harness.
