### PR TITLE
Add buildPluginSdk function to build the plugin SDK during dev run

### DIFF
--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -162,10 +162,15 @@ async function buildPluginSdk() {
     ["--filter", "@paperclipai/plugin-sdk", "build"],
     { stdio: "inherit" },
   );
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
   if (result.code !== 0) {
     console.error("[paperclip] plugin sdk build failed");
     process.exit(result.code);
   }
+}
 }
 
 await buildPluginSdk();


### PR DESCRIPTION
Without this, the server won't start if plugin sdk hasn't been built yet.