### PR TITLE
Harden HTTP request logging redaction

### DIFF
--- a/server/src/__tests__/logger-redaction.test.ts
+++ b/server/src/__tests__/logger-redaction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeHttpLogObject, sanitizeSerializedRequestForLog } from "../middleware/logger.js";
+
+describe("http logger redaction", () => {
+  it("redacts sensitive headers from serialized requests", () => {
+    const sanitized = sanitizeSerializedRequestForLog({
+      method: "GET",
+      url: "/api/health",
+      headers: {
+        host: "127.0.0.1:3100",
+        authorization: "Bearer super-secret-token",
+        cookie: "sid=session-secret",
+        "x-openclaw-token": "openclaw-secret",
+      },
+    }) as Record<string, unknown>;
+
+    const headers = sanitized.headers as Record<string, unknown>;
+
+    expect(headers.host).toBe("127.0.0.1:3100");
+    expect(headers.authorization).toBe("***REDACTED***");
+    expect(headers.cookie).toBe("***REDACTED***");
+    expect(headers["x-openclaw-token"]).toBe("***REDACTED***");
+  });
+
+  it("redacts sensitive keys from request props payloads", () => {
+    const sanitized = sanitizeHttpLogObject({
+      title: "wake issue",
+      nested: {
+        apiKey: "plain-text-api-key",
+        safe: "ok",
+      },
+      password: "hunter2",
+    }) as Record<string, unknown>;
+
+    expect(sanitized).toEqual({
+      title: "wake issue",
+      nested: {
+        apiKey: "***REDACTED***",
+        safe: "ok",
+      },
+      password: "***REDACTED***",
+    });
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -4,6 +4,7 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
+import { REDACTED_EVENT_VALUE, sanitizeRecord } from "../redaction.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -26,6 +27,30 @@ const sharedOpts = {
   singleLine: true,
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function sanitizeHttpLogObject(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  return sanitizeRecord(value);
+}
+
+export function sanitizeSerializedRequestForLog(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  const sanitized = { ...value };
+  if (isRecord(sanitized.headers)) {
+    const headers = sanitizeRecord(sanitized.headers);
+    for (const key of Object.keys(sanitized.headers)) {
+      if (/token/i.test(key)) {
+        headers[key] = REDACTED_EVENT_VALUE;
+      }
+    }
+    sanitized.headers = headers;
+  }
+  return sanitized;
+}
+
 export const logger = pino({
   level: "debug",
 }, pino.transport({
@@ -45,6 +70,11 @@ export const logger = pino({
 
 export const httpLogger = pinoHttp({
   logger,
+  serializers: {
+    req(req) {
+      return sanitizeSerializedRequestForLog(pino.stdSerializers.req(req));
+    },
+  },
   customLogLevel(_req, res, err) {
     if (err || res.statusCode >= 500) return "error";
     if (res.statusCode >= 400) return "warn";
@@ -64,21 +94,21 @@ export const httpLogger = pinoHttp({
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: ctx.reqBody,
-          reqParams: ctx.reqParams,
-          reqQuery: ctx.reqQuery,
+          reqBody: sanitizeHttpLogObject(ctx.reqBody),
+          reqParams: sanitizeHttpLogObject(ctx.reqParams),
+          reqQuery: sanitizeHttpLogObject(ctx.reqQuery),
         };
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = sanitizeHttpLogObject(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
-        props.reqParams = params;
+        props.reqParams = sanitizeHttpLogObject(params);
       }
       if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = query;
+        props.reqQuery = sanitizeHttpLogObject(query);
       }
       if ((req as any).route?.path) {
         props.routePath = (req as any).route.path;


### PR DESCRIPTION
## Summary
- redact sensitive request headers in HTTP access logs (`authorization`, `cookie`, and token-like headers)
- sanitize logged request body/params/query props for 4xx/5xx log entries
- add regression tests for logger redaction behavior
- update roadmap follow-up plan Phase A to explicitly include this hardening item

## Validation
- `pnpm -r typecheck`
- `pnpm test:run server/src/__tests__/logger-redaction.test.ts server/src/__tests__/redaction.test.ts`
- `pnpm build`

## Notes
- Full `pnpm test:run` is not stable in this sandbox due socket/listen EPERM and existing tracked `._*` files being picked up by Vitest.
