### PR TITLE
fix: release() must clear execution lock fields

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1034,6 +1034,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
+          executionAgentNameKey: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

- `release()` in `server/src/services/issues.ts` cleared `checkoutRunId` but left `executionRunId`, `executionLockedAt`, and `executionAgentNameKey` intact
- This created orphaned execution locks that permanently blocked all mutations (checkout, comment, PATCH, release) on affected issues
- Adds the three missing null-clears to the `release()` `.set()` call, symmetric with the checkout path

## Impact

Multiple issues were permanently locked (DLD-129, DLD-139, DLD-84, DLD-64). The heartbeat stale lock cleanup (heartbeat.js:1587-1597) handles some cases but cannot recover orphaned states where `checkoutRunId` is null but `executionRunId` persists.

## Test plan

- [ ] Verify `release()` clears all execution lock fields alongside `checkoutRunId`
- [ ] Confirm no regression in checkout/release lifecycle
- [ ] Verify previously locked issues become unlockable after deploy

Fixes: DLD-149