### PR TITLE
fix: add npm provenance package metadata

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -16,10 +16,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip.git",
+    "url": "https://github.com/paperclipai/paperclip",
     "directory": "cli"
   },
   "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-utils",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapter-utils"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-claude-local",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/claude-local"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-codex-local",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/codex-local"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/cursor-local/package.json
+++ b/packages/adapters/cursor-local/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-cursor-local",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/cursor-local"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/gemini-local/package.json
+++ b/packages/adapters/gemini-local/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-gemini-local",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/gemini-local"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/openclaw-gateway/package.json
+++ b/packages/adapters/openclaw-gateway/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-openclaw-gateway",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/openclaw-gateway"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-opencode-local",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/opencode-local"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapters/pi-local/package.json
+++ b/packages/adapters/pi-local/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/adapter-pi-local",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/pi-local"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/db",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/db"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/plugins/create-paperclip-plugin/package.json
+++ b/packages/plugins/create-paperclip-plugin/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/create-paperclip-plugin",
   "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/plugins/create-paperclip-plugin"
+  },
   "type": "module",
   "bin": {
     "create-paperclip-plugin": "./dist/index.js"

--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -2,6 +2,16 @@
   "name": "@paperclipai/plugin-sdk",
   "version": "1.0.0",
   "description": "Stable public API for Paperclip plugins — worker-side context and UI bridge hooks",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/plugins/sdk"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/shared",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/shared"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/scripts/generate-npm-package-json.mjs
+++ b/scripts/generate-npm-package-json.mjs
@@ -94,6 +94,7 @@ const publishPkg = {
   license: cliPkg.license,
   repository: cliPkg.repository,
   homepage: cliPkg.homepage,
+  bugs: cliPkg.bugs,
   files: cliPkg.files,
   engines: { node: ">=20" },
   dependencies: sortedDeps,

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@paperclipai/server",
   "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "server"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## Summary
- add required npm provenance metadata to every published package manifest
- normalize repository.url to https://github.com/paperclipai/paperclip
- preserve the same metadata in the generated publishable CLI manifest

## Verification
- metadata audit across all non-private published packages
- regenerate CLI publish manifest and confirm required metadata is preserved