### PR TITLE
feat: unified scheduling page with OpenClaw cron + Paperclip recurring tasks

### DIFF
--- a/packages/shared/src/cron-occurrences.ts
+++ b/packages/shared/src/cron-occurrences.ts
@@ -1,0 +1,161 @@
+/**
+ * Cron occurrence calculator — computes future execution times for cron expressions.
+ * Ported from Mission Control's src/lib/cron-occurrences.ts.
+ */
+
+export interface CronOccurrence {
+  atMs: number;
+  dayKey: string; // YYYY-MM-DD
+}
+
+/**
+ * Parse a cron field into a set of matching values.
+ */
+function parseCronField(field: string, min: number, max: number): Set<number> | null {
+  if (field === "*") return null; // null means "any"
+
+  const values = new Set<number>();
+
+  for (const part of field.split(",")) {
+    const stepMatch = part.match(/^(.+)\/(\d+)$/);
+    if (stepMatch) {
+      const step = parseInt(stepMatch[2], 10);
+      const base = stepMatch[1];
+      let start = min;
+      let end = max;
+
+      if (base !== "*") {
+        const rangeMatch = base.match(/^(\d+)-(\d+)$/);
+        if (rangeMatch) {
+          start = parseInt(rangeMatch[1], 10);
+          end = parseInt(rangeMatch[2], 10);
+        } else {
+          start = parseInt(base, 10);
+          end = max;
+        }
+      }
+
+      for (let i = start; i <= end; i += step) {
+        values.add(i);
+      }
+      continue;
+    }
+
+    const rangeMatch = part.match(/^(\d+)-(\d+)$/);
+    if (rangeMatch) {
+      const start = parseInt(rangeMatch[1], 10);
+      const end = parseInt(rangeMatch[2], 10);
+      for (let i = start; i <= end; i++) {
+        values.add(i);
+      }
+      continue;
+    }
+
+    const num = parseInt(part, 10);
+    if (!isNaN(num)) {
+      values.add(num);
+    }
+  }
+
+  return values.size > 0 ? values : null;
+}
+
+function buildDayKeyFromDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function buildDayKey(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * Get all cron occurrences within a time range.
+ */
+export function getCronOccurrences(
+  schedule: string,
+  rangeStartMs: number,
+  rangeEndMs: number,
+  max = 1000,
+): CronOccurrence[] {
+  // Strip timezone suffix if present: "0 9 * * * (America/Monterrey)" → "0 9 * * *"
+  const normalized = schedule.replace(/\s*\([^)]+\)\s*$/, "").trim();
+  const parts = normalized.split(/\s+/);
+  if (parts.length !== 5) return [];
+
+  const minuteSet = parseCronField(parts[0], 0, 59);
+  const hourSet = parseCronField(parts[1], 0, 23);
+  const domSet = parseCronField(parts[2], 1, 31);
+  const monthSet = parseCronField(parts[3], 1, 12);
+  const dowSet = parseCronField(parts[4], 0, 6);
+
+  // Normalize dow: 7 = 0 (Sunday)
+  if (dowSet?.has(7)) {
+    dowSet.add(0);
+    dowSet.delete(7);
+  }
+
+  const results: CronOccurrence[] = [];
+  const start = new Date(rangeStartMs);
+  const end = new Date(rangeEndMs);
+
+  // Iterate minute by minute would be too slow. Instead iterate by day, then check hours/minutes.
+  const cursor = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+
+  while (cursor.getTime() <= end.getTime() && results.length < max) {
+    const month1 = cursor.getMonth() + 1;
+    const dom = cursor.getDate();
+    const dow = cursor.getDay();
+
+    // Check month
+    if (monthSet && !monthSet.has(month1)) {
+      cursor.setDate(cursor.getDate() + 1);
+      continue;
+    }
+
+    // Check DOM and DOW — if both are restricted (not *), match either (OR logic per cron spec)
+    const domMatch = domSet ? domSet.has(dom) : true;
+    const dowMatch = dowSet ? dowSet.has(dow) : true;
+
+    if (domSet && dowSet) {
+      if (!domMatch && !dowMatch) {
+        cursor.setDate(cursor.getDate() + 1);
+        continue;
+      }
+    } else {
+      if (!domMatch || !dowMatch) {
+        cursor.setDate(cursor.getDate() + 1);
+        continue;
+      }
+    }
+
+    // Iterate hours and minutes for this day
+    const hours = hourSet ? Array.from(hourSet).sort((a, b) => a - b) : Array.from({ length: 24 }, (_, i) => i);
+    const minutes = minuteSet ? Array.from(minuteSet).sort((a, b) => a - b) : Array.from({ length: 60 }, (_, i) => i);
+
+    for (const h of hours) {
+      for (const m of minutes) {
+        const t = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate(), h, m);
+        const ms = t.getTime();
+        if (ms < rangeStartMs) continue;
+        if (ms > rangeEndMs) break;
+        results.push({ atMs: ms, dayKey: buildDayKeyFromDate(t) });
+        if (results.length >= max) return results;
+      }
+    }
+
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return results;
+}
+
+/**
+ * Get the next occurrence of a cron expression after a given time.
+ */
+export function getNextCronOccurrence(cronExpr: string, afterMs: number): number | null {
+  const results = getCronOccurrences(cronExpr, afterMs, afterMs + 366 * 24 * 60 * 60 * 1000, 1);
+  return results.length > 0 ? results[0].atMs : null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -122,7 +122,16 @@ export type {
   AgentEnvConfig,
   CompanySecret,
   SecretProviderDescriptor,
+  UnifiedScheduledJob,
+  RunHistoryEntry,
 } from "./types/index.js";
+
+export {
+  getCronOccurrences,
+  getNextCronOccurrence,
+  buildDayKey,
+  type CronOccurrence,
+} from "./cron-occurrences.js";
 
 export {
   createCompanySchema,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -22,6 +22,7 @@ export type {
   IssueLabel,
 } from "./issue.js";
 export type { Goal } from "./goal.js";
+export type { UnifiedScheduledJob, RunHistoryEntry } from "./scheduling.js";
 export type { Approval, ApprovalComment } from "./approval.js";
 export type {
   SecretProvider,

--- a/packages/shared/src/types/scheduling.ts
+++ b/packages/shared/src/types/scheduling.ts
@@ -1,0 +1,43 @@
+export interface UnifiedScheduledJob {
+  id: string;
+  name: string;
+  source: "openclaw" | "paperclip";
+  enabled: boolean;
+  cronExpr: string;
+  scheduleText: string;
+  agentId?: string;
+  agentName?: string;
+  lastRunAt?: number;
+  nextRunAt?: number;
+  lastStatus?: "success" | "error" | "running";
+  lastError?: string;
+  // OpenClaw-specific
+  command?: string;
+  fullPrompt?: string;
+  model?: string;
+  timezone?: string;
+  payloadKind?: string;
+  sessionTarget?: string;
+  wakeMode?: string;
+  deliveryMode?: string;
+  lastDurationMs?: number;
+  createdAt?: number;
+  updatedAt?: number;
+  // Paperclip-specific
+  issueId?: string;
+  issueIdentifier?: string;
+  issueStatus?: string;
+  priority?: string;
+  projectName?: string;
+  spawnCount?: number;
+}
+
+export interface RunHistoryEntry {
+  jobId: string;
+  status: string;
+  deliveryStatus?: string;
+  timestamp?: number;
+  startedAtMs?: number;
+  durationMs?: number;
+  error?: string;
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -24,6 +24,7 @@ import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { schedulingRoutes } from "./routes/scheduling.js";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 
 type UiMode = "none" | "static" | "vite-dev";
@@ -112,6 +113,7 @@ export async function createApp(
   api.use(activityRoutes(db));
   api.use(dashboardRoutes(db));
   api.use(sidebarBadgeRoutes(db));
+  api.use(schedulingRoutes(db));
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/scheduling.ts
+++ b/server/src/routes/scheduling.ts
@@ -1,0 +1,161 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { issues, agents, projects } from "@paperclipai/db";
+import { eq, and } from "drizzle-orm";
+import { describeCron } from "@paperclipai/shared";
+import { getNextCronOccurrence } from "@paperclipai/shared";
+import type { UnifiedScheduledJob, RunHistoryEntry } from "@paperclipai/shared";
+import { openclawCronService, type OpenClawCronJob } from "../services/openclaw-cron.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+
+function mapLastStatus(status?: string): "success" | "error" | "running" | undefined {
+  if (!status) return undefined;
+  const s = status.toLowerCase();
+  if (s === "success" || s === "completed" || s === "updated") return "success";
+  if (s === "error" || s === "failed") return "error";
+  if (s === "running" || s === "pending") return "running";
+  return "success";
+}
+
+function mapOpenClawJob(job: OpenClawCronJob): UnifiedScheduledJob {
+  // Handle different schedule kinds: "cron" has expr, "at" has at (one-time date)
+  const cronExpr = job.schedule.expr ?? "";
+  const atDate = (job.schedule as any).at as string | undefined;
+
+  let scheduleText = "";
+  if (cronExpr) {
+    scheduleText = describeCron(cronExpr);
+  } else if (atDate) {
+    scheduleText = `Once at ${new Date(atDate).toLocaleString()}`;
+  } else {
+    scheduleText = job.schedule.kind ?? "unknown";
+  }
+
+  const fullPrompt = job.payload?.message ?? "";
+  const payloadSummary = fullPrompt
+    ? fullPrompt.slice(0, 200) + (fullPrompt.length > 200 ? "..." : "")
+    : `${job.payload?.kind ?? "unknown"} (${job.agentId})`;
+
+  const nextRunAt = job.state?.nextRunAtMs
+    ?? (atDate ? new Date(atDate).getTime() : undefined)
+    ?? (job.enabled && cronExpr ? getNextCronOccurrence(cronExpr, Date.now()) ?? undefined : undefined);
+
+  return {
+    id: job.id,
+    name: job.name,
+    source: "openclaw",
+    enabled: job.enabled,
+    cronExpr,
+    scheduleText,
+    agentId: job.agentId,
+    agentName: job.agentId,
+    lastRunAt: job.state?.lastRunAtMs,
+    nextRunAt,
+    lastStatus: mapLastStatus(job.state?.lastStatus),
+    lastError: job.state?.lastError,
+    command: payloadSummary,
+    fullPrompt,
+    model: job.payload?.model,
+    timezone: job.schedule.tz,
+    payloadKind: job.payload?.kind,
+    sessionTarget: job.sessionTarget,
+    wakeMode: job.wakeMode,
+    deliveryMode: job.delivery?.mode,
+    lastDurationMs: job.state?.lastDurationMs,
+    createdAt: job.createdAtMs,
+    updatedAt: job.updatedAtMs,
+  };
+}
+
+export function schedulingRoutes(db: Db) {
+  const router = Router();
+  const cronSvc = openclawCronService();
+
+  // List all scheduled jobs (OpenClaw + Paperclip recurring)
+  router.get("/companies/:companyId/scheduling/jobs", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    // 1. Load OpenClaw cron jobs
+    const openclawJobs = await cronSvc.loadCronJobs();
+    const mappedOcJobs = openclawJobs.map(mapOpenClawJob);
+
+    // 2. Load Paperclip recurring issues
+    const recurringIssues = await db
+      .select({
+        issue: issues,
+        agent: agents,
+        project: projects,
+      })
+      .from(issues)
+      .leftJoin(agents, eq(issues.assigneeAgentId, agents.id))
+      .leftJoin(projects, eq(issues.projectId, projects.id))
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.recurrenceEnabled, true),
+        ),
+      );
+
+    const paperclipJobs: UnifiedScheduledJob[] = recurringIssues.map(({ issue, agent, project }) => {
+      const cronExpr = issue.recurrenceCronExpr ?? "";
+      return {
+        id: `paperclip:${issue.id}`,
+        name: issue.title,
+        source: "paperclip" as const,
+        enabled: issue.recurrenceEnabled,
+        cronExpr,
+        scheduleText: issue.recurrenceText ?? (cronExpr ? describeCron(cronExpr) : ""),
+        agentId: agent?.id ?? undefined,
+        agentName: agent?.name ?? undefined,
+        lastRunAt: issue.recurrenceLastSpawnedAt?.getTime() ?? undefined,
+        nextRunAt: cronExpr ? getNextCronOccurrence(cronExpr, Date.now()) ?? undefined : undefined,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier ?? undefined,
+        issueStatus: issue.status,
+        priority: issue.priority,
+        projectName: project?.name ?? undefined,
+      };
+    });
+
+    const jobs = [...mappedOcJobs, ...paperclipJobs];
+    res.json({ jobs });
+  });
+
+  // Run history for an OpenClaw job
+  router.get("/companies/:companyId/scheduling/history", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const jobId = req.query.jobId as string;
+    if (!jobId) {
+      res.status(400).json({ error: "jobId required" });
+      return;
+    }
+
+    const page = parseInt(req.query.page as string) || 0;
+    const result = await cronSvc.loadRunHistory(jobId, page);
+    res.json(result);
+  });
+
+  // Toggle an OpenClaw cron job
+  router.post("/companies/:companyId/scheduling/toggle", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const { jobId, enabled } = req.body as { jobId: string; enabled: boolean };
+    if (!jobId || typeof enabled !== "boolean") {
+      res.status(400).json({ error: "jobId and enabled required" });
+      return;
+    }
+
+    const success = await cronSvc.toggleJob(jobId, enabled);
+    if (!success) {
+      res.status(404).json({ error: "Job not found" });
+      return;
+    }
+    res.json({ ok: true, enabled });
+  });
+
+  return router;
+}

