### PR TITLE
fix(claude-local): check result payload before exit code in hello probe

### DIFF
--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -186,6 +186,25 @@ export async function testEnvironment(
             ? `Run \`claude login\` and complete sign-in at ${loginMeta.loginUrl}, then retry.`
             : "Run `claude login` in this environment, then retry the probe.",
         });
+      } else if (parsed && asString(parsed.subtype, "") === "success") {
+        // Claude responded successfully — trust the result even if exit code
+        // is non-zero (e.g. an MCP server failed to connect but the response
+        // itself completed fine).
+        const summary = parsedStream.summary.trim();
+        const hasHello = /\bhello\b/i.test(summary);
+        checks.push({
+          code: hasHello ? "claude_hello_probe_passed" : "claude_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "Claude hello probe succeeded."
+            : "Claude probe ran but did not return `hello` as expected.",
+          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+          ...(hasHello
+            ? {}
+            : {
+                hint: "Try the probe manually (`claude --print - --output-format stream-json --verbose`) and prompt `Respond with hello`.",
+              }),
+        });
       } else if ((probe.exitCode ?? 1) === 0) {
         const summary = parsedStream.summary.trim();
         const hasHello = /\bhello\b/i.test(summary);


### PR DESCRIPTION
## Summary

- Claude CLI can exit with code 1 even when the response succeeds (e.g. when an MCP server like `planetscale` fails to connect with `needs-auth`)
- The hello probe previously relied solely on exit code, causing **false failures** during agent creation environment test
- Now checks `result.subtype === "success"` from the stream-json output before falling back to exit code

## Test plan

- [ ] Configure a Claude local agent with an MCP server that fails to connect (e.g. `planetscale` with `needs-auth`)
- [ ] Run "Test Environment" — should pass if Claude responds successfully despite non-zero exit code
- [ ] Verify probe still fails correctly when Claude genuinely fails (e.g. invalid model, auth required)