### PR TITLE
feat(relay): zero-config remote access via tunnel with binary multiplexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 **What does a typical setup look like?**
 Locally, a single Node.js process manages an embedded Postgres and local file storage. For production, point it at your own Postgres and deploy however you like. Configure projects, agents, and goals — the agents take care of the rest.
 
-If you're a solo-entreprenuer you can use Tailscale to access Paperclip on the go. Then later you can deploy to e.g. Vercel when you need it.
+If you're a solo-entreprenuer you can use the built-in relay or Tailscale to access Paperclip on the go. The relay gives your instance a public URL (e.g. `https://d4lsc.your-relay.com`) with zero port forwarding — just set `PAPERCLIP_RELAY_URL` and the server handles the rest. A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI — deploy your own for production). See [doc/RELAY.md](doc/RELAY.md) for details. Both relay and Tailscale require `authenticated` deployment mode.
 
 **Can I run multiple companies?**
 Yes. A single deployment can run an unlimited number of companies with complete data isolation.

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -37,11 +37,19 @@ Current CLI behavior:
 
 Target behavior (planned) is documented in `doc/DEPLOYMENT-MODES.md` section 5.
 
-Allow an authenticated/private hostname (for example custom Tailscale DNS):
+Allow an authenticated/private hostname (for example custom Tailscale DNS or relay subdomain):
 
 ```sh
 pnpm paperclipai allowed-hostname dotta-macbook-pro
 ```
+
+Enable relay tunnel for remote access (requires `authenticated` mode):
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm paperclipai run
+```
+
+A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI — deploy your own for production). See `doc/RELAY.md` for relay architecture and deployment.
 
 All client commands support:
 

--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -32,12 +32,14 @@ This keeps one authenticated auth stack while still separating low-friction priv
 - loopback-only host binding
 - no human login flow
 - optimized for fastest local startup
+- relay tunnel is blocked (server refuses to start)
 
 ## `authenticated + private`
 
 - login required
 - low-friction URL handling (`auto` base URL mode)
 - private-host trust policy required
+- required for relay tunnel (see `doc/RELAY.md`)
 
 ## `authenticated + public`
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -53,6 +53,14 @@ Allow additional private hostnames (for example custom Tailscale hostnames):
 pnpm paperclipai allowed-hostname dotta-macbook-pro
 ```
 
+Relay tunnel dev mode (remote access without port forwarding):
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm dev --tailscale-auth
+```
+
+On first start, the server auto-registers and prints a public URL (e.g. `https://d4lsc.your-relay-server.com`). Token and hostname are persisted automatically. A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI — deploy your own for production). See `doc/RELAY.md` for relay architecture and server source.
+
 ## One-Command Local Run
 
 For a first-time local install, you can bootstrap and run in one command:

