### PR TITLE
feat: add company import/export and skill visibility filtering

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import type { Agent } from "@paperclipai/shared";
 import {
+  listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
-  resolvePaperclipSkillsDir,
 } from "@paperclipai/adapter-utils/server-utils";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -43,6 +43,8 @@ interface SkillsInstallSummary {
   failed: Array<{ name: string; error: string }>;
 }
 
+type SkillEntry = { name: string; source: string };
+
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 function codexSkillsHome(): string {
@@ -58,7 +60,7 @@ function claudeSkillsHome(): string {
 }
 
 async function installSkillsForTarget(
-  sourceSkillsDir: string,
+  sourceSkillsEntries: SkillEntry[],
   targetSkillsDir: string,
   tool: "codex" | "claude",
 ): Promise<SkillsInstallSummary> {
@@ -72,14 +74,13 @@ async function installSkillsForTarget(
   };
 
   await fs.mkdir(targetSkillsDir, { recursive: true });
-  const entries = await fs.readdir(sourceSkillsDir, { withFileTypes: true });
   summary.removed = await removeMaintainerOnlySkillSymlinks(
     targetSkillsDir,
-    entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
+    sourceSkillsEntries.map((entry) => entry.name),
   );
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const source = path.join(sourceSkillsDir, entry.name);
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  for (const entry of sourceSkillsEntries) {
+    const source = entry.source;
     const target = path.join(targetSkillsDir, entry.name);
     const existing = await fs.lstat(target).catch(() => null);
     if (existing) {
@@ -90,7 +91,7 @@ async function installSkillsForTarget(
         } catch (err) {
           await fs.unlink(target);
           try {
-            await fs.symlink(source, target);
+            await fs.symlink(source, target, symlinkType);
             summary.linked.push(entry.name);
             continue;
           } catch (linkErr) {
@@ -128,7 +129,7 @@ async function installSkillsForTarget(
     }
 
     try {
-      await fs.symlink(source, target);
+      await fs.symlink(source, target, symlinkType);
       summary.linked.push(entry.name);
     } catch (err) {
       summary.failed.push({
@@ -248,16 +249,20 @@ export function registerAgentCommands(program: Command): void {
 
           const installSummaries: SkillsInstallSummary[] = [];
           if (opts.installSkills !== false) {
-            const skillsDir = await resolvePaperclipSkillsDir(__moduleDir, [path.resolve(process.cwd(), "skills")]);
-            if (!skillsDir) {
+            const skillsEntries = await listPaperclipSkillEntries(__moduleDir, [
+              path.resolve(process.cwd(), ".agents", "skills"),
+              path.resolve(process.cwd(), ".claude", "skills"),
+              path.resolve(process.cwd(), "skills"),
+            ]);
+            if (skillsEntries.length === 0) {
               throw new Error(
-                "Could not locate local Paperclip skills directory. Expected ./skills in the repo checkout.",
+                "Could not locate local Paperclip skills directory. Expected .agents/skills, .claude/skills, or ./skills in the repo checkout.",
               );
             }
 
             installSummaries.push(
-              await installSkillsForTarget(skillsDir, codexSkillsHome(), "codex"),
-              await installSkillsForTarget(skillsDir, claudeSkillsHome(), "claude"),
+              await installSkillsForTarget(skillsEntries, codexSkillsHome(), "codex"),
+              await installSkillsForTarget(skillsEntries, claudeSkillsHome(), "claude"),
             );
           }
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -36,6 +36,14 @@ const PAPERCLIP_SKILL_ROOT_RELATIVE_CANDIDATES = [
   "../../skills",
   "../../../../../skills",
 ];
+const PAPERCLIP_SKILL_MULTI_ROOT_RELATIVE_CANDIDATES = [
+  "../../.agents/skills",
+  "../../.claude/skills",
+  "../../skills",
+  "../../../../../.agents/skills",
+  "../../../../../.claude/skills",
+  "../../../../../skills",
+];
 
 export interface PaperclipSkillEntry {
   name: string;
@@ -71,6 +79,18 @@ export function asBoolean(value: unknown, fallback: boolean): boolean {
 
 export function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+export function normalizeSelectedSkillNames(value: unknown): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of asStringArray(value)) {
+    const skillName = raw.trim().toLowerCase();
+    if (!skillName || seen.has(skillName)) continue;
+    seen.add(skillName);
+    normalized.push(skillName);
+  }
+  return normalized;
 }
 
 export function parseJson(value: string): Record<string, unknown> | null {
@@ -296,20 +316,43 @@ export async function listPaperclipSkillEntries(
   moduleDir: string,
   additionalCandidates: string[] = [],
 ): Promise<PaperclipSkillEntry[]> {
-  const root = await resolvePaperclipSkillsDir(moduleDir, additionalCandidates);
-  if (!root) return [];
+  const candidates = [
+    ...PAPERCLIP_SKILL_MULTI_ROOT_RELATIVE_CANDIDATES.map((relativePath) => path.resolve(moduleDir, relativePath)),
+    ...additionalCandidates.map((candidate) => path.resolve(candidate)),
+  ];
+  const seenRoots = new Set<string>();
+  const seenNames = new Set<string>();
+  const result: PaperclipSkillEntry[] = [];
 
-  try {
-    const entries = await fs.readdir(root, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => ({
+  for (const root of candidates) {
+    if (seenRoots.has(root)) continue;
+    seenRoots.add(root);
+    const isDirectory = await fs.stat(root).then((stats) => stats.isDirectory()).catch(() => false);
+    if (!isDirectory) continue;
+
+    const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (seenNames.has(entry.name)) continue;
+      seenNames.add(entry.name);
+      result.push({
         name: entry.name,
         source: path.join(root, entry.name),
-      }));
-  } catch {
-    return [];
+      });
+    }
   }
+
+  return result;
+}
+
+export function filterPaperclipSkillEntriesBySelection(
+  entries: PaperclipSkillEntry[],
+  selectedSkillNames: unknown,
+): PaperclipSkillEntry[] {
+  const selected = normalizeSelectedSkillNames(selectedSkillNames);
+  if (selected.length === 0) return entries;
+  const allowed = new Set(selected);
+  return entries.filter((entry) => allowed.has(entry.name.toLowerCase()));
 }
 
 export async function readPaperclipSkillMarkdown(
@@ -333,8 +376,10 @@ export async function readPaperclipSkillMarkdown(
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
-  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) => {
+    const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+    return fs.symlink(linkSource, linkTarget, symlinkType);
+  },
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -17,6 +17,8 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -29,39 +31,25 @@ import {
 } from "./parse.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-const PAPERCLIP_SKILLS_CANDIDATES = [
-  path.resolve(__moduleDir, "../../skills"),         // published: <pkg>/dist/server/ -> <pkg>/skills/
-  path.resolve(__moduleDir, "../../../../../skills"), // dev: src/server/ -> repo root/skills/
-];
-
-async function resolvePaperclipSkillsDir(): Promise<string | null> {
-  for (const candidate of PAPERCLIP_SKILLS_CANDIDATES) {
-    const isDir = await fs.stat(candidate).then((s) => s.isDirectory()).catch(() => false);
-    if (isDir) return candidate;
-  }
-  return null;
-}
 
 /**
  * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
  * the repo's `skills/` directory, so `--add-dir` makes Claude Code discover
  * them as proper registered skills.
  */
-async function buildSkillsDir(): Promise<string> {
+async function buildSkillsDir(selectedSkillNames?: unknown): Promise<string> {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-skills-"));
   const target = path.join(tmp, ".claude", "skills");
   await fs.mkdir(target, { recursive: true });
-  const skillsDir = await resolvePaperclipSkillsDir();
-  if (!skillsDir) return tmp;
-  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      await fs.symlink(
-        path.join(skillsDir, entry.name),
-        path.join(target, entry.name),
-      );
-    }
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
+  if (skillsEntries.length === 0) return tmp;
+
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  for (const entry of skillsEntries) {
+    await fs.symlink(entry.source, path.join(target, entry.name), symlinkType);
   }
+
   return tmp;
 }
 
@@ -341,7 +329,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     extraArgs,
   } = runtimeConfig;
   const billingType = resolveClaudeBillingType(env);
-  const skillsDir = await buildSkillsDir();
+  const skillsDir = await buildSkillsDir(config.skills);
 
   // When instructionsFilePath is configured, create a combined temp file that
   // includes both the file content and the path directive, so we only need

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   joinPromptSections,
@@ -92,6 +93,7 @@ async function isLikelyPaperclipRuntimeSkillSource(candidate: string, skillName:
 type EnsureCodexSkillsInjectedOptions = {
   skillsHome?: string;
   skillsEntries?: Awaited<ReturnType<typeof listPaperclipSkillEntries>>;
+  selectedSkillNames?: unknown;
   linkSkill?: (source: string, target: string) => Promise<void>;
 };
 
@@ -99,7 +101,11 @@ export async function ensureCodexSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   options: EnsureCodexSkillsInjectedOptions = {},
 ) {
-  const skillsEntries = options.skillsEntries ?? await listPaperclipSkillEntries(__moduleDir);
+  const allSkillsEntries = options.skillsEntries ?? await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(
+    allSkillsEntries,
+    options.selectedSkillNames,
+  );
   if (skillsEntries.length === 0) return;
 
   const skillsHome = options.skillsHome ?? path.join(resolveCodexHomeDir(process.env), "skills");
@@ -114,7 +120,8 @@ export async function ensureCodexSkillsInjected(
       `[paperclip] Removed maintainer-only Codex skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill;
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target, symlinkType));
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
 
@@ -131,11 +138,7 @@ export async function ensureCodexSkillsInjected(
           (await isLikelyPaperclipRuntimeSkillSource(resolvedLinkedPath, entry.name))
         ) {
           await fs.unlink(target);
-          if (linkSkill) {
-            await linkSkill(entry.source, target);
-          } else {
-            await fs.symlink(entry.source, target);
-          }
+          await linkSkill(entry.source, target);
           await onLog(
             "stderr",
             `[paperclip] Repaired Codex skill "${entry.name}" into ${skillsHome}\n`,
@@ -220,7 +223,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveCodexHome = configuredCodexHome ?? preparedWorktreeCodexHome;
   await ensureCodexSkillsInjected(
     onLog,
-    effectiveCodexHome ? { skillsHome: path.join(effectiveCodexHome, "skills") } : {},
+    effectiveCodexHome
+      ? { skillsHome: path.join(effectiveCodexHome, "skills"), selectedSkillNames: config.skills }
+      : { selectedSkillNames: config.skills },
   );
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   joinPromptSections,
@@ -84,6 +85,7 @@ function cursorSkillsHome(): string {
 type EnsureCursorSkillsInjectedOptions = {
   skillsDir?: string | null;
   skillsEntries?: Array<{ name: string; source: string }>;
+  selectedSkillNames?: unknown;
   skillsHome?: string;
   linkSkill?: (source: string, target: string) => Promise<void>;
 };
@@ -92,12 +94,16 @@ export async function ensureCursorSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   options: EnsureCursorSkillsInjectedOptions = {},
 ) {
-  const skillsEntries = options.skillsEntries
+  const allSkillsEntries = options.skillsEntries
     ?? (options.skillsDir
       ? (await fs.readdir(options.skillsDir, { withFileTypes: true }))
           .filter((entry) => entry.isDirectory())
           .map((entry) => ({ name: entry.name, source: path.join(options.skillsDir!, entry.name) }))
       : await listPaperclipSkillEntries(__moduleDir));
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(
+    allSkillsEntries,
+    options.selectedSkillNames,
+  );
   if (skillsEntries.length === 0) return;
 
   const skillsHome = options.skillsHome ?? cursorSkillsHome();
@@ -120,7 +126,8 @@ export async function ensureCursorSkillsInjected(
       `[paperclip] Removed maintainer-only Cursor skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target));
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target, symlinkType));
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
     try {
@@ -168,7 +175,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  await ensureCursorSkillsInjected(onLog);
+  await ensureCursorSkillsInjected(onLog, { selectedSkillNames: config.skills });
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   joinPromptSections,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   parseObject,
   redactEnvForLogs,
@@ -84,8 +85,10 @@ function geminiSkillsHome(): string {
  */
 async function ensureGeminiSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
+  selectedSkillNames?: unknown,
 ): Promise<void> {
-  const skillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
   if (skillsEntries.length === 0) return;
 
   const skillsHome = geminiSkillsHome();
@@ -109,11 +112,14 @@ async function ensureGeminiSkillsInjected(
     );
   }
 
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = (source: string, target: string) => fs.symlink(source, target, symlinkType);
+
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
 
     try {
-      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      const result = await ensurePaperclipSkillSymlink(entry.source, target, linkSkill);
       if (result === "skipped") continue;
       await onLog(
         "stderr",
@@ -156,7 +162,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  await ensureGeminiSkillsInjected(onLog);
+  await ensureGeminiSkillsInjected(onLog, config.skills);
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -13,7 +13,11 @@ import {
   redactEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
+  ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
+  removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -21,10 +25,6 @@ import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-const PAPERCLIP_SKILLS_CANDIDATES = [
-  path.resolve(__moduleDir, "../../skills"),
-  path.resolve(__moduleDir, "../../../../../skills"),
-];
 
 function firstNonEmptyLine(text: string): string {
   return (
@@ -46,33 +46,38 @@ function claudeSkillsHome(): string {
   return path.join(os.homedir(), ".claude", "skills");
 }
 
-async function resolvePaperclipSkillsDir(): Promise<string | null> {
-  for (const candidate of PAPERCLIP_SKILLS_CANDIDATES) {
-    const isDir = await fs.stat(candidate).then((s) => s.isDirectory()).catch(() => false);
-    if (isDir) return candidate;
-  }
-  return null;
-}
-
-async function ensureOpenCodeSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
-  const skillsDir = await resolvePaperclipSkillsDir();
-  if (!skillsDir) return;
+async function ensureOpenCodeSkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  selectedSkillNames?: unknown,
+) {
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
+  if (skillsEntries.length === 0) return;
 
   const skillsHome = claudeSkillsHome();
   await fs.mkdir(skillsHome, { recursive: true });
-  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const source = path.join(skillsDir, entry.name);
+  const removedSkills = await removeMaintainerOnlySkillSymlinks(
+    skillsHome,
+    skillsEntries.map((entry) => entry.name),
+  );
+  for (const skillName of removedSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed maintainer-only OpenCode skill "${skillName}" from ${skillsHome}\n`,
+    );
+  }
+
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = (source: string, target: string) => fs.symlink(source, target, symlinkType);
+  for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
-    const existing = await fs.lstat(target).catch(() => null);
-    if (existing) continue;
 
     try {
-      await fs.symlink(source, target);
+      const result = await ensurePaperclipSkillSymlink(entry.source, target, linkSkill);
+      if (result === "skipped") continue;
       await onLog(
         "stderr",
-        `[paperclip] Injected OpenCode skill "${entry.name}" into ${skillsHome}\n`,
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Injected"} OpenCode skill "${entry.name}" into ${skillsHome}\n`,
       );
     } catch (err) {
       await onLog(
@@ -111,7 +116,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  await ensureOpenCodeSkillsInjected(onLog);
+  await ensureOpenCodeSkillsInjected(onLog, config.skills);
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   runChildProcess,
@@ -50,8 +51,12 @@ function parseModelId(model: string | null): string | null {
   return trimmed.slice(trimmed.indexOf("/") + 1).trim() || null;
 }
 
-async function ensurePiSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
-  const skillsEntries = await listPaperclipSkillEntries(__moduleDir);
+async function ensurePiSkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  selectedSkillNames?: unknown,
+) {
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
   if (skillsEntries.length === 0) return;
 
   const piSkillsHome = path.join(os.homedir(), ".pi", "agent", "skills");
@@ -67,11 +72,14 @@ async function ensurePiSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
     );
   }
 
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = (source: string, target: string) => fs.symlink(source, target, symlinkType);
+
   for (const entry of skillsEntries) {
     const target = path.join(piSkillsHome, entry.name);
 
     try {
-      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      const result = await ensurePaperclipSkillSymlink(entry.source, target, linkSkill);
       if (result === "skipped") continue;
       await onLog(
         "stderr",
@@ -133,7 +141,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   await ensureSessionsDir();
   
   // Inject skills
-  await ensurePiSkillsInjected(onLog);
+  await ensurePiSkillsInjected(onLog, config.skills);
 
   // Build environment
   const envConfig = parseObject(config.env);

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -19,19 +19,23 @@ describe("paperclip skill utils", () => {
     cleanupDirs.clear();
   });
 
-  it("lists runtime skills from ./skills without pulling in .agents/skills", async () => {
+  it("lists runtime skills from .agents/.claude/skills roots with deterministic priority", async () => {
     const root = await makeTempDir("paperclip-skill-roots-");
     cleanupDirs.add(root);
 
     const moduleDir = path.join(root, "a", "b", "c", "d", "e");
     await fs.mkdir(moduleDir, { recursive: true });
-    await fs.mkdir(path.join(root, "skills", "paperclip"), { recursive: true });
     await fs.mkdir(path.join(root, ".agents", "skills", "release"), { recursive: true });
+    await fs.mkdir(path.join(root, ".claude", "skills", "review"), { recursive: true });
+    await fs.mkdir(path.join(root, "skills", "paperclip"), { recursive: true });
+    await fs.mkdir(path.join(root, "skills", "release"), { recursive: true });
 
     const entries = await listPaperclipSkillEntries(moduleDir);
 
-    expect(entries.map((entry) => entry.name)).toEqual(["paperclip"]);
-    expect(entries[0]?.source).toBe(path.join(root, "skills", "paperclip"));
+    expect(entries.map((entry) => entry.name)).toEqual(["release", "review", "paperclip"]);
+    expect(entries[0]?.source).toBe(path.join(root, ".agents", "skills", "release"));
+    expect(entries[1]?.source).toBe(path.join(root, ".claude", "skills", "review"));
+    expect(entries[2]?.source).toBe(path.join(root, "skills", "paperclip"));
   });
 
   it("removes stale maintainer-only symlinks from a shared skills home", async () => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -28,6 +28,7 @@ import {
   PERMISSION_KEYS
 } from "@paperclipai/shared";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+import { listPaperclipSkillEntries } from "@paperclipai/adapter-utils/server-utils";
 import {
   forbidden,
   conflict,
@@ -95,28 +96,35 @@ function requestBaseUrl(req: Request) {
   return `${proto}://${host}`;
 }
 
-function readSkillMarkdown(skillName: string): string | null {
-  const normalized = skillName.trim().toLowerCase();
-  if (
-    normalized !== "paperclip" &&
-    normalized !== "paperclip-create-agent" &&
-    normalized !== "para-memory-files"
-  )
-    return null;
-  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    path.resolve(moduleDir, "../../skills", normalized, "SKILL.md"), // published: dist/routes/ -> <pkg>/skills/
-    path.resolve(process.cwd(), "skills", normalized, "SKILL.md"), // cwd (e.g. monorepo root)
-    path.resolve(moduleDir, "../../../skills", normalized, "SKILL.md") // dev: src/routes/ -> repo root/skills/
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function resolveServerSkillCandidates(): string[] {
+  return [
+    path.resolve(__moduleDir, "../../../.agents/skills"),
+    path.resolve(__moduleDir, "../../../.claude/skills"),
+    path.resolve(__moduleDir, "../../../skills"),
+    path.resolve(__moduleDir, "../../.agents/skills"),
+    path.resolve(__moduleDir, "../../.claude/skills"),
+    path.resolve(__moduleDir, "../../skills"),
+    path.resolve(process.cwd(), ".agents", "skills"),
+    path.resolve(process.cwd(), ".claude", "skills"),
+    path.resolve(process.cwd(), "skills"),
   ];
-  for (const skillPath of candidates) {
-    try {
-      return fs.readFileSync(skillPath, "utf8");
-    } catch {
-      // Continue to next candidate.
-    }
+}
+
+async function readSkillMarkdown(skillName: string): Promise<string | null> {
+  const normalized = skillName.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const entries = await listPaperclipSkillEntries(__moduleDir, resolveServerSkillCandidates());
+  const match = entries.find((entry) => entry.name === normalized);
+  if (!match) return null;
+
+  try {
+    return await fs.promises.readFile(path.join(match.source, "SKILL.md"), "utf8");
+  } catch {
+    return null;
   }
-  return null;
 }
 
 function toJoinRequestResponse(row: typeof joinRequests.$inferSelect) {
@@ -1610,25 +1618,19 @@ export function accessRoutes(
     return { token, created, normalizedAgentMessage };
   }
 
-  router.get("/skills/index", (_req, res) => {
+  router.get("/skills/index", async (_req, res) => {
+    const skills = await listPaperclipSkillEntries(__moduleDir, resolveServerSkillCandidates());
     res.json({
-      skills: [
-        { name: "paperclip", path: "/api/skills/paperclip" },
-        {
-          name: "para-memory-files",
-          path: "/api/skills/para-memory-files"
-        },
-        {
-          name: "paperclip-create-agent",
-          path: "/api/skills/paperclip-create-agent"
-        }
-      ]
+      skills: skills.map((entry) => ({
+        name: entry.name,
+        path: `/api/skills/${entry.name}`
+      }))
     });
   });
 
-  router.get("/skills/:skillName", (req, res) => {
+  router.get("/skills/:skillName", async (req, res) => {
     const skillName = (req.params.skillName as string).trim().toLowerCase();
-    const markdown = readSkillMarkdown(skillName);
+    const markdown = await readSkillMarkdown(skillName);
     if (!markdown) throw notFound("Skill not found");
     res.type("text/markdown").send(markdown);
   });

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -23,6 +23,11 @@ export interface AdapterModel {
   label: string;
 }
 
+export interface SkillIndexEntry {
+  name: string;
+  path: string;
+}
+
 export interface ClaudeLoginResult {
   exitCode: number | null;
   signal: string | null;
@@ -130,6 +135,10 @@ export const agentsApi = {
       `/companies/${companyId}/adapters/${type}/test-environment`,
       data,
     ),
+  listSkills: async () => {
+    const payload = await api.get<{ skills: SkillIndexEntry[] }>("/skills/index");
+    return (payload.skills ?? []).map((entry) => entry.name);
+  },
   invoke: (id: string, companyId?: string) => api.post<HeartbeatRun>(agentPath(id, companyId, "/heartbeat/invoke"), {}),
   wakeup: (
     id: string,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -126,6 +126,20 @@ function formatArgList(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+function normalizeSkillSelection(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const name = item.trim().toLowerCase();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
 const codexThinkingEffortOptions = [
   { id: "", label: "Auto" },
   { id: "minimal", label: "Minimal" },
@@ -300,6 +314,14 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     enabled: Boolean(selectedCompanyId),
   });
   const models = fetchedModels ?? externalModels ?? [];
+  const {
+    data: availableSkills = [],
+    error: availableSkillsError,
+  } = useQuery({
+    queryKey: ["skills", "index", selectedCompanyId ?? "__no-company__"],
+    queryFn: () => agentsApi.listSkills(),
+    enabled: Boolean(selectedCompanyId),
+  });
 
   /** Props passed to adapter-specific config field components */
   const adapterFieldProps = {
@@ -319,6 +341,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   // Popover states
   const [modelOpen, setModelOpen] = useState(false);
   const [thinkingEffortOpen, setThinkingEffortOpen] = useState(false);
+  const [skillsOpen, setSkillsOpen] = useState(false);
 
   // Create mode helpers
   const val = isCreate ? props.values : null;
@@ -383,6 +406,20 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const codexSearchEnabled = adapterType === "codex_local"
     ? (isCreate ? Boolean(val!.search) : eff("adapterConfig", "search", Boolean(config.search)))
     : false;
+  const selectedSkillsRaw = !isCreate
+    ? eff("adapterConfig", "skills", normalizeSkillSelection(config.skills))
+    : [];
+  const selectedSkills = normalizeSkillSelection(selectedSkillsRaw);
+  const skillOptions = useMemo(() => {
+    const merged = [...availableSkills, ...selectedSkills];
+    const seen = new Set<string>();
+    return merged.filter((name) => {
+      const normalized = name.trim().toLowerCase();
+      if (!normalized || seen.has(normalized)) return false;
+      seen.add(normalized);
+      return true;
+    });
+  }, [availableSkills, selectedSkills]);
 
   return (
     <div className={cn("relative", cards && "space-y-6")}>
@@ -663,6 +700,25 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     ? fetchedModelsError.message
                     : "Failed to load adapter models."}
                 </p>
+              )}
+
+              {!isCreate && (
+                <>
+                  <SkillsDropdown
+                    options={skillOptions}
+                    value={selectedSkills}
+                    onChange={(next) => mark("adapterConfig", "skills", next.length > 0 ? next : undefined)}
+                    open={skillsOpen}
+                    onOpenChange={setSkillsOpen}
+                  />
+                  {availableSkillsError && (
+                    <p className="text-xs text-destructive">
+                      {availableSkillsError instanceof Error
+                        ? availableSkillsError.message
+                        : "Failed to load skills index."}
+                    </p>
+                  )}
+                </>
               )}
 
               {showThinkingEffort && (
@@ -1360,6 +1416,83 @@ function ModelDropdown({
             {filteredModels.length === 0 && (
               <p className="px-2 py-1.5 text-xs text-muted-foreground">No models found.</p>
             )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </Field>
+  );
+}
+
+function SkillsDropdown({
+  options,
+  value,
+  onChange,
+  open,
+  onOpenChange,
+}: {
+  options: string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((name) => name.toLowerCase().includes(q));
+  }, [options, search]);
+
+  const toggle = (name: string) => {
+    onChange(value.includes(name) ? value.filter((entry) => entry !== name) : [...value, name]);
+  };
+
+  return (
+    <Field label="Skills" hint={help.skills}>
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          onOpenChange(nextOpen);
+          if (!nextOpen) setSearch("");
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
+            <span className={cn(value.length === 0 && "text-muted-foreground")}>
+              {value.length === 0 ? "All discovered skills" : `${value.length} selected`}
+            </span>
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-1" align="start">
+          <input
+            className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
+            placeholder="Search skills..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+          <div className="max-h-[220px] overflow-y-auto">
+            {filtered.map((name) => {
+              const checked = value.includes(name);
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  className={cn(
+                    "flex items-center justify-between w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
+                    checked && "bg-accent",
+                  )}
+                  onClick={() => toggle(name)}
+                >
+                  <span>{name}</span>
+                  {checked ? <span className="text-xs text-muted-foreground">Selected</span> : null}
+                </button>
+              );
+            })}
+            {filtered.length === 0 ? (
+              <p className="px-2 py-2 text-xs text-muted-foreground">No matching skills</p>
+            ) : null}
           </div>
         </PopoverContent>
       </Popover>

--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Paperclip, Plus } from "lucide-react";
-import { useQueries } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { Paperclip, Plus, Upload } from "lucide-react";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
   DndContext,
   closestCenter,
@@ -28,8 +28,18 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { Company } from "@paperclipai/shared";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Company, CompanyPortabilityExportResult } from "@paperclipai/shared";
 import { CompanyPatternIcon } from "./CompanyPatternIcon";
+import { companiesApi } from "../api/companies";
+import { useToast } from "../context/ToastContext";
 
 const ORDER_STORAGE_KEY = "paperclip.companyOrder";
 
@@ -155,6 +165,9 @@ function SortableCompanyItem({
 export function CompanyRail() {
   const { companies, selectedCompanyId, setSelectedCompanyId } = useCompany();
   const { openOnboarding } = useDialog();
+  const { pushToast } = useToast();
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const isInstanceRoute = location.pathname.startsWith("/instance/");
@@ -265,6 +278,38 @@ export function CompanyRail() {
     [orderedCompanies]
   );
 
+  const handleImportFile = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    try {
+      const parsed = JSON.parse(await file.text()) as CompanyPortabilityExportResult;
+      const payload = {
+        source: { type: "inline" as const, manifest: parsed.manifest, files: parsed.files },
+        include: { company: true, agents: true },
+        target: { mode: "new_company" as const },
+        agents: "all" as const,
+        collisionStrategy: "rename" as const,
+      };
+      const preview = await companiesApi.importPreview(payload);
+      if (preview.errors.length > 0) throw new Error(preview.errors.join("; "));
+      const imported = await companiesApi.importBundle(payload);
+      const importedCompany = await companiesApi.get(imported.company.id);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+      setSelectedCompanyId(importedCompany.id);
+      pushToast({ title: "Company imported", body: importedCompany.name, tone: "success" });
+      if (isInstanceRoute) {
+        navigate(`/${importedCompany.issuePrefix}/dashboard`);
+      }
+    } catch (error) {
+      pushToast({
+        title: "Import failed",
+        body: error instanceof Error ? error.message : "Unable to import company",
+        tone: "error",
+      });
+    }
+  }, [isInstanceRoute, navigate, pushToast, queryClient, setSelectedCompanyId]);
+
   return (
     <div className="flex flex-col items-center w-[72px] shrink-0 h-full bg-background border-r border-border">
       {/* Paperclip icon - aligned with top sections (implied line, no visible border) */}
@@ -305,23 +350,45 @@ export function CompanyRail() {
       {/* Separator before add button */}
       <div className="w-8 h-px bg-border mx-auto shrink-0" />
 
-      {/* Add company button */}
       <div className="flex items-center justify-center py-2 shrink-0">
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => openOnboarding()}
-              className="flex items-center justify-center w-11 h-11 rounded-[22px] hover:rounded-[14px] border-2 border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground transition-[border-color,color,border-radius] duration-150"
-              aria-label="Add company"
-            >
-              <Plus className="h-5 w-5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={8}>
-            <p>Add company</p>
-          </TooltipContent>
-        </Tooltip>
+        <DropdownMenu>
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex items-center justify-center w-11 h-11 rounded-[22px] hover:rounded-[14px] border-2 border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground transition-[border-color,color,border-radius] duration-150"
+                  aria-label="Add company"
+                >
+                  <Plus className="h-5 w-5" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>
+              <p>Add company</p>
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent side="right" align="start" sideOffset={8}>
+            <DropdownMenuLabel>Import</DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => fileInputRef.current?.click()}>
+              <Upload className="h-4 w-4" />
+              Import Company
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Create</DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => openOnboarding()}>
+              <Plus className="h-4 w-4" />
+              Create Company
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json,.json"
+        className="hidden"
+        onChange={handleImportFile}
+      />
     </div>
   );
 }

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -28,6 +28,7 @@ export const help: Record<string, string> = {
   cwd: "Default working directory fallback for local adapters. Use an absolute path on the machine running Paperclip.",
   promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Use it for current-task framing, not large static instructions. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} and other template variables.",
   model: "Override the default model used by the adapter.",
+  skills: "Limit this agent to selected Paperclip skills. Leave empty to allow all discovered skills.",
   thinkingEffort: "Control model reasoning depth. Supported values vary by adapter/model.",
   chrome: "Enable Claude's Chrome integration by passing --chrome.",
   dangerouslySkipPermissions: "Run Claude without permission prompts. Required for unattended operation.",

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -6,7 +6,7 @@ import { companiesApi } from "../api/companies";
 import { accessApi } from "../api/access";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
-import { Settings, Check } from "lucide-react";
+import { Settings, Check, Download } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
 import {
   Field,
@@ -47,6 +47,7 @@ export function CompanySettings() {
   const [inviteSnippet, setInviteSnippet] = useState<string | null>(null);
   const [snippetCopied, setSnippetCopied] = useState(false);
   const [snippetCopyDelightId, setSnippetCopyDelightId] = useState(0);
+  const [exporting, setExporting] = useState(false);
 
   const generalDirty =
     !!selectedCompany &&
@@ -178,11 +179,41 @@ export function CompanySettings() {
     });
   }
 
+  async function handleExportCompany() {
+    if (!selectedCompanyId || !selectedCompany) return;
+    try {
+      setExporting(true);
+      const exported = await companiesApi.exportBundle(selectedCompanyId, {
+        include: { company: true, agents: true }
+      });
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const safeName = selectedCompany.name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "company";
+      const blob = new Blob([JSON.stringify(exported, null, 2)], { type: "application/json;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `${safeName}-${selectedCompany.issuePrefix}-${timestamp}.paperclip.json`;
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } finally {
+      setExporting(false);
+    }
+  }
+
   return (
     <div className="max-w-2xl space-y-6">
-      <div className="flex items-center gap-2">
-        <Settings className="h-5 w-5 text-muted-foreground" />
-        <h1 className="text-lg font-semibold">Company Settings</h1>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Settings className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Company Settings</h1>
+        </div>
+        <Button size="sm" variant="outline" onClick={handleExportCompany} disabled={exporting}>
+          <Download className="h-4 w-4 mr-1.5" />
+          {exporting ? "Exporting..." : "Export Company"}
+        </Button>
       </div>
 
       {/* General */}


### PR DESCRIPTION
## I've made the following improvements to the Paperclip project:
1. I've improved the Windows deployment and addressed the skills injection issue (replacing it with junction injection).
2. I've provided a configurable skills list for each agent, or for every future agent, allowing for user-defined skills configuration (no need to worry about clutter).
3. I've added an import/export mechanism for company structure, enabling one-click export or import.

### SKILLS LIST
<img width="782" height="354" alt="image" src="https://github.com/user-attachments/assets/66f2a1eb-09e1-41d0-9b85-f7e1f971ad8b" />

### IMPORT/EXPORT COMPANY
- <img width="711" height="85" alt="image" src="https://github.com/user-attachments/assets/bf07c3ff-dc1c-42b4-8db8-ed4c480a26f1" />

- <img width="328" height="52" alt="image" src="https://github.com/user-attachments/assets/27f08cf3-1464-48c2-b215-12b83a0b0ab2" />

- <img width="258" height="165" alt="image" src="https://github.com/user-attachments/assets/5d88f4e5-62da-4173-a894-28cd975fd150" />

### TEST PLAN
**All tests were successful.**