### PR TITLE
Deduplicate scheduler heartbeat timer buckets

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
   buildHeartbeatTimerBucket,
+  isHeartbeatTimerWakePending,
   resolveRuntimeSessionParamsForWorkspace,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -171,5 +172,17 @@ describe("buildHeartbeatTimerBucket", () => {
     const now = new Date("2026-03-16T10:00:30.000Z");
 
     expect(buildHeartbeatTimerBucket(baseline, now, 60)).toBeNull();
+  });
+});
+
+describe("isHeartbeatTimerWakePending", () => {
+  it("treats queued and claimed wakes as in-flight duplicates", () => {
+    expect(isHeartbeatTimerWakePending("queued")).toBe(true);
+    expect(isHeartbeatTimerWakePending("claimed")).toBe(true);
+  });
+
+  it("does not treat completed or coalesced wakes as blocking recovery", () => {
+    expect(isHeartbeatTimerWakePending("completed")).toBe(false);
+    expect(isHeartbeatTimerWakePending("coalesced")).toBe(false);
   });
 });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  buildHeartbeatTimerBucket,
   resolveRuntimeSessionParamsForWorkspace,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -149,5 +150,26 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("buildHeartbeatTimerBucket", () => {
+  it("builds a stable bucket key for the same elapsed timer window", () => {
+    const baseline = new Date("2026-03-16T10:00:00.000Z");
+    const now = new Date("2026-03-16T10:05:30.000Z");
+
+    const bucket = buildHeartbeatTimerBucket(baseline, now, 60);
+
+    expect(bucket).toMatchObject({
+      bucketKey: "1773655200000:60000:2026-03-16T10:05:00.000Z",
+    });
+    expect(bucket?.bucketStart.toISOString()).toBe("2026-03-16T10:05:00.000Z");
+  });
+
+  it("returns null when the interval has not elapsed yet", () => {
+    const baseline = new Date("2026-03-16T10:00:00.000Z");
+    const now = new Date("2026-03-16T10:00:30.000Z");
+
+    expect(buildHeartbeatTimerBucket(baseline, now, 60)).toBeNull();
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -48,6 +48,7 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const HEARTBEAT_TIMER_BUCKET_KEY = "heartbeatTimerBucket";
+const HEARTBEAT_TIMER_PENDING_STATUSES = ["queued", "claimed"] as const;
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const SESSIONED_LOCAL_ADAPTERS = new Set([
@@ -539,6 +540,10 @@ export function buildHeartbeatTimerBucket(
     bucketKey: `${baselineMs}:${intervalMs}:${bucketStart.toISOString()}`,
     bucketStart,
   };
+}
+
+export function isHeartbeatTimerWakePending(status: string | null | undefined) {
+  return HEARTBEAT_TIMER_PENDING_STATUSES.includes(status as (typeof HEARTBEAT_TIMER_PENDING_STATUSES)[number]);
 }
 
 function truncateDisplayId(value: string | null | undefined, max = 128) {
@@ -2424,7 +2429,7 @@ export function heartbeatService(db: Db) {
             eq(agentWakeupRequests.agentId, agentId),
             eq(agentWakeupRequests.source, "timer"),
             sql`${agentWakeupRequests.payload} ->> ${HEARTBEAT_TIMER_BUCKET_KEY} = ${timerBucketKey}`,
-            inArray(agentWakeupRequests.status, ["queued", "claimed", "completed", "coalesced"]),
+            inArray(agentWakeupRequests.status, [...HEARTBEAT_TIMER_PENDING_STATUSES]),
           ),
         )
         .orderBy(asc(agentWakeupRequests.requestedAt))
@@ -3211,9 +3216,6 @@ export function heartbeatService(db: Db) {
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 
         checked += 1;
-        const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
-        const elapsedMs = now.getTime() - baseline;
-        if (elapsedMs < policy.intervalSec * 1000) continue;
         const timerBucket = buildHeartbeatTimerBucket(new Date(agent.lastHeartbeatAt ?? agent.createdAt), now, policy.intervalSec);
         if (!timerBucket) continue;
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -47,6 +47,7 @@ const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+const HEARTBEAT_TIMER_BUCKET_KEY = "heartbeatTimerBucket";
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const SESSIONED_LOCAL_ADAPTERS = new Set([
@@ -518,6 +519,26 @@ function runTaskKey(run: typeof heartbeatRuns.$inferSelect) {
 
 function isSameTaskScope(left: string | null, right: string | null) {
   return (left ?? null) === (right ?? null);
+}
+
+export function buildHeartbeatTimerBucket(
+  baseline: Date,
+  now: Date,
+  intervalSec: number,
+) {
+  const intervalMs = Math.max(1, Math.floor(intervalSec)) * 1000;
+  const baselineMs = baseline.getTime();
+  const nowMs = now.getTime();
+  const elapsedMs = nowMs - baselineMs;
+
+  if (elapsedMs < intervalMs) return null;
+
+  const bucketOffsetMs = Math.floor(elapsedMs / intervalMs) * intervalMs;
+  const bucketStart = new Date(baselineMs + bucketOffsetMs);
+  return {
+    bucketKey: `${baselineMs}:${intervalMs}:${bucketStart.toISOString()}`,
+    bucketStart,
+  };
 }
 
 function truncateDisplayId(value: string | null | undefined, max = 128) {
@@ -2385,6 +2406,64 @@ export function heartbeatService(db: Db) {
       return null;
     }
 
+    const timerBucketKey =
+      source === "timer"
+        ? readNonEmptyString(
+          parseObject(payload)[HEARTBEAT_TIMER_BUCKET_KEY] ??
+            enrichedContextSnapshot[HEARTBEAT_TIMER_BUCKET_KEY],
+        )
+        : null;
+
+    if (source === "timer" && timerBucketKey) {
+      const existingTimerWake = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, agent.companyId),
+            eq(agentWakeupRequests.agentId, agentId),
+            eq(agentWakeupRequests.source, "timer"),
+            sql`${agentWakeupRequests.payload} ->> ${HEARTBEAT_TIMER_BUCKET_KEY} = ${timerBucketKey}`,
+            inArray(agentWakeupRequests.status, ["queued", "claimed", "completed", "coalesced"]),
+          ),
+        )
+        .orderBy(asc(agentWakeupRequests.requestedAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      if (existingTimerWake) {
+        const existingTimerRun = existingTimerWake.runId
+          ? await db
+            .select()
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, existingTimerWake.runId))
+            .then((rows) => rows[0] ?? null)
+          : null;
+
+        if (existingTimerRun && (existingTimerRun.status === "queued" || existingTimerRun.status === "running")) {
+          await db.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "heartbeat_timer_duplicate_bucket",
+            payload,
+            status: "coalesced",
+            coalescedCount: 1,
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            runId: existingTimerRun.id,
+            finishedAt: new Date(),
+          });
+          return existingTimerRun;
+        }
+
+        await writeSkippedRequest("heartbeat_timer_duplicate_bucket");
+        return null;
+      }
+    }
+
     const bypassIssueExecutionLock =
       reason === "issue_comment_mentioned" ||
       readNonEmptyString(enrichedContextSnapshot.wakeReason) === "issue_comment_mentioned";
@@ -3135,14 +3214,21 @@ export function heartbeatService(db: Db) {
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
+        const timerBucket = buildHeartbeatTimerBucket(new Date(agent.lastHeartbeatAt ?? agent.createdAt), now, policy.intervalSec);
+        if (!timerBucket) continue;
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",
           triggerDetail: "system",
           reason: "heartbeat_timer",
+          payload: {
+            [HEARTBEAT_TIMER_BUCKET_KEY]: timerBucket.bucketKey,
+            scheduledFor: timerBucket.bucketStart.toISOString(),
+          },
           requestedByActorType: "system",
           requestedByActorId: "heartbeat_scheduler",
           contextSnapshot: {
+            [HEARTBEAT_TIMER_BUCKET_KEY]: timerBucket.bucketKey,
             source: "scheduler",
             reason: "interval_elapsed",
             now: now.toISOString(),


### PR DESCRIPTION
Problem
Scheduler retries can replay the same heartbeat interval without a stable per-bucket identity, which risks duplicate wakeup receipts or duplicate work when restart timing lines up badly.

Why now
The timer path in `heartbeat.ts` already coalesces active runs, but it had no durable bucket key to distinguish a replay of the same interval from a genuinely new interval. That makes dedupe depend on transient run state instead of a persisted scheduler contract.

What changed
- added a stable heartbeat timer bucket helper and threaded that bucket through timer wakeup payload/context
- taught `enqueueWakeup` to short-circuit duplicate timer buckets against persisted wakeup receipts
- added focused unit coverage for timer bucket generation semantics

Validation
- `pnpm test:run server/src/__tests__/heartbeat-workspace-session.test.ts` ✅
- `pnpm --filter @paperclipai/server typecheck` ✅

Refs #1041
