### PR TITLE
fix: Fix company deletion FK cascade order

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -8,6 +8,7 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   issues,
+  issueAttachments,
   issueComments,
   issueReadStates,
   projects,
@@ -18,11 +19,13 @@ import {
   approvalComments,
   approvals,
   activityLog,
+  assets,
   companySecrets,
   joinRequests,
   invites,
   principalPermissionGrants,
   companyMemberships,
+  workspaceRuntimeServices,
 } from "@paperclipai/db";
 
 export function companyService(db: Db) {
@@ -101,6 +104,10 @@ export function companyService(db: Db) {
     remove: (id: string) =>
       db.transaction(async (tx) => {
         // Delete from child tables in dependency order
+        // issueAttachments has FK to assets — must delete before assets
+        await tx.delete(issueAttachments).where(eq(issueAttachments.companyId, id));
+        await tx.delete(assets).where(eq(assets.companyId, id));
+        await tx.delete(workspaceRuntimeServices).where(eq(workspaceRuntimeServices.companyId, id));
         // activityLog has FK to heartbeatRuns — must delete first
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));


### PR DESCRIPTION
## Summary

Fix two foreign key constraint violations in `companyService.remove()` that prevent company deletion and block users from reaching the onboarding flow after deleting their last company.

## Problem

DELETE /api/companies/:id returns 500 Internal Server Error with:
```
PostgresError: update or delete on table heartbeat_runs violates foreign key constraint 
activity_log_run_id_heartbeat_runs_id_fk on table activity_log
```

and:

```
PostgresError: update or delete on table issues violates foreign key constraint 
issue_read_states_issue_id_issues_id_fk on table issue_read_states
```

## Root Cause

1. `activityLog` was being deleted AFTER `heartbeatRuns`, but `activity_log.run_id` FK references `heartbeat_runs.id`
2. `issueReadStates` was never deleted, but `issue_read_states.issue_id` FK references `issues.id`

## Fix

1. Move `activityLog` deletion to the beginning of the cascade (before `heartbeatRuns`)
2. Add `issueReadStates` deletion before `issues`

## Testing

- [x] Verified deleting company with issues, agents, and activity log
- [x] Verified onboarding flow appears after last company is deleted