### PR TITLE
fix(ui): show error toast when agent config save fails

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -12,6 +12,7 @@ import { useSidebar } from "../context/SidebarContext";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { AgentConfigForm } from "../components/AgentConfigForm";
 import { PageTabBar } from "../components/PageTabBar";
@@ -1044,6 +1045,7 @@ function ConfigurationTab({
   updatePermissions: { mutate: (canCreate: boolean) => void; isPending: boolean };
 }) {
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
   const [awaitingRefreshAfterSave, setAwaitingRefreshAfterSave] = useState(false);
   const lastAgentRef = useRef(agent);
 
@@ -1066,8 +1068,19 @@ function ConfigurationTab({
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.configRevisions(agent.id) });
     },
-    onError: () => {
+    onError: (error: unknown) => {
       setAwaitingRefreshAfterSave(false);
+      // Show user-friendly error message
+      let errorMessage = "Failed to save configuration";
+      if (error instanceof ApiError) {
+        const body = error.body as { error?: string } | undefined;
+        if (body?.error) {
+          errorMessage = body.error;
+        }
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      pushToast({ title: "Save failed", body: errorMessage, tone: "error" });
     },
   });
 


### PR DESCRIPTION
## Summary
When saving agent configuration fails (e.g., invalid OpenCode model format), the error was silently swallowed. Users had to check browser dev tools to see the actual error message.

## Changes
- Added toast notification when save fails in `ConfigurationTab`
- Extracts server error message from `ApiError.body`
- Uses existing `ToastContext` infrastructure

## Before/After

**Before:** Save fails silently, error only visible in network tab

**After:** User sees toast: "Save failed: Invalid opencode_local adapterConfig: OpenCode requires `adapterConfig.model` in provider/model format."

## Testing
- `pnpm typecheck` passes
- Manually tested with invalid OpenCode config

Fixes #751