### PR TITLE
feat: inject goal context into adapter execution context

### DIFF
--- a/server/src/__tests__/heartbeat-goal-context.test.ts
+++ b/server/src/__tests__/heartbeat-goal-context.test.ts
@@ -24,10 +24,10 @@ interface GoalRow {
  *
  *   if (issueGoal) {
  *     context.goalId = issueGoal.id;
- *     context.goalTitle = issueGoal.title;
- *     context.goalDescription = issueGoal.description ?? null;
- *     context.goalLevel = issueGoal.level;
- *     context.goalStatus = issueGoal.status;
+ *     ...
+ *   } else {
+ *     delete context.goalId;
+ *     ...
  *   }
  */
 function injectGoalContext(
@@ -40,6 +40,12 @@ function injectGoalContext(
     context.goalDescription = issueGoal.description ?? null;
     context.goalLevel = issueGoal.level;
     context.goalStatus = issueGoal.status;
+  } else {
+    delete context.goalId;
+    delete context.goalTitle;
+    delete context.goalDescription;
+    delete context.goalLevel;
+    delete context.goalStatus;
   }
 }
 
@@ -143,6 +149,59 @@ describe("heartbeat goal context injection", () => {
       });
       expect(context.goalLevel).toBe(level);
     }
+  });
+
+  it("clears stale goal fields when goal is removed from issue", () => {
+    // Simulate a context that had goal fields from a previous run
+    const context: Record<string, unknown> = {
+      issueId: "issue-1",
+      taskId: "issue-1",
+      goalId: "old-goal-1",
+      goalTitle: "Old goal title",
+      goalDescription: "Old description",
+      goalLevel: "company",
+      goalStatus: "active",
+    };
+
+    // Goal has been unlinked from the issue
+    injectGoalContext(context, null);
+
+    expect(context.goalId).toBeUndefined();
+    expect(context.goalTitle).toBeUndefined();
+    expect(context.goalDescription).toBeUndefined();
+    expect(context.goalLevel).toBeUndefined();
+    expect(context.goalStatus).toBeUndefined();
+
+    // Non-goal fields are preserved
+    expect(context.issueId).toBe("issue-1");
+    expect(context.taskId).toBe("issue-1");
+  });
+
+  it("replaces goal fields when issue is reassigned to a different goal", () => {
+    // Context has goal fields from a previous run
+    const context: Record<string, unknown> = {
+      issueId: "issue-1",
+      goalId: "old-goal",
+      goalTitle: "Old goal",
+      goalDescription: "Old description",
+      goalLevel: "company",
+      goalStatus: "planned",
+    };
+
+    // Issue is now linked to a different goal
+    injectGoalContext(context, {
+      id: "new-goal",
+      title: "New goal",
+      description: "New description",
+      level: "task",
+      status: "active",
+    });
+
+    expect(context.goalId).toBe("new-goal");
+    expect(context.goalTitle).toBe("New goal");
+    expect(context.goalDescription).toBe("New description");
+    expect(context.goalLevel).toBe("task");
+    expect(context.goalStatus).toBe("active");
   });
 
   it("handles all goal statuses correctly", () => {

--- a/server/src/__tests__/heartbeat-goal-context.test.ts
+++ b/server/src/__tests__/heartbeat-goal-context.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests for goal context injection into the adapter execution context.
+ *
+ * The heartbeat service enriches the `context` object passed to adapters
+ * with goal fields (goalId, goalTitle, goalDescription, goalLevel, goalStatus)
+ * when the current issue has a linked goal.
+ *
+ * These tests verify the enrichment logic in isolation by simulating
+ * the context mutation pattern used in heartbeat.ts.
+ */
+
+interface GoalRow {
+  id: string;
+  title: string;
+  description: string | null;
+  level: string;
+  status: string;
+}
+
+/**
+ * Mirrors the goal context injection logic from heartbeat.ts:
+ *
+ *   if (issueGoal) {
+ *     context.goalId = issueGoal.id;
+ *     context.goalTitle = issueGoal.title;
+ *     context.goalDescription = issueGoal.description ?? null;
+ *     context.goalLevel = issueGoal.level;
+ *     context.goalStatus = issueGoal.status;
+ *   }
+ */
+function injectGoalContext(
+  context: Record<string, unknown>,
+  issueGoal: GoalRow | null,
+): void {
+  if (issueGoal) {
+    context.goalId = issueGoal.id;
+    context.goalTitle = issueGoal.title;
+    context.goalDescription = issueGoal.description ?? null;
+    context.goalLevel = issueGoal.level;
+    context.goalStatus = issueGoal.status;
+  }
+}
+
+describe("heartbeat goal context injection", () => {
+  it("injects goal fields into context when issue has a linked goal", () => {
+    const context: Record<string, unknown> = {
+      issueId: "issue-1",
+      taskId: "issue-1",
+    };
+
+    const goal: GoalRow = {
+      id: "goal-1",
+      title: "Make the site functional and perform well",
+      description: "Ensure all user-facing features work correctly",
+      level: "task",
+      status: "active",
+    };
+
+    injectGoalContext(context, goal);
+
+    expect(context.goalId).toBe("goal-1");
+    expect(context.goalTitle).toBe("Make the site functional and perform well");
+    expect(context.goalDescription).toBe("Ensure all user-facing features work correctly");
+    expect(context.goalLevel).toBe("task");
+    expect(context.goalStatus).toBe("active");
+  });
+
+  it("does not inject goal fields when issue has no linked goal", () => {
+    const context: Record<string, unknown> = {
+      issueId: "issue-1",
+      taskId: "issue-1",
+    };
+
+    injectGoalContext(context, null);
+
+    expect(context.goalId).toBeUndefined();
+    expect(context.goalTitle).toBeUndefined();
+    expect(context.goalDescription).toBeUndefined();
+    expect(context.goalLevel).toBeUndefined();
+    expect(context.goalStatus).toBeUndefined();
+  });
+
+  it("sets goalDescription to null when goal has no description", () => {
+    const context: Record<string, unknown> = {};
+
+    const goal: GoalRow = {
+      id: "goal-2",
+      title: "Get first user",
+      description: null,
+      level: "company",
+      status: "active",
+    };
+
+    injectGoalContext(context, goal);
+
+    expect(context.goalId).toBe("goal-2");
+    expect(context.goalTitle).toBe("Get first user");
+    expect(context.goalDescription).toBeNull();
+    expect(context.goalLevel).toBe("company");
+    expect(context.goalStatus).toBe("active");
+  });
+
+  it("preserves existing context fields when injecting goal", () => {
+    const context: Record<string, unknown> = {
+      issueId: "issue-1",
+      taskId: "issue-1",
+      projectId: "project-1",
+      paperclipWorkspace: { cwd: "/tmp/workspace" },
+    };
+
+    const goal: GoalRow = {
+      id: "goal-3",
+      title: "Develop go to market plan",
+      description: null,
+      level: "company",
+      status: "planned",
+    };
+
+    injectGoalContext(context, goal);
+
+    // Goal fields are injected
+    expect(context.goalId).toBe("goal-3");
+    expect(context.goalTitle).toBe("Develop go to market plan");
+
+    // Existing fields are preserved
+    expect(context.issueId).toBe("issue-1");
+    expect(context.taskId).toBe("issue-1");
+    expect(context.projectId).toBe("project-1");
+    expect(context.paperclipWorkspace).toEqual({ cwd: "/tmp/workspace" });
+  });
+
+  it("handles all goal levels correctly", () => {
+    for (const level of ["company", "task", "milestone"]) {
+      const context: Record<string, unknown> = {};
+      injectGoalContext(context, {
+        id: `goal-${level}`,
+        title: `Goal at ${level} level`,
+        description: null,
+        level,
+        status: "active",
+      });
+      expect(context.goalLevel).toBe(level);
+    }
+  });
+
+  it("handles all goal statuses correctly", () => {
+    for (const status of ["planned", "active", "completed", "archived"]) {
+      const context: Record<string, unknown> = {};
+      injectGoalContext(context, {
+        id: `goal-${status}`,
+        title: `Goal with ${status} status`,
+        description: null,
+        level: "task",
+        status,
+      });
+      expect(context.goalStatus).toBe(status);
+    }
+  });
+});
+
+describe("inbox-lite goalTitle enrichment", () => {
+  /**
+   * Mirrors the inbox-lite mapping from agents.ts:
+   *
+   *   goalTitle: "goal" in issue && issue.goal != null
+   *     ? (issue.goal as { title: string }).title
+   *     : null,
+   */
+  function mapInboxLiteGoalTitle(issue: Record<string, unknown>): string | null {
+    return "goal" in issue && issue.goal != null
+      ? (issue.goal as { title: string }).title
+      : null;
+  }
+
+  it("returns goal title when issue has a linked goal", () => {
+    const issue = {
+      id: "issue-1",
+      goalId: "goal-1",
+      goal: { title: "Make the site functional", description: null, level: "task", status: "active" },
+    };
+
+    expect(mapInboxLiteGoalTitle(issue)).toBe("Make the site functional");
+  });
+
+  it("returns null when issue has no linked goal", () => {
+    const issue = {
+      id: "issue-1",
+      goalId: null,
+      goal: null,
+    };
+
+    expect(mapInboxLiteGoalTitle(issue)).toBeNull();
+  });
+
+  it("returns null when goal field is missing from issue", () => {
+    const issue = {
+      id: "issue-1",
+      goalId: null,
+    };
+
+    expect(mapInboxLiteGoalTitle(issue)).toBeNull();
+  });
+});

--- a/server/src/__tests__/heartbeat-goal-context.test.ts
+++ b/server/src/__tests__/heartbeat-goal-context.test.ts
@@ -1,186 +1,80 @@
 import { describe, expect, it } from "vitest";
+import { GOAL_LEVELS, GOAL_STATUSES, type GoalLevel, type GoalStatus } from "@paperclipai/shared";
+import { applyIssueGoalContext, readIssueGoalTitle, type IssueGoalContext } from "../lib/goal-context.js";
 
-/**
- * Tests for goal context injection into the adapter execution context.
- *
- * The heartbeat service enriches the `context` object passed to adapters
- * with goal fields (goalId, goalTitle, goalDescription, goalLevel, goalStatus)
- * when the current issue has a linked goal.
- *
- * These tests verify the enrichment logic in isolation by simulating
- * the context mutation pattern used in heartbeat.ts.
- */
-
-interface GoalRow {
-  id: string;
-  title: string;
-  description: string | null;
-  level: string;
-  status: string;
+function createGoal(overrides: Partial<IssueGoalContext> = {}): IssueGoalContext {
+  return {
+    id: "goal-1",
+    title: "Ship the feature",
+    description: "Deliver the operator-visible change",
+    level: "task",
+    status: "active",
+    ...overrides,
+  };
 }
 
-/**
- * Mirrors the goal context injection logic from heartbeat.ts:
- *
- *   if (issueGoal) {
- *     context.goalId = issueGoal.id;
- *     ...
- *   } else {
- *     delete context.goalId;
- *     ...
- *   }
- */
-function injectGoalContext(
-  context: Record<string, unknown>,
-  issueGoal: GoalRow | null,
-): void {
-  if (issueGoal) {
-    context.goalId = issueGoal.id;
-    context.goalTitle = issueGoal.title;
-    context.goalDescription = issueGoal.description ?? null;
-    context.goalLevel = issueGoal.level;
-    context.goalStatus = issueGoal.status;
-  } else {
-    delete context.goalId;
-    delete context.goalTitle;
-    delete context.goalDescription;
-    delete context.goalLevel;
-    delete context.goalStatus;
-  }
-}
+describe("applyIssueGoalContext", () => {
+  it("injects goal fields into the adapter context", () => {
+    const context: Record<string, unknown> = { issueId: "issue-1", taskId: "issue-1" };
 
-describe("heartbeat goal context injection", () => {
-  it("injects goal fields into context when issue has a linked goal", () => {
-    const context: Record<string, unknown> = {
+    applyIssueGoalContext(context, createGoal());
+
+    expect(context).toMatchObject({
       issueId: "issue-1",
       taskId: "issue-1",
-    };
-
-    const goal: GoalRow = {
-      id: "goal-1",
-      title: "Make the site functional and perform well",
-      description: "Ensure all user-facing features work correctly",
-      level: "task",
-      status: "active",
-    };
-
-    injectGoalContext(context, goal);
-
-    expect(context.goalId).toBe("goal-1");
-    expect(context.goalTitle).toBe("Make the site functional and perform well");
-    expect(context.goalDescription).toBe("Ensure all user-facing features work correctly");
-    expect(context.goalLevel).toBe("task");
-    expect(context.goalStatus).toBe("active");
+      goalId: "goal-1",
+      goalTitle: "Ship the feature",
+      goalDescription: "Deliver the operator-visible change",
+      goalLevel: "task",
+      goalStatus: "active",
+    });
   });
 
-  it("does not inject goal fields when issue has no linked goal", () => {
+  it("keeps unrelated context values intact", () => {
     const context: Record<string, unknown> = {
       issueId: "issue-1",
-      taskId: "issue-1",
-    };
-
-    injectGoalContext(context, null);
-
-    expect(context.goalId).toBeUndefined();
-    expect(context.goalTitle).toBeUndefined();
-    expect(context.goalDescription).toBeUndefined();
-    expect(context.goalLevel).toBeUndefined();
-    expect(context.goalStatus).toBeUndefined();
-  });
-
-  it("sets goalDescription to null when goal has no description", () => {
-    const context: Record<string, unknown> = {};
-
-    const goal: GoalRow = {
-      id: "goal-2",
-      title: "Get first user",
-      description: null,
-      level: "company",
-      status: "active",
-    };
-
-    injectGoalContext(context, goal);
-
-    expect(context.goalId).toBe("goal-2");
-    expect(context.goalTitle).toBe("Get first user");
-    expect(context.goalDescription).toBeNull();
-    expect(context.goalLevel).toBe("company");
-    expect(context.goalStatus).toBe("active");
-  });
-
-  it("preserves existing context fields when injecting goal", () => {
-    const context: Record<string, unknown> = {
-      issueId: "issue-1",
-      taskId: "issue-1",
       projectId: "project-1",
       paperclipWorkspace: { cwd: "/tmp/workspace" },
     };
 
-    const goal: GoalRow = {
-      id: "goal-3",
-      title: "Develop go to market plan",
-      description: null,
-      level: "company",
-      status: "planned",
-    };
+    applyIssueGoalContext(context, createGoal({ id: "goal-2", title: "Keep context stable" }));
 
-    injectGoalContext(context, goal);
-
-    // Goal fields are injected
-    expect(context.goalId).toBe("goal-3");
-    expect(context.goalTitle).toBe("Develop go to market plan");
-
-    // Existing fields are preserved
-    expect(context.issueId).toBe("issue-1");
-    expect(context.taskId).toBe("issue-1");
     expect(context.projectId).toBe("project-1");
     expect(context.paperclipWorkspace).toEqual({ cwd: "/tmp/workspace" });
+    expect(context.goalId).toBe("goal-2");
+    expect(context.goalTitle).toBe("Keep context stable");
   });
 
-  it("handles all goal levels correctly", () => {
-    for (const level of ["company", "task", "milestone"]) {
-      const context: Record<string, unknown> = {};
-      injectGoalContext(context, {
-        id: `goal-${level}`,
-        title: `Goal at ${level} level`,
-        description: null,
-        level,
-        status: "active",
-      });
-      expect(context.goalLevel).toBe(level);
-    }
+  it("writes null descriptions through to the prompt context", () => {
+    const context: Record<string, unknown> = {};
+
+    applyIssueGoalContext(context, createGoal({ description: null }));
+
+    expect(context.goalDescription).toBeNull();
   });
 
-  it("clears stale goal fields when goal is removed from issue", () => {
-    // Simulate a context that had goal fields from a previous run
+  it("clears stale goal fields when an issue no longer has a goal", () => {
     const context: Record<string, unknown> = {
       issueId: "issue-1",
-      taskId: "issue-1",
-      goalId: "old-goal-1",
-      goalTitle: "Old goal title",
+      goalId: "stale-goal",
+      goalTitle: "Old goal",
       goalDescription: "Old description",
       goalLevel: "company",
-      goalStatus: "active",
+      goalStatus: "planned",
     };
 
-    // Goal has been unlinked from the issue
-    injectGoalContext(context, null);
+    applyIssueGoalContext(context, null);
 
+    expect(context.issueId).toBe("issue-1");
     expect(context.goalId).toBeUndefined();
     expect(context.goalTitle).toBeUndefined();
     expect(context.goalDescription).toBeUndefined();
     expect(context.goalLevel).toBeUndefined();
     expect(context.goalStatus).toBeUndefined();
-
-    // Non-goal fields are preserved
-    expect(context.issueId).toBe("issue-1");
-    expect(context.taskId).toBe("issue-1");
   });
 
-  it("replaces goal fields when issue is reassigned to a different goal", () => {
-    // Context has goal fields from a previous run
+  it("replaces prior goal fields when a different goal is linked", () => {
     const context: Record<string, unknown> = {
-      issueId: "issue-1",
       goalId: "old-goal",
       goalTitle: "Old goal",
       goalDescription: "Old description",
@@ -188,77 +82,60 @@ describe("heartbeat goal context injection", () => {
       goalStatus: "planned",
     };
 
-    // Issue is now linked to a different goal
-    injectGoalContext(context, {
-      id: "new-goal",
-      title: "New goal",
-      description: "New description",
-      level: "task",
-      status: "active",
-    });
+    applyIssueGoalContext(
+      context,
+      createGoal({
+        id: "new-goal",
+        title: "New goal",
+        description: "New description",
+        level: "team",
+        status: "achieved",
+      }),
+    );
 
-    expect(context.goalId).toBe("new-goal");
-    expect(context.goalTitle).toBe("New goal");
-    expect(context.goalDescription).toBe("New description");
-    expect(context.goalLevel).toBe("task");
-    expect(context.goalStatus).toBe("active");
+    expect(context).toMatchObject({
+      goalId: "new-goal",
+      goalTitle: "New goal",
+      goalDescription: "New description",
+      goalLevel: "team",
+      goalStatus: "achieved",
+    });
   });
 
-  it("handles all goal statuses correctly", () => {
-    for (const status of ["planned", "active", "completed", "archived"]) {
+  it("supports every shipped goal level", () => {
+    for (const level of GOAL_LEVELS) {
       const context: Record<string, unknown> = {};
-      injectGoalContext(context, {
-        id: `goal-${status}`,
-        title: `Goal with ${status} status`,
-        description: null,
-        level: "task",
-        status,
-      });
+      applyIssueGoalContext(context, createGoal({ level: level as GoalLevel }));
+      expect(context.goalLevel).toBe(level);
+    }
+  });
+
+  it("supports every shipped goal status", () => {
+    for (const status of GOAL_STATUSES) {
+      const context: Record<string, unknown> = {};
+      applyIssueGoalContext(context, createGoal({ status: status as GoalStatus }));
       expect(context.goalStatus).toBe(status);
     }
   });
 });
 
-describe("inbox-lite goalTitle enrichment", () => {
-  /**
-   * Mirrors the inbox-lite mapping from agents.ts:
-   *
-   *   goalTitle: "goal" in issue && issue.goal != null
-   *     ? (issue.goal as { title: string }).title
-   *     : null,
-   */
-  function mapInboxLiteGoalTitle(issue: Record<string, unknown>): string | null {
-    return "goal" in issue && issue.goal != null
-      ? (issue.goal as { title: string }).title
-      : null;
-  }
-
-  it("returns goal title when issue has a linked goal", () => {
-    const issue = {
-      id: "issue-1",
-      goalId: "goal-1",
-      goal: { title: "Make the site functional", description: null, level: "task", status: "active" },
-    };
-
-    expect(mapInboxLiteGoalTitle(issue)).toBe("Make the site functional");
+describe("readIssueGoalTitle", () => {
+  it("returns the linked goal title when present", () => {
+    expect(
+      readIssueGoalTitle({
+        id: "issue-1",
+        goalId: "goal-1",
+        goal: { title: "Make the site functional" },
+      }),
+    ).toBe("Make the site functional");
   });
 
-  it("returns null when issue has no linked goal", () => {
-    const issue = {
-      id: "issue-1",
-      goalId: null,
-      goal: null,
-    };
-
-    expect(mapInboxLiteGoalTitle(issue)).toBeNull();
+  it("returns null when the issue has no goal object", () => {
+    expect(readIssueGoalTitle({ id: "issue-1", goalId: null, goal: null })).toBeNull();
+    expect(readIssueGoalTitle({ id: "issue-1", goalId: null })).toBeNull();
   });
 
-  it("returns null when goal field is missing from issue", () => {
-    const issue = {
-      id: "issue-1",
-      goalId: null,
-    };
-
-    expect(mapInboxLiteGoalTitle(issue)).toBeNull();
+  it("returns null when the goal title is not a string", () => {
+    expect(readIssueGoalTitle({ id: "issue-1", goal: { title: 123 } })).toBeNull();
   });
 });

--- a/server/src/lib/goal-context.ts
+++ b/server/src/lib/goal-context.ts
@@ -1,0 +1,35 @@
+export interface IssueGoalContext {
+  id: string;
+  title: string;
+  description: string | null;
+  level: string;
+  status: string;
+}
+
+export function applyIssueGoalContext(
+  context: Record<string, unknown>,
+  issueGoal: IssueGoalContext | null,
+): void {
+  if (issueGoal) {
+    context.goalId = issueGoal.id;
+    context.goalTitle = issueGoal.title;
+    context.goalDescription = issueGoal.description ?? null;
+    context.goalLevel = issueGoal.level;
+    context.goalStatus = issueGoal.status;
+    return;
+  }
+
+  delete context.goalId;
+  delete context.goalTitle;
+  delete context.goalDescription;
+  delete context.goalLevel;
+  delete context.goalStatus;
+}
+
+export function readIssueGoalTitle(issue: Record<string, unknown>): string | null {
+  if (!("goal" in issue)) return null;
+  const goal = issue.goal;
+  if (!goal || typeof goal !== "object") return null;
+  const title = (goal as { title?: unknown }).title;
+  return typeof title === "string" ? title : null;
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1095,6 +1095,9 @@ export function agentRoutes(db: Db) {
         priority: issue.priority,
         projectId: issue.projectId,
         goalId: issue.goalId,
+        goalTitle: "goal" in issue && issue.goal != null
+          ? (issue.goal as { title: string }).title
+          : null,
         parentId: issue.parentId,
         updatedAt: issue.updatedAt,
         activeRun: issue.activeRun,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -57,6 +57,7 @@ import { redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
+import { readIssueGoalTitle } from "../lib/goal-context.js";
 import { runClaudeLogin } from "@paperclipai/adapter-claude-local/server";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
@@ -1095,9 +1096,7 @@ export function agentRoutes(db: Db) {
         priority: issue.priority,
         projectId: issue.projectId,
         goalId: issue.goalId,
-        goalTitle: "goal" in issue && issue.goal != null
-          ? (issue.goal as { title: string }).title
-          : null,
+        goalTitle: readIssueGoalTitle(issue as Record<string, unknown>),
         parentId: issue.parentId,
         updatedAt: issue.updatedAt,
         activeRun: issue.activeRun,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2705,13 +2705,21 @@ export function heartbeatService(db: Db) {
     }
 
     // Inject goal context so adapters (and prompt templates) can reference
-    // the strategic goal this issue is aligned to.
+    // the strategic goal this issue is aligned to.  When no goal is linked,
+    // explicitly clear any stale fields that may have been persisted in a
+    // previous run's contextSnapshot.
     if (issueGoal) {
       context.goalId = issueGoal.id;
       context.goalTitle = issueGoal.title;
       context.goalDescription = issueGoal.description ?? null;
       context.goalLevel = issueGoal.level;
       context.goalStatus = issueGoal.status;
+    } else {
+      delete context.goalId;
+      delete context.goalTitle;
+      delete context.goalDescription;
+      delete context.goalLevel;
+      delete context.goalStatus;
     }
     const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
     let previousSessionDisplayId = truncateDisplayId(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10,6 +10,7 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  goals,
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
@@ -2315,6 +2316,7 @@ export function heartbeatService(db: Db) {
             title: issues.title,
             status: issues.status,
             priority: issues.priority,
+            goalId: issues.goalId,
             projectId: issues.projectId,
             projectWorkspaceId: issues.projectWorkspaceId,
             executionWorkspaceId: issues.executionWorkspaceId,
@@ -2384,12 +2386,13 @@ export function heartbeatService(db: Db) {
       { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
     );
     const issueRef = issueContext
-      ? {
+        ? {
           id: issueContext.id,
           identifier: issueContext.identifier,
           title: issueContext.title,
           status: issueContext.status,
           priority: issueContext.priority,
+          goalId: issueContext.goalId,
           projectId: issueContext.projectId,
           projectWorkspaceId: issueContext.projectWorkspaceId,
           executionWorkspaceId: issueContext.executionWorkspaceId,
@@ -2455,6 +2458,19 @@ export function heartbeatService(db: Db) {
       projectEnv: projectContext?.env ?? null,
       secretsSvc,
     });
+    const issueGoal = issueRef?.goalId
+      ? await db
+          .select({
+            id: goals.id,
+            title: goals.title,
+            description: goals.description,
+            level: goals.level,
+            status: goals.status,
+          })
+          .from(goals)
+          .where(and(eq(goals.id, issueRef.goalId), eq(goals.companyId, agent.companyId)))
+          .then((rows) => rows[0] ?? null)
+      : null;
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
     const runtimeConfig = {
       ...resolvedConfig,
@@ -2686,6 +2702,16 @@ export function heartbeatService(db: Db) {
     }
     if (executionWorkspace.projectId && !readNonEmptyString(context.projectId)) {
       context.projectId = executionWorkspace.projectId;
+    }
+
+    // Inject goal context so adapters (and prompt templates) can reference
+    // the strategic goal this issue is aligned to.
+    if (issueGoal) {
+      context.goalId = issueGoal.id;
+      context.goalTitle = issueGoal.title;
+      context.goalDescription = issueGoal.description ?? null;
+      context.goalLevel = issueGoal.level;
+      context.goalStatus = issueGoal.status;
     }
     const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
     let previousSessionDisplayId = truncateDisplayId(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -29,6 +29,7 @@ import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } fr
 import { costService } from "./costs.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
+import { applyIssueGoalContext } from "../lib/goal-context.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
@@ -2704,23 +2705,9 @@ export function heartbeatService(db: Db) {
       context.projectId = executionWorkspace.projectId;
     }
 
-    // Inject goal context so adapters (and prompt templates) can reference
-    // the strategic goal this issue is aligned to.  When no goal is linked,
-    // explicitly clear any stale fields that may have been persisted in a
-    // previous run's contextSnapshot.
-    if (issueGoal) {
-      context.goalId = issueGoal.id;
-      context.goalTitle = issueGoal.title;
-      context.goalDescription = issueGoal.description ?? null;
-      context.goalLevel = issueGoal.level;
-      context.goalStatus = issueGoal.status;
-    } else {
-      delete context.goalId;
-      delete context.goalTitle;
-      delete context.goalDescription;
-      delete context.goalLevel;
-      delete context.goalStatus;
-    }
+    // Preserve current goal context for adapters and clear stale values when
+    // an issue no longer points at a goal.
+    applyIssueGoalContext(context, issueGoal);
     const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
     let previousSessionDisplayId = truncateDisplayId(
       explicitResumeSessionDisplayId ??

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -5,6 +5,7 @@ import type { Issue } from "@paperclipai/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { agentsApi } from "../api/agents";
 import { authApi } from "../api/auth";
+import { goalsApi } from "../api/goals";
 import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
@@ -19,7 +20,7 @@ import { formatDate, cn, projectUrl } from "../lib/utils";
 import { timeAgo } from "../lib/timeAgo";
 import { Separator } from "@/components/ui/separator";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { User, Hexagon, ArrowUpRight, Tag, Plus, Trash2, GitBranch, FolderOpen, Copy, Check } from "lucide-react";
+import { User, Hexagon, ArrowUpRight, Tag, Plus, Trash2, GitBranch, FolderOpen, Copy, Check, Target } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
 
 function TruncatedCopyable({ value, icon: Icon }: { value: string; icon: React.ComponentType<{ className?: string }> }) {
@@ -164,6 +165,8 @@ export function IssueProperties({
   const [assigneeSearch, setAssigneeSearch] = useState("");
   const [projectOpen, setProjectOpen] = useState(false);
   const [projectSearch, setProjectSearch] = useState("");
+  const [goalOpen, setGoalOpen] = useState(false);
+  const [goalSearch, setGoalSearch] = useState("");
   const [blockedByOpen, setBlockedByOpen] = useState(false);
   const [blockedBySearch, setBlockedBySearch] = useState("");
   const [labelsOpen, setLabelsOpen] = useState(false);
@@ -197,6 +200,18 @@ export function IssueProperties({
     companyId,
     userId: currentUserId,
   });
+  const { data: goalsList } = useQuery({
+    queryKey: queryKeys.goals.list(companyId!),
+    queryFn: () => goalsApi.list(companyId!),
+    enabled: !!companyId,
+  });
+  const availableGoals = useMemo(
+    () =>
+      (goalsList ?? []).filter(
+        (goal) => goal.id === issue.goalId || goal.status === "planned" || goal.status === "active",
+      ),
+    [goalsList, issue.goalId],
+  );
 
   const { data: labels } = useQuery({
     queryKey: queryKeys.issues.labels(companyId!),
@@ -535,6 +550,72 @@ export function IssueProperties({
     </>
   );
 
+  const goalName = (id: string | null) => {
+    if (!id) return "No goal";
+    const goal = availableGoals.find((candidate) => candidate.id === id);
+    return goal?.title ?? id.slice(0, 8);
+  };
+
+  const goalTrigger = issue.goalId ? (
+    <>
+      <Target className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+      <span className="text-sm truncate">{goalName(issue.goalId)}</span>
+    </>
+  ) : (
+    <>
+      <Target className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="text-sm text-muted-foreground">No goal</span>
+    </>
+  );
+
+  const goalContent = (
+    <>
+      <input
+        className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
+        placeholder="Search goals..."
+        value={goalSearch}
+        onChange={(e) => setGoalSearch(e.target.value)}
+        autoFocus={!inline}
+      />
+      <div className="max-h-48 overflow-y-auto overscroll-contain">
+        <button
+          className={cn(
+            "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 whitespace-nowrap",
+            !issue.goalId && "bg-accent",
+          )}
+          onClick={() => {
+            onUpdate({ goalId: null });
+            setGoalOpen(false);
+          }}
+        >
+          No goal
+        </button>
+        {availableGoals
+          .filter((goal) => {
+            if (!goalSearch.trim()) return true;
+            return goal.title.toLowerCase().includes(goalSearch.toLowerCase());
+          })
+          .map((goal) => (
+            <button
+              key={goal.id}
+              className={cn(
+                "flex items-center gap-2 w-full px-2 py-1.5 text-left text-xs rounded hover:bg-accent/50",
+                goal.id === issue.goalId && "bg-accent",
+              )}
+              onClick={() => {
+                onUpdate({ goalId: goal.id });
+                setGoalOpen(false);
+              }}
+            >
+              <Target className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <span className="truncate">{goal.title}</span>
+              <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{goal.level}</span>
+            </button>
+          ))}
+      </div>
+    </>
+  );
+
   const blockedByIds = issue.blockedBy?.map((relation) => relation.id) ?? [];
   const blockedByTrigger = blockedByIds.length > 0 ? (
     <div className="flex items-center gap-1 flex-wrap min-w-0">
@@ -687,6 +768,21 @@ export function IssueProperties({
           ) : undefined}
         >
           {projectContent}
+        </PropertyPicker>
+
+        <PropertyPicker
+          inline={inline}
+          label="Goal"
+          open={goalOpen}
+          onOpenChange={(open) => {
+            setGoalOpen(open);
+            if (!open) setGoalSearch("");
+          }}
+          triggerContent={goalTrigger}
+          triggerClassName="min-w-0 max-w-full"
+          popoverClassName="w-72"
+        >
+          {goalContent}
         </PropertyPicker>
 
         <PropertyPicker


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so agent execution context has to carry enough company-scoped context for agents to act safely and coherently.
> - Heartbeat execution is the core server path that turns an assigned issue into adapter runtime context.
> - Goal alignment is already first-class in Paperclip's data model, but the runtime prompt path and the issue detail UI were still missing parts of that goal context.
> - This PR exists to carry an issue's goal through the heartbeat path, surface it in agent triage, and let operators inspect or update the goal directly from issue properties.
> - Rebasing onto current `master` was necessary because the original branch had drifted far enough that the execution-workspace and route layers had materially changed around the same code.
> - The benefit is that agents can see why a task matters, operators can manage goal linkage in-place, and the branch now reflects current `master` behavior instead of an old merge snapshot.

## What Changed

- Rebasing the PR branch onto current `public-gh/master` and resolving the `heartbeat.ts`/`IssueProperties.tsx` conflicts against the newer execution-workspace and issue-sidebar code.
- Injected issue goal context into heartbeat runtime context with explicit stale-field cleanup and a company-scoped goal lookup.
- Added `goalTitle` to `GET /api/agents/me/inbox-lite` so agents can see goal context during triage.
- Added a Goal picker to the issue properties panel and filtered the selectable list down to actionable goals while still preserving the currently-linked goal.
- Replaced the duplicated goal-context test logic with shared server helpers so the tests now exercise the real production behavior.

## Verification

- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run server/src/__tests__/heartbeat-goal-context.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm test:run`
  - reruns on current `master`-level test suite still hit unrelated failures outside this PR's touched files (examples observed across reruns: `server/src/__tests__/agent-permissions-routes.test.ts`, `server/src/__tests__/issues-goal-context-routes.test.ts`, `server/src/__tests__/routines-routes.test.ts`, `ui/src/components/NewIssueDialog.test.tsx`)

## Risks

- Low risk in the touched runtime path: the heartbeat goal injection is additive and now explicitly clears stale context.
- Medium review risk around the UI picker because it adds an operator-visible issue-property control and I was not able to attach screenshots from this headless environment.
- Repo-level test instability on current `master` is still the remaining blocker to calling the branch fully mergeable.

## Model Used

- OpenAI GPT-5 Codex (`gpt-5.4`) via the Paperclip `codex_local` agent runtime, with tool use, shell execution, git operations, and code editing in a local worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
