### PR TITLE
feat: openclaw-gateway adapter — include contextUsagePercent in run result metadata (ALE-1129)

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -824,7 +824,32 @@ function parseUsage(value: unknown): AdapterExecutionResult["usage"] | undefined
     0,
   );
 
-  if (inputTokens <= 0 && outputTokens <= 0 && cachedInputTokens <= 0) {
+  // Context window usage — populated by OpenClaw gateway when session status is available
+  const contextUsagePercent = asNumber(
+    record.contextUsagePercent ??
+    record.context_usage_percent ??
+    record.usagePercent ??
+    record.usage_percent,
+    -1,
+  );
+  const contextTokensUsed = asNumber(
+    record.contextTokensUsed ?? record.context_tokens_used ?? record.inputTokens,
+    0,
+  );
+  const contextTokensMax = asNumber(
+    record.contextTokensMax ?? record.context_tokens_max ?? record.contextWindow ?? record.context_window,
+    0,
+  );
+
+  // Derive contextUsagePercent from tokens if not explicitly provided
+  const derivedContextPercent =
+    contextUsagePercent >= 0
+      ? contextUsagePercent
+      : contextTokensUsed > 0 && contextTokensMax > 0
+        ? Math.round((contextTokensUsed / contextTokensMax) * 100)
+        : -1;
+
+  if (inputTokens <= 0 && outputTokens <= 0 && cachedInputTokens <= 0 && derivedContextPercent < 0) {
     return undefined;
   }
 
@@ -832,6 +857,9 @@ function parseUsage(value: unknown): AdapterExecutionResult["usage"] | undefined
     inputTokens,
     outputTokens,
     ...(cachedInputTokens > 0 ? { cachedInputTokens } : {}),
+    ...(derivedContextPercent >= 0 ? { contextUsagePercent: derivedContextPercent } : {}),
+    ...(contextTokensUsed > 0 ? { contextTokensUsed } : {}),
+    ...(contextTokensMax > 0 ? { contextTokensMax } : {}),
   };
 }
 
@@ -1188,9 +1216,44 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         null;
       const summary = summaryFromEvents || summaryFromPayload || null;
 
-      const meta = asRecord(asRecord(acceptedPayload?.result)?.meta) ?? asRecord(acceptedPayload?.meta);
+      // Result metadata may live in different places depending on the gateway protocol path:
+      // - acceptedPayload.result.meta (when agent returns status=ok immediately)
+      // - acceptedPayload.meta (legacy / direct)
+      // - latestResultPayload.result.meta (agent.wait terminal snapshot — most common for long runs)
+      // - latestResultPayload.meta (legacy agent.wait format)
+      const latestPayloadRecord = asRecord(latestResultPayload);
+      const meta =
+        asRecord(asRecord(acceptedPayload?.result)?.meta) ??
+        asRecord(acceptedPayload?.meta) ??
+        asRecord(asRecord(latestPayloadRecord?.result)?.meta) ??
+        asRecord(latestPayloadRecord?.meta);
       const agentMeta = asRecord(meta?.agentMeta);
-      const usage = parseUsage(agentMeta?.usage ?? meta?.usage);
+      // lastCallUsage reflects only the final API call's token counts — the most accurate
+      // snapshot of actual context window consumption. Unlike the accumulated usage.input
+      // (which sums input tokens across all tool-use loops), lastCallUsage.input represents
+      // the real context size at the end of the run and is used as contextTokensUsed.
+      const lastCallUsage = asRecord(agentMeta?.lastCallUsage);
+      // Merge usage fields: explicit usage object + top-level agentMeta context fields
+      // so contextUsagePercent / contextTokensUsed / contextTokensMax are captured
+      // even when sent at the agentMeta level rather than nested under usage.
+      const rawUsage = {
+        ...(asRecord(agentMeta?.usage ?? meta?.usage) ?? {}),
+        ...(agentMeta?.contextUsagePercent != null ? { contextUsagePercent: agentMeta.contextUsagePercent } : {}),
+        ...(agentMeta?.contextTokensUsed != null ? { contextTokensUsed: agentMeta.contextTokensUsed } : {}),
+        ...(agentMeta?.contextTokensMax != null ? { contextTokensMax: agentMeta.contextTokensMax } : {}),
+        ...(meta?.contextUsagePercent != null ? { contextUsagePercent: meta.contextUsagePercent } : {}),
+        ...(meta?.contextTokensUsed != null ? { contextTokensUsed: meta.contextTokensUsed } : {}),
+        ...(meta?.contextTokensMax != null ? { contextTokensMax: meta.contextTokensMax } : {}),
+        // When the gateway provides lastCallUsage but no explicit contextTokensUsed, use
+        // lastCallUsage.input as contextTokensUsed. This overrides the accumulated
+        // usage.input (which overstates context by summing across all tool-use loops).
+        ...(lastCallUsage?.input != null &&
+        agentMeta?.contextTokensUsed == null &&
+        meta?.contextTokensUsed == null
+          ? { contextTokensUsed: lastCallUsage.input }
+          : {}),
+      };
+      const usage = parseUsage(Object.keys(rawUsage).length > 0 ? rawUsage : undefined);
       const provider = nonEmpty(agentMeta?.provider) ?? nonEmpty(meta?.provider) ?? "openclaw";
       const model = nonEmpty(agentMeta?.model) ?? nonEmpty(meta?.model) ?? null;
       const costUsd = asNumber(agentMeta?.costUsd ?? meta?.costUsd, 0);

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -435,6 +435,107 @@ describe("openclaw gateway adapter execute", () => {
     }
   });
 
