### PR TITLE
feat(ui): add bulk stop/start/retry actions for agents

### DIFF
--- a/ui/src/components/AgentBulkActions.tsx
+++ b/ui/src/components/AgentBulkActions.tsx
@@ -1,0 +1,52 @@
+import type { Agent } from "@paperclipai/shared";
+import { Pause, Play, RotateCcw, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAgentBulkActions } from "../hooks/useAgentBulkActions";
+
+interface AgentBulkActionsProps {
+  agents: Agent[];
+  companyId: string;
+}
+
+export function AgentBulkActions({ agents, companyId }: AgentBulkActionsProps) {
+  const { stoppableCount, startableCount, retryableCount, stopAll, startAll, retryFailed } =
+    useAgentBulkActions(agents, companyId);
+
+  const anyPending = stopAll.isPending || startAll.isPending || retryFailed.isPending;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="xs"
+        disabled={stoppableCount === 0 || anyPending}
+        onClick={() => {
+          if (window.confirm(`Pause ${stoppableCount} active agent${stoppableCount !== 1 ? "s" : ""}?`)) {
+            stopAll.mutate();
+          }
+        }}
+      >
+        {stopAll.isPending ? <Loader2 className="animate-spin" /> : <Pause />}
+        <span className="hidden sm:inline">Stop All</span>
+      </Button>
+      <Button
+        variant="ghost"
+        size="xs"
+        disabled={startableCount === 0 || anyPending}
+        onClick={() => startAll.mutate()}
+      >
+        {startAll.isPending ? <Loader2 className="animate-spin" /> : <Play />}
+        <span className="hidden sm:inline">Start All</span>
+      </Button>
+      <Button
+        variant="ghost"
+        size="xs"
+        disabled={retryableCount === 0 || anyPending}
+        onClick={() => retryFailed.mutate()}
+      >
+        {retryFailed.isPending ? <Loader2 className="animate-spin" /> : <RotateCcw />}
+        <span className="hidden sm:inline">Retry Failed</span>
+      </Button>
+    </>
+  );
+}

