### PR TITLE
fix(cli): read version from package.json instead of hardcoding

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,8 @@
 import { Command } from "commander";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
 import { onboard } from "./commands/onboard.js";
 import { doctor } from "./commands/doctor.js";
 import { envCommand } from "./commands/env.js";
@@ -27,7 +31,7 @@ const DATA_DIR_OPTION_HELP =
 program
   .name("paperclipai")
   .description("Paperclip CLI — setup, diagnose, and configure your instance")
-  .version("0.2.7");
+  .version(pkg.version);
 
 program.hook("preAction", (_thisCommand, actionCommand) => {
   const options = actionCommand.optsWithGlobals() as DataDirOptionLike;


### PR DESCRIPTION
## Summary
The CLI version was hardcoded as `0.2.7` while package.json declared `0.3.1`, causing version mismatch.

## Changes
- Use `createRequire` to dynamically read version from package.json
- Remove hardcoded version string

## Before/After

```bash
# Before
$ paperclipai --version
0.2.7  # Wrong!

# After  
$ paperclipai --version
0.3.1  # Matches package.json
```

## Testing
- `pnpm typecheck` passes

Fixes #941