### PR TITLE
fix(ui): always navigate on company switch in CompanyRail

### DIFF
--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -293,9 +293,7 @@ export function CompanyRail() {
                 hasUnreadInbox={hasUnreadInboxByCompanyId.get(company.id) ?? false}
                 onSelect={() => {
                   setSelectedCompanyId(company.id);
-                  if (isInstanceRoute) {
-                    navigate(`/${company.issuePrefix}/dashboard`);
-                  }
+                  navigate(`/${company.issuePrefix}/dashboard`);
                 }}
               />
             ))}


### PR DESCRIPTION
## Problem

Clicking a company icon in the CompanyRail sidebar does nothing on normal pages (e.g. `/VIZ/dashboard`). Repeated clicks cause the URL to accumulate prefixes like `/VIZ/BUB/VIZ/BUB/VIZ/BUB/.../instance/settings`.

## Root Cause

The `onSelect` handler only called `navigate()` when `isInstanceRoute` was true:

```tsx
onSelect={() => {
  setSelectedCompanyId(company.id);
  if (isInstanceRoute) {          // ← navigation skipped on normal pages
    navigate(`/${company.issuePrefix}/dashboard`);
  }
}}
```

On normal company routes, clicking a company icon:
1. Calls `setSelectedCompanyId(newCompanyId)` — updates state/localStorage
2. Does **not** navigate — URL stays at e.g. `/VIZ/dashboard`
3. `AppLayout`'s `useEffect` sees URL prefix still matches old company, route_syncs `selectedCompanyId` back to the original company

The URL accumulation happened because intermediate React state caused `Layout.tsx`'s navigation logic to prepend the current prefix to a path that already contained a prefix segment.

## Fix

Remove the `isInstanceRoute` guard — always navigate when switching companies:

```tsx
onSelect={() => {
  setSelectedCompanyId(company.id);
  navigate(`/${company.issuePrefix}/dashboard`);
}}
```

The `isInstanceRoute` variable is preserved — it's still used by `highlightedCompanyId` to correctly deselect company icons when on instance settings routes.

## Testing

- Switch between companies from any normal page → navigates correctly
- Switch between companies from `/instance/settings` → navigates correctly  
- URL never accumulates repeated prefixes