+  it("extracts contextTokensUsed from agentMeta.lastCallUsage when no explicit contextTokensUsed", async () => {
+    const server = createServer();
+    const wss = new WebSocketServer({ server });
+
+    wss.on("connection", (socket) => {
+      socket.send(
+        JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "nonce-ctx" } }),
+      );
+
+      socket.on("message", (raw) => {
+        const text = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw);
+        const frame = JSON.parse(text) as { type: string; id: string; method: string; params?: Record<string, unknown> };
+        if (frame.type !== "req") return;
+
+        if (frame.method === "connect") {
+          socket.send(JSON.stringify({
+            type: "res", id: frame.id, ok: true,
+            payload: {
+              type: "hello-ok", protocol: 3,
+              server: { version: "test", connId: "conn-ctx" },
+              features: { methods: ["connect", "agent", "agent.wait"], events: ["agent"] },
+              snapshot: { version: 1, ts: Date.now() },
+              policy: { maxPayload: 1_000_000, maxBufferedBytes: 1_000_000, tickIntervalMs: 30_000 },
+            },
+          }));
+          return;
+        }
+
+        if (frame.method === "agent") {
+          socket.send(JSON.stringify({
+            type: "res", id: frame.id, ok: true,
+            payload: { runId: "run-ctx", status: "accepted", acceptedAt: Date.now() },
+          }));
+          return;
+        }
+
+        if (frame.method === "agent.wait") {
+          socket.send(JSON.stringify({
+            type: "res", id: frame.id, ok: true,
+            payload: {
+              runId: "run-ctx",
+              status: "ok",
+              startedAt: 1,
+              endedAt: 2,
+              // Simulate OpenClaw gateway result with agentMeta including lastCallUsage
+              result: {
+                meta: {
+                  agentMeta: {
+                    provider: "anthropic",
+                    model: "claude-3-5-sonnet",
+                    usage: {
+                      // Accumulated across all tool-use loops (overstates context)
+                      input: 50000,
+                      output: 800,
+                      cacheRead: 10000,
+                      cacheWrite: 0,
+                      total: 60800,
+                    },
+                    lastCallUsage: {
+                      // Only the last API call — true context snapshot
+                      input: 35000,
+                      output: 800,
+                      cacheRead: 10000,
+                      cacheWrite: 0,
+                      total: 45800,
+                    },
+                    promptTokens: 45000,
+                  },
+                },
+                payloads: [{ text: "done" }],
+              },
+            },
+          }));
+        }
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("failed to get address");
+    const url = `ws://127.0.0.1:${(address as { port: number }).port}`;
+
+    try {
+      const result = await execute(buildContext({
+        url,
+        headers: { "x-openclaw-token": "token" },
+        waitTimeoutMs: 2000,
+      }));
+
+      expect(result.exitCode).toBe(0);
+      expect(result.usage).toBeDefined();
+      // contextTokensUsed should be lastCallUsage.input (35000), NOT accumulated usage.input (50000)
+      expect(result.usage?.contextTokensUsed).toBe(35000);
+      // inputTokens should still be the accumulated usage.input
+      expect(result.usage?.inputTokens).toBe(50000);
+    } finally {
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("fails fast when url is missing", async () => {
     const result = await execute(buildContext({}));
     expect(result.exitCode).toBe(1);


### PR DESCRIPTION
## Summary

Resolves ALE-1129.

The OpenClaw gateway cloud adapter now correctly surfaces context window usage (percentage, tokens used, and context window size) in the run result's `usage` field.

## Changes

### `packages/adapters/openclaw-gateway/src/server/execute.ts`

**1. Extend `parseUsage()` with context window fields**
- Extracts `contextUsagePercent`, `contextTokensUsed`, `contextTokensMax` from the raw usage record
- Derives `contextUsagePercent` from token counts when not explicitly provided: `Math.round(contextTokensUsed / contextTokensMax * 100)`
- These are forwarded into `AdapterExecutionResult.usage` which Paperclip stores and surfaces in the live-agents dashboard

**2. Fix meta lookup to also cover `agent.wait` response**
Previously, `result.meta.agentMeta` was only read from `acceptedPayload` (the initial agent response). For most runs, OpenClaw sends the final result metadata inside the `agent.wait` terminal snapshot. The code now checks both:
```
acceptedPayload.result.meta  → acceptedPayload.meta
  → latestResultPayload.result.meta  → latestResultPayload.meta
```

**3. Use `lastCallUsage.input` as `contextTokensUsed`**
OpenClaw's `agentMeta.usage.input` is the accumulated sum of input tokens across all tool-use loops in a run. This overstates the actual context window consumption. `agentMeta.lastCallUsage.input` reflects only the last API call — the true context snapshot at end of run. When `lastCallUsage.input` is available and no explicit `contextTokensUsed` is provided, it is used as the preferred source.

**4. Merge all context fields into rawUsage**
Explicit `contextUsagePercent` / `contextTokensUsed` / `contextTokensMax` at both `agentMeta` and `meta` levels are merged into the `rawUsage` object so they override the accumulated token fallbacks.

### `server/src/__tests__/openclaw-gateway-adapter.test.ts`

Added a new test that:
- Creates a mock gateway returning `agentMeta.lastCallUsage` (with `input: 35000`) alongside `agentMeta.usage.input` (accumulated: `50000`) in the `agent.wait` response
- Asserts `result.usage.contextTokensUsed === 35000` (lastCallUsage wins)
- Asserts `result.usage.inputTokens === 50000` (accumulated usage unchanged)

## Test results

```
Test Files  34 passed (34)
     Tests  144 passed (144)
```