### PR TITLE
fix: advance canary after partial publish

### DIFF
--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -133,29 +133,38 @@ NODE
 
 next_canary_version() {
   local stable_version="$1"
-  local versions_json
+  shift
 
-  versions_json="$(npm view paperclipai versions --json 2>/dev/null || echo '[]')"
-
-  node - "$stable_version" "$versions_json" <<'NODE'
+  node - "$stable_version" "$@" <<'NODE'
 const stable = process.argv[2];
-const versionsArg = process.argv[3];
-
-let versions = [];
-try {
-  const parsed = JSON.parse(versionsArg);
-  versions = Array.isArray(parsed) ? parsed : [parsed];
-} catch {
-  versions = [];
-}
+const packageNames = process.argv.slice(3);
+const { execSync } = require("node:child_process");
 
 const pattern = new RegExp(`^${stable.replace(/\./g, '\\.')}-canary\\.(\\d+)$`);
 let max = -1;
 
-for (const version of versions) {
-  const match = version.match(pattern);
-  if (!match) continue;
-  max = Math.max(max, Number(match[1]));
+for (const packageName of packageNames) {
+  let versions = [];
+
+  try {
+    const raw = execSync(`npm view ${JSON.stringify(packageName)} versions --json`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      versions = Array.isArray(parsed) ? parsed : [parsed];
+    }
+  } catch {
+    versions = [];
+  }
+
+  for (const version of versions) {
+    const match = version.match(pattern);
+    if (!match) continue;
+    max = Math.max(max, Number(match[1]));
+  }
 }
 
 process.stdout.write(`${stable}-canary.${max + 1}`);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -122,9 +122,14 @@ TARGET_STABLE_VERSION="$(stable_version_for_date "$RELEASE_DATE")"
 TARGET_PUBLISH_VERSION="$TARGET_STABLE_VERSION"
 DIST_TAG="latest"
 
+PUBLIC_PACKAGE_INFO="$(list_public_package_info)"
+mapfile -t PUBLIC_PACKAGE_NAMES < <(printf '%s\n' "$PUBLIC_PACKAGE_INFO" | cut -f2)
+
+[ -n "$PUBLIC_PACKAGE_INFO" ] || release_fail "no public packages were found in the workspace."
+
 if [ "$channel" = "canary" ]; then
   require_on_master_branch
-  TARGET_PUBLISH_VERSION="$(next_canary_version "$TARGET_STABLE_VERSION")"
+  TARGET_PUBLISH_VERSION="$(next_canary_version "$TARGET_STABLE_VERSION" "${PUBLIC_PACKAGE_NAMES[@]}")"
   DIST_TAG="canary"
   tag_name="$(canary_tag_name "$TARGET_PUBLISH_VERSION")"
 else
@@ -135,11 +140,6 @@ NOTES_FILE="$(release_notes_file "$TARGET_STABLE_VERSION")"
 
 require_clean_worktree
 require_npm_publish_auth "$dry_run"
-
-PUBLIC_PACKAGE_INFO="$(list_public_package_info)"
-PUBLIC_PACKAGE_NAMES="$(printf '%s\n' "$PUBLIC_PACKAGE_INFO" | cut -f2)"
-
-[ -n "$PUBLIC_PACKAGE_INFO" ] || release_fail "no public packages were found in the workspace."
 
 if [ "$channel" = "stable" ] && [ ! -f "$NOTES_FILE" ]; then
   release_fail "stable release notes file is required at $NOTES_FILE before publishing stable."
@@ -158,7 +158,7 @@ while IFS= read -r package_name; do
   if npm_package_version_exists "$package_name" "$TARGET_PUBLISH_VERSION"; then
     release_fail "npm version ${package_name}@${TARGET_PUBLISH_VERSION} already exists."
   fi
-done <<< "$PUBLIC_PACKAGE_NAMES"
+done <<< "$(printf '%s\n' "${PUBLIC_PACKAGE_NAMES[@]}")"
 
 release_info ""
 release_info "==> Release plan"


### PR DESCRIPTION
## Summary
- compute the next canary ordinal from the whole publish set instead of only the paperclipai package
- avoid reusing canary.0 when a release partially published some workspace packages before failing

## Verification
- bash -n scripts/release.sh scripts/release-lib.sh
- manual check against current npm state confirms the old logic reused 2026.3.17-canary.0 because paperclipai had no 2026.3.17 canary yet, while other published packages already did