### PR TITLE
fix: worktree branding not applied in vite dev mode

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -242,7 +242,7 @@ export async function createApp(
     const { createServer: createViteServer } = await import("vite");
     const vite = await createViteServer({
       root: uiRoot,
-      appType: "spa",
+      appType: "custom",
       server: {
         middlewareMode: true,
         hmr: {


### PR DESCRIPTION
## Summary
- Vite dev server was configured with `appType: "spa"`, which adds its own SPA fallback middleware that serves `index.html` directly — bypassing the custom catch-all route that calls `applyUiBranding()`
- Changed `appType` to `"custom"` so our route handles HTML serving and injects worktree-colored favicon + banner meta tags
- No impact on non-worktree dev or production — branding is gated on `PAPERCLIP_IN_WORKTREE` env var which is only set by the CLI's worktree init commands

## Test plan
- [x] Verified via `curl` that worktree meta tags and dynamic favicon are injected after fix
- [ ] Visually confirm colored banner and favicon at `http://127.0.0.1:<port>` in a worktree instance
- [ ] Confirm normal dev (no worktree) still serves default favicon and no banner
- [ ] Confirm production/static mode is unaffected (different code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)