### PR TITLE
feat(heartbeat): add cron-style scheduled cadence

### DIFF
--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -120,6 +120,7 @@ export interface InstanceSchedulerHeartbeatAgent {
   status: AgentStatus;
   adapterType: string;
   intervalSec: number;
+  cronSchedule: string | null;
   heartbeatEnabled: boolean;
   schedulerActive: boolean;
   lastHeartbeatAt: Date | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,6 @@ importers:
       better-auth:
         specifier: 1.4.18
         version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
-      cron-parser:
-        specifier: ^5.5.0
-        version: 5.5.0
       detect-port:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3464,10 +3461,6 @@ packages:
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
-  cron-parser@5.5.0:
-    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
-    engines: {node: '>=18'}
-
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -4397,10 +4390,6 @@ packages:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
-    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -9310,10 +9299,6 @@ snapshots:
 
   crelt@1.0.6: {}
 
-  cron-parser@5.5.0:
-    dependencies:
-      luxon: 3.7.2
-
   cross-env@10.1.0:
     dependencies:
       '@epic-web/invariant': 1.0.0
@@ -10237,8 +10222,6 @@ snapshots:
   lucide-react@0.574.0(react@19.2.4):
     dependencies:
       react: 19.2.4
-
-  luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       better-auth:
         specifier: 1.4.18
         version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      cron-parser:
+        specifier: ^5.5.0
+        version: 5.5.0
       detect-port:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3461,6 +3464,10 @@ packages:
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
+
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -4390,6 +4397,10 @@ packages:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -9299,6 +9310,10 @@ snapshots:
 
   crelt@1.0.6: {}
 
+  cron-parser@5.5.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-env@10.1.0:
     dependencies:
       '@epic-web/invariant': 1.0.0
@@ -10222,6 +10237,8 @@ snapshots:
   lucide-react@0.574.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
     "@paperclipai/db": "workspace:*",
     "@paperclipai/shared": "workspace:*",
     "better-auth": "1.4.18",
+    "cron-parser": "^5.5.0",
     "detect-port": "^2.1.0",
     "dotenv": "^17.0.1",
     "drizzle-orm": "^0.38.4",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -213,9 +213,11 @@ export function agentRoutes(db: Db) {
 
   function parseSchedulerHeartbeatPolicy(runtimeConfig: unknown) {
     const heartbeat = asRecord(asRecord(runtimeConfig)?.heartbeat) ?? {};
+    const rawCron = typeof heartbeat.cronSchedule === "string" ? heartbeat.cronSchedule.trim() : "";
     return {
       enabled: parseBooleanLike(heartbeat.enabled) ?? true,
       intervalSec: Math.max(0, parseNumberLike(heartbeat.intervalSec) ?? 0),
+      cronSchedule: rawCron,
     };
   }
 
@@ -523,13 +525,14 @@ export function agentRoutes(db: Db) {
           status: row.status as InstanceSchedulerHeartbeatAgent["status"],
           adapterType: row.adapterType,
           intervalSec: policy.intervalSec,
+          cronSchedule: policy.cronSchedule || null,
           heartbeatEnabled: policy.enabled,
-          schedulerActive: statusEligible && policy.enabled && policy.intervalSec > 0,
+          schedulerActive: statusEligible && policy.enabled && (policy.intervalSec > 0 || !!policy.cronSchedule),
           lastHeartbeatAt: row.lastHeartbeatAt,
         };
       })
       .filter((item) =>
-        item.intervalSec > 0 &&
+        (item.intervalSec > 0 || !!item.cronSchedule) &&
         item.status !== "paused" &&
         item.status !== "terminated" &&
         item.status !== "pending_approval",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,6 +1,7 @@
 import { Router, type Request } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
+import { CronExpressionParser } from "cron-parser";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
@@ -214,10 +215,14 @@ export function agentRoutes(db: Db) {
   function parseSchedulerHeartbeatPolicy(runtimeConfig: unknown) {
     const heartbeat = asRecord(asRecord(runtimeConfig)?.heartbeat) ?? {};
     const rawCron = typeof heartbeat.cronSchedule === "string" ? heartbeat.cronSchedule.trim() : "";
+    let validCron = "";
+    if (rawCron) {
+      try { CronExpressionParser.parse(rawCron); validCron = rawCron; } catch { /* invalid */ }
+    }
     return {
       enabled: parseBooleanLike(heartbeat.enabled) ?? true,
       intervalSec: Math.max(0, parseNumberLike(heartbeat.intervalSec) ?? 0),
-      cronSchedule: rawCron,
+      cronSchedule: validCron,
     };
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1123,10 +1123,16 @@ export function heartbeatService(db: Db) {
     const heartbeat = parseObject(runtimeConfig.heartbeat);
 
     const rawCron = typeof heartbeat.cronSchedule === "string" ? heartbeat.cronSchedule.trim() : "";
+    const cronTimezone = typeof heartbeat.cronTimezone === "string" ? heartbeat.cronTimezone.trim() : "";
+    let validCron = "";
+    if (rawCron) {
+      try { CronExpressionParser.parse(rawCron); validCron = rawCron; } catch { /* invalid - treat as unset */ }
+    }
     return {
       enabled: asBoolean(heartbeat.enabled, true),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
-      cronSchedule: rawCron,
+      cronSchedule: validCron,
+      cronTimezone,
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };
@@ -2813,6 +2819,7 @@ export function heartbeatService(db: Db) {
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
 
         let shouldFire = false;
+        let fireReason = "interval_elapsed";
 
         if (policy.intervalSec > 0) {
           const elapsedMs = now.getTime() - baseline;
@@ -2820,12 +2827,17 @@ export function heartbeatService(db: Db) {
         }
 
         if (!shouldFire && policy.cronSchedule) {
+          const cronOpts: { currentDate: Date; tz?: string } = { currentDate: new Date(baseline) };
+          if (policy.cronTimezone) cronOpts.tz = policy.cronTimezone;
           try {
-            const cron = CronExpressionParser.parse(policy.cronSchedule, { currentDate: new Date(baseline) });
+            const cron = CronExpressionParser.parse(policy.cronSchedule, cronOpts);
             const nextFire = cron.next().toDate();
-            if (nextFire.getTime() <= now.getTime()) shouldFire = true;
+            if (nextFire.getTime() <= now.getTime()) {
+              shouldFire = true;
+              fireReason = "cron_schedule";
+            }
           } catch {
-            // Invalid cron expression - skip silently
+            // Invalid cron expression - already filtered in parseHeartbeatPolicy
           }
         }
 
@@ -2839,7 +2851,7 @@ export function heartbeatService(db: Db) {
           requestedByActorId: "heartbeat_scheduler",
           contextSnapshot: {
             source: "scheduler",
-            reason: "interval_elapsed",
+            reason: fireReason,
             now: now.toISOString(),
           },
         });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21,6 +21,7 @@ import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import { CronExpressionParser } from "cron-parser";
 import { costService } from "./costs.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
@@ -1121,9 +1122,11 @@ export function heartbeatService(db: Db) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
 
+    const rawCron = typeof heartbeat.cronSchedule === "string" ? heartbeat.cronSchedule.trim() : "";
     return {
       enabled: asBoolean(heartbeat.enabled, true),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
+      cronSchedule: rawCron,
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };
@@ -2804,12 +2807,29 @@ export function heartbeatService(db: Db) {
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
-        if (!policy.enabled || policy.intervalSec <= 0) continue;
+        if (!policy.enabled || (policy.intervalSec <= 0 && !policy.cronSchedule)) continue;
 
         checked += 1;
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
-        const elapsedMs = now.getTime() - baseline;
-        if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        let shouldFire = false;
+
+        if (policy.intervalSec > 0) {
+          const elapsedMs = now.getTime() - baseline;
+          if (elapsedMs >= policy.intervalSec * 1000) shouldFire = true;
+        }
+
+        if (!shouldFire && policy.cronSchedule) {
+          try {
+            const cron = CronExpressionParser.parse(policy.cronSchedule, { currentDate: new Date(baseline) });
+            const nextFire = cron.next().toDate();
+            if (nextFire.getTime() <= now.getTime()) shouldFire = true;
+          } catch {
+            // Invalid cron expression - skip silently
+          }
+        }
+
+        if (!shouldFire) continue;
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents wake on heartbeat intervals to perform recurring work like CEO morning reviews
> - Fixed intervals alone cannot express "every weekday at 6am" - only "every N seconds"
> - Users in Discord were working around this by having agents self-install system cron jobs
> - This adds native cronSchedule support to the heartbeat policy alongside intervalSec
> - Agents can now wake at specific times of day without brittle self-installed workarounds

## Summary

Adds an optional `cronSchedule` field to the heartbeat policy so agents can wake at specific times of day, not just on fixed intervals.

- Extends `parseHeartbeatPolicy()` to read `runtimeConfig.heartbeat.cronSchedule`
- Updates `tickTimers()` to check both `intervalSec` and `cronSchedule` - whichever fires first wins
- Adds `cronSchedule` to the `InstanceSchedulerHeartbeatAgent` shared type and scheduler API response
- Uses `cron-parser` v5 for cron evaluation
- Invalid cron expressions are silently skipped (no crash)

### Usage

Set `runtimeConfig.heartbeat.cronSchedule` on any agent:

```json
{
  "heartbeat": {
    "enabled": true,
    "cronSchedule": "0 6 * * 1-5"
  }
}
```

Examples:
- `0 6 * * 1-5` - Weekday mornings at 6am
- `0 9,17 * * *` - Twice daily at 9am and 5pm
- `0 */4 * * *` - Every 4 hours on the hour

Works alongside `intervalSec` - set both for "every N seconds OR at these specific times."

### Discord signal

This was surfaced from the Paperclip Discord community:

> **creativecat** in #general: "Does that mean doing work on a particular cadence is still being worked on? I haven't been able to tell the CEO, for example, 'every morning do X and create issues based on Y' so that it runs automatically"

> **dotta** (maintainer) in #general: "you could still patch it in with your agents HEARTBEAT.md - like just ask him to wake up every morning at 6am and he should know how to install cron and kickoff himself via paperclip api"

The workaround (agents self-installing cron) confirms this isn't natively supported yet. This PR adds native support.

## Test plan

- [ ] Set `cronSchedule: "* * * * *"` (every minute) on a test agent, verify it fires
- [ ] Set both `intervalSec: 3600` and `cronSchedule: "0 9 * * *"`, verify whichever is sooner fires
- [ ] Set invalid cron expression, verify no crash (silently skipped)
- [ ] Scheduler heartbeats API returns `cronSchedule` field
- [ ] Existing CI passes (typecheck, tests, build)

This contribution was developed with AI assistance (Claude Code).
