### PR TITLE
fix(adapters): preserve default prompt context

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -110,12 +110,38 @@ export function resolvePathValue(obj: Record<string, unknown>, dottedPath: strin
 
 export const DEFAULT_HEARTBEAT_PROMPT_TEMPLATE =
   "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.";
+const DEFAULT_PROMPT_PLACEHOLDER_RE = /{{\s*defaultPrompt\s*}}/;
+
+interface BuildHeartbeatPromptRenderDataArgs {
+  agent: { id: string; companyId: string; name: string };
+  runId: string;
+  context: Record<string, unknown>;
+}
 
 export function resolveHeartbeatPromptTemplate(rawTemplate: unknown) {
   const template = typeof rawTemplate === "string" ? rawTemplate.trim() : "";
   if (!template) return DEFAULT_HEARTBEAT_PROMPT_TEMPLATE;
-  if (template.includes("{{defaultPrompt}}")) return template;
+  if (DEFAULT_PROMPT_PLACEHOLDER_RE.test(template)) return template;
   return `${DEFAULT_HEARTBEAT_PROMPT_TEMPLATE}\n\n${template}`;
+}
+
+export function buildHeartbeatPromptRenderData({
+  agent,
+  runId,
+  context,
+}: BuildHeartbeatPromptRenderDataArgs): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+
+  data.defaultPrompt = renderTemplate(DEFAULT_HEARTBEAT_PROMPT_TEMPLATE, data);
+  return data;
 }
 
 export function renderTemplate(template: string, data: Record<string, unknown>) {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -108,6 +108,16 @@ export function resolvePathValue(obj: Record<string, unknown>, dottedPath: strin
   }
 }
 
+export const DEFAULT_HEARTBEAT_PROMPT_TEMPLATE =
+  "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.";
+
+export function resolveHeartbeatPromptTemplate(rawTemplate: unknown) {
+  const template = typeof rawTemplate === "string" ? rawTemplate.trim() : "";
+  if (!template) return DEFAULT_HEARTBEAT_PROMPT_TEMPLATE;
+  if (template.includes("{{defaultPrompt}}")) return template;
+  return `${DEFAULT_HEARTBEAT_PROMPT_TEMPLATE}\n\n${template}`;
+}
+
 export function renderTemplate(template: string, data: Record<string, unknown>) {
   return template.replace(/{{\s*([a-zA-Z0-9_.-]+)\s*}}/g, (_, path) => resolvePathValue(data, path));
 }

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -19,7 +19,7 @@ Core fields:
 - model (string, optional): Claude model id
 - effort (string, optional): reasoning effort passed via --effort (low|medium|high)
 - chrome (boolean, optional): pass --chrome when running Claude
