### PR TITLE
feat: add browser-viewable project workspace file links

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { healthRoutes } from "./routes/health.js";
+import { assertCompanyAccess } from "./routes/authz.js";
 import { companyRoutes } from "./routes/companies.js";
 import { agentRoutes } from "./routes/agents.js";
 import { projectRoutes } from "./routes/projects.js";
@@ -26,6 +27,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { applyUiBranding } from "./ui-branding.js";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
+import { companyService, projectService } from "./services/index.js";
 
 type UiMode = "none" | "static" | "vite-dev";
 
@@ -125,6 +127,76 @@ export async function createApp(
   app.use("/api", api);
   app.use("/api", (_req, res) => {
     res.status(404).json({ error: "API route not found" });
+  });
+
+  const companiesSvc = companyService(db);
+  const projectsSvc = projectService(db);
+
+  app.get(/^\/([A-Za-z0-9_-]+)\/projects\/([^/]+)\/files\/(.+)$/, async (req, res, next) => {
+    try {
+      const match = req.path.match(/^\/([A-Za-z0-9_-]+)\/projects\/([^/]+)\/files\/(.+)$/);
+      if (!match) {
+        res.status(404).end();
+        return;
+      }
+      const [, companyPrefixRaw, projectRefRaw, relativePathRaw] = match;
+      const companyPrefix = companyPrefixRaw.trim().toUpperCase();
+      const projectRef = decodeURIComponent(projectRefRaw);
+      const relativePath = decodeURIComponent(relativePathRaw);
+
+      const company = await companiesSvc.getByIssuePrefix(companyPrefix);
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      assertCompanyAccess(req, company.id);
+
+      const resolved = await projectsSvc.resolveByReference(company.id, projectRef);
+      if (resolved.ambiguous) {
+        res.status(409).json({ error: "Project reference is ambiguous" });
+        return;
+      }
+      const project = resolved.project ? await projectsSvc.getById(resolved.project.id) : null;
+      if (!project) {
+        res.status(404).json({ error: "Project not found" });
+        return;
+      }
+
+      const primaryWorkspace = project.primaryWorkspace ?? project.workspaces.find((workspace) => workspace.isPrimary) ?? null;
+      if (!primaryWorkspace?.cwd) {
+        res.status(404).json({ error: "Project workspace not found" });
+        return;
+      }
+
+      const workspaceRoot = path.resolve(primaryWorkspace.cwd);
+      const candidatePath = path.resolve(workspaceRoot, relativePath);
+      const relativeFromRoot = path.relative(workspaceRoot, candidatePath);
+      if (
+        relativeFromRoot.startsWith("..")
+        || path.isAbsolute(relativeFromRoot)
+        || relativePath.includes("\0")
+      ) {
+        res.status(403).json({ error: "Path escapes project workspace" });
+        return;
+      }
+
+      const stat = await fs.promises.stat(candidatePath).catch(() => null);
+      if (!stat || !stat.isFile()) {
+        res.status(404).json({ error: "File not found" });
+        return;
+      }
+
+      res.type(path.extname(candidatePath) || "text/plain");
+      res.setHeader("Content-Length", String(stat.size));
+      res.setHeader("Cache-Control", "private, max-age=30");
+      res.setHeader(
+        "Content-Disposition",
+        `inline; filename="${path.basename(candidatePath).replaceAll("\"", "")}"`,
+      );
+      fs.createReadStream(candidatePath).on("error", next).pipe(res);
+    } catch (err) {
+      next(err);
+    }
   });
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -79,6 +79,13 @@ export function companyService(db: Db) {
         .where(eq(companies.id, id))
         .then((rows) => rows[0] ?? null),
 
+    getByIssuePrefix: (issuePrefix: string) =>
+      db
+        .select()
+        .from(companies)
+        .where(eq(companies.issuePrefix, issuePrefix))
+        .then((rows) => rows[0] ?? null),
+
     create: async (data: typeof companies.$inferInsert) => createCompanyWithUniquePrefix(data),
 
     update: (id: string, data: Partial<typeof companies.$inferInsert>) =>

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -147,7 +147,7 @@ export function MarkdownBody({ children, className }: MarkdownBodyProps) {
               );
             }
             return (
-              <a href={href} rel="noreferrer">
+              <a href={href} target="_blank" rel="noreferrer">
                 {linkChildren}
               </a>
             );


### PR DESCRIPTION
## Summary
- add a read-only route for browser-viewable files inside a project's primary workspace
- resolve companies by issue prefix so links can use `/<prefix>/projects/<project>/files/<path>`
- open markdown/body links in a new tab so issue context is preserved while reviewing artifacts

## Why
Agents already write useful markdown deliverables into project workspaces, but Paperclip had no clean last-mile UX for opening them from issue comments. This adds a safe browser-viewable route and keeps reviewers on the issue page while opening artifacts.

## Example
- `/RUBAA/projects/propaign/files/projectname-mvp-discovery-2026-03-12.md`

## Validation
- `pnpm typecheck`
- manually verified the new project file route returns `200 text/markdown` for a workspace markdown file
- manually verified comment markdown links now open in a new tab
