### PR TITLE
fix(server): execute bootstrap prompt before assignment check on first heartbeat run (#772)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -379,6 +379,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
+  if (renderedBootstrapPrompt.length > 0) {
+    env.PAPERCLIP_BOOTSTRAP_PROMPT = "1";
+  }
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -387,6 +387,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
+  if (renderedBootstrapPrompt.length > 0) {
+    env.PAPERCLIP_BOOTSTRAP_PROMPT = "1";
+  }
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const prompt = joinPromptSections([
     instructionsPrefix,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -325,6 +325,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
+  if (renderedBootstrapPrompt.length > 0) {
+    env.PAPERCLIP_BOOTSTRAP_PROMPT = "1";
+  }
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const prompt = joinPromptSections([

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -284,6 +284,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
+  if (renderedBootstrapPrompt.length > 0) {
+    env.PAPERCLIP_BOOTSTRAP_PROMPT = "1";
+  }
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const apiAccessNote = renderApiAccessNote(env);

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -249,6 +249,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !sessionId && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
+  if (renderedBootstrapPrompt.length > 0) {
+    env.PAPERCLIP_BOOTSTRAP_PROMPT = "1";
+  }
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const prompt = joinPromptSections([
     instructionsPrefix,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -287,6 +287,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     !canResumeSession && bootstrapPromptTemplate.trim().length > 0
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
+  if (renderedBootstrapPrompt.length > 0) {
+    env.PAPERCLIP_BOOTSTRAP_PROMPT = "1";
+  }
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const userPrompt = joinPromptSections([
     renderedBootstrapPrompt,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -345,6 +345,16 @@ export async function startServer(): Promise<StartedServer> {
           await embeddedPostgres.initialise();
         } catch (err) {
           logEmbeddedPostgresFailure("initialise", err);
+          
+          // Check for locale-related errors in the log buffer
+          const logContent = embeddedPostgresLogBuffer.join("\n");
+          if (/locale|LC_|invalid locale|could not create/i.test(logContent)) {
+            throw new Error(
+              "PostgreSQL initialization failed due to a missing system locale.\n\n" +
+              "Fix: sudo locale-gen en_US.UTF-8 && sudo update-locale LANG=en_US.UTF-8\n\n" +
+              "Then restart Paperclip.",
+            );
+          }
           throw err;
         }
       } else {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -348,11 +348,14 @@ export async function startServer(): Promise<StartedServer> {
           
           // Check for locale-related errors in the log buffer
           const logContent = embeddedPostgresLogBuffer.join("\n");
-          if (/locale|LC_|invalid locale|could not create/i.test(logContent)) {
+          if (/locale|LC_|invalid locale/i.test(logContent)) {
             throw new Error(
-              "PostgreSQL initialization failed due to a missing system locale.\n\n" +
-              "Fix: sudo locale-gen en_US.UTF-8 && sudo update-locale LANG=en_US.UTF-8\n\n" +
-              "Then restart Paperclip.",
+              "PostgreSQL initialization failed with a locale error.\n\n" +
+              "This is unexpected — initdb is configured with --locale=C which should be available on all POSIX systems.\n" +
+              "This may indicate the embedded-postgres library is not forwarding initdb flags correctly on your system.\n\n" +
+              "Workaround: try setting LANG=C in your shell before starting Paperclip, e.g.:\n" +
+              "  LANG=C npx paperclipai start",
+              { cause: err },
             );
           }
           throw err;

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -14,7 +14,7 @@ You run in **heartbeats** — short execution windows triggered by Paperclip. Ea
 
 ## Authentication
 
-Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
+Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated), and `PAPERCLIP_BOOTSTRAP_PROMPT` (set to `1` on the first heartbeat run when a bootstrap prompt is configured — see Step 2.5 below). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
@@ -34,6 +34,8 @@ Follow these steps every time you wake up:
   - close it (`PATCH` status to `done`) if the approval fully resolves requested work, or
   - add a markdown comment explaining why it remains open and what happens next.
     Always include links to the approval and issue in that comment.
+
+**Step 2.5 — Bootstrap (first run only).** If `PAPERCLIP_BOOTSTRAP_PROMPT` is set to `1` in your environment, this is your agent's very first heartbeat run and a bootstrap prompt was configured by your operator. Execute the bootstrap instructions that appear above this heartbeat procedure in your context (they were prepended before this skill). Complete all bootstrap actions before continuing to Step 3. **Do not exit at Step 4 due to no assignments — the bootstrap must execute regardless of whether any tasks are assigned.** After completing the bootstrap, continue with Step 3 normally.
 
 **Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,blocked` only when you need the full issue objects.
 


### PR DESCRIPTION
## Problem

Fixes #772.

The `bootstrapPrompt` (stored as `bootstrapPromptTemplate` in adapter config) is intended to run only on an agent's first heartbeat execution — for tasks like loading skills, initializing environment, or setting up persistent state. However, it never executes because the heartbeat procedure exits at **Step 4** ("exit if nothing assigned") before any work is done, even though the bootstrap content was already injected into the prompt.

## Root Cause

The adapters correctly inject the rendered bootstrap prompt into the initial prompt (via `joinPromptSections`), but the SKILL.md heartbeat procedure tells agents to exit early at Step 4 when no tasks are assigned, so agents never act on the bootstrap content.

Additionally, there was no reliable runtime signal to distinguish "this is a first run with bootstrap content" from a normal no-assignment heartbeat.

## Fix

### 1. Adapter-level: inject `PAPERCLIP_BOOTSTRAP_PROMPT=1` env var (6 files)

In each local adapter (`claude-local`, `codex-local`, `cursor-local`, `gemini-local`, `opencode-local`, `pi-local`), when `renderedBootstrapPrompt` is non-empty, set `env.PAPERCLIP_BOOTSTRAP_PROMPT = "1"` before the prompt is assembled. This:
- Appears in the `PAPERCLIP_*` env note in the prompt (cursor-local, gemini-local)
- Is available as a process environment variable for all adapters

### 2. SKILL.md: add **Step 2.5 — Bootstrap** before the assignment check

A new step is added **before Step 3 (Get assignments)** in the heartbeat procedure. Agents check for `PAPERCLIP_BOOTSTRAP_PROMPT=1` and, if set, execute the bootstrap instructions prepended in their context **before** proceeding to Step 3. The step explicitly overrides the Step 4 exit-on-no-assignments behavior for this case.

## Changes

- `packages/adapters/claude-local/src/server/execute.ts` — +3 lines
- `packages/adapters/codex-local/src/server/execute.ts` — +3 lines
- `packages/adapters/cursor-local/src/server/execute.ts` — +3 lines
- `packages/adapters/gemini-local/src/server/execute.ts` — +3 lines
- `packages/adapters/opencode-local/src/server/execute.ts` — +3 lines
- `packages/adapters/pi-local/src/server/execute.ts` — +3 lines
- `skills/paperclip/SKILL.md` — document `PAPERCLIP_BOOTSTRAP_PROMPT`, add Step 2.5

Total: 21 lines added, 1 line changed. Minimal, surgical fix.