--- a/server/src/routes/scheduling.ts
+++ b/server/src/routes/scheduling.ts
@@ -4,9 +4,10 @@ import { issues, agents, projects } from "@paperclipai/db";
 import { eq, and } from "drizzle-orm";
 import { describeCron } from "@paperclipai/shared";
 import { getNextCronOccurrence } from "@paperclipai/shared";
-import type { UnifiedScheduledJob, RunHistoryEntry } from "@paperclipai/shared";
+import type { UnifiedScheduledJob } from "@paperclipai/shared";
 import { openclawCronService, type OpenClawCronJob } from "../services/openclaw-cron.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertCompanyAccess } from "./authz.js";
+import { logger } from "../middleware/logger.js";
 
 function mapLastStatus(status?: string): "success" | "error" | "running" | undefined {
   if (!status) return undefined;
@@ -14,11 +15,28 @@ function mapLastStatus(status?: string): "success" | "error" | "running" | undef
   if (s === "success" || s === "completed" || s === "updated") return "success";
   if (s === "error" || s === "failed") return "error";
   if (s === "running" || s === "pending") return "running";
-  return "success";
+  // Unknown status — return undefined rather than falsely claiming success
+  return undefined;
 }
 
-function mapOpenClawJob(job: OpenClawCronJob): UnifiedScheduledJob {
-  // Handle different schedule kinds: "cron" has expr, "at" has at (one-time date)
+/**
+ * Build an agent name lookup from Paperclip agents table.
+ * Used to resolve OpenClaw agentId strings to human-readable names.
+ */
+async function buildAgentNameMap(db: Db): Promise<Map<string, string>> {
+  const allAgents = await db.select({ id: agents.id, name: agents.name }).from(agents);
+  const map = new Map<string, string>();
+  for (const a of allAgents) map.set(a.id, a.name);
+  // Also index by name (OpenClaw uses name-based IDs like "sdr", "diego")
+  for (const a of allAgents) map.set(a.name.toLowerCase(), a.name);
+  return map;
+}
+
+function resolveAgentName(agentId: string, nameMap: Map<string, string>): string {
+  return nameMap.get(agentId) ?? nameMap.get(agentId.toLowerCase()) ?? agentId;
+}
+
+function mapOpenClawJob(job: OpenClawCronJob, agentNameMap: Map<string, string>): UnifiedScheduledJob {
   const cronExpr = job.schedule.expr ?? "";
   const atDate = (job.schedule as any).at as string | undefined;
 
@@ -48,7 +66,7 @@ function mapOpenClawJob(job: OpenClawCronJob): UnifiedScheduledJob {
     cronExpr,
     scheduleText,
     agentId: job.agentId,
-    agentName: job.agentId,
+    agentName: resolveAgentName(job.agentId, agentNameMap),
     lastRunAt: job.state?.lastRunAtMs,
     nextRunAt,
     lastStatus: mapLastStatus(job.state?.lastStatus),
@@ -76,50 +94,60 @@ export function schedulingRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
-    // 1. Load OpenClaw cron jobs
-    const openclawJobs = await cronSvc.loadCronJobs();
-    const mappedOcJobs = openclawJobs.map(mapOpenClawJob);
+    try {
+      // Build agent name lookup for resolving OpenClaw agent IDs
+      const agentNameMap = await buildAgentNameMap(db);
 
-    // 2. Load Paperclip recurring issues
-    const recurringIssues = await db
-      .select({
-        issue: issues,
-        agent: agents,
-        project: projects,
-      })
-      .from(issues)
-      .leftJoin(agents, eq(issues.assigneeAgentId, agents.id))
-      .leftJoin(projects, eq(issues.projectId, projects.id))
-      .where(
-        and(
-          eq(issues.companyId, companyId),
-          eq(issues.recurrenceEnabled, true),
-        ),
-      );
+      // 1. Load OpenClaw cron jobs
+      // Note: OpenClaw jobs are not company-scoped (single-tenant file).
+      // In a multi-tenant deployment, this should be filtered or gated.
+      const openclawJobs = await cronSvc.loadCronJobs();
+      const mappedOcJobs = openclawJobs.map((j) => mapOpenClawJob(j, agentNameMap));
 
-    const paperclipJobs: UnifiedScheduledJob[] = recurringIssues.map(({ issue, agent, project }) => {
-      const cronExpr = issue.recurrenceCronExpr ?? "";
-      return {
-        id: `paperclip:${issue.id}`,
-        name: issue.title,
-        source: "paperclip" as const,
-        enabled: issue.recurrenceEnabled,
-        cronExpr,
-        scheduleText: issue.recurrenceText ?? (cronExpr ? describeCron(cronExpr) : ""),
-        agentId: agent?.id ?? undefined,
-        agentName: agent?.name ?? undefined,
-        lastRunAt: issue.recurrenceLastSpawnedAt?.getTime() ?? undefined,
-        nextRunAt: cronExpr ? getNextCronOccurrence(cronExpr, Date.now()) ?? undefined : undefined,
-        issueId: issue.id,
-        issueIdentifier: issue.identifier ?? undefined,
-        issueStatus: issue.status,
-        priority: issue.priority,
-        projectName: project?.name ?? undefined,
-      };
-    });
+      // 2. Load Paperclip recurring issues (company-scoped)
+      const recurringIssues = await db
+        .select({
+          issue: issues,
+          agent: agents,
+          project: projects,
+        })
+        .from(issues)
+        .leftJoin(agents, eq(issues.assigneeAgentId, agents.id))
+        .leftJoin(projects, eq(issues.projectId, projects.id))
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.recurrenceEnabled, true),
+          ),
+        );
 
-    const jobs = [...mappedOcJobs, ...paperclipJobs];
-    res.json({ jobs });
+      const paperclipJobs: UnifiedScheduledJob[] = recurringIssues.map(({ issue, agent, project }) => {
+        const cronExpr = issue.recurrenceCronExpr ?? "";
+        return {
+          id: `paperclip:${issue.id}`,
+          name: issue.title,
+          source: "paperclip" as const,
+          enabled: issue.recurrenceEnabled,
+          cronExpr,
+          scheduleText: issue.recurrenceText ?? (cronExpr ? describeCron(cronExpr) : ""),
+          agentId: agent?.id ?? undefined,
+          agentName: agent?.name ?? undefined,
+          lastRunAt: issue.recurrenceLastSpawnedAt?.getTime() ?? undefined,
+          nextRunAt: cronExpr ? getNextCronOccurrence(cronExpr, Date.now()) ?? undefined : undefined,
+          issueId: issue.id,
+          issueIdentifier: issue.identifier ?? undefined,
+          issueStatus: issue.status,
+          priority: issue.priority,
+          projectName: project?.name ?? undefined,
+        };
+      });
+
+      const jobs = [...mappedOcJobs, ...paperclipJobs];
+      res.json({ jobs });
+    } catch (err) {
+      logger.error({ err }, "Failed to load scheduling jobs");
+      res.status(500).json({ error: "Failed to load scheduling data" });
+    }
   });
 
   // Run history for an OpenClaw job

