### PR TITLE
docs: add Railway one-click deploy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 
 **Or deploy on Railway:** One-click deploy with Postgres, persistent storage, and a browser-based setup flow. Access Paperclip from anywhere.
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/paperclip?referralCode=uXzB-u)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/paperclip)
 
 <br/>
 


### PR DESCRIPTION
Adds a "Deploy on Railway" option to the Quickstart section so users can spin up Paperclip (app + Postgres + volume + setup UI) with one click.

- Template repo: https://github.com/Lukem121/paperclip-railway-template
- Template is live on Railway's marketplace; this PR only adds the link and badge to the README.