### PR TITLE
fix: prevent trailing interactive controls being swallowed by EntityR…

### DIFF
--- a/ui/src/components/EntityRow.tsx
+++ b/ui/src/components/EntityRow.tsx
@@ -26,44 +26,74 @@ export function EntityRow({
   className,
 }: EntityRowProps) {
   const isClickable = !!(to || onClick);
-  const classes = cn(
+  const baseClasses = cn(
     "flex items-center gap-3 px-4 py-2 text-sm border-b border-border last:border-b-0 transition-colors",
     isClickable && "cursor-pointer hover:bg-accent/50",
     selected && "bg-accent/30",
     className
   );
 
-  const content = (
-    <>
-      {leading && <div className="flex items-center gap-2 shrink-0">{leading}</div>}
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          {identifier && (
-            <span className="text-xs text-muted-foreground font-mono shrink-0 relative top-[1px]">
-              {identifier}
-            </span>
-          )}
-          <span className="truncate">{title}</span>
-        </div>
-        {subtitle && (
-          <p className="text-xs text-muted-foreground truncate mt-0.5">{subtitle}</p>
+  const leadingEl = leading ? (
+    <div className="flex items-center gap-2 shrink-0">{leading}</div>
+  ) : null;
+
+  const bodyEl = (
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center gap-2">
+        {identifier && (
+          <span className="text-xs text-muted-foreground font-mono shrink-0 relative top-[1px]">
+            {identifier}
+          </span>
         )}
+        <span className="truncate">{title}</span>
       </div>
-      {trailing && <div className="flex items-center gap-2 shrink-0">{trailing}</div>}
-    </>
+      {subtitle && (
+        <p className="text-xs text-muted-foreground truncate mt-0.5">{subtitle}</p>
+      )}
+    </div>
   );
+
+  const trailingEl = trailing ? (
+    <div className="flex items-center gap-2 shrink-0">{trailing}</div>
+  ) : null;
+
+  // When there is both a nav target and trailing interactive content, split the
+  // row: a Link covers the leading + body (left side), while trailing sits in
+  // normal flow at a higher z-index so its buttons/menus are never swallowed
+  // by the link's click area.
+  if (to && trailing) {
+    return (
+      <div className={cn(baseClasses, "relative")}>
+        <Link
+          to={to}
+          className="absolute inset-0 no-underline"
+          onClick={onClick}
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+        {leadingEl}
+        {bodyEl}
+        <div className="relative z-10 flex items-center gap-2 shrink-0">
+          {trailing}
+        </div>
+      </div>
+    );
+  }
 
   if (to) {
     return (
-      <Link to={to} className={cn(classes, "no-underline text-inherit")} onClick={onClick}>
-        {content}
+      <Link to={to} className={cn(baseClasses, "no-underline text-inherit")} onClick={onClick}>
+        {leadingEl}
+        {bodyEl}
       </Link>
     );
   }
 
   return (
-    <div className={classes} onClick={onClick}>
-      {content}
+    <div className={baseClasses} onClick={onClick}>
+      {leadingEl}
+      {bodyEl}
+      {trailingEl}
     </div>
   );
 }


### PR DESCRIPTION
When a row has both a navigation target (to=) and trailing content (buttons, menus), the Link element previously covered the entire row, making trailing controls unclickable. Split the layout so a decorative full-bleed Link sits behind the content (z-index / aria-hidden) while trailing children render at a higher z-index in normal document flow.