### PR TITLE
fix(server): detect missing locale in embedded postgres init and show actionable error (#806)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -345,6 +345,16 @@ export async function startServer(): Promise<StartedServer> {
           await embeddedPostgres.initialise();
         } catch (err) {
           logEmbeddedPostgresFailure("initialise", err);
+          
+          // Check for locale-related errors in the log buffer
+          const logContent = embeddedPostgresLogBuffer.join("\n");
+          if (/locale|LC_|invalid locale|could not create/i.test(logContent)) {
+            throw new Error(
+              "PostgreSQL initialization failed due to a missing system locale.\n\n" +
+              "Fix: sudo locale-gen en_US.UTF-8 && sudo update-locale LANG=en_US.UTF-8\n\n" +
+              "Then restart Paperclip.",
+            );
+          }
           throw err;
         }
       } else {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -348,11 +348,14 @@ export async function startServer(): Promise<StartedServer> {
           
           // Check for locale-related errors in the log buffer
           const logContent = embeddedPostgresLogBuffer.join("\n");
-          if (/locale|LC_|invalid locale|could not create/i.test(logContent)) {
+          if (/locale|LC_|invalid locale/i.test(logContent)) {
             throw new Error(
-              "PostgreSQL initialization failed due to a missing system locale.\n\n" +
-              "Fix: sudo locale-gen en_US.UTF-8 && sudo update-locale LANG=en_US.UTF-8\n\n" +
-              "Then restart Paperclip.",
+              "PostgreSQL initialization failed with a locale error.\n\n" +
+              "This is unexpected — initdb is configured with --locale=C which should be available on all POSIX systems.\n" +
+              "This may indicate the embedded-postgres library is not forwarding initdb flags correctly on your system.\n\n" +
+              "Workaround: try setting LANG=C in your shell before starting Paperclip, e.g.:\n" +
+              "  LANG=C npx paperclipai start",
+              { cause: err },
             );
           }
           throw err;


### PR DESCRIPTION
Fixes #806

## Problem
When embedded PostgreSQL's `initialise()` fails due to missing `en_US.UTF-8` locale, there is no actionable error message.

## Solution
Added locale error detection in the catch block of `embeddedPostgres.initialise()`:
- Inspects `embeddedPostgresLogBuffer` for locale-related keywords
- Throws error with actionable fix if detected
- Otherwise re-throws original error

## Changes
- `server/src/index.ts` - Enhanced initialise() catch block