### PR TITLE
feat(relay): zero-config remote access via tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 **What does a typical setup look like?**
 Locally, a single Node.js process manages an embedded Postgres and local file storage. For production, point it at your own Postgres and deploy however you like. Configure projects, agents, and goals — the agents take care of the rest.
 
-If you're a solo-entreprenuer you can use Tailscale to access Paperclip on the go. Then later you can deploy to e.g. Vercel when you need it.
+If you're a solo-entreprenuer you can use the built-in relay or Tailscale to access Paperclip on the go. The relay gives your instance a public URL (e.g. `https://d4lsc.your-relay.com`) with zero port forwarding — just set `PAPERCLIP_RELAY_URL` and the server handles the rest. A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI — deploy your own for production). See [doc/RELAY.md](doc/RELAY.md) for details. Both relay and Tailscale require `authenticated` deployment mode.
 
 **Can I run multiple companies?**
 Yes. A single deployment can run an unlimited number of companies with complete data isolation.

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -37,11 +37,19 @@ Current CLI behavior:
 
 Target behavior (planned) is documented in `doc/DEPLOYMENT-MODES.md` section 5.
 
-Allow an authenticated/private hostname (for example custom Tailscale DNS):
+Allow an authenticated/private hostname (for example custom Tailscale DNS or relay subdomain):
 
 ```sh
 pnpm paperclipai allowed-hostname dotta-macbook-pro
 ```
+
+Enable relay tunnel for remote access (requires `authenticated` mode):
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm paperclipai run
+```
+
+A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI — deploy your own for production). See `doc/RELAY.md` for relay architecture and deployment.
 
 All client commands support:
 

--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -32,12 +32,14 @@ This keeps one authenticated auth stack while still separating low-friction priv
 - loopback-only host binding
 - no human login flow
 - optimized for fastest local startup
+- relay tunnel is blocked (server refuses to start)
 
 ## `authenticated + private`
 
 - login required
 - low-friction URL handling (`auto` base URL mode)
 - private-host trust policy required
+- required for relay tunnel (see `doc/RELAY.md`)
 
 ## `authenticated + public`
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -53,6 +53,14 @@ Allow additional private hostnames (for example custom Tailscale hostnames):
 pnpm paperclipai allowed-hostname dotta-macbook-pro
 ```
 
+Relay tunnel dev mode (remote access without port forwarding):
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm dev --tailscale-auth
+```
+
+On first start, the server auto-registers and prints a public URL (e.g. `https://d4lsc.your-relay-server.com`). Token and hostname are persisted automatically. A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI — deploy your own for production). See `doc/RELAY.md` for relay architecture and server source.
+
 ## One-Command Local Run
 
 For a first-time local install, you can bootstrap and run in one command:

