### PR TITLE
fix(heartbeat): add agent_config cwd fallback in resolveWorkspaceForRun

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -921,7 +921,12 @@ export function heartbeatService(db: Db) {
         .stat(agentConfigCwd)
         .then((s) => s.isDirectory())
         .catch(() => false);
-      if (agentConfigCwdExists) {
+      // Also verify the directory is inside a git repository — worktree agents require a valid
+      // git root. A misconfigured non-git directory would cause the same crash this fix prevents.
+      const agentConfigCwdIsGit = agentConfigCwdExists
+        ? await fs.stat(`${agentConfigCwd}/.git`).then(() => true).catch(() => false)
+        : false;
+      if (agentConfigCwdExists && agentConfigCwdIsGit) {
         return {
           cwd: agentConfigCwd,
           source: "agent_config" as const,


### PR DESCRIPTION
## Problem

Fixes #952 — `git_worktree` agents crash when invoked without an associated issue or prior session. In that scenario, `resolveWorkspaceForRun` falls through all configured fallbacks to an empty non-git directory, causing the worktree operation to fail.

## Root cause

The fallback chain skipped the agent's own `adapterConfig.cwd`, which is a valid git repository configured by the operator for the agent.

## Solution

Insert **step 3** in the fallback chain — check `agent.adapterConfig.cwd` before reaching the empty default workspace:

| Step | Source | Description |
|------|--------|-------------|
| 1 | `project_primary` | Issue's project workspace cwd |
| 2 | `task_session` | Previous session recorded cwd |
| 3 | `agent_config` ← **NEW** | `adapterConfig.cwd` — valid git repo |
| 4 | `agent_home` | Empty default dir (non-git, last resort) |

Also extends `ResolvedWorkspaceForRun.source` union with `"agent_config"`.

## Verification

```bash
grep -n "agent_config" server/src/services/heartbeat.ts
# Must show: type union extension + new fallback block
```

## Test plan

- [ ] Agent with `adapterConfig.cwd` set to a valid git repo, no issue context → resolves to `agent_config` source, no crash
- [ ] Agent with `adapterConfig.cwd` pointing to non-existent path → falls through to `agent_home`
- [ ] Agent with no `adapterConfig.cwd` → unchanged behaviour
- [ ] Existing `project_primary` and `task_session` paths unchanged