### PR TITLE
feat(heartbeat): zero-cost timer-skip when no assigned open task

### DIFF
--- a/server/src/__tests__/heartbeat-timer-skip.test.ts
+++ b/server/src/__tests__/heartbeat-timer-skip.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isTimerSkipEnabled } from "../services/heartbeat.ts";
+import { isTimerSkipEnabled, shouldSkipTimerWake } from "../services/heartbeat.ts";
 
 describe("isTimerSkipEnabled", () => {
   it("returns false when runtimeConfig is absent", () => {
@@ -40,5 +40,34 @@ describe("isTimerSkipEnabled", () => {
     expect(
       isTimerSkipEnabled({ budget: { monthlyCents: 5000 }, heartbeat: { skipTimerWhenNoAssignedOpenIssue: true } }),
     ).toBe(true);
+  });
+});
+
+const enabledConfig = { heartbeat: { skipTimerWhenNoAssignedOpenIssue: true } };
+const disabledConfig = { heartbeat: { skipTimerWhenNoAssignedOpenIssue: false } };
+
+describe("shouldSkipTimerWake", () => {
+  it("skips when flag is enabled and agent has no open issues", () => {
+    expect(shouldSkipTimerWake(enabledConfig, 0)).toBe(true);
+  });
+
+  it("does not skip when flag is enabled and agent has open issues", () => {
+    expect(shouldSkipTimerWake(enabledConfig, 1)).toBe(false);
+    expect(shouldSkipTimerWake(enabledConfig, 5)).toBe(false);
+  });
+
+  it("does not skip when flag is disabled, regardless of issue count", () => {
+    expect(shouldSkipTimerWake(disabledConfig, 0)).toBe(false);
+    expect(shouldSkipTimerWake(disabledConfig, 3)).toBe(false);
+  });
+
+  it("does not skip when flag is absent, regardless of issue count", () => {
+    expect(shouldSkipTimerWake(null, 0)).toBe(false);
+    expect(shouldSkipTimerWake({}, 0)).toBe(false);
+    expect(shouldSkipTimerWake({ heartbeat: {} }, 0)).toBe(false);
+  });
+
+  it("does not skip when count is non-zero with flag enabled (boundary check)", () => {
+    expect(shouldSkipTimerWake(enabledConfig, 1)).toBe(false);
   });
 });

--- a/server/src/__tests__/heartbeat-timer-skip.test.ts
+++ b/server/src/__tests__/heartbeat-timer-skip.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { isTimerSkipEnabled } from "../services/heartbeat.ts";
+
+describe("isTimerSkipEnabled", () => {
+  it("returns false when runtimeConfig is absent", () => {
+    expect(isTimerSkipEnabled(null)).toBe(false);
+    expect(isTimerSkipEnabled(undefined)).toBe(false);
+  });
+
+  it("returns false when runtimeConfig has no heartbeat key", () => {
+    expect(isTimerSkipEnabled({})).toBe(false);
+  });
+
+  it("returns false when heartbeat object has no flag", () => {
+    expect(isTimerSkipEnabled({ heartbeat: {} })).toBe(false);
+  });
+
+  it("returns false when flag is explicitly false", () => {
+    expect(
+      isTimerSkipEnabled({ heartbeat: { skipTimerWhenNoAssignedOpenIssue: false } }),
+    ).toBe(false);
+  });
+
+  it("returns true when flag is enabled", () => {
+    expect(
+      isTimerSkipEnabled({ heartbeat: { skipTimerWhenNoAssignedOpenIssue: true } }),
+    ).toBe(true);
+  });
+
+  it("returns false for truthy non-boolean values (strict boolean check)", () => {
+    expect(
+      isTimerSkipEnabled({ heartbeat: { skipTimerWhenNoAssignedOpenIssue: 1 } }),
+    ).toBe(false);
+    expect(
+      isTimerSkipEnabled({ heartbeat: { skipTimerWhenNoAssignedOpenIssue: "true" } }),
+    ).toBe(false);
+  });
+
+  it("ignores unrelated runtimeConfig keys", () => {
+    expect(
+      isTimerSkipEnabled({ budget: { monthlyCents: 5000 }, heartbeat: { skipTimerWhenNoAssignedOpenIssue: true } }),
+    ).toBe(true);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -365,6 +365,16 @@ export function isTimerSkipEnabled(runtimeConfig: unknown): boolean {
   return (heartbeat as Record<string, unknown>).skipTimerWhenNoAssignedOpenIssue === true;
 }
 
+/**
+ * Returns true when a timer wake should be skipped for an agent.
+ * The flag must be enabled AND the agent must have zero open assigned issues.
+ * Callers are responsible for querying the issue count.
+ */
+export function shouldSkipTimerWake(runtimeConfig: unknown, openIssueCount: number): boolean {
+  if (!isTimerSkipEnabled(runtimeConfig)) return false;
+  return openIssueCount === 0;
+}
+
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -1138,7 +1148,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
-      skipTimerWhenNoAssignedOpenIssue: isTimerSkipEnabled(agent.runtimeConfig),
+      skipTimerWhenNoAssignedOpenIssue: heartbeat.skipTimerWhenNoAssignedOpenIssue === true,
     };
   }
 
@@ -2835,7 +2845,7 @@ export function heartbeatService(db: Db) {
                 inArray(issues.status, ["todo", "in_progress", "blocked", "in_review"]),
               ),
             );
-          if (Number(count ?? 0) === 0) {
+          if (shouldSkipTimerWake(agent.runtimeConfig, Number(count ?? 0))) {
             skipped += 1;
             continue;
           }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -353,6 +353,18 @@ function deriveTaskKey(
   );
 }
 
+/**
+ * Returns true when the agent's runtimeConfig explicitly enables the timer-skip
+ * optimization. Intentionally strict: only a literal `true` boolean enables it,
+ * so absent or string-truthy values keep the default (disabled) behavior.
+ */
+export function isTimerSkipEnabled(runtimeConfig: unknown): boolean {
+  if (runtimeConfig === null || typeof runtimeConfig !== "object") return false;
+  const heartbeat = (runtimeConfig as Record<string, unknown>).heartbeat;
+  if (heartbeat === null || typeof heartbeat !== "object") return false;
+  return (heartbeat as Record<string, unknown>).skipTimerWhenNoAssignedOpenIssue === true;
+}
+
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -1126,6 +1138,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      skipTimerWhenNoAssignedOpenIssue: isTimerSkipEnabled(agent.runtimeConfig),
     };
   }
 
@@ -2810,6 +2823,23 @@ export function heartbeatService(db: Db) {
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        if (policy.skipTimerWhenNoAssignedOpenIssue) {
+          const [{ count }] = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(issues)
+            .where(
+              and(
+                eq(issues.companyId, agent.companyId),
+                eq(issues.assigneeAgentId, agent.id),
+                inArray(issues.status, ["todo", "in_progress", "blocked", "in_review"]),
+              ),
+            );
+          if (Number(count ?? 0) === 0) {
+            skipped += 1;
+            continue;
+          }
+        }
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -877,6 +877,16 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   className={inputClass}
                 />
               </Field>
+              <ToggleField
+                label="Skip timer when no assigned open task"
+                hint={help.skipTimerWhenNoAssignedOpenIssue}
+                checked={eff(
+                  "heartbeat",
+                  "skipTimerWhenNoAssignedOpenIssue",
+                  heartbeat.skipTimerWhenNoAssignedOpenIssue === true,
+                )}
+                onChange={(v) => mark("heartbeat", "skipTimerWhenNoAssignedOpenIssue", v)}
+              />
             </div>
           </CollapsibleSection>
           </div>

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -54,6 +54,7 @@ export const help: Record<string, string> = {
   wakeOnDemand: "Allow this agent to be woken by assignments, API calls, UI actions, or automated systems.",
   cooldownSec: "Minimum seconds between consecutive heartbeat runs.",
   maxConcurrentRuns: "Maximum number of heartbeat runs that can execute simultaneously for this agent.",
+  skipTimerWhenNoAssignedOpenIssue: "When enabled, scheduled interval heartbeats are skipped if the agent has no assigned task in an actionable state (todo, in progress, blocked, or in review). Assignment, approval, comment, and manual wakes are unaffected.",
   budgetMonthlyCents: "Monthly spending limit in cents. 0 means no limit.",
 };
 


### PR DESCRIPTION
## Summary

Adds a default-off per-agent toggle that skips scheduled interval heartbeats entirely when the agent has no assigned task in an actionable state — at zero LLM or API cost.

## Motivation

Agents that heartbeat on a timer but spend long stretches without assigned work incur unnecessary infrastructure and token cost just to discover there is nothing to do. This toggle lets operators opt specific agents out of empty timer wakes at the scheduler level, before any run is enqueued or a worker is invoked.

## Relationship to PR #786

PR #786 addresses the same complaint via a cheap LLM pre-screen inside `executeRun`. This PR takes a complementary, lower-level approach:

| | This PR | PR #786 |
|---|---|---|
| Insertion point | `tickTimers()` — before wakeup is enqueued | `executeRun()` — after run is claimed by a worker |
| Cost when idle | Zero (one SQL `COUNT(*)`) | Small (cheap model API call) |
| Works for non-issue work | No | Yes (LLM reasons freely) |
| Best for | Worker agents whose work is entirely Paperclip issues | Strategic/manager agents with broader responsibilities |

The two changes touch different functions and different config fields — no conflict, they compose cleanly.

## What changes

**Config** — no schema migration, stored in existing `runtimeConfig` jsonb:
```ts
runtimeConfig.heartbeat.skipTimerWhenNoAssignedOpenIssue: boolean  // default: false/absent
```

**Behavior contract**
- Applies only to `source: "timer"` wakes from `tickTimers()`
- Does not affect assignment, approval, comment, automation, or manual wakes
- Default off; operators enable per agent in the UI (Advanced Run Policy)
- Actionable statuses counted: `todo`, `in_progress`, `blocked`, `in_review`
- `backlog`, `done`, `cancelled` do not satisfy the guard

**Files changed**

| File | Change |
|---|---|
| `server/src/services/heartbeat.ts` | Export `isTimerSkipEnabled()` + `shouldSkipTimerWake()` pure helpers; extend `parseHeartbeatPolicy()`; add `COUNT(*)` guard in `tickTimers()` |
| `server/src/__tests__/heartbeat-timer-skip.test.ts` | 12 unit tests covering config reading and skip decision logic (new file) |
| `ui/src/components/AgentConfigForm.tsx` | Toggle under Advanced Run Policy |
| `ui/src/components/agent-config-primitives.tsx` | Help text entry |

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm test:run` — 310 passing, 1 skipped, 0 failures (72 files)
- [x] `pnpm build` — clean
- [ ] Manual: enable toggle on a worker agent with no open issues, verify timer wakes stop appearing in run history
- [ ] Manual: assign an issue to that agent, verify timer wakes resume
- [ ] Manual: confirm on-demand and assignment wakes still fire with toggle enabled

Made with [Cursor](https://cursor.com)