### PR TITLE
fix: enhance project route error handling

### DIFF
--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -35,7 +35,9 @@ export function projectRoutes(db: Db) {
   async function normalizeProjectReference(req: Request, rawId: string) {
     if (isUuidLike(rawId)) return rawId;
     const companyId = await resolveCompanyIdForProjectReference(req);
-    if (!companyId) return rawId;
+    if (!companyId) {
+      throw notFound("Project not found");
+    }
     const resolved = await svc.resolveByReference(companyId, rawId);
     if (resolved.ambiguous) {
       throw conflict("Project shortname is ambiguous in this company. Use the project ID.");


### PR DESCRIPTION
**Summary**

- Return a typed `notFound` error when a project cannot be found, instead of leaking a Postgres `invalid input syntax for type uuid` error.
- Update the project lookup logic to validate the project ID and throw `notFound` rather than returning `undefined` for non‑existent or malformed IDs.

---

**Context**

- After completing the initial onboard flow and creating the first company, navigating to an invalid project path (for example: `default2`) caused the API to respond with a `500` and a Postgres error.
- The server tried to use the path segment as a UUID, which resulted in `invalid input syntax for type uuid: "default2"` and a full Postgres stack trace in the logs.

---

**Before (broken behavior)**

<img width="747" height="247" alt="image" src="https://github.com/user-attachments/assets/e8cb221c-89c7-4b04-91eb-942f9ccf9bcd" />

<details><summary>server log</summary>
<p>

```log

[19:47:55] ERROR: GET /api/projects/default2?companyId=dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe 500 — invalid input syntax for type uuid: "default2" {"errorContext":{"message":"invalid input syntax for type uuid: \"default2\"","stack":"PostgresError: invalid input syntax for type uuid: \"default2\"\n    at ErrorResponse (file:///Users/epikem/paperclip-pr-fix-project-not-found-internal-error/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/src/connection.js:815:30)\n    at handle (file:///Users/epikem/paperclip-pr-fix-project-not-found-internal-error/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/src/connection.js:489:6)\n    at Socket.data (file:///Users/epikem/paperclip-pr-fix-project-not-found-internal-error/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/src/connection.js:324:9)\n    at Socket.emit (node:events:519:28)\n    at addChunk (node:internal/streams/readable:561:12)\n    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)\n    at Readable.push (node:internal/streams/readable:392:5)\n    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)","name":"PostgresError"},"reqParams":{},"reqQuery":{"companyId":"dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe"}}
    err: {
      "type": "PostgresError",
      "message": "invalid input syntax for type uuid: \"default2\"",
      "stack":
          PostgresError: invalid input syntax for type uuid: "default2"
              at ErrorResponse (file:///Users/epikem/paperclip-pr-fix-project-not-found-internal-error/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/src/connection.js:815:30)
              at handle (file:///Users/epikem/paperclip-pr-fix-project-not-found-internal-error/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/src/connection.js:489:6)
              at Socket.data (file:///Users/epikem/paperclip-pr-fix-project-not-found-internal-error/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/src/connection.js:324:9)
              at Socket.emit (node:events:519:28)
              at addChunk (node:internal/streams/readable:561:12)
              at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
              at Readable.push (node:internal/streams/readable:392:5)
              at TCP.onStreamRead (node:internal/stream_base_commons:189:23)
      "name": "PostgresError",
      "severity_local": "ERROR",
      "severity": "ERROR",
      "code": "22P02",
      "where": "unnamed portal parameter $1 = '...'",
      "file": "uuid.c",
      "line": "177",
      "routine": "string_to_uuid"
    }
```

</p>
</details>

---

**After (fixed behavior)**

- The same request to an invalid project path now returns `404 Not Found` with a structured `notFound` error instead of a `500`:

<img width="735" height="167" alt="image" src="https://github.com/user-attachments/assets/fd51af38-b232-4535-8e47-77fddaddf567" />

<details><summary>server log</summary>
<p>

```log

[19:51:12] INFO: GET /companies/dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe/dashboard 304
[19:51:12] WARN: GET /api/projects/default2?companyId=dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe 404 {"reqQuery":{"companyId":"dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe"},"routePath":"/projects/:id"}
[19:51:12] INFO: GET /companies/dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe/agents 304
[19:51:12] INFO: GET /companies/dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe/sidebar-badges 304
[19:51:12] INFO: GET /companies/dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe/issues?status=backlog%2Ctodo%2Cin_progress%2Cin_review%2Cblocked%2Cdone&touchedByUserId=me 304
[19:51:12] INFO: GET /companies/dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe/projects 304
[19:51:13] WARN: GET /api/projects/default2?companyId=dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe 404 {"reqQuery":{"companyId":"dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe"},"routePath":"/projects/:id"}
[19:51:15] WARN: GET /api/projects/default2?companyId=dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe 404 {"reqQuery":{"companyId":"dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe"},"routePath":"/projects/:id"}
[19:51:19] WARN: GET /api/projects/default2?companyId=dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe 404 {"reqQuery":{"companyId":"dbda4af0-8c1a-4e7f-b189-c4b7b2bcb5fe"},"routePath":"/projects/:id"}
```

<img width="745" height="263" alt="image" src="https://github.com/user-attachments/assets/9e774fdd-073f-44b1-8106-48d655107aa5" />

</p>
</details>

---

**Test plan**

- [x] Complete initial onboard flow and create the first company (with its default project).
- [x] Manually navigate to an invalid project path such as `default2` (e.g. `/api/projects/default2?companyId=<company-id>`).
  - Confirm the API now returns `404 Not Found` instead of `500`.
  - Confirm the server logs show `WARN` 404 entries and no Postgres `invalid input syntax for type uuid` stack trace.