-- promptTemplate (string, optional): run prompt template
+- promptTemplate (string, optional): extra run prompt instructions; default heartbeat context is preserved automatically, or use {{defaultPrompt}} to position it explicitly
 - maxTurnsPerRun (number, optional): max turns for one run
 - dangerouslySkipPermissions (boolean, optional): pass --dangerously-skip-permissions to claude
 - command (string, optional): defaults to "claude"

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -19,6 +19,8 @@ import {
   ensurePathInEnv,
   renderTemplate,
   runChildProcess,
+  resolveHeartbeatPromptTemplate,
+  buildHeartbeatPromptRenderData,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
@@ -301,10 +303,7 @@ export async function runClaudeLogin(input: {
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
 
-  const promptTemplate = asString(
-    config.promptTemplate,
-    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
-  );
+  const promptTemplate = resolveHeartbeatPromptTemplate(config.promptTemplate);
   const model = asString(config.model, "");
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
@@ -365,19 +364,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
   }
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
-  const templateData = {
-    agentId: agent.id,
-    companyId: agent.companyId,
-    runId,
-    company: { id: agent.companyId },
-    agent,
-    run: { id: runId, source: "on_demand" },
-    context,
-  };
-  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const promptData = buildHeartbeatPromptRenderData({ agent, runId, context });
+  const renderedPrompt = renderTemplate(promptTemplate, promptData);
   const renderedBootstrapPrompt =
     !sessionId && bootstrapPromptTemplate.trim().length > 0
-      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      ? renderTemplate(bootstrapPromptTemplate, promptData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const prompt = joinPromptSections([

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -25,7 +25,7 @@ Core fields:
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to stdin prompt at runtime
 - model (string, optional): Codex model id
 - modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high) passed via -c model_reasoning_effort=...
-- promptTemplate (string, optional): run prompt template
+- promptTemplate (string, optional): extra run prompt instructions; default heartbeat context is preserved automatically, or use {{defaultPrompt}} to position it explicitly
 - search (boolean, optional): run codex with --search
 - dangerouslyBypassApprovalsAndSandbox (boolean, optional): run with bypass flag
 - command (string, optional): defaults to "codex"

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -19,6 +19,8 @@ import {
   renderTemplate,
   joinPromptSections,
   runChildProcess,
+  resolveHeartbeatPromptTemplate,
+  buildHeartbeatPromptRenderData,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareWorktreeCodexHome, resolveCodexHomeDir } from "./codex-home.js";
@@ -163,10 +165,7 @@ export async function ensureCodexSkillsInjected(
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
 
-  const promptTemplate = asString(
-    config.promptTemplate,
-    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
-  );
+  const promptTemplate = resolveHeartbeatPromptTemplate(config.promptTemplate);
   const command = asString(config.command, "codex");
   const model = asString(config.model, "");
   const modelReasoningEffort = asString(
@@ -373,19 +372,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ];
   })();
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
-  const templateData = {
-    agentId: agent.id,
-    companyId: agent.companyId,
-    runId,
-    company: { id: agent.companyId },
-    agent,
-    run: { id: runId, source: "on_demand" },
-    context,
-  };
-  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const promptData = buildHeartbeatPromptRenderData({ agent, runId, context });
+  const renderedPrompt = renderTemplate(promptTemplate, promptData);
   const renderedBootstrapPrompt =
     !sessionId && bootstrapPromptTemplate.trim().length > 0
-      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      ? renderTemplate(bootstrapPromptTemplate, promptData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const prompt = joinPromptSections([

--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -63,7 +63,7 @@ Don't use when:
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
-- promptTemplate (string, optional): run prompt template
+- promptTemplate (string, optional): extra run prompt instructions; default heartbeat context is preserved automatically, or use {{defaultPrompt}} to position it explicitly
 - model (string, optional): Cursor model id (for example auto or gpt-5.3-codex)
 - mode (string, optional): Cursor execution mode passed as --mode (plan|ask). Leave unset for normal autonomous runs.
 - command (string, optional): defaults to "agent"

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -19,6 +19,8 @@ import {
   renderTemplate,
   joinPromptSections,
   runChildProcess,
+  resolveHeartbeatPromptTemplate,
+  buildHeartbeatPromptRenderData,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
@@ -143,10 +145,7 @@ export async function ensureCursorSkillsInjected(
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
 
-  const promptTemplate = asString(
-    config.promptTemplate,
-    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
-  );
+  const promptTemplate = resolveHeartbeatPromptTemplate(config.promptTemplate);
   const command = asString(config.command, "agent");
   const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
   const mode = normalizeMode(asString(config.mode, ""));
@@ -311,19 +310,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   })();
 
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
-  const templateData = {
-    agentId: agent.id,
-    companyId: agent.companyId,
-    runId,
-    company: { id: agent.companyId },
-    agent,
-    run: { id: runId, source: "on_demand" },
-    context,
-  };
-  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const promptData = buildHeartbeatPromptRenderData({ agent, runId, context });
+  const renderedPrompt = renderTemplate(promptTemplate, promptData);
   const renderedBootstrapPrompt =
     !sessionId && bootstrapPromptTemplate.trim().length > 0
-      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      ? renderTemplate(bootstrapPromptTemplate, promptData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -22,7 +22,7 @@ Core fields:
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
 - variant (string, optional): provider-specific model variant (for example minimal|low|medium|high|max)
-- promptTemplate (string, optional): run prompt template
+- promptTemplate (string, optional): extra run prompt instructions; default heartbeat context is preserved automatically, or use {{defaultPrompt}} to position it explicitly
 - command (string, optional): defaults to "opencode"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -16,6 +16,8 @@ import {
   ensurePathInEnv,
   renderTemplate,
   runChildProcess,
+  resolveHeartbeatPromptTemplate,
+  buildHeartbeatPromptRenderData,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
@@ -86,10 +88,7 @@ async function ensureOpenCodeSkillsInjected(onLog: AdapterExecutionContext["onLo
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
 
-  const promptTemplate = asString(
-    config.promptTemplate,
-    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
-  );
+  const promptTemplate = resolveHeartbeatPromptTemplate(config.promptTemplate);
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
   const variant = asString(config.variant, "").trim();
@@ -235,19 +234,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   })();
 
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
-  const templateData = {
-    agentId: agent.id,
-    companyId: agent.companyId,
-    runId,
-    company: { id: agent.companyId },
-    agent,
-    run: { id: runId, source: "on_demand" },
-    context,
-  };
-  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const promptData = buildHeartbeatPromptRenderData({ agent, runId, context });
+  const renderedPrompt = renderTemplate(promptTemplate, promptData);
   const renderedBootstrapPrompt =
     !sessionId && bootstrapPromptTemplate.trim().length > 0
-      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      ? renderTemplate(bootstrapPromptTemplate, promptData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const prompt = joinPromptSections([

--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -21,7 +21,7 @@ Don't use when:
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file appended to system prompt via --append-system-prompt
-- promptTemplate (string, optional): user prompt template passed via -p flag
+- promptTemplate (string, optional): extra user prompt instructions; default heartbeat context is preserved automatically, or use {{defaultPrompt}} to position it explicitly
 - model (string, required): Pi model id in provider/model format (for example xai/grok-4)
 - thinking (string, optional): thinking level (off, minimal, low, medium, high, xhigh)
 - command (string, optional): defaults to "pi"

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -19,6 +19,8 @@ import {
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   runChildProcess,
+  resolveHeartbeatPromptTemplate,
+  buildHeartbeatPromptRenderData,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isPiUnknownSessionError, parsePiJsonl } from "./parse.js";
 import { ensurePiModelConfiguredAndAvailable } from "./models.js";
@@ -99,10 +101,7 @@ function buildSessionPath(agentId: string, timestamp: string): string {
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
 
-  const promptTemplate = asString(
-    config.promptTemplate,
-    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
-  );
+  const promptTemplate = resolveHeartbeatPromptTemplate(config.promptTemplate);
   const command = asString(config.command, "pi");
   const model = asString(config.model, "").trim();
   const thinking = asString(config.thinking, "").trim();
@@ -272,20 +271,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
 
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
-  const templateData = {
-    agentId: agent.id,
-    companyId: agent.companyId,
-    runId,
-    company: { id: agent.companyId },
-    agent,
-    run: { id: runId, source: "on_demand" },
-    context,
-  };
-  const renderedSystemPromptExtension = renderTemplate(systemPromptExtension, templateData);
-  const renderedHeartbeatPrompt = renderTemplate(promptTemplate, templateData);
+  const promptData = buildHeartbeatPromptRenderData({ agent, runId, context });
+  const renderedSystemPromptExtension = renderTemplate(systemPromptExtension, promptData);
+  const renderedHeartbeatPrompt = renderTemplate(promptTemplate, promptData);
   const renderedBootstrapPrompt =
     !canResumeSession && bootstrapPromptTemplate.trim().length > 0
-      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      ? renderTemplate(bootstrapPromptTemplate, promptData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const userPrompt = joinPromptSections([

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -160,7 +160,7 @@ describe("cursor execute", () => {
           env: {
             PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
           },
-          promptTemplate: "Custom prefix. {{defaultPrompt}} Custom suffix.",
+          promptTemplate: "Custom prefix. {{ defaultPrompt }} Custom suffix.",
         },
         context: {},
         authToken: "run-jwt-token",

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -110,8 +110,70 @@ describe("cursor execute", () => {
       );
       expect(capture.prompt).toContain("Paperclip runtime note:");
       expect(capture.prompt).toContain("PAPERCLIP_API_KEY");
+      expect(capture.prompt).toContain("You are agent agent-1 (Cursor Coder). Continue your Paperclip work.");
+      expect(capture.prompt).toContain("Follow the paperclip heartbeat.");
       expect(invocationPrompt).toContain("Paperclip runtime note:");
       expect(invocationPrompt).toContain("PAPERCLIP_API_URL");
+      expect(invocationPrompt).toContain("You are agent agent-1 (Cursor Coder). Continue your Paperclip work.");
+      expect(invocationPrompt).toContain("Follow the paperclip heartbeat.");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("supports explicit {{defaultPrompt}} placement in custom templates", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cursor-execute-default-prompt-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCursorCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-default-prompt",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Cursor Coder",
+          adapterType: "cursor",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "auto",
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Custom prefix. {{defaultPrompt}} Custom suffix.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.prompt).toContain("Custom prefix.");
+      expect(capture.prompt).toContain("You are agent agent-1 (Cursor Coder). Continue your Paperclip work.");
+      expect(capture.prompt).toContain("Custom suffix.");
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME;

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -137,6 +137,7 @@ describe("cursor execute", () => {
     const previousHome = process.env.HOME;
     process.env.HOME = root;
 
+    let invocationPrompt = "";
     try {
       const result = await execute({
         runId: "run-default-prompt",
@@ -165,15 +166,29 @@ describe("cursor execute", () => {
         context: {},
         authToken: "run-jwt-token",
         onLog: async () => {},
+        onMeta: async (meta) => {
+          invocationPrompt = meta.prompt ?? "";
+        },
       });
 
       expect(result.exitCode).toBe(0);
       expect(result.errorMessage).toBeNull();
 
       const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
-      expect(capture.prompt).toContain("Custom prefix.");
-      expect(capture.prompt).toContain("You are agent agent-1 (Cursor Coder). Continue your Paperclip work.");
-      expect(capture.prompt).toContain("Custom suffix.");
+      const defaultPrompt = "You are agent agent-1 (Cursor Coder). Continue your Paperclip work.";
+      const prefixIdx = capture.prompt.indexOf("Custom prefix.");
+      const defaultIdx = capture.prompt.indexOf(defaultPrompt);
+      const suffixIdx = capture.prompt.indexOf("Custom suffix.");
+      expect(prefixIdx).toBeGreaterThanOrEqual(0);
+      expect(defaultIdx).toBeGreaterThan(prefixIdx);
+      expect(suffixIdx).toBeGreaterThan(defaultIdx);
+
+      const metaPrefixIdx = invocationPrompt.indexOf("Custom prefix.");
+      const metaDefaultIdx = invocationPrompt.indexOf(defaultPrompt);
+      const metaSuffixIdx = invocationPrompt.indexOf("Custom suffix.");
+      expect(metaPrefixIdx).toBeGreaterThanOrEqual(0);
+      expect(metaDefaultIdx).toBeGreaterThan(metaPrefixIdx);
+      expect(metaSuffixIdx).toBeGreaterThan(metaDefaultIdx);
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME;

--- a/server/src/__tests__/heartbeat-prompt-template.test.ts
+++ b/server/src/__tests__/heartbeat-prompt-template.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HEARTBEAT_PROMPT_TEMPLATE,
+  buildHeartbeatPromptRenderData,
+  resolveHeartbeatPromptTemplate,
+} from "@paperclipai/adapter-utils/server-utils";
+
+describe("resolveHeartbeatPromptTemplate", () => {
+  it("returns the default prompt when template is empty", () => {
+    expect(resolveHeartbeatPromptTemplate("")).toBe(DEFAULT_HEARTBEAT_PROMPT_TEMPLATE);
+    expect(resolveHeartbeatPromptTemplate("   ")).toBe(DEFAULT_HEARTBEAT_PROMPT_TEMPLATE);
+    expect(resolveHeartbeatPromptTemplate(null)).toBe(DEFAULT_HEARTBEAT_PROMPT_TEMPLATE);
+  });
+
+  it("prepends the default prompt when custom template omits the placeholder", () => {
+    expect(resolveHeartbeatPromptTemplate("Custom suffix.")).toBe(
+      `${DEFAULT_HEARTBEAT_PROMPT_TEMPLATE}\n\nCustom suffix.`,
+    );
+  });
+
+  it("preserves explicit placeholder placement including spaced form", () => {
+    expect(resolveHeartbeatPromptTemplate("Before {{defaultPrompt}} after")).toBe(
+      "Before {{defaultPrompt}} after",
+    );
+    expect(resolveHeartbeatPromptTemplate("Before {{ defaultPrompt }} after")).toBe(
+      "Before {{ defaultPrompt }} after",
+    );
+  });
+});
+
+describe("buildHeartbeatPromptRenderData", () => {
+  it("builds defaultPrompt from the same render context", () => {
+    const data = buildHeartbeatPromptRenderData({
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Cursor Coder",
+      },
+      runId: "run-1",
+      context: {
+        issueId: "issue-1",
+      },
+    });
+
+    expect(data).toMatchObject({
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+      company: { id: "company-1" },
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Cursor Coder",
+      },
+      run: { id: "run-1", source: "on_demand" },
+      context: { issueId: "issue-1" },
+    });
+
+    expect(data.defaultPrompt).toBe(
+      "You are agent agent-1 (Cursor Coder). Continue your Paperclip work.",
+    );
+  });
+});

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -26,7 +26,7 @@ export const help: Record<string, string> = {
   capabilities: "Describes what this agent can do. Shown in the org chart and used for task routing.",
   adapterType: "How this agent runs: local CLI (Claude/Codex/OpenCode), OpenClaw Gateway, spawned process, or generic HTTP webhook.",
   cwd: "Default working directory fallback for local adapters. Use an absolute path on the machine running Paperclip.",
-  promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Use it for current-task framing, not large static instructions. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} and other template variables.",
+  promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Paperclip preserves the default heartbeat context automatically; use {{defaultPrompt}} if you want to position it explicitly. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }}, {{defaultPrompt}}, and other template variables.",
   model: "Override the default model used by the adapter.",
   thinkingEffort: "Control model reasoning depth. Supported values vary by adapter/model.",
   chrome: "Enable Claude's Chrome integration by passing --chrome.",


### PR DESCRIPTION
## Summary

Fresh replacement for #557 from current `master`.

- keeps the built-in default heartbeat prompt context unless operators intentionally reposition it
- supports explicit `{{defaultPrompt}}` placement
- hardens rendering so spaced placeholder forms are handled consistently
- centralizes default prompt render data instead of relying on each adapter call site

## Why this PR

The original PR #557 became conflict-stale. This branch was re-cut from current upstream to keep the fix reviewable.

## Verification

Targeted regression test passes locally:

```sh
cd server && pnpm vitest run src/__tests__/cursor-local-execute.test.ts
```

Supersedes #557.