### PR TITLE
feat: managed hosting hooks for SaaS deployment (C1–C6)

### DIFF
--- a/Dockerfile.managed
+++ b/Dockerfile.managed
@@ -42,7 +42,7 @@ ENV NODE_ENV=production \
   HOST=0.0.0.0 \
   PORT=3100 \
   PAPERCLIP_HOME=/paperclip \
-  PAPERCLIP_INSTANCE_ID=default
+  PAPERCLIP_MANAGED_INSTANCE_ID=default
 
 VOLUME ["/paperclip"]
 EXPOSE 3100

--- a/Dockerfile.managed
+++ b/Dockerfile.managed
@@ -1,0 +1,50 @@
+FROM node:24-trixie-slim AS base
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl locales \
+  && sed -i 's/# en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen && locale-gen \
+  && rm -rf /var/lib/apt/lists/*
+RUN corepack enable
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY cli/package.json cli/
+COPY server/package.json server/
+COPY ui/package.json ui/
+COPY packages/shared/package.json packages/shared/
+COPY packages/db/package.json packages/db/
+COPY packages/adapter-utils/package.json packages/adapter-utils/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+COPY packages/plugins/create-paperclip-plugin/package.json packages/plugins/create-paperclip-plugin/
+COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
+COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
+COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
+COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
+COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
+COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
+COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+RUN pnpm install --frozen-lockfile
+
+FROM base AS build
+WORKDIR /app
+COPY --from=deps /app /app
+COPY . .
+RUN pnpm --filter @paperclipai/server build
+RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
+
+FROM base AS production
+WORKDIR /app
+COPY --chown=node:node --from=build /app /app
+RUN mkdir -p /paperclip && chown node:node /paperclip
+
+ENV NODE_ENV=production \
+  HOME=/paperclip \
+  HOST=0.0.0.0 \
+  PORT=3100 \
+  PAPERCLIP_HOME=/paperclip \
+  PAPERCLIP_INSTANCE_ID=default
+
+VOLUME ["/paperclip"]
+EXPOSE 3100
+USER node
+CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,7 +1,7 @@
 export const COMPANY_STATUSES = ["active", "paused", "archived"] as const;
 export type CompanyStatus = (typeof COMPANY_STATUSES)[number];
 
-export const DEPLOYMENT_MODES = ["local_trusted", "authenticated"] as const;
+export const DEPLOYMENT_MODES = ["local_trusted", "authenticated", "managed"] as const;
 export type DeploymentMode = (typeof DEPLOYMENT_MODES)[number];
 
 export const DEPLOYMENT_EXPOSURES = ["private", "public"] as const;
@@ -167,6 +167,7 @@ export const SECRET_PROVIDERS = [
   "aws_secrets_manager",
   "gcp_secret_manager",
   "vault",
+  "external_api",
 ] as const;
 export type SecretProvider = (typeof SECRET_PROVIDERS)[number];
 

--- a/packages/shared/src/types/secrets.ts
+++ b/packages/shared/src/types/secrets.ts
@@ -2,7 +2,8 @@ export type SecretProvider =
   | "local_encrypted"
   | "aws_secrets_manager"
   | "gcp_secret_manager"
-  | "vault";
+  | "vault"
+  | "external_api";
 
 export type SecretVersionSelector = number | "latest";
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -58,6 +58,7 @@ export async function createApp(
     bindHost: string;
     authReady: boolean;
     companyDeletionEnabled: boolean;
+    managedSecret?: string;
     instanceId?: string;
     hostVersion?: string;
     localPluginDir?: string;
@@ -89,6 +90,7 @@ export async function createApp(
   app.use(
     actorMiddleware(db, {
       deploymentMode: opts.deploymentMode,
+      managedSecret: opts.managedSecret,
       resolveSession: opts.resolveSession,
     }),
   );
@@ -124,6 +126,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
       companyDeletionEnabled: opts.companyDeletionEnabled,
+      managedSecret: opts.managedSecret,
     }),
   );
   api.use("/companies", companyRoutes(db));

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -87,9 +87,20 @@ export function loadConfig(): Config {
       }
     } catch { /* ignore malformed managed config */ }
   }
-  // Write managed overrides into process.env so all code (not just config.ts) sees them
+  // Only allow managed config to set the keys the platform legitimately controls.
+  // Unrestricted process.env mutation would let a compromised config file override
+  // security-critical vars like DATABASE_URL or PAPERCLIP_MANAGEMENT_SECRET.
+  const MANAGED_CONFIG_ALLOWLIST = new Set([
+    "PAPERCLIP_MANAGED_INSTANCE_ID",
+    "PAPERCLIP_MANAGEMENT_SECRET",
+    "PAPERCLIP_LIFECYCLE_URL",
+    "PAPERCLIP_USAGE_REPORT_URL",
+    "PAPERCLIP_SECRETS_API_URL",
+    "PAPERCLIP_SECRETS_PROVIDER",
+    "PAPERCLIP_DEPLOYMENT_MODE",
+  ]);
   for (const [k, v] of Object.entries(managedOverrides)) {
-    process.env[k] = v;
+    if (MANAGED_CONFIG_ALLOWLIST.has(k)) process.env[k] = v;
   }
   const env = (key: string) => process.env[key];
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,5 +1,5 @@
 import { readConfigFile } from "./config-file.js";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { config as loadDotenv } from "dotenv";
 import { resolvePaperclipEnvPath } from "./paths.js";
