### PR TITLE
feat: add skipWhenIdle heartbeat policy to avoid wasteful timer wakeups

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -854,6 +854,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      skipWhenIdle: asBoolean(heartbeat.skipWhenIdle, false),
     };
   }
 
@@ -2437,6 +2438,25 @@ export function heartbeatService(db: Db) {
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 
         checked += 1;
+
+        // When skipWhenIdle is enabled, skip timer wakeup if agent has no actionable
+        // assigned issues — avoids wasting tokens on empty heartbeat runs.
+        if (policy.skipWhenIdle) {
+          const [{ count: assignedCount }] = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(issues)
+            .where(
+              and(
+                eq(issues.assigneeAgentId, agent.id),
+                inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+              ),
+            );
+          if (Number(assignedCount) === 0) {
+            skipped += 1;
+            continue;
+          }
+        }
+
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2431,6 +2431,7 @@ export function heartbeatService(db: Db) {
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
+      let idleSkipped = 0;
 
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
@@ -2438,6 +2439,10 @@ export function heartbeatService(db: Db) {
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 
         checked += 1;
+
+        const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
+        const elapsedMs = now.getTime() - baseline;
+        if (elapsedMs < policy.intervalSec * 1000) continue;
 
         // When skipWhenIdle is enabled, skip timer wakeup if agent has no actionable
         // assigned issues — avoids wasting tokens on empty heartbeat runs.
@@ -2452,14 +2457,10 @@ export function heartbeatService(db: Db) {
               ),
             );
           if (Number(assignedCount) === 0) {
-            skipped += 1;
+            idleSkipped += 1;
             continue;
           }
         }
-
-        const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
-        const elapsedMs = now.getTime() - baseline;
-        if (elapsedMs < policy.intervalSec * 1000) continue;
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",
@@ -2477,7 +2478,7 @@ export function heartbeatService(db: Db) {
         else skipped += 1;
       }
 
-      return { checked, enqueued, skipped };
+      return { checked, enqueued, skipped, idleSkipped };
     },
 
     cancelRun: async (runId: string) => {


### PR DESCRIPTION
## Problem

The heartbeat scheduler wakes agents on their configured timer interval regardless of whether they have any assigned work. This burns tokens on context loading and "nothing to do" reasoning every cycle.

## Solution

Adds a new `skipWhenIdle` option to the heartbeat policy (default: `false`). When enabled, `tickTimers` checks whether the agent has any assigned issues in actionable states (`todo`, `in_progress`, `in_review`, `blocked`) before waking it. Agents with zero actionable issues are skipped.

**Non-breaking** — existing behavior is unchanged unless explicitly opted in.

### Configuration

```json
{
  "heartbeat": {
    "skipWhenIdle": true
  }
}
```

### What it doesn't affect
- On-demand wakeups (manual, assignment callbacks) still work normally
- Agents with `skipWhenIdle: false` (default) behave exactly as before