### PR TITLE
fix(ui): make new goal dialog scrollable when content overflows

### DIFF
--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -120,7 +120,7 @@ export function NewGoalDialog() {
         onKeyDown={handleKeyDown}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border shrink-0">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             {selectedCompany && (
               <span className="bg-muted px-1.5 py-0.5 rounded text-xs font-medium">


### PR DESCRIPTION
## Summary
- Adds `max-h-[85vh]` and `flex flex-col` to the goal dialog so it never exceeds the viewport
- Makes the description area scrollable (`overflow-y-auto min-h-0`) while keeping header, property chips, and the "Create goal" button pinned
- Adds `shrink-0` to the property chips and footer sections so they always remain visible

## Problem
When pasting a large goal description, the dialog grows beyond the viewport height and the "Create goal" button disappears off-screen, making it impossible to submit.

## Test plan
- [ ] Open the "New Goal" dialog
- [ ] Paste a large block of text into the description field
- [ ] Verify the description area scrolls and the "Create goal" button remains visible
- [ ] Test in both normal and expanded dialog modes
- [ ] Verify short descriptions still render without unnecessary scrollbars

## QA: 
### Before fix: 

<img width="1445" height="1026" alt="Screenshot 2026-03-16 at 23 38 26" src="https://github.com/user-attachments/assets/f68a872a-f87a-411a-949c-2ca94e7b38c2" />

### After fix:
<img width="878" height="913" alt="Screenshot 2026-03-16 at 23 37 40" src="https://github.com/user-attachments/assets/91d2ccbd-cda0-40b4-9a75-9f2e3a77342e" />
