### PR TITLE
feat: graceful company-level pause — drain active runs before stopping

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,4 +1,4 @@
-export const COMPANY_STATUSES = ["active", "paused", "archived"] as const;
+export const COMPANY_STATUSES = ["active", "pausing", "paused", "archived"] as const;
 export type CompanyStatus = (typeof COMPANY_STATUSES)[number];
 
 export const DEPLOYMENT_MODES = ["local_trusted", "authenticated"] as const;

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -146,6 +146,48 @@ export function companyRoutes(db: Db) {
     res.json(company);
   });
 
+  router.post("/:companyId/pause", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const force = req.query.force === "true";
+    const company = await svc.pause(companyId, force);
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: company.status === "paused" ? "company.paused" : "company.pausing",
+      entityType: "company",
+      entityId: companyId,
+      details: { force, status: company.status },
+    });
+    res.json(company);
+  });
+
+  router.post("/:companyId/resume", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const company = await svc.resume(companyId);
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "company.resumed",
+      entityType: "company",
+      entityId: companyId,
+    });
+    res.json(company);
+  });
+
   router.post("/:companyId/archive", async (req, res) => {
     assertBoard(req);
     const companyId = req.params.companyId as string;

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -1,4 +1,4 @@
-import { eq, count } from "drizzle-orm";
+import { eq, and, count, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   companies,
@@ -93,6 +93,55 @@ export function companyService(db: Db) {
       db
         .update(companies)
         .set({ status: "archived", updatedAt: new Date() })
+        .where(eq(companies.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null),
+
+    countActiveRuns: async (companyId: string) => {
+      const [{ value }] = await db
+        .select({ value: sql<number>`count(*)` })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.companyId, companyId), inArray(heartbeatRuns.status, ["queued", "running"])));
+      return Number(value ?? 0);
+    },
+
+    pause: async (id: string, force = false) => {
+      const company = await db
+        .select()
+        .from(companies)
+        .where(eq(companies.id, id))
+        .then((rows) => rows[0] ?? null);
+      if (!company) return null;
+
+      if (force) {
+        return db
+          .update(companies)
+          .set({ status: "paused", updatedAt: new Date() })
+          .where(eq(companies.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+      }
+
+      // Check for active runs
+      const [{ value }] = await db
+        .select({ value: sql<number>`count(*)` })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.companyId, id), inArray(heartbeatRuns.status, ["queued", "running"])));
+      const activeRuns = Number(value ?? 0);
+
+      const nextStatus = activeRuns > 0 ? "pausing" : "paused";
+      return db
+        .update(companies)
+        .set({ status: nextStatus, updatedAt: new Date() })
+        .where(eq(companies.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+
+    resume: (id: string) =>
+      db
+        .update(companies)
+        .set({ status: "active", updatedAt: new Date() })
         .where(eq(companies.id, id))
         .returning()
         .then((rows) => rows[0] ?? null),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12,6 +12,7 @@ import {
   issues,
   projects,
   projectWorkspaces,
+  companies,
 } from "@paperclipai/db";
 import { conflict, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -1218,6 +1219,29 @@ export function heartbeatService(db: Db) {
     }
   }
 
+  async function checkCompanyGracefulPause(companyId: string) {
+    const company = await db
+      .select({ status: companies.status })
+      .from(companies)
+      .where(eq(companies.id, companyId))
+      .then((rows) => rows[0] ?? null);
+    if (!company || company.status !== "pausing") return;
+
+    const [{ value }] = await db
+      .select({ value: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), inArray(heartbeatRuns.status, ["queued", "running"])));
+    const activeRuns = Number(value ?? 0);
+    if (activeRuns > 0) return;
+
+    await db
+      .update(companies)
+      .set({ status: "paused", updatedAt: new Date() })
+      .where(eq(companies.id, companyId));
+
+    logger.info({ companyId }, "company graceful pause complete: pausing → paused");
+  }
+
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
@@ -1952,6 +1976,7 @@ export function heartbeatService(db: Db) {
         }
       }
       await finalizeAgentStatus(agent.id, outcome);
+      await checkCompanyGracefulPause(agent.companyId);
     } catch (err) {
       const message = redactCurrentUserText(err instanceof Error ? err.message : "Unknown adapter failure");
       logger.error({ err, runId }, "heartbeat execution failed");
@@ -2013,6 +2038,7 @@ export function heartbeatService(db: Db) {
       }
 
       await finalizeAgentStatus(agent.id, "failed");
+      await checkCompanyGracefulPause(agent.companyId);
     }
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
@@ -2043,6 +2069,7 @@ export function heartbeatService(db: Db) {
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
           await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
+          await checkCompanyGracefulPause(run.companyId).catch(() => undefined);
         } finally {
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
           activeRunExecutions.delete(run.id);
@@ -2231,6 +2258,16 @@ export function heartbeatService(db: Db) {
       agent.status === "pending_approval"
     ) {
       throw conflict("Agent is not invokable in its current state", { status: agent.status });
+    }
+
+    // Block new wakeups for pausing/paused companies
+    const company = await db
+      .select({ status: companies.status })
+      .from(companies)
+      .where(eq(companies.id, agent.companyId))
+      .then((rows) => rows[0] ?? null);
+    if (company && (company.status === "pausing" || company.status === "paused")) {
+      throw conflict("Company is paused or pausing — no new runs allowed", { companyStatus: company.status });
     }
 
     const policy = parseHeartbeatPolicy(agent);
@@ -2797,11 +2834,19 @@ export function heartbeatService(db: Db) {
 
     tickTimers: async (now = new Date()) => {
       const allAgents = await db.select().from(agents);
+      const pausedCompanyIds = new Set(
+        (await db
+          .select({ id: companies.id })
+          .from(companies)
+          .where(inArray(companies.status, ["pausing", "paused"]))
+        ).map((c) => c.id),
+      );
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
 
       for (const agent of allAgents) {
+        if (pausedCompanyIds.has(agent.companyId)) continue;
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -25,6 +25,9 @@ export const companiesApi = {
       >
     >,
   ) => api.patch<Company>(`/companies/${companyId}`, data),
+  pause: (companyId: string, force = false) =>
+    api.post<Company>(`/companies/${companyId}/pause${force ? "?force=true" : ""}`, {}),
+  resume: (companyId: string) => api.post<Company>(`/companies/${companyId}/resume`, {}),
   archive: (companyId: string) => api.post<Company>(`/companies/${companyId}/archive`, {}),
   remove: (companyId: string) => api.delete<{ ok: true }>(`/companies/${companyId}`),
   exportBundle: (companyId: string, data: { include?: { company?: boolean; agents?: boolean } }) =>

--- a/ui/src/lib/status-colors.ts
+++ b/ui/src/lib/status-colors.ts
@@ -43,6 +43,7 @@ export const statusBadge: Record<string, string> = {
   // Agent statuses
   active: "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300",
   running: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300",
+  pausing: "bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300",
   paused: "bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300",
   idle: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300",
   archived: "bg-muted text-muted-foreground",

--- a/ui/src/pages/Companies.tsx
+++ b/ui/src/pages/Companies.tsx
@@ -171,12 +171,14 @@ export function Companies() {
                         className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
                           company.status === "active"
                             ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                            : company.status === "paused"
-                              ? "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400"
-                              : "bg-muted text-muted-foreground"
+                            : company.status === "pausing"
+                              ? "bg-orange-500/10 text-orange-600 dark:text-orange-400"
+                              : company.status === "paused"
+                                ? "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400"
+                                : "bg-muted text-muted-foreground"
                         }`}
                       >
-                        {company.status}
+                        {company.status === "pausing" ? "pausing..." : company.status}
                       </span>
                       <Button
                         variant="ghost"

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -6,7 +6,7 @@ import { companiesApi } from "../api/companies";
 import { accessApi } from "../api/access";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
-import { Settings, Check } from "lucide-react";
+import { Settings, Check, Pause, Play, Loader2 } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
 import {
   Field,
@@ -134,6 +134,21 @@ export function CompanySettings() {
     setSnippetCopied(false);
     setSnippetCopyDelightId(0);
   }, [selectedCompanyId]);
+  const pauseMutation = useMutation({
+    mutationFn: ({ force }: { force?: boolean } = {}) =>
+      companiesApi.pause(selectedCompanyId!, force),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
+
+  const resumeMutation = useMutation({
+    mutationFn: () => companiesApi.resume(selectedCompanyId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
+
   const archiveMutation = useMutation({
     mutationFn: ({
       companyId,
@@ -375,6 +390,82 @@ export function CompanySettings() {
                 </div>
               </div>
             </div>
+          )}
+        </div>
+      </div>
+
+      {/* Pause / Resume */}
+      <div className="space-y-4">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Operations
+        </div>
+        <div className="space-y-3 rounded-md border border-border px-4 py-4">
+          <p className="text-sm text-muted-foreground">
+            {selectedCompany.status === "pausing"
+              ? "Company is draining — waiting for active runs to finish before fully pausing."
+              : selectedCompany.status === "paused"
+                ? "Company is paused. No new heartbeats will be scheduled. Resume to re-enable."
+                : "Pause this company to stop scheduling new heartbeats. Active runs will finish before the company is fully paused."}
+          </p>
+
+          {selectedCompany.status === "pausing" && (
+            <div className="flex items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-300">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Draining — waiting for active runs to complete
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            {selectedCompany.status === "active" ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  const confirmed = window.confirm(
+                    `Pause company "${selectedCompany.name}"? Active runs will finish before the company is fully paused.`
+                  );
+                  if (confirmed) pauseMutation.mutate({});
+                }}
+                disabled={pauseMutation.isPending}
+              >
+                <Pause className="h-3.5 w-3.5 mr-1" />
+                {pauseMutation.isPending ? "Pausing..." : "Pause company"}
+              </Button>
+            ) : selectedCompany.status === "pausing" || selectedCompany.status === "paused" ? (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => resumeMutation.mutate()}
+                  disabled={resumeMutation.isPending}
+                >
+                  <Play className="h-3.5 w-3.5 mr-1" />
+                  {resumeMutation.isPending ? "Resuming..." : "Resume company"}
+                </Button>
+                {selectedCompany.status === "pausing" && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      const confirmed = window.confirm(
+                        "Force pause immediately? This will NOT cancel running processes, but will mark the company as paused right away."
+                      );
+                      if (confirmed) pauseMutation.mutate({ force: true });
+                    }}
+                    disabled={pauseMutation.isPending}
+                  >
+                    {pauseMutation.isPending ? "..." : "Force pause now"}
+                  </Button>
+                )}
+              </>
+            ) : null}
+          </div>
+          {(pauseMutation.isError || resumeMutation.isError) && (
+            <span className="text-xs text-destructive">
+              {(pauseMutation.error ?? resumeMutation.error) instanceof Error
+                ? ((pauseMutation.error ?? resumeMutation.error) as Error).message
+                : "Action failed"}
+            </span>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Add company-level **graceful pause**: transition to `pausing` state, let all active issue runs complete, then move to `paused`
- Backend routes: `POST /api/companies/:id/pause` (with optional `?force=true`) and `/resume`
- Frontend: pause/resume toggle with visual indicators for `pausing` (draining) vs `paused` states
- Extends existing agent-level pause to work coherently at the company level

## Motivation

Operators need a way to stop a company without yanking the plug mid-run. Current options are either agent-by-agent pause or bulk pause (PR #829 / #871), both of which immediately stop agents. This PR adds a company-level action that waits for in-flight runs to finish before fully pausing — no lost work, no interrupted issue runs.

## State Machine
```
active → pausing (draining) → paused → active
active → paused (force, skip drain)
```

## Changes

### Backend (3 files)
- **`packages/shared/src/constants.ts`** — Added `"pausing"` to `COMPANY_STATUSES` enum
- **`server/src/services/companies.ts`** — `pause(id, force)`, `resume(id)`, `countActiveRuns()` service methods
- **`server/src/routes/companies.ts`** — `POST /:companyId/pause` and `POST /:companyId/resume` routes with activity logging
- **`server/src/services/heartbeat.ts`** —
  - `tickTimers()` skips agents from pausing/paused companies
  - `enqueueWakeup()` blocks new wakeups for pausing/paused companies
  - `checkCompanyGracefulPause()` — run completion hook that auto-transitions pausing → paused when last active run finishes

### Frontend (4 files)
- **`ui/src/api/companies.ts`** — `pause()` and `resume()` API methods
- **`ui/src/pages/CompanySettings.tsx`** — New "Operations" section with pause/resume buttons, draining indicator, force pause option, confirmation dialogs
- **`ui/src/pages/Companies.tsx`** — Distinct "pausing..." badge (orange) vs "paused" (yellow)
- **`ui/src/lib/status-colors.ts`** — Added `pausing` status badge color

## Test plan
- [x] `POST /companies/:id/pause` transitions status to `pausing` when active runs exist
- [x] `POST /companies/:id/pause` transitions directly to `paused` when no active runs
- [x] Heartbeat scheduler skips `pausing` / `paused` companies
- [x] `enqueueWakeup` rejects new wakeups with 409 for pausing/paused companies
- [x] After last run finishes, status auto-transitions pausing → paused
- [x] `?force=true` immediately transitions to `paused`
- [x] `POST /companies/:id/resume` transitions back to `active`
- [x] UI shows distinct visual states for `pausing` vs `paused`
- [x] Activity log captures pause/resume events
- [x] All packages build cleanly (shared, server, ui)
- [x] Existing tests pass (7 pre-existing failures in unrelated opencode-local-adapter tests)

Closes #873
Follows up on #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)