### PR TITLE
fix: show elapsed timer on run cards for cloud adapters (#235)

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import type { Issue } from "@paperclipai/shared";
@@ -13,6 +13,21 @@ import { RunTranscriptView } from "./transcript/RunTranscriptView";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 
 const MIN_DASHBOARD_RUNS = 4;
+
+function useElapsedTime(since: string | Date, enabled: boolean): string {
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const id = window.setInterval(() => tick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [enabled]);
+
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(since).getTime()) / 1000));
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return minutes > 0 ? `${minutes}m ${remainingSeconds}s` : `${remainingSeconds}s`;
+}
 
 function isRunActive(run: LiveRunForIssue): boolean {
   return run.status === "queued" || run.status === "running";
@@ -89,13 +104,23 @@ function AgentRunCard({
   hasOutput: boolean;
   isActive: boolean;
 }) {
+  const timerStart = run.status === "running" ? run.startedAt ?? run.createdAt : run.createdAt;
+  const elapsed = useElapsedTime(timerStart, isActive && !hasOutput);
+  const emptyMessage = hasOutput
+    ? "Waiting for transcript parsing..."
+    : isActive
+      ? `${run.status === "queued" ? "Queued" : "Running"} (${elapsed})...`
+      : "No transcript captured.";
+
   return (
-    <div className={cn(
-      "flex h-[320px] flex-col overflow-hidden rounded-xl border shadow-sm",
-      isActive
-        ? "border-cyan-500/25 bg-cyan-500/[0.04] shadow-[0_16px_40px_rgba(6,182,212,0.08)]"
-        : "border-border bg-background/70",
-    )}>
+    <div
+      className={cn(
+        "flex h-[320px] flex-col overflow-hidden rounded-xl border shadow-sm",
+        isActive
+          ? "border-cyan-500/25 bg-cyan-500/[0.04] shadow-[0_16px_40px_rgba(6,182,212,0.08)]"
+          : "border-border bg-background/70",
+      )}
+    >
       <div className="border-b border-border/60 px-3 py-3">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
@@ -111,7 +136,9 @@ function AgentRunCard({
               <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
             </div>
             <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-              <span>{isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}</span>
+              <span>
+                {isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}
+              </span>
             </div>
           </div>
 
@@ -148,7 +175,7 @@ function AgentRunCard({
           streaming={isActive}
           collapseStdout
           thinkingClassName="!text-[10px] !leading-4"
-          emptyMessage={hasOutput ? "Waiting for transcript parsing..." : isActive ? "Waiting for output..." : "No transcript captured."}
+          emptyMessage={emptyMessage}
         />
       </div>
     </div>

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -23,7 +23,9 @@ function useElapsedTime(since: string | Date, enabled: boolean): string {
     return () => window.clearInterval(id);
   }, [enabled]);
 
-  const seconds = Math.max(0, Math.floor((Date.now() - new Date(since).getTime()) / 1000));
+  const seconds = enabled
+    ? Math.max(0, Math.floor((Date.now() - new Date(since).getTime()) / 1000))
+    : 0;
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = seconds % 60;
   return minutes > 0 ? `${minutes}m ${remainingSeconds}s` : `${remainingSeconds}s`;


### PR DESCRIPTION
## Summary

Fresh replacement for #442 from current `master`.

- shows elapsed time instead of a static waiting message when a run has no transcript output yet
- distinguishes `Queued (...)` vs `Running (...)`
- uses `startedAt` for running runs with `createdAt` fallback where needed

## Why this PR

The original PR #442 became conflict-stale. This branch was re-cut from current upstream and adapted to the current `RunTranscriptView`-based implementation.

## Verification

- re-applied on top of current `master`
- preserved the behavior requested in the original review follow-up
- diff remains limited to `ui/src/components/ActiveAgentsPanel.tsx`

Supersedes #442.