### PR TITLE
feat(ui): add filter and pause controls to agents sidebar

### DIFF
--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -7,6 +7,7 @@ import { ChevronRight, Plus, Eye, EyeOff, PauseCircle, CircleSlash } from "lucid
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
+import { useToast } from "../context/ToastContext";
 
 import { agentsApi } from "../api/agents";
 import { heartbeatsApi } from "../api/heartbeats";
@@ -103,6 +104,7 @@ export function SidebarAgents() {
   const { isMobile, setSidebarOpen } = useSidebar();
   const location = useLocation();
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
 
   const { filters, updateFilter } = useAgentFilters(selectedCompanyId);
 
@@ -149,6 +151,10 @@ export function SidebarAgents() {
       );
       if (failures.length > 0) {
         console.error(`Failed to pause ${failures.length} agent(s)`, failures);
+        pushToast({
+          title: `Failed to pause ${failures.length} agent(s)`,
+          tone: "error",
+        });
       }
     },
   });

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -1,21 +1,71 @@
 import { useMemo, useState } from "react";
+import type { ComponentType } from "react";
 import { NavLink, useLocation } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Plus } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ChevronRight, Plus, Eye, EyeOff, PauseCircle, CircleSlash } from "lucide-react";
+
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
+
 import { agentsApi } from "../api/agents";
 import { heartbeatsApi } from "../api/heartbeats";
+
 import { queryKeys } from "../lib/queryKeys";
 import { cn, agentRouteRef, agentUrl } from "../lib/utils";
+
+import { useAgentFilters } from "../hooks/useAgentFilters";
+
 import { AgentIcon } from "./AgentIconPicker";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+
 import type { Agent } from "@paperclipai/shared";
+
+// Small tooltip-wrapped icon button used for the filter toolbar
+function FilterButton({
+  icon: Icon,
+  label,
+  onClick,
+  disabled,
+  className,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+          }}
+          disabled={disabled}
+          className={cn(
+            "flex items-center justify-center h-4 w-4 rounded transition-colors",
+            className,
+          )}
+          aria-label={label}
+        >
+          <Icon className="h-3 w-3" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 /** BFS sort: roots first (no reportsTo), then their direct reports, etc. */
 function sortByHierarchy(agents: Agent[]): Agent[] {
@@ -38,12 +88,23 @@ function sortByHierarchy(agents: Agent[]): Agent[] {
   return sorted;
 }
 
+const PAUSABLE_STATUSES = new Set(["active", "running", "idle"]);
+
+function pauseAllClassName(isPending: boolean, pausableCount: number): string {
+  if (isPending) return "text-muted-foreground/40 animate-pulse";
+  if (pausableCount === 0) return "text-muted-foreground/30 cursor-not-allowed";
+  return "text-muted-foreground/60 hover:text-foreground hover:bg-accent/50";
+}
+
 export function SidebarAgents() {
   const [open, setOpen] = useState(true);
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialog();
   const { isMobile, setSidebarOpen } = useSidebar();
   const location = useLocation();
+  const queryClient = useQueryClient();
+
+  const { filters, updateFilter } = useAgentFilters(selectedCompanyId);
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -66,12 +127,41 @@ export function SidebarAgents() {
     return counts;
   }, [liveRuns]);
 
+  const pausableAgents = useMemo(
+    () => (agents ?? []).filter((a: Agent) => PAUSABLE_STATUSES.has(a.status)),
+    [agents],
+  );
+
+  const pauseAll = useMutation({
+    mutationFn: (agentsToPause: Agent[]) => {
+      if (!selectedCompanyId) return Promise.resolve([] as PromiseSettledResult<Agent>[]);
+      return Promise.allSettled(
+        agentsToPause.map((a) => agentsApi.pause(a.id, selectedCompanyId))
+      );
+    },
+    onSuccess: (results) => {
+      if (selectedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.liveRuns(selectedCompanyId) });
+      }
+      const failures = results.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected"
+      );
+      if (failures.length > 0) {
+        console.error(`Failed to pause ${failures.length} agent(s)`, failures);
+      }
+    },
+  });
+
   const visibleAgents = useMemo(() => {
     const filtered = (agents ?? []).filter(
-      (a: Agent) => a.status !== "terminated"
+      (a: Agent) =>
+        a.status !== "terminated" &&
+        !(filters.hideIdle && a.status === "idle") &&
+        !(filters.hidePaused && a.status === "paused")
     );
     return sortByHierarchy(filtered);
-  }, [agents]);
+  }, [agents, filters.hideIdle, filters.hidePaused]);
 
   const agentMatch = location.pathname.match(/^\/(?:[^/]+\/)?agents\/([^/]+)/);
   const activeAgentId = agentMatch?.[1] ?? null;
