### PR TITLE
refactor: replace hard-coded CLI version with dynamic version file

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { CLI_VERSION } from "./version.js";
 import { onboard } from "./commands/onboard.js";
 import { doctor } from "./commands/doctor.js";
 import { envCommand } from "./commands/env.js";
@@ -26,7 +27,7 @@ const DATA_DIR_OPTION_HELP =
 program
   .name("paperclipai")
   .description("Paperclip CLI — setup, diagnose, and configure your instance")
-  .version("0.2.7");
+  .version(CLI_VERSION);
 
 program.hook("preAction", (_thisCommand, actionCommand) => {
   const options = actionCommand.optsWithGlobals() as DataDirOptionLike;

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,0 +1,1 @@
+export const CLI_VERSION = "development";

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -189,29 +189,52 @@ for (const [dir, name] of rows) {
 NODE
 }
 
-replace_version_string() {
-  local from_version="$1"
-  local to_version="$2"
+update_version_to() {
+  local target_version="$1"
 
-  node - "$REPO_ROOT" "$from_version" "$to_version" <<'NODE'
+  node - "$REPO_ROOT" "$target_version" <<'NODE'
 const fs = require('fs');
 const path = require('path');
 
 const root = process.argv[2];
-const fromVersion = process.argv[3];
-const toVersion = process.argv[4];
+const targetVersion = process.argv[3];
 
 const roots = ['packages', 'server', 'ui', 'cli'];
-const targets = new Set(['package.json', 'CHANGELOG.md']);
-const extraFiles = [path.join('cli', 'src', 'index.ts')];
 
-function rewriteFile(filePath) {
+// Update package.json files using targeted string replacement to preserve formatting
+function updatePackageJson(filePath) {
   if (!fs.existsSync(filePath)) return;
-  const current = fs.readFileSync(filePath, 'utf8');
-  if (!current.includes(fromVersion)) return;
-  fs.writeFileSync(filePath, current.split(fromVersion).join(toVersion));
+  const content = fs.readFileSync(filePath, 'utf8');
+  const updated = content.replace(
+    /("version"\s*:\s*)"[^"]*"/,
+    `$1"${targetVersion}"`
+  );
+  if (updated !== content) {
+    fs.writeFileSync(filePath, updated);
+  }
 }
 
+// Update CHANGELOG.md: replace version in header lines like "## [1.2.3-canary.0] - 2024-01-01"
+function updateChangelog(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, 'utf8');
+  const updated = content.replace(/^## \[([0-9]+\.[0-9]+\.[0-9]+(?:-canary\.\d+)?)\]/gm, (match, version) => {
+    if (version.endsWith('-canary.0')) {
+      return `## [${targetVersion}]`;
+    }
+    return match;
+  });
+  if (updated !== content) {
+    fs.writeFileSync(filePath, updated);
+  }
+}
+
+// Update cli/src/version.ts: write the version file with target version
+function updateCliVersion(filePath) {
+  fs.writeFileSync(filePath, `export const CLI_VERSION = "${targetVersion}";\n`);
+}
+
+// Walk directories and update package.json and CHANGELOG.md files
 function walk(relDir) {
   const absDir = path.join(root, relDir);
   if (!fs.existsSync(absDir)) return;
@@ -223,8 +246,10 @@ function walk(relDir) {
       continue;
     }
 
-    if (targets.has(entry.name)) {
-      rewriteFile(path.join(absDir, entry.name));
+    if (entry.name === 'package.json') {
+      updatePackageJson(path.join(absDir, entry.name));
+    } else if (entry.name === 'CHANGELOG.md') {
+      updateChangelog(path.join(absDir, entry.name));
     }
   }
 }
@@ -233,9 +258,8 @@ for (const rel of roots) {
   walk(rel);
 }
 
-for (const relFile of extraFiles) {
-  rewriteFile(path.join(root, relFile));
-}
+// Special handling for cli/src/version.ts
+updateCliVersion(path.join(root, 'cli', 'src', 'version.ts'));
 NODE
 }
 
@@ -348,13 +372,7 @@ if [ "$canary" = true ]; then
   npx changeset pre enter canary
 fi
 npx changeset version
-
-if [ "$canary" = true ]; then
-  BASE_CANARY_VERSION="${TARGET_STABLE_VERSION}-canary.0"
-  if [ "$TARGET_PUBLISH_VERSION" != "$BASE_CANARY_VERSION" ]; then
-    replace_version_string "$BASE_CANARY_VERSION" "$TARGET_PUBLISH_VERSION"
-  fi
-fi
+update_version_to "$TARGET_PUBLISH_VERSION"
 
 VERSION_IN_CLI_PACKAGE="$(node -e "console.log(require('$CLI_DIR/package.json').version)")"
 if [ "$VERSION_IN_CLI_PACKAGE" != "$TARGET_PUBLISH_VERSION" ]; then


### PR DESCRIPTION
# What

Refactors the CLI version handling to eliminate hard-coded version strings.
Introduces a dedicated version.ts file that serves as the single source of truth for the CLI version.
Updates the release script to automatically update version.ts during the release process.

# Why

The previous implementation hard-coded the CLI version (0.2.7) in cli/src/index.ts, which caused a mismatch with the actual package.json version (0.3.0).
This created problems where the CLI would report an incorrect version when running commands.
The new approach provides a clean, maintainable solution where the version is dynamically sourced from a tracked file.
Local development shows "development" as the version, while production builds use the correct version from package.json.

# How to test

Run `pnpm paperclipai --version` locally and verify it shows "development".
Build the CLI package and verify the bundled version matches the package.json version.
Test the release script to ensure it properly updates version.ts during version bumping.

# Note

I did not test the release workflow and only generated this code update. 