--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -14,7 +14,7 @@ import {
 import { Fragment } from "react";
 
 export function BreadcrumbBar() {
-  const { breadcrumbs } = useBreadcrumbs();
+  const { breadcrumbs, actions } = useBreadcrumbs();
   const { toggleSidebar, isMobile } = useSidebar();
 
   if (breadcrumbs.length === 0) return null;
@@ -31,14 +31,19 @@ export function BreadcrumbBar() {
     </Button>
   );
 
+  const actionsSlot = actions ? (
+    <div className="flex items-center gap-1.5 shrink-0 ml-auto pl-2">{actions}</div>
+  ) : null;
+
   // Single breadcrumb = page title (uppercase)
   if (breadcrumbs.length === 1) {
     return (
       <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center min-w-0 overflow-hidden">
         {menuButton}
-        <h1 className="text-sm font-semibold uppercase tracking-wider truncate">
+        <h1 className="text-sm font-semibold uppercase tracking-wider truncate flex-1 min-w-0">
           {breadcrumbs[0].label}
         </h1>
+        {actionsSlot}
       </div>
     );
   }
@@ -47,7 +52,7 @@ export function BreadcrumbBar() {
   return (
     <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center min-w-0 overflow-hidden">
       {menuButton}
-      <Breadcrumb className="min-w-0 overflow-hidden">
+      <Breadcrumb className="min-w-0 overflow-hidden flex-1">
         <BreadcrumbList className="flex-nowrap">
           {breadcrumbs.map((crumb, i) => {
             const isLast = i === breadcrumbs.length - 1;
@@ -68,6 +73,7 @@ export function BreadcrumbBar() {
           })}
         </BreadcrumbList>
       </Breadcrumb>
+      {actionsSlot}
     </div>
   );
 }

--- a/ui/src/context/BreadcrumbContext.tsx
+++ b/ui/src/context/BreadcrumbContext.tsx
@@ -8,15 +8,22 @@ export interface Breadcrumb {
 interface BreadcrumbContextValue {
   breadcrumbs: Breadcrumb[];
   setBreadcrumbs: (crumbs: Breadcrumb[]) => void;
+  actions: ReactNode;
+  setActions: (node: ReactNode) => void;
 }
 
 const BreadcrumbContext = createContext<BreadcrumbContextValue | null>(null);
 
 export function BreadcrumbProvider({ children }: { children: ReactNode }) {
   const [breadcrumbs, setBreadcrumbsState] = useState<Breadcrumb[]>([]);
+  const [actions, setActionsState] = useState<ReactNode>(null);
 
   const setBreadcrumbs = useCallback((crumbs: Breadcrumb[]) => {
     setBreadcrumbsState(crumbs);
+  }, []);
+
+  const setActions = useCallback((node: ReactNode) => {
+    setActionsState(node);
   }, []);
 
   useEffect(() => {
@@ -29,7 +36,7 @@ export function BreadcrumbProvider({ children }: { children: ReactNode }) {
   }, [breadcrumbs]);
 
   return (
-    <BreadcrumbContext.Provider value={{ breadcrumbs, setBreadcrumbs }}>
+    <BreadcrumbContext.Provider value={{ breadcrumbs, setBreadcrumbs, actions, setActions }}>
       {children}
     </BreadcrumbContext.Provider>
   );

--- a/ui/src/hooks/useAgentBulkActions.ts
+++ b/ui/src/hooks/useAgentBulkActions.ts
@@ -1,0 +1,90 @@
+import { useMemo } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { Agent } from "@paperclipai/shared";
+import { agentsApi } from "../api/agents";
+import { useToast } from "../context/ToastContext";
+import { queryKeys } from "../lib/queryKeys";
+
+interface BulkResult {
+  succeeded: number;
+  failed: number;
+}
+
+function summarize(results: PromiseSettledResult<unknown>[]): BulkResult {
+  let succeeded = 0;
+  let failed = 0;
+  for (const r of results) {
+    if (r.status === "fulfilled") succeeded++;
+    else failed++;
+  }
+  return { succeeded, failed };
+}
+
+function formatResult(verb: string, { succeeded, failed }: BulkResult) {
+  const s = succeeded !== 1 ? "s" : "";
+  if (failed === 0) return { title: `${verb} ${succeeded} agent${s}`, tone: "success" as const };
+  if (succeeded === 0) return { title: `Failed to ${verb.toLowerCase()} ${failed} agent${failed !== 1 ? "s" : ""}`, tone: "error" as const };
+  return { title: `${verb} ${succeeded} agent${s}, ${failed} failed`, tone: "warn" as const };
+}
+
+export function useAgentBulkActions(agents: Agent[], companyId: string) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+
+  const stoppable = useMemo(
+    () => agents.filter((a) => a.status === "active" || a.status === "idle"),
+    [agents],
+  );
+  const startable = useMemo(
+    () => agents.filter((a) => a.status === "paused"),
+    [agents],
+  );
+  const retryable = useMemo(
+    () => agents.filter((a) => a.status === "error"),
+    [agents],
+  );
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(companyId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.org(companyId) });
+  };
+
+  const stopAll = useMutation({
+    mutationFn: () =>
+      Promise.allSettled(stoppable.map((a) => agentsApi.pause(a.id, companyId))).then(summarize),
+    onSuccess: (r) => {
+      pushToast(formatResult("Paused", r));
+      invalidate();
+    },
+    onError: () => pushToast({ title: "Failed to pause agents", tone: "error" }),
+  });
+
+  const startAll = useMutation({
+    mutationFn: () =>
+      Promise.allSettled(startable.map((a) => agentsApi.resume(a.id, companyId))).then(summarize),
+    onSuccess: (r) => {
+      pushToast(formatResult("Resumed", r));
+      invalidate();
+    },
+    onError: () => pushToast({ title: "Failed to resume agents", tone: "error" }),
+  });
+
+  const retryFailed = useMutation({
+    mutationFn: () =>
+      Promise.allSettled(retryable.map((a) => agentsApi.invoke(a.id, companyId))).then(summarize),
+    onSuccess: (r) => {
+      pushToast(formatResult("Retried", r));
+      invalidate();
+    },
+    onError: () => pushToast({ title: "Failed to retry agents", tone: "error" }),
+  });
+
+  return {
+    stoppableCount: stoppable.length,
+    startableCount: startable.length,
+    retryableCount: retryable.length,
+    stopAll,
+    startAll,
+    retryFailed,
+  };
+}

--- a/ui/src/hooks/useAgentBulkActions.ts
+++ b/ui/src/hooks/useAgentBulkActions.ts
@@ -32,7 +32,7 @@ export function useAgentBulkActions(agents: Agent[], companyId: string) {
   const { pushToast } = useToast();
 
   const stoppable = useMemo(
-    () => agents.filter((a) => a.status === "active" || a.status === "idle"),
+    () => agents.filter((a) => a.status === "active" || a.status === "idle" || a.status === "running"),
     [agents],
   );
   const startable = useMemo(
@@ -50,8 +50,12 @@ export function useAgentBulkActions(agents: Agent[], companyId: string) {
   };
 
   const stopAll = useMutation({
-    mutationFn: () =>
-      Promise.allSettled(stoppable.map((a) => agentsApi.pause(a.id, companyId))).then(summarize),
+    mutationFn: async () => {
+      const results = await Promise.allSettled(stoppable.map((a) => agentsApi.pause(a.id, companyId)));
+      const result = summarize(results);
+      if (result.succeeded === 0 && result.failed > 0) throw new Error("All pause calls failed");
+      return result;
+    },
     onSuccess: (r) => {
       pushToast(formatResult("Paused", r));
       invalidate();
@@ -60,8 +64,12 @@ export function useAgentBulkActions(agents: Agent[], companyId: string) {
   });
 
   const startAll = useMutation({
-    mutationFn: () =>
-      Promise.allSettled(startable.map((a) => agentsApi.resume(a.id, companyId))).then(summarize),
+    mutationFn: async () => {
+      const results = await Promise.allSettled(startable.map((a) => agentsApi.resume(a.id, companyId)));
+      const result = summarize(results);
+      if (result.succeeded === 0 && result.failed > 0) throw new Error("All resume calls failed");
+      return result;
+    },
     onSuccess: (r) => {
       pushToast(formatResult("Resumed", r));
       invalidate();
@@ -70,8 +78,12 @@ export function useAgentBulkActions(agents: Agent[], companyId: string) {
   });
 
   const retryFailed = useMutation({
-    mutationFn: () =>
-      Promise.allSettled(retryable.map((a) => agentsApi.invoke(a.id, companyId))).then(summarize),
+    mutationFn: async () => {
+      const results = await Promise.allSettled(retryable.map((a) => agentsApi.invoke(a.id, companyId)));
+      const result = summarize(results);
+      if (result.succeeded === 0 && result.failed > 0) throw new Error("All invoke calls failed");
+      return result;
+    },
     onSuccess: (r) => {
       pushToast(formatResult("Retried", r));
       invalidate();

--- a/ui/src/hooks/useAgentHeaderActions.ts
+++ b/ui/src/hooks/useAgentHeaderActions.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import type { Agent } from "@paperclipai/shared";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { AgentBulkActions } from "../components/AgentBulkActions";
+import { createElement } from "react";
+
+export function useAgentHeaderActions(agents: Agent[] | undefined, companyId: string | null) {
+  const { setActions } = useBreadcrumbs();
+
+  useEffect(() => {
+    if (!agents || !companyId) {
+      setActions(null);
+      return;
+    }
+    setActions(createElement(AgentBulkActions, { agents, companyId }));
+    return () => setActions(null);
+  }, [agents, companyId, setActions]);
+}

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -19,7 +19,7 @@ import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Bot, Plus, List, GitBranch, SlidersHorizontal } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
-import { AgentBulkActions } from "../components/AgentBulkActions";
+import { useAgentHeaderActions } from "../hooks/useAgentHeaderActions";
 
 const adapterLabels: Record<string, string> = {
   claude_local: "Claude",
@@ -62,7 +62,7 @@ function filterOrgTree(nodes: OrgNode[], tab: FilterTab, showTerminated: boolean
 export function Agents() {
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialog();
-  const { setBreadcrumbs, setActions } = useBreadcrumbs();
+  const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
   const location = useLocation();
   const { isMobile } = useSidebar();
@@ -118,14 +118,7 @@ export function Agents() {
     setBreadcrumbs([{ label: "Agents" }]);
   }, [setBreadcrumbs]);
 
-  useEffect(() => {
-    if (!agents || !selectedCompanyId) {
-      setActions(null);
-      return;
-    }
-    setActions(<AgentBulkActions agents={agents} companyId={selectedCompanyId} />);
-    return () => setActions(null);
-  }, [agents, selectedCompanyId, setActions]);
+  useAgentHeaderActions(agents, selectedCompanyId);
 
   if (!selectedCompanyId) {
     return <EmptyState icon={Bot} message="Select a company to view agents." />;

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -19,6 +19,7 @@ import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Bot, Plus, List, GitBranch, SlidersHorizontal } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
+import { AgentBulkActions } from "../components/AgentBulkActions";
 
 const adapterLabels: Record<string, string> = {
   claude_local: "Claude",
@@ -61,7 +62,7 @@ function filterOrgTree(nodes: OrgNode[], tab: FilterTab, showTerminated: boolean
 export function Agents() {
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialog();
-  const { setBreadcrumbs } = useBreadcrumbs();
+  const { setBreadcrumbs, setActions } = useBreadcrumbs();
   const navigate = useNavigate();
   const location = useLocation();
   const { isMobile } = useSidebar();
@@ -116,6 +117,15 @@ export function Agents() {
   useEffect(() => {
     setBreadcrumbs([{ label: "Agents" }]);
   }, [setBreadcrumbs]);
+
+  useEffect(() => {
+    if (!agents || !selectedCompanyId) {
+      setActions(null);
+      return;
+    }
+    setActions(<AgentBulkActions agents={agents} companyId={selectedCompanyId} />);
+    return () => setActions(null);
+  }, [agents, selectedCompanyId, setActions]);
 
   if (!selectedCompanyId) {
     return <EmptyState icon={Bot} message="Select a company to view agents." />;
@@ -408,3 +418,4 @@ function LiveRunIndicator({
     </Link>
   );
 }
+

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import { timeAgo } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
 import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
-import { AgentBulkActions } from "../components/AgentBulkActions";
+import { useAgentHeaderActions } from "../hooks/useAgentHeaderActions";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
 import type { Agent, Issue } from "@paperclipai/shared";
@@ -34,7 +34,7 @@ function getRecentIssues(issues: Issue[]): Issue[] {
 export function Dashboard() {
   const { selectedCompanyId, companies } = useCompany();
   const { openOnboarding } = useDialog();
-  const { setBreadcrumbs, setActions } = useBreadcrumbs();
+  const { setBreadcrumbs } = useBreadcrumbs();
   const [animatedActivityIds, setAnimatedActivityIds] = useState<Set<string>>(new Set());
   const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const hydratedActivityRef = useRef(false);
@@ -50,14 +50,7 @@ export function Dashboard() {
     setBreadcrumbs([{ label: "Dashboard" }]);
   }, [setBreadcrumbs]);
 
-  useEffect(() => {
-    if (!agents || !selectedCompanyId) {
-      setActions(null);
-      return;
-    }
-    setActions(<AgentBulkActions agents={agents} companyId={selectedCompanyId} />);
-    return () => setActions(null);
-  }, [agents, selectedCompanyId, setActions]);
+  useAgentHeaderActions(agents, selectedCompanyId);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -21,6 +21,7 @@ import { timeAgo } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
 import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
+import { AgentBulkActions } from "../components/AgentBulkActions";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
 import type { Agent, Issue } from "@paperclipai/shared";
@@ -33,7 +34,7 @@ function getRecentIssues(issues: Issue[]): Issue[] {
 export function Dashboard() {
   const { selectedCompanyId, companies } = useCompany();
   const { openOnboarding } = useDialog();
-  const { setBreadcrumbs } = useBreadcrumbs();
+  const { setBreadcrumbs, setActions } = useBreadcrumbs();
   const [animatedActivityIds, setAnimatedActivityIds] = useState<Set<string>>(new Set());
   const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const hydratedActivityRef = useRef(false);
@@ -48,6 +49,15 @@ export function Dashboard() {
   useEffect(() => {
     setBreadcrumbs([{ label: "Dashboard" }]);
   }, [setBreadcrumbs]);
+
+  useEffect(() => {
+    if (!agents || !selectedCompanyId) {
+      setActions(null);
+      return;
+    }
+    setActions(<AgentBulkActions agents={agents} companyId={selectedCompanyId} />);
+    return () => setActions(null);
+  }, [agents, selectedCompanyId, setActions]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),


### PR DESCRIPTION
## Summary

- Add **Stop All**, **Start All**, and **Retry Failed** buttons to the header bar on the Agents and Dashboard pages
- Buttons fan out individual `pause` / `resume` / `invoke` API calls via `Promise.allSettled` and report results through toast notifications
- Extend `BreadcrumbContext` with a reusable `actions` slot so any page can inject buttons into the header

## What changed

| File | Change |
|------|--------|
| `ui/src/hooks/useAgentBulkActions.ts` | New hook — filters agents by status, executes bulk mutations, formats toast feedback |
| `ui/src/components/AgentBulkActions.tsx` | New shared component — renders the three action buttons with loading/disabled states |
| `ui/src/context/BreadcrumbContext.tsx` | Added `actions` ReactNode slot + `setActions` setter to context |
| `ui/src/components/BreadcrumbBar.tsx` | Renders `actions` on the right side of the header bar |
| `ui/src/pages/Agents.tsx` | Injects `AgentBulkActions` into header via `setActions` |
| `ui/src/pages/Dashboard.tsx` | Same — injects `AgentBulkActions` into header |

## How it works

- **Stop All** → `agentsApi.pause()` for each `active`/`idle` agent (with confirmation dialog)
- **Start All** → `agentsApi.resume()` for each `paused` agent
- **Retry Failed** → `agentsApi.invoke()` for each `error` agent
- All buttons auto-disable when no matching agents exist or while an operation is pending
- Partial failures handled gracefully — toast shows e.g. "Paused 4 agents, 1 failed"

## Test plan

- [ ] Navigate to Agents page — verify buttons appear in header bar
- [ ] Navigate to Dashboard — verify same buttons appear
- [ ] With active agents, click Stop All — confirm dialog appears, agents pause
- [ ] With paused agents, click Start All — agents resume
- [ ] With errored agents, click Retry Failed — heartbeat invoked
- [ ] Verify buttons disable when no agents match the filter
- [ ] Verify loading spinner shows during operation
- [ ] Verify toast notification appears with correct counts
- [ ] Navigate away from Agents page — verify buttons disappear from header
- [ ] Mobile: verify icon-only buttons render correctly