### PR TITLE
fix: inject safe.directory config for git workspace operations

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { parse as parseEnvContents } from "dotenv";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   agents,
   companies,

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { parse as parseEnvContents } from "dotenv";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   agents,
   companies,
@@ -19,6 +19,7 @@ import {
 } from "@paperclipai/db";
 import { eq } from "drizzle-orm";
 import {
+  buildSafeDirectoryEnv,
   buildWorkspaceRuntimeDesiredStatePatch,
   cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
@@ -3358,5 +3359,87 @@ describe("normalizeAdapterManagedRuntimeServices", () => {
       scopeId: "execution-workspace-1",
       executionWorkspaceId: "execution-workspace-1",
     });
+  });
+});
+
+describe("buildSafeDirectoryEnv (safe.directory injection)", () => {
+  let originalGitConfigEnv: Record<string, string> = {};
+
+  beforeEach(() => {
+    originalGitConfigEnv = {};
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("GIT_CONFIG_")) {
+        originalGitConfigEnv[key] = process.env[key] as string;
+      }
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("GIT_CONFIG_")) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalGitConfigEnv)) {
+      process.env[key] = value;
+    }
+  });
+
+  it("sets GIT_CONFIG_COUNT, KEY, and VALUE for safe.directory when no prior config exists", () => {
+    delete process.env.GIT_CONFIG_COUNT;
+    const env = buildSafeDirectoryEnv("/tmp/my-repo");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/tmp/my-repo");
+  });
+
+  it("increments existing GIT_CONFIG_COUNT and uses the next index", () => {
+    process.env.GIT_CONFIG_COUNT = "2";
+    process.env.GIT_CONFIG_KEY_0 = "core.autocrlf";
+    process.env.GIT_CONFIG_VALUE_0 = "false";
+    process.env.GIT_CONFIG_KEY_1 = "user.email";
+    process.env.GIT_CONFIG_VALUE_1 = "test@example.com";
+
+    const env = buildSafeDirectoryEnv("/workspace/project");
+    expect(env.GIT_CONFIG_COUNT).toBe("3");
+    expect(env.GIT_CONFIG_KEY_2).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_2).toBe("/workspace/project");
+    expect(env.GIT_CONFIG_KEY_0).toBe("core.autocrlf");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("false");
+    expect(env.GIT_CONFIG_KEY_1).toBe("user.email");
+    expect(env.GIT_CONFIG_VALUE_1).toBe("test@example.com");
+  });
+
+  it("guards against non-numeric GIT_CONFIG_COUNT by treating it as 0", () => {
+    process.env.GIT_CONFIG_COUNT = "not-a-number";
+    const env = buildSafeDirectoryEnv("/repo");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/repo");
+  });
+
+  it("guards against negative GIT_CONFIG_COUNT by clamping to 0", () => {
+    process.env.GIT_CONFIG_COUNT = "-5";
+    const env = buildSafeDirectoryEnv("/repo");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/repo");
+  });
+
+  it("scopes safe.directory to the specific cwd, not a wildcard", () => {
+    delete process.env.GIT_CONFIG_COUNT;
+    const env = buildSafeDirectoryEnv("/specific/path");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/specific/path");
+    expect(env.GIT_CONFIG_VALUE_0).not.toBe("*");
+  });
+
+  it("does not mutate process.env", () => {
+    delete process.env.GIT_CONFIG_COUNT;
+    delete process.env.GIT_CONFIG_KEY_0;
+    delete process.env.GIT_CONFIG_VALUE_0;
+    buildSafeDirectoryEnv("/tmp/test");
+    expect(process.env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(process.env.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(process.env.GIT_CONFIG_VALUE_0).toBeUndefined();
   });
 });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3239,9 +3239,16 @@ describe("normalizeAdapterManagedRuntimeServices", () => {
 });
 
 describe("buildSafeDirectoryEnv (safe.directory injection)", () => {
-  const originalGitConfigCount = process.env.GIT_CONFIG_COUNT;
-  const originalGitConfigKey0 = process.env.GIT_CONFIG_KEY_0;
-  const originalGitConfigValue0 = process.env.GIT_CONFIG_VALUE_0;
+  let originalGitConfigEnv: Record<string, string> = {};
+
+  beforeEach(() => {
+    originalGitConfigEnv = {};
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("GIT_CONFIG_")) {
+        originalGitConfigEnv[key] = process.env[key] as string;
+      }
+    }
+  });
 
   afterEach(() => {
     for (const key of Object.keys(process.env)) {
@@ -3249,9 +3256,9 @@ describe("buildSafeDirectoryEnv (safe.directory injection)", () => {
         delete process.env[key];
       }
     }
-    if (originalGitConfigCount !== undefined) process.env.GIT_CONFIG_COUNT = originalGitConfigCount;
-    if (originalGitConfigKey0 !== undefined) process.env.GIT_CONFIG_KEY_0 = originalGitConfigKey0;
-    if (originalGitConfigValue0 !== undefined) process.env.GIT_CONFIG_VALUE_0 = originalGitConfigValue0;
+    for (const [key, value] of Object.entries(originalGitConfigEnv)) {
+      process.env[key] = value;
+    }
   });
 
   it("sets GIT_CONFIG_COUNT, KEY, and VALUE for safe.directory when no prior config exists", () => {
@@ -3275,6 +3282,8 @@ describe("buildSafeDirectoryEnv (safe.directory injection)", () => {
     expect(env.GIT_CONFIG_VALUE_2).toBe("/workspace/project");
     expect(env.GIT_CONFIG_KEY_0).toBe("core.autocrlf");
     expect(env.GIT_CONFIG_VALUE_0).toBe("false");
+    expect(env.GIT_CONFIG_KEY_1).toBe("user.email");
+    expect(env.GIT_CONFIG_VALUE_1).toBe("test@example.com");
   });
 
   it("guards against non-numeric GIT_CONFIG_COUNT by treating it as 0", () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@paperclipai/db";
 import { eq } from "drizzle-orm";
 import {
+  buildSafeDirectoryEnv,
   buildWorkspaceRuntimeDesiredStatePatch,
   cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
@@ -3234,5 +3235,78 @@ describe("normalizeAdapterManagedRuntimeServices", () => {
       scopeId: "execution-workspace-1",
       executionWorkspaceId: "execution-workspace-1",
     });
+  });
+});
+
+describe("buildSafeDirectoryEnv (safe.directory injection)", () => {
+  const originalGitConfigCount = process.env.GIT_CONFIG_COUNT;
+  const originalGitConfigKey0 = process.env.GIT_CONFIG_KEY_0;
+  const originalGitConfigValue0 = process.env.GIT_CONFIG_VALUE_0;
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("GIT_CONFIG_")) {
+        delete process.env[key];
+      }
+    }
+    if (originalGitConfigCount !== undefined) process.env.GIT_CONFIG_COUNT = originalGitConfigCount;
+    if (originalGitConfigKey0 !== undefined) process.env.GIT_CONFIG_KEY_0 = originalGitConfigKey0;
+    if (originalGitConfigValue0 !== undefined) process.env.GIT_CONFIG_VALUE_0 = originalGitConfigValue0;
+  });
+
+  it("sets GIT_CONFIG_COUNT, KEY, and VALUE for safe.directory when no prior config exists", () => {
+    delete process.env.GIT_CONFIG_COUNT;
+    const env = buildSafeDirectoryEnv("/tmp/my-repo");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/tmp/my-repo");
+  });
+
+  it("increments existing GIT_CONFIG_COUNT and uses the next index", () => {
+    process.env.GIT_CONFIG_COUNT = "2";
+    process.env.GIT_CONFIG_KEY_0 = "core.autocrlf";
+    process.env.GIT_CONFIG_VALUE_0 = "false";
+    process.env.GIT_CONFIG_KEY_1 = "user.email";
+    process.env.GIT_CONFIG_VALUE_1 = "test@example.com";
+
+    const env = buildSafeDirectoryEnv("/workspace/project");
+    expect(env.GIT_CONFIG_COUNT).toBe("3");
+    expect(env.GIT_CONFIG_KEY_2).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_2).toBe("/workspace/project");
+    expect(env.GIT_CONFIG_KEY_0).toBe("core.autocrlf");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("false");
+  });
+
+  it("guards against non-numeric GIT_CONFIG_COUNT by treating it as 0", () => {
+    process.env.GIT_CONFIG_COUNT = "not-a-number";
+    const env = buildSafeDirectoryEnv("/repo");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/repo");
+  });
+
+  it("guards against negative GIT_CONFIG_COUNT by clamping to 0", () => {
+    process.env.GIT_CONFIG_COUNT = "-5";
+    const env = buildSafeDirectoryEnv("/repo");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/repo");
+  });
+
+  it("scopes safe.directory to the specific cwd, not a wildcard", () => {
+    delete process.env.GIT_CONFIG_COUNT;
+    const env = buildSafeDirectoryEnv("/specific/path");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("/specific/path");
+    expect(env.GIT_CONFIG_VALUE_0).not.toBe("*");
+  });
+
+  it("does not mutate process.env", () => {
+    delete process.env.GIT_CONFIG_COUNT;
+    delete process.env.GIT_CONFIG_KEY_0;
+    delete process.env.GIT_CONFIG_VALUE_0;
+    buildSafeDirectoryEnv("/tmp/test");
+    expect(process.env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(process.env.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(process.env.GIT_CONFIG_VALUE_0).toBeUndefined();
   });
 });

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -462,6 +462,23 @@ function createProcessOutputCapture(maxBytes: number): ProcessOutputAccumulator 
   };
 }
 
