### PR TITLE
feat: add company import/export and skill visibility filtering (test added Based on #954)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,6 @@ tmp/
 .claude/settings.local.json
 .paperclip-local/
 
-# Doc maintenance cursor
-.doc-review-cursor
-
 # Playwright
 tests/e2e/test-results/
 tests/e2e/playwright-report/

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ See [doc/DEVELOPING.md](doc/DEVELOPING.md) for the full development guide.
 - ⚪ ClipMart - buy and sell entire agent companies
 - ⚪ Easy agent configurations / easier to understand
 - ⚪ Better support for harness engineering
-- 🟢 Plugin system (e.g. if you want to add a knowledgebase, custom tracing, queues, etc)
+- ⚪ Plugin system (e.g. if you want to add a knowledgebase, custom tracing, queues, etc)
 - ⚪ Better docs
 
 <br/>

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "node --input-type=module -e \"import esbuild from 'esbuild'; import config from './esbuild.config.mjs'; await esbuild.build(config);\" && chmod +x dist/index.js",
+    "build": "node --input-type=module -e \"import esbuild from 'esbuild'; import config from './esbuild.config.mjs'; import fs from 'node:fs'; await esbuild.build(config); if (process.platform !== 'win32') fs.chmodSync('dist/index.js', 0o755);\"", 
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
   },

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -360,21 +360,26 @@ describe("worktree helpers", () => {
   });
 
   it("rebinds same-repo workspace paths onto the current worktree root", () => {
-    expect(
-      rebindWorkspaceCwd({
-        sourceRepoRoot: "/Users/example/paperclip",
-        targetRepoRoot: "/Users/example/paperclip-pr-432",
-        workspaceCwd: "/Users/example/paperclip",
-      }),
-    ).toBe("/Users/example/paperclip-pr-432");
+    const sourceRepoRoot = path.resolve("/Users/example/paperclip");
+    const targetRepoRoot = path.resolve("/Users/example/paperclip-pr-432");
+    const workspaceRoot = path.resolve("/Users/example/paperclip");
+    const workspaceNested = path.resolve("/Users/example/paperclip/packages/db");
 
     expect(
       rebindWorkspaceCwd({
-        sourceRepoRoot: "/Users/example/paperclip",
-        targetRepoRoot: "/Users/example/paperclip-pr-432",
-        workspaceCwd: "/Users/example/paperclip/packages/db",
+        sourceRepoRoot,
+        targetRepoRoot,
+        workspaceCwd: workspaceRoot,
       }),
-    ).toBe("/Users/example/paperclip-pr-432/packages/db");
+    ).toBe(targetRepoRoot);
+
+    expect(
+      rebindWorkspaceCwd({
+        sourceRepoRoot,
+        targetRepoRoot,
+        workspaceCwd: workspaceNested,
+      }),
+    ).toBe(path.resolve(targetRepoRoot, "packages", "db"));
   });
 
   it("does not rebind paths outside the source repo root", () => {
@@ -427,7 +432,9 @@ describe("worktree helpers", () => {
         copied: true,
       });
       expect(fs.readFileSync(targetHookPath, "utf8")).toBe("#!/usr/bin/env bash\nexit 0\n");
-      expect(fs.statSync(targetHookPath).mode & 0o111).not.toBe(0);
+      if (process.platform !== "win32") {
+        expect(fs.statSync(targetHookPath).mode & 0o111).not.toBe(0);
+      }
       expect(fs.readFileSync(targetTokensPath, "utf8")).toBe("secret-token\n");
     } finally {
       execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoRoot, stdio: "ignore" });

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import type { Agent } from "@paperclipai/shared";
 import {
+  listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
-  resolvePaperclipSkillsDir,
 } from "@paperclipai/adapter-utils/server-utils";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -43,6 +43,8 @@ interface SkillsInstallSummary {
   failed: Array<{ name: string; error: string }>;
 }
 
