### PR TITLE
Emit skipped wakeup receipts for paused timer heartbeats

### DIFF
--- a/server/src/__tests__/heartbeat-skipped-receipts.test.ts
+++ b/server/src/__tests__/heartbeat-skipped-receipts.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const mockBudgetService = vi.hoisted(() => ({
+  getInvocationBlock: vi.fn(),
+}));
+
+vi.mock("../services/budgets.js", () => ({
+  budgetService: () => mockBudgetService,
+}));
+
+type SelectResult = unknown[];
+
+function createDbStub(selectResults: SelectResult[]) {
+  const pendingSelects = [...selectResults];
+  const inserted: unknown[] = [];
+
+  const selectWhere = vi.fn(async () => pendingSelects.shift() ?? []);
+  const selectThen = vi.fn((resolve: (value: unknown[]) => unknown) => Promise.resolve(resolve(pendingSelects.shift() ?? [])));
+  const selectFrom = vi.fn(() => ({
+    where: selectWhere,
+    then: selectThen,
+  }));
+  const select = vi.fn(() => ({
+    from: selectFrom,
+  }));
+
+  const insertValues = vi.fn(async (value: unknown) => {
+    inserted.push(value);
+    return [];
+  });
+  const insert = vi.fn(() => ({
+    values: insertValues,
+  }));
+
+  return {
+    db: {
+      select,
+      insert,
+    },
+    inserted,
+    insertValues,
+  };
+}
+
+describe("heartbeatService skipped wakeup receipts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBudgetService.getInvocationBlock.mockResolvedValue(null);
+  });
+
+  it("records a skipped timer wakeup when the agent is paused", async () => {
+    const pausedAgent = {
+      id: "agent-1",
+      companyId: "company-1",
+      adapterType: "codex_local",
+      status: "paused",
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 30,
+          wakeOnDemand: true,
+        },
+      },
+      lastHeartbeatAt: new Date("2026-03-17T10:00:00.000Z"),
+      createdAt: new Date("2026-03-17T09:00:00.000Z"),
+    };
+    const dbStub = createDbStub([[pausedAgent], [pausedAgent]]);
+
+    const service = heartbeatService(dbStub.db as any);
+    const result = await service.tickTimers(new Date("2026-03-17T10:01:00.000Z"));
+
+    expect(result).toEqual({ checked: 1, enqueued: 0, skipped: 1 });
+    expect(dbStub.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyId: "company-1",
+        agentId: "agent-1",
+        source: "timer",
+        reason: "agent.paused",
+        status: "skipped",
+      }),
+    );
+  });
+
+  it("records a skipped wakeup before rejecting a budget-blocked invocation", async () => {
+    const activeAgent = {
+      id: "agent-1",
+      companyId: "company-1",
+      adapterType: "codex_local",
+      status: "running",
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 30,
+          wakeOnDemand: true,
+        },
+      },
+      createdAt: new Date("2026-03-17T09:00:00.000Z"),
+    };
+    const dbStub = createDbStub([[activeAgent]]);
+    mockBudgetService.getInvocationBlock.mockResolvedValue({
+      reason: "Agent budget is paused.",
+      scopeType: "agent",
+      scopeId: "agent-1",
+    });
+
+    const service = heartbeatService(dbStub.db as any);
+
+    await expect(service.wakeup("agent-1")).rejects.toMatchObject({
+      status: 409,
+    });
+    expect(dbStub.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyId: "company-1",
+        agentId: "agent-1",
+        source: "on_demand",
+        reason: "budget.blocked",
+        status: "skipped",
+      }),
+    );
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2371,6 +2371,10 @@ export function heartbeatService(db: Db) {
       agent.status === "terminated" ||
       agent.status === "pending_approval"
     ) {
+      await writeSkippedRequest(`agent.${agent.status}`);
+      if (source === "timer") {
+        return null;
+      }
       throw conflict("Agent is not invokable in its current state", { status: agent.status });
     }
 
@@ -3127,7 +3131,7 @@ export function heartbeatService(db: Db) {
       let skipped = 0;
 
       for (const agent of allAgents) {
-        if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
+        if (agent.status === "terminated" || agent.status === "pending_approval") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 


### PR DESCRIPTION
Closes #1120

## Problem
Paused agents are skipped before timer heartbeats reach `enqueueWakeup`, so operators never get an explicit skipped wakeup receipt explaining why no run happened.

## What changed
- route paused timer heartbeats through `enqueueWakeup` instead of silently skipping them
- write skipped wakeup receipts for non-invokable agent states before returning/conflicting
- add focused heartbeat tests for paused timer receipts and budget-blocked receipts

## Validation
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-skipped-receipts.test.ts`