### PR TITLE
fix: include in_review status in agent inbox-lite query

### DIFF
--- a/docs/guides/agent-developer/heartbeat-protocol.md
+++ b/docs/guides/agent-developer/heartbeat-protocol.md
@@ -31,7 +31,7 @@ Close linked issues if the approval resolves them, or comment on why they remain
 ### Step 3: Get Assignments
 
 ```
-GET /api/companies/{companyId}/issues?assigneeAgentId={yourId}&status=todo,in_progress,blocked
+GET /api/companies/{companyId}/issues?assigneeAgentId={yourId}&status=todo,in_progress,blocked,in_review
 ```
 
 Results are sorted by priority. This is your inbox.

--- a/docs/guides/agent-developer/task-workflow.md
+++ b/docs/guides/agent-developer/task-workflow.md
@@ -82,7 +82,7 @@ This releases your ownership. Leave a comment explaining why.
 
 ```
 GET /api/agents/me
-GET /api/companies/company-1/issues?assigneeAgentId=agent-42&status=todo,in_progress,blocked
+GET /api/companies/company-1/issues?assigneeAgentId=agent-42&status=todo,in_progress,blocked,in_review
 # -> [{ id: "issue-101", status: "in_progress" }, { id: "issue-99", status: "todo" }]
 
 # Continue in_progress work

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -397,7 +397,7 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     "   - If instructions require a comment, POST /api/issues/{issueId}/comments with {\"body\":\"...\"}.",
     "   - PATCH /api/issues/{issueId} with {\"status\":\"done\",\"comment\":\"what changed and why\"}.",
     "4) If issueId does not exist:",
-    "   - GET /api/companies/$PAPERCLIP_COMPANY_ID/issues?assigneeAgentId=$PAPERCLIP_AGENT_ID&status=todo,in_progress,blocked",
+    "   - GET /api/companies/$PAPERCLIP_COMPANY_ID/issues?assigneeAgentId=$PAPERCLIP_AGENT_ID&status=todo,in_progress,blocked,in_review",
     "   - Pick in_progress first, then todo, then blocked, then execute step 3.",
     "",
     "Useful endpoints for issue work:",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -584,7 +584,7 @@ export function agentRoutes(db: Db) {
     const issuesSvc = issueService(db);
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
-      status: "todo,in_progress,blocked",
+      status: "todo,in_progress,blocked,in_review",
     });
 
     res.json(

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -35,7 +35,7 @@ Follow these steps every time you wake up:
   - add a markdown comment explaining why it remains open and what happens next.
     Always include links to the approval and issue in that comment.
 
-**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,blocked` only when you need the full issue objects.
+**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,blocked,in_review` only when you need the full issue objects.
 
 **Step 4 — Pick work (with mention exception).** Work on `in_progress` first, then `todo`. Skip `blocked` unless you can unblock it.
 **Blocked-task dedup:** Before working on a `blocked` task, fetch its comment thread. If your most recent comment was a blocked-status update AND no new comments from other agents or users have been posted since, skip the task entirely — do not checkout, do not post another comment. Exit the heartbeat (or move to the next task) instead. Only re-engage with a blocked task when new context exists (a new comment, status change, or event-based wake like `PAPERCLIP_WAKE_COMMENT_ID`).
@@ -234,7 +234,7 @@ PATCH /api/agents/{agentId}/instructions-path
 | ------------------------------------- | ------------------------------------------------------------------------------------------ |
 | My identity                           | `GET /api/agents/me`                                                                       |
 | My compact inbox                      | `GET /api/agents/me/inbox-lite`                                                            |
-| My assignments                        | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=todo,in_progress,blocked` |
+| My assignments                        | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=todo,in_progress,blocked,in_review` |
 | Checkout task                         | `POST /api/issues/:issueId/checkout`                                                       |
 | Get task + ancestors                  | `GET /api/issues/:issueId`                                                                 |
 | Get compact heartbeat context         | `GET /api/issues/:issueId/heartbeat-context`                                               |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -129,7 +129,7 @@ GET /api/agents/me
 -> { id: "agent-42", companyId: "company-1", ... }
 
 # 2. Check inbox
-GET /api/companies/company-1/issues?assigneeAgentId=agent-42&status=todo,in_progress,blocked
+GET /api/companies/company-1/issues?assigneeAgentId=agent-42&status=todo,in_progress,blocked,in_review
 -> [
     { id: "issue-101", title: "Fix rate limiter bug", status: "in_progress", priority: "high" },
     { id: "issue-99", title: "Implement login API", status: "todo", priority: "medium" }


### PR DESCRIPTION
## Summary

- **Root cause**: `inbox-lite` only queried `todo,in_progress,blocked` statuses. When an agent set an issue to `in_review` and the user commented asking for changes, the agent woke up but `inbox-lite` returned empty → agent exited with "No assignments"
- Added `in_review` to the status filter in the `inbox-lite` endpoint
- Updated all documentation, skill instructions, and the openclaw-gateway adapter to match

**Evidence from PAP-5 run log**: Agent received `issue_commented` wake with correct `PAPERCLIP_TASK_ID` and `PAPERCLIP_WAKE_COMMENT_ID`, called `inbox-lite`, got `[]`, and exited after 11 seconds saying "No assignments. Exiting heartbeat."

## Test plan

- [ ] Comment on an `in_review` issue assigned to an agent → verify agent wakes and sees the issue in inbox-lite
- [ ] Verify `inbox-lite` still excludes `done`, `cancelled`, and `backlog` issues
- [ ] Verify agent can process the comment and take action on the `in_review` issue

Resolves PAP-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)