### PR TITLE
fix: add @embedded-postgres/darwin-arm64 dependency for macOS ARM64

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
-    "cross-env": "^10.1.0",
     "@playwright/test": "^1.58.2",
+    "cross-env": "^10.1.0",
     "esbuild": "^0.27.3",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"
@@ -44,5 +44,8 @@
   "engines": {
     "node": ">=20"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4",
+  "dependencies": {
+    "@embedded-postgres/darwin-arm64": "18.1.0-beta.15"
+  }
 }


### PR DESCRIPTION
## Problem

When running `pnpm dev` on macOS ARM64 systems, the following error occurs:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@embedded-postgres/darwin-arm64'
```

## Solution

The `embedded-postgres` package requires platform-specific binaries, but the `darwin-arm64` package was not being installed automatically by pnpm.

This PR adds `@embedded-postgres/darwin-arm64` as an explicit dependency to ensure it's available on macOS ARM64 systems.

## Testing

- ✅ Successfully ran `pnpm install`
- ✅ Successfully ran `pnpm dev`
- ✅ Server started without errors on macOS ARM64

## Notes

Following the repository's lockfile policy, `pnpm-lock.yaml` is not included in this PR. GitHub Actions will regenerate it upon merge.