+/**
+ * Build a process env that injects safe.directory for the target cwd via
+ * one-shot GIT_CONFIG env vars so git doesn't reject cross-filesystem paths
+ * (e.g. WSL mounts accessed from Windows). Only affects the spawned subprocess.
+ */
+export function buildSafeDirectoryEnv(cwd: string): Record<string, string> {
+  const env: Record<string, string> = Object.fromEntries(
+    Object.entries(process.env).filter((e): e is [string, string] => e[1] != null),
+  );
+  const parsed = parseInt(env.GIT_CONFIG_COUNT ?? "0", 10);
+  const existingCount = Math.max(0, Number.isFinite(parsed) ? parsed : 0);
+  env.GIT_CONFIG_COUNT = String(existingCount + 1);
+  env[`GIT_CONFIG_KEY_${existingCount}`] = "safe.directory";
+  env[`GIT_CONFIG_VALUE_${existingCount}`] = cwd;
+  return env;
+}
+
 async function executeProcess(input: {
   command: string;
   args: string[];
@@ -517,6 +534,7 @@ async function runGit(args: string[], cwd: string): Promise<string> {
     command: "git",
     args,
     cwd,
+    env: buildSafeDirectoryEnv(cwd) as NodeJS.ProcessEnv,
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);
@@ -795,6 +813,7 @@ async function recordGitOperation(
         command: "git",
         args: input.args,
         cwd: input.cwd,
+        env: buildSafeDirectoryEnv(input.cwd) as NodeJS.ProcessEnv,
       });
       stdout = result.stdout;
       stderr = result.stderr;

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -457,16 +457,16 @@ function createProcessOutputCapture(maxBytes: number): ProcessOutputAccumulator 
 }
 
 /**
- * Build a process env that injects safe.directory=* via one-shot GIT_CONFIG
- * env vars so git doesn't reject cross-filesystem paths (e.g. WSL mounts
- * accessed from Windows). Only affects the spawned subprocess.
+ * Build a process env that injects safe.directory for the target cwd via
+ * one-shot GIT_CONFIG env vars so git doesn't reject cross-filesystem paths
+ * (e.g. WSL mounts accessed from Windows). Only affects the spawned subprocess.
  */
