### PR TITLE
feat: allow managers with direct reports to assign tasks

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -107,6 +107,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       if (allowedByGrant) return;
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
       if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
+      if (actorAgent && actorAgent.companyId === companyId) {
+        const isManager = await agentsSvc.hasDirectReports(companyId, req.actor.agentId);
+        if (isManager) return;
+      }
       throw forbidden("Missing permission: tasks:assign");
     }
     throw unauthorized();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -93,7 +93,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
-  async function assertCanAssignTasks(req: Request, companyId: string) {
+  async function assertCanAssignTasks(req: Request, companyId: string, targetAgentId?: string | null) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
       if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
@@ -109,7 +109,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
       if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
       if (actorAgent && actorAgent.companyId === companyId) {
         const isManager = await agentsSvc.hasDirectReports(companyId, req.actor.agentId);
-        if (isManager) return;
+        if (isManager) {
+          // Managers may only assign within their direct team. If the target is
+          // another agent (not null / a user assignment), verify it reports to them.
+          if (targetAgentId) {
+            const inTeam = await agentsSvc.isDirectReport(companyId, req.actor.agentId, targetAgentId);
+            if (!inTeam) throw forbidden("Managers may only assign tasks to their direct reports");
+          }
+          return;
+        }
       }
       throw forbidden("Missing permission: tasks:assign");
     }
@@ -757,7 +765,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
-      await assertCanAssignTasks(req, companyId);
+      await assertCanAssignTasks(req, companyId, req.body.assigneeAgentId ?? null);
     }
 
     const actor = getActorInfo(req);
@@ -819,7 +827,9 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
     if (assigneeWillChange) {
       if (!isAgentReturningIssueToCreator) {
-        await assertCanAssignTasks(req, existing.companyId);
+        const newAssigneeAgentId =
+          req.body.assigneeAgentId !== undefined ? req.body.assigneeAgentId : existing.assigneeAgentId;
+        await assertCanAssignTasks(req, existing.companyId, newAssigneeAgentId ?? null);
       }
     }
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -525,7 +525,23 @@ export function agentService(db: Db) {
       const rows = await db
         .select({ id: agents.id })
         .from(agents)
-        .where(and(eq(agents.companyId, companyId), eq(agents.reportsTo, agentId)))
+        .where(and(eq(agents.companyId, companyId), eq(agents.reportsTo, agentId), ne(agents.status, "terminated")))
+        .limit(1);
+      return rows.length > 0;
+    },
+
+    isDirectReport: async (companyId: string, managerAgentId: string, targetAgentId: string): Promise<boolean> => {
+      const rows = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(
+          and(
+            eq(agents.companyId, companyId),
+            eq(agents.reportsTo, managerAgentId),
+            eq(agents.id, targetAgentId),
+            ne(agents.status, "terminated"),
+          ),
+        )
         .limit(1);
       return rows.length > 0;
     },

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -521,6 +521,15 @@ export function agentService(db: Db) {
       return updated ? normalizeAgentRow(updated) : null;
     },
 
+    hasDirectReports: async (companyId: string, agentId: string): Promise<boolean> => {
+      const rows = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.companyId, companyId), eq(agents.reportsTo, agentId)))
+        .limit(1);
+      return rows.length > 0;
+    },
+
     listConfigRevisions: async (id: string) =>
       db
         .select()


### PR DESCRIPTION
## Summary

Managers (agents with at least one direct report) were unable to assign tasks to their team members. This fix automatically grants task-assignment permission to any agent that has direct reports, without requiring an explicit `tasks:assign` permission grant.

- **`server/src/services/agents.ts`** — added `hasDirectReports(companyId, agentId)` helper that queries whether any agent has `reportsTo` set to the given agent
- **`server/src/routes/issues.ts`** — updated `assertCanAssignTasks` to call `hasDirectReports`; any agent managing at least one direct report is now permitted to assign tasks

## Test plan

- [ ] Verify an agent with direct reports can assign tasks (e.g. SRE Lead assigning to SRE team members)
- [ ] Verify an agent with no direct reports and no `tasks:assign` grant still cannot assign tasks
- [ ] Verify CEO/board users still retain assignment capability
- [ ] Verify newly-promoted agents gain the capability as soon as a direct report is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)