### PR TITLE
Fix auto-constructed Claude agent permissions

### DIFF
--- a/server/src/__tests__/agent-route-defaults.test.ts
+++ b/server/src/__tests__/agent-route-defaults.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { applyCreateDefaultsByAdapterType } from "../routes/agents.js";
+
+describe("applyCreateDefaultsByAdapterType", () => {
+  it("enables unattended Claude permissions bypass by default for programmatic agent creation", () => {
+    expect(applyCreateDefaultsByAdapterType("claude_local", {})).toMatchObject({
+      dangerouslySkipPermissions: true,
+    });
+  });
+
+  it("preserves an explicit Claude permission choice", () => {
+    expect(
+      applyCreateDefaultsByAdapterType("claude_local", { dangerouslySkipPermissions: false }),
+    ).toMatchObject({
+      dangerouslySkipPermissions: false,
+    });
+  });
+
+  it("keeps existing Codex unattended defaults", () => {
+    expect(applyCreateDefaultsByAdapterType("codex_local", {})).toMatchObject({
+      model: expect.any(String),
+      dangerouslyBypassApprovalsAndSandbox: expect.any(Boolean),
+    });
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -43,6 +43,57 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
 
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function applyCreateDefaultsByAdapterTypeInternal(
+  adapterType: string | null | undefined,
+  adapterConfig: Record<string, unknown>,
+  ensureGatewayDeviceKey: (
+    adapterType: string | null | undefined,
+    adapterConfig: Record<string, unknown>,
+  ) => Record<string, unknown>,
+): Record<string, unknown> {
+  const next = { ...adapterConfig };
+  if (adapterType === "claude_local") {
+    if (typeof next.dangerouslySkipPermissions !== "boolean") {
+      next.dangerouslySkipPermissions = true;
+    }
+    return ensureGatewayDeviceKey(adapterType, next);
+  }
+  if (adapterType === "codex_local") {
+    if (!asNonEmptyString(next.model)) {
+      next.model = DEFAULT_CODEX_LOCAL_MODEL;
+    }
+    const hasBypassFlag =
+      typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean" ||
+      typeof next.dangerouslyBypassSandbox === "boolean";
+    if (!hasBypassFlag) {
+      next.dangerouslyBypassApprovalsAndSandbox = DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+    }
+    return ensureGatewayDeviceKey(adapterType, next);
+  }
+  if (adapterType === "gemini_local" && !asNonEmptyString(next.model)) {
+    next.model = DEFAULT_GEMINI_LOCAL_MODEL;
+    return ensureGatewayDeviceKey(adapterType, next);
+  }
+  // OpenCode requires explicit model selection — no default
+  if (adapterType === "cursor" && !asNonEmptyString(next.model)) {
+    next.model = DEFAULT_CURSOR_LOCAL_MODEL;
+  }
+  return ensureGatewayDeviceKey(adapterType, next);
+}
+
+export function applyCreateDefaultsByAdapterType(
+  adapterType: string | null | undefined,
+  adapterConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  return applyCreateDefaultsByAdapterTypeInternal(adapterType, adapterConfig, (_adapterType, nextConfig) => nextConfig);
+}
+
 export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
     claude_local: "instructionsFilePath",
@@ -180,12 +231,6 @@ export function agentRoutes(db: Db) {
     return value as Record<string, unknown>;
   }
 
-  function asNonEmptyString(value: unknown): string | null {
-    if (typeof value !== "string") return null;
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-
   function parseBooleanLike(value: unknown): boolean | null {
     if (typeof value === "boolean") return value;
     if (typeof value === "number") {
@@ -233,34 +278,6 @@ export function agentRoutes(db: Db) {
     if (disableDeviceAuth) return adapterConfig;
     if (asNonEmptyString(adapterConfig.devicePrivateKeyPem)) return adapterConfig;
     return { ...adapterConfig, devicePrivateKeyPem: generateEd25519PrivateKeyPem() };
-  }
-
-  function applyCreateDefaultsByAdapterType(
-    adapterType: string | null | undefined,
-    adapterConfig: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const next = { ...adapterConfig };
-    if (adapterType === "codex_local") {
-      if (!asNonEmptyString(next.model)) {
-        next.model = DEFAULT_CODEX_LOCAL_MODEL;
-      }
-      const hasBypassFlag =
-        typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean" ||
-        typeof next.dangerouslyBypassSandbox === "boolean";
-      if (!hasBypassFlag) {
-        next.dangerouslyBypassApprovalsAndSandbox = DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
-      }
-      return ensureGatewayDeviceKey(adapterType, next);
-    }
-    if (adapterType === "gemini_local" && !asNonEmptyString(next.model)) {
-      next.model = DEFAULT_GEMINI_LOCAL_MODEL;
-      return ensureGatewayDeviceKey(adapterType, next);
-    }
-    // OpenCode requires explicit model selection — no default
-    if (adapterType === "cursor" && !asNonEmptyString(next.model)) {
-      next.model = DEFAULT_CURSOR_LOCAL_MODEL;
-    }
-    return ensureGatewayDeviceKey(adapterType, next);
   }
 
   async function assertAdapterConfigConstraints(
@@ -341,6 +358,13 @@ export function agentRoutes(db: Db) {
       adapterConfig: {},
       runtimeConfig: {},
     };
+  }
+
+  function applyCreateDefaultsByAdapterType(
+    adapterType: string | null | undefined,
+    adapterConfig: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return applyCreateDefaultsByAdapterTypeInternal(adapterType, adapterConfig, ensureGatewayDeviceKey);
   }
 
   function redactAgentConfiguration(agent: Awaited<ReturnType<typeof svc.getById>>) {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -86,6 +86,7 @@ const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; valu
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },
     { path: ["maxTurnsPerRun"], value: 300 },
+    { path: ["dangerouslySkipPermissions"], value: true },
   ],
   openclaw_gateway: [
     { path: ["timeoutSec"], value: 120 },


### PR DESCRIPTION
Auto-constructed Claude agents were being created without the unattended permission default used by onboarding, which could cause runs to fail with errors like:
permission requested: external_directory (...); auto-rejecting
This change aligns server-side agent creation defaults with the existing onboarding behavior by enabling unless it is explicitly set.

Changes
add unattended Claude default in server-side agent creation flow
preserve explicit values when provided
sync Claude portability defaults so exports do not treat this as a custom override
add a regression test for the defaulting behavior
Verification
I was able to validate the code changes and push the fix branch successfully.

I was not able to run full typecheck/tests/build in this environment because workspace dependencies are not installed yet (node_modules and local tsc/vitest binaries are missing).