### PR TITLE
Add CLAUDE.md pointing to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Adds a `CLAUDE.md` file that references `AGENTS.md`, following the OpenClaw convention
- This lets Claude Code (and other Claude-based tools) discover the repo's agent instructions via the standard `CLAUDE.md` entry point, while keeping the actual instructions in the agent-agnostic `AGENTS.md`

## Test plan
- [x] Verify `CLAUDE.md` exists and contains `AGENTS.md`
- [x] Confirm Claude Code picks up the reference when working in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)