### PR TITLE
fix: use printenv in skill curl examples for reliable env var expansion

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -24,26 +24,26 @@ If you do not have this permission, escalate to your CEO or board.
 ### 1. Confirm identity and company context
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/agents/me" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/agents/me" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 ### 2. Discover adapter configuration for this Paperclip instance
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-configuration.txt" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
 # Then the specific adapter you plan to use, e.g. claude_local:
-curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-configuration/claude_local.txt" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 ### 3. Compare existing agent configurations
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/companies/$(printenv PAPERCLIP_COMPANY_ID)/agent-configurations" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 Note naming, icon, reporting-line, and adapter conventions the company already follows.
@@ -67,8 +67,8 @@ State which path you took in your hire-request comment so the board can see the 
 ### 5. Discover allowed agent icons
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-icons.txt" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 ### 6. Draft the new hire config
@@ -96,8 +96,8 @@ Before submitting, walk the draft-review checklist end-to-end and fix any item t
 ### 8. Submit hire request
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/companies/$(printenv PAPERCLIP_COMPANY_ID)/agent-hires" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "CTO",
@@ -122,11 +122,11 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
 - when the board approves, you will be woken with `PAPERCLIP_APPROVAL_ID`; read linked issues and close/comment follow-up
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/approvals/<approval-id>" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/<approval-id>" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
-curl -sS -X POST "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/approvals/<approval-id>/comments" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{"body":"## CTO hire request submitted\n\n- Approval: [<approval-id>](/approvals/<approval-id>)\n- Pending agent: [<agent-ref>](/agents/<agent-url-key-or-id>)\n- Source issue: [<issue-ref>](/issues/<issue-identifier-or-id>)\n\nUpdated prompt and adapter config per board feedback."}'
 ```
@@ -134,8 +134,8 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
 If the approval already exists and needs manual linking to the issue:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/issues/<issue-id>/approvals" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{"approvalId":"<approval-id>"}'
 ```
@@ -143,11 +143,11 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
 After approval is granted, run this follow-up loop:
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$(printenv PAPERCLIP_APPROVAL_ID)" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
-curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$(printenv PAPERCLIP_APPROVAL_ID)/issues" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 For each linked issue, either:

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -24,26 +24,26 @@ If you do not have this permission, escalate to your CEO or board.
 ### 1. Confirm identity and company context
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/agents/me" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/agents/me" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 ### 2. Discover adapter configuration for this Paperclip instance
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-configuration.txt" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
 # Then the specific adapter you plan to use, e.g. claude_local:
-curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-configuration/claude_local.txt" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 ### 3. Compare existing agent configurations
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 Note naming, icon, reporting-line, and adapter conventions the company already follows.
@@ -67,8 +67,8 @@ State which path you took in your hire-request comment so the board can see the 
 ### 5. Discover allowed agent icons
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-icons.txt" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 ### 6. Draft the new hire config
@@ -96,8 +96,8 @@ Before submitting, walk the draft-review checklist end-to-end and fix any item t
 ### 8. Submit hire request
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "CTO",
@@ -121,11 +121,11 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
 - when the board approves, you will be woken with `PAPERCLIP_APPROVAL_ID`; read linked issues and close/comment follow-up
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/approvals/<approval-id>" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/<approval-id>" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
-curl -sS -X POST "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/approvals/<approval-id>/comments" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{"body":"## CTO hire request submitted\n\n- Approval: [<approval-id>](/approvals/<approval-id>)\n- Pending agent: [<agent-ref>](/agents/<agent-url-key-or-id>)\n- Source issue: [<issue-ref>](/issues/<issue-identifier-or-id>)\n\nUpdated prompt and adapter config per board feedback."}'
 ```
@@ -133,8 +133,8 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
 If the approval already exists and needs manual linking to the issue:
 
 ```sh
-curl -sS -X POST "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/issues/<issue-id>/approvals" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{"approvalId":"<approval-id>"}'
 ```
@@ -142,11 +142,11 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
 After approval is granted, run this follow-up loop:
 
 ```sh
-curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$PAPERCLIP_APPROVAL_ID" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
-curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
+  -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
 For each linked issue, either:

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -42,7 +42,7 @@ curl -sS "$(printenv PAPERCLIP_API_URL)/llms/agent-configuration/claude_local.tx
 ### 3. Compare existing agent configurations
 
 ```sh
-curl -sS "$(printenv PAPERCLIP_API_URL)/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/companies/$(printenv PAPERCLIP_COMPANY_ID)/agent-configurations" \
   -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 
@@ -96,7 +96,7 @@ Before submitting, walk the draft-review checklist end-to-end and fix any item t
 ### 8. Submit hire request
 
 ```sh
-curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
+curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/companies/$(printenv PAPERCLIP_COMPANY_ID)/agent-hires" \
   -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)" \
   -H "Content-Type: application/json" \
   -d '{
@@ -142,10 +142,10 @@ curl -sS -X POST "$(printenv PAPERCLIP_API_URL)/api/issues/<issue-id>/approvals"
 After approval is granted, run this follow-up loop:
 
 ```sh
-curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$PAPERCLIP_APPROVAL_ID" \
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$(printenv PAPERCLIP_APPROVAL_ID)" \
   -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 
-curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
+curl -sS "$(printenv PAPERCLIP_API_URL)/api/approvals/$(printenv PAPERCLIP_APPROVAL_ID)/issues" \
   -H "Authorization: Bearer $(printenv PAPERCLIP_API_KEY)"
 ```
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -23,7 +23,7 @@ Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
-**Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
+**Run audit trail:** You MUST include `-H "X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)"` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
 
 ## The Heartbeat Procedure
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -17,11 +17,13 @@ You run in **heartbeats** — short execution windows triggered by Paperclip. Ea
 
 Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
 
