### PR TITLE
docs(skill): document attachment API (upload/list/download)

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -256,6 +256,9 @@ PATCH /api/agents/{agentId}/instructions-path
 | List agents                           | `GET /api/companies/:companyId/agents`                                                     |
 | Dashboard                             | `GET /api/companies/:companyId/dashboard`                                                  |
 | Search issues                         | `GET /api/companies/:companyId/issues?q=search+term`                                       |
+| Upload attachment (image)             | `POST /api/companies/:companyId/issues/:issueId/attachments` (multipart, `file` field)     |
+| List attachments                      | `GET /api/issues/:issueId/attachments`                                                     |
+| Get attachment content                | `GET /api/attachments/:attachmentId/content`                                               |
 
 ## Searching Issues
 
@@ -266,6 +269,23 @@ GET /api/companies/{companyId}/issues?q=dockerfile
 ```
 
 Results are ranked by relevance: title matches first, then identifier, description, and comments. You can combine `q` with other filters (`status`, `assigneeAgentId`, `projectId`, `labelId`).
+
+## Attachments
+
+Upload images to issues using multipart form-data:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -F "file=@/path/to/screenshot.png" \
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/{issueId}/attachments"
+```
+
+- The upload endpoint is **company-scoped**: `/api/companies/{companyId}/issues/{issueId}/attachments`
+- Only `image/*` MIME types are currently accepted
+- Each attachment response includes a `contentPath` for downloading (e.g. `/api/attachments/{id}/content`)
+- List all attachments on an issue: `GET /api/issues/{issueId}/attachments`
 
 ## Self-Test Playbook (App-Level)
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -256,7 +256,7 @@ PATCH /api/agents/{agentId}/instructions-path
 | List agents                           | `GET /api/companies/:companyId/agents`                                                     |
 | Dashboard                             | `GET /api/companies/:companyId/dashboard`                                                  |
 | Search issues                         | `GET /api/companies/:companyId/issues?q=search+term`                                       |
-| Upload attachment                     | `POST /api/companies/:companyId/issues/:issueId/attachments` (multipart, `file` field)     |
+| Attach file to issue                  | `POST /api/companies/:companyId/issues/:issueId/attachments` (multipart, `file` field)     |
 | List attachments                      | `GET /api/issues/:issueId/attachments`                                                     |
 | Get attachment content                | `GET /api/attachments/:attachmentId/content`                                               |
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -259,6 +259,7 @@ PATCH /api/agents/{agentId}/instructions-path
 | Attach file to issue                  | `POST /api/companies/:companyId/issues/:issueId/attachments` (multipart, `file` field)     |
 | List attachments                      | `GET /api/issues/:issueId/attachments`                                                     |
 | Get attachment content                | `GET /api/attachments/:attachmentId/content`                                               |
+| Delete attachment                     | `DELETE /api/attachments/:attachmentId`                                                    |
 
 ## Searching Issues
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -283,7 +283,7 @@ curl -X POST \
 ```
 
 - The upload endpoint is **company-scoped**: `/api/companies/{companyId}/issues/{issueId}/attachments`
-- Default accepted types: `image/*`, `application/pdf`, `text/markdown`, `text/plain`, `application/json`, `text/csv`, `text/html` — operators can expand via `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES`
+- Default accepted types: `image/png`, `image/jpeg`, `image/jpg`, `image/webp`, `image/gif`, `application/pdf`, `text/markdown`, `text/plain`, `application/json`, `text/csv`, `text/html` — operators can expand via `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES`
 - Each attachment response includes a `contentPath` for downloading (e.g. `/api/attachments/{id}/content`)
 - List all attachments on an issue: `GET /api/issues/{issueId}/attachments`
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -280,10 +280,13 @@ curl -X POST \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -F "file=@/path/to/screenshot.png" \
   "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/$PAPERCLIP_TASK_ID/attachments"
+# Note: $PAPERCLIP_TASK_ID is only set when this heartbeat was triggered for a specific task.
+# Replace it with the target issueId when attaching to a different issue.
 ```
 
 - The upload endpoint is **company-scoped**: `/api/companies/{companyId}/issues/{issueId}/attachments`
 - Default accepted types: `image/png`, `image/jpeg`, `image/jpg`, `image/webp`, `image/gif`, `application/pdf`, `text/markdown`, `text/plain`, `application/json`, `text/csv`, `text/html` — operators can expand via `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES`
+- Default maximum file size is **10 MB**; operators can override via `PAPERCLIP_ATTACHMENT_MAX_BYTES`
 - Each attachment response includes a `contentPath` for downloading (e.g. `/api/attachments/{id}/content`)
 - List all attachments on an issue: `GET /api/issues/{issueId}/attachments`
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -256,7 +256,7 @@ PATCH /api/agents/{agentId}/instructions-path
 | List agents                           | `GET /api/companies/:companyId/agents`                                                     |
 | Dashboard                             | `GET /api/companies/:companyId/dashboard`                                                  |
 | Search issues                         | `GET /api/companies/:companyId/issues?q=search+term`                                       |
-| Upload attachment (image)             | `POST /api/companies/:companyId/issues/:issueId/attachments` (multipart, `file` field)     |
+| Upload attachment                     | `POST /api/companies/:companyId/issues/:issueId/attachments` (multipart, `file` field)     |
 | List attachments                      | `GET /api/issues/:issueId/attachments`                                                     |
 | Get attachment content                | `GET /api/attachments/:attachmentId/content`                                               |
 
@@ -272,18 +272,18 @@ Results are ranked by relevance: title matches first, then identifier, descripti
 
 ## Attachments
 
-Upload images to issues using multipart form-data:
+Upload files to issues using multipart form-data:
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -F "file=@/path/to/screenshot.png" \
-  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/{issueId}/attachments"
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/$PAPERCLIP_TASK_ID/attachments"
 ```
 
 - The upload endpoint is **company-scoped**: `/api/companies/{companyId}/issues/{issueId}/attachments`
-- Only `image/*` MIME types are currently accepted
+- Default accepted types: `image/*`, `application/pdf`, `text/markdown`, `text/plain`, `application/json`, `text/csv`, `text/html` — operators can expand via `PAPERCLIP_ALLOWED_ATTACHMENT_TYPES`
 - Each attachment response includes a `contentPath` for downloading (e.g. `/api/attachments/{id}/content`)
 - List all attachments on an issue: `GET /api/issues/{issueId}/attachments`
 


### PR DESCRIPTION
## Summary

- Adds upload/list/download attachment endpoints to the **Key Endpoints** quick reference table in `skills/paperclip/SKILL.md`
- Adds a new **Attachments** section with a curl example, accepted MIME types, and usage notes

## Motivation

The attachment API (`POST /api/companies/{companyId}/issues/{issueId}/attachments`) exists and works, but agents can't discover it because the skill docs don't mention it. An agent tried to upload a screenshot and hit a 404 on `/api/issues/{id}/attachments` (wrong path) — the correct company-scoped route was only found through trial and error. This change makes the endpoint discoverable so agents can use attachments without guessing.

Fixes #28

## Changes

- **+3 rows** to Key Endpoints table (upload, list, download)
- **+1 section** ("Attachments") with curl example and 4 bullet points

## Review feedback addressed

- Corrected MIME type docs to match `server/src/attachment-types.ts` (not image-only — also PDF, markdown, plain text, JSON, CSV, HTML)
- Removed image-only language from table label and section opener
- Switched to `$PAPERCLIP_TASK_ID` for consistent placeholder style in curl example

---

🤖 This PR was authored by an AI agent via [Paperclip](https://paperclip.ing)