### PR TITLE
feat(codex-local): add optional costApi for external quota-based cost tracking

### DIFF
--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -21,6 +21,49 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 | `timeoutSec` | number | No | Process timeout (0 = no timeout) |
 | `graceSec` | number | No | Grace period before force-kill |
 | `dangerouslyBypassApprovalsAndSandbox` | boolean | No | Skip safety checks (dev only) |
+| `costApi` | object | No | External quota API for real cost tracking (see below) |
+
+## Cost Tracking via External Quota API
+
+By default, `codex_local` reports `costUsd: null` because OpenAI Codex subscription plans do not return per-request cost data. If you use an OpenAI-compatible proxy (such as [The Claw Bay](https://theclawbay.com)) that tracks usage costs, you can configure `costApi` to enable real cost tracking in Paperclip's budget enforcement and cost dashboard.
+
+### How it works
+
+The adapter takes one quota snapshot **before** the run and one **after** (covering retries), computes the delta, and reports it as `costUsd`. Paperclip's existing heartbeat pipeline then converts this to cents, inserts a `cost_events` row, and updates `spent_monthly_cents` — budget auto-pause works as normal.
+
+### `costApi` fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | Yes | — | GET endpoint that returns a JSON quota object |
+| `key` | string | Yes | — | Bearer token for `Authorization` header |
+| `field` | string | Yes | — | Dot-path to the cumulative cost number in the response (e.g. `usage.fiveHour.estimatedCostUsdUsed`) |
+| `timeoutMs` | number | No | `5000` | Per-fetch timeout in milliseconds |
+| `attributionMode` | string | No | `strict_dedicated_key` | Attribution semantics (see below) |
+
+### Attribution modes
+
+| Mode | Suitable for enforcement? | Description |
+|------|--------------------------|-------------|
+| `strict_dedicated_key` | ✅ Yes | One dedicated proxy API key per agent. Delta reliably attributes only that agent's usage. **Required for budget enforcement.** |
+| `best_effort_shared_key` | ⚠️ No | API key is shared between agents or other processes. Delta is approximate telemetry. Should not be used for budget enforcement decisions. |
+
+### Example: The Claw Bay
+
+```json
+{
+  "costApi": {
+    "url": "https://theclawbay.com/api/codex-auth/v1/quota",
+    "key": "ca_v1.YOUR_KEY_HERE",
+    "field": "usage.fiveHour.estimatedCostUsdUsed",
+    "attributionMode": "strict_dedicated_key"
+  }
+}
+```
+
+### Fail-open behavior
+
+Cost API errors never fail the agent run. If the quota endpoint is unreachable, returns an error, times out, or returns unexpected data, a warning is logged to stderr and `costUsd: null` is returned — identical to the default behavior without `costApi` configured.
 
 ## Session Persistence
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -23,6 +23,129 @@ import {
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareWorktreeCodexHome, resolveCodexHomeDir } from "./codex-home.js";
 
+// ---------------------------------------------------------------------------
+// Cost API integration — optional external quota-based cost tracking
+// ---------------------------------------------------------------------------
+
+type CostApiAttributionMode = "strict_dedicated_key" | "best_effort_shared_key";
+
+interface CostApiConfig {
+  url: string;
+  key: string;
+  /** Dot-path to the cumulative cost number in the quota response JSON. */
+  field: string;
+  /** Fetch timeout in ms (default: 5000). */
+  timeoutMs: number;
+  /**
+   * `strict_dedicated_key` (default): one dedicated proxy API key per agent.
+   *   Suitable for budget enforcement.
+   * `best_effort_shared_key`: approximate telemetry; not authoritative for enforcement.
+   */
+  attributionMode: CostApiAttributionMode;
+}
+
+function parseCostApiConfig(raw: unknown): CostApiConfig | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const url = typeof obj.url === "string" ? obj.url.trim() : "";
+  const key = typeof obj.key === "string" ? obj.key.trim() : "";
+  const field = typeof obj.field === "string" ? obj.field.trim() : "";
+  if (!url || !key || !field) return null;
+  const timeoutMs = typeof obj.timeoutMs === "number" && obj.timeoutMs > 0 ? obj.timeoutMs : 5000;
+  const rawMode = typeof obj.attributionMode === "string" ? obj.attributionMode : "";
+  const attributionMode: CostApiAttributionMode =
+    rawMode === "best_effort_shared_key" ? "best_effort_shared_key" : "strict_dedicated_key";
+  return { url, key, field, timeoutMs, attributionMode };
+}
+
+/**
+ * Resolves a dot-separated key path into a JSON object.
+ * Returns the numeric value at the path, or null if missing or non-numeric.
+ */
+export function resolveDotPath(obj: unknown, dotPath: string): number | null {
+  const parts = dotPath.split(".");
+  let cursor: unknown = obj;
+  for (const part of parts) {
+    if (cursor === null || typeof cursor !== "object") return null;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return typeof cursor === "number" ? cursor : null;
+}
+
+/**
+ * Fetches a cumulative cost value from a quota API endpoint.
+ * Returns the numeric value at `costApi.field`, or null on any error.
+ * Fail-open: errors are logged as warnings and never propagate.
+ */
+export async function fetchQuotaCost(
+  costApi: CostApiConfig,
+  onWarn: (msg: string) => Promise<void>,
+): Promise<number | null> {
+  let response: Response;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), costApi.timeoutMs);
+    try {
+      response = await fetch(costApi.url, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${costApi.key}` },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const isTimeout = msg.toLowerCase().includes("abort") || msg.toLowerCase().includes("signal");
+    await onWarn(
+      `[paperclip] costApi quota fetch ${isTimeout ? "timed out" : "failed"}: ${msg}\n`,
+    );
+    return null;
+  }
+
+  if (!response.ok) {
+    await onWarn(`[paperclip] costApi quota fetch returned HTTP ${response.status}; skipping cost tracking.\n`);
+    return null;
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    await onWarn(`[paperclip] costApi quota response is not valid JSON; skipping cost tracking.\n`);
+    return null;
+  }
+
+  const value = resolveDotPath(body, costApi.field);
+  if (value === null) {
+    await onWarn(
+      `[paperclip] costApi field "${costApi.field}" did not resolve to a number; skipping cost tracking.\n`,
+    );
+    return null;
+  }
+
+  return value;
+}
+
+/**
+ * Computes the run cost from two cumulative quota snapshots.
+ * Returns null if either snapshot is missing or delta is non-positive.
+ */
+function computeCostDelta(
+  before: number | null,
+  after: number | null,
+  onWarnSync: (msg: string) => void,
+): number | null {
+  if (before === null || after === null) return null;
+  const delta = after - before;
+  if (delta < 0) {
+    onWarnSync("[paperclip] costApi: quota window reset detected (negative delta); skipping cost for this run.\n");
+    return null;
+  }
+  if (delta === 0) return null;
+  return delta;
+}
+
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
   /^\d{4}-\d{2}-\d{2}T[^\s]+\s+ERROR\s+codex_core::rollout::list:\s+state db missing rollout path for thread\s+[a-z0-9-]+$/i;
@@ -316,6 +439,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     env.PAPERCLIP_API_KEY = authToken;
   }
   const billingType = resolveCodexBillingType(env);
+  const costApi = parseCostApiConfig(parseObject(config.costApi));
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   await ensureCommandResolvable(command, cwd, runtimeEnv);
 
@@ -466,6 +590,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const toResult = (
     attempt: { proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string }; rawStderr: string; parsed: ReturnType<typeof parseCodexJsonl> },
+    costUsd: number | null,
     clearSessionOnMissingSession = false,
   ): AdapterExecutionResult => {
     if (attempt.proc.timedOut) {
@@ -474,6 +599,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         signal: attempt.proc.signal,
         timedOut: true,
         errorMessage: `Timed out after ${timeoutSec}s`,
+        costUsd: costUsd ?? null,
         clearSession: clearSessionOnMissingSession,
       };
     }
@@ -510,7 +636,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       provider: "openai",
       model,
       billingType,
-      costUsd: null,
+      costUsd: costUsd ?? null,
       resultJson: {
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,
@@ -519,6 +645,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       clearSession: Boolean(clearSessionOnMissingSession && !resolvedSessionId),
     };
   };
+
+  // One before/after snapshot pair for the full execute() invocation (covers retries).
+  const onWarn = (msg: string) => onLog("stderr", msg);
+  const beforeCost = costApi ? await fetchQuotaCost(costApi, onWarn) : null;
 
   const initial = await runAttempt(sessionId);
   if (
@@ -532,8 +662,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
     );
     const retry = await runAttempt(null);
-    return toResult(retry, true);
+    const afterCost = costApi ? await fetchQuotaCost(costApi, onWarn) : null;
+    const costUsd = computeCostDelta(beforeCost, afterCost, (msg) => { void onLog("stderr", msg); });
+    return toResult(retry, costUsd, true);
   }
 
-  return toResult(initial);
+  const afterCost = costApi ? await fetchQuotaCost(costApi, onWarn) : null;
+  const costUsd = computeCostDelta(beforeCost, afterCost, (msg) => { void onLog("stderr", msg); });
+  return toResult(initial, costUsd);
 }

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,4 +1,4 @@
-export { execute, ensureCodexSkillsInjected } from "./execute.js";
+export { execute, ensureCodexSkillsInjected, resolveDotPath, fetchQuotaCost } from "./execute.js";
 export { testEnvironment } from "./test.js";
 export { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";

--- a/server/src/__tests__/codex-local-cost-api-integration.test.ts
+++ b/server/src/__tests__/codex-local-cost-api-integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Integration tests for costApi integration in codex_local adapter.
+ * These tests run a fake codex command and a fake quota HTTP server
+ * to verify end-to-end cost delta attribution.
+ */
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-codex-local/server";
+
+// Writes a minimal fake codex CLI that exits 0 with one turn completed.
+async function writeFakeCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "thread.started", thread_id: "session-cost-test" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "done" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+// Starts a tiny HTTP server that returns the given quota responses in sequence.
+function startQuotaServer(responses: Array<Record<string, unknown>>): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    let callIndex = 0;
+    const server = http.createServer((_req, res) => {
+      const body = responses[callIndex % responses.length] ?? {};
+      callIndex += 1;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        port: addr.port,
+        close: () => new Promise<void>((r, reject) => server.close((err) => (err ? reject(err) : r()))),
+      });
+    });
+  });
+}
+
+function baseCtx(commandPath: string, workspace: string, extraConfig: Record<string, unknown> = {}) {
+  return {
+    runId: "run-cost-test",
+    agent: {
+      id: "agent-cost-test",
+      companyId: "company-1",
+      name: "Cost Test Agent",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: commandPath,
+      cwd: workspace,
+      promptTemplate: "Do work.",
+      ...extraConfig,
+    },
+    context: {},
+    authToken: "test-token",
+    onLog: async () => {},
+  };
+}
+
+describe("codex_local costApi integration", () => {
+  it("4.3: returns positive costUsd when costApi is configured and delta is positive", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cost-api-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    // quota server returns before=3.40, after=3.86 (delta=0.46)
+    const quotaServer = await startQuotaServer([
+      { usage: { fiveHour: { estimatedCostUsdUsed: 3.40 } } },
+      { usage: { fiveHour: { estimatedCostUsdUsed: 3.86 } } },
+    ]);
+
+    try {
+      const ctx = baseCtx(commandPath, workspace, {
+        costApi: {
+          url: `http://127.0.0.1:${quotaServer.port}/quota`,
+          key: "test-key",
+          field: "usage.fiveHour.estimatedCostUsdUsed",
+        },
+      });
+
+      const result = await execute(ctx);
+      expect(result.exitCode).toBe(0);
+      expect(result.costUsd).toBeCloseTo(0.46, 5);
+    } finally {
+      await quotaServer.close();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("4.4: resume-retry flow returns one run-level delta covering both attempts", async () => {
+    // Fake codex that fails first (unknown session error) then succeeds
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cost-api-retry-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const callCountPath = path.join(root, "calls.txt");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.writeFile(callCountPath, "0", "utf8");
+
+    const retryScript = `#!/usr/bin/env node
+const fs = require("node:fs");
+const callCountPath = ${JSON.stringify(callCountPath)};
+const n = parseInt(fs.readFileSync(callCountPath, "utf8"), 10);
+fs.writeFileSync(callCountPath, String(n + 1), "utf8");
+if (n === 0 && process.argv.includes("resume")) {
+  // Simulate unknown session error on first attempt with resume arg
+  process.stderr.write("ERROR codex_core::rollout::list: state db missing rollout path for thread old-session\\n");
+  process.exit(1);
+}
+console.log(JSON.stringify({ type: "thread.started", thread_id: "session-retry-test" }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
+`;
+    await fs.writeFile(commandPath, retryScript, "utf8");
+    await fs.chmod(commandPath, 0o755);
+
+    // quota server: before=5.00, after first fail=5.10, after retry=5.35
+    // execute() takes one before snapshot then one after snapshot at the end
+    // so delta = 5.35 - 5.00 = 0.35
+    const quotaServer = await startQuotaServer([
+      { usage: { fiveHour: { estimatedCostUsdUsed: 5.00 } } },
+      { usage: { fiveHour: { estimatedCostUsdUsed: 5.35 } } },
+    ]);
+
+    try {
+      const ctx = {
+        ...baseCtx(commandPath, workspace, {
+          costApi: {
+            url: `http://127.0.0.1:${quotaServer.port}/quota`,
+            key: "test-key",
+            field: "usage.fiveHour.estimatedCostUsdUsed",
+          },
+        }),
+        runtime: {
+          sessionId: "old-session",
+          sessionParams: { sessionId: "old-session", cwd: workspace },
+          sessionDisplayId: "old-session",
+          taskKey: null,
+        },
+      };
+
+      const result = await execute(ctx);
+      // The retry should succeed
+      expect(result.exitCode).toBe(0);
+      // One delta for the full run (both attempts included)
+      expect(result.costUsd).toBeCloseTo(0.35, 5);
+    } finally {
+      await quotaServer.close();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("4.5: no costApi returns costUsd: null (backward compatibility)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cost-api-none-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    try {
+      const ctx = baseCtx(commandPath, workspace); // no costApi
+      const result = await execute(ctx);
+      expect(result.exitCode).toBe(0);
+      expect(result.costUsd).toBeNull();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("4.6: quota server error causes costUsd: null but run still succeeds", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cost-api-err-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    try {
+      const ctx = baseCtx(commandPath, workspace, {
+        costApi: {
+          // Use an unroutable address to simulate network failure
+          url: "http://127.0.0.1:1/quota",
+          key: "test-key",
+          field: "usage.fiveHour.estimatedCostUsdUsed",
+          timeoutMs: 500,
+        },
+      });
+      const warnings: string[] = [];
+      const result = await execute({ ...ctx, onLog: async (_, msg) => { warnings.push(msg); } });
+      expect(result.exitCode).toBe(0);
+      expect(result.costUsd).toBeNull();
+      expect(warnings.some((w) => w.includes("[paperclip] costApi"))).toBe(true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/__tests__/codex-local-cost-api.test.ts
+++ b/server/src/__tests__/codex-local-cost-api.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { resolveDotPath, fetchQuotaCost } from "@paperclipai/adapter-codex-local/server";
+
+// ---------------------------------------------------------------------------
+// resolveDotPath
+// ---------------------------------------------------------------------------
+
+describe("resolveDotPath", () => {
+  it("resolves a top-level numeric field", () => {
+    expect(resolveDotPath({ totalCostUsd: 12.5 }, "totalCostUsd")).toBe(12.5);
+  });
+
+  it("resolves a nested dot-path", () => {
+    const obj = { usage: { fiveHour: { estimatedCostUsdUsed: 3.46 } } };
+    expect(resolveDotPath(obj, "usage.fiveHour.estimatedCostUsdUsed")).toBe(3.46);
+  });
+
+  it("returns null for a missing path", () => {
+    expect(resolveDotPath({ a: { b: 1 } }, "a.c")).toBeNull();
+  });
+
+  it("returns null when the resolved value is a string, not a number", () => {
+    expect(resolveDotPath({ cost: "3.46" }, "cost")).toBeNull();
+  });
+
+  it("returns null when the resolved value is null", () => {
+    expect(resolveDotPath({ cost: null }, "cost")).toBeNull();
+  });
+
+  it("returns null when obj is not an object", () => {
+    expect(resolveDotPath(null, "cost")).toBeNull();
+    expect(resolveDotPath(42, "cost")).toBeNull();
+    expect(resolveDotPath("string", "cost")).toBeNull();
+  });
+
+  it("returns 0 for a zero value (valid number)", () => {
+    expect(resolveDotPath({ cost: 0 }, "cost")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchQuotaCost
+// ---------------------------------------------------------------------------
+
+const baseCostApi = {
+  url: "https://example.com/quota",
+  key: "test-key",
+  field: "usage.fiveHour.estimatedCostUsdUsed",
+  timeoutMs: 5000,
+  attributionMode: "strict_dedicated_key" as const,
+};
+
+describe("fetchQuotaCost", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the resolved numeric value on a successful 200 response", async () => {
+    const body = { usage: { fiveHour: { estimatedCostUsdUsed: 3.46 } } };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => body,
+    }));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBe(3.46);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("returns null and warns on HTTP 401", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    }));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBeNull();
+    expect(warnings.some((w) => w.includes("HTTP 401"))).toBe(true);
+  });
+
+  it("returns null and warns on HTTP 403", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+    }));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBeNull();
+    expect(warnings.some((w) => w.includes("HTTP 403"))).toBe(true);
+  });
+
+  it("returns null and warns on network/fetch error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(new Error("connection refused")));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBeNull();
+    expect(warnings.some((w) => w.includes("connection refused"))).toBe(true);
+  });
+
+  it("returns null and warns on abort/timeout", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(new DOMException("The operation was aborted.", "AbortError")));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBeNull();
+    expect(warnings.some((w) => w.includes("timed out") || w.includes("failed"))).toBe(true);
+  });
+
+  it("returns null and warns when response JSON is malformed", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => { throw new Error("Unexpected token"); },
+    }));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBeNull();
+    expect(warnings.some((w) => w.includes("not valid JSON"))).toBe(true);
+  });
+
+  it("returns null and warns when configured field does not exist in response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ usage: { daily: { estimatedCostUsdUsed: 1.0 } } }),
+    }));
+
+    const warnings: string[] = [];
+    const result = await fetchQuotaCost(baseCostApi, async (msg) => { warnings.push(msg); });
+
+    expect(result).toBeNull();
+    expect(warnings.some((w) => w.includes("did not resolve to a number"))).toBe(true);
+  });
+
+  it("sends Authorization Bearer header", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ usage: { fiveHour: { estimatedCostUsdUsed: 1.0 } } }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchQuotaCost(baseCostApi, async () => {});
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect((options as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer test-key",
+    });
+  });
+});


### PR DESCRIPTION
The codex_local adapter currently hardcodes costUsd: null. This PR adds an optional costApi config to fetch real cost data from an OpenAI-compatible proxy quota endpoint (e.g. The Claw Bay). 19 new tests (15 unit + 4 integration). Fully backwards compatible.