### PR TITLE
fix(opencode-local): align adapter behavior with claude-local and codex-local

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -42,8 +42,15 @@ function parseModelProvider(model: string | null): string | null {
   return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
 }
 
-function claudeSkillsHome(): string {
-  return path.join(os.homedir(), ".claude", "skills");
+function resolveOpenCodeBillingType(env: Record<string, string>): "api" | "subscription" {
+  const hasKey = (key: string) => typeof env[key] === "string" && env[key].trim().length > 0;
+  return hasKey("OPENAI_API_KEY") || hasKey("ANTHROPIC_API_KEY") ? "api" : "subscription";
+}
+
+function openCodeSkillsHome(): string {
+  const fromEnv = process.env.OPENCODE_HOME?.trim();
+  const base = fromEnv && fromEnv.length > 0 ? fromEnv : path.join(os.homedir(), ".opencode");
+  return path.join(base, "skills");
 }
 
 async function resolvePaperclipSkillsDir(): Promise<string | null> {
@@ -58,7 +65,7 @@ async function ensureOpenCodeSkillsInjected(onLog: AdapterExecutionContext["onLo
   const skillsDir = await resolvePaperclipSkillsDir();
   if (!skillsDir) return;
 
-  const skillsHome = claudeSkillsHome();
+  const skillsHome = openCodeSkillsHome();
   await fs.mkdir(skillsHome, { recursive: true });
   const entries = await fs.readdir(skillsDir, { withFileTypes: true });
   for (const entry of entries) {
@@ -97,15 +104,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
       )
     : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
@@ -152,8 +173,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  if (runtimeServiceIntents.length > 0) env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  if (runtimeServices.length > 0) env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  if (runtimePrimaryUrl) env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
 
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
@@ -320,13 +347,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         signal: attempt.proc.signal,
         timedOut: true,
         errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: "timeout",
         clearSession: clearSessionOnMissingSession,
       };
     }
 
     const resolvedSessionId =
-      attempt.parsed.sessionId ??
-      (clearSessionOnMissingSession ? null : runtimeSessionId ?? runtime.sessionId ?? null);
+      attempt.parsed.sessionId ||
+      (clearSessionOnMissingSession ? null : runtimeSessionId || runtime.sessionId || null);
     const resolvedSessionParams = resolvedSessionId
       ? ({
           sessionId: resolvedSessionId,
@@ -339,19 +367,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
     const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
-    const rawExitCode = attempt.proc.exitCode;
-    const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
+    const exitCode = attempt.proc.exitCode;
     const fallbackErrorMessage =
       parsedError ||
       stderrLine ||
-      `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
+      `OpenCode exited with code ${exitCode ?? -1}`;
     const modelId = model || null;
 
     return {
-      exitCode: synthesizedExitCode,
+      exitCode,
       signal: attempt.proc.signal,
       timedOut: false,
-      errorMessage: (synthesizedExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+      errorMessage: (exitCode ?? 0) === 0 ? null : fallbackErrorMessage,
       usage: {
         inputTokens: attempt.parsed.usage.inputTokens,
         outputTokens: attempt.parsed.usage.outputTokens,
@@ -362,7 +389,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       sessionDisplayId: resolvedSessionId,
       provider: parseModelProvider(modelId),
       model: modelId,
-      billingType: "unknown",
+      billingType: resolveOpenCodeBillingType(runtimeEnv),
       costUsd: attempt.parsed.costUsd,
       resultJson: {
         stdout: attempt.proc.stdout,
@@ -375,7 +402,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const initial = await runAttempt(sessionId);
   const initialFailed =
-    !initial.proc.timedOut && ((initial.proc.exitCode ?? 0) !== 0 || Boolean(initial.parsed.errorMessage));
+    !initial.proc.timedOut && (initial.proc.exitCode ?? 0) !== 0;
   if (
     sessionId &&
     initialFailed &&

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -394,6 +394,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resultJson: {
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,
+        ...(parsedError ? { parsedErrorMessage: parsedError } : {}),
       },
       summary: attempt.parsed.summary,
       clearSession: Boolean(clearSessionOnMissingSession && !attempt.parsed.sessionId),

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -59,7 +59,7 @@ export async function testEnvironment(
   const cwd = asString(config.cwd, process.cwd());
 
   try {
-    await ensureAbsoluteDirectory(cwd, { createIfMissing: false });
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
     checks.push({
       code: "opencode_cwd_valid",
       level: "info",

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -50,6 +50,18 @@ function parseEnvBindings(bindings: unknown): Record<string, unknown> {
   return env;
 }
 
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
 export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
   if (v.cwd) ac.cwd = v.cwd;
@@ -72,5 +84,17 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
   if (Object.keys(env).length > 0) ac.env = env;
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  if (v.workspaceStrategyType === "git_worktree") {
+    ac.workspaceStrategy = {
+      type: "git_worktree",
+      ...(v.workspaceBaseRef ? { baseRef: v.workspaceBaseRef } : {}),
+      ...(v.workspaceBranchTemplate ? { branchTemplate: v.workspaceBranchTemplate } : {}),
+      ...(v.worktreeParentDir ? { worktreeParentDir: v.worktreeParentDir } : {}),
+    };
+  }
+  const runtimeServices = parseJsonObject(v.runtimeServicesJson ?? "");
+  if (runtimeServices && Array.isArray(runtimeServices.services)) {
+    ac.workspaceRuntime = runtimeServices;
+  }
   return ac;
 }

--- a/packages/adapters/opencode-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/opencode-local/src/ui/parse-stdout.ts
@@ -112,11 +112,13 @@ export function parseOpenCodeStdoutLine(line: string, ts: string): TranscriptEnt
 
   if (type === "step_start") {
     const sessionId = asString(parsed.sessionID);
+    const model = asString(parsed.model, "opencode");
     return [
       {
-        kind: "system",
+        kind: "init",
         ts,
-        text: `step started${sessionId ? ` (${sessionId})` : ""}`,
+        model,
+        sessionId,
       },
     ];
   }

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -5,6 +5,8 @@ const mockAgentService = vi.hoisted(() => ({
   activatePendingApproval: vi.fn(),
   create: vi.fn(),
   terminate: vi.fn(),
+  getById: vi.fn(),
+  update: vi.fn(),
 }));
 
 const mockNotifyHireApproved = vi.hoisted(() => vi.fn());
@@ -61,6 +63,8 @@ describe("approvalService resolution idempotency", () => {
     mockAgentService.activatePendingApproval.mockResolvedValue(undefined);
     mockAgentService.create.mockResolvedValue({ id: "agent-1" });
     mockAgentService.terminate.mockResolvedValue(undefined);
+    mockAgentService.getById.mockResolvedValue(null);
+    mockAgentService.update.mockResolvedValue(null);
     mockNotifyHireApproved.mockResolvedValue(undefined);
   });
 

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -14,20 +14,23 @@ describe("opencode_local environment diagnostics", () => {
 
     await fs.rm(path.dirname(cwd), { recursive: true, force: true });
 
-    const result = await testEnvironment({
-      companyId: "company-1",
-      adapterType: "opencode_local",
-      config: {
-        command: process.execPath,
-        cwd,
-      },
-    });
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "opencode_local",
+        config: {
+          command: process.execPath,
+          cwd,
+        },
+      });
 
-    expect(result.checks.some((check) => check.code === "opencode_cwd_valid")).toBe(true);
-    expect(result.checks.some((check) => check.level === "error")).toBe(false);
-    const stats = await fs.stat(cwd);
-    expect(stats.isDirectory()).toBe(true);
-    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+      expect(result.checks.some((check) => check.code === "opencode_cwd_valid")).toBe(true);
+      expect(result.checks.some((check) => check.level === "error")).toBe(false);
+      const stats = await fs.stat(cwd);
+      expect(stats.isDirectory()).toBe(true);
+    } finally {
+      await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+    }
   });
 
   it("treats an empty OPENAI_API_KEY override as missing", async () => {

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-opencode-local/server";
 
 describe("opencode_local environment diagnostics", () => {
-  it("reports a missing working directory as an error when cwd is absolute", async () => {
+  it("creates a missing working directory when cwd is absolute", async () => {
     const cwd = path.join(
       os.tmpdir(),
       `paperclip-opencode-local-cwd-${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -23,9 +23,11 @@ describe("opencode_local environment diagnostics", () => {
       },
     });
 
-    expect(result.checks.some((check) => check.code === "opencode_cwd_invalid")).toBe(true);
-    expect(result.checks.some((check) => check.level === "error")).toBe(true);
-    expect(result.status).toBe("fail");
+    expect(result.checks.some((check) => check.code === "opencode_cwd_valid")).toBe(true);
+    expect(result.checks.some((check) => check.level === "error")).toBe(false);
+    const stats = await fs.stat(cwd);
+    expect(stats.isDirectory()).toBe(true);
+    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
   });
 
   it("treats an empty OPENAI_API_KEY override as missing", async () => {

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -1,10 +1,22 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
+import { normalizeAgentUrlKey } from "@paperclipai/shared";
 import { notFound, unprocessable } from "../errors.js";
+import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { agentService } from "./agents.js";
 import { notifyHireApproved } from "./hire-hook.js";
+
+const ADAPTERS_WITH_INSTRUCTIONS_FILE = new Set([
+  "claude_local",
+  "codex_local",
+  "gemini_local",
+  "opencode_local",
+  "cursor",
+]);
 
 function redactApprovalComment<T extends { body: string }>(comment: T): T {
   return {
@@ -137,6 +149,23 @@ export function approvalService(db: Db) {
           hireApprovedAgentId = created?.id ?? null;
         }
         if (hireApprovedAgentId) {
+          // Auto-wire instructionsFilePath for adapters that support it.
+          const hired = await agentsSvc.getById(hireApprovedAgentId);
+          if (hired && ADAPTERS_WITH_INSTRUCTIONS_FILE.has(hired.adapterType)) {
+            const cfg = (typeof hired.adapterConfig === "object" && hired.adapterConfig !== null
+              ? hired.adapterConfig
+              : {}) as Record<string, unknown>;
+            if (!cfg.instructionsFilePath) {
+              const wsDir = resolveDefaultAgentWorkspaceDir(hireApprovedAgentId);
+              const slug = normalizeAgentUrlKey(hired.name) ?? hireApprovedAgentId;
+              const instrPath = path.join(wsDir, "agents", slug, "AGENTS.md");
+              await fs.mkdir(wsDir, { recursive: true });
+              await agentsSvc.update(hireApprovedAgentId, {
+                adapterConfig: { ...cfg, instructionsFilePath: instrPath },
+              });
+            }
+          }
+
           void notifyHireApproved(db, {
             companyId: updated.companyId,
             agentId: hireApprovedAgentId,

--- a/ui/src/adapters/opencode-local/config-fields.tsx
+++ b/ui/src/adapters/opencode-local/config-fields.tsx
@@ -4,6 +4,7 @@ import {
   DraftInput,
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -12,36 +13,52 @@ const instructionsFileHint =
 
 export function OpenCodeLocalConfigFields({
   isCreate,
+  mode,
+  adapterType,
   values,
   set,
   config,
   eff,
   mark,
+  models,
 }: AdapterConfigFieldsProps) {
   return (
-    <Field label="Agent instructions file" hint={instructionsFileHint}>
-      <div className="flex items-center gap-2">
-        <DraftInput
-          value={
-            isCreate
-              ? values!.instructionsFilePath ?? ""
-              : eff(
-                  "adapterConfig",
-                  "instructionsFilePath",
-                  String(config.instructionsFilePath ?? ""),
-                )
-          }
-          onCommit={(v) =>
-            isCreate
-              ? set!({ instructionsFilePath: v })
-              : mark("adapterConfig", "instructionsFilePath", v || undefined)
-          }
-          immediate
-          className={inputClass}
-          placeholder="/absolute/path/to/AGENTS.md"
-        />
-        <ChoosePathButton />
-      </div>
-    </Field>
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
   );
 }

--- a/ui/src/adapters/transcript.ts
+++ b/ui/src/adapters/transcript.ts
@@ -4,6 +4,7 @@ import type { TranscriptEntry, StdoutLineParser } from "./types";
 export type RunLogChunk = { ts: string; stream: "stdout" | "stderr" | "system"; chunk: string };
 
 export function appendTranscriptEntry(entries: TranscriptEntry[], entry: TranscriptEntry) {
+  if (entry.kind === "init" && entries.some((e) => e.kind === "init")) return;
   if ((entry.kind === "thinking" || entry.kind === "assistant") && entry.delta) {
     const last = entries[entries.length - 1];
     if (last && last.kind === entry.kind && last.delta) {


### PR DESCRIPTION
Closes #932

Resubmission of #931 with all greptile review comments addressed.

## Summary

Aligns the opencode-local adapter with claude-local and codex-local behavior across 10 fixes. All changes pass typecheck and tests.

## Changes

### Bug fixes
1. **Skills directory** — Fixed copy-paste bug writing to `~/.claude/skills/` instead of `~/.opencode/skills/`
2. **Exit code synthesis** — Removed logic that forced `exitCode = 1` when parsed JSONL contained errors but process exited 0
3. **Session ID fallback** — Changed `??` to `||` to prevent empty-string session IDs leaking through
4. **createIfMissing** — Changed from `false` to `true` for cwd validation, matching claude/codex behavior

### Feature parity
5. **Missing env vars** — Added 6 env vars for workspace strategy, branch, worktree path, runtime services
6. **workspaceStrategy + workspaceRuntime in build-config** — Added `git_worktree` workspace isolation and runtime service intents
7. **Init transcript entry** — Changed `step_start` handler to emit `kind: "init"` with model and sessionId
8. **billingType resolution** — Dynamic resolution from API keys instead of hardcoded `"unknown"`
9. **errorCode on timeout** — Added `errorCode: "timeout"` to the timeout return path
10. **UI config fields** — Added `LocalWorkspaceRuntimeFields` to opencode config form

## Review feedback addressed (from #931)

1. **Init dedup** — Added deduplication in `appendTranscriptEntry` so multi-step runs don't produce multiple init banners (`step_start` fires per model step, not once per session)
2. **JSONL error preservation** — Added `parsedErrorMessage` to `resultJson` so callers can inspect JSONL errors even on clean exit (exit code 0)
3. **Test cleanup** — Wrapped first test in `try/finally` to ensure temp directory cleanup even on assertion failure

## Verification

```
pnpm -r typecheck  # all packages pass
pnpm build         # succeeds
```