### PR TITLE
feat: add kiro_local adapter for Kiro CLI integration

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-kiro-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
+import { printKiroStreamEvent } from "@paperclipai/adapter-kiro-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
@@ -29,6 +30,11 @@ const piLocalCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printPiStreamEvent,
 };
 
+const kiroLocalCLIAdapter: CLIAdapterModule = {
+  type: "kiro_local",
+  formatStdoutEvent: printKiroStreamEvent,
+};
+
 const cursorLocalCLIAdapter: CLIAdapterModule = {
   type: "cursor",
   formatStdoutEvent: printCursorStreamEvent,
@@ -50,6 +56,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     codexLocalCLIAdapter,
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,
+    kiroLocalCLIAdapter,
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,
     openclawGatewayCLIAdapter,

--- a/packages/adapters/kiro-local/package.json
+++ b/packages/adapters/kiro-local/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@paperclipai/adapter-kiro-local",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/kiro-local/src/cli/format-event.ts
+++ b/packages/adapters/kiro-local/src/cli/format-event.ts
@@ -1,0 +1,19 @@
+import pc from "picocolors";
+import { stripAnsi } from "../server/parse.js";
+
+const CREDIT_RE = /(\d+(?:\.\d+)?)\s*credits?\s*used/i;
+
+/**
+ * Kiro CLI outputs plain text. Print each line, highlighting credit usage.
+ */
+export function printKiroStreamEvent(raw: string, _debug: boolean): void {
+  const line = stripAnsi(raw).trim();
+  if (!line) return;
+
+  if (CREDIT_RE.test(line)) {
+    console.log(pc.blue(line));
+    return;
+  }
+
+  console.log(line);
+}

--- a/packages/adapters/kiro-local/src/cli/index.ts
+++ b/packages/adapters/kiro-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printKiroStreamEvent } from "./format-event.js";

--- a/packages/adapters/kiro-local/src/index.ts
+++ b/packages/adapters/kiro-local/src/index.ts
@@ -1,0 +1,37 @@
+export const type = "kiro_local";
+export const label = "Kiro CLI (local)";
+
+export const models: Array<{ id: string; label: string }> = [];
+
+export const agentConfigurationDoc = `# kiro_local agent configuration
+
+Adapter: kiro_local
+
+Use when:
+- You want Paperclip to run Kiro CLI locally as the agent runtime
+- You want session resume across heartbeats via --resume
+- You need Kiro CLI's built-in tools (read, write, shell, grep, glob, aws, web_search, code, etc.)
+
+Don't use when:
+- You need structured JSON streaming output (Kiro CLI outputs plain text)
+- Kiro CLI is not installed on the machine
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the prompt at runtime
+- promptTemplate (string, optional): run prompt template
+- trustAllTools (boolean, optional): pass --trust-all-tools when running Kiro CLI (default: true)
+- command (string, optional): defaults to "kiro-cli"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Kiro CLI uses --no-interactive mode for headless execution.
+- Sessions are directory-based; --resume resumes the most recent session in the working directory.
+- Output is plain text; token/cost tracking is best-effort via regex parsing of credit usage lines.
+- Kiro CLI uses Auto model selection by default.
+`;