-function buildGitSafeDirectoryEnv(): NodeJS.ProcessEnv {
+function buildGitSafeDirectoryEnv(cwd: string): NodeJS.ProcessEnv {
   const gitEnv = { ...process.env } as Record<string, string>;
-  const existingCount = parseInt(gitEnv.GIT_CONFIG_COUNT ?? "0", 10) || 0;
+  const existingCount = Math.max(0, parseInt(gitEnv.GIT_CONFIG_COUNT ?? "0", 10) || 0);
   gitEnv.GIT_CONFIG_COUNT = String(existingCount + 1);
   gitEnv[`GIT_CONFIG_KEY_${existingCount}`] = "safe.directory";
-  gitEnv[`GIT_CONFIG_VALUE_${existingCount}`] = "*";
+  gitEnv[`GIT_CONFIG_VALUE_${existingCount}`] = cwd;
   return gitEnv;
 }
 
@@ -525,7 +525,7 @@ async function runGit(args: string[], cwd: string): Promise<string> {
     command: "git",
     args,
     cwd,
-    env: buildGitSafeDirectoryEnv(),
+    env: buildGitSafeDirectoryEnv(cwd),
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -456,6 +456,20 @@ function createProcessOutputCapture(maxBytes: number): ProcessOutputAccumulator 
   };
 }
 
