### PR TITLE
feat: virtual office view with real-time agent visualization

### DIFF
--- a/packages/db/src/migrations/0026_office_config.sql
+++ b/packages/db/src/migrations/0026_office_config.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "companies" ADD COLUMN "office_config" jsonb;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1772807461603,
       "tag": "0025_nasty_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1773849600000,
+      "tag": "0026_office_config",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, integer, timestamp, boolean, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, integer, timestamp, boolean, jsonb, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const companies = pgTable(
   "companies",
@@ -15,6 +15,7 @@ export const companies = pgTable(
       .notNull()
       .default(true),
     brandColor: text("brand_color"),
+    officeConfig: jsonb("office_config").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -122,7 +122,13 @@ export type {
   AgentEnvConfig,
   CompanySecret,
   SecretProviderDescriptor,
+  OfficeArea,
+  OfficeMovementRule,
+  OfficeConfig,
+  OfficeAgentPosition,
 } from "./types/index.js";
+
+export { DEFAULT_OFFICE_CONFIG } from "./types/index.js";
 
 export {
   createCompanySchema,

--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -1,4 +1,5 @@
 import type { CompanyStatus } from "../constants.js";
+import type { OfficeConfig } from "./office.js";
 
 export interface Company {
   id: string;
@@ -11,6 +12,7 @@ export interface Company {
   spentMonthlyCents: number;
   requireBoardApprovalForNewAgents: boolean;
   brandColor: string | null;
+  officeConfig: OfficeConfig | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -22,6 +22,13 @@ export type {
   IssueLabel,
 } from "./issue.js";
 export type { Goal } from "./goal.js";
+export type {
+  OfficeArea,
+  OfficeMovementRule,
+  OfficeConfig,
+  OfficeAgentPosition,
+} from "./office.js";
+export { DEFAULT_OFFICE_CONFIG } from "./office.js";
 export type { Approval, ApprovalComment } from "./approval.js";
 export type {
   SecretProvider,

--- a/packages/shared/src/types/office.ts
+++ b/packages/shared/src/types/office.ts
@@ -1,0 +1,149 @@
+export interface OfficeArea {
+  id: string;
+  name: string;
+  icon: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+  description?: string;
+}
+
+export interface OfficeMovementRule {
+  id: string;
+  priority: number;
+  condition: {
+    status?: string[];
+    role?: string[];
+    adapterType?: string[];
+  };
+  targetAreaId: string;
+}
+
+export interface OfficeConfig {
+  areas: OfficeArea[];
+  movementRules: OfficeMovementRule[];
+  defaultAreaId: string;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+export interface OfficeAgentPosition {
+  agentId: string;
+  areaId: string;
+  x: number;
+  y: number;
+}
+
+export const DEFAULT_OFFICE_CONFIG: OfficeConfig = {
+  canvasWidth: 1200,
+  canvasHeight: 800,
+  defaultAreaId: "break-room",
+  areas: [
+    {
+      id: "executive-suite",
+      name: "Executive Suite",
+      icon: "Crown",
+      x: 420,
+      y: 20,
+      width: 360,
+      height: 200,
+      color: "#6366f1",
+      description: "C-suite and leadership",
+    },
+    {
+      id: "engineering-lab",
+      name: "Engineering Lab",
+      icon: "Code",
+      x: 20,
+      y: 20,
+      width: 380,
+      height: 340,
+      color: "#06b6d4",
+      description: "Where engineers build",
+    },
+    {
+      id: "meeting-room",
+      name: "Meeting Room",
+      icon: "Users",
+      x: 420,
+      y: 240,
+      width: 360,
+      height: 200,
+      color: "#22c55e",
+      description: "Collaboration and reviews",
+    },
+    {
+      id: "server-room",
+      name: "Server Room",
+      icon: "Server",
+      x: 800,
+      y: 20,
+      width: 380,
+      height: 340,
+      color: "#64748b",
+      description: "DevOps and infrastructure",
+    },
+    {
+      id: "break-room",
+      name: "Break Room",
+      icon: "Coffee",
+      x: 20,
+      y: 400,
+      width: 560,
+      height: 200,
+      color: "#f59e0b",
+      description: "Idle and paused agents",
+    },
+    {
+      id: "error-bay",
+      name: "Error Bay",
+      icon: "AlertTriangle",
+      x: 800,
+      y: 400,
+      width: 380,
+      height: 200,
+      color: "#ef4444",
+      description: "Agents needing attention",
+    },
+  ],
+  movementRules: [
+    {
+      id: "error-agents",
+      priority: 100,
+      condition: { status: ["error"] },
+      targetAreaId: "error-bay",
+    },
+    {
+      id: "executives",
+      priority: 90,
+      condition: { role: ["ceo", "cto", "cfo", "cmo"] },
+      targetAreaId: "executive-suite",
+    },
+    {
+      id: "devops-running",
+      priority: 80,
+      condition: { status: ["running", "active"], role: ["devops"] },
+      targetAreaId: "server-room",
+    },
+    {
+      id: "engineers-running",
+      priority: 70,
+      condition: { status: ["running", "active"], role: ["engineer", "designer", "qa"] },
+      targetAreaId: "engineering-lab",
+    },
+    {
+      id: "reviewing",
+      priority: 60,
+      condition: { status: ["pending_approval"] },
+      targetAreaId: "meeting-room",
+    },
+    {
+      id: "idle-paused",
+      priority: 10,
+      condition: { status: ["idle", "paused", "terminated"] },
+      targetAreaId: "break-room",
+    },
+  ],
+};

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
+import { z } from "zod";
 import {
   companyPortabilityExportSchema,
   companyPortabilityImportSchema,
@@ -9,6 +10,33 @@ import {
   DEFAULT_OFFICE_CONFIG,
 } from "@paperclipai/shared";
 import type { OfficeConfig } from "@paperclipai/shared";
+
+const officeConfigSchema = z.object({
+  areas: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    icon: z.string(),
+    x: z.number(),
+    y: z.number(),
+    width: z.number().positive(),
+    height: z.number().positive(),
+    color: z.string(),
+    description: z.string().optional(),
+  })),
+  movementRules: z.array(z.object({
+    id: z.string(),
+    priority: z.number(),
+    condition: z.object({
+      status: z.array(z.string()).optional(),
+      role: z.array(z.string()).optional(),
+      adapterType: z.array(z.string()).optional(),
+    }),
+    targetAreaId: z.string(),
+  })),
+  defaultAreaId: z.string(),
+  canvasWidth: z.number().positive(),
+  canvasHeight: z.number().positive(),
+});
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import { accessService, companyPortabilityService, companyService, logActivity } from "../services/index.js";
@@ -199,8 +227,13 @@ export function companyRoutes(db: Db) {
     assertBoard(req);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    const parsed = officeConfigSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(422).json({ error: "Invalid office config", details: parsed.error.format() });
+      return;
+    }
     const company = await svc.update(companyId, {
-      officeConfig: req.body as Record<string, unknown>,
+      officeConfig: parsed.data as unknown as Record<string, unknown>,
     });
     if (!company) {
       res.status(404).json({ error: "Company not found" });

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -6,7 +6,9 @@ import {
   companyPortabilityPreviewSchema,
   createCompanySchema,
   updateCompanySchema,
+  DEFAULT_OFFICE_CONFIG,
 } from "@paperclipai/shared";
+import type { OfficeConfig } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
 import { accessService, companyPortabilityService, companyService, logActivity } from "../services/index.js";
@@ -176,6 +178,35 @@ export function companyRoutes(db: Db) {
       return;
     }
     res.json({ ok: true });
+  });
+
+  // ── Office Config endpoints ──────────────────────────────────────────────
+
+  router.get("/:companyId/office-config", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const company = await svc.getById(companyId);
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    const config = (company.officeConfig as OfficeConfig | null) ?? DEFAULT_OFFICE_CONFIG;
+    res.json(config);
+  });
+
+  router.patch("/:companyId/office-config", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const company = await svc.update(companyId, {
+      officeConfig: req.body as Record<string, unknown>,
+    });
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    res.json(company.officeConfig ?? DEFAULT_OFFICE_CONFIG);
   });
 
   return router;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,6 +24,7 @@ import { Inbox } from "./pages/Inbox";
 import { CompanySettings } from "./pages/CompanySettings";
 import { DesignGuide } from "./pages/DesignGuide";
 import { OrgChart } from "./pages/OrgChart";
+import { Office } from "./pages/Office";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
@@ -107,6 +108,7 @@ function boardRoutes() {
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
       <Route path="org" element={<OrgChart />} />
+      <Route path="office" element={<Office />} />
       <Route path="agents" element={<Navigate to="/agents/all" replace />} />
       <Route path="agents/all" element={<Agents />} />
       <Route path="agents/active" element={<Agents />} />

--- a/ui/src/api/office.ts
+++ b/ui/src/api/office.ts
@@ -1,0 +1,9 @@
+import type { OfficeConfig } from "@paperclipai/shared";
+import { api } from "./client";
+
+export const officeApi = {
+  getConfig: (companyId: string) =>
+    api.get<OfficeConfig>(`/companies/${companyId}/office-config`),
+  updateConfig: (companyId: string, config: OfficeConfig) =>
+    api.patch<OfficeConfig>(`/companies/${companyId}/office-config`, config),
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   SquarePen,
   Network,
+  Building2,
   Settings,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -97,6 +98,7 @@ export function Sidebar() {
 
         <SidebarSection label="Company">
           <SidebarNavItem to="/org" label="Org" icon={Network} />
+          <SidebarNavItem to="/office" label="Office" icon={Building2} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />
           <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />

--- a/ui/src/components/office/OfficeAgent.tsx
+++ b/ui/src/components/office/OfficeAgent.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import type { Agent } from "@paperclipai/shared";
+import { AgentIcon } from "../AgentIconPicker";
+
+const statusRingColor: Record<string, string> = {
+  running: "#22d3ee",
+  active: "#4ade80",
+  paused: "#facc15",
+  idle: "#a3a3a3",
+  error: "#f87171",
+  pending_approval: "#a78bfa",
+  terminated: "#6b7280",
+};
+
+const statusLabel: Record<string, string> = {
+  running: "Running",
+  active: "Active",
+  paused: "Paused",
+  idle: "Idle",
+  error: "Error",
+  pending_approval: "Pending",
+  terminated: "Off",
+};
+
+interface OfficeAgentProps {
+  agent: Agent;
+  x: number;
+  y: number;
+  onSelect: (agent: Agent) => void;
+  onRightClick?: (agent: Agent, pos: { x: number; y: number }) => void;
+  selected?: boolean;
+}
+
+export function OfficeAgentAvatar({ agent, x, y, onSelect, onRightClick, selected }: OfficeAgentProps) {
+  const ringColor = statusRingColor[agent.status] ?? "#a3a3a3";
+  const isRunning = agent.status === "running" || agent.status === "active";
+  const isError = agent.status === "error";
+
+  return (
+    <div
+      data-office-agent
+      className="absolute transition-all duration-[1500ms] ease-in-out"
+      style={{ transform: `translate(${x}px, ${y}px)` }}
+    >
+      <button
+        className={`flex flex-col items-center gap-0.5 cursor-pointer group ${selected ? "scale-110" : ""}`}
+        onClick={(e) => { e.stopPropagation(); onSelect(agent); }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onRightClick?.(agent, { x: e.clientX, y: e.clientY });
+        }}
+      >
+        {/* Avatar */}
+        <div className="relative">
+          <div
+            className={`
+              w-11 h-11 rounded-full bg-card border-[2.5px] flex items-center justify-center
+              shadow-md group-hover:shadow-lg transition-shadow duration-200
+              ${isRunning ? "animate-pulse" : ""}
+              ${isError ? "animate-[shake_0.5s_ease-in-out_infinite]" : ""}
+              ${selected ? "ring-2 ring-primary ring-offset-1 ring-offset-background" : ""}
+            `}
+            style={{ borderColor: ringColor }}
+          >
+            <AgentIcon icon={agent.icon} className="h-5 w-5 text-foreground/80" />
+          </div>
+          {/* Status dot */}
+          <span
+            className="absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-card"
+            style={{ backgroundColor: ringColor }}
+          />
+          {/* Running glow */}
+          {isRunning && (
+            <span
+              className="absolute inset-0 rounded-full animate-ping opacity-20"
+              style={{ backgroundColor: ringColor }}
+            />
+          )}
+        </div>
+        {/* Name + status */}
+        <span className="text-[10px] font-semibold text-foreground max-w-[72px] truncate leading-tight text-center drop-shadow-sm">
+          {agent.name.split(" ")[0]}
+        </span>
+        <span className="text-[8px] text-muted-foreground font-medium" style={{ color: ringColor }}>
+          {statusLabel[agent.status] ?? agent.status}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/ui/src/components/office/OfficeArea.tsx
+++ b/ui/src/components/office/OfficeArea.tsx
@@ -1,0 +1,57 @@
+import {
+  Code,
+  Coffee,
+  Crown,
+  Server,
+  Users,
+  AlertTriangle,
+  type LucideIcon,
+} from "lucide-react";
+
+const iconMap: Record<string, LucideIcon> = {
+  Code,
+  Coffee,
+  Crown,
+  Server,
+  Users,
+  AlertTriangle,
+};
+
+interface OfficeAreaProps {
+  id: string;
+  name: string;
+  icon: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+}
+
+export function OfficeAreaRect({ name, icon, x, y, width, height, color }: OfficeAreaProps) {
+  const Icon = iconMap[icon] ?? Code;
+
+  return (
+    <div
+      className="absolute rounded-xl border-2 select-none pointer-events-none"
+      style={{
+        left: x,
+        top: y,
+        width,
+        height,
+        borderColor: `${color}40`,
+        background: `linear-gradient(135deg, ${color}08 0%, ${color}15 100%)`,
+      }}
+    >
+      <div
+        className="flex items-center gap-2 px-3 py-2"
+        style={{ color }}
+      >
+        <Icon className="h-4 w-4" />
+        <span className="text-xs font-semibold uppercase tracking-wider opacity-80">
+          {name}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/office/OfficeConfigPanel.tsx
+++ b/ui/src/components/office/OfficeConfigPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { OfficeConfig, OfficeArea, OfficeMovementRule } from "@paperclipai/shared";
 import { DEFAULT_OFFICE_CONFIG, AGENT_STATUSES, AGENT_ROLES } from "@paperclipai/shared";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -15,6 +15,11 @@ interface OfficeConfigPanelProps {
 
 export function OfficeConfigPanel({ open, onOpenChange, config, onSave }: OfficeConfigPanelProps) {
   const [draft, setDraft] = useState<OfficeConfig>(config);
+
+  // Reset draft when panel opens (so cancelled edits don't persist)
+  useEffect(() => {
+    if (open) setDraft(config);
+  }, [open, config]);
 
   const updateArea = (id: string, patch: Partial<OfficeArea>) => {
     setDraft((prev) => ({

--- a/ui/src/components/office/OfficeConfigPanel.tsx
+++ b/ui/src/components/office/OfficeConfigPanel.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import type { OfficeConfig, OfficeArea, OfficeMovementRule } from "@paperclipai/shared";
+import { DEFAULT_OFFICE_CONFIG, AGENT_STATUSES, AGENT_ROLES } from "@paperclipai/shared";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Trash2, Plus, RotateCcw } from "lucide-react";
+
+interface OfficeConfigPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  config: OfficeConfig;
+  onSave: (config: OfficeConfig) => void;
+}
+
+export function OfficeConfigPanel({ open, onOpenChange, config, onSave }: OfficeConfigPanelProps) {
+  const [draft, setDraft] = useState<OfficeConfig>(config);
+
+  const updateArea = (id: string, patch: Partial<OfficeArea>) => {
+    setDraft((prev) => ({
+      ...prev,
+      areas: prev.areas.map((a) => (a.id === id ? { ...a, ...patch } : a)),
+    }));
+  };
+
+  const removeArea = (id: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      areas: prev.areas.filter((a) => a.id !== id),
+    }));
+  };
+
+  const addArea = () => {
+    const id = `area-${Date.now()}`;
+    setDraft((prev) => ({
+      ...prev,
+      areas: [
+        ...prev.areas,
+        {
+          id,
+          name: "New Area",
+          icon: "Code",
+          x: 20,
+          y: 20,
+          width: 300,
+          height: 200,
+          color: "#6366f1",
+        },
+      ],
+    }));
+  };
+
+  const updateRule = (id: string, patch: Partial<OfficeMovementRule>) => {
+    setDraft((prev) => ({
+      ...prev,
+      movementRules: prev.movementRules.map((r) =>
+        r.id === id ? { ...r, ...patch } : r,
+      ),
+    }));
+  };
+
+  const removeRule = (id: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      movementRules: prev.movementRules.filter((r) => r.id !== id),
+    }));
+  };
+
+  const addRule = () => {
+    const id = `rule-${Date.now()}`;
+    setDraft((prev) => ({
+      ...prev,
+      movementRules: [
+        ...prev.movementRules,
+        {
+          id,
+          priority: 50,
+          condition: { status: ["idle"] },
+          targetAreaId: prev.areas[0]?.id ?? "break-room",
+        },
+      ],
+    }));
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-[400px] sm:w-[480px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Office Configuration</SheetTitle>
+        </SheetHeader>
+
+        <div className="space-y-6 mt-4">
+          {/* Areas */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold">Areas</h3>
+              <Button variant="ghost" size="sm" onClick={addArea}>
+                <Plus className="h-3 w-3 mr-1" /> Add
+              </Button>
+            </div>
+            <div className="space-y-3">
+              {draft.areas.map((area) => (
+                <div key={area.id} className="rounded-lg border border-border p-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="color"
+                      value={area.color}
+                      onChange={(e) => updateArea(area.id, { color: e.target.value })}
+                      className="h-6 w-6 rounded cursor-pointer bg-transparent p-0"
+                    />
+                    <Input
+                      value={area.name}
+                      onChange={(e) => updateArea(area.id, { name: e.target.value })}
+                      className="h-7 text-xs flex-1"
+                    />
+                    <button
+                      className="p-1 text-muted-foreground hover:text-destructive"
+                      onClick={() => removeArea(area.id)}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-4 gap-1.5">
+                    <div>
+                      <label className="text-[10px] text-muted-foreground">X</label>
+                      <Input
+                        type="number"
+                        value={area.x}
+                        onChange={(e) => updateArea(area.id, { x: Number(e.target.value) })}
+                        className="h-6 text-xs"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-muted-foreground">Y</label>
+                      <Input
+                        type="number"
+                        value={area.y}
+                        onChange={(e) => updateArea(area.id, { y: Number(e.target.value) })}
+                        className="h-6 text-xs"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-muted-foreground">W</label>
+                      <Input
+                        type="number"
+                        value={area.width}
+                        onChange={(e) => updateArea(area.id, { width: Number(e.target.value) })}
+                        className="h-6 text-xs"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-muted-foreground">H</label>
+                      <Input
+                        type="number"
+                        value={area.height}
+                        onChange={(e) => updateArea(area.id, { height: Number(e.target.value) })}
+                        className="h-6 text-xs"
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Movement Rules */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold">Movement Rules</h3>
+              <Button variant="ghost" size="sm" onClick={addRule}>
+                <Plus className="h-3 w-3 mr-1" /> Add
+              </Button>
+            </div>
+            <div className="space-y-3">
+              {[...draft.movementRules]
+                .sort((a, b) => b.priority - a.priority)
+                .map((rule) => (
+                  <div key={rule.id} className="rounded-lg border border-border p-3 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        <label className="text-[10px] text-muted-foreground">Priority</label>
+                        <Input
+                          type="number"
+                          value={rule.priority}
+                          onChange={(e) => updateRule(rule.id, { priority: Number(e.target.value) })}
+                          className="h-6 text-xs"
+                        />
+                      </div>
+                      <div className="flex-1">
+                        <label className="text-[10px] text-muted-foreground">Target Area</label>
+                        <select
+                          value={rule.targetAreaId}
+                          onChange={(e) => updateRule(rule.id, { targetAreaId: e.target.value })}
+                          className="w-full h-6 text-xs rounded border border-border bg-background px-1"
+                        >
+                          {draft.areas.map((a) => (
+                            <option key={a.id} value={a.id}>{a.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <button
+                        className="p-1 text-muted-foreground hover:text-destructive mt-3"
+                        onClick={() => removeRule(rule.id)}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </button>
+                    </div>
+                    <div className="space-y-1.5">
+                      <div>
+                        <label className="text-[10px] text-muted-foreground">Status (comma-separated)</label>
+                        <Input
+                          value={(rule.condition.status ?? []).join(", ")}
+                          onChange={(e) =>
+                            updateRule(rule.id, {
+                              condition: {
+                                ...rule.condition,
+                                status: e.target.value
+                                  .split(",")
+                                  .map((s) => s.trim())
+                                  .filter(Boolean),
+                              },
+                            })
+                          }
+                          className="h-6 text-xs"
+                          placeholder="e.g. running, active"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-[10px] text-muted-foreground">Role (comma-separated)</label>
+                        <Input
+                          value={(rule.condition.role ?? []).join(", ")}
+                          onChange={(e) =>
+                            updateRule(rule.id, {
+                              condition: {
+                                ...rule.condition,
+                                role: e.target.value
+                                  .split(",")
+                                  .map((s) => s.trim())
+                                  .filter(Boolean),
+                              },
+                            })
+                          }
+                          className="h-6 text-xs"
+                          placeholder="e.g. engineer, devops"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </section>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 pt-2 border-t border-border">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setDraft(DEFAULT_OFFICE_CONFIG);
+              }}
+            >
+              <RotateCcw className="h-3 w-3 mr-1" /> Reset to Default
+            </Button>
+            <div className="flex-1" />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => {
+                onSave(draft);
+                onOpenChange(false);
+              }}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/ui/src/components/office/useOfficePositions.ts
+++ b/ui/src/components/office/useOfficePositions.ts
@@ -23,12 +23,16 @@ export function useOfficePositions(
       const index = areaAgentCounts.get(area.id) ?? 0;
       areaAgentCounts.set(area.id, index + 1);
 
-      // Grid layout within area with padding
+      // Grid layout within area with padding, clamped to area bounds
       const padding = 20;
       const avatarSize = 56;
       const cols = Math.max(1, Math.floor((area.width - padding * 2) / (avatarSize + 12)));
-      const row = Math.floor(index / cols);
-      const col = index % cols;
+      const maxRows = Math.max(1, Math.floor((area.height - 36 - padding * 2) / (avatarSize + 16)));
+      const maxVisible = cols * maxRows;
+      // Wrap positions to stay within area bounds
+      const wrappedIndex = index % maxVisible;
+      const row = Math.floor(wrappedIndex / cols);
+      const col = wrappedIndex % cols;
 
       // Slight hash-based offset for organic feel
       const hash = simpleHash(agent.id);

--- a/ui/src/components/office/useOfficePositions.ts
+++ b/ui/src/components/office/useOfficePositions.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import type { Agent, OfficeConfig, OfficeAgentPosition, OfficeMovementRule } from "@paperclipai/shared";
+
+/**
+ * Evaluate movement rules and compute agent positions within office areas.
+ * Rules are evaluated in priority order (highest first). First match wins.
+ */
+export function useOfficePositions(
+  agents: Agent[],
+  config: OfficeConfig,
+): OfficeAgentPosition[] {
+  return useMemo(() => {
+    const sortedRules = [...config.movementRules].sort((a, b) => b.priority - a.priority);
+    const areaAgentCounts = new Map<string, number>();
+
+    return agents.map((agent) => {
+      const targetAreaId = resolveArea(agent, sortedRules, config.defaultAreaId);
+      const area = config.areas.find((a) => a.id === targetAreaId) ?? config.areas[0];
+      if (!area) {
+        return { agentId: agent.id, areaId: targetAreaId, x: 0, y: 0 };
+      }
+
+      const index = areaAgentCounts.get(area.id) ?? 0;
+      areaAgentCounts.set(area.id, index + 1);
+
+      // Grid layout within area with padding
+      const padding = 20;
+      const avatarSize = 56;
+      const cols = Math.max(1, Math.floor((area.width - padding * 2) / (avatarSize + 12)));
+      const row = Math.floor(index / cols);
+      const col = index % cols;
+
+      // Slight hash-based offset for organic feel
+      const hash = simpleHash(agent.id);
+      const offsetX = (hash % 7) - 3;
+      const offsetY = ((hash >> 4) % 7) - 3;
+
+      return {
+        agentId: agent.id,
+        areaId: area.id,
+        x: area.x + padding + col * (avatarSize + 12) + offsetX,
+        y: area.y + 36 + padding + row * (avatarSize + 16) + offsetY,
+      };
+    });
+  }, [agents, config]);
+}
+
+function resolveArea(
+  agent: Agent,
+  rules: OfficeMovementRule[],
+  defaultAreaId: string,
+): string {
+  for (const rule of rules) {
+    if (matchesCondition(agent, rule.condition)) {
+      return rule.targetAreaId;
+    }
+  }
+  return defaultAreaId;
+}
+
+function matchesCondition(
+  agent: Agent,
+  condition: OfficeMovementRule["condition"],
+): boolean {
+  const checks: boolean[] = [];
+
+  if (condition.status?.length) {
+    checks.push(condition.status.includes(agent.status));
+  }
+  if (condition.role?.length) {
+    checks.push(condition.role.includes(agent.role));
+  }
+  if (condition.adapterType?.length) {
+    checks.push(condition.adapterType.includes(agent.adapterType));
+  }
+
+  // All specified conditions must match (AND logic)
+  return checks.length > 0 && checks.every(Boolean);
+}
+
+function simpleHash(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -3,6 +3,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "companies",
   "company",
   "org",
+  "office",
   "agents",
   "projects",
   "issues",

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -71,4 +71,5 @@ export const queryKeys = {
   liveRuns: (companyId: string) => ["live-runs", companyId] as const,
   runIssues: (runId: string) => ["run-issues", runId] as const,
   org: (companyId: string) => ["org", companyId] as const,
+  officeConfig: (companyId: string) => ["office-config", companyId] as const,
 };

--- a/ui/src/pages/Office.tsx
+++ b/ui/src/pages/Office.tsx
@@ -77,8 +77,18 @@ export function Office() {
     return () => { window.removeEventListener("click", close); window.removeEventListener("keydown", onKey); };
   }, [contextMenu]);
 
-  // Center the office — retry until container has size
+  // Re-fit when config dimensions change
+  const canvasDimsRef = useRef(`${config.canvasWidth}x${config.canvasHeight}`);
   const hasInitialized = useRef(false);
+  useEffect(() => {
+    const key = `${config.canvasWidth}x${config.canvasHeight}`;
+    if (canvasDimsRef.current !== key) {
+      canvasDimsRef.current = key;
+      hasInitialized.current = false;
+    }
+  }, [config.canvasWidth, config.canvasHeight]);
+
+  // Center the office — retry until container has size
   useEffect(() => {
     if (hasInitialized.current) return;
     const container = containerRef.current;
@@ -175,7 +185,7 @@ export function Office() {
 
   return (
     <>
-      <div className={`flex gap-0 h-[calc(100vh-4rem)] ${selectedAgent ? "" : ""}`}>
+      <div className="flex gap-0 h-[calc(100vh-4rem)]">
       <div
         ref={containerRef}
         className={`flex-1 min-w-0 overflow-hidden relative bg-muted/20 border border-border rounded-lg ${selectedAgent ? "rounded-r-none border-r-0" : ""}`}

--- a/ui/src/pages/Office.tsx
+++ b/ui/src/pages/Office.tsx
@@ -1,0 +1,488 @@
+import { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { agentsApi } from "../api/agents";
+import { officeApi } from "../api/office";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { OfficeAreaRect } from "../components/office/OfficeArea";
+import { OfficeAgentAvatar } from "../components/office/OfficeAgent";
+import { OfficeConfigPanel } from "../components/office/OfficeConfigPanel";
+import { useOfficePositions } from "../components/office/useOfficePositions";
+import { Building2, Settings, ArrowUpRight, User } from "lucide-react";
+import { AgentIcon } from "../components/AgentIconPicker";
+import { StatusIcon } from "../components/StatusIcon";
+import { Link, useNavigate } from "@/lib/router";
+import { issuesApi } from "../api/issues";
+import { Button } from "@/components/ui/button";
+import { DEFAULT_OFFICE_CONFIG, AGENT_ROLE_LABELS } from "@paperclipai/shared";
+import type { Agent, OfficeConfig } from "@paperclipai/shared";
+import { agentUrl } from "../lib/utils";
+
+export function Office() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
+
+  const { data: agents, isLoading: agentsLoading } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 5_000,
+  });
+
+  const { data: officeConfig, isLoading: configLoading } = useQuery({
+    queryKey: queryKeys.officeConfig(selectedCompanyId!),
+    queryFn: () => officeApi.getConfig(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const updateConfig = useMutation({
+    mutationFn: (config: OfficeConfig) => officeApi.updateConfig(selectedCompanyId!, config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.officeConfig(selectedCompanyId!) });
+    },
+  });
+
+  const config = officeConfig ?? DEFAULT_OFFICE_CONFIG;
+  const activeAgents = useMemo(
+    () => (agents ?? []).filter((a) => a.status !== "terminated"),
+    [agents],
+  );
+  const positions = useOfficePositions(activeAgents, config);
+
+  // Pan & zoom state (same pattern as OrgChart)
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [dragging, setDragging] = useState(false);
+  const dragStart = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
+  const [configOpen, setConfigOpen] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ agent: Agent; x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Office" }]);
+  }, [setBreadcrumbs]);
+
+  // Close context menu on click anywhere or Escape
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = () => setContextMenu(null);
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => { window.removeEventListener("click", close); window.removeEventListener("keydown", onKey); };
+  }, [contextMenu]);
+
+  // Center the office — retry until container has size
+  const hasInitialized = useRef(false);
+  useEffect(() => {
+    if (hasInitialized.current) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const tryFit = () => {
+      const containerW = container.clientWidth;
+      const containerH = container.clientHeight;
+      if (containerW < 100 || containerH < 100) return false; // not ready
+
+      const scaleX = (containerW - 40) / config.canvasWidth;
+      const scaleY = (containerH - 40) / config.canvasHeight;
+      const fitZoom = Math.min(scaleX, scaleY, 1.2);
+
+      const chartW = config.canvasWidth * fitZoom;
+      const chartH = config.canvasHeight * fitZoom;
+
+      setZoom(fitZoom);
+      setPan({
+        x: (containerW - chartW) / 2,
+        y: Math.max(10, (containerH - chartH) / 2),
+      });
+      hasInitialized.current = true;
+      return true;
+    };
+
+    if (!tryFit()) {
+      const timer = setTimeout(tryFit, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [config, agents]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      if (target.closest("[data-office-agent]")) return;
+      setDragging(true);
+      dragStart.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y };
+    },
+    [pan],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!dragging) return;
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      setPan({ x: dragStart.current.panX + dx, y: dragStart.current.panY + dy });
+    },
+    [dragging],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setDragging(false);
+  }, []);
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      e.preventDefault();
+      const container = containerRef.current;
+      if (!container) return;
+
+      const rect = container.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+
+      const factor = e.deltaY < 0 ? 1.1 : 0.9;
+      const newZoom = Math.min(Math.max(zoom * factor, 0.3), 2);
+
+      const scale = newZoom / zoom;
+      setPan({
+        x: mouseX - scale * (mouseX - pan.x),
+        y: mouseY - scale * (mouseY - pan.y),
+      });
+      setZoom(newZoom);
+    },
+    [zoom, pan],
+  );
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={Building2} message="Select a company to view the office." />;
+  }
+
+  if (agentsLoading || configLoading) {
+    return <PageSkeleton variant="org-chart" />;
+  }
+
+  if (!agents || agents.length === 0) {
+    return <EmptyState icon={Building2} message="No agents found. Create agents to see them in the office." />;
+  }
+
+  const positionMap = new Map(positions.map((p) => [p.agentId, p]));
+
+  return (
+    <>
+      <div className={`flex gap-0 h-[calc(100vh-4rem)] ${selectedAgent ? "" : ""}`}>
+      <div
+        ref={containerRef}
+        className={`flex-1 min-w-0 overflow-hidden relative bg-muted/20 border border-border rounded-lg ${selectedAgent ? "rounded-r-none border-r-0" : ""}`}
+        style={{ cursor: dragging ? "grabbing" : "grab" }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+      >
+        {/* Top controls */}
+        <div className="absolute top-3 right-3 z-10 flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => setConfigOpen(true)}
+          >
+            <Settings className="h-3 w-3 mr-1" />
+            Configure
+          </Button>
+          <div className="flex flex-col gap-1 ml-1">
+            <button
+              className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+              onClick={() => {
+                const newZoom = Math.min(zoom * 1.2, 2);
+                const container = containerRef.current;
+                if (container) {
+                  const cx = container.clientWidth / 2;
+                  const cy = container.clientHeight / 2;
+                  const scale = newZoom / zoom;
+                  setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
+                }
+                setZoom(newZoom);
+              }}
+              aria-label="Zoom in"
+            >
+              +
+            </button>
+            <button
+              className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+              onClick={() => {
+                const newZoom = Math.max(zoom * 0.8, 0.3);
+                const container = containerRef.current;
+                if (container) {
+                  const cx = container.clientWidth / 2;
+                  const cy = container.clientHeight / 2;
+                  const scale = newZoom / zoom;
+                  setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
+                }
+                setZoom(newZoom);
+              }}
+              aria-label="Zoom out"
+            >
+              &minus;
+            </button>
+            <button
+              className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-accent transition-colors"
+              onClick={() => {
+                if (!containerRef.current) return;
+                const cW = containerRef.current.clientWidth;
+                const cH = containerRef.current.clientHeight;
+                const scaleX = (cW - 40) / config.canvasWidth;
+                const scaleY = (cH - 40) / config.canvasHeight;
+                const fitZoom = Math.min(scaleX, scaleY, 1);
+                const chartW = config.canvasWidth * fitZoom;
+                const chartH = config.canvasHeight * fitZoom;
+                setZoom(fitZoom);
+                setPan({ x: (cW - chartW) / 2, y: (cH - chartH) / 2 });
+              }}
+              title="Fit to screen"
+              aria-label="Fit to screen"
+            >
+              Fit
+            </button>
+          </div>
+        </div>
+
+        {/* Agent count */}
+        <div className="absolute top-3 left-3 z-10 text-xs text-muted-foreground bg-background/80 backdrop-blur-sm rounded px-2 py-1 border border-border">
+          {activeAgents.length} agent{activeAgents.length !== 1 ? "s" : ""} in office
+        </div>
+
+        {/* Canvas */}
+        <div
+          className="absolute inset-0"
+          style={{
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transformOrigin: "0 0",
+          }}
+        >
+          {/* Areas */}
+          {config.areas.map((area) => (
+            <OfficeAreaRect key={area.id} {...area} />
+          ))}
+
+          {/* Agents */}
+          {activeAgents.map((agent) => {
+            const pos = positionMap.get(agent.id);
+            if (!pos) return null;
+            return (
+              <OfficeAgentAvatar
+                key={agent.id}
+                agent={agent}
+                x={pos.x}
+                y={pos.y}
+                onSelect={setSelectedAgent}
+                onRightClick={(a, pos) => setContextMenu({ agent: a, ...pos })}
+                selected={selectedAgent?.id === agent.id}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Context menu (floating, outside canvas transform) */}
+      {contextMenu && (
+        <AgentContextMenu
+          agent={contextMenu.agent}
+          x={contextMenu.x}
+          y={contextMenu.y}
+          companyId={selectedCompanyId!}
+        />
+      )}
+
+      {/* Right: Agent detail panel */}
+      {selectedAgent && (
+        <AgentDetailSidebar agent={selectedAgent} onClose={() => setSelectedAgent(null)} />
+      )}
+      </div>
+
+      <OfficeConfigPanel
+        open={configOpen}
+        onOpenChange={setConfigOpen}
+        config={config}
+        onSave={(c) => updateConfig.mutate(c)}
+      />
+
+      {/* Shake animation keyframes */}
+      <style>{`
+        @keyframes shake {
+          0%, 100% { transform: translateX(0); }
+          25% { transform: translateX(-2px); }
+          75% { transform: translateX(2px); }
+        }
+      `}</style>
+    </>
+  );
+}
+
+// ── Agent Context Menu (right-click) ────────────────────────────────────
+
+function AgentContextMenu({ agent, x, y, companyId }: { agent: Agent; x: number; y: number; companyId: string }) {
+  const navigate = useNavigate();
+
+  const { data: issues } = useQuery({
+    queryKey: [...queryKeys.issues.list(companyId), "agent-context", agent.id],
+    queryFn: () => issuesApi.list(companyId, { assigneeAgentId: agent.id }),
+    staleTime: 10_000,
+  });
+
+  const recentIssues = (issues ?? [])
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 10);
+
+  // Clamp position to viewport
+  const menuX = Math.min(x, window.innerWidth - 280);
+  const menuY = Math.min(y, window.innerHeight - 400);
+
+  return (
+    <div
+      className="fixed z-50 w-[260px] rounded-lg border border-border bg-card shadow-xl py-1 animate-in fade-in zoom-in-95 duration-100"
+      style={{ left: menuX, top: menuY }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-border">
+        <p className="text-xs font-semibold truncate">{agent.name}</p>
+        <p className="text-[10px] text-muted-foreground capitalize">{agent.role}</p>
+      </div>
+
+      {/* Quick actions */}
+      <div className="py-1 border-b border-border">
+        <button
+          className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 flex items-center gap-2"
+          onClick={() => navigate(agentUrl(agent))}
+        >
+          <User className="h-3 w-3 text-muted-foreground" />
+          View Profile
+        </button>
+      </div>
+
+      {/* Recent issues */}
+      <div className="py-1">
+        <p className="px-3 py-1 text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">
+          Recent Tasks ({recentIssues.length})
+        </p>
+        {recentIssues.length === 0 ? (
+          <p className="px-3 py-2 text-xs text-muted-foreground">No tasks assigned</p>
+        ) : (
+          <div className="max-h-[240px] overflow-y-auto">
+            {recentIssues.map((issue) => (
+              <button
+                key={issue.id}
+                className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 flex items-center gap-2"
+                onClick={() => navigate(`/issues/${issue.identifier ?? issue.id}`)}
+              >
+                <span className="shrink-0" onClick={(e) => e.stopPropagation()}>
+                  <StatusIcon status={issue.status} />
+                </span>
+                <span className="text-muted-foreground font-mono text-[10px] shrink-0">
+                  {issue.identifier ?? issue.id.slice(0, 6)}
+                </span>
+                <span className="truncate">{issue.title}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Agent Detail Sidebar ────────────────────────────────────────────────
+
+const statusColors: Record<string, string> = {
+  running: "text-cyan-500 bg-cyan-500/15",
+  active: "text-green-500 bg-green-500/15",
+  paused: "text-yellow-500 bg-yellow-500/15",
+  idle: "text-gray-400 bg-gray-500/15",
+  error: "text-red-500 bg-red-500/15",
+  pending_approval: "text-purple-500 bg-purple-500/15",
+  terminated: "text-gray-500 bg-gray-500/15",
+};
+
+const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
+
+function AgentDetailSidebar({ agent, onClose }: { agent: Agent; onClose: () => void }) {
+  const ringColor = statusColors[agent.status] ?? "text-gray-400 bg-gray-500/15";
+
+  return (
+    <div className="w-[320px] shrink-0 h-full border border-border rounded-r-lg bg-card overflow-y-auto">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-border flex items-center gap-3">
+        <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center shrink-0">
+          <AgentIcon icon={agent.icon} className="h-5 w-5 text-foreground/70" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-bold truncate">{agent.name}</h3>
+          <p className="text-xs text-muted-foreground">{agent.title ?? roleLabels[agent.role] ?? agent.role}</p>
+        </div>
+        <button className="text-muted-foreground hover:text-foreground text-lg leading-none" onClick={onClose}>
+          x
+        </button>
+      </div>
+
+      {/* Status */}
+      <div className="px-4 py-3 border-b border-border">
+        <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${ringColor}`}>
+          <span className="w-2 h-2 rounded-full" style={{ backgroundColor: "currentColor" }} />
+          {agent.status}
+        </span>
+      </div>
+
+      {/* Details */}
+      <div className="px-4 py-3 space-y-3 text-xs">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">Role</span>
+            <p className="mt-0.5 capitalize">{roleLabels[agent.role] ?? agent.role}</p>
+          </div>
+          <div>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">Adapter</span>
+            <p className="mt-0.5 font-mono">{agent.adapterType}</p>
+          </div>
+          {agent.lastHeartbeatAt && (
+            <div className="col-span-2">
+              <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">Last Active</span>
+              <p className="mt-0.5">{new Date(agent.lastHeartbeatAt).toLocaleString()}</p>
+            </div>
+          )}
+          <div>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">Budget</span>
+            <p className="mt-0.5">${(agent.budgetMonthlyCents / 100).toFixed(2)}/mo</p>
+          </div>
+          <div>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">Spent</span>
+            <p className="mt-0.5">${(agent.spentMonthlyCents / 100).toFixed(2)}/mo</p>
+          </div>
+        </div>
+
+        {agent.capabilities && (
+          <div>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-semibold">Capabilities</span>
+            <p className="mt-0.5 text-xs leading-relaxed whitespace-pre-wrap">{agent.capabilities}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="px-4 py-3 border-t border-border">
+        <Link to={agentUrl(agent)}>
+          <Button variant="outline" size="sm" className="w-full text-xs">
+            View Full Profile <ArrowUpRight className="h-3 w-3 ml-1" />
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New "Office" page with 2D virtual office floor plan
- Agents appear as animated avatars positioned in configurable rooms based on status and role
- 6 default areas: Executive Suite, Engineering Lab, Meeting Room, Server Room, Break Room, Error Bay
- Click agent → detail sidebar with profile, role, budget, capabilities
- Right-click agent → context menu with recent Paperclip tasks
- Configurable movement rules (status + role conditions → target area)
- Configuration panel to edit areas and rules
- Company-level JSONB storage for office layout
- Pan/zoom canvas (same proven pattern as OrgChart)
- 5-second polling for real-time position updates

## How it works
- Movement rules are evaluated in priority order (highest first)
- First matching rule determines the agent's area
- Agents smoothly animate between areas via CSS transitions (1.5s ease)
- Status-specific animations: pulse for running, shake for error

## Test plan
- [ ] Navigate to Office page — 6 colored areas render with agents positioned
- [ ] Click an agent → detail sidebar shows profile info
- [ ] Right-click an agent → context menu with recent tasks
- [ ] Pan by dragging, zoom with scroll wheel
- [ ] Open Configure panel → edit area colors, add movement rules
- [ ] Verify dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)