### PR TITLE
feat(ui): add parent issue picker to New Issue dialog

### DIFF
--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -476,6 +476,7 @@ export function NewIssueDialog() {
       ...(selectedAssigneeAgentId ? { assigneeAgentId: selectedAssigneeAgentId } : {}),
       ...(selectedAssigneeUserId ? { assigneeUserId: selectedAssigneeUserId } : {}),
       ...(projectId ? { projectId } : {}),
+      ...(parentId ? { parentId } : {}),
       ...(assigneeAdapterOverrides ? { assigneeAdapterOverrides } : {}),
       ...(executionWorkspaceSettings ? { executionWorkspaceSettings } : {}),
     });

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -877,6 +877,9 @@ export function NewIssueDialog() {
                 searchPlaceholder="Search by title or ID..."
                 emptyMessage="No issues found."
                 onChange={setParentId}
+                onConfirm={() => {
+                  descriptionEditorRef.current?.focus();
+                }}
                 renderTriggerValue={(option) =>
                   option ? (
                     <span className="flex items-center gap-1 truncate max-w-[160px]">

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -71,6 +71,7 @@ interface IssueDraft {
   assigneeValue: string;
   assigneeId?: string;
   projectId: string;
+  parentId?: string;
   assigneeModelOverride: string;
   assigneeThinkingEffort: string;
   assigneeChrome: boolean;
@@ -181,6 +182,7 @@ export function NewIssueDialog() {
   const [priority, setPriority] = useState("");
   const [assigneeValue, setAssigneeValue] = useState("");
   const [projectId, setProjectId] = useState("");
+  const [parentId, setParentId] = useState("");
   const [assigneeOptionsOpen, setAssigneeOptionsOpen] = useState(false);
   const [assigneeModelOverride, setAssigneeModelOverride] = useState("");
   const [assigneeThinkingEffort, setAssigneeThinkingEffort] = useState("");
@@ -406,6 +408,7 @@ export function NewIssueDialog() {
     setPriority("");
     setAssigneeValue("");
     setProjectId("");
+    setParentId("");
     setAssigneeOptionsOpen(false);
     setAssigneeModelOverride("");
     setAssigneeThinkingEffort("");
@@ -422,6 +425,7 @@ export function NewIssueDialog() {
     setDialogCompanyId(companyId);
     setAssigneeValue("");
     setProjectId("");
+    setParentId("");
     setAssigneeModelOverride("");
     setAssigneeThinkingEffort("");
     setAssigneeChrome(false);

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -881,16 +881,30 @@ export function NewIssueDialog() {
                 onConfirm={() => {
                   descriptionEditorRef.current?.focus();
                 }}
-                renderTriggerValue={(option) =>
-                  option ? (
-                    <span className="flex items-center gap-1 truncate max-w-[160px]">
+                renderTriggerValue={(option) => {
+                  if (!option) return <span className="text-muted-foreground">Parent</span>;
+                  const spaceIdx = option.label.indexOf(" ");
+                  const identifier = spaceIdx >= 0 ? option.label.slice(0, spaceIdx) : option.label;
+                  const title = spaceIdx >= 0 ? option.label.slice(spaceIdx + 1) : "";
+                  return (
+                    <span className="flex items-center gap-1 min-w-0 max-w-[180px]">
                       <span className="shrink-0 text-muted-foreground">⤴</span>
-                      <span className="truncate">{option.label}</span>
+                      <span className="shrink-0">{identifier}</span>
+                      {title && <span className="truncate text-muted-foreground">{title}</span>}
                     </span>
-                  ) : (
-                    <span className="text-muted-foreground">Parent</span>
-                  )
-                }
+                  );
+                }}
+                renderOption={(option) => {
+                  const spaceIdx = option.label.indexOf(" ");
+                  const identifier = spaceIdx >= 0 ? option.label.slice(0, spaceIdx) : option.label;
+                  const title = spaceIdx >= 0 ? option.label.slice(spaceIdx + 1) : "";
+                  return (
+                    <span className="flex items-center gap-2 min-w-0 w-full">
+                      <span className="shrink-0 text-muted-foreground text-xs font-mono">{identifier}</span>
+                      {title && <span className="truncate">{title}</span>}
+                    </span>
+                  );
+                }}
               />
             </div>
           </div>

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -217,6 +217,13 @@ export function NewIssueDialog() {
     queryFn: () => projectsApi.list(effectiveCompanyId!),
     enabled: !!effectiveCompanyId && newIssueOpen,
   });
+
+  const { data: allIssues } = useQuery({
+    queryKey: queryKeys.issues.list(effectiveCompanyId!),
+    queryFn: () => issuesApi.list(effectiveCompanyId!, {}),
+    enabled: !!effectiveCompanyId && newIssueOpen,
+  });
+
   const { data: session } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -545,6 +552,17 @@ export function NewIssueDialog() {
       })),
     [orderedProjects],
   );
+
+  const parentOptions = useMemo<InlineEntityOption[]>(
+    () =>
+      (allIssues ?? []).map((issue) => ({
+        id: issue.id,
+        label: `${issue.identifier ?? issue.id.slice(0, 8)} ${issue.title}`,
+        searchText: `${issue.identifier ?? issue.id.slice(0, 8)} ${issue.title}`,
+      })),
+    [allIssues],
+  );
+
   const savedDraft = loadDraft();
   const hasSavedDraft = Boolean(savedDraft?.title.trim() || savedDraft?.description.trim());
   const canDiscardDraft = hasDraft || hasSavedDraft;

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -309,6 +309,7 @@ export function NewIssueDialog() {
       priority,
       assigneeValue,
       projectId,
+      parentId,
       assigneeModelOverride,
       assigneeThinkingEffort,
       assigneeChrome,
@@ -321,6 +322,7 @@ export function NewIssueDialog() {
     priority,
     assigneeValue,
     projectId,
+    parentId,
     assigneeModelOverride,
     assigneeThinkingEffort,
     assigneeChrome,
@@ -342,6 +344,7 @@ export function NewIssueDialog() {
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
       setProjectId(newIssueDefaults.projectId ?? "");
+      setParentId(newIssueDefaults.parentId ?? "");
       setAssigneeValue(assigneeValueFromSelection(newIssueDefaults));
       setAssigneeModelOverride("");
       setAssigneeThinkingEffort("");
@@ -358,6 +361,7 @@ export function NewIssueDialog() {
           : (draft.assigneeValue ?? draft.assigneeId ?? ""),
       );
       setProjectId(newIssueDefaults.projectId ?? draft.projectId);
+      setParentId(newIssueDefaults.parentId ?? draft.parentId ?? "");
       setAssigneeModelOverride(draft.assigneeModelOverride ?? "");
       setAssigneeThinkingEffort(draft.assigneeThinkingEffort ?? "");
       setAssigneeChrome(draft.assigneeChrome ?? false);
@@ -366,6 +370,7 @@ export function NewIssueDialog() {
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
       setProjectId(newIssueDefaults.projectId ?? "");
+      setParentId(newIssueDefaults.parentId ?? "");
       setAssigneeValue(assigneeValueFromSelection(newIssueDefaults));
       setAssigneeModelOverride("");
       setAssigneeThinkingEffort("");

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -867,6 +867,27 @@ export function NewIssueDialog() {
                   );
                 }}
               />
+              <span>under</span>
+              <InlineEntitySelector
+                value={parentId}
+                options={parentOptions}
+                placeholder="Parent"
+                disablePortal
+                noneLabel="No parent"
+                searchPlaceholder="Search by title or ID..."
+                emptyMessage="No issues found."
+                onChange={setParentId}
+                renderTriggerValue={(option) =>
+                  option ? (
+                    <span className="flex items-center gap-1 truncate max-w-[160px]">
+                      <span className="shrink-0 text-muted-foreground">⤴</span>
+                      <span className="truncate">{option.label}</span>
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">Parent</span>
+                  )
+                }
+              />
             </div>
           </div>
         </div>

--- a/ui/src/context/DialogContext.tsx
+++ b/ui/src/context/DialogContext.tsx
@@ -8,6 +8,7 @@ interface NewIssueDefaults {
   assigneeUserId?: string;
   title?: string;
   description?: string;
+  parentId?: string;
 }
 
 interface NewGoalDefaults {


### PR DESCRIPTION
## Summary

- Adds a **Parent** pill to the New Issue toolbar via `InlineEntitySelector`, letting users assign a parent issue at creation time
- Fetches the company's issue list and formats options as `IDENTIFIER Title` for easy scanning
- Renders the selected parent in the pill with identifier (`shrink-0`) and title (`truncate`) so long titles never clip the ID
- Persists `parentId` in the draft (localStorage) and includes it in the `createIssue` mutation payload

## Changes

| File | What changed |
|------|-------------|
| `ui/src/components/NewIssueDialog.tsx` | Parent state, draft persistence, `parentOptions` query, toolbar pill, submit payload |
| `ui/src/types/issues.ts` | Added `parentId` to `NewIssueDefaults` |

## Test Plan

- [ ] Open New Issue dialog — **Parent** pill appears in toolbar
- [ ] Click pill — dropdown lists issues with `IDENTIFIER Title` format
- [ ] Select a parent — pill shows `⤴ IDENTIFIER Title` with title truncating on overflow
- [ ] Keyboard: Enter/Tab confirms selection
- [ ] Submit issue — created issue has `parentId` set correctly
- [ ] Reload page mid-draft — parent selection is restored from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)