### PR TITLE
fix(ui): prevent duplicate company/agent creation when navigating back in onboarding wizard

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -342,6 +342,10 @@ export function OnboardingWizard() {
   }
 
   async function handleStep1Next() {
+    if (createdCompanyId) {
+      setStep(2);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -376,6 +380,10 @@ export function OnboardingWizard() {
 
   async function handleStep2Next() {
     if (!createdCompanyId) return;
+    if (createdAgentId) {
+      setStep(3);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {


### PR DESCRIPTION
When a user navigates back and then forward through the onboarding steps, `handleStep1Next` and `handleStep2Next` unconditionally call the creation APIs, resulting in duplicate companies, CEO agents, and heartbeat configurations.

## Root Cause

- `handleStep1Next` has **no guard** — always calls `companiesApi.create()`. Back → Next = duplicate company.
- `handleStep2Next` checks `if (!createdCompanyId) return` but does **not** check `if (createdAgentId)`. Back → Next = duplicate CEO agent + heartbeat config.
- `handleLaunch` (step 3/4) already has the correct pattern: `if (!issueRef) { ... create ... }`

## Fix

Add early-return guards that skip creation when the entity has already been created (`createdCompanyId` / `createdAgentId` are already set), matching the existing pattern in `handleLaunch`.

## Related

- Likely root cause of #12 (409 "Agent shortname is ambiguous") — duplicate CEO agents created during onboarding back/forward navigation.