+/**
+ * Build a process env that injects safe.directory=* via one-shot GIT_CONFIG
+ * env vars so git doesn't reject cross-filesystem paths (e.g. WSL mounts
+ * accessed from Windows). Only affects the spawned subprocess.
+ */
+function buildGitSafeDirectoryEnv(): NodeJS.ProcessEnv {
+  const gitEnv = { ...process.env } as Record<string, string>;
+  const existingCount = parseInt(gitEnv.GIT_CONFIG_COUNT ?? "0", 10) || 0;
+  gitEnv.GIT_CONFIG_COUNT = String(existingCount + 1);
+  gitEnv[`GIT_CONFIG_KEY_${existingCount}`] = "safe.directory";
+  gitEnv[`GIT_CONFIG_VALUE_${existingCount}`] = "*";
+  return gitEnv;
+}
+
 async function executeProcess(input: {
   command: string;
   args: string[];
@@ -511,6 +525,7 @@ async function runGit(args: string[], cwd: string): Promise<string> {
     command: "git",
     args,
     cwd,
+    env: buildGitSafeDirectoryEnv(),
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -461,13 +461,16 @@ function createProcessOutputCapture(maxBytes: number): ProcessOutputAccumulator 
  * one-shot GIT_CONFIG env vars so git doesn't reject cross-filesystem paths
  * (e.g. WSL mounts accessed from Windows). Only affects the spawned subprocess.
  */
-function buildGitSafeDirectoryEnv(cwd: string): NodeJS.ProcessEnv {
-  const gitEnv = { ...process.env } as Record<string, string>;
-  const existingCount = Math.max(0, parseInt(gitEnv.GIT_CONFIG_COUNT ?? "0", 10) || 0);
-  gitEnv.GIT_CONFIG_COUNT = String(existingCount + 1);
-  gitEnv[`GIT_CONFIG_KEY_${existingCount}`] = "safe.directory";
-  gitEnv[`GIT_CONFIG_VALUE_${existingCount}`] = cwd;
-  return gitEnv;
+export function buildSafeDirectoryEnv(cwd: string): Record<string, string> {
+  const env: Record<string, string> = Object.fromEntries(
+    Object.entries(process.env).filter((e): e is [string, string] => e[1] != null),
+  );
+  const parsed = parseInt(env.GIT_CONFIG_COUNT ?? "0", 10);
+  const existingCount = Math.max(0, Number.isFinite(parsed) ? parsed : 0);
+  env.GIT_CONFIG_COUNT = String(existingCount + 1);
+  env[`GIT_CONFIG_KEY_${existingCount}`] = "safe.directory";
+  env[`GIT_CONFIG_VALUE_${existingCount}`] = cwd;
+  return env;
 }
 
 async function executeProcess(input: {
@@ -525,7 +528,7 @@ async function runGit(args: string[], cwd: string): Promise<string> {
     command: "git",
     args,
     cwd,
-    env: buildGitSafeDirectoryEnv(cwd),
+    env: buildSafeDirectoryEnv(cwd) as NodeJS.ProcessEnv,
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);
@@ -803,6 +806,7 @@ async function recordGitOperation(
         command: "git",
         args: input.args,
         cwd: input.cwd,
+        env: buildSafeDirectoryEnv(input.cwd) as NodeJS.ProcessEnv,
       });
       stdout = result.stdout;
       stderr = result.stderr;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents work in isolated workspaces that Paperclip provisions via git worktrees
> - These workspaces may live on cross-OS mounts (e.g. WSL paths accessed from Windows, Docker volumes)
> - Git 2.35.2+ rejects repos with mismatched directory ownership as "dubious ownership"
> - This causes agent workspace provisioning to fail with `adapter_failed`
> - This PR injects `safe.directory` trust via per-process `GIT_CONFIG_*` env vars, scoped to the specific workspace cwd
> - No global git config is modified — the trust only applies to the spawned git subprocess
> - The benefit is that agents can reliably provision workspaces on cross-OS mounts without manual git config or elevated permissions
## Summary

Git 2.35.2+ rejects repos with mismatched ownership ("dubious ownership" fatal error), causing `adapter_failed` when realizing isolated workspaces on WSL mounts accessed from Windows.

- Extracts `buildSafeDirectoryEnv()` helper that injects `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_N`/`GIT_CONFIG_VALUE_N` env vars scoped to the workspace `cwd`
- No global git config is modified — only the spawned subprocess sees the override
- Covers both `runGit` and `recordGitOperation` code paths
- Handles pre-existing `GIT_CONFIG_COUNT` values with `Math.max(0, ...)` + `Number.isFinite` guard

Fixes #1684

## Root cause

When Paperclip creates git worktrees or runs git commands in isolated workspaces on WSL mounts (or any cross-OS mount where directory ownership differs), Git 2.35.2+ rejects the repo with a fatal "dubious ownership" error unless explicitly trusted via `safe.directory`.

## Approach

Instead of modifying the user's global `~/.gitconfig` (which would be a side effect and security concern), we inject the trust via environment variables that are scoped to the child process:

1. **`GIT_CONFIG_COUNT`** / **`GIT_CONFIG_KEY_N`** / **`GIT_CONFIG_VALUE_N`**: Git reads these as config overrides, scoped to the process only
2. **Per-directory scoping**: We set `safe.directory` to the specific `cwd` rather than `*`, avoiding a blanket trust-all
3. **Incremental count**: If `GIT_CONFIG_COUNT` is already set (e.g., by a parent process), we increment rather than overwrite
4. **Type-safe env construction**: Uses `Object.entries(process.env).filter()` to properly handle `undefined` values

This is the same pattern used by GitHub Actions and VS Code's git integration.

## Test plan

- [x] 6 unit tests for `buildSafeDirectoryEnv()`: fresh count, incremental, non-numeric guard, negative guard, scoped cwd, process.env non-mutation
- [x] Verify agent workspace checkout succeeds on WSL-mounted paths
- [x] Verify no regression on native paths (non-WSL)
- [x] Confirm global git config is not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>