### PR TITLE
Validate X-Paperclip-Run-Id as UUID, support multi-value assigneeAgentId

### DIFF
--- a/server/src/__tests__/auth-run-id-validation.test.ts
+++ b/server/src/__tests__/auth-run-id-validation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { actorMiddleware } from "../middleware/auth.js";
+
+function mockReq(headers: Record<string, string> = {}): Request {
+  return {
+    header: (name: string) => headers[name.toLowerCase()],
+    actor: { type: "none", source: "none" },
+  } as unknown as Request;
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      res.body = data;
+      return res;
+    },
+  };
+  return res as unknown as Response;
+}
+
+describe("actorMiddleware run ID validation", () => {
+  const fakeDb = {} as Parameters<typeof actorMiddleware>[0];
+
+  it("rejects non-UUID X-Paperclip-Run-Id with 400", async () => {
+    const middleware = actorMiddleware(fakeDb, { deploymentMode: "local_trusted" });
+    const req = mockReq({ "x-paperclip-run-id": "manual-hb-1773752289" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid UUID X-Paperclip-Run-Id", async () => {
+    const middleware = actorMiddleware(fakeDb, { deploymentMode: "local_trusted" });
+    const req = mockReq({ "x-paperclip-run-id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.actor.runId).toBe("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d");
+  });
+
+  it("allows requests without X-Paperclip-Run-Id", async () => {
+    const middleware = actorMiddleware(fakeDb, { deploymentMode: "local_trusted" });
+    const req = mockReq({});
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("rejects 'none' as run ID", async () => {
+    const middleware = actorMiddleware(fakeDb, { deploymentMode: "local_trusted" });
+    const req = mockReq({ "x-paperclip-run-id": "none" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentApiKeys, agents, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
-import type { DeploymentMode } from "@paperclipai/shared";
+import { isUuidLike, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 
@@ -18,13 +18,17 @@ interface ActorMiddlewareOptions {
 }
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
-  return async (req, _res, next) => {
+  return async (req, res, next) => {
     req.actor =
       opts.deploymentMode === "local_trusted"
         ? { type: "board", userId: "local-board", isInstanceAdmin: true, source: "local_implicit" }
         : { type: "none", source: "none" };
 
     const runIdHeader = req.header("x-paperclip-run-id");
+    if (runIdHeader && !isUuidLike(runIdHeader)) {
+      res.status(400).json({ error: "X-Paperclip-Run-Id must be a valid UUID" });
+      return;
+    }
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -19,7 +19,7 @@ import {
   projectWorkspaces,
   projects,
 } from "@paperclipai/db";
-import { extractProjectMentionIds } from "@paperclipai/shared";
+import { extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -503,12 +503,14 @@ export function issueService(db: Db) {
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
       if (filters?.assigneeAgentId) {
-        const agentIds = filters.assigneeAgentId.split(",").map((s) => s.trim());
-        conditions.push(
-          agentIds.length === 1
-            ? eq(issues.assigneeAgentId, agentIds[0])
-            : inArray(issues.assigneeAgentId, agentIds),
-        );
+        const agentIds = filters.assigneeAgentId.split(",").map((s) => s.trim()).filter(isUuidLike);
+        if (agentIds.length > 0) {
+          conditions.push(
+            agentIds.length === 1
+              ? eq(issues.assigneeAgentId, agentIds[0])
+              : inArray(issues.assigneeAgentId, agentIds),
+          );
+        }
       }
       if (filters?.assigneeUserId) {
         conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -503,7 +503,12 @@ export function issueService(db: Db) {
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
       if (filters?.assigneeAgentId) {
-        conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+        const agentIds = filters.assigneeAgentId.split(",").map((s) => s.trim());
+        conditions.push(
+          agentIds.length === 1
+            ? eq(issues.assigneeAgentId, agentIds[0])
+            : inArray(issues.assigneeAgentId, agentIds),
+        );
       }
       if (filters?.assigneeUserId) {
         conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));


### PR DESCRIPTION
Fixes #1136

Non-UUID values in `X-Paperclip-Run-Id` (e.g. `manual-hb-1773752289`, `heartbeat-*`, `none`) get passed directly to PostgreSQL, which rejects them with `invalid input syntax for type uuid`, returning 500 instead of 400.

This validates the header early in the auth middleware using the existing `isUuidLike` helper and returns a 400 with a clear message.

Also fixes the `assigneeAgentId` query parameter to support comma-separated UUIDs (matching the existing `status` filter pattern), since passing `?assigneeAgentId=uuid1,uuid2` was treated as a single string and caused the same PostgresError.