--- a/server/src/services/openclaw-cron.ts
+++ b/server/src/services/openclaw-cron.ts
@@ -1,0 +1,116 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { logger } from "../middleware/logger.js";
+
+export interface OpenClawCronJob {
+  id: string;
+  agentId: string;
+  name: string;
+  enabled: boolean;
+  createdAtMs?: number;
+  updatedAtMs?: number;
+  schedule: {
+    kind: string;
+    expr?: string;
+    at?: string;
+    tz?: string;
+  };
+  sessionTarget?: string;
+  wakeMode?: string;
+  payload: {
+    kind: string;
+    message?: string;
+    model?: string;
+    thinking?: string;
+    timeoutSeconds?: number;
+  };
+  delivery?: {
+    mode: string;
+    channel?: string;
+    to?: string;
+  };
+  state?: {
+    nextRunAtMs?: number;
+    lastRunAtMs?: number;
+    lastStatus?: string;
+    lastDurationMs?: number;
+    lastError?: string;
+  };
+}
+
+interface OpenClawCronFile {
+  version: number;
+  jobs: OpenClawCronJob[];
+}
+
+interface OpenClawRunEntry {
+  jobId: string;
+  status: string;
+  deliveryStatus?: string;
+  timestamp?: number;
+  startedAtMs?: number;
+  durationMs?: number;
+  error?: string;
+}
+
+function getOpenClawStateDir(): string {
+  return process.env.OPENCLAW_STATE_DIR ?? join(homedir(), ".openclaw");
+}
+
+function getCronFilePath(): string {
+  return join(getOpenClawStateDir(), "cron", "jobs.json");
+}
+
+function getRunsFilePath(): string {
+  return join(getOpenClawStateDir(), "cron", "runs.json");
+}
+
+export function openclawCronService() {
+  return {
+    async loadCronJobs(): Promise<OpenClawCronJob[]> {
+      try {
+        const raw = await readFile(getCronFilePath(), "utf-8");
+        const data: OpenClawCronFile = JSON.parse(raw);
+        return data.jobs ?? [];
+      } catch {
+        return [];
+      }
+    },
+
+    async loadRunHistory(
+      jobId: string,
+      page = 0,
+      pageSize = 20,
+    ): Promise<{ entries: OpenClawRunEntry[]; total: number; hasMore: boolean }> {
+      try {
+        const raw = await readFile(getRunsFilePath(), "utf-8");
+        const allRuns: OpenClawRunEntry[] = JSON.parse(raw);
+        const filtered = allRuns
+          .filter((r) => r.jobId === jobId)
+          .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
+        const start = page * pageSize;
+        const entries = filtered.slice(start, start + pageSize);
+        return { entries, total: filtered.length, hasMore: start + pageSize < filtered.length };
+      } catch {
+        return { entries: [], total: 0, hasMore: false };
+      }
+    },
+
+    async toggleJob(jobId: string, enabled: boolean): Promise<boolean> {
+      try {
+        const raw = await readFile(getCronFilePath(), "utf-8");
+        const data: OpenClawCronFile = JSON.parse(raw);
+        const job = data.jobs.find((j) => j.id === jobId);
+        if (!job) return false;
+        job.enabled = enabled;
+        job.updatedAtMs = Date.now();
+        await writeFile(getCronFilePath(), JSON.stringify(data, null, 2));
+        return true;
+      } catch (err) {
+        logger.error({ err }, "Failed to toggle OpenClaw cron job");
+        return false;
+      }
+    },
+  };
+}

