### PR TITLE
chore(server): avoid `any` types for db parameter in startup sequence

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -174,7 +174,7 @@ export async function startServer(): Promise<StartedServer> {
   const LOCAL_BOARD_USER_EMAIL = "local@paperclip.local";
   const LOCAL_BOARD_USER_NAME = "Board";
   
-  async function ensureLocalTrustedBoardPrincipal(db: any): Promise<void> {
+  async function ensureLocalTrustedBoardPrincipal(db: import("@paperclipai/db").Db): Promise<void> {
     const now = new Date();
     const existingUser = await db
       .select({ id: authUsers.id })
@@ -230,7 +230,7 @@ export async function startServer(): Promise<StartedServer> {
     }
   }
   
-  let db;
+  let db: import("@paperclipai/db").Db;
   let embeddedPostgres: EmbeddedPostgresInstance | null = null;
   let embeddedPostgresStartedByThisProcess = false;
   let migrationSummary: MigrationSummary = "skipped";
@@ -419,7 +419,7 @@ export async function startServer(): Promise<StartedServer> {
     | ((headers: Headers) => Promise<BetterAuthSessionResult | null>)
     | undefined;
   if (config.deploymentMode === "local_trusted") {
-    await ensureLocalTrustedBoardPrincipal(db as any);
+    await ensureLocalTrustedBoardPrincipal(db);
   }
   if (config.deploymentMode === "authenticated") {
     const {
@@ -454,18 +454,18 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Authenticated mode auth origin configuration",
     );
-    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
+    const auth = createBetterAuthInstance(db, config, effectiveTrustedOrigins);
     betterAuthHandler = createBetterAuthHandler(auth);
     resolveSession = (req) => resolveBetterAuthSession(auth, req);
     resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);
-    await initializeBoardClaimChallenge(db as any, { deploymentMode: config.deploymentMode });
+    await initializeBoardClaimChallenge(db, { deploymentMode: config.deploymentMode });
     authReady = true;
   }
   
   const listenPort = await detectPort(config.port);
   const uiMode = config.uiDevMiddleware ? "vite-dev" : config.serveUi ? "static" : "none";
   const storageService = createStorageServiceFromConfig(config);
-  const app = await createApp(db as any, {
+  const app = await createApp(db, {
     uiMode,
     serverPort: listenPort,
     storageService,
@@ -493,12 +493,12 @@ export async function startServer(): Promise<StartedServer> {
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
   process.env.PAPERCLIP_API_URL = `http://${runtimeApiHost}:${listenPort}`;
   
-  setupLiveEventsWebSocketServer(server, db as any, {
+  setupLiveEventsWebSocketServer(server, db, {
     deploymentMode: config.deploymentMode,
     resolveSessionFromHeaders,
   });
 
-  void reconcilePersistedRuntimeServicesOnStartup(db as any)
+  void reconcilePersistedRuntimeServicesOnStartup(db)
     .then((result) => {
       if (result.reconciled > 0) {
         logger.warn(
@@ -512,7 +512,7 @@ export async function startServer(): Promise<StartedServer> {
     });
   
   if (config.heartbeatSchedulerEnabled) {
-    const heartbeat = heartbeatService(db as any);
+    const heartbeat = heartbeatService(db);
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.


### PR DESCRIPTION
Fixes #897\n\nRefactored `server/src/index.ts` to use explicit `import(\@paperclipai/db\).Db` type for the `db` variable and the `ensureLocalTrustedBoardPrincipal` function parameter instead of relying on `any`. This eliminates several `db as any` casts throughout the initialization sequence (such as `createApp`, `setupLiveEventsWebSocketServer`, etc.), improving type safety.