### PR TITLE
fix(ui): hide sidebar scrollbar track until hover

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -178,9 +178,15 @@
   background: oklch(0.5 0 0);
 }
 
-/* Auto-hide scrollbar: transparent by default, visible on container hover */
+/* Auto-hide scrollbar: fully transparent by default, visible on container hover */
+.scrollbar-auto-hide::-webkit-scrollbar-track {
+  background: transparent !important;
+}
 .scrollbar-auto-hide::-webkit-scrollbar-thumb {
   background: transparent !important;
+}
+.scrollbar-auto-hide:hover::-webkit-scrollbar-track {
+  background: oklch(0.205 0 0) !important;
 }
 .scrollbar-auto-hide:hover::-webkit-scrollbar-thumb {
   background: oklch(0.4 0 0) !important;


### PR DESCRIPTION
## Summary
- make `.scrollbar-auto-hide` hide both the scrollbar thumb and track by default
- restore the normal dark track and thumb colors on hover
- remove the visible idle scrollbar well in the sidebar

Fixes PAP-374

## Verification
- not run locally from the PR worktree; the temporary worktree does not have an installed workspace dependency graph