### PR TITLE
feat: default new projects to isolated git worktree execution

### DIFF
--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -370,6 +370,20 @@ export function projectService(db: Db) {
         projectData.color = nextColor;
       }
 
+      // Default to isolated git worktree execution if no policy provided
+      if (!projectData.executionWorkspacePolicy) {
+        projectData.executionWorkspacePolicy = {
+          enabled: true,
+          defaultMode: "isolated",
+          allowIssueOverride: true,
+          workspaceStrategy: {
+            type: "git_worktree",
+            branchTemplate: "{{issue.identifier}}-{{slug}}",
+            worktreeParentDir: ".paperclip/worktrees",
+          },
+        };
+      }
+
       const existingProjects = await db
         .select({ id: projects.id, name: projects.name })
         .from(projects)


### PR DESCRIPTION
## Summary

- New projects now automatically get `executionWorkspacePolicy` with `isolated` mode and `git_worktree` strategy when no policy is explicitly provided
- Prevents parallel agents from clobbering each other's git state by giving each issue its own worktree branch
- Existing projects can still override by passing an explicit policy at creation time

Resolves OCT-181

## Test plan

- [x] TypeScript typecheck passes
- [ ] Create a new project without specifying `executionWorkspacePolicy` and verify it defaults to isolated git worktree mode
- [ ] Create a new project with an explicit policy and verify the explicit policy is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)