@@ -70,9 +70,25 @@ export interface Config {
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
+  managedInstanceId: string | undefined;
+  managedSecret: string | undefined;
+  managedUsageReportUrl: string | undefined;
+  managedLifecycleUrl: string | undefined;
 }
 
 export function loadConfig(): Config {
+  const managedConfigPath = process.env.PAPERCLIP_MANAGED_CONFIG_PATH;
+  const managedOverrides: Record<string, string> = {};
+  if (managedConfigPath && existsSync(managedConfigPath)) {
+    try {
+      const raw = JSON.parse(readFileSync(managedConfigPath, "utf-8")) as Record<string, unknown>;
+      for (const [k, v] of Object.entries(raw)) {
+        if (typeof v === "string") managedOverrides[k] = v;
+      }
+    } catch { /* ignore malformed managed config */ }
+  }
+  const env = (key: string) => managedOverrides[key] ?? process.env[key];
+
   const fileConfig = readConfigFile();
   const fileDatabaseMode =
     (fileConfig?.database.mode === "postgres" ? "postgres" : "embedded-postgres") as DatabaseMode;
@@ -84,13 +100,13 @@ export function loadConfig(): Config {
   const fileDatabaseBackup = fileConfig?.database.backup;
   const fileSecrets = fileConfig?.secrets;
   const fileStorage = fileConfig?.storage;
-  const strictModeFromEnv = process.env.PAPERCLIP_SECRETS_STRICT_MODE;
+  const strictModeFromEnv = env("PAPERCLIP_SECRETS_STRICT_MODE");
   const secretsStrictMode =
     strictModeFromEnv !== undefined
       ? strictModeFromEnv === "true"
       : (fileSecrets?.strictMode ?? false);
 
-  const providerFromEnvRaw = process.env.PAPERCLIP_SECRETS_PROVIDER;
+  const providerFromEnvRaw = env("PAPERCLIP_SECRETS_PROVIDER");
   const providerFromEnv =
     providerFromEnvRaw && SECRET_PROVIDERS.includes(providerFromEnvRaw as SecretProvider)
       ? (providerFromEnvRaw as SecretProvider)
@@ -98,33 +114,33 @@ export function loadConfig(): Config {
   const providerFromFile = fileSecrets?.provider;
   const secretsProvider: SecretProvider = providerFromEnv ?? providerFromFile ?? "local_encrypted";
 
-  const storageProviderFromEnvRaw = process.env.PAPERCLIP_STORAGE_PROVIDER;
+  const storageProviderFromEnvRaw = env("PAPERCLIP_STORAGE_PROVIDER");
   const storageProviderFromEnv =
     storageProviderFromEnvRaw && STORAGE_PROVIDERS.includes(storageProviderFromEnvRaw as StorageProvider)
       ? (storageProviderFromEnvRaw as StorageProvider)
       : null;
   const storageProvider: StorageProvider = storageProviderFromEnv ?? fileStorage?.provider ?? "local_disk";
   const storageLocalDiskBaseDir = resolveHomeAwarePath(
-    process.env.PAPERCLIP_STORAGE_LOCAL_DIR ??
+    env("PAPERCLIP_STORAGE_LOCAL_DIR") ??
       fileStorage?.localDisk?.baseDir ??
       resolveDefaultStorageDir(),
   );
-  const storageS3Bucket = process.env.PAPERCLIP_STORAGE_S3_BUCKET ?? fileStorage?.s3?.bucket ?? "paperclip";
-  const storageS3Region = process.env.PAPERCLIP_STORAGE_S3_REGION ?? fileStorage?.s3?.region ?? "us-east-1";
-  const storageS3Endpoint = process.env.PAPERCLIP_STORAGE_S3_ENDPOINT ?? fileStorage?.s3?.endpoint ?? undefined;
-  const storageS3Prefix = process.env.PAPERCLIP_STORAGE_S3_PREFIX ?? fileStorage?.s3?.prefix ?? "";
+  const storageS3Bucket = env("PAPERCLIP_STORAGE_S3_BUCKET") ?? fileStorage?.s3?.bucket ?? "paperclip";
+  const storageS3Region = env("PAPERCLIP_STORAGE_S3_REGION") ?? fileStorage?.s3?.region ?? "us-east-1";
+  const storageS3Endpoint = env("PAPERCLIP_STORAGE_S3_ENDPOINT") ?? fileStorage?.s3?.endpoint ?? undefined;
+  const storageS3Prefix = env("PAPERCLIP_STORAGE_S3_PREFIX") ?? fileStorage?.s3?.prefix ?? "";
   const storageS3ForcePathStyle =
-    process.env.PAPERCLIP_STORAGE_S3_FORCE_PATH_STYLE !== undefined
-      ? process.env.PAPERCLIP_STORAGE_S3_FORCE_PATH_STYLE === "true"
+    env("PAPERCLIP_STORAGE_S3_FORCE_PATH_STYLE") !== undefined
+      ? env("PAPERCLIP_STORAGE_S3_FORCE_PATH_STYLE") === "true"
       : (fileStorage?.s3?.forcePathStyle ?? false);
 
-  const deploymentModeFromEnvRaw = process.env.PAPERCLIP_DEPLOYMENT_MODE;
+  const deploymentModeFromEnvRaw = env("PAPERCLIP_DEPLOYMENT_MODE");
   const deploymentModeFromEnv =
     deploymentModeFromEnvRaw && DEPLOYMENT_MODES.includes(deploymentModeFromEnvRaw as DeploymentMode)
       ? (deploymentModeFromEnvRaw as DeploymentMode)
       : null;
   const deploymentMode: DeploymentMode = deploymentModeFromEnv ?? fileConfig?.server.deploymentMode ?? "local_trusted";
-  const deploymentExposureFromEnvRaw = process.env.PAPERCLIP_DEPLOYMENT_EXPOSURE;
+  const deploymentExposureFromEnvRaw = env("PAPERCLIP_DEPLOYMENT_EXPOSURE");
   const deploymentExposureFromEnv =
     deploymentExposureFromEnvRaw &&
     DEPLOYMENT_EXPOSURES.includes(deploymentExposureFromEnvRaw as DeploymentExposure)
@@ -252,5 +268,9 @@ export function loadConfig(): Config {
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
+    managedInstanceId: env("PAPERCLIP_MANAGED_INSTANCE_ID") ?? undefined,
+    managedSecret: env("PAPERCLIP_MANAGEMENT_SECRET") ?? undefined,
+    managedUsageReportUrl: env("PAPERCLIP_USAGE_REPORT_URL") ?? undefined,
+    managedLifecycleUrl: env("PAPERCLIP_LIFECYCLE_URL") ?? undefined,
   };
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -87,7 +87,11 @@ export function loadConfig(): Config {
       }
     } catch { /* ignore malformed managed config */ }
   }
-  const env = (key: string) => managedOverrides[key] ?? process.env[key];
+  // Write managed overrides into process.env so all code (not just config.ts) sees them
+  for (const [k, v] of Object.entries(managedOverrides)) {
+    process.env[k] = v;
+  }
+  const env = (key: string) => process.env[key];
 
   const fileConfig = readConfigFile();
   const fileDatabaseMode =
@@ -150,17 +154,17 @@ export function loadConfig(): Config {
     deploymentMode === "local_trusted"
       ? "private"
       : (deploymentExposureFromEnv ?? fileConfig?.server.exposure ?? "private");
-  const authBaseUrlModeFromEnvRaw = process.env.PAPERCLIP_AUTH_BASE_URL_MODE;
+  const authBaseUrlModeFromEnvRaw = env("PAPERCLIP_AUTH_BASE_URL_MODE");
   const authBaseUrlModeFromEnv =
     authBaseUrlModeFromEnvRaw &&
     AUTH_BASE_URL_MODES.includes(authBaseUrlModeFromEnvRaw as AuthBaseUrlMode)
       ? (authBaseUrlModeFromEnvRaw as AuthBaseUrlMode)
       : null;
-  const publicUrlFromEnv = process.env.PAPERCLIP_PUBLIC_URL;
+  const publicUrlFromEnv = env("PAPERCLIP_PUBLIC_URL");
   const authPublicBaseUrlRaw =
-    process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL ??
-    process.env.BETTER_AUTH_URL ??
-    process.env.BETTER_AUTH_BASE_URL ??
+    env("PAPERCLIP_AUTH_PUBLIC_BASE_URL") ??
+    env("BETTER_AUTH_URL") ??
+    env("BETTER_AUTH_BASE_URL") ??
     publicUrlFromEnv ??
     fileConfig?.auth?.publicBaseUrl;
   const authPublicBaseUrl = authPublicBaseUrlRaw?.trim() || undefined;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -695,8 +695,11 @@ export async function startServer(): Promise<StartedServer> {
     process.exit(0);
   };
 
-  process.once("SIGINT", () => void gracefulShutdown("SIGINT"));
-  process.once("SIGTERM", () => void gracefulShutdown("SIGTERM"));
+  const needsGracefulShutdown = (embeddedPostgres && embeddedPostgresStartedByThisProcess) || !!lifecycleOpts || !!usageStop;
+  if (needsGracefulShutdown) {
+    process.once("SIGINT", () => void gracefulShutdown("SIGINT"));
+    process.once("SIGTERM", () => void gracefulShutdown("SIGTERM"));
+  }
 
   return {
     server,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -653,26 +653,44 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
-  if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
-    const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
-      logger.info({ signal }, "Stopping embedded PostgreSQL");
-      try {
-        await embeddedPostgres?.stop();
-      } catch (err) {
-        logger.error({ err }, "Failed to stop embedded PostgreSQL cleanly");
-      } finally {
-        process.exit(0);
-      }
-    };
-  
-    process.once("SIGINT", () => {
-      void shutdown("SIGINT");
-    });
-    process.once("SIGTERM", () => {
-      void shutdown("SIGTERM");
-    });
+
+  // Managed-mode lifecycle & usage reporting
+  const lifecycleOpts = config.managedLifecycleUrl && config.managedInstanceId && config.managedSecret
+    ? { url: config.managedLifecycleUrl, instanceId: config.managedInstanceId, secret: config.managedSecret }
+    : null;
+  let usageStop: (() => void) | undefined;
+  let notifyShutdownFn: ((opts: NonNullable<typeof lifecycleOpts>) => Promise<void>) | undefined;
+  if (lifecycleOpts) {
+    const { notifyReady, notifyShutdown } = await import("./services/lifecycle-hooks.js");
+    void notifyReady(lifecycleOpts);
+    notifyShutdownFn = notifyShutdown;
   }
+  if (config.managedUsageReportUrl && config.managedInstanceId && config.managedSecret) {
+    const { startUsageReporter } = await import("./services/usage-reporter.js");
+    const reporter = startUsageReporter(db, {
+      url: config.managedUsageReportUrl,
+      instanceId: config.managedInstanceId,
+      secret: config.managedSecret,
+    });
+    usageStop = reporter.stop;
+  }
+
+  const gracefulShutdown = async (signal: "SIGINT" | "SIGTERM") => {
+    usageStop?.();
+    if (lifecycleOpts && notifyShutdownFn) {
+      await notifyShutdownFn(lifecycleOpts);
+    }
+    if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
+      logger.info({ signal }, "Stopping embedded PostgreSQL");
+      try { await embeddedPostgres.stop(); } catch (err) {
+        logger.error({ err }, "Failed to stop embedded PostgreSQL cleanly");
+      }
+    }
+    process.exit(0);
+  };
+
+  process.once("SIGINT", () => void gracefulShutdown("SIGINT"));
+  process.once("SIGTERM", () => void gracefulShutdown("SIGTERM"));
 
   return {
     server,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -475,6 +475,7 @@ export async function startServer(): Promise<StartedServer> {
     bindHost: config.host,
     authReady,
     companyDeletionEnabled: config.companyDeletionEnabled,
+    managedSecret: config.managedSecret,
     betterAuthHandler,
     resolveSession,
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,6 +29,7 @@ import { heartbeatService, reconcilePersistedRuntimeServicesOnStartup } from "./
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
+import { setStartedAt } from "./routes/health.js";
 
 type BetterAuthSessionUser = {
   id: string;
@@ -409,6 +410,10 @@ export async function startServer(): Promise<StartedServer> {
       }
     }
   }
+
+  if (config.deploymentMode === "managed" && !config.managedSecret) {
+    throw new Error("managed mode requires PAPERCLIP_MANAGEMENT_SECRET to be set");
+  }
   
   let authReady = config.deploymentMode === "local_trusted";
   let betterAuthHandler: RequestHandler | undefined;
@@ -603,6 +608,7 @@ export async function startServer(): Promise<StartedServer> {
     server.once("error", onError);
     server.listen(listenPort, config.host, () => {
       server.off("error", onError);
+      setStartedAt(Date.now());
       logger.info(`Server listening on ${config.host}:${listenPort}`);
       if (process.env.PAPERCLIP_OPEN_ON_LISTEN === "true") {
         const openHost = config.host === "0.0.0.0" || config.host === "::" ? "127.0.0.1" : config.host;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -14,11 +14,18 @@ function hashToken(token: string) {
 
 interface ActorMiddlewareOptions {
   deploymentMode: DeploymentMode;
+  managedSecret?: string;
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
 }
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   return async (req, _res, next) => {
+    // Managed-mode: trust instance identity from management proxy
+    const instanceIdHeader = req.header("x-paperclip-instance-id");
+    if (instanceIdHeader && opts.managedSecret && req.header("x-paperclip-management-secret") === opts.managedSecret) {
+      (req as unknown as Record<string, unknown>).managedInstanceId = instanceIdHeader;
+    }
+
     req.actor =
       opts.deploymentMode === "local_trusted"
         ? { type: "board", userId: "local-board", isInstanceAdmin: true, source: "local_implicit" }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -27,7 +27,9 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       const a = Buffer.from(incoming);
       const b = Buffer.from(opts.managedSecret);
       if (a.length === b.length && timingSafeEqual(a, b)) {
-        (req as unknown as Record<string, unknown>).managedInstanceId = instanceIdHeader;
+        req.actor = { type: "board", userId: "managed", isInstanceAdmin: true, source: "managed" };
+        next();
+        return;
       }
     }
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { Request, RequestHandler } from "express";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
@@ -22,8 +22,13 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
   return async (req, _res, next) => {
     // Managed-mode: trust instance identity from management proxy
     const instanceIdHeader = req.header("x-paperclip-instance-id");
-    if (instanceIdHeader && opts.managedSecret && req.header("x-paperclip-management-secret") === opts.managedSecret) {
-      (req as unknown as Record<string, unknown>).managedInstanceId = instanceIdHeader;
+    if (instanceIdHeader && opts.managedSecret) {
+      const incoming = req.header("x-paperclip-management-secret") ?? "";
+      const a = Buffer.from(incoming);
+      const b = Buffer.from(opts.managedSecret);
+      if (a.length === b.length && timingSafeEqual(a, b)) {
+        (req as unknown as Record<string, unknown>).managedInstanceId = instanceIdHeader;
+      }
     }
 
     req.actor =

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -22,7 +22,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
   return async (req, _res, next) => {
     // Managed-mode: trust instance identity from management proxy
     const instanceIdHeader = req.header("x-paperclip-instance-id");
-    if (instanceIdHeader && opts.managedSecret) {
+    if (opts.deploymentMode === "managed" && instanceIdHeader && opts.managedSecret) {
       const incoming = req.header("x-paperclip-management-secret") ?? "";
       const a = Buffer.from(incoming);
       const b = Buffer.from(opts.managedSecret);

--- a/server/src/middleware/board-mutation-guard.ts
+++ b/server/src/middleware/board-mutation-guard.ts
@@ -52,7 +52,7 @@ export function boardMutationGuard(): RequestHandler {
     // Local-trusted mode uses an implicit board actor for localhost-only development.
     // In this mode, origin/referer headers can be omitted by some clients for multipart
     // uploads; do not block those mutations.
-    if (req.actor.source === "local_implicit") {
+    if (req.actor.source === "local_implicit" || req.actor.source === "managed") {
       next();
       return;
     }

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -5,7 +5,8 @@ import { and, count, eq, gt, isNull, sql } from "drizzle-orm";
 import { agents, heartbeatRuns, instanceUserRoles, invites } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 
-const startedAt = Date.now();
+const startedAt = { value: Date.now() };
+export function setStartedAt(ts: number) { startedAt.value = ts; }
 
 export function healthRoutes(
   db?: Db,
@@ -81,7 +82,7 @@ export function healthRoutes(
       db.select({ count: count() }).from(agents).where(eq(agents.status, "active")).then((r) => Number(r[0]?.count ?? 0)),
       db.select({ count: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "running")).then((r) => Number(r[0]?.count ?? 0)),
     ]);
-    res.json({ status: "ok", uptimeMs: Date.now() - startedAt, activeAgents: agentCount, runningRuns: runningCount });
+    res.json({ status: "ok", uptimeMs: Date.now() - startedAt.value, activeAgents: agentCount, runningRuns: runningCount });
   });
 
   return router;

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
 import { and, count, eq, gt, isNull, sql } from "drizzle-orm";
-import { instanceUserRoles, invites } from "@paperclipai/db";
+import { agents, heartbeatRuns, instanceUserRoles, invites } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+
+const startedAt = Date.now();
 
 export function healthRoutes(
   db?: Db,
@@ -11,6 +13,7 @@ export function healthRoutes(
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
     companyDeletionEnabled: boolean;
+    managedSecret?: string;
   } = {
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
@@ -65,6 +68,18 @@ export function healthRoutes(
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },
     });
+  });
+
+  router.get("/detailed", async (req, res) => {
+    if (!db || !opts.managedSecret || req.header("x-paperclip-management-secret") !== opts.managedSecret) {
+      res.status(404).json({ error: "not_found" });
+      return;
+    }
+    const [agentCount, runningCount] = await Promise.all([
+      db.select({ count: count() }).from(agents).where(eq(agents.status, "active")).then((r) => Number(r[0]?.count ?? 0)),
+      db.select({ count: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "running")).then((r) => Number(r[0]?.count ?? 0)),
+    ]);
+    res.json({ status: "ok", uptimeMs: Date.now() - startedAt, activeAgents: agentCount, runningRuns: runningCount });
   });
 
   return router;

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { timingSafeEqual } from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { and, count, eq, gt, isNull, sql } from "drizzle-orm";
 import { agents, heartbeatRuns, instanceUserRoles, invites } from "@paperclipai/db";
@@ -71,10 +72,11 @@ export function healthRoutes(
   });
 
   router.get("/detailed", async (req, res) => {
-    if (!db || !opts.managedSecret || req.header("x-paperclip-management-secret") !== opts.managedSecret) {
-      res.status(404).json({ error: "not_found" });
-      return;
-    }
+    if (!db || !opts.managedSecret) { res.status(404).json({ error: "not_found" }); return; }
+    const incoming = req.header("x-paperclip-management-secret") ?? "";
+    const a = Buffer.from(incoming);
+    const b = Buffer.from(opts.managedSecret);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) { res.status(404).json({ error: "not_found" }); return; }
     const [agentCount, runningCount] = await Promise.all([
       db.select({ count: count() }).from(agents).where(eq(agents.status, "active")).then((r) => Number(r[0]?.count ?? 0)),
       db.select({ count: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "running")).then((r) => Number(r[0]?.count ?? 0)),

--- a/server/src/secrets/external-api-provider.ts
+++ b/server/src/secrets/external-api-provider.ts
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
 import type { SecretProviderModule } from "./types.js";
 
-const apiUrl = process.env.PAPERCLIP_SECRETS_API_URL;
-const secret = process.env.PAPERCLIP_MANAGEMENT_SECRET;
+const apiUrl = () => process.env.PAPERCLIP_SECRETS_API_URL;
+const secret = () => process.env.PAPERCLIP_MANAGEMENT_SECRET;
 
 function headers() {
   const h: Record<string, string> = { "content-type": "application/json" };
-  if (secret) h["x-paperclip-management-secret"] = secret;
+  const s = secret();
+  if (s) h["x-paperclip-management-secret"] = s;
   return h;
 }
 
@@ -14,8 +15,9 @@ export const externalApiProvider: SecretProviderModule = {
   id: "external_api",
   descriptor: { id: "external_api", label: "External API", requiresExternalRef: false },
   async createVersion({ value, externalRef }) {
-    if (!apiUrl) throw new Error("PAPERCLIP_SECRETS_API_URL is not configured");
-    const res = await fetch(`${apiUrl}/secrets`, {
+    const url = apiUrl();
+    if (!url) throw new Error("PAPERCLIP_SECRETS_API_URL is not configured");
+    const res = await fetch(`${url}/secrets`, {
       method: "POST",
       headers: headers(),
       body: JSON.stringify({ value, externalRef }),
@@ -30,15 +32,17 @@ export const externalApiProvider: SecretProviderModule = {
     };
   },
   async resolveVersion({ material }) {
-    if (!apiUrl) throw new Error("PAPERCLIP_SECRETS_API_URL is not configured");
+    const url = apiUrl();
+    if (!url) throw new Error("PAPERCLIP_SECRETS_API_URL is not configured");
     const ref = (material as { ref?: string }).ref;
     if (!ref) throw new Error("Missing secret ref in material");
-    const res = await fetch(`${apiUrl}/secrets/${encodeURIComponent(ref)}`, {
+    const res = await fetch(`${url}/secrets/${encodeURIComponent(ref)}`, {
       headers: headers(),
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) throw new Error(`External secrets API returned ${res.status}`);
-    const body = (await res.json()) as { value: string };
+    const body = (await res.json()) as { value?: unknown };
+    if (typeof body.value !== "string" || !body.value) throw new Error("External secrets API returned an invalid or empty value");
     return body.value;
   },
 };

--- a/server/src/secrets/external-api-provider.ts
+++ b/server/src/secrets/external-api-provider.ts
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+import type { SecretProviderModule } from "./types.js";
+
+const apiUrl = process.env.PAPERCLIP_SECRETS_API_URL;
+const secret = process.env.PAPERCLIP_MANAGEMENT_SECRET;
+
+function headers() {
+  const h: Record<string, string> = { "content-type": "application/json" };
+  if (secret) h["x-paperclip-management-secret"] = secret;
+  return h;
+}
+
+export const externalApiProvider: SecretProviderModule = {
+  id: "external_api",
+  descriptor: { id: "external_api", label: "External API", requiresExternalRef: false },
+  async createVersion({ value, externalRef }) {
+    if (!apiUrl) throw new Error("PAPERCLIP_SECRETS_API_URL is not configured");
+    const res = await fetch(`${apiUrl}/secrets`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ value, externalRef }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) throw new Error(`External secrets API returned ${res.status}`);
+    const body = (await res.json()) as { ref: string };
+    return {
+      material: { ref: body.ref },
+      valueSha256: createHash("sha256").update(value).digest("hex"),
+      externalRef: body.ref,
+    };
+  },
+  async resolveVersion({ material }) {
+    if (!apiUrl) throw new Error("PAPERCLIP_SECRETS_API_URL is not configured");
+    const ref = (material as { ref?: string }).ref;
+    if (!ref) throw new Error("Missing secret ref in material");
+    const res = await fetch(`${apiUrl}/secrets/${encodeURIComponent(ref)}`, {
+      headers: headers(),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) throw new Error(`External secrets API returned ${res.status}`);
+    const body = (await res.json()) as { value: string };
+    return body.value;
+  },
+};

--- a/server/src/secrets/external-api-provider.ts
+++ b/server/src/secrets/external-api-provider.ts
@@ -24,7 +24,8 @@ export const externalApiProvider: SecretProviderModule = {
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) throw new Error(`External secrets API returned ${res.status}`);
-    const body = (await res.json()) as { ref: string };
+    const body = (await res.json()) as { ref?: unknown };
+    if (typeof body.ref !== "string" || !body.ref) throw new Error("External secrets API returned an invalid or empty ref");
     return {
       material: { ref: body.ref },
       valueSha256: createHash("sha256").update(value).digest("hex"),

--- a/server/src/secrets/provider-registry.ts
+++ b/server/src/secrets/provider-registry.ts
@@ -5,6 +5,7 @@ import {
   gcpSecretManagerProvider,
   vaultProvider,
 } from "./external-stub-providers.js";
+import { externalApiProvider } from "./external-api-provider.js";
 import type { SecretProviderModule } from "./types.js";
 import { unprocessable } from "../errors.js";
 
@@ -13,6 +14,7 @@ const providers: SecretProviderModule[] = [
   awsSecretsManagerProvider,
   gcpSecretManagerProvider,
   vaultProvider,
+  externalApiProvider,
 ];
 
 const providerById = new Map<SecretProvider, SecretProviderModule>(

--- a/server/src/services/lifecycle-hooks.ts
+++ b/server/src/services/lifecycle-hooks.ts
@@ -8,12 +8,13 @@ interface LifecycleOpts {
 
 async function notify(opts: LifecycleOpts, event: string) {
   try {
-    await fetch(opts.url, {
+    const res = await fetch(opts.url, {
       method: "POST",
       headers: { "content-type": "application/json", "x-paperclip-instance-id": opts.instanceId, "x-paperclip-management-secret": opts.secret },
       body: JSON.stringify({ instanceId: opts.instanceId, event, timestamp: new Date().toISOString() }),
       signal: AbortSignal.timeout(5_000),
     });
+    if (!res.ok) logger.warn({ event, status: res.status }, "Lifecycle hook returned non-OK status");
   } catch (err) {
     logger.warn({ err, event }, "Lifecycle hook notification failed");
   }

--- a/server/src/services/lifecycle-hooks.ts
+++ b/server/src/services/lifecycle-hooks.ts
@@ -1,0 +1,23 @@
+import { logger } from "../middleware/logger.js";
+
+interface LifecycleOpts {
+  url: string;
+  instanceId: string;
+  secret: string;
+}
+
+async function notify(opts: LifecycleOpts, event: string) {
+  try {
+    await fetch(opts.url, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-paperclip-instance-id": opts.instanceId, "x-paperclip-management-secret": opts.secret },
+      body: JSON.stringify({ instanceId: opts.instanceId, event, timestamp: new Date().toISOString() }),
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    logger.warn({ err, event }, "Lifecycle hook notification failed");
+  }
+}
+
+export const notifyReady = (opts: LifecycleOpts) => notify(opts, "ready");
+export const notifyShutdown = (opts: LifecycleOpts) => notify(opts, "shutdown");

--- a/server/src/services/usage-reporter.ts
+++ b/server/src/services/usage-reporter.ts
@@ -1,0 +1,33 @@
+import type { Db } from "@paperclipai/db";
+import { count, eq, sql } from "drizzle-orm";
+import { agents, costEvents, heartbeatRuns } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+export function startUsageReporter(
+  db: Db,
+  opts: { url: string; instanceId: string; secret: string; intervalMs?: number },
+) {
+  const intervalMs = opts.intervalMs ?? 5 * 60_000;
+
+  const report = async () => {
+    try {
+      const [agentCount, runCount, tokenUsage] = await Promise.all([
+        db.select({ count: count() }).from(agents).where(eq(agents.status, "active")).then((r) => Number(r[0]?.count ?? 0)),
+        db.select({ count: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "running")).then((r) => Number(r[0]?.count ?? 0)),
+        db.select({ total: sql<number>`coalesce(sum(${costEvents.inputTokens}) + sum(${costEvents.outputTokens}), 0)` }).from(costEvents).then((r) => Number(r[0]?.total ?? 0)),
+      ]);
+      await fetch(opts.url, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-paperclip-instance-id": opts.instanceId, "x-paperclip-management-secret": opts.secret },
+        body: JSON.stringify({ instanceId: opts.instanceId, activeAgents: agentCount, runningRuns: runCount, totalTokens: tokenUsage, reportedAt: new Date().toISOString() }),
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (err) {
+      logger.warn({ err }, "Usage report failed");
+    }
+  };
+
+  const timer = setInterval(() => void report(), intervalMs);
+  void report();
+  return { stop: () => clearInterval(timer) };
+}

--- a/server/src/services/usage-reporter.ts
+++ b/server/src/services/usage-reporter.ts
@@ -16,12 +16,13 @@ export function startUsageReporter(
         db.select({ count: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "running")).then((r) => Number(r[0]?.count ?? 0)),
         db.select({ total: sql<number>`coalesce(sum(${costEvents.inputTokens}) + sum(${costEvents.outputTokens}), 0)` }).from(costEvents).then((r) => Number(r[0]?.total ?? 0)),
       ]);
-      await fetch(opts.url, {
+      const res = await fetch(opts.url, {
         method: "POST",
         headers: { "content-type": "application/json", "x-paperclip-instance-id": opts.instanceId, "x-paperclip-management-secret": opts.secret },
         body: JSON.stringify({ instanceId: opts.instanceId, activeAgents: agentCount, runningRuns: runCount, totalTokens: tokenUsage, reportedAt: new Date().toISOString() }),
         signal: AbortSignal.timeout(10_000),
       });
+      if (!res.ok) logger.warn({ status: res.status }, "Usage report endpoint returned non-OK status");
     } catch (err) {
       logger.warn({ err }, "Usage report failed");
     }

--- a/server/src/services/usage-reporter.ts
+++ b/server/src/services/usage-reporter.ts
@@ -1,5 +1,5 @@
 import type { Db } from "@paperclipai/db";
-import { count, eq, sql } from "drizzle-orm";
+import { count, eq, gt, sql } from "drizzle-orm";
 import { agents, costEvents, heartbeatRuns } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 
@@ -8,21 +8,26 @@ export function startUsageReporter(
   opts: { url: string; instanceId: string; secret: string; intervalMs?: number },
 ) {
   const intervalMs = opts.intervalMs ?? 5 * 60_000;
+  let lastReportedAt = new Date(0);
 
   const report = async () => {
+    const periodStart = lastReportedAt;
+    const periodEnd = new Date();
     try {
       const [agentCount, runCount, tokenUsage] = await Promise.all([
         db.select({ count: count() }).from(agents).where(eq(agents.status, "active")).then((r) => Number(r[0]?.count ?? 0)),
         db.select({ count: count() }).from(heartbeatRuns).where(eq(heartbeatRuns.status, "running")).then((r) => Number(r[0]?.count ?? 0)),
-        db.select({ total: sql<number>`coalesce(sum(${costEvents.inputTokens}) + sum(${costEvents.outputTokens}), 0)` }).from(costEvents).then((r) => Number(r[0]?.total ?? 0)),
+        db.select({ total: sql<number>`coalesce(sum(${costEvents.inputTokens}) + sum(${costEvents.outputTokens}), 0)` })
+          .from(costEvents).where(gt(costEvents.occurredAt, periodStart)).then((r) => Number(r[0]?.total ?? 0)),
       ]);
       const res = await fetch(opts.url, {
         method: "POST",
         headers: { "content-type": "application/json", "x-paperclip-instance-id": opts.instanceId, "x-paperclip-management-secret": opts.secret },
-        body: JSON.stringify({ instanceId: opts.instanceId, activeAgents: agentCount, runningRuns: runCount, totalTokens: tokenUsage, reportedAt: new Date().toISOString() }),
+        body: JSON.stringify({ instanceId: opts.instanceId, activeAgents: agentCount, runningRuns: runCount, periodTokens: tokenUsage, periodStart: periodStart.toISOString(), periodEnd: periodEnd.toISOString() }),
         signal: AbortSignal.timeout(10_000),
       });
       if (!res.ok) logger.warn({ status: res.status }, "Usage report endpoint returned non-OK status");
+      else lastReportedAt = periodEnd;
     } catch (err) {
       logger.warn({ err }, "Usage report failed");
     }

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -12,7 +12,7 @@ declare global {
         isInstanceAdmin?: boolean;
         keyId?: string;
         runId?: string;
-        source?: "local_implicit" | "session" | "agent_key" | "agent_jwt" | "none";
+        source?: "local_implicit" | "session" | "agent_key" | "agent_jwt" | "managed" | "none";
       };
     }
   }


### PR DESCRIPTION
Adds managed deployment mode for SaaS/hosted Paperclip instances.

## Changes

### New capabilities
- **C1** — `PAPERCLIP_DEPLOYMENT_MODE=managed` accepted; managed config env vars read at startup
- **C2** — `X-Paperclip-Instance-Id` + `X-Paperclip-Management-Secret` headers grant board-level actor to management proxy requests
- **C3** — `/api/health/detailed` endpoint (secret-gated) returns `uptimeMs`, `activeAgents`, `runningRuns`
- **C4** — Usage reporting webhook: POSTs token/agent/run metrics to `PAPERCLIP_USAGE_REPORT_URL` every 5 min
- **C5** — Lifecycle hooks: `ready` on server listen, `shutdown` on SIGTERM/SIGINT, sent to `PAPERCLIP_LIFECYCLE_URL`
- **C6** — External secrets provider (`PAPERCLIP_SECRETS_PROVIDER=external_api`): delegates store/resolve to `PAPERCLIP_SECRETS_API_URL`

### Fixes (addressing review feedback on #1040)
- `Dockerfile.managed`: env var name `PAPERCLIP_INSTANCE_ID` → `PAPERCLIP_MANAGED_INSTANCE_ID` (was silently disabling C4/C5)
- `external-api-provider`: validate `body.ref` before storing to prevent silent data loss on missing ref
- `auth`: wire managed identity into actor resolution — C2 was a no-op, verified requests fell through to `{ type: "none" }`
- `board-mutation-guard`: exempt `managed` source from CSRF origin check — platform API calls don't carry browser Origin headers
- `health`: fix `startedAt` to capture server-ready time (was captured at module-load)
- `index`: add managed mode startup validation — fail fast if `PAPERCLIP_MANAGEMENT_SECRET` is missing
- `lifecycle-hooks` / `usage-reporter`: log warning on non-OK HTTP responses (previously silently swallowed)

## Verification
All C1–C6 verified end-to-end against a Docker container with a live webhook receiver.