--- a/doc/RELAY.md
+++ b/doc/RELAY.md
@@ -1,0 +1,585 @@
+# Relay
+
+Status: Experimental
+Date: 2026-03-13
+
+## 1. Purpose
+
+The relay gives any Paperclip instance a public HTTPS URL with zero configuration. It enables remote access from any device without VPN, port forwarding, or extra software.
+
+```
+Any browser/device                     Paperclip server (behind NAT)
+       │                                          │
+       │──HTTPS──▶ ┌──────────────┐  ◀──WSS──────│
+       │           │ Relay Server │   outbound     │
+       │◀──HTTPS── │ (CF Worker)  │   tunnel       │
+       │           └──────────────┘               │
+       │            Public internet          127.0.0.1:3100
+```
+
+Each instance gets its own subdomain (e.g. `d4lsc.relay.example.com`). The relay is a generic transport layer — it forwards HTTP requests and WebSocket frames without inspecting payloads. All authentication is handled by Paperclip's existing auth layer.
+
+## 2. What Gets Tunneled
+
+- Static web UI assets (HTML/JS/CSS) — full Paperclip dashboard in any browser
+- REST API calls — all existing endpoints work unchanged
+- WebSocket connections — real-time events and live updates
+
+## 3. Configuration
+
+One environment variable enables the relay:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://relay.example.com
+```
+
+When set, the server auto-registers on first startup (obtaining a token and instance ID), then connects to the relay and prints the public subdomain URL:
+
+```
+$ npx paperclipai run
+
+  Server listening on 127.0.0.1:3100
+  Relay           https://d4lsc.relay.example.com
+```
+
+The server stays bound to `127.0.0.1`. The relay client runs inside the same process and forwards to localhost.
+
+## 4. Setup
+
+### 4.1 Deploy the relay server
+
+> **Test relay available**: `paperclip-relay.com` is a community-run relay for testing purposes. It is not affiliated with or operated by Paperclip AI. For production use, deploy your own relay server.
+
+The relay is a Cloudflare Worker with a Durable Object. See section 8 for the full source.
+
+```sh
+npm create cloudflare@latest paperclip-relay -- --type worker
+cd paperclip-relay
+# copy source files from section 8
+# set RELAY_DOMAIN in wrangler.toml [vars] to your domain
+# add wildcard DNS (*.your-domain.com) pointing to the Worker
+npx wrangler deploy
+```
+
+### 4.2 Configure Paperclip
+
+Add the relay URL to `.env` or set as an environment variable:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://relay.example.com
+```
+
+That's it. On first startup, the server automatically:
+
+1. Registers with the relay (`POST /register`)
+2. Saves the token to `.env` (`PAPERCLIP_RELAY_TOKEN=rl_...`)
+3. Adds the subdomain hostname (e.g. `d4lsc.relay.example.com`) to `allowedHostnames` in `config.json`
+
+On subsequent startups, the saved token is reused — the server reconnects to the same relay instance with the same subdomain.
+
+### 4.3 Open from anywhere
+
+Navigate to `https://<id>.relay.example.com` in any browser. Each Paperclip instance gets its own subdomain, so multiple Macs can use the same relay server without conflict.
+
+## 5. Why Subdomains
+
+SPAs use absolute paths for assets (e.g. `/assets/main.js`). Browsers resolve these against the domain root, not the current path. Path-prefix routing (`relay.example.com/abc12/`) would cause the browser to request `relay.example.com/assets/main.js` — wrong instance, or 404.
+
+Subdomains avoid this entirely: `abc12.relay.example.com/assets/main.js` stays within the same instance. This is the same approach used by Vercel, Netlify, and ngrok.
+
+## 6. Security
+
+**The relay requires `authenticated` deployment mode.** The server refuses to start the relay in `local_trusted` mode and logs an error. This is enforced because `local_trusted` has no login — enabling the relay would expose the instance to the public internet without any authentication.
+
+| Layer | Protection |
+|---|---|
+| Deployment mode | Must be `authenticated` — enforced at startup |
+| Client to relay | HTTPS/TLS (Cloudflare certificate) |
+| Relay to Paperclip | WSS/TLS |
+| Tunnel auth | Token — only the registered instance can connect |
+| API auth | Better Auth session cookies pass through unchanged |
+
+The relay sees traffic in plaintext at the proxy layer. This is the same trust model as any reverse proxy (Cloudflare, nginx, Caddy). Paperclip's own auth layer protects the API.
+
+## 7. Limitations
+
+- **Latency**: adds 20-100ms per request (Cloudflare edge round-trip)
+- **Tunnel single point**: if the server disconnects (sleep, restart), the relay returns 502 until reconnect
+- **No end-to-end encryption**: the relay sees plaintext (same as any reverse proxy)
+
+## 8. Relay Server Source
+
+The relay server is a Cloudflare Worker with a Durable Object. The Durable Object holds the persistent tunnel WebSocket from the Paperclip server and forwards requests through it.
+
+Key implementation details:
+
+- **Subdomain routing**: Each instance gets a subdomain (`<id>.relay.example.com`). The Worker extracts the instance ID from the `Host` header and routes to the corresponding Durable Object. Admin endpoints (`/register`, `/tunnel`, `/health`) live on the root domain.
+- **Configurable domain**: The relay domain is set via `RELAY_DOMAIN` in `wrangler.toml` — not hardcoded. Anyone can deploy their own relay on any domain.
+- **Hibernation recovery**: Durable Objects hibernate when idle, losing in-memory state. WebSockets are restored in the constructor via `getWebSockets()` using tags (`"__tunnel__"` for the tunnel, wsId for clients).
+- **Multi-value headers**: `set-cookie` headers cannot be comma-joined (cookie values contain commas in date strings). These are sent as JSON arrays with a companion `x-relay-multi-<header>` flag.
+
+### 8.1 `wrangler.toml`
+
+```toml
+name = "paperclip-relay"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+workers_dev = true
+
+routes = [
+  { pattern = "your-domain.com/*", zone_name = "your-domain.com" },
+  { pattern = "*.your-domain.com/*", zone_name = "your-domain.com" },
+]
+
+[vars]
+RELAY_DOMAIN = "your-domain.com"
+
+[durable_objects]
+bindings = [
+  { name = "TUNNEL", class_name = "TunnelDO" }
+]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["TunnelDO"]
+```
+
+### 8.2 `package.json`
+
+```json
+{
+  "name": "paperclip-relay",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250301.0",
+    "wrangler": "^4.0.0"
+  }
+}
+```
+
+### 8.3 `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}
+```
+
+### 8.4 `src/index.ts`
+
+```typescript
+export { TunnelDO } from "./tunnel";
+
+interface Env {
+  TUNNEL: DurableObjectNamespace;
+  RELAY_DOMAIN: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const instanceId = extractSubdomain(url.hostname, env.RELAY_DOMAIN);
+
+    // Subdomain request (e.g. skl1l.relay.example.com) → proxy to instance DO
+    if (instanceId) {
+      const stub = env.TUNNEL.get(env.TUNNEL.idFromName(instanceId));
+      return stub.fetch(request);
+    }
+
+    // Admin routes on root domain
+    if (url.pathname === "/register" && request.method === "POST") {
+      return handleRegister(env);
+    }
+
+    if (url.pathname === "/tunnel") {
+      const authHeader = request.headers.get("authorization") ?? "";
+      const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+      if (!token) return new Response("Missing token", { status: 401 });
+      return routeToTunnel(env, token, request);
+    }
+
+    if (url.pathname === "/health") {
+      return Response.json({ status: "ok" });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};
+
+/** Extract instance ID from subdomain: skl1l.example.com → skl1l (given base "example.com") */
+function extractSubdomain(hostname: string, relayDomain: string): string | null {
+  const suffix = `.${relayDomain}`;
+  if (hostname.endsWith(suffix)) {
+    return hostname.slice(0, -suffix.length) || null;
+  }
+  return null;
+}
+
+async function handleRegister(env: Env): Promise<Response> {
+  const instanceId = generateId(5);
+  const token = "rl_" + generateId(32);
+
+  // Initialize the instance DO
+  const doId = env.TUNNEL.idFromName(instanceId);
+  const stub = env.TUNNEL.get(doId);
+  await stub.fetch(new Request("http://internal/init", {
+    method: "POST",
+    body: JSON.stringify({ token, instanceId, relayDomain: env.RELAY_DOMAIN }),
+  }));
+
+  // Store token → instanceId mapping in the registry DO
+  const registry = env.TUNNEL.get(env.TUNNEL.idFromName("__token_registry__"));
+  await registry.fetch(new Request("http://internal/register-token", {
+    method: "POST",
+    body: JSON.stringify({ token, instanceId }),
+  }));
+
+  const publicUrl = `https://${instanceId}.${env.RELAY_DOMAIN}`;
+  return Response.json({ token, instanceId, publicUrl });
+}
+
+/** Look up instanceId from token, then route to the tunnel DO */
+async function routeToTunnel(
+  env: Env,
+  token: string,
+  request: Request,
+): Promise<Response> {
+  const registry = env.TUNNEL.get(env.TUNNEL.idFromName("__token_registry__"));
+  const resp = await registry.fetch(new Request("http://internal/lookup", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  }));
+  if (!resp.ok) return new Response("Invalid token", { status: 401 });
+  const { instanceId } = await resp.json() as { instanceId: string };
+
+  const stub = env.TUNNEL.get(env.TUNNEL.idFromName(instanceId));
+  return stub.fetch(request);
+}
+
+function generateId(length: number): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => chars[b % chars.length]).join("");
+}
+```
+
+### 8.5 `src/tunnel.ts`
+
+```typescript
+interface PendingRequest {
+  resolve: (response: Response) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+export class TunnelDO {
+  private state: DurableObjectState;
+  private tunnelWs: WebSocket | null = null;
+  private pendingRequests = new Map<string, PendingRequest>();
+  private clientWebSockets = new Map<string, WebSocket>();
+  private instanceId: string | null = null;
+  private relayDomain: string | null = null;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+
+    // Restore WebSockets after hibernation. Durable Objects may hibernate
+    // when idle, losing all in-memory state. The tunnel WS is tagged
+    // "__tunnel__"; client WSes are tagged with their wsId.
+    for (const ws of this.state.getWebSockets()) {
+      const tags = this.state.getTags(ws);
+      if (tags.includes("__tunnel__")) {
+        this.tunnelWs = ws;
+      } else if (tags.length > 0) {
+        this.clientWebSockets.set(tags[0], ws);
+      }
+    }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/init" && request.method === "POST") {
+      return this.handleInit(request);
+    }
+
+    if (url.pathname === "/register-token" && request.method === "POST") {
+      return this.handleRegisterToken(request);
+    }
+
+    if (url.pathname === "/lookup" && request.method === "POST") {
+      return this.handleTokenLookup(request);
+    }
+
+    if (url.pathname === "/tunnel") {
+      return this.handleTunnelConnect();
+    }
+
+    if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      return this.handleClientWebSocket(request, url);
+    }
+
+    return this.handleHttpProxy(request, url);
+  }
+
+  // -- Internal routes -------------------------------------------------------
+
+  private async handleInit(request: Request): Promise<Response> {
+    const { token, instanceId, relayDomain } = await request.json() as {
+      token: string; instanceId: string; relayDomain: string;
+    };
+    this.instanceId = instanceId;
+    this.relayDomain = relayDomain;
+    await this.state.storage.put("token", token);
+    await this.state.storage.put("instanceId", instanceId);
+    await this.state.storage.put("relayDomain", relayDomain);
+    return new Response("OK");
+  }
+
+  private async handleRegisterToken(request: Request): Promise<Response> {
+    const { token, instanceId } = await request.json() as { token: string; instanceId: string };
+    await this.state.storage.put(`token:${token}`, instanceId);
+    return new Response("OK");
+  }
+
+  private async handleTokenLookup(request: Request): Promise<Response> {
+    const { token } = await request.json() as { token: string };
+    const instanceId = await this.state.storage.get<string>(`token:${token}`);
+    if (!instanceId) return new Response("Not found", { status: 404 });
+    return Response.json({ instanceId });
+  }
+
+  // -- Tunnel connection -----------------------------------------------------
+
+  private handleTunnelConnect(): Response {
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+
+    // Tag with "__tunnel__" so we can restore this WebSocket after hibernation
+    this.state.acceptWebSocket(server, ["__tunnel__"]);
+    this.tunnelWs = server;
+
+    void Promise.all([
+      this.state.storage.get<string>("instanceId"),
+      this.state.storage.get<string>("relayDomain"),
+    ]).then(([id, domain]) => {
+      this.instanceId = id ?? null;
+      this.relayDomain = domain ?? null;
+      if (this.instanceId && this.relayDomain) {
+        server.send(JSON.stringify({
+          type: "tunnel-ready",
+          instanceId: this.instanceId,
+          publicUrl: `https://${this.instanceId}.${this.relayDomain}`,
+        }));
+      }
+    });
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  // -- HTTP proxy ------------------------------------------------------------
+
+  private handleHttpProxy(request: Request, url: URL): Promise<Response> {
+    if (!this.tunnelWs || this.tunnelWs.readyState !== WebSocket.OPEN) {
+      return Promise.resolve(new Response("Tunnel offline", { status: 502 }));
+    }
+
+    const id = crypto.randomUUID();
+
+    return new Promise<Response>(async (resolve) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        resolve(new Response("Gateway Timeout", { status: 504 }));
+      }, 30_000);
+
+      this.pendingRequests.set(id, { resolve, timeout });
+
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+      }
+      headers["x-forwarded-host"] = url.host;
+      headers["x-forwarded-proto"] = "https";
+
+      const bodyBuf = request.body
+        ? await request.arrayBuffer()
+        : new ArrayBuffer(0);
+
+      this.tunnelWs!.send(JSON.stringify({
+        id,
+        type: "http-request",
+        method: request.method,
+        path: url.pathname + url.search,
+        headers,
+        body: arrayBufferToBase64(bodyBuf),
+      }));
+    });
+  }
+
+  // -- WebSocket proxy -------------------------------------------------------
+
+  private handleClientWebSocket(request: Request, url: URL): Response {
+    if (!this.tunnelWs || this.tunnelWs.readyState !== WebSocket.OPEN) {
+      return new Response("Tunnel offline", { status: 502 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    const wsId = crypto.randomUUID();
+
+    this.state.acceptWebSocket(server, [wsId]);
+    this.clientWebSockets.set(wsId, server);
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+
+    this.tunnelWs.send(JSON.stringify({
+      type: "ws-open",
+      id: wsId,
+      path: url.pathname + url.search,
+      headers,
+    }));
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  // -- WebSocket event handlers ----------------------------------------------
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const data = typeof message === "string"
+      ? message
+      : new TextDecoder().decode(message);
+
+    if (ws === this.tunnelWs) {
+      this.handleTunnelMessage(data);
+      return;
+    }
+
+    for (const [wsId, clientWs] of this.clientWebSockets) {
+      if (clientWs === ws) {
+        this.tunnelWs?.send(JSON.stringify({
+          type: "ws-message",
+          id: wsId,
+          data,
+        }));
+        return;
+      }
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number): Promise<void> {
+    if (ws === this.tunnelWs) {
+      this.tunnelWs = null;
+      this.clientWebSockets.forEach((cws) => cws.close(1001));
+      this.clientWebSockets.clear();
+      this.pendingRequests.forEach((p) => {
+        clearTimeout(p.timeout);
+        p.resolve(new Response("Tunnel disconnected", { status: 502 }));
+      });
+      this.pendingRequests.clear();
+      return;
+    }
+
+    for (const [wsId, clientWs] of this.clientWebSockets) {
+      if (clientWs === ws) {
+        this.clientWebSockets.delete(wsId);
+        this.tunnelWs?.send(JSON.stringify({
+          type: "ws-close",
+          id: wsId,
+          code,
+        }));
+        return;
+      }
+    }
+  }
+
+  async webSocketError(ws: WebSocket): Promise<void> {
+    void this.webSocketClose(ws, 1006);
+  }
+
+  // -- Private helpers -------------------------------------------------------
+
+  private handleTunnelMessage(data: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
+
+    if (msg.type === "http-response") {
+      const pending = this.pendingRequests.get(msg.id);
+      if (!pending) return;
+      clearTimeout(pending.timeout);
+      this.pendingRequests.delete(msg.id);
+
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(msg.headers as Record<string, string>)) {
+        if (key.startsWith("x-relay-multi-")) continue;
+        if (msg.headers[`x-relay-multi-${key}`]) {
+          try {
+            for (const v of JSON.parse(value) as string[]) {
+              headers.append(key, v);
+            }
+          } catch {
+            headers.set(key, value);
+          }
+        } else {
+          headers.set(key, value);
+        }
+      }
+
+      pending.resolve(new Response(base64ToArrayBuffer(msg.body), {
+        status: msg.status,
+        headers,
+      }));
+    } else if (msg.type === "ws-message") {
+      this.clientWebSockets.get(msg.id)?.send(msg.data);
+    } else if (msg.type === "ws-close" || msg.type === "ws-error") {
+      const clientWs = this.clientWebSockets.get(msg.id);
+      if (clientWs) {
+        clientWs.close(msg.code ?? 1000);
+        this.clientWebSockets.delete(msg.id);
+      }
+    }
+  }
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+```
+
+## 9. Relationship to Other Docs
+
+- deployment modes: `doc/DEPLOYMENT-MODES.md` — `authenticated` mode is required for relay

--- a/docs/deploy/deployment-modes.md
+++ b/docs/deploy/deployment-modes.md
@@ -13,6 +13,7 @@ The default mode. Optimized for single-operator local use.
 - **Authentication**: no login required
 - **Use case**: local development, solo experimentation
 - **Board identity**: auto-created local board user
+- **Relay tunnel**: blocked (server refuses to start)
 
 ```sh
 # Set during onboard
@@ -26,18 +27,19 @@ Login required. Supports two exposure policies.
 
 ### `authenticated` + `private`
 
-For private network access (Tailscale, VPN, LAN).
+For private network access (Tailscale, VPN, LAN) and relay tunnel.
 
 - **Authentication**: login required via Better Auth
 - **URL handling**: auto base URL mode (lower friction)
 - **Host trust**: private-host trust policy required
+- **Relay tunnel**: supported (see [Relay Tunnel](/deploy/relay-tunnel))
 
 ```sh
 pnpm paperclipai onboard
 # Choose "authenticated" -> "private"
 ```
 
-Allow custom Tailscale hostnames:
+Allow custom Tailscale or relay hostnames:
 
 ```sh
 pnpm paperclipai allowed-hostname my-machine
@@ -69,6 +71,13 @@ A signed-in user visits this URL to claim board ownership. This:
 - Promotes the current user to instance admin
 - Demotes the auto-created local board admin
 - Ensures active company membership for the claiming user
+
+## Remote Access
+
+Two options for accessing Paperclip from outside your local machine (both require `authenticated` mode):
+
+- **Tailscale**: binds to `0.0.0.0` on a private network. See [Tailscale Private Access](/deploy/tailscale-private-access).
+- **Relay tunnel**: connects to a relay server for a public subdomain URL (e.g. `https://d4lsc.relay.com`). No port forwarding required. See [Relay Tunnel](/deploy/relay-tunnel).
 
 ## Changing Modes
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -16,6 +16,15 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_INSTANCE_ID` | `default` | Instance identifier (for multiple local instances) |
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 
+## Relay Tunnel
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAPERCLIP_RELAY_URL` | (none) | WebSocket URL of relay server (e.g. `wss://your-relay-server.com`). Enables relay tunnel. |
+| `PAPERCLIP_RELAY_TOKEN` | (none) | Relay authentication token. Auto-generated on first connect if not set. |
+
+See [Relay Tunnel](/deploy/relay-tunnel) for setup details. Requires `authenticated` deployment mode.
+
 ## Secrets
 
 | Variable | Default | Description |

--- a/docs/deploy/local-development.md
+++ b/docs/deploy/local-development.md
@@ -62,6 +62,20 @@ pnpm paperclipai allowed-hostname dotta-macbook-pro
 
 For full setup and troubleshooting, see [Tailscale Private Access](/deploy/tailscale-private-access).
 
+## Relay Tunnel Dev Mode
+
+To access your local instance remotely without port forwarding, set the relay URL:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm dev --tailscale-auth
+```
+
+On first start, the server auto-registers with the relay and prints your public URL (e.g. `https://d4lsc.your-relay-server.com`). The token and hostname are persisted automatically.
+
+> A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI). Deploy your own for production.
+
+See [Relay Tunnel](/deploy/relay-tunnel) for full details.
+
 ## Health Checks
 
 ```sh

--- a/docs/deploy/overview.md
+++ b/docs/deploy/overview.md
@@ -27,7 +27,8 @@ Paperclip supports three deployment configurations, from zero-friction local to 
 - Login required via Better Auth
 - Binds to all interfaces for network access
 - Auto base URL mode (lower friction)
-- Best for: team access over Tailscale or local network
+- Supports relay tunnel for remote access without port forwarding
+- Best for: team access over Tailscale, relay tunnel, or local network
 
 ### Authenticated + Public
 
@@ -40,6 +41,7 @@ Paperclip supports three deployment configurations, from zero-friction local to 
 
 - **Just trying Paperclip?** Use `local_trusted` (the default)
 - **Sharing with a team on private network?** Use `authenticated` + `private`
+- **Want remote access without port forwarding?** Use `authenticated` + `private` with [relay tunnel](/deploy/relay-tunnel)
 - **Deploying to the cloud?** Use `authenticated` + `public`
 
 Set the mode during onboarding:

--- a/docs/deploy/relay-tunnel.md
+++ b/docs/deploy/relay-tunnel.md
@@ -1,0 +1,81 @@
+---
+title: Relay Tunnel
+summary: Remote access to a local Paperclip instance via relay tunnel
+---
+
+Access your Paperclip instance from anywhere without port forwarding. The relay tunnel connects your local server to a Cloudflare Workers-based relay, giving you a public subdomain URL (e.g. `https://d4lsc.relay.com`).
+
+## Prerequisites
+
+- `authenticated` deployment mode (relay is blocked in `local_trusted`)
+- A relay server URL (self-hosted, or `wss://paperclip-relay.com` for testing)
+
+## 1. Set deployment mode to authenticated
+
+```sh
+pnpm paperclipai onboard
+# Choose "authenticated" -> "private"
+```
+
+Or if already configured:
+
+```sh
+pnpm paperclipai configure --section server
+```
+
+## 2. Set the relay URL
+
+Add the relay URL to your instance `.env`:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com
+```
+
+Or pass it at startup:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm dev
+```
+
+> **Test relay**: `paperclip-relay.com` is a community-run test relay, not affiliated with Paperclip AI. You can use `wss://paperclip-relay.com` to try things out, but deploy your own relay server for production. See `doc/RELAY.md` for the full source and deployment instructions.
+
+## 3. Start the server
+
+```sh
+pnpm dev
+```
+
+On first start, the server:
+
+1. Registers with the relay and receives a token + instance ID
+2. Saves `PAPERCLIP_RELAY_TOKEN` to `.env` for future starts
+3. Adds the relay hostname (e.g. `d4lsc.your-relay-server.com`) to `allowedHostnames`
+4. Prints your public URL in the console
+
+Subsequent starts reuse the saved token and reconnect automatically.
+
+## 4. Access from any device
+
+Open the printed URL (e.g. `https://d4lsc.your-relay-server.com`) from any browser.
+
+## How it works
+
+The relay client maintains a persistent WebSocket connection to the relay server. When a request arrives at your subdomain, the relay forwards it through the tunnel. The client then makes the request to `127.0.0.1:<port>` and sends the response back. WebSocket connections (for real-time features) are bridged transparently.
+
+## Comparison with Tailscale
+
+| | Tailscale | Relay Tunnel |
+|---|---|---|
+| **Network** | Private mesh VPN | Public internet |
+| **Setup** | Install Tailscale on all devices | Set one env var |
+| **URL** | Private hostname + port | Public subdomain |
+| **Use case** | Team on same Tailscale network | Access from anywhere, mobile |
+| **Requires** | `authenticated` mode | `authenticated` mode |
+
+Both options can be used simultaneously.
+
+## Troubleshooting
+
+- **Server refuses to start with relay URL**: ensure deployment mode is `authenticated`, not `local_trusted`.
+- **Relay connects but page doesn't load**: check that the relay hostname was added to `allowedHostnames` in `config.json`.
+- **Token errors on reconnect**: delete `PAPERCLIP_RELAY_TOKEN` from `.env` and restart to re-register.

--- a/docs/deploy/tailscale-private-access.md
+++ b/docs/deploy/tailscale-private-access.md
@@ -70,6 +70,10 @@ Expected result:
 {"status":"ok"}
 ```
 
+## Alternative: Relay Tunnel
+
+If you don't use Tailscale or need access from outside your private network, consider the [relay tunnel](/deploy/relay-tunnel) instead. It gives your instance a public subdomain URL (e.g. `https://d4lsc.relay.com`) with zero port forwarding. Both options require `authenticated` deployment mode.
+
 ## Troubleshooting
 
 - Login or redirect errors on a private hostname: add it with `paperclipai allowed-hostname`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,7 @@
               "deploy/overview",
               "deploy/local-development",
               "deploy/tailscale-private-access",
+              "deploy/relay-tunnel",
               "deploy/docker",
               "deploy/deployment-modes",
               "deploy/database",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -61,6 +61,8 @@ export interface Config {
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
+  relayUrl: string | undefined;
+  relayToken: string | undefined;
 }
 
 export function loadConfig(): Config {
@@ -243,5 +245,7 @@ export function loadConfig(): Config {
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
+    relayUrl: process.env.PAPERCLIP_RELAY_URL || undefined,
+    relayToken: process.env.PAPERCLIP_RELAY_TOKEN || undefined,
   };
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -69,6 +69,29 @@ export interface StartedServer {
 
 export async function startServer(): Promise<StartedServer> {
   const config = loadConfig();
+
+  // Enforce relay security requirement before any registration or config mutation.
+  if (config.relayUrl && config.deploymentMode !== "authenticated") {
+    throw new Error(
+      "Relay requires authenticated deployment mode. " +
+        "Use authenticated mode for relay deployments or remove PAPERCLIP_RELAY_URL.",
+    );
+  }
+
+  // Auto-register with relay if URL is configured but no token exists yet.
+  // Must happen before createApp() so the hostname guard includes the relay domain.
+  if (config.relayUrl && !config.relayToken) {
+    const { autoRegisterRelay } = await import("./relay/auto-register.js");
+    const result = await autoRegisterRelay(config.relayUrl);
+    if (result) {
+      config.relayToken = result.token;
+      process.env.PAPERCLIP_RELAY_TOKEN = result.token;
+      if (!config.allowedHostnames.includes(result.relayHostname)) {
+        config.allowedHostnames.push(result.relayHostname);
+      }
+    }
+  }
+
   if (process.env.PAPERCLIP_SECRETS_PROVIDER === undefined) {
     process.env.PAPERCLIP_SECRETS_PROVIDER = config.secretsProvider;
   }
@@ -395,7 +418,7 @@ export async function startServer(): Promise<StartedServer> {
   if (config.deploymentMode === "local_trusted" && config.deploymentExposure !== "private") {
     throw new Error("local_trusted mode only supports private exposure");
   }
-  
+
   if (config.deploymentMode === "authenticated") {
     if (config.authBaseUrlMode === "explicit" && !config.authPublicBaseUrl) {
       throw new Error("auth.baseUrlMode=explicit requires auth.publicBaseUrl");
@@ -652,9 +675,27 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
+
+  let relayClient: { close: () => void } | null = null;
+  if (config.relayUrl && config.relayToken) {
+    const { startRelayClient } = await import("./relay/relay-client.js");
+    relayClient = startRelayClient({
+      relayUrl: config.relayUrl,
+      relayToken: config.relayToken,
+      localPort: listenPort,
+      onReady: (instanceId, publicUrl) => {
+        logger.info({ instanceId, publicUrl }, "Relay tunnel connected");
+        console.log(`\n  \x1b[36mRelay\x1b[0m           ${publicUrl}\n`);
+      },
+    });
+  }
+
   if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+      if (relayClient) {
+        logger.info("Closing relay tunnel");
+        relayClient.close();
+      }
       logger.info({ signal }, "Stopping embedded PostgreSQL");
       try {
         await embeddedPostgres?.stop();

--- a/server/src/relay/auto-register.ts
+++ b/server/src/relay/auto-register.ts
@@ -1,0 +1,97 @@
+/**
+ * Auto-registers with the relay server when PAPERCLIP_RELAY_URL is set
+ * but no token exists yet. Persists the token to .env and adds the relay
+ * hostname to config.json so subsequent restarts skip registration.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePaperclipConfigPath, resolvePaperclipEnvPath } from "../paths.js";
+import { logger } from "../middleware/logger.js";
+
+interface RegisterResult {
+  token: string;
+  instanceId: string;
+  relayHostname: string;
+}
+
+export async function autoRegisterRelay(relayUrl: string): Promise<RegisterResult | null> {
+  const registerUrl = relayUrl
+    .replace(/^wss:\/\//, "https://")
+    .replace(/^ws:\/\//, "http://")
+    .replace(/\/+$/, "") + "/register";
+
+  logger.info({ registerUrl }, "Relay: no token found, auto-registering");
+
+  let resp: Response;
+  try {
+    resp = await fetch(registerUrl, { method: "POST" });
+  } catch (err) {
+    logger.error({ err }, "Relay: failed to reach relay server for registration");
+    return null;
+  }
+
+  if (!resp.ok) {
+    logger.error({ status: resp.status }, "Relay: registration failed");
+    return null;
+  }
+
+  const data = await resp.json() as { token: string; instanceId: string; publicUrl: string };
+  const relayHostname = new URL(data.publicUrl).hostname;
+
+  // Persist token to .env
+  appendToEnvFile("PAPERCLIP_RELAY_TOKEN", data.token);
+
+  // Add relay hostname to config.json allowedHostnames
+  addAllowedHostname(relayHostname);
+
+  logger.info(
+    { instanceId: data.instanceId, relayHostname },
+    "Relay: registered successfully",
+  );
+
+  return { token: data.token, instanceId: data.instanceId, relayHostname };
+}
+
+function appendToEnvFile(key: string, value: string): void {
+  const envPath = resolvePaperclipEnvPath();
+  try {
+    let content = "";
+    if (fs.existsSync(envPath)) {
+      content = fs.readFileSync(envPath, "utf-8");
+      if (!content.endsWith("\n")) content += "\n";
+    }
+    // Remove existing key if present (shouldn't be, but safe)
+    const lines = content.split("\n").filter((l) => !l.startsWith(`${key}=`));
+    lines.push(`${key}=${value}`);
+    fs.writeFileSync(envPath, lines.join("\n") + "\n", "utf-8");
+    logger.info({ path: envPath }, `Relay: saved ${key} to .env`);
+  } catch (err) {
+    logger.warn({ err, path: envPath }, `Relay: could not persist ${key} to .env`);
+  }
+}
+
+function addAllowedHostname(hostname: string): void {
+  const configPath = resolvePaperclipConfigPath();
+  try {
+    if (!fs.existsSync(configPath)) return;
+
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    const hostnames: string[] = raw?.server?.allowedHostnames ?? [];
+    const normalized = hostname.trim().toLowerCase();
+
+    if (hostnames.some((h: string) => h.trim().toLowerCase() === normalized)) {
+      return; // already present
+    }
+
+    hostnames.push(normalized);
+    if (!raw.server) {
+      raw.server = {};
+    }
+    raw.server.allowedHostnames = hostnames;
+    fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
+    logger.info({ hostname, path: configPath }, "Relay: added hostname to config.json allowedHostnames");
+  } catch (err) {
+    logger.warn({ err }, "Relay: could not update config.json allowedHostnames");
+  }
+}

--- a/server/src/relay/http-forwarder.ts
+++ b/server/src/relay/http-forwarder.ts
@@ -1,0 +1,71 @@
+/**
+ * Forwards serialized HTTP requests from the relay tunnel to the local
+ * Paperclip server and returns serialized responses.
+ */
+
+import * as http from "node:http";
+import type { HttpRequest, HttpResponse } from "./protocol.js";
+
+// Headers where comma-joining is unsafe (values contain literal commas).
+// These are sent as JSON arrays via a companion header instead.
+const MULTI_VALUE_HEADERS = new Set(["set-cookie"]);
+
+export function forwardHttpRequest(
+  req: HttpRequest,
+  localPort: number,
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const body = Buffer.from(req.body, "base64");
+
+    const opts: http.RequestOptions = {
+      hostname: "127.0.0.1",
+      port: localPort,
+      path: req.path,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host: `127.0.0.1:${localPort}`,
+      },
+    };
+
+    const proxyReq = http.request(opts, (proxyRes) => {
+      const chunks: Buffer[] = [];
+      proxyRes.on("data", (chunk: Buffer) => chunks.push(chunk));
+      proxyRes.on("error", (err) => reject(err));
+      proxyRes.on("end", () => {
+        const responseBody = Buffer.concat(chunks);
+
+        // Collect headers. Multi-value headers like set-cookie cannot be
+        // comma-joined (cookie values contain commas in date strings).
+        // These are sent as JSON arrays in a companion header.
+        const headers: Record<string, string> = {};
+        for (const [key, value] of Object.entries(proxyRes.headers)) {
+          if (value === undefined) continue;
+          if (Array.isArray(value) && MULTI_VALUE_HEADERS.has(key)) {
+            headers[key] = JSON.stringify(value);
+            headers[`x-relay-multi-${key}`] = "1";
+          } else {
+            headers[key] = Array.isArray(value) ? value.join(", ") : value;
+          }
+        }
+
+        resolve({
+          id: req.id,
+          type: "http-response",
+          status: proxyRes.statusCode ?? 502,
+          headers,
+          body: responseBody.toString("base64"),
+        });
+      });
+    });
+
+    proxyReq.on("error", (err) => {
+      reject(err);
+    });
+
+    if (body.length > 0) {
+      proxyReq.write(body);
+    }
+    proxyReq.end();
+  });
+}

--- a/server/src/relay/protocol.ts
+++ b/server/src/relay/protocol.ts
@@ -1,0 +1,72 @@
+/**
+ * Relay tunnel protocol message types.
+ *
+ * These messages are sent over the persistent WebSocket tunnel between the
+ * Paperclip server (tunnel client) and the relay server. The relay forwards
+ * HTTP requests and WebSocket frames without inspecting payloads.
+ */
+
+// ── Tunnel lifecycle ────────────────────────────────────────────────────────
+
+export interface TunnelReady {
+  type: "tunnel-ready";
+  instanceId: string;
+  publicUrl?: string;
+}
+
+// ── HTTP request/response ───────────────────────────────────────────────────
+
+export interface HttpRequest {
+  id: string;
+  type: "http-request";
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: string; // base64-encoded
+}
+
+export interface HttpResponse {
+  id: string;
+  type: "http-response";
+  status: number;
+  headers: Record<string, string>;
+  body: string; // base64-encoded
+}
+
+// ── WebSocket bridging ──────────────────────────────────────────────────────
+
+export interface WsOpen {
+  type: "ws-open";
+  id: string;
+  path: string;
+  headers: Record<string, string>;
+}
+
+export interface WsMessage {
+  type: "ws-message";
+  id: string;
+  data: string;
+}
+
+export interface WsClose {
+  type: "ws-close";
+  id: string;
+  code?: number;
+}
+
+export interface WsError {
+  type: "ws-error";
+  id: string;
+  message: string;
+}
+
+// ── Union type ──────────────────────────────────────────────────────────────
+
+export type TunnelMessage =
+  | TunnelReady
+  | HttpRequest
+  | HttpResponse
+  | WsOpen
+  | WsMessage
+  | WsClose
+  | WsError;

--- a/server/src/relay/relay-client.ts
+++ b/server/src/relay/relay-client.ts
@@ -1,0 +1,138 @@
+/**
+ * Relay tunnel client. Maintains an outbound WebSocket connection to the relay
+ * server and dispatches incoming messages to the HTTP forwarder and WS bridge.
+ */
+
+import { createRequire } from "node:module";
+import { forwardHttpRequest } from "./http-forwarder.js";
+import { handleWsOpen, handleWsMessage, handleWsClose, closeAllBridges } from "./ws-bridge.js";
+import type { TunnelMessage } from "./protocol.js";
+import { logger } from "../middleware/logger.js";
+
+const require = createRequire(import.meta.url);
+const WS = require("ws") as { new (url: string, opts?: { headers?: Record<string, string> }): WsInstance; OPEN: number };
+
+interface WsInstance {
+  readyState: number;
+  on(event: string, cb: (...args: any[]) => void): void;
+  send(data: string): void;
+  close(code?: number): void;
+}
+
+const BACKOFF_SCHEDULE = [1000, 2000, 5000, 10_000, 30_000];
+
+export interface RelayClientOptions {
+  relayUrl: string;
+  relayToken: string;
+  localPort: number;
+  onReady?: (instanceId: string, publicUrl: string) => void;
+}
+
+export function startRelayClient(opts: RelayClientOptions): { close: () => void } {
+  let ws: WsInstance | null = null;
+  let closed = false;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function send(msg: TunnelMessage): void {
+    if (ws && ws.readyState === WS.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  }
+
+  function connect(): void {
+    if (closed) return;
+
+    const url = `${opts.relayUrl}/tunnel`;
+    ws = new WS(url, {
+      headers: { authorization: `Bearer ${opts.relayToken}` },
+    });
+
+    ws.on("open", () => {
+      reconnectAttempt = 0;
+      logger.info("Relay tunnel WebSocket connected");
+    });
+
+    ws.on("message", (data: { toString(): string }) => {
+      let msg: TunnelMessage;
+      try {
+        msg = JSON.parse(data.toString()) as TunnelMessage;
+      } catch {
+        logger.warn("Relay: received unparseable message");
+        return;
+      }
+
+      switch (msg.type) {
+        case "tunnel-ready": {
+          // Construct the public URL from the relay base URL (wss:// → https://)
+          const relayOrigin = opts.relayUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+          const publicUrl = msg.publicUrl || relayOrigin;
+          logger.info({ instanceId: msg.instanceId, publicUrl }, "Relay tunnel ready");
+          opts.onReady?.(msg.instanceId, publicUrl);
+          break;
+        }
+
+        case "http-request":
+          forwardHttpRequest(msg, opts.localPort)
+            .then((res) => send(res))
+            .catch((err) => {
+              logger.error({ err, requestId: msg.id }, "Relay: failed to forward HTTP request");
+              send({
+                id: msg.id,
+                type: "http-response",
+                status: 502,
+                headers: { "content-type": "text/plain" },
+                body: Buffer.from("Bad Gateway: local server unreachable").toString("base64"),
+              });
+            });
+          break;
+
+        case "ws-open":
+          handleWsOpen(msg, opts.localPort, send);
+          break;
+
+        case "ws-message":
+          handleWsMessage(msg);
+          break;
+
+        case "ws-close":
+          handleWsClose(msg);
+          break;
+
+        default:
+          break;
+      }
+    });
+
+    ws.on("close", () => {
+      closeAllBridges();
+      scheduleReconnect();
+    });
+
+    ws.on("error", (err: Error) => {
+      logger.warn({ err: err.message }, "Relay tunnel WebSocket error");
+    });
+  }
+
+  function scheduleReconnect(): void {
+    if (closed) return;
+    const delay = BACKOFF_SCHEDULE[Math.min(reconnectAttempt, BACKOFF_SCHEDULE.length - 1)];
+    reconnectAttempt++;
+    logger.info({ delay, attempt: reconnectAttempt }, "Relay: reconnecting");
+    reconnectTimer = setTimeout(connect, delay);
+  }
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      closeAllBridges();
+      if (ws) {
+        ws.close(1000);
+        ws = null;
+      }
+    },
+  };
+}

--- a/server/src/relay/ws-bridge.ts
+++ b/server/src/relay/ws-bridge.ts
@@ -1,0 +1,83 @@
+/**
+ * Bridges WebSocket connections from the relay tunnel to local Paperclip
+ * WebSocket endpoints. Each bridged connection is identified by a unique ID.
+ */
+
+import { createRequire } from "node:module";
+import type { WsOpen, WsMessage, WsClose, TunnelMessage } from "./protocol.js";
+
+const require = createRequire(import.meta.url);
+const WS = require("ws") as { new (url: string, opts?: object): WsInstance; OPEN: number };
+
+interface WsInstance {
+  readyState: number;
+  on(event: string, cb: (...args: any[]) => void): void;
+  send(data: string): void;
+  close(code?: number): void;
+}
+
+type SendFn = (msg: TunnelMessage) => void;
+
+const activeBridges = new Map<string, WsInstance>();
+
+export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void {
+  const url = `ws://127.0.0.1:${localPort}${msg.path}`;
+
+  const headers: Record<string, string> = { ...msg.headers };
+  headers.host = `127.0.0.1:${localPort}`;
+
+  const localWs = new WS(url, { headers });
+
+  localWs.on("open", () => {
+    activeBridges.set(msg.id, localWs);
+  });
+
+  localWs.on("message", (data: { toString(): string }) => {
+    send({
+      type: "ws-message",
+      id: msg.id,
+      data: data.toString(),
+    });
+  });
+
+  localWs.on("close", (code: number) => {
+    activeBridges.delete(msg.id);
+    send({
+      type: "ws-close",
+      id: msg.id,
+      code,
+    });
+  });
+
+  localWs.on("error", (err: Error) => {
+    activeBridges.delete(msg.id);
+    send({
+      type: "ws-error",
+      id: msg.id,
+      message: err.message,
+    });
+  });
+}
+
+export function handleWsMessage(msg: WsMessage): void {
+  const localWs = activeBridges.get(msg.id);
+  if (localWs && localWs.readyState === WS.OPEN) {
+    localWs.send(msg.data);
+  }
+}
+
+export function handleWsClose(msg: WsClose): void {
+  const localWs = activeBridges.get(msg.id);
+  if (localWs) {
+    activeBridges.delete(msg.id);
+    const code = msg.code && msg.code >= 1000 && msg.code <= 4999 ? msg.code : 1000;
+    localWs.close(code);
+  }
+}
+
+export function closeAllBridges(): void {
+  activeBridges.forEach((ws, id) => {
+    ws.close(1001);
+    activeBridges.delete(id);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a relay tunnel client that connects to a Cloudflare Workers-based relay server, enabling remote access without port forwarding
- Each instance gets a unique subdomain (e.g. `d4lsc.relay-domain.com`) — no hardcoded domains, fully configurable via `RELAY_DOMAIN` env var on the relay server
- Auto-registration: set `PAPERCLIP_RELAY_URL` and the server registers itself, persists token, and adds the relay hostname to `allowedHostnames`
- Security: relay requires `authenticated` deployment mode, matching the existing Tailscale guard pattern
- WebSocket bridge for real-time features through the tunnel
- Full documentation in `doc/RELAY.md`

Closes #742

## Test plan
- [x] Server starts with `PAPERCLIP_RELAY_URL` set, auto-registers, persists token to `.env`
- [x] Relay connects and instance is accessible at `https://<id>.paperclip-relay.com`
- [x] `local_trusted` mode with relay URL throws error on startup (auth guard works)
- [x] Type-check passes (`pnpm typecheck`)
- [x] End-to-end: UI loads through relay subdomain, returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)