### PR TITLE
fix: use junction symlinks on Windows to avoid EPERM error

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -59,6 +59,7 @@ async function buildSkillsDir(): Promise<string> {
       await fs.symlink(
         path.join(skillsDir, entry.name),
         path.join(target, entry.name),
+        process.platform === "win32" ? "junction" : undefined,
       );
     }
   }


### PR DESCRIPTION
## Problem

On Windows, creating directory symlinks requires either Developer Mode or elevated (admin) privileges. When the \claude-local\ adapter calls \uildSkillsDir()\, it fails with:

\\\
EPERM: operation not permitted, symlink '...\paperclip\skills\paperclip' -> '...\AppData\Local\Temp\paperclip-skills-XXXXXX\.claude\skills\paperclip'
\\\

This causes every agent heartbeat run to fail immediately with \dapter_failed\.

## Fix

NTFS **junctions** are a Windows-specific directory link type that work without any special permissions. By passing \'junction'\ as the symlink type on \win32\, we avoid the permission requirement entirely while keeping the same behaviour on macOS/Linux.

## Change

One line in \packages/adapters/claude-local/src/server/execute.ts\:

\\\	s
await fs.symlink(
  path.join(skillsDir, entry.name),
  path.join(target, entry.name),
  process.platform === 'win32' ? 'junction' : undefined,
);
\\\

Tested on Windows 11 with Developer Mode **disabled** — agent heartbeats now run successfully.