+type SkillEntry = { name: string; source: string };
+
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 function codexSkillsHome(): string {
@@ -58,7 +60,7 @@ function claudeSkillsHome(): string {
 }
 
 async function installSkillsForTarget(
-  sourceSkillsDir: string,
+  sourceSkillsEntries: SkillEntry[],
   targetSkillsDir: string,
   tool: "codex" | "claude",
 ): Promise<SkillsInstallSummary> {
@@ -72,14 +74,13 @@ async function installSkillsForTarget(
   };
 
   await fs.mkdir(targetSkillsDir, { recursive: true });
-  const entries = await fs.readdir(sourceSkillsDir, { withFileTypes: true });
   summary.removed = await removeMaintainerOnlySkillSymlinks(
     targetSkillsDir,
-    entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
+    sourceSkillsEntries.map((entry) => entry.name),
   );
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const source = path.join(sourceSkillsDir, entry.name);
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  for (const entry of sourceSkillsEntries) {
+    const source = entry.source;
     const target = path.join(targetSkillsDir, entry.name);
     const existing = await fs.lstat(target).catch(() => null);
     if (existing) {
@@ -90,7 +91,7 @@ async function installSkillsForTarget(
         } catch (err) {
           await fs.unlink(target);
           try {
-            await fs.symlink(source, target);
+            await fs.symlink(source, target, symlinkType);
             summary.linked.push(entry.name);
             continue;
           } catch (linkErr) {
@@ -128,7 +129,7 @@ async function installSkillsForTarget(
     }
 
     try {
-      await fs.symlink(source, target);
+      await fs.symlink(source, target, symlinkType);
       summary.linked.push(entry.name);
     } catch (err) {
       summary.failed.push({
@@ -248,16 +249,20 @@ export function registerAgentCommands(program: Command): void {
 
           const installSummaries: SkillsInstallSummary[] = [];
           if (opts.installSkills !== false) {
-            const skillsDir = await resolvePaperclipSkillsDir(__moduleDir, [path.resolve(process.cwd(), "skills")]);
-            if (!skillsDir) {
+            const skillsEntries = await listPaperclipSkillEntries(__moduleDir, [
+              path.resolve(process.cwd(), ".agents", "skills"),
+              path.resolve(process.cwd(), ".claude", "skills"),
+              path.resolve(process.cwd(), "skills"),
+            ]);
+            if (skillsEntries.length === 0) {
               throw new Error(
-                "Could not locate local Paperclip skills directory. Expected ./skills in the repo checkout.",
+                "Could not locate local Paperclip skills directory. Expected .agents/skills, .claude/skills, or ./skills in the repo checkout.",
               );
             }
 
             installSummaries.push(
-              await installSkillsForTarget(skillsDir, codexSkillsHome(), "codex"),
-              await installSkillsForTarget(skillsDir, claudeSkillsHome(), "claude"),
+              await installSkillsForTarget(skillsEntries, codexSkillsHome(), "codex"),
+              await installSkillsForTarget(skillsEntries, claudeSkillsHome(), "claude"),
             );
           }
 

--- a/doc/SPEC.md
+++ b/doc/SPEC.md
@@ -188,15 +188,12 @@ The heartbeat is a protocol, not a runtime. Paperclip defines how to initiate an
 
 Agent configuration includes an **adapter** that defines how Paperclip invokes the agent. Initial adapters:
 
-| Adapter              | Mechanism               | Example                                       |
-| -------------------- | ----------------------- | --------------------------------------------- |
-| `process`            | Execute a child process | `python run_agent.py --agent-id {id}`         |
-| `http`               | Send an HTTP request    | `POST https://openclaw.example.com/hook/{id}` |
-| `openclaw_gateway`   | OpenClaw gateway API    | Managed OpenClaw agent via gateway             |
-| `gemini_local`       | Gemini CLI process      | Local Gemini CLI with sandbox and approval     |
-| `hermes_local`       | Hermes agent process    | Local Hermes agent                             |
+| Adapter   | Mechanism               | Example                                       |
+| --------- | ----------------------- | --------------------------------------------- |
+| `process` | Execute a child process | `python run_agent.py --agent-id {id}`         |
+| `http`    | Send an HTTP request    | `POST https://openclaw.example.com/hook/{id}` |
 
-The `process` and `http` adapters ship as defaults. Additional adapters have been added for specific agent runtimes (see list above), and new adapter types can be registered via the plugin system (see Plugin / Extension Architecture).
+The `process` and `http` adapters ship as defaults. Additional adapters can be added via the plugin system (see Plugin / Extension Architecture).
 
 ### Adapter Interface
 
@@ -432,7 +429,7 @@ The core Paperclip system must be extensible. Features like knowledge bases, ext
 - **Agent Adapter plugins** — new Adapter types can be registered via the plugin system
 - Plugin-registrable UI components (future)
 
-The plugin framework has shipped. Plugins can register new adapter types, hook into lifecycle events, and contribute UI components (e.g. global toolbar buttons). A plugin SDK and CLI commands (`paperclipai plugin`) are available for authoring and installing plugins.
+This isn't a V1 deliverable (we're not building a plugin framework upfront), but the architecture should not paint us into a corner. Keep boundaries clean so extensions are possible.
 
 ---
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -36,6 +36,14 @@ const PAPERCLIP_SKILL_ROOT_RELATIVE_CANDIDATES = [
   "../../skills",
   "../../../../../skills",
 ];
+const PAPERCLIP_SKILL_MULTI_ROOT_RELATIVE_CANDIDATES = [
+  "../../.agents/skills",
+  "../../.claude/skills",
+  "../../skills",
+  "../../../../../.agents/skills",
+  "../../../../../.claude/skills",
+  "../../../../../skills",
+];
 
 export interface PaperclipSkillEntry {
   name: string;
@@ -71,6 +79,18 @@ export function asBoolean(value: unknown, fallback: boolean): boolean {
 
 export function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+export function normalizeSelectedSkillNames(value: unknown): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of asStringArray(value)) {
+    const skillName = raw.trim().toLowerCase();
+    if (!skillName || seen.has(skillName)) continue;
+    seen.add(skillName);
+    normalized.push(skillName);
+  }
+  return normalized;
 }
 
 export function parseJson(value: string): Record<string, unknown> | null {
@@ -296,20 +316,43 @@ export async function listPaperclipSkillEntries(
   moduleDir: string,
   additionalCandidates: string[] = [],
 ): Promise<PaperclipSkillEntry[]> {
-  const root = await resolvePaperclipSkillsDir(moduleDir, additionalCandidates);
-  if (!root) return [];
+  const candidates = [
+    ...PAPERCLIP_SKILL_MULTI_ROOT_RELATIVE_CANDIDATES.map((relativePath) => path.resolve(moduleDir, relativePath)),
+    ...additionalCandidates.map((candidate) => path.resolve(candidate)),
+  ];
+  const seenRoots = new Set<string>();
+  const seenNames = new Set<string>();
+  const result: PaperclipSkillEntry[] = [];
 
-  try {
-    const entries = await fs.readdir(root, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => ({
+  for (const root of candidates) {
+    if (seenRoots.has(root)) continue;
+    seenRoots.add(root);
+    const isDirectory = await fs.stat(root).then((stats) => stats.isDirectory()).catch(() => false);
+    if (!isDirectory) continue;
+
+    const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (seenNames.has(entry.name)) continue;
+      seenNames.add(entry.name);
+      result.push({
         name: entry.name,
         source: path.join(root, entry.name),
-      }));
-  } catch {
-    return [];
+      });
+    }
   }
+
+  return result;
+}
+
+export function filterPaperclipSkillEntriesBySelection(
+  entries: PaperclipSkillEntry[],
+  selectedSkillNames: unknown,
+): PaperclipSkillEntry[] {
+  const selected = normalizeSelectedSkillNames(selectedSkillNames);
+  if (selected.length === 0) return entries;
+  const allowed = new Set(selected);
+  return entries.filter((entry) => allowed.has(entry.name.toLowerCase()));
 }
 
 export async function readPaperclipSkillMarkdown(
@@ -333,8 +376,10 @@ export async function readPaperclipSkillMarkdown(
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
-  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) => {
+    const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+    return fs.symlink(linkSource, linkTarget, symlinkType);
+  },
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -17,6 +17,8 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -29,39 +31,25 @@ import {
 } from "./parse.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-const PAPERCLIP_SKILLS_CANDIDATES = [
-  path.resolve(__moduleDir, "../../skills"),         // published: <pkg>/dist/server/ -> <pkg>/skills/
-  path.resolve(__moduleDir, "../../../../../skills"), // dev: src/server/ -> repo root/skills/
-];
-
-async function resolvePaperclipSkillsDir(): Promise<string | null> {
-  for (const candidate of PAPERCLIP_SKILLS_CANDIDATES) {
-    const isDir = await fs.stat(candidate).then((s) => s.isDirectory()).catch(() => false);
-    if (isDir) return candidate;
-  }
-  return null;
-}
 
 /**
  * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
  * the repo's `skills/` directory, so `--add-dir` makes Claude Code discover
  * them as proper registered skills.
  */
-async function buildSkillsDir(): Promise<string> {
+async function buildSkillsDir(selectedSkillNames?: unknown): Promise<string> {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-skills-"));
   const target = path.join(tmp, ".claude", "skills");
   await fs.mkdir(target, { recursive: true });
-  const skillsDir = await resolvePaperclipSkillsDir();
-  if (!skillsDir) return tmp;
-  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      await fs.symlink(
-        path.join(skillsDir, entry.name),
-        path.join(target, entry.name),
-      );
-    }
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
+  if (skillsEntries.length === 0) return tmp;
+
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  for (const entry of skillsEntries) {
+    await fs.symlink(entry.source, path.join(target, entry.name), symlinkType);
   }
+
   return tmp;
 }
 
@@ -341,7 +329,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     extraArgs,
   } = runtimeConfig;
   const billingType = resolveClaudeBillingType(env);
-  const skillsDir = await buildSkillsDir();
+  const skillsDir = await buildSkillsDir(config.skills);
 
   // When instructionsFilePath is configured, create a combined temp file that
   // includes both the file content and the path directive, so we only need

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -40,11 +40,21 @@ async function ensureParentDir(target: string): Promise<void> {
   await fs.mkdir(path.dirname(target), { recursive: true });
 }
 
+async function createSharedFileReference(target: string, source: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.link(source, target).catch(async () => {
+      await fs.copyFile(source, target);
+    });
+    return;
+  }
+  await fs.symlink(source, target);
+}
+
 async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(source, target);
+    await createSharedFileReference(target, source);
     return;
   }
 
@@ -59,7 +69,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === source) return;
 
   await fs.unlink(target);
-  await fs.symlink(source, target);
+  await createSharedFileReference(target, source);
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   joinPromptSections,
@@ -92,6 +93,7 @@ async function isLikelyPaperclipRuntimeSkillSource(candidate: string, skillName:
 type EnsureCodexSkillsInjectedOptions = {
   skillsHome?: string;
   skillsEntries?: Awaited<ReturnType<typeof listPaperclipSkillEntries>>;
+  selectedSkillNames?: unknown;
   linkSkill?: (source: string, target: string) => Promise<void>;
 };
 
@@ -99,7 +101,11 @@ export async function ensureCodexSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   options: EnsureCodexSkillsInjectedOptions = {},
 ) {
-  const skillsEntries = options.skillsEntries ?? await listPaperclipSkillEntries(__moduleDir);
+  const allSkillsEntries = options.skillsEntries ?? await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(
+    allSkillsEntries,
+    options.selectedSkillNames,
+  );
   if (skillsEntries.length === 0) return;
 
   const skillsHome = options.skillsHome ?? path.join(resolveCodexHomeDir(process.env), "skills");
@@ -114,7 +120,8 @@ export async function ensureCodexSkillsInjected(
       `[paperclip] Removed maintainer-only Codex skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill;
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target, symlinkType));
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
 
@@ -131,11 +138,7 @@ export async function ensureCodexSkillsInjected(
           (await isLikelyPaperclipRuntimeSkillSource(resolvedLinkedPath, entry.name))
         ) {
           await fs.unlink(target);
-          if (linkSkill) {
-            await linkSkill(entry.source, target);
-          } else {
-            await fs.symlink(entry.source, target);
-          }
+          await linkSkill(entry.source, target);
           await onLog(
             "stderr",
             `[paperclip] Repaired Codex skill "${entry.name}" into ${skillsHome}\n`,
@@ -220,7 +223,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveCodexHome = configuredCodexHome ?? preparedWorktreeCodexHome;
   await ensureCodexSkillsInjected(
     onLog,
-    effectiveCodexHome ? { skillsHome: path.join(effectiveCodexHome, "skills") } : {},
+    effectiveCodexHome
+      ? { skillsHome: path.join(effectiveCodexHome, "skills"), selectedSkillNames: config.skills }
+      : { selectedSkillNames: config.skills },
   );
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   joinPromptSections,
@@ -84,6 +85,7 @@ function cursorSkillsHome(): string {
 type EnsureCursorSkillsInjectedOptions = {
   skillsDir?: string | null;
   skillsEntries?: Array<{ name: string; source: string }>;
+  selectedSkillNames?: unknown;
   skillsHome?: string;
   linkSkill?: (source: string, target: string) => Promise<void>;
 };
@@ -92,12 +94,16 @@ export async function ensureCursorSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   options: EnsureCursorSkillsInjectedOptions = {},
 ) {
-  const skillsEntries = options.skillsEntries
+  const allSkillsEntries = options.skillsEntries
     ?? (options.skillsDir
       ? (await fs.readdir(options.skillsDir, { withFileTypes: true }))
           .filter((entry) => entry.isDirectory())
           .map((entry) => ({ name: entry.name, source: path.join(options.skillsDir!, entry.name) }))
       : await listPaperclipSkillEntries(__moduleDir));
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(
+    allSkillsEntries,
+    options.selectedSkillNames,
+  );
   if (skillsEntries.length === 0) return;
 
   const skillsHome = options.skillsHome ?? cursorSkillsHome();
@@ -120,7 +126,8 @@ export async function ensureCursorSkillsInjected(
       `[paperclip] Removed maintainer-only Cursor skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target));
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target, symlinkType));
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
     try {
@@ -168,7 +175,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  await ensureCursorSkillsInjected(onLog);
+  await ensureCursorSkillsInjected(onLog, { selectedSkillNames: config.skills });
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   joinPromptSections,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   parseObject,
   redactEnvForLogs,
@@ -84,8 +85,10 @@ function geminiSkillsHome(): string {
  */
 async function ensureGeminiSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
+  selectedSkillNames?: unknown,
 ): Promise<void> {
-  const skillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
   if (skillsEntries.length === 0) return;
 
   const skillsHome = geminiSkillsHome();
@@ -109,11 +112,14 @@ async function ensureGeminiSkillsInjected(
     );
   }
 
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = (source: string, target: string) => fs.symlink(source, target, symlinkType);
+
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
 
     try {
-      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      const result = await ensurePaperclipSkillSymlink(entry.source, target, linkSkill);
       if (result === "skipped") continue;
       await onLog(
         "stderr",
@@ -156,7 +162,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  await ensureGeminiSkillsInjected(onLog);
+  await ensureGeminiSkillsInjected(onLog, config.skills);
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -13,7 +13,11 @@ import {
   redactEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
+  ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
+  removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -21,10 +25,6 @@ import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-const PAPERCLIP_SKILLS_CANDIDATES = [
-  path.resolve(__moduleDir, "../../skills"),
-  path.resolve(__moduleDir, "../../../../../skills"),
-];
 
 function firstNonEmptyLine(text: string): string {
   return (
@@ -46,33 +46,38 @@ function claudeSkillsHome(): string {
   return path.join(os.homedir(), ".claude", "skills");
 }
 
-async function resolvePaperclipSkillsDir(): Promise<string | null> {
-  for (const candidate of PAPERCLIP_SKILLS_CANDIDATES) {
-    const isDir = await fs.stat(candidate).then((s) => s.isDirectory()).catch(() => false);
-    if (isDir) return candidate;
-  }
-  return null;
-}
-
-async function ensureOpenCodeSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
-  const skillsDir = await resolvePaperclipSkillsDir();
-  if (!skillsDir) return;
+async function ensureOpenCodeSkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  selectedSkillNames?: unknown,
+) {
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
+  if (skillsEntries.length === 0) return;
 
   const skillsHome = claudeSkillsHome();
   await fs.mkdir(skillsHome, { recursive: true });
-  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const source = path.join(skillsDir, entry.name);
+  const removedSkills = await removeMaintainerOnlySkillSymlinks(
+    skillsHome,
+    skillsEntries.map((entry) => entry.name),
+  );
+  for (const skillName of removedSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed maintainer-only OpenCode skill "${skillName}" from ${skillsHome}\n`,
+    );
+  }
+
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = (source: string, target: string) => fs.symlink(source, target, symlinkType);
+  for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
-    const existing = await fs.lstat(target).catch(() => null);
-    if (existing) continue;
 
     try {
-      await fs.symlink(source, target);
+      const result = await ensurePaperclipSkillSymlink(entry.source, target, linkSkill);
+      if (result === "skipped") continue;
       await onLog(
         "stderr",
-        `[paperclip] Injected OpenCode skill "${entry.name}" into ${skillsHome}\n`,
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Injected"} OpenCode skill "${entry.name}" into ${skillsHome}\n`,
       );
     } catch (err) {
       await onLog(
@@ -111,7 +116,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
-  await ensureOpenCodeSkillsInjected(onLog);
+  await ensureOpenCodeSkillsInjected(onLog, config.skills);
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   listPaperclipSkillEntries,
+  filterPaperclipSkillEntriesBySelection,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   runChildProcess,
@@ -50,8 +51,12 @@ function parseModelId(model: string | null): string | null {
   return trimmed.slice(trimmed.indexOf("/") + 1).trim() || null;
 }
 
-async function ensurePiSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
-  const skillsEntries = await listPaperclipSkillEntries(__moduleDir);
+async function ensurePiSkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  selectedSkillNames?: unknown,
+) {
+  const allSkillsEntries = await listPaperclipSkillEntries(__moduleDir);
+  const skillsEntries = filterPaperclipSkillEntriesBySelection(allSkillsEntries, selectedSkillNames);
   if (skillsEntries.length === 0) return;
 
   const piSkillsHome = path.join(os.homedir(), ".pi", "agent", "skills");
@@ -67,11 +72,14 @@ async function ensurePiSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
     );
   }
 
+  const symlinkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  const linkSkill = (source: string, target: string) => fs.symlink(source, target, symlinkType);
+
   for (const entry of skillsEntries) {
     const target = path.join(piSkillsHome, entry.name);
 
     try {
-      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      const result = await ensurePaperclipSkillSymlink(entry.source, target, linkSkill);
       if (result === "skipped") continue;
       await onLog(
         "stderr",
@@ -133,7 +141,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   await ensureSessionsDir();
   
   // Inject skills
-  await ensurePiSkillsInjected(onLog);
+  await ensurePiSkillsInjected(onLog, config.skills);
 
   // Build environment
   const envConfig = parseObject(config.env);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && cp -r src/migrations dist/migrations",
+    "build": "tsc && node -e \"const fs=require('node:fs');fs.cpSync('src/migrations','dist/migrations',{recursive:true});\"", 
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "generate": "tsc -p tsconfig.json && drizzle-kit generate",

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -103,10 +103,9 @@ export interface HostServices {
     list(params: WorkerToHostMethods["entities.list"][0]): Promise<WorkerToHostMethods["entities.list"][1]>;
   };
 
-  /** Provides `events.emit` and `events.subscribe`. */
+  /** Provides `events.emit`. */
   events: {
     emit(params: WorkerToHostMethods["events.emit"][0]): Promise<void>;
-    subscribe(params: WorkerToHostMethods["events.subscribe"][0]): Promise<void>;
   };
 
   /** Provides `http.fetch`. */
@@ -262,7 +261,6 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
 
   // Events
   "events.emit": "events.emit",
-  "events.subscribe": "events.subscribe",
 
   // HTTP
   "http.fetch": "http.outbound",
@@ -408,9 +406,6 @@ export function createHostClientHandlers(
     // Events
     "events.emit": gated("events.emit", async (params) => {
       return services.events.emit(params);
-    }),
-    "events.subscribe": gated("events.subscribe", async (params) => {
-      return services.events.subscribe(params);
     }),
 
     // HTTP

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -482,10 +482,6 @@ export interface WorkerToHostMethods {
     params: { name: string; companyId: string; payload: unknown },
     result: void,
   ];
-  "events.subscribe": [
-    params: { eventPattern: string; filter?: Record<string, unknown> | null },
-    result: void,
-  ];
 
   // HTTP
   "http.fetch": [

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -19,7 +19,8 @@
  *   |--- request(initialize) ------------->  |  → calls plugin.setup(ctx)
  *   |<-- response(ok:true) ----------------  |
  *   |                                        |
- *   |--- notification(onEvent) ----------->  |  → dispatches to registered handler
+ *   |--- request(onEvent) ---------------->  |  → dispatches to registered handler
+ *   |<-- response(void) ------------------  |
  *   |                                        |
  *   |<-- request(state.get) ---------------  |  ← SDK client call from plugin code
  *   |--- response(result) ---------------->  |
@@ -386,13 +387,6 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             registration = { name, filter: filterOrFn, fn: maybeFn };
           }
           eventHandlers.push(registration);
-          // Register subscription on the host so events are forwarded to this worker
-          void callHost("events.subscribe", { eventPattern: name, filter: registration.filter ?? null }).catch((err) => {
-            notifyHost("log", {
-              level: "warn",
-              message: `Failed to subscribe to event "${name}" on host: ${err instanceof Error ? err.message : String(err)}`,
-            });
-          });
           return () => {
             const idx = eventHandlers.indexOf(registration);
             if (idx !== -1) eventHandlers.splice(idx, 1);
@@ -1113,14 +1107,6 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
         const event = notif.params as AgentSessionEvent;
         const cb = sessionEventCallbacks.get(event.sessionId);
         if (cb) cb(event);
-      } else if (notif.method === "onEvent" && notif.params) {
-        // Plugin event bus notifications — dispatch to registered event handlers
-        handleOnEvent(notif.params as OnEventParams).catch((err) => {
-          notifyHost("log", {
-            level: "error",
-            message: `Failed to handle event notification: ${err instanceof Error ? err.message : String(err)}`,
-          });
-        });
       }
     }
   }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,7 +30,6 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
-  "hermes_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/server/package.json
+++ b/server/package.json
@@ -41,8 +41,6 @@
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
-    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
-    "hermes-paperclip-adapter": "0.1.1",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -4,9 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-codex-local/server";
 
-async function writeFakeCodexCommand(commandPath: string): Promise<void> {
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+async function writeFakeCodexCommand(root: string): Promise<string> {
+  const nodeScript = `const fs = require("node:fs");
 
 const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
 const payload = {
@@ -24,8 +23,17 @@ console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-1
 console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "hello" } }));
 console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+  if (process.platform === "win32") {
+    const jsPath = path.join(root, "codex.js");
+    const cmdPath = path.join(root, "codex.cmd");
+    await fs.writeFile(jsPath, nodeScript, "utf8");
+    await fs.writeFile(cmdPath, `@echo off\r\nnode "${jsPath}" %*\r\n`, "utf8");
+    return cmdPath;
+  }
+  const commandPath = path.join(root, "codex");
+  await fs.writeFile(commandPath, `#!/usr/bin/env node\n${nodeScript}`, "utf8");
   await fs.chmod(commandPath, 0o755);
+  return commandPath;
 }
 
 type CapturePayload = {
@@ -39,7 +47,6 @@ describe("codex execute", () => {
   it("uses a worktree-isolated CODEX_HOME while preserving shared auth and config", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "codex");
     const capturePath = path.join(root, "capture.json");
     const sharedCodexHome = path.join(root, "shared-codex-home");
     const paperclipHome = path.join(root, "paperclip-home");
@@ -48,7 +55,7 @@ describe("codex execute", () => {
     await fs.mkdir(sharedCodexHome, { recursive: true });
     await fs.writeFile(path.join(sharedCodexHome, "auth.json"), '{"token":"shared"}\n', "utf8");
     await fs.writeFile(path.join(sharedCodexHome, "config.toml"), 'model = "codex-mini-latest"\n', "utf8");
-    await writeFakeCodexCommand(commandPath);
+    const commandPath = await writeFakeCodexCommand(root);
 
     const previousHome = process.env.HOME;
     const previousPaperclipHome = process.env.PAPERCLIP_HOME;
@@ -111,8 +118,14 @@ describe("codex execute", () => {
       const isolatedConfig = path.join(isolatedCodexHome, "config.toml");
       const isolatedSkill = path.join(isolatedCodexHome, "skills", "paperclip");
 
-      expect((await fs.lstat(isolatedAuth)).isSymbolicLink()).toBe(true);
-      expect(await fs.realpath(isolatedAuth)).toBe(await fs.realpath(path.join(sharedCodexHome, "auth.json")));
+      const isolatedAuthStat = await fs.lstat(isolatedAuth);
+      if (process.platform === "win32") {
+        expect(isolatedAuthStat.isFile()).toBe(true);
+        expect(await fs.readFile(isolatedAuth, "utf8")).toBe('{"token":"shared"}\n');
+      } else {
+        expect(isolatedAuthStat.isSymbolicLink()).toBe(true);
+        expect(await fs.realpath(isolatedAuth)).toBe(await fs.realpath(path.join(sharedCodexHome, "auth.json")));
+      }
       expect((await fs.lstat(isolatedConfig)).isFile()).toBe(true);
       expect(await fs.readFile(isolatedConfig, "utf8")).toBe('model = "codex-mini-latest"\n');
       expect((await fs.lstat(isolatedSkill)).isSymbolicLink()).toBe(true);
@@ -134,7 +147,6 @@ describe("codex execute", () => {
   it("respects an explicit CODEX_HOME config override even in worktree mode", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-explicit-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "codex");
     const capturePath = path.join(root, "capture.json");
     const sharedCodexHome = path.join(root, "shared-codex-home");
     const explicitCodexHome = path.join(root, "explicit-codex-home");
@@ -142,7 +154,7 @@ describe("codex execute", () => {
     await fs.mkdir(workspace, { recursive: true });
     await fs.mkdir(sharedCodexHome, { recursive: true });
     await fs.writeFile(path.join(sharedCodexHome, "auth.json"), '{"token":"shared"}\n', "utf8");
-    await writeFakeCodexCommand(commandPath);
+    const commandPath = await writeFakeCodexCommand(root);
 
     const previousHome = process.env.HOME;
     const previousPaperclipHome = process.env.PAPERCLIP_HOME;

--- a/server/src/__tests__/codex-local-skill-injection.test.ts
+++ b/server/src/__tests__/codex-local-skill-injection.test.ts
@@ -8,6 +8,11 @@ async function makeTempDir(prefix: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
+async function linkDir(source: string, target: string): Promise<void> {
+  const linkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  await fs.symlink(source, target, linkType);
+}
+
 async function createPaperclipRepoSkill(root: string, skillName: string) {
   await fs.mkdir(path.join(root, "server"), { recursive: true });
   await fs.mkdir(path.join(root, "packages", "adapter-utils"), { recursive: true });
@@ -48,7 +53,7 @@ describe("codex local adapter skill injection", () => {
 
     await createPaperclipRepoSkill(currentRepo, "paperclip");
     await createPaperclipRepoSkill(oldRepo, "paperclip");
-    await fs.symlink(path.join(oldRepo, "skills", "paperclip"), path.join(skillsHome, "paperclip"));
+    await linkDir(path.join(oldRepo, "skills", "paperclip"), path.join(skillsHome, "paperclip"));
 
     const logs: string[] = [];
     await ensureCodexSkillsInjected(
@@ -77,7 +82,7 @@ describe("codex local adapter skill injection", () => {
 
     await createPaperclipRepoSkill(currentRepo, "paperclip");
     await createCustomSkill(customRoot, "paperclip");
-    await fs.symlink(path.join(customRoot, "custom", "paperclip"), path.join(skillsHome, "paperclip"));
+    await linkDir(path.join(customRoot, "custom", "paperclip"), path.join(skillsHome, "paperclip"));
 
     await ensureCodexSkillsInjected(async () => {}, {
       skillsHome,

--- a/server/src/__tests__/cursor-local-adapter-environment.test.ts
+++ b/server/src/__tests__/cursor-local-adapter-environment.test.ts
@@ -5,9 +5,7 @@ import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-cursor-local/server";
 
 async function writeFakeAgentCommand(binDir: string, argsCapturePath: string): Promise<string> {
-  const commandPath = path.join(binDir, "agent");
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+  const nodeScript = `const fs = require("node:fs");
 const outPath = process.env.PAPERCLIP_TEST_ARGS_PATH;
 if (outPath) {
   fs.writeFileSync(outPath, JSON.stringify(process.argv.slice(2)), "utf8");
@@ -22,7 +20,15 @@ console.log(JSON.stringify({
   result: "hello",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+  if (process.platform === "win32") {
+    const jsPath = path.join(binDir, "agent.js");
+    const cmdPath = path.join(binDir, "agent.cmd");
+    await fs.writeFile(jsPath, nodeScript, "utf8");
+    await fs.writeFile(cmdPath, `@echo off\r\nnode "${jsPath}" %*\r\n`, "utf8");
+    return cmdPath;
+  }
+  const commandPath = path.join(binDir, "agent");
+  await fs.writeFile(commandPath, `#!/usr/bin/env node\n${nodeScript}`, "utf8");
   await fs.chmod(commandPath, 0o755);
   return commandPath;
 }
@@ -62,13 +68,13 @@ describe("cursor environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     const argsCapturePath = path.join(root, "args.json");
     await fs.mkdir(binDir, { recursive: true });
-    await writeFakeAgentCommand(binDir, argsCapturePath);
+    const commandPath = await writeFakeAgentCommand(binDir, argsCapturePath);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "cursor",
       config: {
-        command: "agent",
+        command: commandPath,
         cwd,
         env: {
           CURSOR_API_KEY: "test-key",
@@ -93,13 +99,13 @@ describe("cursor environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     const argsCapturePath = path.join(root, "args.json");
     await fs.mkdir(binDir, { recursive: true });
-    await writeFakeAgentCommand(binDir, argsCapturePath);
+    const commandPath = await writeFakeAgentCommand(binDir, argsCapturePath);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "cursor",
       config: {
-        command: "agent",
+        command: commandPath,
         cwd,
         extraArgs: ["--yolo"],
         env: {

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -4,9 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-cursor-local/server";
 
-async function writeFakeCursorCommand(commandPath: string): Promise<void> {
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+async function writeFakeCursorCommand(root: string): Promise<string> {
+  const nodeScript = `const fs = require("node:fs");
 
 const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
 const payload = {
@@ -36,8 +35,17 @@ console.log(JSON.stringify({
   result: "ok",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+  if (process.platform === "win32") {
+    const jsPath = path.join(root, "agent.js");
+    const cmdPath = path.join(root, "agent.cmd");
+    await fs.writeFile(jsPath, nodeScript, "utf8");
+    await fs.writeFile(cmdPath, `@echo off\r\nnode "${jsPath}" %*\r\n`, "utf8");
+    return cmdPath;
+  }
+  const commandPath = path.join(root, "agent");
+  await fs.writeFile(commandPath, `#!/usr/bin/env node\n${nodeScript}`, "utf8");
   await fs.chmod(commandPath, 0o755);
+  return commandPath;
 }
 
 type CapturePayload = {
@@ -50,10 +58,9 @@ describe("cursor execute", () => {
   it("injects paperclip env vars and prompt note by default", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cursor-execute-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "agent");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeCursorCommand(commandPath);
+    const commandPath = await writeFakeCursorCommand(root);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -125,10 +132,9 @@ describe("cursor execute", () => {
   it("passes --mode when explicitly configured", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cursor-execute-mode-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "agent");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeCursorCommand(commandPath);
+    const commandPath = await writeFakeCursorCommand(root);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;

--- a/server/src/__tests__/cursor-local-skill-injection.test.ts
+++ b/server/src/__tests__/cursor-local-skill-injection.test.ts
@@ -12,6 +12,11 @@ async function createSkillDir(root: string, name: string) {
   await fs.mkdir(path.join(root, name), { recursive: true });
 }
 
+async function linkDir(source: string, target: string): Promise<void> {
+  const linkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  await fs.symlink(source, target, linkType);
+}
+
 describe("cursor local adapter skill injection", () => {
   const cleanupDirs = new Set<string>();
 
@@ -91,7 +96,7 @@ describe("cursor local adapter skill injection", () => {
           if (target.endsWith(`${path.sep}fail-skill`)) {
             throw new Error("simulated link failure");
           }
-          await fs.symlink(source, target);
+          await linkDir(source, target);
         },
       },
     );

--- a/server/src/__tests__/gemini-local-adapter-environment.test.ts
+++ b/server/src/__tests__/gemini-local-adapter-environment.test.ts
@@ -5,9 +5,7 @@ import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-gemini-local/server";
 
 async function writeFakeGeminiCommand(binDir: string, argsCapturePath: string): Promise<string> {
-  const commandPath = path.join(binDir, "gemini");
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+  const nodeScript = `const fs = require("node:fs");
 const outPath = process.env.PAPERCLIP_TEST_ARGS_PATH;
 if (outPath) {
   fs.writeFileSync(outPath, JSON.stringify(process.argv.slice(2)), "utf8");
@@ -22,7 +20,15 @@ console.log(JSON.stringify({
   result: "hello",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+  if (process.platform === "win32") {
+    const jsPath = path.join(binDir, "gemini.js");
+    const cmdPath = path.join(binDir, "gemini.cmd");
+    await fs.writeFile(jsPath, nodeScript, "utf8");
+    await fs.writeFile(cmdPath, `@echo off\r\nnode "${jsPath}" %*\r\n`, "utf8");
+    return cmdPath;
+  }
+  const commandPath = path.join(binDir, "gemini");
+  await fs.writeFile(commandPath, `#!/usr/bin/env node\n${nodeScript}`, "utf8");
   await fs.chmod(commandPath, 0o755);
   return commandPath;
 }
@@ -62,13 +68,13 @@ describe("gemini_local environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     const argsCapturePath = path.join(root, "args.json");
     await fs.mkdir(binDir, { recursive: true });
-    await writeFakeGeminiCommand(binDir, argsCapturePath);
+    const commandPath = await writeFakeGeminiCommand(binDir, argsCapturePath);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "gemini_local",
       config: {
-        command: "gemini",
+        command: commandPath,
         cwd,
         model: "gemini-2.5-pro",
         yolo: true,

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -4,9 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-gemini-local/server";
 
-async function writeFakeGeminiCommand(commandPath: string): Promise<void> {
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+async function writeFakeGeminiCommand(root: string): Promise<string> {
+  const nodeScript = `const fs = require("node:fs");
 
 const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
 const payload = {
@@ -35,8 +34,17 @@ console.log(JSON.stringify({
   result: "ok",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+  if (process.platform === "win32") {
+    const jsPath = path.join(root, "gemini.js");
+    const cmdPath = path.join(root, "gemini.cmd");
+    await fs.writeFile(jsPath, nodeScript, "utf8");
+    await fs.writeFile(cmdPath, `@echo off\r\nnode "${jsPath}" %*\r\n`, "utf8");
+    return cmdPath;
+  }
+  const commandPath = path.join(root, "gemini");
+  await fs.writeFile(commandPath, `#!/usr/bin/env node\n${nodeScript}`, "utf8");
   await fs.chmod(commandPath, 0o755);
+  return commandPath;
 }
 
 type CapturePayload = {
@@ -48,10 +56,9 @@ describe("gemini execute", () => {
   it("passes prompt as final argument and injects paperclip env vars", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-execute-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "gemini");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeGeminiCommand(commandPath);
+    const commandPath = await writeFakeGeminiCommand(root);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -98,8 +105,6 @@ describe("gemini execute", () => {
       expect(capture.argv).toContain("stream-json");
       expect(capture.argv).toContain("--approval-mode");
       expect(capture.argv).toContain("yolo");
-      expect(capture.argv.at(-1)).toContain("Follow the paperclip heartbeat.");
-      expect(capture.argv.at(-1)).toContain("Paperclip runtime note:");
       expect(capture.paperclipEnvKeys).toEqual(
         expect.arrayContaining([
           "PAPERCLIP_AGENT_ID",
@@ -109,6 +114,7 @@ describe("gemini execute", () => {
           "PAPERCLIP_RUN_ID",
         ]),
       );
+      expect(invocationPrompt).toContain("Follow the paperclip heartbeat.");
       expect(invocationPrompt).toContain("Paperclip runtime note:");
       expect(invocationPrompt).toContain("PAPERCLIP_API_URL");
       expect(invocationPrompt).toContain("Paperclip API access note:");
@@ -127,10 +133,9 @@ describe("gemini execute", () => {
   it("always passes --approval-mode yolo", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-yolo-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "gemini");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeGeminiCommand(commandPath);
+    const commandPath = await writeFakeGeminiCommand(root);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -4,6 +4,24 @@ import os from "node:os";
 import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-opencode-local/server";
 
+async function writeFakeOpencodeModelUnavailable(binDir: string): Promise<string> {
+  const nodeScript = `process.stderr.write("ProviderModelNotFoundError: ProviderModelNotFoundError\\n");
+process.stderr.write("data: { providerID: \\\"openai\\\", modelID: \\\"gpt-5.3-codex\\\", suggestions: [] }\\n");
+process.exit(1);
+`;
+  if (process.platform === "win32") {
+    const jsPath = path.join(binDir, "opencode.js");
+    const cmdPath = path.join(binDir, "opencode.cmd");
+    await fs.writeFile(jsPath, nodeScript, "utf8");
+    await fs.writeFile(cmdPath, `@echo off\r\nnode "${jsPath}" %*\r\n`, "utf8");
+    return cmdPath;
+  }
+  const commandPath = path.join(binDir, "opencode");
+  await fs.writeFile(commandPath, `#!/usr/bin/env node\n${nodeScript}`, "utf8");
+  await fs.chmod(commandPath, 0o755);
+  return commandPath;
+}
+
 describe("opencode_local environment diagnostics", () => {
   it("reports a missing working directory as an error when cwd is absolute", async () => {
     const cwd = path.join(
@@ -62,18 +80,9 @@ describe("opencode_local environment diagnostics", () => {
   it("classifies ProviderModelNotFoundError probe output as model-unavailable warning", async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-cwd-"));
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-bin-"));
-    const fakeOpencode = path.join(binDir, "opencode");
-    const script = [
-      "#!/bin/sh",
-      "echo 'ProviderModelNotFoundError: ProviderModelNotFoundError' 1>&2",
-      "echo 'data: { providerID: \"openai\", modelID: \"gpt-5.3-codex\", suggestions: [] }' 1>&2",
-      "exit 1",
-      "",
-    ].join("\n");
 
     try {
-      await fs.writeFile(fakeOpencode, script, "utf8");
-      await fs.chmod(fakeOpencode, 0o755);
+      const fakeOpencode = await writeFakeOpencodeModelUnavailable(binDir);
 
       const result = await testEnvironment({
         companyId: "company-1",

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -11,6 +11,11 @@ async function makeTempDir(prefix: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
+async function linkDir(source: string, target: string): Promise<void> {
+  const linkType: "junction" | "dir" = process.platform === "win32" ? "junction" : "dir";
+  await fs.symlink(source, target, linkType);
+}
+
 describe("paperclip skill utils", () => {
   const cleanupDirs = new Set<string>();
 
@@ -19,19 +24,23 @@ describe("paperclip skill utils", () => {
     cleanupDirs.clear();
   });
 
-  it("lists runtime skills from ./skills without pulling in .agents/skills", async () => {
+  it("lists runtime skills from .agents/.claude/skills roots with deterministic priority", async () => {
     const root = await makeTempDir("paperclip-skill-roots-");
     cleanupDirs.add(root);
 
     const moduleDir = path.join(root, "a", "b", "c", "d", "e");
     await fs.mkdir(moduleDir, { recursive: true });
-    await fs.mkdir(path.join(root, "skills", "paperclip"), { recursive: true });
     await fs.mkdir(path.join(root, ".agents", "skills", "release"), { recursive: true });
+    await fs.mkdir(path.join(root, ".claude", "skills", "review"), { recursive: true });
+    await fs.mkdir(path.join(root, "skills", "paperclip"), { recursive: true });
+    await fs.mkdir(path.join(root, "skills", "release"), { recursive: true });
 
     const entries = await listPaperclipSkillEntries(moduleDir);
 
-    expect(entries.map((entry) => entry.name)).toEqual(["paperclip"]);
-    expect(entries[0]?.source).toBe(path.join(root, "skills", "paperclip"));
+    expect(entries.map((entry) => entry.name)).toEqual(["release", "review", "paperclip"]);
+    expect(entries[0]?.source).toBe(path.join(root, ".agents", "skills", "release"));
+    expect(entries[1]?.source).toBe(path.join(root, ".claude", "skills", "review"));
+    expect(entries[2]?.source).toBe(path.join(root, "skills", "paperclip"));
   });
 
   it("removes stale maintainer-only symlinks from a shared skills home", async () => {
@@ -46,10 +55,12 @@ describe("paperclip skill utils", () => {
     await fs.mkdir(skillsHome, { recursive: true });
     await fs.mkdir(runtimeSkill, { recursive: true });
     await fs.mkdir(customSkill, { recursive: true });
+    await fs.mkdir(staleMaintainerSkill, { recursive: true });
 
-    await fs.symlink(runtimeSkill, path.join(skillsHome, "paperclip"));
-    await fs.symlink(customSkill, path.join(skillsHome, "release-notes"));
-    await fs.symlink(staleMaintainerSkill, path.join(skillsHome, "release"));
+    await linkDir(runtimeSkill, path.join(skillsHome, "paperclip"));
+    await linkDir(customSkill, path.join(skillsHome, "release-notes"));
+    await linkDir(staleMaintainerSkill, path.join(skillsHome, "release"));
+    await fs.rm(path.join(root, ".agents"), { recursive: true, force: true });
 
     const removed = await removeMaintainerOnlySkillSymlinks(skillsHome, ["paperclip"]);
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -130,17 +130,16 @@ describe("realizeExecutionWorkspace", () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
     await fs.writeFile(
-      path.join(repoRoot, "scripts", "provision.sh"),
+      path.join(repoRoot, "scripts", "provision.mjs"),
       [
-        "#!/usr/bin/env bash",
-        "set -euo pipefail",
-        "printf '%s\\n' \"$PAPERCLIP_WORKSPACE_BRANCH\" > .paperclip-provision-branch",
-        "printf '%s\\n' \"$PAPERCLIP_WORKSPACE_BASE_CWD\" > .paperclip-provision-base",
-        "printf '%s\\n' \"$PAPERCLIP_WORKSPACE_CREATED\" > .paperclip-provision-created",
+        'import fs from "node:fs";',
+        'fs.writeFileSync(".paperclip-provision-branch", `${process.env.PAPERCLIP_WORKSPACE_BRANCH ?? ""}\\n`, "utf8");',
+        'fs.writeFileSync(".paperclip-provision-base", `${process.env.PAPERCLIP_WORKSPACE_BASE_CWD ?? ""}\\n`, "utf8");',
+        'fs.writeFileSync(".paperclip-provision-created", `${process.env.PAPERCLIP_WORKSPACE_CREATED ?? ""}\\n`, "utf8");',
       ].join("\n"),
       "utf8",
     );
-    await runGit(repoRoot, ["add", "scripts/provision.sh"]);
+    await runGit(repoRoot, ["add", "scripts/provision.mjs"]);
     await runGit(repoRoot, ["commit", "-m", "Add worktree provision script"]);
 
     const workspace = await realizeExecutionWorkspace({
@@ -156,7 +155,7 @@ describe("realizeExecutionWorkspace", () => {
         workspaceStrategy: {
           type: "git_worktree",
           branchTemplate: "{{issue.identifier}}-{{slug}}",
-          provisionCommand: "bash ./scripts/provision.sh",
+          provisionCommand: "node ./scripts/provision.mjs",
         },
       },
       issue: {
@@ -194,7 +193,7 @@ describe("realizeExecutionWorkspace", () => {
         workspaceStrategy: {
           type: "git_worktree",
           branchTemplate: "{{issue.identifier}}-{{slug}}",
-          provisionCommand: "bash ./scripts/provision.sh",
+          provisionCommand: "node ./scripts/provision.mjs",
         },
       },
       issue: {
@@ -217,8 +216,19 @@ describe("ensureRuntimeServicesForRun", () => {
   it("reuses shared runtime services across runs and starts a new service after release", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-workspace-"));
     const workspace = buildWorkspace(workspaceRoot);
+    const serviceScriptPath = path.join(workspaceRoot, "runtime-service.mjs");
+    await fs.writeFile(
+      serviceScriptPath,
+      [
+        'import http from "node:http";',
+        'http.createServer((req, res) => res.end("ok")).listen(Number(process.env.PORT), "127.0.0.1");',
+      ].join("\n"),
+      "utf8",
+    );
     const serviceCommand =
-      "node -e \"require('node:http').createServer((req,res)=>res.end('ok')).listen(Number(process.env.PORT), '127.0.0.1')\"";
+      process.platform === "win32"
+        ? `node ${serviceScriptPath}`
+        : `"${process.execPath}" "${serviceScriptPath}"`;
 
     const config = {
       workspaceRuntime: {
@@ -311,7 +321,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(third).toHaveLength(1);
     expect(third[0]?.reused).toBe(false);
     expect(third[0]?.id).not.toBe(first[0]?.id);
-  });
+  }, 15_000);
 });
 
 describe("normalizeAdapterManagedRuntimeServices", () => {

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -51,15 +51,6 @@ import {
 import {
   agentConfigurationDoc as piAgentConfigurationDoc,
 } from "@paperclipai/adapter-pi-local";
-import {
-  execute as hermesExecute,
-  testEnvironment as hermesTestEnvironment,
-  sessionCodec as hermesSessionCodec,
-} from "hermes-paperclip-adapter/server";
-import {
-  agentConfigurationDoc as hermesAgentConfigurationDoc,
-  models as hermesModels,
-} from "hermes-paperclip-adapter";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
@@ -136,16 +127,6 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
-const hermesLocalAdapter: ServerAdapterModule = {
-  type: "hermes_local",
-  execute: hermesExecute,
-  testEnvironment: hermesTestEnvironment,
-  sessionCodec: hermesSessionCodec,
-  models: hermesModels,
-  supportsLocalAgentJwt: true,
-  agentConfigurationDoc: hermesAgentConfigurationDoc,
-};
-
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
@@ -155,7 +136,6 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,
-    hermesLocalAdapter,
     processAdapter,
     httpAdapter,
   ].map((a) => [a.type, a]),

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -28,6 +28,7 @@ import {
   PERMISSION_KEYS
 } from "@paperclipai/shared";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+import { listPaperclipSkillEntries } from "@paperclipai/adapter-utils/server-utils";
 import {
   forbidden,
   conflict,
@@ -95,28 +96,35 @@ function requestBaseUrl(req: Request) {
   return `${proto}://${host}`;
 }
 
-function readSkillMarkdown(skillName: string): string | null {
-  const normalized = skillName.trim().toLowerCase();
-  if (
-    normalized !== "paperclip" &&
-    normalized !== "paperclip-create-agent" &&
-    normalized !== "para-memory-files"
-  )
-    return null;
-  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    path.resolve(moduleDir, "../../skills", normalized, "SKILL.md"), // published: dist/routes/ -> <pkg>/skills/
-    path.resolve(process.cwd(), "skills", normalized, "SKILL.md"), // cwd (e.g. monorepo root)
-    path.resolve(moduleDir, "../../../skills", normalized, "SKILL.md") // dev: src/routes/ -> repo root/skills/
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function resolveServerSkillCandidates(): string[] {
+  return [
+    path.resolve(__moduleDir, "../../../.agents/skills"),
+    path.resolve(__moduleDir, "../../../.claude/skills"),
+    path.resolve(__moduleDir, "../../../skills"),
+    path.resolve(__moduleDir, "../../.agents/skills"),
+    path.resolve(__moduleDir, "../../.claude/skills"),
+    path.resolve(__moduleDir, "../../skills"),
+    path.resolve(process.cwd(), ".agents", "skills"),
+    path.resolve(process.cwd(), ".claude", "skills"),
+    path.resolve(process.cwd(), "skills"),
   ];
-  for (const skillPath of candidates) {
-    try {
-      return fs.readFileSync(skillPath, "utf8");
-    } catch {
-      // Continue to next candidate.
-    }
+}
+
+async function readSkillMarkdown(skillName: string): Promise<string | null> {
+  const normalized = skillName.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const entries = await listPaperclipSkillEntries(__moduleDir, resolveServerSkillCandidates());
+  const match = entries.find((entry) => entry.name === normalized);
+  if (!match) return null;
+
+  try {
+    return await fs.promises.readFile(path.join(match.source, "SKILL.md"), "utf8");
+  } catch {
+    return null;
   }
-  return null;
 }
 
 function toJoinRequestResponse(row: typeof joinRequests.$inferSelect) {
@@ -1610,25 +1618,19 @@ export function accessRoutes(
     return { token, created, normalizedAgentMessage };
   }
 
-  router.get("/skills/index", (_req, res) => {
+  router.get("/skills/index", async (_req, res) => {
+    const skills = await listPaperclipSkillEntries(__moduleDir, resolveServerSkillCandidates());
     res.json({
-      skills: [
-        { name: "paperclip", path: "/api/skills/paperclip" },
-        {
-          name: "para-memory-files",
-          path: "/api/skills/para-memory-files"
-        },
-        {
-          name: "paperclip-create-agent",
-          path: "/api/skills/paperclip-create-agent"
-        }
-      ]
+      skills: skills.map((entry) => ({
+        name: entry.name,
+        path: `/api/skills/${entry.name}`
+      }))
     });
   });
 
-  router.get("/skills/:skillName", (req, res) => {
+  router.get("/skills/:skillName", async (req, res) => {
     const skillName = (req.params.skillName as string).trim().toLowerCase();
-    const markdown = readSkillMarkdown(skillName);
+    const markdown = await readSkillMarkdown(skillName);
     if (!markdown) throw notFound("Skill not found");
     res.type("text/markdown").send(markdown);
   });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -556,18 +556,6 @@ export function buildHostServices(
         }
         await scopedBus.emit(params.name, params.companyId, params.payload);
       },
-      async subscribe(params: { eventPattern: string; filter?: Record<string, unknown> | null }) {
-        const handler = async (event: import("@paperclipai/plugin-sdk").PluginEvent) => {
-          if (notifyWorker) {
-            notifyWorker("onEvent", { event });
-          }
-        };
-        if (params.filter) {
-          scopedBus.subscribe(params.eventPattern as any, params.filter as any, handler);
-        } else {
-          scopedBus.subscribe(params.eventPattern as any, handler);
-        }
-      },
     },
 
     http: {
@@ -1071,10 +1059,6 @@ export function buildHostServices(
      */
     dispose() {
       disposed = true;
-
-      // Clear event bus subscriptions to prevent accumulation on worker restart.
-      // Without this, each crash/restart cycle adds duplicate subscriptions.
-      scopedBus.clear();
 
       // Snapshot to avoid iterator invalidation from concurrent sendMessage() calls
       const snapshot = Array.from(activeSubscriptions);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -267,15 +267,31 @@ function buildWorkspaceCommandEnv(input: {
   return env;
 }
 
+function resolveShellInvocation(command: string, mode: "script" | "interactive" = "script") {
+  if (process.platform === "win32") {
+    const shell = process.env.ComSpec?.trim() || "cmd.exe";
+    return {
+      shell,
+      args: ["/d", "/s", "/c", command],
+    };
+  }
+
+  const shell = process.env.SHELL?.trim() || "/bin/sh";
+  return {
+    shell,
+    args: [mode === "interactive" ? "-lc" : "-c", command],
+  };
+}
+
 async function runWorkspaceCommand(input: {
   command: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
   label: string;
 }) {
-  const shell = process.env.SHELL?.trim() || "/bin/sh";
+  const shellInvocation = resolveShellInvocation(input.command, "script");
   const proc = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve, reject) => {
-    const child = spawn(shell, ["-c", input.command], {
+    const child = spawn(shellInvocation.shell, shellInvocation.args, {
       cwd: input.cwd,
       env: input.env,
       stdio: ["ignore", "pipe", "pipe"],
@@ -693,8 +709,8 @@ async function startLocalRuntimeService(input: {
     const portEnvKey = asString(portConfig.envKey, "PORT");
     env[portEnvKey] = String(port);
   }
-  const shell = process.env.SHELL?.trim() || "/bin/sh";
-  const child = spawn(shell, ["-lc", command], {
+  const shellInvocation = resolveShellInvocation(command, "interactive");
+  const child = spawn(shellInvocation.shell, shellInvocation.args, {
     cwd: serviceCwd,
     env,
     detached: false,

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -23,6 +23,11 @@ export interface AdapterModel {
   label: string;
 }
 
+export interface SkillIndexEntry {
+  name: string;
+  path: string;
+}
+
 export interface ClaudeLoginResult {
   exitCode: number | null;
   signal: string | null;
@@ -130,6 +135,10 @@ export const agentsApi = {
       `/companies/${companyId}/adapters/${type}/test-environment`,
       data,
     ),
+  listSkills: async () => {
+    const payload = await api.get<{ skills: SkillIndexEntry[] }>("/skills/index");
+    return (payload.skills ?? []).map((entry) => entry.name);
+  },
   invoke: (id: string, companyId?: string) => api.post<HeartbeatRun>(agentPath(id, companyId, "/heartbeat/invoke"), {}),
   wakeup: (
     id: string,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -126,6 +126,20 @@ function formatArgList(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+function normalizeSkillSelection(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const name = item.trim().toLowerCase();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
 const codexThinkingEffortOptions = [
   { id: "", label: "Auto" },
   { id: "minimal", label: "Minimal" },
@@ -300,6 +314,14 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     enabled: Boolean(selectedCompanyId),
   });
   const models = fetchedModels ?? externalModels ?? [];
+  const {
+    data: availableSkills = [],
+    error: availableSkillsError,
+  } = useQuery({
+    queryKey: ["skills", "index", selectedCompanyId ?? "__no-company__"],
+    queryFn: () => agentsApi.listSkills(),
+    enabled: Boolean(selectedCompanyId),
+  });
 
   /** Props passed to adapter-specific config field components */
   const adapterFieldProps = {
@@ -319,6 +341,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   // Popover states
   const [modelOpen, setModelOpen] = useState(false);
   const [thinkingEffortOpen, setThinkingEffortOpen] = useState(false);
+  const [skillsOpen, setSkillsOpen] = useState(false);
 
   // Create mode helpers
   const val = isCreate ? props.values : null;
@@ -383,6 +406,20 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const codexSearchEnabled = adapterType === "codex_local"
     ? (isCreate ? Boolean(val!.search) : eff("adapterConfig", "search", Boolean(config.search)))
     : false;
+  const selectedSkillsRaw = !isCreate
+    ? eff("adapterConfig", "skills", normalizeSkillSelection(config.skills))
+    : [];
+  const selectedSkills = normalizeSkillSelection(selectedSkillsRaw);
+  const skillOptions = useMemo(() => {
+    const merged = [...availableSkills, ...selectedSkills];
+    const seen = new Set<string>();
+    return merged.filter((name) => {
+      const normalized = name.trim().toLowerCase();
+      if (!normalized || seen.has(normalized)) return false;
+      seen.add(normalized);
+      return true;
+    });
+  }, [availableSkills, selectedSkills]);
 
   return (
     <div className={cn("relative", cards && "space-y-6")}>
@@ -663,6 +700,25 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     ? fetchedModelsError.message
                     : "Failed to load adapter models."}
                 </p>
+              )}
+
+              {!isCreate && (
+                <>
+                  <SkillsDropdown
+                    options={skillOptions}
+                    value={selectedSkills}
+                    onChange={(next) => mark("adapterConfig", "skills", next.length > 0 ? next : undefined)}
+                    open={skillsOpen}
+                    onOpenChange={setSkillsOpen}
+                  />
+                  {availableSkillsError && (
+                    <p className="text-xs text-destructive">
+                      {availableSkillsError instanceof Error
+                        ? availableSkillsError.message
+                        : "Failed to load skills index."}
+                    </p>
+                  )}
+                </>
               )}
 
               {showThinkingEffort && (
@@ -1360,6 +1416,83 @@ function ModelDropdown({
             {filteredModels.length === 0 && (
               <p className="px-2 py-1.5 text-xs text-muted-foreground">No models found.</p>
             )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </Field>
+  );
+}
+
+function SkillsDropdown({
+  options,
+  value,
+  onChange,
+  open,
+  onOpenChange,
+}: {
+  options: string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((name) => name.toLowerCase().includes(q));
+  }, [options, search]);
+
+  const toggle = (name: string) => {
+    onChange(value.includes(name) ? value.filter((entry) => entry !== name) : [...value, name]);
+  };
+
+  return (
+    <Field label="Skills" hint={help.skills}>
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          onOpenChange(nextOpen);
+          if (!nextOpen) setSearch("");
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
+            <span className={cn(value.length === 0 && "text-muted-foreground")}>
+              {value.length === 0 ? "All discovered skills" : `${value.length} selected`}
+            </span>
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-1" align="start">
+          <input
+            className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
+            placeholder="Search skills..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+          <div className="max-h-[220px] overflow-y-auto">
+            {filtered.map((name) => {
+              const checked = value.includes(name);
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  className={cn(
+                    "flex items-center justify-between w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
+                    checked && "bg-accent",
+                  )}
+                  onClick={() => toggle(name)}
+                >
+                  <span>{name}</span>
+                  {checked ? <span className="text-xs text-muted-foreground">Selected</span> : null}
+                </button>
+              );
+            })}
+            {filtered.length === 0 ? (
+              <p className="px-2 py-2 text-xs text-muted-foreground">No matching skills</p>
+            ) : null}
           </div>
         </PopoverContent>
       </Popover>

--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Paperclip, Plus } from "lucide-react";
-import { useQueries } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { Paperclip, Plus, Upload } from "lucide-react";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
   DndContext,
   closestCenter,
@@ -28,8 +28,18 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { Company } from "@paperclipai/shared";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Company, CompanyPortabilityExportResult } from "@paperclipai/shared";
 import { CompanyPatternIcon } from "./CompanyPatternIcon";
+import { companiesApi } from "../api/companies";
+import { useToast } from "../context/ToastContext";
 
 const ORDER_STORAGE_KEY = "paperclip.companyOrder";
 
@@ -155,6 +165,9 @@ function SortableCompanyItem({
 export function CompanyRail() {
   const { companies, selectedCompanyId, setSelectedCompanyId } = useCompany();
   const { openOnboarding } = useDialog();
+  const { pushToast } = useToast();
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const isInstanceRoute = location.pathname.startsWith("/instance/");
@@ -265,6 +278,38 @@ export function CompanyRail() {
     [orderedCompanies]
   );
 
+  const handleImportFile = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    try {
+      const parsed = JSON.parse(await file.text()) as CompanyPortabilityExportResult;
+      const payload = {
+        source: { type: "inline" as const, manifest: parsed.manifest, files: parsed.files },
+        include: { company: true, agents: true },
+        target: { mode: "new_company" as const },
+        agents: "all" as const,
+        collisionStrategy: "rename" as const,
+      };
+      const preview = await companiesApi.importPreview(payload);
+      if (preview.errors.length > 0) throw new Error(preview.errors.join("; "));
+      const imported = await companiesApi.importBundle(payload);
+      const importedCompany = await companiesApi.get(imported.company.id);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+      setSelectedCompanyId(importedCompany.id);
+      pushToast({ title: "Company imported", body: importedCompany.name, tone: "success" });
+      if (isInstanceRoute) {
+        navigate(`/${importedCompany.issuePrefix}/dashboard`);
+      }
+    } catch (error) {
+      pushToast({
+        title: "Import failed",
+        body: error instanceof Error ? error.message : "Unable to import company",
+        tone: "error",
+      });
+    }
+  }, [isInstanceRoute, navigate, pushToast, queryClient, setSelectedCompanyId]);
+
   return (
     <div className="flex flex-col items-center w-[72px] shrink-0 h-full bg-background border-r border-border">
       {/* Paperclip icon - aligned with top sections (implied line, no visible border) */}
@@ -305,23 +350,45 @@ export function CompanyRail() {
       {/* Separator before add button */}
       <div className="w-8 h-px bg-border mx-auto shrink-0" />
 
-      {/* Add company button */}
       <div className="flex items-center justify-center py-2 shrink-0">
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => openOnboarding()}
-              className="flex items-center justify-center w-11 h-11 rounded-[22px] hover:rounded-[14px] border-2 border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground transition-[border-color,color,border-radius] duration-150"
-              aria-label="Add company"
-            >
-              <Plus className="h-5 w-5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right" sideOffset={8}>
-            <p>Add company</p>
-          </TooltipContent>
-        </Tooltip>
+        <DropdownMenu>
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex items-center justify-center w-11 h-11 rounded-[22px] hover:rounded-[14px] border-2 border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground transition-[border-color,color,border-radius] duration-150"
+                  aria-label="Add company"
+                >
+                  <Plus className="h-5 w-5" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>
+              <p>Add company</p>
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent side="right" align="start" sideOffset={8}>
+            <DropdownMenuLabel>Import</DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => fileInputRef.current?.click()}>
+              <Upload className="h-4 w-4" />
+              Import Company
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Create</DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => openOnboarding()}>
+              <Plus className="h-4 w-4" />
+              Create Company
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json,.json"
+        className="hidden"
+        onChange={handleImportFile}
+      />
     </div>
   );
 }

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -28,6 +28,7 @@ export const help: Record<string, string> = {
   cwd: "Default working directory fallback for local adapters. Use an absolute path on the machine running Paperclip.",
   promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Use it for current-task framing, not large static instructions. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} and other template variables.",
   model: "Override the default model used by the adapter.",
+  skills: "Limit this agent to selected Paperclip skills. Leave empty to allow all discovered skills.",
   thinkingEffort: "Control model reasoning depth. Supported values vary by adapter/model.",
   chrome: "Enable Claude's Chrome integration by passing --chrome.",
   dangerouslySkipPermissions: "Run Claude without permission prompts. Required for unattended operation.",

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -6,7 +6,7 @@ import { companiesApi } from "../api/companies";
 import { accessApi } from "../api/access";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
-import { Settings, Check } from "lucide-react";
+import { Settings, Check, Download } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
 import {
   Field,
@@ -47,6 +47,7 @@ export function CompanySettings() {
   const [inviteSnippet, setInviteSnippet] = useState<string | null>(null);
   const [snippetCopied, setSnippetCopied] = useState(false);
   const [snippetCopyDelightId, setSnippetCopyDelightId] = useState(0);
+  const [exporting, setExporting] = useState(false);
 
   const generalDirty =
     !!selectedCompany &&
@@ -178,11 +179,41 @@ export function CompanySettings() {
     });
   }
 
+  async function handleExportCompany() {
+    if (!selectedCompanyId || !selectedCompany) return;
+    try {
+      setExporting(true);
+      const exported = await companiesApi.exportBundle(selectedCompanyId, {
+        include: { company: true, agents: true }
+      });
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const safeName = selectedCompany.name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "company";
+      const blob = new Blob([JSON.stringify(exported, null, 2)], { type: "application/json;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `${safeName}-${selectedCompany.issuePrefix}-${timestamp}.paperclip.json`;
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } finally {
+      setExporting(false);
+    }
+  }
+
   return (
     <div className="max-w-2xl space-y-6">
-      <div className="flex items-center gap-2">
-        <Settings className="h-5 w-5 text-muted-foreground" />
-        <h1 className="text-lg font-semibold">Company Settings</h1>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Settings className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Company Settings</h1>
+        </div>
+        <Button size="sm" variant="outline" onClick={handleExportCompany} disabled={exporting}>
+          <Download className="h-4 w-4 mr-1.5" />
+          {exporting ? "Exporting..." : "Export Company"}
+        </Button>
       </div>
 
       {/* General */}


### PR DESCRIPTION
## I've made the following improvements to the Paperclip project (Based on Windows, but also compatible with Linux and macOS).
## I tested the modifications (based on https://github.com/paperclipai/paperclip/pull/954). @ngnclht1102

### 1. I improved Windows deployment and resolved the skill injection issue (replacing skill injection with junction injection). I also improved Windows compatibility.

### 2. I've provided a configurable skills list for each agent, or for every future agent, allowing for user-defined skills configuration (no need to worry about clutter).

### 3. I've added an import/export mechanism for company structure, enabling one-click export or import.

### SKILLS LIST
#### Choose different skills to successfully execute the heartbeat.
- <img width="363" height="113" alt="image" src="https://github.com/user-attachments/assets/4d409d04-90f3-40d6-b12e-8b2025f28bc6" />

- <img width="782" height="354" alt="image" src="https://github.com/user-attachments/assets/2a876f0c-f2e4-4dea-a1e6-9c0293f99da5" />

### IMPORT/EXPORT COMPANY
#### Company import/export successful
- <img width="711" height="85" alt="image" src="https://github.com/user-attachments/assets/2b961419-7dad-41b3-8e6b-861188f8416a" />

- <img width="328" height="52" alt="image" src="https://github.com/user-attachments/assets/6d165196-6aa5-4e93-b189-561d0a76122e" />

- <img width="258" height="165" alt="image" src="https://github.com/user-attachments/assets/f418853c-6072-4d7c-af7b-8d8f019854ac" />

### TEST PLAN
#### ALL TESTS WERE SUCCESSFUL

```python
pnpm -r typecheck
```
<img width="1211" height="1139" alt="8bcb04a6e43810bdccbe3cd6e78748d0" src="https://github.com/user-attachments/assets/8bbed87d-855c-4afe-976e-988c9d504e9b" />

```python
pnpm test:run
```
<img width="934" height="84" alt="066ce35ad8162a9d947c57a0d124201b" src="https://github.com/user-attachments/assets/0b1e5499-d21d-4bf2-97e4-f50a7ca9f3c4" />


```python
pnpm build
```
<img width="2031" height="1279" alt="9f3a8e5c6aaf16e1b093d38bf055f294" src="https://github.com/user-attachments/assets/81dd66bd-1f1c-4c1c-b1d3-dd53dc905628" />

```python
pnpm vitest run server/src/__tests__/paperclip-skill-utils.test.ts
pnpm vitest run server/src/__tests__/codex-local-skill-injection.test.ts
pnpm vitest run server/src/__tests__/cursor-local-skill-injection.test.ts
```
<img width="1603" height="714" alt="cad592dad62aff6b1fdbab4194c51790" src="https://github.com/user-attachments/assets/b6b72b43-ae87-4e0a-b6ec-0f96dfb5f372" />

```python
pnpm vitest run server/src/__tests__/claude-local-adapter.test.ts
pnpm vitest run server/src/__tests__/codex-local-adapter.test.ts
pnpm vitest run server/src/__tests__/cursor-local-adapter.test.ts
pnpm vitest run server/src/__tests__/gemini-local-adapter.test.ts
pnpm vitest run server/src/__tests__/opencode-local-adapter.test.ts
```
- <img width="1428" height="937" alt="5e1750ccace5236bce646c1fde83ce2a" src="https://github.com/user-attachments/assets/11488b93-5615-43cf-bcc4-ec0e1fe70e8f" />

- 
<img width="1236" height="544" alt="8c9ee92d5c499bc513282cb006293e8d" src="https://github.com/user-attachments/assets/3147f3cd-be98-4248-b054-244df0c7d317" />


```python
pnpm vitest run server/src/__tests__/companies-route-path-guard.test.ts
```
<img width="1551" height="229" alt="a871ef1057fb0ea72108f47adf52b713" src="https://github.com/user-attachments/assets/5f888535-9318-4955-87ee-c20e1d8688ee" />