--- a/packages/adapters/kiro-local/src/server/execute.ts
+++ b/packages/adapters/kiro-local/src/server/execute.ts
@@ -1,0 +1,328 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { parseKiroOutput, stripAnsi } from "./parse.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+/** Patterns in stripped stderr that are Kiro CLI chrome noise. */
+const STDERR_NOISE_RE =
+  /^$|^\s*$|^All tools are now trusted|^Agents can sometimes do unexpected|^Learn more at|^\s*▸\s*Time:|^\s*▸\s*Cost:/;
+
+/** Wrap onLog to strip ANSI and filter Kiro CLI chrome from stderr. */
+function wrapOnLog(
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>,
+): (stream: "stdout" | "stderr", chunk: string) => Promise<void> {
+  return async (stream, chunk) => {
+    if (stream === "stderr") {
+      const cleaned = stripAnsi(chunk);
+      // Drop lines that are pure ANSI control / Kiro chrome
+      const meaningful = cleaned
+        .split(/\r?\n/)
+        .filter((line) => !STDERR_NOISE_RE.test(line.trim()))
+        .join("\n")
+        .trim();
+      if (!meaningful) return;
+      return onLog(stream, meaningful + "\n");
+    }
+    return onLog(stream, chunk);
+  };
+}
+
+const SKILLS_CANDIDATES = [
+  path.resolve(__moduleDir, "../../skills"),
+  path.resolve(__moduleDir, "../../../../../skills"),
+];
+
+async function findSkillsDir(): Promise<string | null> {
+  for (const c of SKILLS_CANDIDATES) {
+    if (await fs.stat(c).then((s) => s.isDirectory()).catch(() => false)) return c;
+  }
+  return null;
+}
+
+/** Read the Paperclip skill markdown files and concatenate them. */
+async function loadSkillContent(): Promise<string> {
+  const dir = await findSkillsDir();
+  if (!dir) return "";
+  const parts: string[] = [];
+  const skillMd = path.join(dir, "paperclip", "SKILL.md");
+  const refMd = path.join(dir, "paperclip", "references", "api-reference.md");
+  for (const f of [skillMd, refMd]) {
+    try {
+      parts.push(await fs.readFile(f, "utf-8"));
+    } catch { /* skip */ }
+  }
+  return parts.join("\n\n---\n\n");
+}
+
+/**
+ * Write `.kiro/steering/paperclip.md` in the workspace so Kiro treats
+ * the Paperclip skill as trusted project context (equivalent to Claude's
+ * `--add-dir` skill injection).
+ */
+async function writeSteeringFile(cwd: string, env: Record<string, string>): Promise<void> {
+  const skillContent = await loadSkillContent();
+  if (!skillContent) return;
+
+  // Embed the actual env var values so Kiro doesn't need to read env vars
+  const envBlock = [
+    "## Your Paperclip Identity (this heartbeat)",
+    "",
+    "Use these values directly in API calls — do not attempt to read environment variables.",
+    "",
+    `- **API URL:** \`${env.PAPERCLIP_API_URL ?? ""}\``,
+    `- **API Key:** \`${env.PAPERCLIP_API_KEY ?? ""}\``,
+    `- **Agent ID:** \`${env.PAPERCLIP_AGENT_ID ?? ""}\``,
+    `- **Company ID:** \`${env.PAPERCLIP_COMPANY_ID ?? ""}\``,
+    `- **Run ID:** \`${env.PAPERCLIP_RUN_ID ?? ""}\``,
+  ];
+  if (env.PAPERCLIP_TASK_ID) envBlock.push(`- **Task ID:** \`${env.PAPERCLIP_TASK_ID}\``);
+  if (env.PAPERCLIP_WAKE_REASON) envBlock.push(`- **Wake Reason:** \`${env.PAPERCLIP_WAKE_REASON}\``);
+  if (env.PAPERCLIP_WAKE_COMMENT_ID) envBlock.push(`- **Wake Comment ID:** \`${env.PAPERCLIP_WAKE_COMMENT_ID}\``);
+  if (env.PAPERCLIP_APPROVAL_ID) envBlock.push(`- **Approval ID:** \`${env.PAPERCLIP_APPROVAL_ID}\``);
+  if (env.PAPERCLIP_APPROVAL_STATUS) envBlock.push(`- **Approval Status:** \`${env.PAPERCLIP_APPROVAL_STATUS}\``);
+  if (env.PAPERCLIP_LINKED_ISSUE_IDS) envBlock.push(`- **Linked Issue IDs:** \`${env.PAPERCLIP_LINKED_ISSUE_IDS}\``);
+
+  const steeringContent = [
+    envBlock.join("\n"),
+    "",
+    "## Constraints",
+    "- You are running headless (non-interactive). Never run commands that require human input (e.g. `aws sso login`, browser-based OAuth flows, interactive prompts). If credentials are expired or missing, report the issue in a task comment and move on.",
+    "",
+    "---",
+    "",
+    skillContent,
+  ].join("\n");
+
+  const steeringDir = path.join(cwd, ".kiro", "steering");
+  await fs.mkdir(steeringDir, { recursive: true });
+  await fs.writeFile(path.join(steeringDir, "paperclip.md"), steeringContent, "utf-8");
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
+
+  const command = asString(config.command, "kiro-cli");
+  const trustAllTools = asBoolean(config.trustAllTools, true);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "") || null;
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "") || null;
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "") || null;
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  // Build environment
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  // Write Paperclip skill as a Kiro steering file (trusted project context)
+  const steeringFilePath = path.join(cwd, ".kiro", "steering", "paperclip.md");
+  let steeringFileWritten = false;
+  try {
+    await writeSteeringFile(cwd, env);
+    steeringFileWritten = true;
+  } catch (err) {
+    await onLog("stderr", `[paperclip] Failed to write steering file: ${err}\n`);
+  }
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  // Session handling: Kiro CLI --resume is directory-based
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const hasSession = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "").length > 0;
+  const canResumeSession =
+    hasSession &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+
+  if (hasSession && !canResumeSession) {
+    await onLog(
+      "stderr",
+      `[paperclip] Kiro session was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  // Build prompt
+  const promptTemplate = asString(config.promptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+
+  let prompt: string;
+  if (promptTemplate) {
+    prompt = renderTemplate(promptTemplate, templateData);
+  } else {
+    prompt = "Follow the Paperclip heartbeat procedure described in the steering files. "
+      + "Use curl to call the Paperclip API. "
+      + "Check your assignments, pick a task, do the work, update status, and leave a comment.";
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  if (instructionsFilePath) {
+    try {
+      const instructions = await fs.readFile(instructionsFilePath, "utf-8");
+      prompt = instructions.trim() + "\n\n" + prompt;
+    } catch (err) {
+      await onLog("stderr", `[paperclip] Could not read instructions file "${instructionsFilePath}": ${err}\n`);
+    }
+  }
+
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  if (sessionHandoffNote) {
+    prompt = sessionHandoffNote + "\n\n" + prompt;
+  }
+
+  // Build args
+  const args = ["chat", "--no-interactive"];
+  if (trustAllTools) args.push("--trust-all-tools");
+  if (canResumeSession) args.push("--resume");
+  if (extraArgs.length > 0) args.push(...extraArgs);
+  args.push(prompt);
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "kiro_local",
+      command,
+      cwd,
+      commandArgs: args,
+      env: redactEnvForLogs(env),
+      prompt,
+      context,
+    });
+  }
+
+  const proc = await runChildProcess(runId, command, args, {
+    cwd,
+    env,
+    timeoutSec,
+    graceSec,
+    onLog: wrapOnLog(onLog),
+  });
+
+  // Clean up steering file (contains credentials)
+  if (steeringFileWritten) {
+    fs.unlink(steeringFilePath).catch(() => {});
+  }
+
+  if (proc.timedOut) {
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: true,
+      errorMessage: `Timed out after ${timeoutSec}s`,
+      errorCode: "timeout",
+    };
+  }
+
+  const parsed = parseKiroOutput(proc.stdout);
+  const sessionId = `kiro-session-${cwd}`;
+  const sessionParams = { sessionId, cwd };
+
+  const stderrLine = proc.stderr
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find(Boolean) ?? "";
+
+  return {
+    exitCode: proc.exitCode,
+    signal: proc.signal,
+    timedOut: false,
+    errorMessage:
+      (proc.exitCode ?? 0) === 0
+        ? null
+        : stderrLine || `Kiro CLI exited with code ${proc.exitCode ?? -1}`,
+    usage: undefined,
+    costUsd: undefined,
+    sessionId,
+    sessionParams,
+    sessionDisplayId: cwd,
+    provider: "kiro",
+    model: "auto",
+    billingType: "subscription",
+    resultJson: { stdout: proc.stdout, stderr: proc.stderr },
+    summary: parsed.summary,
+  };
+}

--- a/packages/adapters/kiro-local/src/server/index.ts
+++ b/packages/adapters/kiro-local/src/server/index.ts
@@ -1,0 +1,31 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(record.cwd) ?? readNonEmptyString(record.workdir);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd) ?? readNonEmptyString(params.workdir);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.cwd) ?? readNonEmptyString(params.sessionId);
+  },
+};
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { parseKiroOutput, stripAnsi } from "./parse.js";

--- a/packages/adapters/kiro-local/src/server/parse.ts
+++ b/packages/adapters/kiro-local/src/server/parse.ts
@@ -1,0 +1,34 @@
+/**
+ * Best-effort parsing of Kiro CLI plain-text stdout.
+ * Kiro CLI outputs plain text in --no-interactive mode.
+ * We attempt to extract credit usage from inline output.
+ */
+
+const CREDIT_USAGE_RE = /(\d+(?:\.\d+)?)\s*credits?\s*used/i;
+const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?(?:\x07|\x1b\\)|\x1b\[[\?]?\d*[a-zA-Z]/g;
+
+export interface ParsedKiroOutput {
+  summary: string;
+  creditsUsed: number;
+}
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+export function parseKiroOutput(stdout: string): ParsedKiroOutput {
+  const clean = stripAnsi(stdout);
+  const lines = clean.split(/\r?\n/);
+  let creditsUsed = 0;
+
+  for (const line of lines) {
+    const match = CREDIT_USAGE_RE.exec(line);
+    if (match) {
+      creditsUsed += Number.parseFloat(match[1]) || 0;
+    }
+  }
+
+  const summary = clean.trim();
+
+  return { summary, creditsUsed };
+}

--- a/packages/adapters/kiro-local/src/server/test.ts
+++ b/packages/adapters/kiro-local/src/server/test.ts
@@ -1,0 +1,101 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "kiro-cli");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({ code: "kiro_cwd_valid", level: "info", message: `Working directory is valid: ${cwd}` });
+  } catch (err) {
+    checks.push({
+      code: "kiro_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({ code: "kiro_command_resolvable", level: "info", message: `Command is executable: ${command}` });
+  } catch (err) {
+    checks.push({
+      code: "kiro_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const canProbe = checks.every(
+    (c) => c.code !== "kiro_cwd_invalid" && c.code !== "kiro_command_unresolvable",
+  );
+
+  if (canProbe) {
+    const probe = await runChildProcess(
+      `kiro-envtest-${Date.now()}`,
+      command,
+      ["whoami", "--format", "json"],
+      { cwd, env, timeoutSec: 15, graceSec: 5, onLog: async () => {} },
+    );
+
+    if (probe.timedOut) {
+      checks.push({
+        code: "kiro_whoami_timed_out",
+        level: "warn",
+        message: "Kiro CLI whoami probe timed out.",
+        hint: "Retry the probe. If this persists, verify kiro-cli can run from this environment.",
+      });
+    } else if ((probe.exitCode ?? 1) === 0) {
+      checks.push({
+        code: "kiro_auth_ok",
+        level: "info",
+        message: "Kiro CLI is authenticated.",
+      });
+    } else {
+      checks.push({
+        code: "kiro_auth_required",
+        level: "warn",
+        message: "Kiro CLI is installed but login may be required.",
+        hint: "Run `kiro-cli login` to authenticate, then retry.",
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/kiro-local/src/ui/build-config.ts
+++ b/packages/adapters/kiro-local/src/ui/build-config.ts
@@ -1,0 +1,64 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest" ? { version: rec.version } : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildKiroLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
+  ac.trustAllTools = v.dangerouslySkipPermissions;
+  ac.timeoutSec = 0;
+  ac.graceSec = 20;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = v.extraArgs;
+  return ac;
+}

--- a/packages/adapters/kiro-local/src/ui/index.ts
+++ b/packages/adapters/kiro-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseKiroStdoutLine } from "./parse-stdout.js";
+export { buildKiroLocalConfig } from "./build-config.js";

--- a/packages/adapters/kiro-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/kiro-local/src/ui/parse-stdout.ts
@@ -1,0 +1,12 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+import { stripAnsi } from "../server/parse.js";
+
+/**
+ * Kiro CLI outputs plain text in --no-interactive mode.
+ * Each line is treated as stdout with ANSI codes stripped.
+ */
+export function parseKiroStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const clean = stripAnsi(line).trim();
+  if (!clean) return [];
+  return [{ kind: "stdout", ts, text: clean }];
+}

--- a/packages/adapters/kiro-local/tsconfig.json
+++ b/packages/adapters/kiro-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -27,6 +27,7 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "gemini_local",
+  "kiro_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kiro-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kiro-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -149,6 +152,22 @@ importers:
         version: 5.9.3
 
   packages/adapters/gemini-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/kiro-local:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -273,6 +292,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kiro-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kiro-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -394,6 +416,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kiro-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kiro-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-kiro-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -51,6 +51,14 @@ import {
 import {
   agentConfigurationDoc as piAgentConfigurationDoc,
 } from "@paperclipai/adapter-pi-local";
+import {
+  execute as kiroExecute,
+  testEnvironment as kiroTestEnvironment,
+  sessionCodec as kiroSessionCodec,
+} from "@paperclipai/adapter-kiro-local/server";
+import {
+  agentConfigurationDoc as kiroAgentConfigurationDoc,
+} from "@paperclipai/adapter-kiro-local";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
@@ -127,12 +135,23 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
+const kiroLocalAdapter: ServerAdapterModule = {
+  type: "kiro_local",
+  execute: kiroExecute,
+  testEnvironment: kiroTestEnvironment,
+  sessionCodec: kiroSessionCodec,
+  models: [],
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: kiroAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
+    kiroLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-kiro-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/ui/src/adapters/kiro-local/config-fields.tsx
+++ b/ui/src/adapters/kiro-local/config-fields.tsx
@@ -1,0 +1,66 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  ToggleField,
+  DraftInput,
+  help,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Prepended to the prompt at runtime.";
+
+export function KiroLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+      <ToggleField
+        label="Trust all tools"
+        hint="Allow Kiro CLI to use any tool without confirmation (--trust-all-tools)"
+        checked={
+          isCreate
+            ? values!.dangerouslySkipPermissions
+            : eff("adapterConfig", "trustAllTools", config.trustAllTools !== false)
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ dangerouslySkipPermissions: v })
+            : mark("adapterConfig", "trustAllTools", v)
+        }
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/kiro-local/index.ts
+++ b/ui/src/adapters/kiro-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseKiroStdoutLine } from "@paperclipai/adapter-kiro-local/ui";
+import { KiroLocalConfigFields } from "./config-fields";
+import { buildKiroLocalConfig } from "@paperclipai/adapter-kiro-local/ui";
+
+export const kiroLocalUIAdapter: UIAdapterModule = {
+  type: "kiro_local",
+  label: "Kiro CLI (local)",
+  parseStdoutLine: parseKiroStdoutLine,
+  ConfigFields: KiroLocalConfigFields,
+  buildAdapterConfig: buildKiroLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { kiroLocalUIAdapter } from "./kiro-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -14,6 +15,7 @@ const adaptersByType = new Map<string, UIAdapterModule>(
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
+    kiroLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -924,7 +924,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "kiro_local", "opencode_local", "cursor"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -18,6 +18,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
+  kiro_local: "Kiro CLI (local)",
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -26,6 +26,7 @@ type AdvancedAdapterType =
   | "claude_local"
   | "codex_local"
   | "gemini_local"
+  | "kiro_local"
   | "opencode_local"
   | "pi_local"
   | "cursor"
@@ -57,6 +58,12 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     label: "Gemini CLI",
     icon: Gem,
     desc: "Local Gemini agent",
+  },
+  {
+    value: "kiro_local",
+    label: "Kiro CLI",
+    icon: Terminal,
+    desc: "Local Kiro agent",
   },
   {
     value: "opencode_local",

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -61,6 +61,7 @@ export const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
+  kiro_local: "Kiro CLI (local)",
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -24,6 +24,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude",
   codex_local: "Codex",
   gemini_local: "Gemini",
+  kiro_local: "Kiro CLI",
   opencode_local: "OpenCode",
   cursor: "Cursor",
   openclaw_gateway: "OpenClaw Gateway",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -16,6 +16,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
+  kiro_local: "Kiro CLI (local)",
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -30,6 +30,7 @@ const SUPPORTED_ADVANCED_ADAPTER_TYPES = new Set<CreateConfigValues["adapterType
   "claude_local",
   "codex_local",
   "gemini_local",
+  "kiro_local",
   "opencode_local",
   "pi_local",
   "cursor",


### PR DESCRIPTION
## Summary

Adds a new `kiro_local` adapter that allows Paperclip agents to use `kiro-cli` as their runtime, mirroring the `claude_local` adapter pattern with Kiro-specific adaptations.

## What's included

### Adapter package (`packages/adapters/kiro-local/`)
- **execute.ts** — Spawns `kiro-cli chat --no-interactive` with `--trust-all-tools` and `--resume` support
- **Steering file injection** — Writes `.kiro/steering/paperclip.md` in the workspace before each run, embedding the full Paperclip skill (heartbeat procedure + API reference) and actual API credentials as trusted project context. This is the Kiro-native equivalent of Claude's `--add-dir` skill injection.
- **parse.ts** — Best-effort regex parsing of stdout for credit/cost info + ANSI stripping (no `--output-format stream-json` available)
- **Stderr filtering** — Strips ANSI escape codes and Kiro CLI chrome noise (trust banner, timing, cursor control) from run logs
- **test.ts** — Environment probe: validates cwd, command resolvability, runs `kiro-cli whoami --format json`
- **Session codec** — Directory-based session resume across heartbeats (`--resume` resumes most recent session in cwd)

### Registries & UI
- `kiro_local` added to `AGENT_ADAPTER_TYPES` constant
- Wired into server, CLI, and UI adapter registries
- UI config fields: instructions file path + "Trust all tools" toggle
- Added to all hardcoded adapter label maps and type unions

## Key design decisions

1. **Steering files over prompt injection** — Kiro CLI has safety filters that reject prompts containing identity assignment, env var references, or framework-specific language. Instead of fighting these filters, the adapter writes Paperclip context as a `.kiro/steering/paperclip.md` file, which Kiro treats as trusted project context.

2. **Embedded credentials** — The steering file includes actual API URL, key, agent ID, etc. as literal values so Kiro can make curl calls directly without needing to read environment variables.

3. **Plain text output** — Unlike Claude's structured JSON stream, Kiro outputs plain text with ANSI codes. The adapter strips ANSI and does best-effort credit extraction via regex.

## Testing

- `pnpm -r typecheck` — all 14 packages pass
- `pnpm build` — all packages build
- Tested end-to-end: agent successfully follows the 9-step heartbeat procedure, checks out tasks, calls Paperclip API via curl, updates status, and leaves structured comments