### PR TITLE
Update issue templates and security policy for Paperclip

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! The more detail you provide, the faster we can help.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the issue clearly. What did you expect vs what actually happened?
+      placeholder: "When an agent's heartbeat fires, the task doesn't get picked up..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps to trigger this issue, starting from a clean state.
+      placeholder: |
+        1. Created a task and assigned it to an agent
+        2. Agent heartbeat fired on schedule
+        3. Task status never changed from "open"
+        4. Checked server logs, saw error below
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is involved?
+      options:
+        - Agents / adapters
+        - Tasks / tickets
+        - Org chart / roles
+        - Governance / approvals
+        - Heartbeats / scheduling
+        - Budgets / cost control
+        - Dashboard UI
+        - CLI
+        - API / server
+        - Database / migrations
+        - Setup / installation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Paste relevant logs. Check these sources:
+        - Server logs: `tail -50 logs/paperclip.log`
+        - Agent adapter output in the dashboard or CLI
+      render: shell
+      placeholder: |
+        [10:24:12.928] INFO: Heartbeat triggered for agent "researcher"
+        [10:24:13.001] ERROR: Task assignment failed
+          err: "budget limit exceeded"
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Run the following and paste the output:
+        ```bash
+        echo "OS: $(uname -s) $(uname -r)"
+        echo "Node: $(node --version)"
+        echo "Paperclip: $(node -p "require('./package.json').version")"
+        ```
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: |
+        Any relevant config — agent config, adapter settings, org chart structure, .env snippets.
+        **Do NOT paste tokens, API keys, or webhook URLs.**
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, error messages, or anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/paperclipai/paperclip/security/advisories/new
+    about: Report security issues privately — do NOT open a public issue
+  - name: Discord Community
+    url: https://discord.gg/m4HZY7xNG3
+    about: Chat with other users and get help

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? We'd love to hear it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point.
+      placeholder: "I want agents to automatically escalate blocked tasks to their manager in the org chart, so nothing stalls silently..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work? Include specific files, config changes, or behavior if you have ideas.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you've tried or other approaches you've thought about.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Agents / adapters
+        - Tasks / tickets
+        - Org chart / roles
+        - Governance / approvals
+        - Heartbeats / scheduling
+        - Budgets / cost control
+        - Dashboard UI
+        - CLI
+        - API / server
+        - Database / migrations
+        - Setup / installation
+        - Other
+    validations:
+      required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,26 @@
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities through GitHub's Security Advisory feature:
-[https://github.com/paperclipai/paperclip/security/advisories/new](https://github.com/paperclipai/paperclip/security/advisories/new)
+**Do NOT open a public issue for security vulnerabilities.**
 
-Do not open public issues for security vulnerabilities.
+Please use GitHub's private vulnerability reporting instead:
+
+1. Go to the [Security Advisories page](https://github.com/paperclipai/paperclip/security/advisories)
+2. Click **"Report a vulnerability"**
+3. Provide as much detail as possible — steps to reproduce, affected components, and potential impact
+
+Reports are private between you and the maintainers until a fix is ready. You'll be credited in the advisory if you'd like.
+
+## What qualifies as a security issue?
+
+- Agent privilege escalation (bypassing governance or approval gates)
+- Secret leakage (API keys, tokens exposed in logs or agent output)
+- Budget enforcement bypass (agents exceeding cost limits)
+- Unauthorized cross-company data access (breaking tenant isolation)
+- Adapter sandbox escape or arbitrary code execution
+
+## Response timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Assessment**: Within 1 week
+- **Fix**: Depends on severity, but critical issues are prioritized immediately


### PR DESCRIPTION
## Summary
   - Provide a SECURITY.md file and also templates for submitting bugs and security vulns.  See note below, need to enable private submissions.
   - Updated component dropdowns, placeholder text, log examples, and environment snippets to reflect
   agents, heartbeats, governance, org chart, budgets, adapters, etc.
 

## Note for maintainers
   The `config.yml` links to `https://github.com/paperclipai/paperclip/security/advisories/new` for
   private vulnerability reporting. This requires **Private vulnerability reporting** to be enabled under
   **Settings → Security → Private vulnerability reporting** in the repo. Worth confirming that's toggled
   on if it hasn't been already.

## Test plan
   - [ ] Verify "New Issue" page on GitHub renders all three template options correctly
   - [ ] Confirm the Security Advisories link in `config.yml` works (requires private vulnerability
   reporting to be enabled)
   - [ ] Review component dropdown options match current Paperclip architecture

   🤖 Generated with [Claude Code](https://claude.com/claude-code)