### PR TITLE
docs(skill): add multi-company key resolution and comment attribution

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -16,6 +16,15 @@ You run in **heartbeats** — short execution windows triggered by Paperclip. Ea
 
 Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
 
+### Multi-Company Key Resolution
+
+The workspace key file (`paperclip-claimed-api-key.json`) may contain keys for multiple companies. When a wake event provides `PAPERCLIP_COMPANY_ID`, look up the matching key from the `keys` object using the company ID. Fall back to `default` only when no company-specific key exists. **Do not always use the default key — it may be scoped to a different company.**
+
+```
+# Read the file, then select: keys[PAPERCLIP_COMPANY_ID].token
+# If no match found, fall back to default.token
+```
+
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
 **Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
@@ -123,6 +132,22 @@ Access control:
 3. Post the prompt in the issue comment so the human can paste it into OpenClaw.
 
 4. After OpenClaw submits the join request, monitor approvals and continue onboarding (approval + API key claim + skill install).
+
+## Comment Attribution (Direct API Calls)
+
+When posting comments or creating issues **outside** a Paperclip heartbeat run (e.g., from a main session via `curl`), include `"authorAgentId"` in the request body. Without it, the comment defaults to the `local-board` user and appears as if the board/human posted it.
+
+```json
+POST /api/issues/{issueId}/comments
+{
+  "body": "Your comment here",
+  "authorAgentId": "{your-agent-id}"
+}
+```
+
+Similarly, when creating issues outside a run, use `"createdByAgentId"` to attribute correctly.
+
+This only matters for direct API calls. During heartbeat runs, Paperclip attributes actions to the running agent automatically.
 
 ## Critical Rules
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -18,12 +18,15 @@ Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP
 
 ### Multi-Company Key Resolution
 
-The workspace key file (`paperclip-claimed-api-key.json`) may contain keys for multiple companies. When a wake event provides `PAPERCLIP_COMPANY_ID`, look up the matching key from the `keys` object using the company ID. Fall back to `default` only when no company-specific key exists. **Do not always use the default key — it may be scoped to a different company.**
+The default Paperclip key file (`paperclip-claimed-api-key.json`) has a flat structure scoped to a single company:
 
+```json
+{ "token": "<api-token>", "apiKey": "<api-key>" }
 ```
-# Read the file, then select: keys[PAPERCLIP_COMPANY_ID].token
-# If no match found, fall back to default.token
-```
+
+This works fine for single-company setups. **Paperclip's adapter does not natively support multi-company key resolution.** If you operate multiple companies on a shared agent workspace, this is a known gap: the adapter will always use whichever key the file contains, regardless of `PAPERCLIP_COMPANY_ID`.
+
+**Workaround (operator-managed):** Operators managing multiple companies can extend the key file themselves using a company-keyed structure (e.g., `{ "<companyId>": { "token": "...", "apiKey": "..." }, ... }`), then add key-selection logic in their agent's startup or wrapper script to set the correct `PAPERCLIP_API_KEY` before the heartbeat runs. This is a custom convention — there is no built-in support for it in the adapter. Native multi-company key resolution is a planned improvement.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
@@ -133,21 +136,11 @@ Access control:
 
 4. After OpenClaw submits the join request, monitor approvals and continue onboarding (approval + API key claim + skill install).
 
-## Comment Attribution (Direct API Calls)
+## Comment Attribution
 
-When posting comments or creating issues **outside** a Paperclip heartbeat run (e.g., from a main session via `curl`), include `"authorAgentId"` in the request body. Without it, the comment defaults to the `local-board` user and appears as if the board/human posted it.
+Comment attribution is determined entirely by the **authenticated API key** in the `Authorization: Bearer` header. Paperclip derives the acting agent from the bearer token via `getActorInfo` — there is no field in the comment body that overrides this.
 
-```json
-POST /api/issues/{issueId}/comments
-{
-  "body": "Your comment here",
-  "authorAgentId": "{your-agent-id}"
-}
-```
-
-Similarly, when creating issues outside a run, use `"createdByAgentId"` to attribute correctly.
-
-This only matters for direct API calls. During heartbeat runs, Paperclip attributes actions to the running agent automatically.
+If comments are appearing under the wrong agent or under the board user, the root cause is that the wrong company's API key was used for the request. Ensure the key in use is scoped to the correct company and agent. See [Multi-Company Key Resolution](#multi-company-key-resolution) above.
 
 ## Critical Rules
 


### PR DESCRIPTION
## What

Two additions to the Paperclip agent skill (`skills/paperclip/SKILL.md`):

### 1. Multi-Company Key Resolution
Documents how agents operating across multiple companies on a single instance should resolve API keys from the workspace key file using `PAPERCLIP_COMPANY_ID` rather than always using the default key.

### 2. Comment Attribution for Direct API Calls
Documents that `authorAgentId` must be included when posting comments outside a heartbeat run. Without it, comments default to `local-board` and appear as board/human posts in the UI.

## Why

Both issues discovered in production running a 5-company single-instance setup with the `openclaw_gateway` adapter. The multi-company key issue caused agents to use the wrong company's API key. The attribution issue caused agent comments to show up as human-authored.

## Changes

- `skills/paperclip/SKILL.md`: +25 lines (two new documentation sections)
- No code changes, no breaking changes

## Related

- #1083 (Multi-Company Agent Identity feature request)
- #1084 (Instance Federation Protocol feature request)