### PR TITLE
fix(ui): restore @mention selection via click, Tab, and Enter

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -552,6 +552,10 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         if (mentionActive) {
           // Space dismisses the popup (let the character be typed normally)
           if (e.key === " ") {
+            if (pendingClearRef.current !== null) {
+              cancelAnimationFrame(pendingClearRef.current);
+              pendingClearRef.current = null;
+            }
             mentionStateRef.current = null;
             setMentionState(null);
             return;
@@ -560,6 +564,10 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           if (e.key === "Escape") {
             e.preventDefault();
             e.stopPropagation();
+            if (pendingClearRef.current !== null) {
+              cancelAnimationFrame(pendingClearRef.current);
+              pendingClearRef.current = null;
+            }
             mentionStateRef.current = null;
             setMentionState(null);
             return;


### PR DESCRIPTION
### Thinking Path

- Paperclip orchestrates AI agents and issue comments are a key control surface for humans.
- Issue comments support `@` mention autocomplete so users can quickly tag an agent.
- In current behavior, the dropdown appears but selection fails for click, Enter, and Tab.
- The root cause is timing: browsers fire `selectionchange` before click/key selection handlers.
- `checkMention()` was clearing `mentionStateRef` synchronously when cursor moved, so by the time selection handlers ran, state was already `null`.
- This PR defers mention dismissal by one animation frame and cancels pending dismissal when selecting, so handlers can consume the current mention state reliably.

## What changed

- **File:** `ui/src/components/MarkdownEditor.tsx`
- Added `pendingClearRef` to track scheduled dismissal.
- Updated `checkMention()` to:
  - cancel any previously scheduled dismissal,
  - schedule dismiss via `requestAnimationFrame` instead of immediate clear when mention is no longer detected.
- Updated `selectMention()` to cancel pending dismissal before reading `mentionStateRef`.
- Added cleanup effect to cancel pending RAF on unmount.

## Why this helps

This prevents a race where `selectionchange` clears mention state just before click/Enter/Tab handlers try to select an option. Result: mention selection works again across mouse and keyboard flows.

## How to verify

1. Start app (`pnpm dev`).
2. Open an issue comment box and type `@` + partial agent name.
3. Confirm dropdown appears.
4. Select by:
   - click,
   - `Enter`,
   - `Tab`.
5. Verify mention inserts correctly in all 3 paths.

## Validation run

- `pnpm --filter @paperclipai/ui typecheck` ✅
- `pnpm --filter @paperclipai/ui build` ✅

## Notes

I also reviewed existing mention-related work:
- #355 (feature request for mention syntax)
- #669 (open PR around mention selection)
- #1112 (multiuser/mentions work)

This PR is a narrow race-condition fix in current `MarkdownEditor` behavior.
