### PR TITLE
fix: detect missing @embedded-postgres platform binary

### DIFF
--- a/cli/src/checks/embedded-postgres-binary-check.ts
+++ b/cli/src/checks/embedded-postgres-binary-check.ts
@@ -1,0 +1,67 @@
+import { createRequire } from "node:module";
+import os from "node:os";
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+
+/**
+ * Maps Node.js os.platform()/os.arch() to the @embedded-postgres package suffix.
+ */
+function getEmbeddedPostgresPlatformPackage(): string | null {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  const map: Record<string, Record<string, string>> = {
+    darwin: { arm64: "darwin-arm64", x64: "darwin-x64" },
+    linux: {
+      arm64: "linux-arm64",
+      arm: "linux-arm",
+      ia32: "linux-ia32",
+      ppc64: "linux-ppc64",
+      x64: "linux-x64",
+    },
+    win32: { x64: "windows-x64" },
+  };
+
+  return map[platform]?.[arch] ?? null;
+}
+
+export function embeddedPostgresBinaryCheck(config: PaperclipConfig): CheckResult {
+  if (config.database.mode !== "embedded-postgres") {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "pass",
+      message: "Not using embedded-postgres; skipped",
+    };
+  }
+
+  const suffix = getEmbeddedPostgresPlatformPackage();
+  if (!suffix) {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "fail",
+      message: `Unsupported platform: ${os.platform()}-${os.arch()}`,
+      canRepair: false,
+      repairHint: "embedded-postgres does not ship a binary for this platform. Use an external PostgreSQL instead: paperclipai configure --section database",
+    };
+  }
+
+  const packageName = `@embedded-postgres/${suffix}`;
+
+  try {
+    const require = createRequire(import.meta.url);
+    require.resolve(packageName);
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "pass",
+      message: `Platform binary found (${packageName})`,
+    };
+  } catch {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "fail",
+      message: `Missing platform binary: ${packageName}`,
+      canRepair: false,
+      repairHint: `Run: npm install -g ${packageName}`,
+    };
+  }
+}

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -16,3 +16,4 @@ export { logCheck } from "./log-check.js";
 export { portCheck } from "./port-check.js";
 export { secretsCheck } from "./secrets-check.js";
 export { storageCheck } from "./storage-check.js";
+export { embeddedPostgresBinaryCheck } from "./embedded-postgres-binary-check.js";

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import {
   configCheck,
   databaseCheck,
   deploymentAuthCheck,
+  embeddedPostgresBinaryCheck,
   llmCheck,
   logCheck,
   portCheck,
@@ -100,6 +101,11 @@ export async function doctor(opts: {
       opts,
     }),
   );
+
+  // 6b. Embedded PostgreSQL binary check
+  const epBinaryResult = embeddedPostgresBinaryCheck(config);
+  results.push(epBinaryResult);
+  printResult(epBinaryResult);
 
   // 7. LLM check
   const llmResult = await llmCheck(config);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -170,6 +170,13 @@ async function importServerEntry(): Promise<StartedServer> {
           `${formatError(err)}`,
       );
     }
+    if (isModuleNotFoundError(err) && missingSpecifier?.startsWith("@embedded-postgres/")) {
+      throw new Error(
+        `Missing embedded-postgres platform binary: ${missingSpecifier}\n` +
+          `This is a known issue with npm not installing optional platform-specific dependencies.\n` +
+          `Fix: npm install -g ${missingSpecifier}`,
+      );
+    }
     throw new Error(
       `Paperclip server failed to start.\n` +
         `${formatError(err)}`,


### PR DESCRIPTION
## Summary

- Adds a new `doctor` check (`embeddedPostgresBinaryCheck`) that verifies the platform-specific `@embedded-postgres/*` binary is installed before starting the server
- Improves the error message in `paperclipai run` when the crash is caused by a missing `@embedded-postgres/*` package, showing the exact `npm install -g` command needed
- Addresses the root cause of the confusing `ERR_MODULE_NOT_FOUND` crash on macOS Apple Silicon (and other platforms where npm fails to install optional deps)

Closes #24

## What happens now

**Before:**
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@embedded-postgres/darwin-arm64' imported from ...
```

**After (`doctor`):**
```
✗ Embedded PostgreSQL binary: Missing platform binary: @embedded-postgres/darwin-arm64
  Run: npm install -g @embedded-postgres/darwin-arm64
```

**After (`run` — if doctor is skipped):**
```
Missing embedded-postgres platform binary: @embedded-postgres/darwin-arm64
This is a known issue with npm not installing optional platform-specific dependencies.
Fix: npm install -g @embedded-postgres/darwin-arm64
```

## Test plan

- [ ] `paperclipai doctor` on macOS ARM without `@embedded-postgres/darwin-arm64` installed → shows fail with install hint
- [ ] `paperclipai doctor` on macOS ARM with the package installed → shows pass
- [ ] `paperclipai run` without the package → shows actionable error instead of raw Node crash
- [ ] `paperclipai doctor` with `database.mode: "postgres"` (external) → skips the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)