--- a/server/src/services/openclaw-cron.ts
+++ b/server/src/services/openclaw-cron.ts
@@ -54,6 +54,15 @@ interface OpenClawRunEntry {
   error?: string;
 }
 
+// Simple async mutex to serialize file writes and prevent race conditions
+let writeLock: Promise<unknown> = Promise.resolve();
+function toggleMutex<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = writeLock;
+  let resolve: () => void;
+  writeLock = new Promise((r) => { resolve = r; });
+  return prev.then(fn).finally(() => resolve!());
+}
+
 function getOpenClawStateDir(): string {
   return process.env.OPENCLAW_STATE_DIR ?? join(homedir(), ".openclaw");
 }
@@ -98,19 +107,22 @@ export function openclawCronService() {
     },
 
     async toggleJob(jobId: string, enabled: boolean): Promise<boolean> {
-      try {
-        const raw = await readFile(getCronFilePath(), "utf-8");
-        const data: OpenClawCronFile = JSON.parse(raw);
-        const job = data.jobs.find((j) => j.id === jobId);
-        if (!job) return false;
-        job.enabled = enabled;
-        job.updatedAtMs = Date.now();
-        await writeFile(getCronFilePath(), JSON.stringify(data, null, 2));
-        return true;
-      } catch (err) {
-        logger.error({ err }, "Failed to toggle OpenClaw cron job");
-        return false;
-      }
+      // Serialize file writes to prevent concurrent read-modify-write corruption
+      return toggleMutex(async () => {
+        try {
+          const raw = await readFile(getCronFilePath(), "utf-8");
+          const data: OpenClawCronFile = JSON.parse(raw);
+          const job = data.jobs.find((j) => j.id === jobId);
+          if (!job) return false;
+          job.enabled = enabled;
+          job.updatedAtMs = Date.now();
+          await writeFile(getCronFilePath(), JSON.stringify(data, null, 2));
+          return true;
+        } catch (err) {
+          logger.error({ err }, "Failed to toggle OpenClaw cron job");
+          return false;
+        }
+      });
     },
   };
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,6 +24,7 @@ import { Inbox } from "./pages/Inbox";
 import { CompanySettings } from "./pages/CompanySettings";
 import { DesignGuide } from "./pages/DesignGuide";
 import { OrgChart } from "./pages/OrgChart";
