### PR TITLE
fix: detect missing @embedded-postgres platform binary (Fixes #24)

### DIFF
--- a/cli/src/checks/embedded-postgres-binary-check.ts
+++ b/cli/src/checks/embedded-postgres-binary-check.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+
+/**
+ * Maps Node.js os.platform()/os.arch() to the corresponding
+ * `@embedded-postgres/<platform>-<arch>` package name.
+ */
+export function getEmbeddedPostgresPlatformPackage(): string | null {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  const platformMap: Record<string, Record<string, string>> = {
+    darwin: {
+      arm64: "@embedded-postgres/darwin-arm64",
+      x64: "@embedded-postgres/darwin-x64",
+    },
+    linux: {
+      arm64: "@embedded-postgres/linux-arm64",
+      x64: "@embedded-postgres/linux-x64",
+    },
+    win32: {
+      x64: "@embedded-postgres/windows-x64",
+    },
+  };
+
+  return platformMap[platform]?.[arch] ?? null;
+}
+
+/**
+ * In a development/monorepo context the server is loaded from local source
+ * via tsx, so the platform binary is resolved differently at runtime.
+ * We skip the binary check in that case to avoid false positives.
+ */
+function isDevContext(): boolean {
+  const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+  const devEntry = path.resolve(projectRoot, "server/src/index.ts");
+  return fs.existsSync(devEntry);
+}
+
+export function embeddedPostgresBinaryCheck(config: PaperclipConfig): CheckResult {
+  if (config.database.mode !== "embedded-postgres") {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "pass",
+      message: "Not using embedded PostgreSQL — skipped",
+    };
+  }
+
+  if (isDevContext()) {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "pass",
+      message: "Development context detected — binary resolved at runtime",
+    };
+  }
+
+  const packageName = getEmbeddedPostgresPlatformPackage();
+
+  if (!packageName) {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "fail",
+      message: `Unsupported platform: ${os.platform()}-${os.arch()}. Embedded PostgreSQL does not provide a binary for this system.`,
+      canRepair: false,
+      repairHint: "Switch to an external PostgreSQL database with `paperclipai configure --section database`",
+    };
+  }
+
+  try {
+    const require = createRequire(import.meta.url);
+    require.resolve(packageName);
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "pass",
+      message: `Platform binary package found: ${packageName}`,
+    };
+  } catch {
+    return {
+      name: "Embedded PostgreSQL binary",
+      status: "warn",
+      message: `Platform binary package not found: ${packageName}. The server may fail to start.`,
+      canRepair: false,
+      repairHint: `Install it manually with: npm install -g ${packageName}`,
+    };
+  }
+}

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -16,3 +16,4 @@ export { logCheck } from "./log-check.js";
 export { portCheck } from "./port-check.js";
 export { secretsCheck } from "./secrets-check.js";
 export { storageCheck } from "./storage-check.js";
+export { embeddedPostgresBinaryCheck } from "./embedded-postgres-binary-check.js";

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import {
   configCheck,
   databaseCheck,
   deploymentAuthCheck,
+  embeddedPostgresBinaryCheck,
   llmCheck,
   logCheck,
   portCheck,
@@ -92,7 +93,12 @@ export async function doctor(opts: {
     }),
   );
 
-  // 6. Database check
+  // 6. Embedded PostgreSQL binary check
+  const embeddedPgResult = embeddedPostgresBinaryCheck(config);
+  results.push(embeddedPgResult);
+  printResult(embeddedPgResult);
+
+  // 7. Database check
   results.push(
     await runRepairableCheck({
       run: () => databaseCheck(config, configPath),
@@ -101,12 +107,12 @@ export async function doctor(opts: {
     }),
   );
 
-  // 7. LLM check
+  // 8. LLM check
   const llmResult = await llmCheck(config);
   results.push(llmResult);
   printResult(llmResult);
 
-  // 8. Log directory check
+  // 9. Log directory check
   results.push(
     await runRepairableCheck({
       run: () => logCheck(config, configPath),
@@ -115,7 +121,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 9. Port check
+  // 10. Port check
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { getEmbeddedPostgresPlatformPackage } from "../checks/embedded-postgres-binary-check.js";
 import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
 import { onboard } from "./onboard.js";
 import { doctor } from "./doctor.js";
@@ -168,6 +169,16 @@ async function importServerEntry(): Promise<StartedServer> {
         `Could not locate a Paperclip server entrypoint.\n` +
           `Tried: ${devEntry}, @paperclipai/server\n` +
           `${formatError(err)}`,
+      );
+    }
+    if (isModuleNotFoundError(err) && missingSpecifier?.startsWith("@embedded-postgres/")) {
+      const expectedPkg = getEmbeddedPostgresPlatformPackage() ?? missingSpecifier;
+      throw new Error(
+        `Missing embedded PostgreSQL platform binary: ${missingSpecifier}\n` +
+          `This is a known issue when installing paperclipai globally on some systems.\n` +
+          `Fix it by running:\n\n` +
+          `  npm install -g ${expectedPkg}\n\n` +
+          `Then retry: paperclipai run`,
       );
     }
     throw new Error(


### PR DESCRIPTION
## Summary

- Add `embeddedPostgresBinaryCheck` to `cli/src/checks/` that maps `os.platform()`/`os.arch()` to the correct `@embedded-postgres/<platform>-<arch>` package name and verifies it can be resolved
- Wire the check into `doctor.ts` so `paperclipai doctor` and `paperclipai run` (which calls doctor) detect the missing binary early with an actionable warning and install command
- Improve error handling in `run.ts` `importServerEntry()` to catch `ERR_MODULE_NOT_FOUND` for `@embedded-postgres/*` packages specifically and display the exact `npm install -g` command needed
- Skip the check in development/monorepo contexts where the server loads from source

Fixes #24

## Test plan

- [x] Existing `doctor.test.ts` passes (51 pass, 0 fail)
- [x] No new type errors in changed files
- [ ] On macOS Apple Silicon without the binary: `paperclipai doctor` shows warning with install command
- [ ] On macOS Apple Silicon without the binary: `paperclipai run` shows actionable error if server fails to start
- [ ] After `npm install -g @embedded-postgres/darwin-arm64`: check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)