@@ -91,6 +181,35 @@ export function SidebarAgents() {
               Agents
             </span>
           </CollapsibleTrigger>
+          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+            <FilterButton
+              icon={filters.hideIdle ? EyeOff : Eye}
+              label={filters.hideIdle ? "Show idle agents" : "Hide idle agents"}
+              onClick={() => updateFilter("hideIdle")}
+              className={
+                filters.hideIdle
+                  ? "text-muted-foreground/80 hover:text-foreground"
+                  : "text-muted-foreground/60 hover:text-foreground hover:bg-accent/50"
+              }
+            />
+            <FilterButton
+              icon={PauseCircle}
+              label="Pause all agents"
+              onClick={() => pauseAll.mutate(pausableAgents)}
+              disabled={pauseAll.isPending || pausableAgents.length === 0}
+              className={pauseAllClassName(pauseAll.isPending, pausableAgents.length)}
+            />
+            <FilterButton
+              icon={CircleSlash}
+              label={filters.hidePaused ? "Show paused agents" : "Hide paused agents"}
+              onClick={() => updateFilter("hidePaused")}
+              className={
+                filters.hidePaused
+                  ? "text-muted-foreground/80 hover:text-foreground"
+                  : "text-muted-foreground/60 hover:text-foreground hover:bg-accent/50"
+              }
+            />
+          </div>
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/ui/src/hooks/useAgentFilters.ts
+++ b/ui/src/hooks/useAgentFilters.ts
@@ -6,12 +6,8 @@ import {
   readAgentFilters,
   writeAgentFilters,
   type AgentFilters,
+  type AgentFiltersUpdatedDetail,
 } from "../lib/agent-filters";
-
-type AgentFiltersUpdatedDetail = {
-  storageKey: string;
-  filters: AgentFilters;
-};
 
 export function useAgentFilters(companyId: string | null | undefined) {
   const storageKey = useMemo(() => {
@@ -63,12 +59,17 @@ export function useAgentFilters(companyId: string | null | undefined) {
       if (!storageKey) return;
       setFilters((prev) => {
         const next = { ...prev, [key]: !prev[key] };
-        writeAgentFilters(storageKey, next);
         return next;
       });
     },
     [storageKey],
   );
+
+  // Persist filter changes to localStorage (side effect kept outside state updater)
+  useEffect(() => {
+    if (!storageKey) return;
+    writeAgentFilters(storageKey, filters);
+  }, [storageKey, filters]);
 
   return { filters, updateFilter };
 }

--- a/ui/src/hooks/useAgentFilters.ts
+++ b/ui/src/hooks/useAgentFilters.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AGENT_FILTERS_UPDATED_EVENT,
+  DEFAULT_AGENT_FILTERS,
+  getAgentFiltersStorageKey,
+  readAgentFilters,
+  writeAgentFilters,
+  type AgentFilters,
+} from "../lib/agent-filters";
+
+type AgentFiltersUpdatedDetail = {
+  storageKey: string;
+  filters: AgentFilters;
+};
+
+export function useAgentFilters(companyId: string | null | undefined) {
+  const storageKey = useMemo(() => {
+    if (!companyId) return null;
+    return getAgentFiltersStorageKey(companyId);
+  }, [companyId]);
+
+  const [filters, setFilters] = useState<AgentFilters>(() =>
+    storageKey ? readAgentFilters(storageKey) : DEFAULT_AGENT_FILTERS
+  );
+
+  // Sync when company changes
+  useEffect(() => {
+    setFilters(storageKey ? readAgentFilters(storageKey) : DEFAULT_AGENT_FILTERS);
+  }, [storageKey]);
+
+  // Multi-tab sync via StorageEvent + custom event
+  useEffect(() => {
+    if (!storageKey) return;
+
+    const syncFrom = (next: AgentFilters) => {
+      setFilters((current) =>
+        current.hideIdle === next.hideIdle && current.hidePaused === next.hidePaused
+          ? current
+          : next
+      );
+    };
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey) return;
+      syncFrom(readAgentFilters(storageKey));
+    };
+    const onCustomEvent = (event: Event) => {
+      const detail = (event as CustomEvent<AgentFiltersUpdatedDetail>).detail;
+      if (!detail || detail.storageKey !== storageKey) return;
+      syncFrom(detail.filters);
+    };
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(AGENT_FILTERS_UPDATED_EVENT, onCustomEvent);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(AGENT_FILTERS_UPDATED_EVENT, onCustomEvent);
+    };
+  }, [storageKey]);
+
+  const updateFilter = useCallback(
+    (key: "hideIdle" | "hidePaused") => {
+      if (!storageKey) return;
+      setFilters((prev) => {
+        const next = { ...prev, [key]: !prev[key] };
+        writeAgentFilters(storageKey, next);
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
+  return { filters, updateFilter };
+}

--- a/ui/src/lib/agent-filters.ts
+++ b/ui/src/lib/agent-filters.ts
@@ -5,7 +5,7 @@ export type AgentFilters = { hideIdle: boolean; hidePaused: boolean };
 
 export const DEFAULT_AGENT_FILTERS: AgentFilters = { hideIdle: false, hidePaused: false };
 
-type AgentFiltersUpdatedDetail = {
+export type AgentFiltersUpdatedDetail = {
   storageKey: string;
   filters: AgentFilters;
 };
@@ -39,6 +39,7 @@ export function writeAgentFilters(storageKey: string, filters: AgentFilters) {
     localStorage.setItem(storageKey, JSON.stringify(normalized));
   } catch {
     // Ignore storage write failures in restricted browser contexts.
+    return;
   }
   if (typeof window !== "undefined") {
     window.dispatchEvent(

--- a/ui/src/lib/agent-filters.ts
+++ b/ui/src/lib/agent-filters.ts
@@ -1,0 +1,50 @@
+export const AGENT_FILTERS_UPDATED_EVENT = "paperclip:agent-filters-updated";
+const AGENT_FILTERS_STORAGE_PREFIX = "paperclip.agentFilters";
+
+export type AgentFilters = { hideIdle: boolean; hidePaused: boolean };
+
+export const DEFAULT_AGENT_FILTERS: AgentFilters = { hideIdle: false, hidePaused: false };
+
+type AgentFiltersUpdatedDetail = {
+  storageKey: string;
+  filters: AgentFilters;
+};
+
+function normalize(value: unknown): AgentFilters {
+  if (typeof value !== "object" || value === null) return DEFAULT_AGENT_FILTERS;
+  const obj = value as Record<string, unknown>;
+  return {
+    hideIdle: obj.hideIdle === true,
+    hidePaused: obj.hidePaused === true,
+  };
+}
+
+export function getAgentFiltersStorageKey(companyId: string): string {
+  return `${AGENT_FILTERS_STORAGE_PREFIX}:${companyId}`;
+}
+
+export function readAgentFilters(storageKey: string): AgentFilters {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return DEFAULT_AGENT_FILTERS;
+    return normalize(JSON.parse(raw));
+  } catch {
+    return DEFAULT_AGENT_FILTERS;
+  }
+}
+
+export function writeAgentFilters(storageKey: string, filters: AgentFilters) {
+  const normalized = normalize(filters);
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(normalized));
+  } catch {
+    // Ignore storage write failures in restricted browser contexts.
+  }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent<AgentFiltersUpdatedDetail>(AGENT_FILTERS_UPDATED_EVENT, {
+        detail: { storageKey, filters: normalized },
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add three action buttons to the AGENTS sidebar section header (visible on hover)
- **Eye/EyeOff** toggle — show/hide idle agents
- **PauseCircle** button — pause all active/running/idle agents at once via `Promise.allSettled`
- **CircleSlash** toggle — hide paused agents from the sidebar list
- Filter state persists in `localStorage` with multi-tab sync via `StorageEvent` + `CustomEvent`

## Implementation
- `ui/src/lib/agent-filters.ts` — localStorage read/write utilities (follows `project-order.ts` pattern)
- `ui/src/hooks/useAgentFilters.ts` — custom hook with company switch sync and multi-tab sync (follows `useProjectOrder.ts` pattern)
- `ui/src/components/SidebarAgents.tsx` — `FilterButton` component + mutation with `onSuccess` error handling

## Test plan
- [ ] Hover over AGENTS header — three icons appear between label and "+"
- [ ] Click Eye icon — idle agents hide/show, icon toggles between Eye/EyeOff
- [ ] Click PauseCircle — all active/running/idle agents get paused, button shows loading state
- [ ] Click CircleSlash — paused agents hide/show
- [ ] Refresh page — filter state persists
- [ ] Switch company — filters reset to that company's saved state
- [ ] Open two tabs — toggling filter in one tab syncs to the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)