+**Shell expansion note:** Some shells (notably Git Bash on Windows) can intermittently fail to expand `$PAPERCLIP_API_KEY` or `$PAPERCLIP_API_URL` inside double-quoted curl arguments. If you get empty bearer tokens or malformed URL errors, use `$(printenv PAPERCLIP_API_KEY)` and `$(printenv PAPERCLIP_API_URL)` instead — these are always reliable.
+
 Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, it contains the compact issue summary and the ordered batch of new comment payloads for this wake. Use it first. For comment wakes, treat that batch as the highest-priority new context in the heartbeat: in your first task update or response, acknowledge the latest comment and say how it changes your next action before broad repo exploration or generic wake boilerplate. Only fetch the thread/comments API immediately when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
-**Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
+**Run audit trail:** You MUST include `-H "X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)"` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
 
 ## The Heartbeat Procedure
 
@@ -57,7 +59,7 @@ Overrides and special cases:
 
 ```
 POST /api/issues/{issueId}/checkout
-Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers: Authorization: Bearer $(printenv PAPERCLIP_API_KEY), X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)
 { "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
 ```
 
@@ -109,7 +111,7 @@ When writing issue descriptions or comments, follow the ticket-linking rule in *
 
 ```json
 PATCH /api/issues/{issueId}
-Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers: X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)
 { "status": "done", "comment": "What was done and why." }
 ```
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -101,8 +101,12 @@ When writing issue descriptions or comments, follow the ticket-linking rule in *
 
 ```json
 PATCH /api/issues/{issueId}
-Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers: X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)
 { "status": "done", "comment": "What was done and why." }
+
+PATCH /api/issues/{issueId}
+Headers: X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)
+{ "status": "blocked", "comment": "What is blocked, why, and who needs to unblock it." }
 ```
 
 For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -17,6 +17,8 @@ You run in **heartbeats** — short execution windows triggered by Paperclip. Ea
 
 Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
 
+**Shell expansion note:** Some shells (notably Git Bash on Windows) can intermittently fail to expand `$PAPERCLIP_API_KEY` or `$PAPERCLIP_API_URL` inside double-quoted curl arguments. If you get empty bearer tokens or malformed URL errors, use `$(printenv PAPERCLIP_API_KEY)` and `$(printenv PAPERCLIP_API_URL)` instead — these are always reliable.
+
 Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, it contains the compact issue summary and the ordered batch of new comment payloads for this wake. Use it first. For comment wakes, treat that batch as the highest-priority new context in the heartbeat: in your first task update or response, acknowledge the latest comment and say how it changes your next action before broad repo exploration or generic wake boilerplate. Only fetch the thread/comments API immediately when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
@@ -57,7 +59,7 @@ Overrides and special cases:
 
 ```
 POST /api/issues/{issueId}/checkout
-Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers: Authorization: Bearer $(printenv PAPERCLIP_API_KEY), X-Paperclip-Run-Id: $(printenv PAPERCLIP_RUN_ID)
 { "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
 ```
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents execute skills that contain curl examples showing how to call the Paperclip API
> - These curl examples use shell environment variables like `$PAPERCLIP_API_KEY` and `$PAPERCLIP_API_URL`
> - But on Windows, agents typically run under Git Bash, which intermittently fails to expand `$VAR` inside double-quoted curl arguments
> - This produces empty bearer tokens (→ 401) or malformed URLs, causing agent heartbeats to fail silently
> - This PR replaces all `$VAR` references in curl examples with `$(printenv VAR)`, which always works because it executes as a subshell command rather than relying on shell parameter expansion
> - The benefit is that agents running on Windows via Git Bash can reliably call the Paperclip API without intermittent authentication or URL failures

## Summary

Replace `$PAPERCLIP_API_KEY`, `$PAPERCLIP_API_URL`, `$PAPERCLIP_RUN_ID`, `$PAPERCLIP_COMPANY_ID`, and `$PAPERCLIP_APPROVAL_ID` with `$(printenv ...)` in all curl examples across:
- `skills/paperclip/SKILL.md` (authentication, checkout, status updates, audit trail)
- `skills/paperclip-create-agent/SKILL.md` (agent config, hire requests, approval follow-up)

Also adds a "Shell expansion note" in the Authentication section explaining the workaround.

## Why

Some shells (notably Git Bash on Windows) intermittently fail to expand env vars inside double-quoted curl arguments, producing:
- Empty bearer tokens → `401 Agent authentication required`
- Malformed URL errors → `Malformed input to a URL function`

`$(printenv VAR)` is always reliable because it executes as a subshell command rather than relying on shell parameter expansion.

## Risks

- **None for correctness**: `$(printenv VAR)` is functionally identical to `$VAR` when the variable is set. If the variable is unset, `printenv` returns empty string (same as `$VAR`).
- **Subshell overhead**: `$(printenv ...)` spawns a subshell per invocation, but this is negligible for documentation-driven curl commands (not hot-path code).
- **Documentation-only change**: No runtime code is modified — only skill markdown files that agents read as instructions.

## Verification

All `$PAPERCLIP_*` references in curl/shell code blocks across both skill files have been converted. Plain-text documentation references (explanations, env var names in prose) are intentionally left as `$VAR` since they are not executed.

Fixes #856
Fixes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)