+import { Scheduling } from "./pages/Scheduling";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
@@ -107,6 +108,7 @@ function boardRoutes() {
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
       <Route path="org" element={<OrgChart />} />
+      <Route path="scheduling" element={<Scheduling />} />
       <Route path="agents" element={<Navigate to="/agents/all" replace />} />
       <Route path="agents/all" element={<Agents />} />
       <Route path="agents/active" element={<Agents />} />

--- a/ui/src/api/scheduling.ts
+++ b/ui/src/api/scheduling.ts
@@ -1,0 +1,16 @@
+import type { UnifiedScheduledJob, RunHistoryEntry } from "@paperclipai/shared";
+import { api } from "./client";
+
+export const schedulingApi = {
+  listJobs: (companyId: string) =>
+    api.get<{ jobs: UnifiedScheduledJob[] }>(`/companies/${companyId}/scheduling/jobs`),
+  getHistory: (companyId: string, jobId: string, page = 0) =>
+    api.get<{ entries: RunHistoryEntry[]; total: number; hasMore: boolean }>(
+      `/companies/${companyId}/scheduling/history?jobId=${jobId}&page=${page}`,
+    ),
+  toggleJob: (companyId: string, jobId: string, enabled: boolean) =>
+    api.post<{ ok: boolean; enabled: boolean }>(
+      `/companies/${companyId}/scheduling/toggle`,
+      { jobId, enabled },
+    ),
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   SquarePen,
   Network,
+  Clock,
   Settings,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -88,6 +89,7 @@ export function Sidebar() {
 
         <SidebarSection label="Work">
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
+          <SidebarNavItem to="/scheduling" label="Schedule" icon={Clock} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
         </SidebarSection>
 

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -3,6 +3,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "companies",
   "company",
   "org",
+  "scheduling",
   "agents",
   "projects",
   "issues",

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -71,4 +71,5 @@ export const queryKeys = {
   liveRuns: (companyId: string) => ["live-runs", companyId] as const,
   runIssues: (runId: string) => ["run-issues", runId] as const,
   org: (companyId: string) => ["org", companyId] as const,
+  scheduling: (companyId: string) => ["scheduling", companyId] as const,
 };

--- a/ui/src/pages/Scheduling.tsx
+++ b/ui/src/pages/Scheduling.tsx
@@ -1,0 +1,920 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { Link } from "@/lib/router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { schedulingApi } from "../api/scheduling";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { cn } from "../lib/utils";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Clock,
+  Repeat,
+  Zap,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  ArrowUpRight,
+} from "lucide-react";
+import { getCronOccurrences, describeCron, type UnifiedScheduledJob, type CronOccurrence } from "@paperclipai/shared";
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function getWeekStart(date: Date): Date {
+  const day = date.getDay();
+  return addDays(startOfDay(date), -(day + 6) % 7);
+}
+
+function getMonthStartGrid(date: Date): Date {
+  const first = new Date(date.getFullYear(), date.getMonth(), 1);
+  return addDays(first, -first.getDay());
+}
+
+function formatDateLabel(date: Date): string {
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatRelativeTime(ms: number | undefined): string {
+  if (!ms) return "--";
+  const diff = Date.now() - ms;
+  const absDiff = Math.abs(diff);
+  const future = diff < 0;
+  if (absDiff < 60000) return future ? "soon" : "just now";
+  if (absDiff < 3600000) {
+    const m = Math.floor(absDiff / 60000);
+    return future ? `in ${m}m` : `${m}m ago`;
+  }
+  if (absDiff < 86400000) {
+    const h = Math.floor(absDiff / 3600000);
+    return future ? `in ${h}h` : `${h}h ago`;
+  }
+  const d = Math.floor(absDiff / 86400000);
+  return future ? `in ${d}d` : `${d}d ago`;
+}
+
+const SOURCE_COLORS = {
+  openclaw: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 border-cyan-500/30",
+  paperclip: "bg-purple-500/15 text-purple-600 dark:text-purple-400 border-purple-500/30",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  success: "text-green-500",
+  error: "text-red-500",
+  running: "text-blue-500",
+};
+
+const AGENT_COLORS = [
+  "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
+  "bg-amber-500/20 text-amber-400 border-amber-500/30",
+  "bg-purple-500/20 text-purple-400 border-purple-500/30",
+  "bg-rose-500/20 text-rose-400 border-rose-500/30",
+  "bg-cyan-500/20 text-cyan-400 border-cyan-500/30",
+  "bg-orange-500/20 text-orange-400 border-orange-500/30",
+  "bg-indigo-500/20 text-indigo-400 border-indigo-500/30",
+];
+
+function getAgentColor(agentId: string, allAgents: string[]): string {
+  const idx = allAgents.indexOf(agentId);
+  return AGENT_COLORS[idx >= 0 ? idx % AGENT_COLORS.length : 0];
+}
+
+type CalendarView = "agenda" | "week" | "month";
+type SourceFilter = "all" | "openclaw" | "paperclip";
+type StateFilter = "all" | "enabled" | "disabled";
+
+interface DayJobSummary {
+  job: UnifiedScheduledJob;
+  runCount: number;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function Scheduling() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Scheduling" }]);
+  }, [setBreadcrumbs]);
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.scheduling(selectedCompanyId!),
+    queryFn: () => schedulingApi.listJobs(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 5_000,
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ jobId, enabled }: { jobId: string; enabled: boolean }) =>
+      schedulingApi.toggleJob(selectedCompanyId!, jobId, enabled),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.scheduling(selectedCompanyId!) }),
+  });
+
+  const jobs = data?.jobs ?? [];
+
+  // Filters
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [stateFilter, setStateFilter] = useState<StateFilter>("all");
+  const [agentFilter, setAgentFilter] = useState("all");
+  const [projectFilter, setProjectFilter] = useState("all");
+  const [calendarView, setCalendarView] = useState<CalendarView>("week");
+  const [calendarDate, setCalendarDate] = useState(startOfDay(new Date()));
+  const [selectedDate, setSelectedDate] = useState(startOfDay(new Date()));
+  const [selectedJob, setSelectedJob] = useState<UnifiedScheduledJob | null>(null);
+
+  const allAgentIds = useMemo(
+    () => [...new Set(jobs.map((j) => j.agentId).filter(Boolean) as string[])],
+    [jobs],
+  );
+
+  const allAgentNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const j of jobs) {
+      if (j.agentId && j.agentName) map.set(j.agentId, j.agentName);
+    }
+    return map;
+  }, [jobs]);
+
+  const allProjects = useMemo(
+    () => [...new Set(jobs.map((j) => j.projectName).filter(Boolean) as string[])].sort(),
+    [jobs],
+  );
+
+  const filteredJobs = useMemo(() => {
+    return jobs.filter((j) => {
+      if (sourceFilter !== "all" && j.source !== sourceFilter) return false;
+      if (stateFilter === "enabled" && !j.enabled) return false;
+      if (stateFilter === "disabled" && j.enabled) return false;
+      if (agentFilter !== "all" && j.agentId !== agentFilter) return false;
+      if (projectFilter !== "all" && (j.projectName ?? "") !== projectFilter) return false;
+      if (searchQuery.trim()) {
+        const q = searchQuery.toLowerCase();
+        if (
+          !j.name.toLowerCase().includes(q) &&
+          !(j.agentName ?? "").toLowerCase().includes(q) &&
+          !(j.command ?? "").toLowerCase().includes(q) &&
+          !(j.issueIdentifier ?? "").toLowerCase().includes(q)
+        )
+          return false;
+      }
+      return true;
+    });
+  }, [jobs, sourceFilter, stateFilter, agentFilter, projectFilter, searchQuery]);
+
+  // Calendar occurrences
+  const calendarRange = useMemo(() => {
+    if (calendarView === "week") {
+      const start = getWeekStart(calendarDate);
+      return { start, end: addDays(start, 7) };
+    }
+    const start = getMonthStartGrid(calendarDate);
+    return { start, end: addDays(start, 42) };
+  }, [calendarView, calendarDate]);
+
+  const dayJobMap = useMemo(() => {
+    const map = new Map<string, DayJobSummary[]>();
+    for (const job of filteredJobs) {
+      if (!job.enabled || !job.cronExpr) continue;
+      const occs = getCronOccurrences(
+        job.cronExpr,
+        calendarRange.start.getTime(),
+        calendarRange.end.getTime(),
+        500,
+      );
+      for (const occ of occs) {
+        const existing = map.get(occ.dayKey);
+        const entry = existing?.find((e) => e.job.id === job.id);
+        if (entry) {
+          entry.runCount++;
+        } else {
+          const arr = existing ?? [];
+          arr.push({ job, runCount: 1 });
+          if (!existing) map.set(occ.dayKey, arr);
+        }
+      }
+    }
+    return map;
+  }, [filteredJobs, calendarRange]);
+
+  const moveCalendar = useCallback(
+    (dir: number) => {
+      if (calendarView === "week") {
+        setCalendarDate((d) => addDays(d, dir * 7));
+      } else {
+        setCalendarDate((d) => {
+          const next = new Date(d);
+          next.setMonth(next.getMonth() + dir);
+          return next;
+        });
+      }
+    },
+    [calendarView],
+  );
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={Clock} message="Select a company to view scheduling." />;
+  }
+  if (isLoading) return <PageSkeleton />;
+
+  const openclawCount = jobs.filter((j) => j.source === "openclaw").length;
+  const paperclipCount = jobs.filter((j) => j.source === "paperclip").length;
+  const today = startOfDay(new Date());
+
+  return (
+    <div className="space-y-4 pb-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">Scheduling</h1>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {openclawCount} OpenClaw cron job{openclawCount !== 1 ? "s" : ""}
+            {" + "}
+            {paperclipCount} Paperclip recurring task{paperclipCount !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search jobs..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-8 pl-8 w-52 text-xs"
+          />
+        </div>
+
+        {/* Source filter */}
+        <div className="flex items-center rounded-md border border-border overflow-hidden">
+          {(["all", "openclaw", "paperclip"] as const).map((s) => (
+            <button
+              key={s}
+              className={cn(
+                "px-2.5 py-1.5 text-xs font-medium transition-colors",
+                sourceFilter === s ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50",
+              )}
+              onClick={() => setSourceFilter(s)}
+            >
+              {s === "all" ? "All" : s === "openclaw" ? "OpenClaw" : "Paperclip"}
+            </button>
+          ))}
+        </div>
+
+        {/* Agent filter */}
+        <select
+          value={agentFilter}
+          onChange={(e) => setAgentFilter(e.target.value)}
+          className="h-8 px-2 text-xs rounded-md border border-border bg-background text-foreground"
+        >
+          <option value="all">All agents</option>
+          {allAgentIds.map((id) => (
+            <option key={id} value={id}>{allAgentNames.get(id) ?? id}</option>
+          ))}
+        </select>
+
+        {/* Project filter */}
+        {allProjects.length > 0 && (
+          <select
+            value={projectFilter}
+            onChange={(e) => setProjectFilter(e.target.value)}
+            className="h-8 px-2 text-xs rounded-md border border-border bg-background text-foreground"
+          >
+            <option value="all">All projects</option>
+            {allProjects.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        )}
+
+        {/* State filter */}
+        <div className="flex items-center rounded-md border border-border overflow-hidden">
+          {(["all", "enabled", "disabled"] as const).map((s) => (
+            <button
+              key={s}
+              className={cn(
+                "px-2.5 py-1.5 text-xs font-medium capitalize transition-colors",
+                stateFilter === s ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50",
+              )}
+              onClick={() => setStateFilter(s)}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+
+        {/* Calendar view */}
+        <div className="flex items-center rounded-md border border-border overflow-hidden ml-auto">
+          {(["agenda", "week", "month"] as const).map((v) => (
+            <button
+              key={v}
+              className={cn(
+                "px-2.5 py-1.5 text-xs font-medium capitalize transition-colors",
+                calendarView === v ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50",
+              )}
+              onClick={() => setCalendarView(v)}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Calendar navigation */}
+      {calendarView !== "agenda" && (
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon-sm" onClick={() => moveCalendar(-1)}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm font-medium min-w-[140px] text-center">
+            {calendarView === "week"
+              ? `${formatDateLabel(getWeekStart(calendarDate))} - ${formatDateLabel(addDays(getWeekStart(calendarDate), 6))}`
+              : calendarDate.toLocaleDateString(undefined, { month: "long", year: "numeric" })}
+          </span>
+          <Button variant="ghost" size="icon-sm" onClick={() => moveCalendar(1)}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button variant="ghost" size="sm" className="text-xs" onClick={() => setCalendarDate(today)}>
+            Today
+          </Button>
+        </div>
+      )}
+
+      <div className="grid lg:grid-cols-[1fr_420px] gap-4">
+        {/* Left: Calendar + Job list */}
+        <div className="space-y-3 min-w-0">
+          {calendarView === "agenda" ? (
+            <AgendaView jobs={filteredJobs} allAgentIds={allAgentIds} onSelect={setSelectedJob} selectedJobId={selectedJob?.id} />
+          ) : calendarView === "week" ? (
+            <WeekView
+              startDate={getWeekStart(calendarDate)}
+              dayJobMap={dayJobMap}
+              selectedDate={selectedDate}
+              onSelectDate={setSelectedDate}
+              today={today}
+              allAgentIds={allAgentIds}
+            />
+          ) : (
+            <MonthView
+              date={calendarDate}
+              dayJobMap={dayJobMap}
+              selectedDate={selectedDate}
+              onSelectDate={setSelectedDate}
+              today={today}
+              allAgentIds={allAgentIds}
+            />
+          )}
+
+          {/* Job list below calendar */}
+          <div>
+            {(() => {
+              const isCalendarMode = calendarView === "week" || calendarView === "month";
+              const selectedDayKey = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, "0")}-${String(selectedDate.getDate()).padStart(2, "0")}`;
+              const daySpecificJobs = isCalendarMode
+                ? (dayJobMap.get(selectedDayKey) ?? []).map((s) => s.job)
+                : filteredJobs;
+              const displayJobs = isCalendarMode ? daySpecificJobs : filteredJobs;
+              const headerLabel = isCalendarMode
+                ? `${displayJobs.length} job${displayJobs.length !== 1 ? "s" : ""} on ${formatDateLabel(selectedDate)}`
+                : `${displayJobs.length} scheduled job${displayJobs.length !== 1 ? "s" : ""}`;
+
+              return (
+                <>
+            <h3 className="text-xs font-semibold text-muted-foreground mb-2">
+              {headerLabel}
+            </h3>
+            <div className="space-y-1 max-h-[40vh] overflow-y-auto">
+              {displayJobs.map((job) => (
+                <button
+                  key={job.id}
+                  className={cn(
+                    "w-full text-left px-3 py-2 rounded-lg border transition-colors",
+                    selectedJob?.id === job.id
+                      ? "border-primary/40 bg-primary/5"
+                      : "border-border hover:border-foreground/20 hover:bg-accent/30",
+                  )}
+                  onClick={() => setSelectedJob(job)}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className={cn("w-2 h-2 rounded-full shrink-0", job.enabled ? "bg-green-500" : "bg-gray-400")} />
+                    <span className="text-sm font-medium truncate flex-1">{job.name}</span>
+                    <span className={cn("text-[10px] font-medium px-1.5 py-0.5 rounded-full border", SOURCE_COLORS[job.source])}>
+                      {job.source === "openclaw" ? "OpenClaw" : "Paperclip"}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                    {job.agentName && (
+                      <span className={cn("px-1.5 py-0.5 rounded border text-[10px]", getAgentColor(job.agentId!, allAgentIds))}>
+                        {job.agentName}
+                      </span>
+                    )}
+                    <span className="font-mono">{job.cronExpr}</span>
+                    <span className="ml-auto">{job.scheduleText}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+                </>
+              );
+            })()}
+          </div>
+        </div>
+
+        {/* Right: Full detail panel (sticky) */}
+        <div className="lg:sticky lg:top-4 lg:self-start">
+          {selectedJob ? (
+            <DetailPanel
+              job={selectedJob}
+              onToggle={(enabled) => {
+                if (selectedJob.source === "openclaw") {
+                  toggleMutation.mutate({ jobId: selectedJob.id, enabled });
+                }
+              }}
+            />
+          ) : (
+            <div className="rounded-lg border border-dashed border-border p-8 text-center">
+              <Clock className="h-8 w-8 text-muted-foreground/30 mx-auto mb-2" />
+              <p className="text-sm text-muted-foreground">Select a job to see details</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Agenda View ──────────────────────────────────────────────────────────
+
+function AgendaView({
+  jobs,
+  allAgentIds,
+  onSelect,
+  selectedJobId,
+}: {
+  jobs: UnifiedScheduledJob[];
+  allAgentIds: string[];
+  onSelect: (j: UnifiedScheduledJob) => void;
+  selectedJobId?: string;
+}) {
+  const upcoming = useMemo(() => {
+    const now = Date.now();
+    const range = 7 * 24 * 60 * 60 * 1000;
+    const items: Array<{ job: UnifiedScheduledJob; atMs: number }> = [];
+
+    for (const job of jobs) {
+      if (!job.enabled || !job.cronExpr) continue;
+      const occs = getCronOccurrences(job.cronExpr, now, now + range, 50);
+      for (const occ of occs) {
+        items.push({ job, atMs: occ.atMs });
+      }
+    }
+
+    return items.sort((a, b) => a.atMs - b.atMs).slice(0, 200);
+  }, [jobs]);
+
+  return (
+    <div className="rounded-lg border border-border max-h-[60vh] overflow-y-auto">
+      {upcoming.length === 0 ? (
+        <div className="p-6 text-center text-sm text-muted-foreground">No upcoming scheduled jobs</div>
+      ) : (
+        <div className="divide-y divide-border">
+          {upcoming.map((item, i) => {
+            const d = new Date(item.atMs);
+            return (
+              <button
+                key={`${item.job.id}-${i}`}
+                className="w-full text-left px-3 py-2 hover:bg-accent/30 transition-colors flex items-center gap-3"
+                onClick={() => onSelect(item.job)}
+              >
+                <span className="text-xs text-muted-foreground font-mono w-32 shrink-0">
+                  {d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}{" "}
+                  {d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+                </span>
+                <span
+                  className={cn(
+                    "w-1.5 h-1.5 rounded-full shrink-0",
+                    item.job.source === "openclaw" ? "bg-cyan-500" : "bg-purple-500",
+                  )}
+                />
+                <span className="text-sm truncate flex-1">{item.job.name}</span>
+                {item.job.agentName && (
+                  <span className={cn("text-[10px] px-1.5 py-0.5 rounded border", getAgentColor(item.job.agentId!, allAgentIds))}>
+                    {item.job.agentName}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Week View ────────────────────────────────────────────────────────────
+
+function WeekView({
+  startDate,
+  dayJobMap,
+  selectedDate,
+  onSelectDate,
+  today,
+  allAgentIds,
+}: {
+  startDate: Date;
+  dayJobMap: Map<string, DayJobSummary[]>;
+  selectedDate: Date;
+  onSelectDate: (d: Date) => void;
+  today: Date;
+  allAgentIds: string[];
+}) {
+  const days = Array.from({ length: 7 }, (_, i) => addDays(startDate, i));
+  const dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+  return (
+    <div className="grid grid-cols-7 gap-1.5">
+      {days.map((day, i) => {
+        const key = `${day.getFullYear()}-${String(day.getMonth() + 1).padStart(2, "0")}-${String(day.getDate()).padStart(2, "0")}`;
+        const summaries = dayJobMap.get(key) ?? [];
+        const isToday = isSameDay(day, today);
+        const isSelected = isSameDay(day, selectedDate);
+
+        return (
+          <button
+            key={key}
+            className={cn(
+              "rounded-lg border p-2 min-h-[140px] text-left transition-colors flex flex-col",
+              isSelected ? "border-primary/40 bg-primary/5" : "border-border hover:border-foreground/20",
+            )}
+            onClick={() => onSelectDate(day)}
+          >
+            <div className="flex items-center justify-between mb-1.5">
+              <span className={cn("text-[10px] font-medium", isToday ? "text-primary" : "text-muted-foreground")}>
+                {dayNames[i]}
+              </span>
+              <span className={cn("text-xs font-semibold", isToday ? "text-primary" : "text-foreground")}>
+                {day.getDate()}
+              </span>
+            </div>
+            <div className="flex-1 space-y-0.5 overflow-hidden">
+              {summaries.slice(0, 5).map((s) => (
+                <div
+                  key={s.job.id}
+                  className={cn(
+                    "text-[9px] px-1 py-0.5 rounded border truncate",
+                    s.job.source === "openclaw"
+                      ? "bg-cyan-500/10 border-cyan-500/20 text-cyan-600 dark:text-cyan-400"
+                      : "bg-purple-500/10 border-purple-500/20 text-purple-600 dark:text-purple-400",
+                  )}
+                >
+                  {s.job.name}
+                </div>
+              ))}
+              {summaries.length > 5 && (
+                <span className="text-[9px] text-muted-foreground">+{summaries.length - 5} more</span>
+              )}
+            </div>
+            {summaries.length > 0 && (
+              <div className="text-[9px] text-muted-foreground mt-1 pt-1 border-t border-border/50">
+                {summaries.reduce((sum, s) => sum + s.runCount, 0)} runs
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Month View ───────────────────────────────────────────────────────────
+
+function MonthView({
+  date,
+  dayJobMap,
+  selectedDate,
+  onSelectDate,
+  today,
+  allAgentIds,
+}: {
+  date: Date;
+  dayJobMap: Map<string, DayJobSummary[]>;
+  selectedDate: Date;
+  onSelectDate: (d: Date) => void;
+  today: Date;
+  allAgentIds: string[];
+}) {
+  const gridStart = getMonthStartGrid(date);
+  const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+  const currentMonth = date.getMonth();
+  const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  return (
+    <div>
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {dayLabels.map((d) => (
+          <div key={d} className="text-center text-[10px] text-muted-foreground font-medium py-1">
+            {d}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-1">
+        {cells.map((day) => {
+          const key = `${day.getFullYear()}-${String(day.getMonth() + 1).padStart(2, "0")}-${String(day.getDate()).padStart(2, "0")}`;
+          const summaries = dayJobMap.get(key) ?? [];
+          const isCurrentMonth = day.getMonth() === currentMonth;
+          const isToday = isSameDay(day, today);
+          const isSelected = isSameDay(day, selectedDate);
+
+          return (
+            <button
+              key={key}
+              className={cn(
+                "rounded-md border p-1 min-h-[80px] text-left transition-colors flex flex-col",
+                !isCurrentMonth && "opacity-40",
+                isSelected ? "border-primary/40 bg-primary/5" : "border-border/50 hover:border-border",
+              )}
+              onClick={() => onSelectDate(day)}
+            >
+              <span className={cn("text-[10px] font-medium", isToday ? "text-primary font-bold" : "text-muted-foreground")}>
+                {day.getDate()}
+              </span>
+              <div className="flex-1 space-y-0.5 mt-0.5 overflow-hidden">
+                {summaries.slice(0, 3).map((s) => (
+                  <div
+                    key={s.job.id}
+                    className={cn(
+                      "text-[8px] px-0.5 rounded truncate",
+                      s.job.source === "openclaw" ? "text-cyan-500" : "text-purple-500",
+                    )}
+                  >
+                    {s.job.name}
+                  </div>
+                ))}
+                {summaries.length > 3 && (
+                  <span className="text-[8px] text-muted-foreground">+{summaries.length - 3}</span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Detail Panel ─────────────────────────────────────────────────────────
+
+function DetailField({ label, children, full }: { label: string; children: React.ReactNode; full?: boolean }) {
+  return (
+    <div className={full ? "col-span-2" : ""}>
+      <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-semibold">{label}</span>
+      <div className="mt-0.5">{children}</div>
+    </div>
+  );
+}
+
+function DetailPanel({
+  job,
+  onToggle,
+}: {
+  job: UnifiedScheduledJob;
+  onToggle: (enabled: boolean) => void;
+}) {
+  const [promptExpanded, setPromptExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-border bg-muted/30">
+        <div className="flex items-center gap-2">
+          {job.source === "openclaw" ? (
+            <Zap className="h-4 w-4 text-cyan-500 shrink-0" />
+          ) : (
+            <Repeat className="h-4 w-4 text-purple-500 shrink-0" />
+          )}
+          <h3 className="text-sm font-semibold flex-1 truncate">{job.name}</h3>
+          <span className={cn("text-[10px] font-medium px-2 py-0.5 rounded-full border shrink-0", SOURCE_COLORS[job.source])}>
+            {job.source === "openclaw" ? "OpenClaw" : "Paperclip"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 mt-1.5">
+          <span className={cn("w-2 h-2 rounded-full", job.enabled ? "bg-green-500" : "bg-gray-400")} />
+          <span className="text-xs text-muted-foreground">{job.enabled ? "Enabled" : "Disabled"}</span>
+          {job.lastStatus && (
+            <>
+              <span className="text-muted-foreground">·</span>
+              <span className={cn("text-xs font-medium capitalize", STATUS_COLORS[job.lastStatus] ?? "text-muted-foreground")}>
+                {job.lastStatus}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-3 space-y-4 max-h-[calc(100vh-14rem)] overflow-y-auto">
+        {/* Schedule section */}
+        <div>
+          <h4 className="text-[11px] font-semibold text-muted-foreground mb-2 uppercase tracking-wider">Schedule</h4>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+            <DetailField label="Cron Expression">
+              <p className="font-mono text-sm">{job.cronExpr || "--"}</p>
+            </DetailField>
+            <DetailField label="Human Readable">
+              <p className="text-sm">{job.scheduleText}</p>
+            </DetailField>
+            {job.timezone && (
+              <DetailField label="Timezone">
+                <p>{job.timezone}</p>
+              </DetailField>
+            )}
+          </div>
+        </div>
+
+        {/* Timing section */}
+        <div className="border-t border-border pt-3">
+          <h4 className="text-[11px] font-semibold text-muted-foreground mb-2 uppercase tracking-wider">Timing</h4>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+            <DetailField label="Last Run">
+              <p>{job.lastRunAt ? new Date(job.lastRunAt).toLocaleString() : "--"}</p>
+              {job.lastRunAt && <p className="text-muted-foreground">{formatRelativeTime(job.lastRunAt)}</p>}
+            </DetailField>
+            <DetailField label="Next Run">
+              <p className="text-primary">{job.nextRunAt ? new Date(job.nextRunAt).toLocaleString() : "--"}</p>
+              {job.nextRunAt && <p className="text-muted-foreground">{formatRelativeTime(job.nextRunAt)}</p>}
+            </DetailField>
+            {job.lastDurationMs != null && (
+              <DetailField label="Last Duration">
+                <p>{(job.lastDurationMs / 1000).toFixed(1)}s</p>
+              </DetailField>
+            )}
+            {job.lastError && (
+              <DetailField label="Last Error" full>
+                <p className="text-red-500 text-xs bg-red-500/10 rounded p-1.5 font-mono">{job.lastError}</p>
+              </DetailField>
+            )}
+          </div>
+        </div>
+
+        {/* Agent section */}
+        {job.agentName && (
+          <div className="border-t border-border pt-3">
+            <h4 className="text-[11px] font-semibold text-muted-foreground mb-2 uppercase tracking-wider">Agent</h4>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+              <DetailField label="Agent">
+                <p className="text-sm font-medium">{job.agentName}</p>
+              </DetailField>
+              {job.model && (
+                <DetailField label="Model">
+                  <p className="font-mono">{job.model}</p>
+                </DetailField>
+              )}
+              {job.sessionTarget && (
+                <DetailField label="Session">
+                  <p className="capitalize">{job.sessionTarget}</p>
+                </DetailField>
+              )}
+              {job.wakeMode && (
+                <DetailField label="Wake Mode">
+                  <p className="capitalize">{job.wakeMode}</p>
+                </DetailField>
+              )}
+              {job.deliveryMode && (
+                <DetailField label="Delivery">
+                  <p className="capitalize">{job.deliveryMode}</p>
+                </DetailField>
+              )}
+              {job.payloadKind && (
+                <DetailField label="Payload Type">
+                  <p className="font-mono">{job.payloadKind}</p>
+                </DetailField>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Prompt / Command section (the full text) */}
+        {(job.fullPrompt || job.command) && (
+          <div className="border-t border-border pt-3">
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+                {job.source === "openclaw" ? "Prompt / Message" : "Description"}
+              </h4>
+              {job.fullPrompt && job.fullPrompt.length > 300 && (
+                <button
+                  className="text-[10px] text-primary hover:underline"
+                  onClick={() => setPromptExpanded(!promptExpanded)}
+                >
+                  {promptExpanded ? "Collapse" : "Expand"}
+                </button>
+              )}
+            </div>
+            <div
+              className={cn(
+                "text-xs font-mono bg-muted/50 rounded-lg p-3 whitespace-pre-wrap break-words leading-relaxed border border-border/50",
+                !promptExpanded && "max-h-[200px] overflow-hidden relative",
+              )}
+            >
+              {job.fullPrompt || job.command}
+              {!promptExpanded && job.fullPrompt && job.fullPrompt.length > 300 && (
+                <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-muted/80 to-transparent" />
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Paperclip-specific section */}
+        {job.source === "paperclip" && (
+          <div className="border-t border-border pt-3">
+            <h4 className="text-[11px] font-semibold text-muted-foreground mb-2 uppercase tracking-wider">Paperclip Issue</h4>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+              {job.issueIdentifier && (
+                <DetailField label="Identifier">
+                  <Link to={`/issues/${job.issueId}`} className="text-primary hover:underline flex items-center gap-1 text-sm font-medium">
+                    {job.issueIdentifier} <ArrowUpRight className="h-3 w-3" />
+                  </Link>
+                </DetailField>
+              )}
+              {job.issueStatus && (
+                <DetailField label="Status">
+                  <p className="capitalize">{job.issueStatus}</p>
+                </DetailField>
+              )}
+              {job.priority && (
+                <DetailField label="Priority">
+                  <p className="capitalize">{job.priority}</p>
+                </DetailField>
+              )}
+              {job.projectName && (
+                <DetailField label="Project">
+                  <p>{job.projectName}</p>
+                </DetailField>
+              )}
+              {job.spawnCount != null && (
+                <DetailField label="Tasks Spawned">
+                  <p className="text-sm font-medium">{job.spawnCount}</p>
+                </DetailField>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Metadata */}
+        {(job.createdAt || job.updatedAt) && (
+          <div className="border-t border-border pt-3">
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+              {job.createdAt && (
+                <div>Created: {new Date(job.createdAt).toLocaleDateString()}</div>
+              )}
+              {job.updatedAt && (
+                <div>Updated: {new Date(job.updatedAt).toLocaleDateString()}</div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Actions footer */}
+      <div className="px-4 py-2.5 border-t border-border bg-muted/20 flex items-center gap-2">
+        {job.source === "openclaw" && (
+          <Button
+            variant={job.enabled ? "outline" : "default"}
+            size="sm"
+            className="text-xs"
+            onClick={() => onToggle(!job.enabled)}
+          >
+            {job.enabled ? "Disable" : "Enable"}
+          </Button>
+        )}
+        {job.issueId && (
+          <Link to={`/issues/${job.issueId}`}>
+            <Button variant="outline" size="sm" className="text-xs">
+              Open Issue <ArrowUpRight className="h-3 w-3 ml-1" />
+            </Button>
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Scheduling.tsx
+++ b/ui/src/pages/Scheduling.tsx
@@ -44,7 +44,9 @@ function getWeekStart(date: Date): Date {
 
 function getMonthStartGrid(date: Date): Date {
   const first = new Date(date.getFullYear(), date.getMonth(), 1);
-  return addDays(first, -first.getDay());
+  // Start on Monday (consistent with week view)
+  const day = first.getDay();
+  return addDays(first, -((day + 6) % 7));
 }
 
 function formatDateLabel(date: Date): string {
@@ -627,7 +629,7 @@ function MonthView({
   const gridStart = getMonthStartGrid(date);
   const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
   const currentMonth = date.getMonth();
-  const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- New "Schedule" page showing OpenClaw cron jobs and Paperclip recurring tasks in a unified view
- Reads OpenClaw cron data from `~/.openclaw/cron/jobs.json` (same source as Mission Control)
- Calendar views: agenda (flat timeline), week (7-column grid), month (42-cell grid)
- Click a calendar day → job list filters to that day's scheduled jobs
- Full detail panel with schedule, timing, agent, model, and complete prompt text
- Source filter (All/OpenClaw/Paperclip), agent filter, project filter, state filter
- Enable/disable OpenClaw cron jobs directly from the UI
- 5-second auto-refresh for real-time status updates

## How it works
- Backend reads `~/.openclaw/cron/jobs.json` for OpenClaw jobs and queries DB for Paperclip recurring issues
- Both normalized into `UnifiedScheduledJob` type with `source` field
- Cron occurrence calculator plots jobs on calendar views
- Toggle writes back to `jobs.json` to enable/disable OpenClaw jobs

## Test plan
- [ ] Navigate to Schedule page — shows OpenClaw cron jobs (blue) + Paperclip recurring tasks (purple)
- [ ] Switch between agenda/week/month views
- [ ] Click a day in week view → job list filters to that day
- [ ] Click a job → detail panel shows full prompt, schedule, agent info
- [ ] Filter by source, agent, state — filters update correctly
- [ ] Toggle enable/disable on an OpenClaw job

🤖 Generated with [Claude Code](https://claude.com/claude-code)