### PR TITLE
fix(opencode-local): resolve HOME from os.userInfo() for model discovery

### DIFF
--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -21,7 +21,7 @@ function resolveOpenCodeCommand(input: unknown): string {
 
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
-const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID"]);
+const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
 
 function dedupeModels(models: AdapterModel[]): AdapterModel[] {
   const seen = new Set<string>();
@@ -112,7 +112,14 @@ export async function discoverOpenCodeModels(input: {
   // When the server is started via `runuser -u <user>`, HOME may still
   // reflect the parent process (e.g. /root), causing OpenCode to miss
   // provider auth credentials stored under the target user's home.
-  const resolvedHome = os.userInfo().homedir;
+  let resolvedHome: string | undefined;
+  try {
+    resolvedHome = os.userInfo().homedir || undefined;
+  } catch {
+    // os.userInfo() throws a SystemError when the current UID has no
+    // /etc/passwd entry (e.g. `docker run --user 1234` with a minimal
+    // image). Fall back to process.env.HOME.
+  }
   const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}) }));
 
   const result = await runChildProcess(


### PR DESCRIPTION
## Summary

- When the Paperclip server is started via `runuser -u node` (common in Docker/Fly.io deployments), the `HOME` env var retains the parent process's value (e.g. `/root`) instead of the target user's home (`/home/node`)
- This causes `opencode models` child processes to miss provider auth credentials stored under the actual user's home directory
- Providers requiring API keys (e.g. `zai`, `zhipuai`) fail model discovery, resulting in `"Configured OpenCode model is unavailable"` errors — even though the adapter test endpoint passes and `opencode models` works when run directly as the correct user
- Fix uses `os.userInfo().homedir` (reads from `/etc/passwd`, not the env) to ensure the child process always sees the correct HOME

## Reproduction

1. Deploy Paperclip in a Docker container where the entrypoint runs as root and drops to `node` via `runuser -u node`
2. Configure an agent with a provider that stores auth under `~/.local/share/opencode/auth.json` (e.g. `zai-coding-plan/glm-5`)
3. Trigger a heartbeat — model discovery fails because `opencode models` inherits `HOME=/root` and can't find the auth file at `/home/node/.local/share/opencode/auth.json`

## Test plan

- [ ] Verify `opencode models` returns the full model list (including auth-gated providers) when spawned from the adapter
- [ ] Verify model discovery cache key still works correctly with the HOME override
- [ ] Verify no regression for providers that don't require auth (e.g. github-copilot-enterprise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)