### PR TITLE
feat: add system status monitoring page

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -25,6 +25,7 @@ import { activityRoutes } from "./routes/activity.js";
 import { dashboardRoutes } from "./routes/dashboard.js";
 import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { instanceSettingsRoutes } from "./routes/instance-settings.js";
+import { systemStatusRoutes } from "./routes/system-status.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
@@ -139,6 +140,7 @@ export async function createApp(
       companyDeletionEnabled: opts.companyDeletionEnabled,
     }),
   );
+  api.use("/system-status", systemStatusRoutes(db));
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(companySkillRoutes(db));
   api.use(agentRoutes(db));

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -9,6 +9,7 @@ export { goalRoutes } from "./goals.js";
 export { approvalRoutes } from "./approvals.js";
 export { secretRoutes } from "./secrets.js";
 export { costRoutes } from "./costs.js";
+export { systemStatusRoutes } from "./system-status.js";
 export { activityRoutes } from "./activity.js";
 export { dashboardRoutes } from "./dashboard.js";
 export { sidebarBadgeRoutes } from "./sidebar-badges.js";

--- a/server/src/routes/system-status.ts
+++ b/server/src/routes/system-status.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
 import { sql } from "drizzle-orm";
-import { forbidden } from "../errors.js";
+import { unauthorized } from "../errors.js";
 
 interface ServiceStatus {
   name: string;
@@ -25,8 +25,12 @@ export function systemStatusRoutes(db: Db) {
 
   router.get("/", async (req, res) => {
     if (req.actor.type === "none") {
-      throw forbidden();
+      throw unauthorized();
     }
+
+    const vllmUrl = process.env.VLLM_API_URL ?? "http://host.docker.internal:8000/v1";
+    const langgraphUrl = process.env.DEERFLOW_LANGGRAPH_URL ?? "http://deerflow-langgraph:2024";
+    const gatewayUrl = process.env.DEERFLOW_GATEWAY_URL ?? "http://deerflow-gateway:8001";
 
     const [postgres, vllm, deerflowLanggraph, deerflowGateway] = await Promise.all([
       (async (): Promise<ServiceStatus> => {
@@ -38,9 +42,9 @@ export function systemStatusRoutes(db: Db) {
           return { name: "PostgreSQL", status: "unhealthy", responseTimeMs: Date.now() - start };
         }
       })(),
-      checkHttp("vLLM", "http://host.docker.internal:8000/v1/models"),
-      checkHttp("DeerFlow LangGraph", "http://deerflow-langgraph:2024/ok"),
-      checkHttp("DeerFlow Gateway", "http://deerflow-gateway:8001/health"),
+      checkHttp("vLLM", `${vllmUrl}/models`),
+      checkHttp("DeerFlow LangGraph", `${langgraphUrl}/ok`),
+      checkHttp("DeerFlow Gateway", `${gatewayUrl}/health`),
     ]);
 
     res.json([postgres, vllm, deerflowLanggraph, deerflowGateway]);

--- a/server/src/routes/system-status.ts
+++ b/server/src/routes/system-status.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { sql } from "drizzle-orm";
+import { forbidden } from "../errors.js";
+
+interface ServiceStatus {
+  name: string;
+  status: "healthy" | "unhealthy";
+  responseTimeMs: number;
+}
+
+async function checkHttp(name: string, url: string): Promise<ServiceStatus> {
+  const start = Date.now();
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    const responseTimeMs = Date.now() - start;
+    return { name, status: res.ok ? "healthy" : "unhealthy", responseTimeMs };
+  } catch {
+    return { name, status: "unhealthy", responseTimeMs: Date.now() - start };
+  }
+}
+
+export function systemStatusRoutes(db: Db) {
+  const router = Router();
+
+  router.get("/", async (req, res) => {
+    if (req.actor.type === "none") {
+      throw forbidden();
+    }
+
+    const [postgres, vllm, deerflowLanggraph, deerflowGateway] = await Promise.all([
+      (async (): Promise<ServiceStatus> => {
+        const start = Date.now();
+        try {
+          await db.execute(sql`SELECT 1`);
+          return { name: "PostgreSQL", status: "healthy", responseTimeMs: Date.now() - start };
+        } catch {
+          return { name: "PostgreSQL", status: "unhealthy", responseTimeMs: Date.now() - start };
+        }
+      })(),
+      checkHttp("vLLM", "http://host.docker.internal:8000/v1/models"),
+      checkHttp("DeerFlow LangGraph", "http://deerflow-langgraph:2024/ok"),
+      checkHttp("DeerFlow Gateway", "http://deerflow-gateway:8001/health"),
+    ]);
+
+    res.json([postgres, vllm, deerflowLanggraph, deerflowGateway]);
+  });
+
+  return router;
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,6 +29,7 @@ import { CompanyExport } from "./pages/CompanyExport";
 import { CompanyImport } from "./pages/CompanyImport";
 import { DesignGuide } from "./pages/DesignGuide";
 import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
+import { SystemStatus } from "./pages/SystemStatus";
 import { InstanceSettings } from "./pages/InstanceSettings";
 import { InstanceExperimentalSettings } from "./pages/InstanceExperimentalSettings";
 import { PluginManager } from "./pages/PluginManager";
@@ -163,6 +164,7 @@ function boardRoutes() {
       <Route path="approvals/all" element={<Approvals />} />
       <Route path="approvals/:approvalId" element={<ApprovalDetail />} />
       <Route path="costs" element={<Costs />} />
+      <Route path="status" element={<SystemStatus />} />
       <Route path="activity" element={<Activity />} />
       <Route path="inbox" element={<InboxRootRedirect />} />
       <Route path="inbox/recent" element={<Inbox />} />

--- a/ui/src/api/systemStatus.ts
+++ b/ui/src/api/systemStatus.ts
@@ -1,0 +1,11 @@
+import { api } from "./client";
+
+export interface ServiceStatus {
+  name: string;
+  status: "healthy" | "unhealthy";
+  responseTimeMs: number;
+}
+
+export const systemStatusApi = {
+  getAll: () => api.get<ServiceStatus[]>("/system-status"),
+};

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -14,6 +14,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "usage",
   "activity",
   "inbox",
+  "status",
   "design-guide",
 ]);
 

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -116,6 +116,7 @@ export const queryKeys = {
     ["usage-window-spend", companyId] as const,
   usageQuotaWindows: (companyId: string) =>
     ["usage-quota-windows", companyId] as const,
+  systemStatus: (companyId: string) => ["system-status", companyId] as const,
   heartbeats: (companyId: string, agentId?: string) =>
     ["heartbeats", companyId, agentId] as const,
   runDetail: (runId: string) => ["heartbeat-run", runId] as const,

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -116,7 +116,7 @@ export const queryKeys = {
     ["usage-window-spend", companyId] as const,
   usageQuotaWindows: (companyId: string) =>
     ["usage-quota-windows", companyId] as const,
-  systemStatus: (companyId: string) => ["system-status", companyId] as const,
+  systemStatus: () => ["system-status"] as const,
   heartbeats: (companyId: string, agentId?: string) =>
     ["heartbeats", companyId, agentId] as const,
   runDetail: (runId: string) => ["heartbeat-run", runId] as const,

--- a/ui/src/pages/SystemStatus.tsx
+++ b/ui/src/pages/SystemStatus.tsx
@@ -29,7 +29,7 @@ export function SystemStatus() {
   }, []);
 
   const { data, isLoading, error, refetch, isFetching } = useQuery({
-    queryKey: queryKeys.systemStatus(selectedCompanyId!),
+    queryKey: queryKeys.systemStatus(),
     queryFn: () => systemStatusApi.getAll(),
     enabled: !!selectedCompanyId,
   });
@@ -101,11 +101,6 @@ export function SystemStatus() {
                 <p className="text-xs text-muted-foreground mt-1.5">
                   Response time: {service.responseTimeMs}ms
                 </p>
-                {lastChecked && (
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    Last checked: {timeAgo(lastChecked)}
-                  </p>
-                )}
               </CardContent>
             </Card>
           ))}

--- a/ui/src/pages/SystemStatus.tsx
+++ b/ui/src/pages/SystemStatus.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Activity } from "lucide-react";
+import { systemStatusApi } from "../api/systemStatus";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { timeAgo } from "../lib/timeAgo";
+import { cn } from "../lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export function SystemStatus() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [lastChecked, setLastChecked] = useState<Date | null>(null);
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "System Status" }]);
+  }, [setBreadcrumbs]);
+
+  // Re-render every 10 seconds to keep "last checked" timestamp fresh
+  useEffect(() => {
+    const id = setInterval(() => tick((n) => n + 1), 10_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { data, isLoading, error, refetch, isFetching } = useQuery({
+    queryKey: queryKeys.systemStatus(selectedCompanyId!),
+    queryFn: () => systemStatusApi.getAll(),
+    enabled: !!selectedCompanyId,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setLastChecked(new Date());
+    }
+  }, [data]);
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={Activity} message="Select a company to view system status." />;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          {lastChecked && (
+            <p className="text-sm text-muted-foreground">
+              Last checked {timeAgo(lastChecked)}
+            </p>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          {isFetching ? "Refreshing..." : "Refresh"}
+        </Button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive">{error.message}</p>
+      )}
+
+      {data && (
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {data.map((service) => (
+            <Card key={service.name}>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium truncate">{service.name}</span>
+                  <div className="flex items-center gap-1.5 shrink-0 ml-2">
+                    <span
+                      className={cn(
+                        "w-2 h-2 rounded-full",
+                        service.status === "healthy" ? "bg-green-500" : "bg-red-500"
+                      )}
+                    />
+                    <span
+                      className={cn(
+                        "text-xs",
+                        service.status === "healthy"
+                          ? "text-green-600 dark:text-green-400"
+                          : "text-red-600 dark:text-red-400"
+                      )}
+                    >
+                      {service.status}
+                    </span>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1.5">
+                  Response time: {service.responseTimeMs}ms
+                </p>
+                {lastChecked && (
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Last checked: {timeAgo(lastChecked)}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {data && data.length === 0 && (
+        <p className="text-sm text-muted-foreground">No services found.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a system status page that shows the health of connected services (PostgreSQL, vLLM, DeerFlow LangGraph, DeerFlow Gateway) with response times.

- New `/system-status/` API endpoint that checks service health
- New System Status UI page with service cards showing status and response times

## Test plan
- [ ] System status page renders at /system-status
- [ ] Services show UP/DOWN with response times
- [ ] Page handles service unavailability gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)