### PR TITLE
feat: add heartbeat wakeup debouncing and parent-child notifications

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1665,10 +1665,16 @@ export function issueRoutes(
     }
     const assigneeChanged =
       issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
+    const assigneeExplicitlySpecified =
+      req.body.assigneeAgentId !== undefined && !!issue.assigneeAgentId;
     const statusChangedFromBacklog =
       existing.status === "backlog" &&
       issue.status !== "backlog" &&
       req.body.status !== undefined;
+    const statusChangedToNonBacklog =
+      req.body.status !== undefined &&
+      issue.status !== "backlog" &&
+      existing.status !== issue.status;
     const previousExecutionState = parseIssueExecutionState(existing.executionState);
     const nextExecutionState = parseIssueExecutionState(issue.executionState);
     const executionStageWakeup = buildExecutionStageWakeup({
@@ -1694,7 +1700,7 @@ export function issueRoutes(
 
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
-      } else if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
+      } else if ((assigneeChanged || assigneeExplicitlySpecified) && issue.assigneeAgentId && issue.status !== "backlog") {
         addWakeup(issue.assigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",
@@ -1722,7 +1728,7 @@ export function issueRoutes(
         });
       }
 
-      if (!assigneeChanged && statusChangedFromBacklog && issue.assigneeAgentId) {
+      if (!assigneeChanged && !assigneeExplicitlySpecified && (statusChangedFromBacklog || statusChangedToNonBacklog) && issue.assigneeAgentId) {
         addWakeup(issue.assigneeAgentId, {
           source: "automation",
           triggerDetail: "system",
@@ -2016,6 +2022,90 @@ export function issueRoutes(
     });
 
     res.json(released);
+  });
+
+  router.post("/issues/:id/retrigger", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+
+    if (!issue.assigneeAgentId) {
+      res.status(422).json({ error: "Issue has no assigned agent" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    let cancelledRunId: string | null = null;
+
+    // Cancel any active run tied to this issue
+    if (issue.executionRunId) {
+      try {
+        const cancelled = await heartbeat.cancelRun(issue.executionRunId);
+        if (cancelled && (cancelled.status === "cancelled")) {
+          cancelledRunId = cancelled.id;
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "heartbeat.cancelled",
+            entityType: "heartbeat_run",
+            entityId: cancelled.id,
+            details: {
+              agentId: cancelled.agentId,
+              source: "issue_retrigger",
+              issueId: issue.id,
+            },
+          });
+        }
+      } catch (err) {
+        logger.warn({ err, issueId: issue.id }, "failed to cancel existing run during retrigger");
+      }
+    }
+
+    // Fire a fresh wake
+    const run = await heartbeat.wakeup(issue.assigneeAgentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "issue_retrigger",
+      payload: { issueId: issue.id, mutation: "retrigger" },
+      requestedByActorType: actor.actorType,
+      requestedByActorId: actor.actorId,
+      contextSnapshot: {
+        issueId: issue.id,
+        source: "issue.retrigger",
+        ...(cancelledRunId ? { cancelledRunId } : {}),
+      },
+    });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.retriggered",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        assigneeAgentId: issue.assigneeAgentId,
+        identifier: issue.identifier,
+        ...(cancelledRunId ? { cancelledRunId } : {}),
+      },
+    });
+
+    res.json({
+      ok: true,
+      issueId: issue.id,
+      agentId: issue.assigneeAgentId,
+      run,
+      cancelledRunId,
+    });
   });
 
   router.get("/issues/:id/comments", async (req, res) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -92,8 +92,11 @@ const WAKEUP_DEBOUNCE_MS = 3000;
 interface DebouncedWakeupEntry {
   timer: ReturnType<typeof setTimeout>;
   contexts: Array<{ issueId: string; wakeReason: string | null; payload: Record<string, unknown> | null }>;
+  // First-write-wins: opts (including actor info) are captured from the first
+  // enqueueWakeup call in the debounce window. Subsequent callers' attribution
+  // is aggregated into contexts but the top-level actor fields reflect the
+  // original trigger.
   opts: WakeupOptions;
-  flushFn: (agentId: string) => Promise<void>;
 }
 
 const wakeupDebounceMap = new Map<string, DebouncedWakeupEntry>();
@@ -369,6 +372,8 @@ interface WakeupOptions {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  /** Internal flag — skip debounce logic (used by flushDebouncedWakeups to avoid re-entering the debounce path). */
+  _skipDebounce?: boolean;
 }
 
 type UsageTotals = {
@@ -3831,6 +3836,7 @@ export function heartbeatService(db: Db) {
         contextSnapshot: batchedContextSnapshot,
         reason: `batch_assignment (${issueIds.length} issues)`,
         payload: { ...(entry.opts.payload ?? {}), issueId: primaryIssueId, issueIds },
+        _skipDebounce: true,
       });
     } catch (err) {
       logger.error({ err, agentId, issueIds }, "Failed to flush debounced wakeups");
@@ -3866,7 +3872,7 @@ export function heartbeatService(db: Db) {
       triggerDetail !== "manual" &&
       issueId;
 
-    if (shouldDebounce) {
+    if (shouldDebounce && !opts._skipDebounce) {
       const existing = wakeupDebounceMap.get(agentId);
       if (existing) {
         existing.contexts.push({
@@ -3882,7 +3888,6 @@ export function heartbeatService(db: Db) {
         timer: setTimeout(() => flushDebouncedWakeups(agentId), WAKEUP_DEBOUNCE_MS),
         contexts: [{ issueId: issueId!, wakeReason: reason, payload: payload ?? {} }],
         opts,
-        flushFn: flushDebouncedWakeups,
       };
       wakeupDebounceMap.set(agentId, entry);
       return null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -83,6 +83,21 @@ const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
+
+// ---------------------------------------------------------------------------
+// Wakeup debounce — batches rapid assignment wakeups for the same agent
+// ---------------------------------------------------------------------------
+const WAKEUP_DEBOUNCE_MS = 3000;
+
+interface DebouncedWakeupEntry {
+  timer: ReturnType<typeof setTimeout>;
+  contexts: Array<{ issueId: string; wakeReason: string | null; payload: Record<string, unknown> | null }>;
+  opts: WakeupOptions;
+  flushFn: (agentId: string) => Promise<void>;
+}
+
+const wakeupDebounceMap = new Map<string, DebouncedWakeupEntry>();
+
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -3530,7 +3545,15 @@ export function heartbeatService(db: Db) {
         err instanceof Error ? err.message : "Unknown adapter failure",
         await getCurrentUserRedactionOptions(),
       );
-      logger.error({ err, runId }, "heartbeat execution failed");
+      const isAuthError = /\b(401|403|Unauthorized|Forbidden)\b/i.test(message)
+        || (err instanceof Error && "statusCode" in err && ((err as any).statusCode === 401 || (err as any).statusCode === 403))
+        || (err instanceof Error && "status" in err && ((err as any).status === 401 || (err as any).status === 403));
+      const errorCode = isAuthError ? "auth_failed" : "adapter_failed";
+      if (isAuthError) {
+        logger.error({ runId, agentId: agent.id }, `heartbeat execution failed with auth error (non-retryable): ${message}`);
+      } else {
+        logger.error({ err, runId }, "heartbeat execution failed");
+      }
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -3542,8 +3565,8 @@ export function heartbeatService(db: Db) {
       }
 
       const failedRun = await setRunStatus(run.id, "failed", {
-        error: message,
-        errorCode: "adapter_failed",
+        error: isAuthError ? `Authentication failed (non-retryable): ${message}` : message,
+        errorCode,
         finishedAt: new Date(),
         stdoutExcerpt,
         stderrExcerpt,
@@ -3785,6 +3808,35 @@ export function heartbeatService(db: Db) {
     await startNextQueuedRunForAgent(promotedRun.agentId);
   }
 
+  async function flushDebouncedWakeups(agentId: string) {
+    const entry = wakeupDebounceMap.get(agentId);
+    wakeupDebounceMap.delete(agentId);
+    if (!entry || entry.contexts.length === 0) return;
+
+    // Create one wakeup with the primary issue context; include all issue IDs
+    // so the agent knows about the batch. The agent's inbox fetch (Step 3) will
+    // return all assigned issues, so a single run naturally handles them all.
+    const issueIds = entry.contexts.map((c) => c.issueId);
+    const primaryIssueId = issueIds[0];
+    const batchedContextSnapshot = {
+      ...(entry.opts.contextSnapshot ?? {}),
+      issueId: primaryIssueId,
+      taskId: primaryIssueId,
+      issueIds,
+    };
+
+    try {
+      await enqueueWakeup(agentId, {
+        ...entry.opts,
+        contextSnapshot: batchedContextSnapshot,
+        reason: `batch_assignment (${issueIds.length} issues)`,
+        payload: { ...(entry.opts.payload ?? {}), issueId: primaryIssueId, issueIds },
+      });
+    } catch (err) {
+      logger.error({ err, agentId, issueIds }, "Failed to flush debounced wakeups");
+    }
+  }
+
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
@@ -3804,6 +3856,37 @@ export function heartbeatService(db: Db) {
       payload,
     });
     let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+
+    // Debounce rapid assignment wakeups for the same agent.
+    // Skip debounce for comment mentions (need immediate response), manual triggers,
+    // and timer-based wakes.
+    const shouldDebounce =
+      !wakeCommentId &&
+      source !== "timer" &&
+      triggerDetail !== "manual" &&
+      issueId;
+
+    if (shouldDebounce) {
+      const existing = wakeupDebounceMap.get(agentId);
+      if (existing) {
+        existing.contexts.push({
+          issueId: issueId!,
+          wakeReason: reason,
+          payload: payload ?? {},
+        });
+        // Return null — no run created yet, will be flushed when timer fires
+        return null;
+      }
+      // Start debounce window
+      const entry: DebouncedWakeupEntry = {
+        timer: setTimeout(() => flushDebouncedWakeups(agentId), WAKEUP_DEBOUNCE_MS),
+        contexts: [{ issueId: issueId!, wakeReason: reason, payload: payload ?? {} }],
+        opts,
+        flushFn: flushDebouncedWakeups,
+      };
+      wakeupDebounceMap.set(agentId, entry);
+      return null;
+    }
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");


### PR DESCRIPTION
## Summary
- Add wakeup debouncing (3s) to batch rapid consecutive assignments
- Improve auth error detection (401/403) with non-retryable flag to prevent infinite retry loops
- Add parent issue notification when child issues complete
- Add `/issues/:id/retrigger` endpoint for manual re-trigger with run cancellation

## Test plan
- [ ] Rapid assignments are debounced into a single wakeup
- [ ] Auth errors (401/403) stop retrying immediately
- [ ] Parent issues get notified when child issues complete
- [ ] Retrigger endpoint cancels current run and restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)