### PR TITLE
fix: shallow-merge adapterConfig and runtimeConfig in PATCH /api/agents/:id

### DIFF
--- a/server/src/__tests__/agents-patch-config-merge.test.ts
+++ b/server/src/__tests__/agents-patch-config-merge.test.ts
@@ -1,0 +1,187 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  hasPermission: vi.fn(),
+  canUser: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({}));
+const mockHeartbeatService = vi.hoisted(() => ({}));
+const mockIssueApprovalService = vi.hoisted(() => ({}));
+const mockIssueService = vi.hoisted(() => ({}));
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(),
+}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  accessService: () => mockAccessService,
+  approvalService: () => mockApprovalService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  issueService: () => mockIssueService,
+  secretService: () => mockSecretService,
+  logActivity: mockLogActivity,
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const existingAgent = {
+  id: "11111111-1111-4111-8111-111111111111",
+  companyId: "company-1",
+  name: "Agent One",
+  role: "general",
+  status: "active",
+  adapterType: "process",
+  adapterConfig: {
+    preserved: "keep-me",
+    overridden: "old-value",
+    clearMe: "remove-me",
+  },
+  runtimeConfig: {
+    retained: "runtime-keep",
+    changed: "runtime-old",
+    clearRuntime: "runtime-remove",
+  },
+};
+
+describe("PATCH /api/agents/:id config merge behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentService.getById.mockResolvedValue(existingAgent);
+    mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(
+      async (_companyId: string, config: Record<string, unknown>) => config,
+    );
+    mockAgentService.update.mockImplementation(
+      async (_id: string, patchData: Record<string, unknown>) => ({ ...existingAgent, ...patchData }),
+    );
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("partially patches adapterConfig/runtimeConfig by shallow-merging existing fields", async () => {
+    const res = await request(createApp())
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: { overridden: "new-value" },
+        runtimeConfig: { changed: "runtime-new" },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: {
+          preserved: "keep-me",
+          overridden: "new-value",
+          clearMe: "remove-me",
+        },
+        runtimeConfig: {
+          retained: "runtime-keep",
+          changed: "runtime-new",
+          clearRuntime: "runtime-remove",
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("applies full config objects when all fields are provided", async () => {
+    const res = await request(createApp())
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          preserved: "adapter-updated",
+          overridden: "adapter-overridden",
+          clearMe: "adapter-reset",
+        },
+        runtimeConfig: {
+          retained: "runtime-updated",
+          changed: "runtime-overridden",
+          clearRuntime: "runtime-reset",
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: {
+          preserved: "adapter-updated",
+          overridden: "adapter-overridden",
+          clearMe: "adapter-reset",
+        },
+        runtimeConfig: {
+          retained: "runtime-updated",
+          changed: "runtime-overridden",
+          clearRuntime: "runtime-reset",
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("supports null values to clear individual config fields while preserving siblings", async () => {
+    const res = await request(createApp())
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: { clearMe: null },
+        runtimeConfig: { clearRuntime: null },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: {
+          preserved: "keep-me",
+          overridden: "old-value",
+          clearMe: null,
+        },
+        runtimeConfig: {
+          retained: "runtime-keep",
+          changed: "runtime-old",
+          clearRuntime: null,
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects non-object runtimeConfig before reaching update", async () => {
+    const res = await request(createApp())
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({ runtimeConfig: "not-an-object" });
+
+    // Schema validation may reject with 400, or our guard returns 422.
+    // Either way, update must not be called with invalid data.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1091,7 +1091,23 @@ export function agentRoutes(db: Db) {
       if (changingInstructionsPath) {
         await assertCanManageInstructionsPath(req, existing);
       }
-      patchData.adapterConfig = adapterConfig;
+      patchData.adapterConfig = {
+        ...(asRecord(existing.adapterConfig) ?? {}),
+        ...adapterConfig,
+      };
+    }
+    if (Object.prototype.hasOwnProperty.call(patchData, "runtimeConfig")) {
+      const runtimeConfig = asRecord(patchData.runtimeConfig);
+      if (patchData.runtimeConfig !== undefined && !runtimeConfig) {
+        res.status(422).json({ error: "runtimeConfig must be an object" });
+        return;
+      }
+      if (runtimeConfig) {
+        patchData.runtimeConfig = {
+          ...(asRecord(existing.runtimeConfig) ?? {}),
+          ...runtimeConfig,
+        };
+      }
     }
 
     const requestedAdapterType =


### PR DESCRIPTION
## Problem

`PATCH /api/agents/:id` replaces `adapterConfig` and `runtimeConfig` entirely instead of shallow-merging with existing values. A partial update like:

```json
{ "adapterConfig": { "newField": "value" } }
```

…wipes all other existing `adapterConfig` fields. This makes it impossible to add a single config field without re-sending the entire config object.

We hit this in a multi-agent OpenClaw deployment where we needed to add `apiKeyPath` to each agent's `adapterConfig` — the PATCH wiped all other fields (url, agentId, payloadTemplate, etc.).

## Fix

Shallow-merge incoming config objects with existing values before persisting:

```ts
patchData.adapterConfig = {
  ...(asRecord(existing.adapterConfig) ?? {}),
  ...adapterConfig,
};
```

Same pattern for `runtimeConfig`.

Partial patches now preserve unspecified fields. Full replacement still works when all fields are provided.

## Changes

- `server/src/routes/agents.ts` — merge logic in PATCH handler
- `server/src/__tests__/agents-patch-config-merge.test.ts` — regression tests (partial merge, full update, null field clearing)

Fixes #964