### PR TITLE
Enforce heartbeat budget hard stops

### DIFF
--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -3,24 +3,95 @@ import type { Db } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 
+export type BudgetBlockScope = "company" | "agent";
+export type BudgetBlockReason = "budget.company_limit_reached" | "budget.agent_limit_reached";
+
+export interface BudgetBlock {
+  scope: BudgetBlockScope;
+  reason: BudgetBlockReason;
+  message: string;
+  budgetCents: number;
+  spentCents: number;
+}
+
+export function resolveBudgetBlock(input: {
+  companyBudgetMonthlyCents: number;
+  companySpentMonthlyCents: number;
+  agentBudgetMonthlyCents: number;
+  agentSpentMonthlyCents: number;
+}): BudgetBlock | null {
+  if (
+    input.companyBudgetMonthlyCents > 0 &&
+    input.companySpentMonthlyCents >= input.companyBudgetMonthlyCents
+  ) {
+    return {
+      scope: "company",
+      reason: "budget.company_limit_reached",
+      message: "Company monthly budget has been exhausted; new heartbeats are blocked until the budget is raised or the month rolls over.",
+      budgetCents: input.companyBudgetMonthlyCents,
+      spentCents: input.companySpentMonthlyCents,
+    };
+  }
+
+  if (
+    input.agentBudgetMonthlyCents > 0 &&
+    input.agentSpentMonthlyCents >= input.agentBudgetMonthlyCents
+  ) {
+    return {
+      scope: "agent",
+      reason: "budget.agent_limit_reached",
+      message: "Agent monthly budget has been exhausted; new heartbeats are blocked until the budget is raised or the month rolls over.",
+      budgetCents: input.agentBudgetMonthlyCents,
+      spentCents: input.agentSpentMonthlyCents,
+    };
+  }
+
+  return null;
+}
+
 export interface CostDateRange {
   from?: Date;
   to?: Date;
 }
 
 export function costService(db: Db) {
-  return {
-    createEvent: async (companyId: string, data: Omit<typeof costEvents.$inferInsert, "companyId">) => {
-      const agent = await db
+  async function getBudgetSnapshot(companyId: string, agentId: string) {
+    const [company, agent] = await Promise.all([
+      db
+        .select()
+        .from(companies)
+        .where(eq(companies.id, companyId))
+        .then((rows) => rows[0] ?? null),
+      db
         .select()
         .from(agents)
-        .where(eq(agents.id, data.agentId))
-        .then((rows) => rows[0] ?? null);
+        .where(eq(agents.id, agentId))
+        .then((rows) => rows[0] ?? null),
+    ]);
 
-      if (!agent) throw notFound("Agent not found");
-      if (agent.companyId !== companyId) {
-        throw unprocessable("Agent does not belong to company");
-      }
+    if (!company) throw notFound("Company not found");
+    if (!agent) throw notFound("Agent not found");
+    if (agent.companyId !== companyId) {
+      throw unprocessable("Agent does not belong to company");
+    }
+
+    return { company, agent };
+  }
+
+  async function pauseAgentIfBudgetBlocked(agentId: string, status: string) {
+    if (status === "paused" || status === "terminated" || status === "pending_approval") {
+      return;
+    }
+
+    await db
+      .update(agents)
+      .set({ status: "paused", updatedAt: new Date() })
+      .where(eq(agents.id, agentId));
+  }
+
+  return {
+    createEvent: async (companyId: string, data: Omit<typeof costEvents.$inferInsert, "companyId">) => {
+      await getBudgetSnapshot(companyId, data.agentId);
 
       const event = await db
         .insert(costEvents)
@@ -44,26 +115,48 @@ export function costService(db: Db) {
         })
         .where(eq(companies.id, companyId));
 
-      const updatedAgent = await db
-        .select()
-        .from(agents)
-        .where(eq(agents.id, event.agentId))
-        .then((rows) => rows[0] ?? null);
+      const {
+        company: updatedCompany,
+        agent: updatedAgent,
+      } = await getBudgetSnapshot(companyId, event.agentId);
+      const budgetBlock = resolveBudgetBlock({
+        companyBudgetMonthlyCents: updatedCompany.budgetMonthlyCents,
+        companySpentMonthlyCents: updatedCompany.spentMonthlyCents,
+        agentBudgetMonthlyCents: updatedAgent.budgetMonthlyCents,
+        agentSpentMonthlyCents: updatedAgent.spentMonthlyCents,
+      });
 
-      if (
-        updatedAgent &&
-        updatedAgent.budgetMonthlyCents > 0 &&
-        updatedAgent.spentMonthlyCents >= updatedAgent.budgetMonthlyCents &&
-        updatedAgent.status !== "paused" &&
-        updatedAgent.status !== "terminated"
-      ) {
-        await db
-          .update(agents)
-          .set({ status: "paused", updatedAt: new Date() })
-          .where(eq(agents.id, updatedAgent.id));
+      if (budgetBlock) {
+        await pauseAgentIfBudgetBlocked(updatedAgent.id, updatedAgent.status);
       }
 
       return event;
+    },
+
+    getBudgetBlock: async (companyId: string, agentId: string) => {
+      const { company, agent } = await getBudgetSnapshot(companyId, agentId);
+      return resolveBudgetBlock({
+        companyBudgetMonthlyCents: company.budgetMonthlyCents,
+        companySpentMonthlyCents: company.spentMonthlyCents,
+        agentBudgetMonthlyCents: agent.budgetMonthlyCents,
+        agentSpentMonthlyCents: agent.spentMonthlyCents,
+      });
+    },
+
+    enforceBudgetBlock: async (companyId: string, agentId: string) => {
+      const { company, agent } = await getBudgetSnapshot(companyId, agentId);
+      const budgetBlock = resolveBudgetBlock({
+        companyBudgetMonthlyCents: company.budgetMonthlyCents,
+        companySpentMonthlyCents: company.spentMonthlyCents,
+        agentBudgetMonthlyCents: agent.budgetMonthlyCents,
+        agentSpentMonthlyCents: agent.spentMonthlyCents,
+      });
+
+      if (budgetBlock) {
+        await pauseAgentIfBudgetBlocked(agent.id, agent.status);
+      }
+
+      return budgetBlock;
     },
 
     summary: async (companyId: string, range?: CostDateRange) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1126,7 +1126,10 @@ export function heartbeatService(db: Db) {
       payload: buildBudgetPayload(parseObject(run.contextSnapshot), budgetBlock),
     });
 
-    if (!cancelledRun) return;
+    if (!cancelledRun) {
+      await releaseIssueExecutionAndPromote(run);
+      return;
+    }
 
     await appendRunEvent(cancelledRun, 1, {
       eventType: "budget_blocked",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21,7 +21,7 @@ import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
-import { costService } from "./costs.js";
+import { costService, type BudgetBlock } from "./costs.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
@@ -556,6 +556,7 @@ export function heartbeatService(db: Db) {
   const runLogStore = getRunLogStore();
   const secretsSvc = secretService(db);
   const issuesSvc = issueService(db);
+  const costs = costService(db);
   const activeRunExecutions = new Set<string>();
 
   async function getAgent(agentId: string) {
@@ -1072,6 +1073,88 @@ export function heartbeatService(db: Db) {
       .where(eq(agentWakeupRequests.id, wakeupRequestId));
   }
 
+  function buildBudgetPayload(
+    existingPayload: Record<string, unknown> | null,
+    budgetBlock: BudgetBlock,
+  ) {
+    return {
+      ...(existingPayload ?? {}),
+      budgetScope: budgetBlock.scope,
+      budgetReason: budgetBlock.reason,
+      budgetCents: budgetBlock.budgetCents,
+      spentCents: budgetBlock.spentCents,
+    };
+  }
+
+  async function recordSkippedBudgetWakeup(input: {
+    agent: typeof agents.$inferSelect;
+    source: WakeupOptions["source"];
+    triggerDetail: WakeupOptions["triggerDetail"] | null;
+    payload: Record<string, unknown> | null;
+    opts: WakeupOptions;
+    budgetBlock: BudgetBlock;
+  }) {
+    const { agent, source, triggerDetail, payload, opts, budgetBlock } = input;
+    await db.insert(agentWakeupRequests).values({
+      companyId: agent.companyId,
+      agentId: agent.id,
+      source,
+      triggerDetail,
+      reason: budgetBlock.reason,
+      payload: buildBudgetPayload(payload, budgetBlock),
+      status: "skipped",
+      requestedByActorType: opts.requestedByActorType ?? null,
+      requestedByActorId: opts.requestedByActorId ?? null,
+      idempotencyKey: opts.idempotencyKey ?? null,
+      finishedAt: new Date(),
+      error: budgetBlock.message,
+    });
+  }
+
+  async function cancelRunForBudgetBlock(run: typeof heartbeatRuns.$inferSelect, budgetBlock: BudgetBlock) {
+    const now = new Date();
+    const cancelledRun = await setRunStatus(run.id, "cancelled", {
+      error: budgetBlock.message,
+      errorCode: budgetBlock.reason,
+      finishedAt: now,
+    });
+
+    await setWakeupStatus(run.wakeupRequestId, "failed", {
+      finishedAt: now,
+      error: budgetBlock.message,
+      reason: budgetBlock.reason,
+      payload: buildBudgetPayload(parseObject(run.contextSnapshot), budgetBlock),
+    });
+
+    if (!cancelledRun) return;
+
+    await appendRunEvent(cancelledRun, 1, {
+      eventType: "budget_blocked",
+      stream: "system",
+      level: "error",
+      message: budgetBlock.message,
+      payload: {
+        budgetScope: budgetBlock.scope,
+        budgetReason: budgetBlock.reason,
+        budgetCents: budgetBlock.budgetCents,
+        spentCents: budgetBlock.spentCents,
+      },
+    });
+    await releaseIssueExecutionAndPromote(cancelledRun);
+  }
+
+  async function cancelQueuedRunsForBudgetBlock(agentId: string, budgetBlock: BudgetBlock) {
+    const queuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
+      .orderBy(asc(heartbeatRuns.createdAt));
+
+    for (const queuedRun of queuedRuns) {
+      await cancelRunForBudgetBlock(queuedRun, budgetBlock);
+    }
+  }
+
   async function appendRunEvent(
     run: typeof heartbeatRuns.$inferSelect,
     seq: number,
@@ -1314,7 +1397,6 @@ export function heartbeatService(db: Db) {
       .where(eq(agentRuntimeState.agentId, agent.id));
 
     if (additionalCostCents > 0 || hasTokenUsage) {
-      const costs = costService(db);
       await costs.createEvent(agent.companyId, {
         agentId: agent.id,
         provider: result.provider ?? "unknown",
@@ -1331,6 +1413,11 @@ export function heartbeatService(db: Db) {
     return withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
+      const budgetBlock = await costs.enforceBudgetBlock(agent.companyId, agent.id);
+      if (budgetBlock) {
+        await cancelQueuedRunsForBudgetBlock(agent.id, budgetBlock);
+        return [];
+      }
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
       const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
@@ -1390,6 +1477,12 @@ export function heartbeatService(db: Db) {
       });
       const failedRun = await getRun(runId);
       if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
+      return;
+    }
+
+    const budgetBlock = await costs.enforceBudgetBlock(agent.companyId, agent.id);
+    if (budgetBlock) {
+      await cancelRunForBudgetBlock(run, budgetBlock);
       return;
     }
 
@@ -2231,6 +2324,19 @@ export function heartbeatService(db: Db) {
       agent.status === "pending_approval"
     ) {
       throw conflict("Agent is not invokable in its current state", { status: agent.status });
+    }
+
+    const budgetBlock = await costs.enforceBudgetBlock(agent.companyId, agent.id);
+    if (budgetBlock) {
+      await recordSkippedBudgetWakeup({
+        agent,
+        source,
+        triggerDetail,
+        payload,
+        opts,
+        budgetBlock,
+      });
+      return null;
     }
 
     const policy = parseHeartbeatPolicy(agent);


### PR DESCRIPTION
## Summary
This PR makes Paperclip's documented budget hard-stop behavior true at runtime.

Today, cost tracking increments spend and may pause an agent after a cost event is recorded, but heartbeat scheduling and run startup can still queue and start new work after the relevant budget has already been exhausted. The docs describe hard stops with no more heartbeats once a limit is reached.

## Changes
- add a shared budget block decision in 
- enforce company and agent budget limits before new wakeups are queued
- prevent queued runs from starting once a budget is already exhausted
- cancel budget-blocked queued runs before execution and record the reason in wake/run metadata
- keep post-cost auto-pause behavior, but extend it to company-level exhaustion as well

## Why this matters
This closes the gap between the cost-control docs and actual control-plane behavior. After this change, exhausted budgets stop additional heartbeats instead of only reacting after more work has already been scheduled or started.

## Notes
- no tests were added in this PR by request
- verification in the local snapshot was limited because the provided folder was not a fully installed workspace