--- a/doc/RELAY.md
+++ b/doc/RELAY.md
@@ -1,0 +1,585 @@
+# Relay
+
+Status: Experimental
+Date: 2026-03-13
+
+## 1. Purpose
+
+The relay gives any Paperclip instance a public HTTPS URL with zero configuration. It enables remote access from any device without VPN, port forwarding, or extra software.
+
+```
+Any browser/device                     Paperclip server (behind NAT)
+       │                                          │
+       │──HTTPS──▶ ┌──────────────┐  ◀──WSS──────│
+       │           │ Relay Server │   outbound     │
+       │◀──HTTPS── │ (CF Worker)  │   tunnel       │
+       │           └──────────────┘               │
+       │            Public internet          127.0.0.1:3100
+```
+
+Each instance gets its own subdomain (e.g. `d4lsc.relay.example.com`). The relay is a generic transport layer — it forwards HTTP requests and WebSocket frames without inspecting payloads. All authentication is handled by Paperclip's existing auth layer.
+
+## 2. What Gets Tunneled
+
+- Static web UI assets (HTML/JS/CSS) — full Paperclip dashboard in any browser
+- REST API calls — all existing endpoints work unchanged
+- WebSocket connections — real-time events and live updates
+
+## 3. Configuration
+
+One environment variable enables the relay:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://relay.example.com
+```
+
+When set, the server auto-registers on first startup (obtaining a token and instance ID), then connects to the relay and prints the public subdomain URL:
+
+```
+$ npx paperclipai run
+
+  Server listening on 127.0.0.1:3100
+  Relay           https://d4lsc.relay.example.com
+```
+
+The server stays bound to `127.0.0.1`. The relay client runs inside the same process and forwards to localhost.
+
+## 4. Setup
+
+### 4.1 Deploy the relay server
+
+> **Test relay available**: `paperclip-relay.com` is a community-run relay for testing purposes. It is not affiliated with or operated by Paperclip AI. For production use, deploy your own relay server.
+
+The relay is a Cloudflare Worker with a Durable Object. See section 8 for the full source.
+
+```sh
+npm create cloudflare@latest paperclip-relay -- --type worker
+cd paperclip-relay
+# copy source files from section 8
+# set RELAY_DOMAIN in wrangler.toml [vars] to your domain
+# add wildcard DNS (*.your-domain.com) pointing to the Worker
+npx wrangler deploy
+```
+
+### 4.2 Configure Paperclip
+
+Add the relay URL to `.env` or set as an environment variable:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://relay.example.com
+```
+
+That's it. On first startup, the server automatically:
+
+1. Registers with the relay (`POST /register`)
+2. Saves the token to `.env` (`PAPERCLIP_RELAY_TOKEN=rl_...`)
+3. Adds the subdomain hostname (e.g. `d4lsc.relay.example.com`) to `allowedHostnames` in `config.json`
+
+On subsequent startups, the saved token is reused — the server reconnects to the same relay instance with the same subdomain.
+
+### 4.3 Open from anywhere
+
+Navigate to `https://<id>.relay.example.com` in any browser. Each Paperclip instance gets its own subdomain, so multiple Macs can use the same relay server without conflict.
+
+## 5. Why Subdomains
+
+SPAs use absolute paths for assets (e.g. `/assets/main.js`). Browsers resolve these against the domain root, not the current path. Path-prefix routing (`relay.example.com/abc12/`) would cause the browser to request `relay.example.com/assets/main.js` — wrong instance, or 404.
+
+Subdomains avoid this entirely: `abc12.relay.example.com/assets/main.js` stays within the same instance. This is the same approach used by Vercel, Netlify, and ngrok.
+
+## 6. Security
+
+**The relay requires `authenticated` deployment mode.** The server refuses to start the relay in `local_trusted` mode and logs an error. This is enforced because `local_trusted` has no login — enabling the relay would expose the instance to the public internet without any authentication.
+
+| Layer | Protection |
+|---|---|
+| Deployment mode | Must be `authenticated` — enforced at startup |
+| Client to relay | HTTPS/TLS (Cloudflare certificate) |
+| Relay to Paperclip | WSS/TLS |
+| Tunnel auth | Token — only the registered instance can connect |
+| API auth | Better Auth session cookies pass through unchanged |
+
+The relay sees traffic in plaintext at the proxy layer. This is the same trust model as any reverse proxy (Cloudflare, nginx, Caddy). Paperclip's own auth layer protects the API.
+
+## 7. Limitations
+
+- **Latency**: adds 20-100ms per request (Cloudflare edge round-trip)
+- **Tunnel single point**: if the server disconnects (sleep, restart), the relay returns 502 until reconnect
+- **No end-to-end encryption**: the relay sees plaintext (same as any reverse proxy)
+
+## 8. Relay Server Source
+
+The relay server is a Cloudflare Worker with a Durable Object. The Durable Object holds the persistent tunnel WebSocket from the Paperclip server and forwards requests through it.
+
+Key implementation details:
+
+- **Subdomain routing**: Each instance gets a subdomain (`<id>.relay.example.com`). The Worker extracts the instance ID from the `Host` header and routes to the corresponding Durable Object. Admin endpoints (`/register`, `/tunnel`, `/health`) live on the root domain.
+- **Configurable domain**: The relay domain is set via `RELAY_DOMAIN` in `wrangler.toml` — not hardcoded. Anyone can deploy their own relay on any domain.
+- **Hibernation recovery**: Durable Objects hibernate when idle, losing in-memory state. WebSockets are restored in the constructor via `getWebSockets()` using tags (`"__tunnel__"` for the tunnel, wsId for clients).
+- **Multi-value headers**: `set-cookie` headers cannot be comma-joined (cookie values contain commas in date strings). These are sent as JSON arrays with a companion `x-relay-multi-<header>` flag.
+
+### 8.1 `wrangler.toml`
+
+```toml
+name = "paperclip-relay"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+workers_dev = true
+
+routes = [
+  { pattern = "your-domain.com/*", zone_name = "your-domain.com" },
+  { pattern = "*.your-domain.com/*", zone_name = "your-domain.com" },
+]
+
+[vars]
+RELAY_DOMAIN = "your-domain.com"
+
+[durable_objects]
+bindings = [
+  { name = "TUNNEL", class_name = "TunnelDO" }
+]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["TunnelDO"]
+```
+
+### 8.2 `package.json`
+
+```json
+{
+  "name": "paperclip-relay",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250301.0",
+    "wrangler": "^4.0.0"
+  }
+}
+```
+
+### 8.3 `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}
+```
+
+### 8.4 `src/index.ts`
+
+```typescript
+export { TunnelDO } from "./tunnel";
+
+interface Env {
+  TUNNEL: DurableObjectNamespace;
+  RELAY_DOMAIN: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const instanceId = extractSubdomain(url.hostname, env.RELAY_DOMAIN);
+
+    // Subdomain request (e.g. skl1l.relay.example.com) → proxy to instance DO
+    if (instanceId) {
+      const stub = env.TUNNEL.get(env.TUNNEL.idFromName(instanceId));
+      return stub.fetch(request);
+    }
+
+    // Admin routes on root domain
+    if (url.pathname === "/register" && request.method === "POST") {
+      return handleRegister(env);
+    }
+
+    if (url.pathname === "/tunnel") {
+      const authHeader = request.headers.get("authorization") ?? "";
+      const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+      if (!token) return new Response("Missing token", { status: 401 });
+      return routeToTunnel(env, token, request);
+    }
+
+    if (url.pathname === "/health") {
+      return Response.json({ status: "ok" });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};
+
+/** Extract instance ID from subdomain: skl1l.example.com → skl1l (given base "example.com") */
+function extractSubdomain(hostname: string, relayDomain: string): string | null {
+  const suffix = `.${relayDomain}`;
+  if (hostname.endsWith(suffix)) {
+    return hostname.slice(0, -suffix.length) || null;
+  }
+  return null;
+}
+
+async function handleRegister(env: Env): Promise<Response> {
+  const instanceId = generateId(5);
+  const token = "rl_" + generateId(32);
+
+  // Initialize the instance DO
+  const doId = env.TUNNEL.idFromName(instanceId);
+  const stub = env.TUNNEL.get(doId);
+  await stub.fetch(new Request("http://internal/init", {
+    method: "POST",
+    body: JSON.stringify({ token, instanceId, relayDomain: env.RELAY_DOMAIN }),
+  }));
+
+  // Store token → instanceId mapping in the registry DO
+  const registry = env.TUNNEL.get(env.TUNNEL.idFromName("__token_registry__"));
+  await registry.fetch(new Request("http://internal/register-token", {
+    method: "POST",
+    body: JSON.stringify({ token, instanceId }),
+  }));
+
+  const publicUrl = `https://${instanceId}.${env.RELAY_DOMAIN}`;
+  return Response.json({ token, instanceId, publicUrl });
+}
+
+/** Look up instanceId from token, then route to the tunnel DO */
+async function routeToTunnel(
+  env: Env,
+  token: string,
+  request: Request,
+): Promise<Response> {
+  const registry = env.TUNNEL.get(env.TUNNEL.idFromName("__token_registry__"));
+  const resp = await registry.fetch(new Request("http://internal/lookup", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  }));
+  if (!resp.ok) return new Response("Invalid token", { status: 401 });
+  const { instanceId } = await resp.json() as { instanceId: string };
+
+  const stub = env.TUNNEL.get(env.TUNNEL.idFromName(instanceId));
+  return stub.fetch(request);
+}
+
+function generateId(length: number): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => chars[b % chars.length]).join("");
+}
+```
+
+### 8.5 `src/tunnel.ts`
+
+```typescript
+interface PendingRequest {
+  resolve: (response: Response) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+export class TunnelDO {
+  private state: DurableObjectState;
+  private tunnelWs: WebSocket | null = null;
+  private pendingRequests = new Map<string, PendingRequest>();
+  private clientWebSockets = new Map<string, WebSocket>();
+  private instanceId: string | null = null;
+  private relayDomain: string | null = null;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+
+    // Restore WebSockets after hibernation. Durable Objects may hibernate
+    // when idle, losing all in-memory state. The tunnel WS is tagged
+    // "__tunnel__"; client WSes are tagged with their wsId.
+    for (const ws of this.state.getWebSockets()) {
+      const tags = this.state.getTags(ws);
+      if (tags.includes("__tunnel__")) {
+        this.tunnelWs = ws;
+      } else if (tags.length > 0) {
+        this.clientWebSockets.set(tags[0], ws);
+      }
+    }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/init" && request.method === "POST") {
+      return this.handleInit(request);
+    }
+
+    if (url.pathname === "/register-token" && request.method === "POST") {
+      return this.handleRegisterToken(request);
+    }
+
+    if (url.pathname === "/lookup" && request.method === "POST") {
+      return this.handleTokenLookup(request);
+    }
+
+    if (url.pathname === "/tunnel") {
+      return this.handleTunnelConnect();
+    }
+
+    if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      return this.handleClientWebSocket(request, url);
+    }
+
+    return this.handleHttpProxy(request, url);
+  }
+
+  // -- Internal routes -------------------------------------------------------
+
+  private async handleInit(request: Request): Promise<Response> {
+    const { token, instanceId, relayDomain } = await request.json() as {
+      token: string; instanceId: string; relayDomain: string;
+    };
+    this.instanceId = instanceId;
+    this.relayDomain = relayDomain;
+    await this.state.storage.put("token", token);
+    await this.state.storage.put("instanceId", instanceId);
+    await this.state.storage.put("relayDomain", relayDomain);
+    return new Response("OK");
+  }
+
+  private async handleRegisterToken(request: Request): Promise<Response> {
+    const { token, instanceId } = await request.json() as { token: string; instanceId: string };
+    await this.state.storage.put(`token:${token}`, instanceId);
+    return new Response("OK");
+  }
+
+  private async handleTokenLookup(request: Request): Promise<Response> {
+    const { token } = await request.json() as { token: string };
+    const instanceId = await this.state.storage.get<string>(`token:${token}`);
+    if (!instanceId) return new Response("Not found", { status: 404 });
+    return Response.json({ instanceId });
+  }
+
+  // -- Tunnel connection -----------------------------------------------------
+
+  private handleTunnelConnect(): Response {
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+
+    // Tag with "__tunnel__" so we can restore this WebSocket after hibernation
+    this.state.acceptWebSocket(server, ["__tunnel__"]);
+    this.tunnelWs = server;
+
+    void Promise.all([
+      this.state.storage.get<string>("instanceId"),
+      this.state.storage.get<string>("relayDomain"),
+    ]).then(([id, domain]) => {
+      this.instanceId = id ?? null;
+      this.relayDomain = domain ?? null;
+      if (this.instanceId && this.relayDomain) {
+        server.send(JSON.stringify({
+          type: "tunnel-ready",
+          instanceId: this.instanceId,
+          publicUrl: `https://${this.instanceId}.${this.relayDomain}`,
+        }));
+      }
+    });
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  // -- HTTP proxy ------------------------------------------------------------
+
+  private handleHttpProxy(request: Request, url: URL): Promise<Response> {
+    if (!this.tunnelWs || this.tunnelWs.readyState !== WebSocket.OPEN) {
+      return Promise.resolve(new Response("Tunnel offline", { status: 502 }));
+    }
+
+    const id = crypto.randomUUID();
+
+    return new Promise<Response>(async (resolve) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        resolve(new Response("Gateway Timeout", { status: 504 }));
+      }, 30_000);
+
+      this.pendingRequests.set(id, { resolve, timeout });
+
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+      }
+      headers["x-forwarded-host"] = url.host;
+      headers["x-forwarded-proto"] = "https";
+
+      const bodyBuf = request.body
+        ? await request.arrayBuffer()
+        : new ArrayBuffer(0);
+
+      this.tunnelWs!.send(JSON.stringify({
+        id,
+        type: "http-request",
+        method: request.method,
+        path: url.pathname + url.search,
+        headers,
+        body: arrayBufferToBase64(bodyBuf),
+      }));
+    });
+  }
+
+  // -- WebSocket proxy -------------------------------------------------------
+
+  private handleClientWebSocket(request: Request, url: URL): Response {
+    if (!this.tunnelWs || this.tunnelWs.readyState !== WebSocket.OPEN) {
+      return new Response("Tunnel offline", { status: 502 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    const wsId = crypto.randomUUID();
+
+    this.state.acceptWebSocket(server, [wsId]);
+    this.clientWebSockets.set(wsId, server);
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+
+    this.tunnelWs.send(JSON.stringify({
+      type: "ws-open",
+      id: wsId,
+      path: url.pathname + url.search,
+      headers,
+    }));
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  // -- WebSocket event handlers ----------------------------------------------
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const data = typeof message === "string"
+      ? message
+      : new TextDecoder().decode(message);
+
+    if (ws === this.tunnelWs) {
+      this.handleTunnelMessage(data);
+      return;
+    }
+
+    for (const [wsId, clientWs] of this.clientWebSockets) {
+      if (clientWs === ws) {
+        this.tunnelWs?.send(JSON.stringify({
+          type: "ws-message",
+          id: wsId,
+          data,
+        }));
+        return;
+      }
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number): Promise<void> {
+    if (ws === this.tunnelWs) {
+      this.tunnelWs = null;
+      this.clientWebSockets.forEach((cws) => cws.close(1001));
+      this.clientWebSockets.clear();
+      this.pendingRequests.forEach((p) => {
+        clearTimeout(p.timeout);
+        p.resolve(new Response("Tunnel disconnected", { status: 502 }));
+      });
+      this.pendingRequests.clear();
+      return;
+    }
+
+    for (const [wsId, clientWs] of this.clientWebSockets) {
+      if (clientWs === ws) {
+        this.clientWebSockets.delete(wsId);
+        this.tunnelWs?.send(JSON.stringify({
+          type: "ws-close",
+          id: wsId,
+          code,
+        }));
+        return;
+      }
+    }
+  }
+
+  async webSocketError(ws: WebSocket): Promise<void> {
+    void this.webSocketClose(ws, 1006);
+  }
+
+  // -- Private helpers -------------------------------------------------------
+
+  private handleTunnelMessage(data: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
+
+    if (msg.type === "http-response") {
+      const pending = this.pendingRequests.get(msg.id);
+      if (!pending) return;
+      clearTimeout(pending.timeout);
+      this.pendingRequests.delete(msg.id);
+
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(msg.headers as Record<string, string>)) {
+        if (key.startsWith("x-relay-multi-")) continue;
+        if (msg.headers[`x-relay-multi-${key}`]) {
+          try {
+            for (const v of JSON.parse(value) as string[]) {
+              headers.append(key, v);
+            }
+          } catch {
+            headers.set(key, value);
+          }
+        } else {
+          headers.set(key, value);
+        }
+      }
+
+      pending.resolve(new Response(base64ToArrayBuffer(msg.body), {
+        status: msg.status,
+        headers,
+      }));
+    } else if (msg.type === "ws-message") {
+      this.clientWebSockets.get(msg.id)?.send(msg.data);
+    } else if (msg.type === "ws-close" || msg.type === "ws-error") {
+      const clientWs = this.clientWebSockets.get(msg.id);
+      if (clientWs) {
+        clientWs.close(msg.code ?? 1000);
+        this.clientWebSockets.delete(msg.id);
+      }
+    }
+  }
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+```
+
+## 9. Relationship to Other Docs
+
+- deployment modes: `doc/DEPLOYMENT-MODES.md` — `authenticated` mode is required for relay

--- a/doc/RELAY.md
+++ b/doc/RELAY.md
@@ -19,6 +19,8 @@ Any browser/device                     Paperclip server (behind NAT)
 
 Each instance gets its own subdomain (e.g. `d4lsc.relay.example.com`). The relay is a generic transport layer — it forwards HTTP requests and WebSocket frames without inspecting payloads. All authentication is handled by Paperclip's existing auth layer.
 
+The tunnel uses a binary multiplexing protocol for WebSocket data — text frames carry JSON control messages, binary frames carry raw WebSocket payloads with a 37-byte stream header. The bridge never inspects message content.
+
 ## 2. What Gets Tunneled
 
 - Static web UI assets (HTML/JS/CSS) — full Paperclip dashboard in any browser
@@ -50,7 +52,7 @@ The server stays bound to `127.0.0.1`. The relay client runs inside the same pro
 
 > **Test relay available**: `paperclip-relay.com` is a community-run relay for testing purposes. It is not affiliated with or operated by Paperclip AI. For production use, deploy your own relay server.
 
-The relay is a Cloudflare Worker with a Durable Object. See section 8 for the full source.
+The relay is a Cloudflare Worker with a Durable Object. See section 9 for the full source.
 
 ```sh
 npm create cloudflare@latest paperclip-relay -- --type worker
@@ -101,13 +103,32 @@ Subdomains avoid this entirely: `abc12.relay.example.com/assets/main.js` stays w
 
 The relay sees traffic in plaintext at the proxy layer. This is the same trust model as any reverse proxy (Cloudflare, nginx, Caddy). Paperclip's own auth layer protects the API.
 
-## 7. Limitations
+## 7. Tunnel Protocol
+
+The tunnel WebSocket between the Paperclip server and the relay carries two frame types:
+
+| Tunnel frame type | Content | Used for |
+|---|---|---|
+| **Text** | JSON | Control messages (`tunnel-ready`, `ws-open`, `ws-close`, `http-request`, `http-response`) |
+| **Binary** | 37-byte header + raw payload | WebSocket data (heartbeats, events, any client/server messages) |
+
+Binary data frame format:
+
+```
+Byte 0:       Flags (bit 0 = isBinary: 0 = original was text, 1 = original was binary)
+Bytes 1–36:   Stream ID (UUID as 36 ASCII chars)
+Bytes 37+:    Raw payload (untouched original WebSocket message bytes)
+```
+
+This design means the bridge never inspects, parses, or serializes WebSocket message content. Both text and binary WebSocket frames from clients are supported transparently. The `flags` byte preserves the original frame type end-to-end.
+
+## 8. Limitations
 
 - **Latency**: adds 20-100ms per request (Cloudflare edge round-trip)
 - **Tunnel single point**: if the server disconnects (sleep, restart), the relay returns 502 until reconnect
 - **No end-to-end encryption**: the relay sees plaintext (same as any reverse proxy)
 
-## 8. Relay Server Source
+## 9. Relay Server Source
 
 The relay server is a Cloudflare Worker with a Durable Object. The Durable Object holds the persistent tunnel WebSocket from the Paperclip server and forwards requests through it.
 
@@ -115,10 +136,11 @@ Key implementation details:
 
 - **Subdomain routing**: Each instance gets a subdomain (`<id>.relay.example.com`). The Worker extracts the instance ID from the `Host` header and routes to the corresponding Durable Object. Admin endpoints (`/register`, `/tunnel`, `/health`) live on the root domain.
 - **Configurable domain**: The relay domain is set via `RELAY_DOMAIN` in `wrangler.toml` — not hardcoded. Anyone can deploy their own relay on any domain.
-- **Hibernation recovery**: Durable Objects hibernate when idle, losing in-memory state. WebSockets are restored in the constructor via `getWebSockets()` using tags (`"__tunnel__"` for the tunnel, wsId for clients).
+- **Hibernation recovery**: Durable Objects hibernate when idle, losing in-memory state. WebSockets are restored in the constructor via `getWebSockets()` using tags (`"__tunnel__"` for the tunnel, wsId for clients). Duplicate tunnel WebSockets (from server restarts before old tunnel closes) are detected and cleaned up.
+- **Binary multiplexing**: WebSocket data frames are sent as binary tunnel frames (37-byte header + raw payload). JSON is only used for control messages. The DO never inspects WebSocket message content.
 - **Multi-value headers**: `set-cookie` headers cannot be comma-joined (cookie values contain commas in date strings). These are sent as JSON arrays with a companion `x-relay-multi-<header>` flag.
 
-### 8.1 `wrangler.toml`
+### 9.1 `wrangler.toml`
 
 ```toml
 name = "paperclip-relay"
@@ -144,7 +166,7 @@ tag = "v1"
 new_classes = ["TunnelDO"]
 ```
 
-### 8.2 `package.json`
+### 9.2 `package.json`
 
 ```json
 {
@@ -162,7 +184,7 @@ new_classes = ["TunnelDO"]
 }
 ```
 
-### 8.3 `tsconfig.json`
+### 9.3 `tsconfig.json`
 
 ```json
 {
@@ -179,7 +201,7 @@ new_classes = ["TunnelDO"]
 }
 ```
 
-### 8.4 `src/index.ts`
+### 9.4 `src/index.ts`
 
 ```typescript
 export { TunnelDO } from "./tunnel";
@@ -278,9 +300,17 @@ function generateId(length: number): string {
 }
 ```
 
-### 8.5 `src/tunnel.ts`
+### 9.5 `src/tunnel.ts`
 
 ```typescript
+/**
+ * Binary data frame format on the tunnel WebSocket:
+ *   Byte 0:       Flags (bit 0 = isBinary: 0 = text, 1 = binary)
+ *   Bytes 1–36:   Stream ID (UUID as 36 ASCII chars)
+ *   Bytes 37+:    Raw payload (untouched)
+ */
+const DATA_FRAME_HEADER_SIZE = 37;
+
 interface PendingRequest {
   resolve: (response: Response) => void;
   timeout: ReturnType<typeof setTimeout>;
@@ -297,15 +327,24 @@ export class TunnelDO {
   constructor(state: DurableObjectState) {
     this.state = state;
 
-    // Restore WebSockets after hibernation. Durable Objects may hibernate
-    // when idle, losing all in-memory state. The tunnel WS is tagged
+    // Restore WebSockets after hibernation. The tunnel WS is tagged
     // "__tunnel__"; client WSes are tagged with their wsId.
-    for (const ws of this.state.getWebSockets()) {
+    // If multiple tunnel WSes exist (e.g., server restarted before old
+    // tunnel closed), keep only the last one and close duplicates.
+    const allWs = this.state.getWebSockets();
+    const tunnelCandidates: WebSocket[] = [];
+    for (const ws of allWs) {
       const tags = this.state.getTags(ws);
       if (tags.includes("__tunnel__")) {
-        this.tunnelWs = ws;
+        tunnelCandidates.push(ws);
       } else if (tags.length > 0) {
         this.clientWebSockets.set(tags[0], ws);
+      }
+    }
+    if (tunnelCandidates.length > 0) {
+      this.tunnelWs = tunnelCandidates[tunnelCandidates.length - 1];
+      for (let i = 0; i < tunnelCandidates.length - 1; i++) {
+        try { tunnelCandidates[i].close(1000, "duplicate tunnel"); } catch {}
       }
     }
   }
@@ -366,10 +405,17 @@ export class TunnelDO {
   // -- Tunnel connection -----------------------------------------------------
 
   private handleTunnelConnect(): Response {
+    // Close any existing tunnel WebSocket(s) before accepting the new one.
+    for (const ws of this.state.getWebSockets()) {
+      const tags = this.state.getTags(ws);
+      if (tags.includes("__tunnel__")) {
+        try { ws.close(1000, "replaced by new tunnel"); } catch {}
+      }
+    }
+
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
 
-    // Tag with "__tunnel__" so we can restore this WebSocket after hibernation
     this.state.acceptWebSocket(server, ["__tunnel__"]);
     this.tunnelWs = server;
 
@@ -462,22 +508,27 @@ export class TunnelDO {
   // -- WebSocket event handlers ----------------------------------------------
 
   async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
-    const data = typeof message === "string"
-      ? message
-      : new TextDecoder().decode(message);
-
     if (ws === this.tunnelWs) {
-      this.handleTunnelMessage(data);
+      this.handleTunnelMessage(message);
       return;
     }
 
+    // Message from a client WebSocket → encode as binary data frame → send through tunnel
     for (const [wsId, clientWs] of this.clientWebSockets) {
       if (clientWs === ws) {
-        this.tunnelWs?.send(JSON.stringify({
-          type: "ws-message",
-          id: wsId,
-          data,
-        }));
+        if (this.tunnelWs && this.tunnelWs.readyState === WebSocket.OPEN) {
+          const isBinary = message instanceof ArrayBuffer;
+          const payload = isBinary
+            ? new Uint8Array(message)
+            : new TextEncoder().encode(message as string);
+
+          const frame = new Uint8Array(DATA_FRAME_HEADER_SIZE + payload.length);
+          frame[0] = isBinary ? 0x01 : 0x00;
+          frame.set(new TextEncoder().encode(wsId), 1);
+          frame.set(payload, DATA_FRAME_HEADER_SIZE);
+
+          this.tunnelWs.send(frame.buffer);
+        }
         return;
       }
     }
@@ -515,10 +566,31 @@ export class TunnelDO {
 
   // -- Private helpers -------------------------------------------------------
 
-  private handleTunnelMessage(data: string): void {
+  private handleTunnelMessage(message: string | ArrayBuffer): void {
+    // Binary frame = raw WS data with stream ID header
+    if (message instanceof ArrayBuffer) {
+      const frame = new Uint8Array(message);
+      if (frame.length < DATA_FRAME_HEADER_SIZE) return;
+
+      const isBinary = (frame[0]! & 0x01) !== 0;
+      const streamId = new TextDecoder().decode(frame.subarray(1, DATA_FRAME_HEADER_SIZE));
+      const payload = frame.subarray(DATA_FRAME_HEADER_SIZE);
+
+      const clientWs = this.clientWebSockets.get(streamId);
+      if (clientWs && clientWs.readyState === WebSocket.OPEN) {
+        if (isBinary) {
+          clientWs.send(payload.buffer);
+        } else {
+          clientWs.send(new TextDecoder().decode(payload));
+        }
+      }
+      return;
+    }
+
+    // Text frame = JSON control/HTTP message
     let msg: any;
     try {
-      msg = JSON.parse(data);
+      msg = JSON.parse(message);
     } catch {
       return;
     }
@@ -549,8 +621,6 @@ export class TunnelDO {
         status: msg.status,
         headers,
       }));
-    } else if (msg.type === "ws-message") {
-      this.clientWebSockets.get(msg.id)?.send(msg.data);
     } else if (msg.type === "ws-close" || msg.type === "ws-error") {
       const clientWs = this.clientWebSockets.get(msg.id);
       if (clientWs) {
@@ -580,6 +650,6 @@ function base64ToArrayBuffer(b64: string): ArrayBuffer {
 }
 ```
 
-## 9. Relationship to Other Docs
+## 10. Relationship to Other Docs
 
 - deployment modes: `doc/DEPLOYMENT-MODES.md` — `authenticated` mode is required for relay

--- a/docs/deploy/deployment-modes.md
+++ b/docs/deploy/deployment-modes.md
@@ -13,6 +13,7 @@ The default mode. Optimized for single-operator local use.
 - **Authentication**: no login required
 - **Use case**: local development, solo experimentation
 - **Board identity**: auto-created local board user
+- **Relay tunnel**: blocked (server refuses to start)
 
 ```sh
 # Set during onboard
@@ -26,18 +27,19 @@ Login required. Supports two exposure policies.
 
 ### `authenticated` + `private`
 
-For private network access (Tailscale, VPN, LAN).
+For private network access (Tailscale, VPN, LAN) and relay tunnel.
 
 - **Authentication**: login required via Better Auth
 - **URL handling**: auto base URL mode (lower friction)
 - **Host trust**: private-host trust policy required
+- **Relay tunnel**: supported (see [Relay Tunnel](/deploy/relay-tunnel))
 
 ```sh
 pnpm paperclipai onboard
 # Choose "authenticated" -> "private"
 ```
 
-Allow custom Tailscale hostnames:
+Allow custom Tailscale or relay hostnames:
 
 ```sh
 pnpm paperclipai allowed-hostname my-machine
@@ -69,6 +71,13 @@ A signed-in user visits this URL to claim board ownership. This:
 - Promotes the current user to instance admin
 - Demotes the auto-created local board admin
 - Ensures active company membership for the claiming user
+
+## Remote Access
+
+Two options for accessing Paperclip from outside your local machine (both require `authenticated` mode):
+
+- **Tailscale**: binds to `0.0.0.0` on a private network. See [Tailscale Private Access](/deploy/tailscale-private-access).
+- **Relay tunnel**: connects to a relay server for a public subdomain URL (e.g. `https://d4lsc.relay.com`). No port forwarding required. See [Relay Tunnel](/deploy/relay-tunnel).
 
 ## Changing Modes
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -16,6 +16,15 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_INSTANCE_ID` | `default` | Instance identifier (for multiple local instances) |
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 
+## Relay Tunnel
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAPERCLIP_RELAY_URL` | (none) | WebSocket URL of relay server (e.g. `wss://your-relay-server.com`). Enables relay tunnel. |
+| `PAPERCLIP_RELAY_TOKEN` | (none) | Relay authentication token. Auto-generated on first connect if not set. |
+
+See [Relay Tunnel](/deploy/relay-tunnel) for setup details. Requires `authenticated` deployment mode.
+
 ## Secrets
 
 | Variable | Default | Description |

--- a/docs/deploy/local-development.md
+++ b/docs/deploy/local-development.md
@@ -62,6 +62,20 @@ pnpm paperclipai allowed-hostname dotta-macbook-pro
 
 For full setup and troubleshooting, see [Tailscale Private Access](/deploy/tailscale-private-access).
 
+## Relay Tunnel Dev Mode
+
+To access your local instance remotely without port forwarding, set the relay URL:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm dev --tailscale-auth
+```
+
+On first start, the server auto-registers with the relay and prints your public URL (e.g. `https://d4lsc.your-relay-server.com`). The token and hostname are persisted automatically.
+
+> A community-run test relay is available at `paperclip-relay.com` (not affiliated with Paperclip AI). Deploy your own for production.
+
+See [Relay Tunnel](/deploy/relay-tunnel) for full details.
+
 ## Health Checks
 
 ```sh

--- a/docs/deploy/overview.md
+++ b/docs/deploy/overview.md
@@ -27,7 +27,8 @@ Paperclip supports three deployment configurations, from zero-friction local to 
 - Login required via Better Auth
 - Binds to all interfaces for network access
 - Auto base URL mode (lower friction)
-- Best for: team access over Tailscale or local network
+- Supports relay tunnel for remote access without port forwarding
+- Best for: team access over Tailscale, relay tunnel, or local network
 
 ### Authenticated + Public
 
@@ -40,6 +41,7 @@ Paperclip supports three deployment configurations, from zero-friction local to 
 
 - **Just trying Paperclip?** Use `local_trusted` (the default)
 - **Sharing with a team on private network?** Use `authenticated` + `private`
+- **Want remote access without port forwarding?** Use `authenticated` + `private` with [relay tunnel](/deploy/relay-tunnel)
 - **Deploying to the cloud?** Use `authenticated` + `public`
 
 Set the mode during onboarding:

--- a/docs/deploy/relay-tunnel.md
+++ b/docs/deploy/relay-tunnel.md
@@ -1,0 +1,81 @@
+---
+title: Relay Tunnel
+summary: Remote access to a local Paperclip instance via relay tunnel
+---
+
+Access your Paperclip instance from anywhere without port forwarding. The relay tunnel connects your local server to a Cloudflare Workers-based relay, giving you a public subdomain URL (e.g. `https://d4lsc.relay.com`).
+
+## Prerequisites
+
+- `authenticated` deployment mode (relay is blocked in `local_trusted`)
+- A relay server URL (self-hosted, or `wss://paperclip-relay.com` for testing)
+
+## 1. Set deployment mode to authenticated
+
+```sh
+pnpm paperclipai onboard
+# Choose "authenticated" -> "private"
+```
+
+Or if already configured:
+
+```sh
+pnpm paperclipai configure --section server
+```
+
+## 2. Set the relay URL
+
+Add the relay URL to your instance `.env`:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com
+```
+
+Or pass it at startup:
+
+```sh
+PAPERCLIP_RELAY_URL=wss://your-relay-server.com pnpm dev
+```
+
+> **Test relay**: `paperclip-relay.com` is a community-run test relay, not affiliated with Paperclip AI. You can use `wss://paperclip-relay.com` to try things out, but deploy your own relay server for production. See `doc/RELAY.md` for the full source and deployment instructions.
+
+## 3. Start the server
+
+```sh
+pnpm dev
+```
+
+On first start, the server:
+
+1. Registers with the relay and receives a token + instance ID
+2. Saves `PAPERCLIP_RELAY_TOKEN` to `.env` for future starts
+3. Adds the relay hostname (e.g. `d4lsc.your-relay-server.com`) to `allowedHostnames`
+4. Prints your public URL in the console
+
+Subsequent starts reuse the saved token and reconnect automatically.
+
+## 4. Access from any device
+
+Open the printed URL (e.g. `https://d4lsc.your-relay-server.com`) from any browser.
+
+## How it works
+
+The relay client maintains a persistent WebSocket connection to the relay server. When a request arrives at your subdomain, the relay forwards it through the tunnel. The client then makes the request to `127.0.0.1:<port>` and sends the response back. WebSocket connections (for real-time features) are bridged transparently.
+
+## Comparison with Tailscale
+
+| | Tailscale | Relay Tunnel |
+|---|---|---|
+| **Network** | Private mesh VPN | Public internet |
+| **Setup** | Install Tailscale on all devices | Set one env var |
+| **URL** | Private hostname + port | Public subdomain |
+| **Use case** | Team on same Tailscale network | Access from anywhere, mobile |
+| **Requires** | `authenticated` mode | `authenticated` mode |
+
+Both options can be used simultaneously.
+
+## Troubleshooting
+
+- **Server refuses to start with relay URL**: ensure deployment mode is `authenticated`, not `local_trusted`.
+- **Relay connects but page doesn't load**: check that the relay hostname was added to `allowedHostnames` in `config.json`.
+- **Token errors on reconnect**: delete `PAPERCLIP_RELAY_TOKEN` from `.env` and restart to re-register.

--- a/docs/deploy/tailscale-private-access.md
+++ b/docs/deploy/tailscale-private-access.md
@@ -70,6 +70,10 @@ Expected result:
 {"status":"ok"}
 ```
 
+## Alternative: Relay Tunnel
+
+If you don't use Tailscale or need access from outside your private network, consider the [relay tunnel](/deploy/relay-tunnel) instead. It gives your instance a public subdomain URL (e.g. `https://d4lsc.relay.com`) with zero port forwarding. Both options require `authenticated` deployment mode.
+
 ## Troubleshooting
 
 - Login or redirect errors on a private hostname: add it with `paperclipai allowed-hostname`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,7 @@
               "deploy/overview",
               "deploy/local-development",
               "deploy/tailscale-private-access",
+              "deploy/relay-tunnel",
               "deploy/docker",
               "deploy/deployment-modes",
               "deploy/database",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -61,6 +61,8 @@ export interface Config {
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
+  relayUrl: string | undefined;
+  relayToken: string | undefined;
 }
 
 export function loadConfig(): Config {
@@ -243,5 +245,7 @@ export function loadConfig(): Config {
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
+    relayUrl: process.env.PAPERCLIP_RELAY_URL || undefined,
+    relayToken: process.env.PAPERCLIP_RELAY_TOKEN || undefined,
   };
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -69,6 +69,29 @@ export interface StartedServer {
 
 export async function startServer(): Promise<StartedServer> {
   const config = loadConfig();
+
+  // Enforce relay security requirement before any registration or config mutation.
+  if (config.relayUrl && config.deploymentMode !== "authenticated") {
+    throw new Error(
+      "Relay requires authenticated deployment mode. " +
+        "Use authenticated mode for relay deployments or remove PAPERCLIP_RELAY_URL.",
+    );
+  }
+
+  // Auto-register with relay if URL is configured but no token exists yet.
+  // Must happen before createApp() so the hostname guard includes the relay domain.
+  if (config.relayUrl && !config.relayToken) {
+    const { autoRegisterRelay } = await import("./relay/auto-register.js");
+    const result = await autoRegisterRelay(config.relayUrl);
+    if (result) {
+      config.relayToken = result.token;
+      process.env.PAPERCLIP_RELAY_TOKEN = result.token;
+      if (!config.allowedHostnames.includes(result.relayHostname)) {
+        config.allowedHostnames.push(result.relayHostname);
+      }
+    }
+  }
+
   if (process.env.PAPERCLIP_SECRETS_PROVIDER === undefined) {
     process.env.PAPERCLIP_SECRETS_PROVIDER = config.secretsProvider;
   }
@@ -395,7 +418,7 @@ export async function startServer(): Promise<StartedServer> {
   if (config.deploymentMode === "local_trusted" && config.deploymentExposure !== "private") {
     throw new Error("local_trusted mode only supports private exposure");
   }
-  
+
   if (config.deploymentMode === "authenticated") {
     if (config.authBaseUrlMode === "explicit" && !config.authPublicBaseUrl) {
       throw new Error("auth.baseUrlMode=explicit requires auth.publicBaseUrl");
@@ -652,19 +675,38 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
-  if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
-    const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+
+  let relayClient: { close: () => void } | null = null;
+  if (config.relayUrl && config.relayToken) {
+    const { startRelayClient } = await import("./relay/relay-client.js");
+    relayClient = startRelayClient({
+      relayUrl: config.relayUrl,
+      relayToken: config.relayToken,
+      localPort: listenPort,
+      onReady: (instanceId, publicUrl) => {
+        logger.info({ instanceId, publicUrl }, "Relay tunnel connected");
+        console.log(`\n  \x1b[36mRelay\x1b[0m           ${publicUrl}\n`);
+      },
+    });
+  }
+
+  const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+    if (relayClient) {
+      logger.info("Closing relay tunnel");
+      relayClient.close();
+    }
+    if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
       logger.info({ signal }, "Stopping embedded PostgreSQL");
       try {
         await embeddedPostgres?.stop();
       } catch (err) {
         logger.error({ err }, "Failed to stop embedded PostgreSQL cleanly");
-      } finally {
-        process.exit(0);
       }
-    };
-  
+    }
+    process.exit(0);
+  };
+
+  if (relayClient || (embeddedPostgres && embeddedPostgresStartedByThisProcess)) {
     process.once("SIGINT", () => {
       void shutdown("SIGINT");
     });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -654,6 +654,7 @@ export async function startServer(): Promise<StartedServer> {
         databaseBackupIntervalMinutes: config.databaseBackupIntervalMinutes,
         databaseBackupRetentionDays: config.databaseBackupRetentionDays,
         databaseBackupDir: config.databaseBackupDir,
+        relayUrl: config.relayUrl,
       });
 
       const boardClaimUrl = getBoardClaimWarningUrl(config.host, listenPort);
@@ -685,7 +686,7 @@ export async function startServer(): Promise<StartedServer> {
       localPort: listenPort,
       onReady: (instanceId, publicUrl) => {
         logger.info({ instanceId, publicUrl }, "Relay tunnel connected");
-        console.log(`\n  \x1b[36mRelay\x1b[0m           ${publicUrl}\n`);
+        console.log(`\n  \x1b[2mRelay           \x1b[0m ${publicUrl}\n`);
       },
     });
   }

--- a/server/src/middleware/board-mutation-guard.ts
+++ b/server/src/middleware/board-mutation-guard.ts
@@ -18,10 +18,12 @@ function parseOrigin(value: string | undefined) {
 
 function trustedOriginsForRequest(req: Request) {
   const origins = new Set(DEFAULT_DEV_ORIGINS.map((value) => value.toLowerCase()));
-  const host = req.header("host")?.trim();
-  if (host) {
-    origins.add(`http://${host}`.toLowerCase());
-    origins.add(`https://${host}`.toLowerCase());
+  for (const header of ["host", "x-forwarded-host"] as const) {
+    const value = req.header(header)?.trim();
+    if (value) {
+      origins.add(`http://${value}`.toLowerCase());
+      origins.add(`https://${value}`.toLowerCase());
+    }
   }
   return origins;
 }

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -205,7 +205,9 @@ export function setupLiveEventsWebSocketServer(
       return;
     }
 
+    logger.info({ companyId: context.companyId, actorType: context.actorType, totalClients: wss.clients.size }, "live-events-ws: subscribing to events");
     const unsubscribe = subscribeCompanyLiveEvents(context.companyId, (event) => {
+      logger.info({ companyId: context.companyId, eventType: event.type, readyState: socket.readyState }, "live-events-ws: dispatching event to client");
       if (socket.readyState !== WebSocket.OPEN) return;
       socket.send(JSON.stringify(event));
     });

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -205,9 +205,7 @@ export function setupLiveEventsWebSocketServer(
       return;
     }
 
-    logger.info({ companyId: context.companyId, actorType: context.actorType, totalClients: wss.clients.size }, "live-events-ws: subscribing to events");
     const unsubscribe = subscribeCompanyLiveEvents(context.companyId, (event) => {
-      logger.info({ companyId: context.companyId, eventType: event.type, readyState: socket.readyState }, "live-events-ws: dispatching event to client");
       if (socket.readyState !== WebSocket.OPEN) return;
       socket.send(JSON.stringify(event));
     });

--- a/server/src/relay/auto-register.ts
+++ b/server/src/relay/auto-register.ts
@@ -1,0 +1,108 @@
+/**
+ * Auto-registers with the relay server when PAPERCLIP_RELAY_URL is set
+ * but no token exists yet. Persists the token to .env and adds the relay
+ * hostname to config.json so subsequent restarts skip registration.
+ */
+
+import fs from "node:fs";
+import { resolvePaperclipConfigPath, resolvePaperclipEnvPath } from "../paths.js";
+import { logger } from "../middleware/logger.js";
+
+interface RegisterResult {
+  token: string;
+  instanceId: string;
+  relayHostname: string;
+}
+
+export async function autoRegisterRelay(relayUrl: string): Promise<RegisterResult | null> {
+  const registerUrl = relayUrl
+    .replace(/^wss:\/\//, "https://")
+    .replace(/^ws:\/\//, "http://")
+    .replace(/\/+$/, "") + "/register";
+
+  logger.info({ registerUrl }, "Relay: no token found, auto-registering");
+
+  let resp: Response;
+  try {
+    resp = await fetch(registerUrl, { method: "POST" });
+  } catch (err) {
+    logger.error({ err }, "Relay: failed to reach relay server for registration");
+    return null;
+  }
+
+  if (!resp.ok) {
+    logger.error({ status: resp.status }, "Relay: registration failed");
+    return null;
+  }
+
+  const data = await resp.json() as { token: string; instanceId: string; publicUrl: string };
+
+  if (!data.token || !data.instanceId || !data.publicUrl) {
+    logger.error("Relay: registration response missing required fields");
+    return null;
+  }
+
+  let relayHostname: string;
+  try {
+    relayHostname = new URL(data.publicUrl).hostname;
+  } catch {
+    logger.error({ publicUrl: data.publicUrl }, "Relay: invalid publicUrl in registration response");
+    return null;
+  }
+
+  // Persist token to .env
+  appendToEnvFile("PAPERCLIP_RELAY_TOKEN", data.token);
+
+  // Add relay hostname to config.json allowedHostnames
+  addAllowedHostname(relayHostname);
+
+  logger.info(
+    { instanceId: data.instanceId, relayHostname },
+    "Relay: registered successfully",
+  );
+
+  return { token: data.token, instanceId: data.instanceId, relayHostname };
+}
+
+function appendToEnvFile(key: string, value: string): void {
+  const envPath = resolvePaperclipEnvPath();
+  try {
+    let content = "";
+    if (fs.existsSync(envPath)) {
+      content = fs.readFileSync(envPath, "utf-8");
+      if (!content.endsWith("\n")) content += "\n";
+    }
+    // Remove existing key if present (shouldn't be, but safe)
+    const lines = content.split("\n").filter((l) => l !== "" && !l.startsWith(`${key}=`));
+    lines.push(`${key}=${value}`);
+    fs.writeFileSync(envPath, lines.join("\n") + "\n", "utf-8");
+    logger.info({ path: envPath }, `Relay: saved ${key} to .env`);
+  } catch (err) {
+    logger.warn({ err, path: envPath }, `Relay: could not persist ${key} to .env`);
+  }
+}
+
+function addAllowedHostname(hostname: string): void {
+  const configPath = resolvePaperclipConfigPath();
+  try {
+    if (!fs.existsSync(configPath)) return;
+
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    const hostnames: string[] = raw?.server?.allowedHostnames ?? [];
+    const normalized = hostname.trim().toLowerCase();
+
+    if (hostnames.some((h: string) => h.trim().toLowerCase() === normalized)) {
+      return; // already present
+    }
+
+    hostnames.push(normalized);
+    if (!raw.server) {
+      raw.server = {};
+    }
+    raw.server.allowedHostnames = hostnames;
+    fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
+    logger.info({ hostname, path: configPath }, "Relay: added hostname to config.json allowedHostnames");
+  } catch (err) {
+    logger.warn({ err }, "Relay: could not update config.json allowedHostnames");
+  }
+}

--- a/server/src/relay/http-forwarder.ts
+++ b/server/src/relay/http-forwarder.ts
@@ -1,0 +1,71 @@
+/**
+ * Forwards serialized HTTP requests from the relay tunnel to the local
+ * Paperclip server and returns serialized responses.
+ */
+
+import * as http from "node:http";
+import type { HttpRequest, HttpResponse } from "./protocol.js";
+
+// Headers where comma-joining is unsafe (values contain literal commas).
+// These are sent as JSON arrays via a companion header instead.
+const MULTI_VALUE_HEADERS = new Set(["set-cookie"]);
+
+export function forwardHttpRequest(
+  req: HttpRequest,
+  localPort: number,
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const body = Buffer.from(req.body, "base64");
+
+    const opts: http.RequestOptions = {
+      hostname: "127.0.0.1",
+      port: localPort,
+      path: req.path,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host: `127.0.0.1:${localPort}`,
+      },
+    };
+
+    const proxyReq = http.request(opts, (proxyRes) => {
+      const chunks: Buffer[] = [];
+      proxyRes.on("data", (chunk: Buffer) => chunks.push(chunk));
+      proxyRes.on("error", (err) => reject(err));
+      proxyRes.on("end", () => {
+        const responseBody = Buffer.concat(chunks);
+
+        // Collect headers. Multi-value headers like set-cookie cannot be
+        // comma-joined (cookie values contain commas in date strings).
+        // These are sent as JSON arrays in a companion header.
+        const headers: Record<string, string> = {};
+        for (const [key, value] of Object.entries(proxyRes.headers)) {
+          if (value === undefined) continue;
+          if (Array.isArray(value) && MULTI_VALUE_HEADERS.has(key)) {
+            headers[key] = JSON.stringify(value);
+            headers[`x-relay-multi-${key}`] = "1";
+          } else {
+            headers[key] = Array.isArray(value) ? value.join(", ") : value;
+          }
+        }
+
+        resolve({
+          id: req.id,
+          type: "http-response",
+          status: proxyRes.statusCode ?? 502,
+          headers,
+          body: responseBody.toString("base64"),
+        });
+      });
+    });
+
+    proxyReq.on("error", (err) => {
+      reject(err);
+    });
+
+    if (body.length > 0) {
+      proxyReq.write(body);
+    }
+    proxyReq.end();
+  });
+}

--- a/server/src/relay/protocol.ts
+++ b/server/src/relay/protocol.ts
@@ -1,0 +1,72 @@
+/**
+ * Relay tunnel protocol message types.
+ *
+ * These messages are sent over the persistent WebSocket tunnel between the
+ * Paperclip server (tunnel client) and the relay server. The relay forwards
+ * HTTP requests and WebSocket frames without inspecting payloads.
+ */
+
+// ── Tunnel lifecycle ────────────────────────────────────────────────────────
+
+export interface TunnelReady {
+  type: "tunnel-ready";
+  instanceId: string;
+  publicUrl?: string;
+}
+
+// ── HTTP request/response ───────────────────────────────────────────────────
+
+export interface HttpRequest {
+  id: string;
+  type: "http-request";
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: string; // base64-encoded
+}
+
+export interface HttpResponse {
+  id: string;
+  type: "http-response";
+  status: number;
+  headers: Record<string, string>;
+  body: string; // base64-encoded
+}
+
+// ── WebSocket bridging ──────────────────────────────────────────────────────
+
+export interface WsOpen {
+  type: "ws-open";
+  id: string;
+  path: string;
+  headers: Record<string, string>;
+}
+
+export interface WsMessage {
+  type: "ws-message";
+  id: string;
+  data: string;
+}
+
+export interface WsClose {
+  type: "ws-close";
+  id: string;
+  code?: number;
+}
+
+export interface WsError {
+  type: "ws-error";
+  id: string;
+  message: string;
+}
+
+// ── Union type ──────────────────────────────────────────────────────────────
+
+export type TunnelMessage =
+  | TunnelReady
+  | HttpRequest
+  | HttpResponse
+  | WsOpen
+  | WsMessage
+  | WsClose
+  | WsError;

--- a/server/src/relay/protocol.ts
+++ b/server/src/relay/protocol.ts
@@ -33,19 +33,13 @@ export interface HttpResponse {
   body: string; // base64-encoded
 }
 
-// ── WebSocket bridging ──────────────────────────────────────────────────────
+// ── WebSocket bridging (control — sent as JSON text frames) ─────────────────
 
 export interface WsOpen {
   type: "ws-open";
   id: string;
   path: string;
   headers: Record<string, string>;
-}
-
-export interface WsMessage {
-  type: "ws-message";
-  id: string;
-  data: string;
 }
 
 export interface WsClose {
@@ -60,13 +54,40 @@ export interface WsError {
   message: string;
 }
 
-// ── Union type ──────────────────────────────────────────────────────────────
+// ── WebSocket data frames (sent as binary tunnel frames, NOT JSON) ──────────
+//
+// Binary frame format on the tunnel WebSocket:
+//
+//   Byte 0:       Flags (bit 0 = original frame was binary; 0 = text, 1 = binary)
+//   Bytes 1–36:   Stream ID (UUID as 36 ASCII chars, e.g. "528a881c-6475-...")
+//   Bytes 37+:    Raw payload (untouched original WebSocket message bytes)
+//
+// Text frames on the tunnel WS carry JSON control/HTTP messages (above).
+// Binary frames on the tunnel WS carry raw WS data (this format).
+// The bridge never inspects or parses the payload — it's a dumb pipe.
+
+export const DATA_FRAME_HEADER_SIZE = 37; // 1 flag + 36 stream ID
+
+export function encodeDataFrame(streamId: string, payload: Buffer | Uint8Array, isBinary: boolean): Buffer {
+  const header = Buffer.alloc(DATA_FRAME_HEADER_SIZE);
+  header[0] = isBinary ? 0x01 : 0x00;
+  header.write(streamId, 1, 36, "ascii");
+  return Buffer.concat([header, payload]);
+}
+
+export function decodeDataFrame(frame: Buffer): { streamId: string; payload: Buffer; isBinary: boolean } {
+  const isBinary = (frame[0]! & 0x01) !== 0;
+  const streamId = frame.subarray(1, 37).toString("ascii");
+  const payload = frame.subarray(37);
+  return { streamId, payload, isBinary };
+}
+
+// ── Union type (JSON control messages only — data frames are binary) ────────
 
 export type TunnelMessage =
   | TunnelReady
   | HttpRequest
   | HttpResponse
   | WsOpen
-  | WsMessage
   | WsClose
   | WsError;

--- a/server/src/relay/relay-client.ts
+++ b/server/src/relay/relay-client.ts
@@ -104,7 +104,8 @@ export function startRelayClient(opts: RelayClientOptions): { close: () => void 
       }
     });
 
-    ws.on("close", () => {
+    ws.on("close", (code: number, reason: Buffer) => {
+      logger.warn({ code, reason: reason?.toString() }, "Relay tunnel WebSocket CLOSED");
       closeAllBridges();
       scheduleReconnect();
     });

--- a/server/src/relay/relay-client.ts
+++ b/server/src/relay/relay-client.ts
@@ -1,12 +1,17 @@
 /**
  * Relay tunnel client. Maintains an outbound WebSocket connection to the relay
  * server and dispatches incoming messages to the HTTP forwarder and WS bridge.
+ *
+ * The tunnel WebSocket carries two frame types:
+ *   - Text frames: JSON control + HTTP messages (parsed and dispatched)
+ *   - Binary frames: raw WS data with a 37-byte header (forwarded without inspection)
  */
 
 import { createRequire } from "node:module";
 import { forwardHttpRequest } from "./http-forwarder.js";
-import { handleWsOpen, handleWsMessage, handleWsClose, closeAllBridges } from "./ws-bridge.js";
+import { handleWsOpen, handleWsData, handleWsClose, closeAllBridges } from "./ws-bridge.js";
 import type { TunnelMessage } from "./protocol.js";
+import { decodeDataFrame } from "./protocol.js";
 import { logger } from "../middleware/logger.js";
 
 const require = createRequire(import.meta.url);
@@ -15,7 +20,7 @@ const WS = require("ws") as { new (url: string, opts?: { headers?: Record<string
 interface WsInstance {
   readyState: number;
   on(event: string, cb: (...args: any[]) => void): void;
-  send(data: string): void;
+  send(data: string | Buffer): void;
   close(code?: number): void;
 }
 
@@ -34,9 +39,17 @@ export function startRelayClient(opts: RelayClientOptions): { close: () => void 
   let reconnectAttempt = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function send(msg: TunnelMessage): void {
+  /** Send a JSON control/HTTP message as a text frame. */
+  function sendJson(msg: TunnelMessage): void {
     if (ws && ws.readyState === WS.OPEN) {
       ws.send(JSON.stringify(msg));
+    }
+  }
+
+  /** Send a pre-encoded binary data frame. */
+  function sendBinary(frame: Buffer): void {
+    if (ws && ws.readyState === WS.OPEN) {
+      ws.send(frame);
     }
   }
 
@@ -53,18 +66,26 @@ export function startRelayClient(opts: RelayClientOptions): { close: () => void 
       logger.info("Relay tunnel WebSocket connected");
     });
 
-    ws.on("message", (data: { toString(): string }) => {
+    ws.on("message", (data: Buffer | string, isBinary: boolean) => {
+      // Binary frames = raw WS data with stream ID header
+      if (isBinary) {
+        const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as string);
+        const { streamId, payload, isBinary: originalIsBinary } = decodeDataFrame(buf);
+        handleWsData(streamId, payload, originalIsBinary);
+        return;
+      }
+
+      // Text frames = JSON control + HTTP messages
       let msg: TunnelMessage;
       try {
-        msg = JSON.parse(data.toString()) as TunnelMessage;
+        msg = JSON.parse(typeof data === "string" ? data : data.toString()) as TunnelMessage;
       } catch {
-        logger.warn("Relay: received unparseable message");
+        logger.warn("Relay: received unparseable text message");
         return;
       }
 
       switch (msg.type) {
         case "tunnel-ready": {
-          // Construct the public URL from the relay base URL (wss:// → https://)
           const relayOrigin = opts.relayUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
           const publicUrl = msg.publicUrl || relayOrigin;
           logger.info({ instanceId: msg.instanceId, publicUrl }, "Relay tunnel ready");
@@ -74,10 +95,10 @@ export function startRelayClient(opts: RelayClientOptions): { close: () => void 
 
         case "http-request":
           forwardHttpRequest(msg, opts.localPort)
-            .then((res) => send(res))
+            .then((res) => sendJson(res))
             .catch((err) => {
               logger.error({ err, requestId: msg.id }, "Relay: failed to forward HTTP request");
-              send({
+              sendJson({
                 id: msg.id,
                 type: "http-response",
                 status: 502,
@@ -88,11 +109,7 @@ export function startRelayClient(opts: RelayClientOptions): { close: () => void 
           break;
 
         case "ws-open":
-          handleWsOpen(msg, opts.localPort, send);
-          break;
-
-        case "ws-message":
-          handleWsMessage(msg);
+          handleWsOpen(msg, opts.localPort, sendJson, sendBinary);
           break;
 
         case "ws-close":

--- a/server/src/relay/relay-client.ts
+++ b/server/src/relay/relay-client.ts
@@ -1,0 +1,138 @@
+/**
+ * Relay tunnel client. Maintains an outbound WebSocket connection to the relay
+ * server and dispatches incoming messages to the HTTP forwarder and WS bridge.
+ */
+
+import { createRequire } from "node:module";
+import { forwardHttpRequest } from "./http-forwarder.js";
+import { handleWsOpen, handleWsMessage, handleWsClose, closeAllBridges } from "./ws-bridge.js";
+import type { TunnelMessage } from "./protocol.js";
+import { logger } from "../middleware/logger.js";
+
+const require = createRequire(import.meta.url);
+const WS = require("ws") as { new (url: string, opts?: { headers?: Record<string, string> }): WsInstance; OPEN: number };
+
+interface WsInstance {
+  readyState: number;
+  on(event: string, cb: (...args: any[]) => void): void;
+  send(data: string): void;
+  close(code?: number): void;
+}
+
+const BACKOFF_SCHEDULE = [1000, 2000, 5000, 10_000, 30_000];
+
+export interface RelayClientOptions {
+  relayUrl: string;
+  relayToken: string;
+  localPort: number;
+  onReady?: (instanceId: string, publicUrl: string) => void;
+}
+
+export function startRelayClient(opts: RelayClientOptions): { close: () => void } {
+  let ws: WsInstance | null = null;
+  let closed = false;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function send(msg: TunnelMessage): void {
+    if (ws && ws.readyState === WS.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  }
+
+  function connect(): void {
+    if (closed) return;
+
+    const url = `${opts.relayUrl.replace(/\/+$/, "")}/tunnel`;
+    ws = new WS(url, {
+      headers: { authorization: `Bearer ${opts.relayToken}` },
+    });
+
+    ws.on("open", () => {
+      reconnectAttempt = 0;
+      logger.info("Relay tunnel WebSocket connected");
+    });
+
+    ws.on("message", (data: { toString(): string }) => {
+      let msg: TunnelMessage;
+      try {
+        msg = JSON.parse(data.toString()) as TunnelMessage;
+      } catch {
+        logger.warn("Relay: received unparseable message");
+        return;
+      }
+
+      switch (msg.type) {
+        case "tunnel-ready": {
+          // Construct the public URL from the relay base URL (wss:// → https://)
+          const relayOrigin = opts.relayUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+          const publicUrl = msg.publicUrl || relayOrigin;
+          logger.info({ instanceId: msg.instanceId, publicUrl }, "Relay tunnel ready");
+          opts.onReady?.(msg.instanceId, publicUrl);
+          break;
+        }
+
+        case "http-request":
+          forwardHttpRequest(msg, opts.localPort)
+            .then((res) => send(res))
+            .catch((err) => {
+              logger.error({ err, requestId: msg.id }, "Relay: failed to forward HTTP request");
+              send({
+                id: msg.id,
+                type: "http-response",
+                status: 502,
+                headers: { "content-type": "text/plain" },
+                body: Buffer.from("Bad Gateway: local server unreachable").toString("base64"),
+              });
+            });
+          break;
+
+        case "ws-open":
+          handleWsOpen(msg, opts.localPort, send);
+          break;
+
+        case "ws-message":
+          handleWsMessage(msg);
+          break;
+
+        case "ws-close":
+          handleWsClose(msg);
+          break;
+
+        default:
+          break;
+      }
+    });
+
+    ws.on("close", () => {
+      closeAllBridges();
+      scheduleReconnect();
+    });
+
+    ws.on("error", (err: Error) => {
+      logger.warn({ err: err.message }, "Relay tunnel WebSocket error");
+    });
+  }
+
+  function scheduleReconnect(): void {
+    if (closed) return;
+    const delay = BACKOFF_SCHEDULE[Math.min(reconnectAttempt, BACKOFF_SCHEDULE.length - 1)];
+    reconnectAttempt++;
+    logger.info({ delay, attempt: reconnectAttempt }, "Relay: reconnecting");
+    reconnectTimer = setTimeout(connect, delay);
+  }
+
+  connect();
+
+  return {
+    close() {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      closeAllBridges();
+      if (ws) {
+        ws.close(1000);
+        ws = null;
+      }
+    },
+  };
+}

--- a/server/src/relay/ws-bridge.ts
+++ b/server/src/relay/ws-bridge.ts
@@ -8,6 +8,7 @@
 
 import { createRequire } from "node:module";
 import type { WsOpen, WsMessage, WsClose, TunnelMessage } from "./protocol.js";
+import { logger } from "../middleware/logger.js";
 
 const require = createRequire(import.meta.url);
 const WS = require("ws") as { new (url: string, opts?: object): WsInstance; OPEN: number };
@@ -51,15 +52,17 @@ export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void
     entry.queue.length = 0;
   });
 
-  localWs.on("message", (data: Buffer | string) => {
-    if (Buffer.isBuffer(data)) {
+  localWs.on("message", (data: Buffer | string, isBinary: boolean) => {
+    if (isBinary) {
       send({ type: "ws-error", id: msg.id, message: "Binary WebSocket frames are not supported through the relay tunnel" });
       return;
     }
+    const text = typeof data === "string" ? data : data.toString();
+    logger.info({ wsId: msg.id, len: text.length }, "ws-bridge: local → tunnel message");
     send({
       type: "ws-message",
       id: msg.id,
-      data: data.toString(),
+      data: text,
     });
   });
 

--- a/server/src/relay/ws-bridge.ts
+++ b/server/src/relay/ws-bridge.ts
@@ -1,14 +1,16 @@
 /**
  * Bridges WebSocket connections from the relay tunnel to local Paperclip
- * WebSocket endpoints. Each bridged connection is identified by a unique ID.
+ * WebSocket endpoints. Each bridged connection is identified by a unique ID
+ * (stream ID).
  *
- * Note: the relay tunnel only supports JSON text frames. Binary WebSocket
- * frames are not supported and will be corrupted by UTF-8 serialization.
+ * WebSocket data frames are sent as binary tunnel frames — the bridge never
+ * inspects or parses the payload. Both text and binary client frames are
+ * supported transparently.
  */
 
 import { createRequire } from "node:module";
-import type { WsOpen, WsMessage, WsClose, TunnelMessage } from "./protocol.js";
-import { logger } from "../middleware/logger.js";
+import type { WsOpen, WsClose, TunnelMessage } from "./protocol.js";
+import { encodeDataFrame } from "./protocol.js";
 
 const require = createRequire(import.meta.url);
 const WS = require("ws") as { new (url: string, opts?: object): WsInstance; OPEN: number };
@@ -16,23 +18,28 @@ const WS = require("ws") as { new (url: string, opts?: object): WsInstance; OPEN
 interface WsInstance {
   readyState: number;
   on(event: string, cb: (...args: any[]) => void): void;
-  send(data: string): void;
+  send(data: string | Buffer): void;
   close(code?: number): void;
 }
 
-type SendFn = (msg: TunnelMessage) => void;
+type SendJsonFn = (msg: TunnelMessage) => void;
+type SendBinaryFn = (frame: Buffer) => void;
+
+interface QueuedMessage {
+  data: string | Buffer;
+}
 
 interface BridgeEntry {
   ws: WsInstance;
   /** Messages received before the local WebSocket handshake completes. */
-  queue: string[];
+  queue: QueuedMessage[];
 }
 
 // Module-level singleton — safe because a single Paperclip server runs one
 // relay client at a time, so all bridged connections share one map.
 const activeBridges = new Map<string, BridgeEntry>();
 
-export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void {
+export function handleWsOpen(msg: WsOpen, localPort: number, sendJson: SendJsonFn, sendBinary: SendBinaryFn): void {
   const url = `ws://127.0.0.1:${localPort}${msg.path}`;
 
   const headers: Record<string, string> = { ...msg.headers };
@@ -47,28 +54,21 @@ export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void
 
   localWs.on("open", () => {
     for (const queued of entry.queue) {
-      localWs.send(queued);
+      localWs.send(queued.data);
     }
     entry.queue.length = 0;
   });
 
   localWs.on("message", (data: Buffer | string, isBinary: boolean) => {
-    if (isBinary) {
-      send({ type: "ws-error", id: msg.id, message: "Binary WebSocket frames are not supported through the relay tunnel" });
-      return;
-    }
-    const text = typeof data === "string" ? data : data.toString();
-    logger.debug({ wsId: msg.id, len: text.length }, "ws-bridge: local → tunnel message");
-    send({
-      type: "ws-message",
-      id: msg.id,
-      data: text,
-    });
+    // Encode as binary tunnel frame — no JSON, no content inspection.
+    const payload = typeof data === "string" ? Buffer.from(data, "utf8") : data;
+    const frame = encodeDataFrame(msg.id, payload, isBinary);
+    sendBinary(frame);
   });
 
   localWs.on("close", (code: number) => {
     activeBridges.delete(msg.id);
-    send({
+    sendJson({
       type: "ws-close",
       id: msg.id,
       code,
@@ -77,7 +77,7 @@ export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void
 
   localWs.on("error", (err: Error) => {
     activeBridges.delete(msg.id);
-    send({
+    sendJson({
       type: "ws-error",
       id: msg.id,
       message: err.message,
@@ -85,15 +85,22 @@ export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void
   });
 }
 
-export function handleWsMessage(msg: WsMessage): void {
-  const entry = activeBridges.get(msg.id);
+/**
+ * Forward a decoded binary data frame to the local WebSocket.
+ * The payload is sent as-is — text or binary depending on isBinary.
+ */
+export function handleWsData(streamId: string, payload: Buffer, isBinary: boolean): void {
+  const entry = activeBridges.get(streamId);
   if (!entry) return;
 
+  // ws library: send Buffer → binary frame, send string → text frame
+  const data = isBinary ? payload : payload.toString("utf8");
+
   if (entry.ws.readyState === WS.OPEN) {
-    entry.ws.send(msg.data);
+    entry.ws.send(data);
   } else {
     // Local WS still connecting — buffer until "open" fires.
-    entry.queue.push(msg.data);
+    entry.queue.push({ data });
   }
 }
 

--- a/server/src/relay/ws-bridge.ts
+++ b/server/src/relay/ws-bridge.ts
@@ -58,7 +58,7 @@ export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void
       return;
     }
     const text = typeof data === "string" ? data : data.toString();
-    logger.info({ wsId: msg.id, len: text.length }, "ws-bridge: local → tunnel message");
+    logger.debug({ wsId: msg.id, len: text.length }, "ws-bridge: local → tunnel message");
     send({
       type: "ws-message",
       id: msg.id,

--- a/server/src/relay/ws-bridge.ts
+++ b/server/src/relay/ws-bridge.ts
@@ -1,0 +1,114 @@
+/**
+ * Bridges WebSocket connections from the relay tunnel to local Paperclip
+ * WebSocket endpoints. Each bridged connection is identified by a unique ID.
+ *
+ * Note: the relay tunnel only supports JSON text frames. Binary WebSocket
+ * frames are not supported and will be corrupted by UTF-8 serialization.
+ */
+
+import { createRequire } from "node:module";
+import type { WsOpen, WsMessage, WsClose, TunnelMessage } from "./protocol.js";
+
+const require = createRequire(import.meta.url);
+const WS = require("ws") as { new (url: string, opts?: object): WsInstance; OPEN: number };
+
+interface WsInstance {
+  readyState: number;
+  on(event: string, cb: (...args: any[]) => void): void;
+  send(data: string): void;
+  close(code?: number): void;
+}
+
+type SendFn = (msg: TunnelMessage) => void;
+
+interface BridgeEntry {
+  ws: WsInstance;
+  /** Messages received before the local WebSocket handshake completes. */
+  queue: string[];
+}
+
+// Module-level singleton — safe because a single Paperclip server runs one
+// relay client at a time, so all bridged connections share one map.
+const activeBridges = new Map<string, BridgeEntry>();
+
+export function handleWsOpen(msg: WsOpen, localPort: number, send: SendFn): void {
+  const url = `ws://127.0.0.1:${localPort}${msg.path}`;
+
+  const headers: Record<string, string> = { ...msg.headers };
+  headers.host = `127.0.0.1:${localPort}`;
+
+  const localWs = new WS(url, { headers });
+  const entry: BridgeEntry = { ws: localWs, queue: [] };
+
+  // Register immediately so messages arriving before "open" are queued
+  // rather than silently dropped.
+  activeBridges.set(msg.id, entry);
+
+  localWs.on("open", () => {
+    for (const queued of entry.queue) {
+      localWs.send(queued);
+    }
+    entry.queue.length = 0;
+  });
+
+  localWs.on("message", (data: Buffer | string) => {
+    if (Buffer.isBuffer(data)) {
+      send({ type: "ws-error", id: msg.id, message: "Binary WebSocket frames are not supported through the relay tunnel" });
+      return;
+    }
+    send({
+      type: "ws-message",
+      id: msg.id,
+      data: data.toString(),
+    });
+  });
+
+  localWs.on("close", (code: number) => {
+    activeBridges.delete(msg.id);
+    send({
+      type: "ws-close",
+      id: msg.id,
+      code,
+    });
+  });
+
+  localWs.on("error", (err: Error) => {
+    activeBridges.delete(msg.id);
+    send({
+      type: "ws-error",
+      id: msg.id,
+      message: err.message,
+    });
+  });
+}
+
+export function handleWsMessage(msg: WsMessage): void {
+  const entry = activeBridges.get(msg.id);
+  if (!entry) return;
+
+  if (entry.ws.readyState === WS.OPEN) {
+    entry.ws.send(msg.data);
+  } else {
+    // Local WS still connecting — buffer until "open" fires.
+    entry.queue.push(msg.data);
+  }
+}
+
+export function handleWsClose(msg: WsClose): void {
+  const entry = activeBridges.get(msg.id);
+  if (entry) {
+    activeBridges.delete(msg.id);
+    try {
+      entry.ws.close(msg.code ?? 1000);
+    } catch {
+      entry.ws.close(1000);
+    }
+  }
+}
+
+export function closeAllBridges(): void {
+  activeBridges.forEach((entry, id) => {
+    entry.ws.close(1001);
+    activeBridges.delete(id);
+  });
+}

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -30,11 +30,14 @@ export function publishLiveEvent(input: {
   payload?: LiveEventPayload;
 }) {
   const event = toLiveEvent(input);
+  const listenerCount = emitter.listenerCount(input.companyId);
+  console.log(`[live-events] PUBLISH type=${input.type} companyId=${input.companyId} listeners=${listenerCount}`);
   emitter.emit(input.companyId, event);
   return event;
 }
 
 export function subscribeCompanyLiveEvents(companyId: string, listener: LiveEventListener) {
+  console.log(`[live-events] SUBSCRIBE companyId=${companyId} totalListeners=${emitter.listenerCount(companyId) + 1}`);
   emitter.on(companyId, listener);
   return () => emitter.off(companyId, listener);
 }

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -30,14 +30,11 @@ export function publishLiveEvent(input: {
   payload?: LiveEventPayload;
 }) {
   const event = toLiveEvent(input);
-  const listenerCount = emitter.listenerCount(input.companyId);
-  console.log(`[live-events] PUBLISH type=${input.type} companyId=${input.companyId} listeners=${listenerCount}`);
   emitter.emit(input.companyId, event);
   return event;
 }
 
 export function subscribeCompanyLiveEvents(companyId: string, listener: LiveEventListener) {
-  console.log(`[live-events] SUBSCRIBE companyId=${companyId} totalListeners=${emitter.listenerCount(companyId) + 1}`);
   emitter.on(companyId, listener);
   return () => emitter.off(companyId, listener);
 }

--- a/server/src/startup-banner.ts
+++ b/server/src/startup-banner.ts
@@ -33,6 +33,7 @@ type StartupBannerOptions = {
   databaseBackupIntervalMinutes: number;
   databaseBackupRetentionDays: number;
   databaseBackupDir: string;
+  relayUrl?: string;
 };
 
 const ansi = {
@@ -164,6 +165,9 @@ export function printStartupBanner(opts: StartupBannerOptions): void {
     row("DB Backup", dbBackup),
     row("Backup Dir", opts.databaseBackupDir),
     row("Config", configPath),
+    opts.relayUrl
+      ? row("Relay", `enabled ${color("(connecting...)", "dim")}`)
+      : null,
     agentJwtSecret.status === "warn"
       ? color("  ───────────────────────────────────────────────────────", "yellow")
       : null,


### PR DESCRIPTION
## Summary

- Zero-config relay tunnel for remote access — one env var (`PAPERCLIP_RELAY_URL`) gives any Paperclip instance a public HTTPS URL with no VPN, port forwarding, or extra software
- Binary multiplexing protocol for WebSocket data — tunnel carries raw bytes with a 37-byte stream header instead of JSON envelopes, eliminating content inspection and silent data loss bugs
- Board mutation guard fix — `x-forwarded-host` included in trusted origins so relay-forwarded requests are transparent
- Full documentation in `doc/RELAY.md` including relay server source (Cloudflare Worker + Durable Object)

Supersedes #830 (closed). Related to #742.

## What changed

### Relay client module (`server/src/relay/`)
- `protocol.ts` — tunnel message types + binary frame encode/decode helpers
- `relay-client.ts` — outbound tunnel WS with reconnect, dispatches text (JSON control) and binary (raw WS data) frames
- `ws-bridge.ts` — bridges relay tunnel to local WebSocket endpoints as a dumb pipe (no content inspection)
- `http-forwarder.ts` — forwards HTTP requests to localhost with header preservation
- `auto-register.ts` — one-time registration with relay server, persists token to `.env`

### Server integration (`server/src/index.ts`)
- Deployment mode guard (relay requires `authenticated` mode)
- Auto-registration before app creation
- Relay client startup after server listen, with graceful shutdown on SIGINT/SIGTERM

### Board mutation guard fix (`server/src/middleware/board-mutation-guard.ts`)
- Include `x-forwarded-host` in trusted origins so relay-proxied requests pass origin validation

### Documentation
- `doc/RELAY.md` — architecture, tunnel protocol, security model, full relay server source
- `docs/deploy/relay-tunnel.md` — user-facing setup guide
- Updates to `CLI.md`, `DEPLOYMENT-MODES.md`, `DEVELOPING.md`, deployment docs

## Tunnel protocol

The tunnel WebSocket carries two frame types:

| Frame type | Content | Used for |
|---|---|---|
| Text | JSON | Control (`tunnel-ready`, `ws-open`, `ws-close`, `http-request/response`) |
| Binary | 37-byte header + raw payload | WebSocket data (no JSON, no inspection) |

Binary data frame: `[1 byte flags][36 bytes stream ID][raw payload]`

The bridge never inspects, parses, or serializes WebSocket message content. Both text and binary client frames are supported transparently.

## Test plan

- [ ] `PAPERCLIP_RELAY_URL=wss://relay.example.com pnpm paperclipai run` — server auto-registers, prints relay URL
- [ ] Open relay URL in browser — full Paperclip UI loads (static assets, API, auth)
- [ ] Sign in via relay — session cookie scoped to relay subdomain
- [ ] WebSocket real-time events flow bidirectionally through relay
- [ ] Board mutations (create/update/delete issues) work through relay without 403
- [ ] Server restart reconnects tunnel automatically
- [ ] No relay code loaded when `PAPERCLIP_RELAY_URL` is not set (dynamic import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)