### PR TITLE
feat(plugins): add agent-routines plugin with cron scheduling (#219)

### DIFF
--- a/packages/plugins/examples/plugin-agent-routines/package.json
+++ b/packages/plugins/examples/plugin-agent-routines/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@paperclipai/plugin-agent-routines",
+  "version": "0.1.0",
+  "description": "Run agents on cron schedules with specific prompts",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/plugins/examples/plugin-agent-routines/src/cron-match.ts
+++ b/packages/plugins/examples/plugin-agent-routines/src/cron-match.ts
@@ -1,0 +1,205 @@
+/**
+ * Lightweight cron matching for the agent-routines plugin worker.
+ *
+ * Re-implements the core parsing logic from `server/src/services/cron.ts`
+ * since plugin workers cannot import server modules. Only includes the
+ * subset needed for matching — no nextCronTick or scheduling helpers.
+ *
+ * Supports standard 5-field cron expressions:
+ *
+ *   ┌────────────── minute (0–59)
+ *   │ ┌──────────── hour   (0–23)
+ *   │ │ ┌────────── day of month (1–31)
+ *   │ │ │ ┌──────── month  (1–12)
+ *   │ │ │ │ ┌────── day of week (0–6, Sun=0)
+ *   │ │ │ │ │
+ *   * * * * *
+ *
+ * Supported syntax per field: *, N, N-M, N/S, N-M/S, comma-separated lists.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ParsedCron {
+  minutes: number[];
+  hours: number[];
+  daysOfMonth: number[];
+  months: number[];
+  daysOfWeek: number[];
+}
+
+interface FieldSpec {
+  min: number;
+  max: number;
+  name: string;
+}
+
+const FIELD_SPECS: FieldSpec[] = [
+  { min: 0, max: 59, name: "minute" },
+  { min: 0, max: 23, name: "hour" },
+  { min: 1, max: 31, name: "day of month" },
+  { min: 1, max: 12, name: "month" },
+  { min: 0, max: 6, name: "day of week" },
+];
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function validateBounds(value: number, spec: FieldSpec): void {
+  if (value < spec.min || value > spec.max) {
+    throw new Error(
+      `Value ${value} out of range [${spec.min}–${spec.max}] for cron ${spec.name} field`,
+    );
+  }
+}
+
+function parseField(token: string, spec: FieldSpec): number[] {
+  const values = new Set<number>();
+  const parts = token.split(",");
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed === "") {
+      throw new Error(`Empty element in cron ${spec.name} field`);
+    }
+
+    // Step syntax: X/S
+    const slashIdx = trimmed.indexOf("/");
+    if (slashIdx !== -1) {
+      const base = trimmed.slice(0, slashIdx);
+      const stepStr = trimmed.slice(slashIdx + 1);
+      const step = parseInt(stepStr, 10);
+      if (isNaN(step) || step <= 0) {
+        throw new Error(`Invalid step "${stepStr}" in cron ${spec.name} field`);
+      }
+
+      let rangeStart = spec.min;
+      let rangeEnd = spec.max;
+
+      if (base === "*") {
+        // */S
+      } else if (base.includes("-")) {
+        const [a, b] = base.split("-").map((s) => parseInt(s, 10));
+        if (isNaN(a!) || isNaN(b!)) {
+          throw new Error(`Invalid range "${base}" in cron ${spec.name} field`);
+        }
+        rangeStart = a!;
+        rangeEnd = b!;
+      } else {
+        const start = parseInt(base, 10);
+        if (isNaN(start)) {
+          throw new Error(`Invalid start "${base}" in cron ${spec.name} field`);
+        }
+        rangeStart = start;
+      }
+
+      validateBounds(rangeStart, spec);
+      validateBounds(rangeEnd, spec);
+
+      for (let i = rangeStart; i <= rangeEnd; i += step) {
+        values.add(i);
+      }
+      continue;
+    }
+
+    // Range syntax: N-M
+    if (trimmed.includes("-")) {
+      const [aStr, bStr] = trimmed.split("-");
+      const a = parseInt(aStr!, 10);
+      const b = parseInt(bStr!, 10);
+      if (isNaN(a) || isNaN(b)) {
+        throw new Error(`Invalid range "${trimmed}" in cron ${spec.name} field`);
+      }
+      validateBounds(a, spec);
+      validateBounds(b, spec);
+      if (a > b) {
+        throw new Error(
+          `Invalid range ${a}-${b} in cron ${spec.name} field (start > end)`,
+        );
+      }
+      for (let i = a; i <= b; i++) {
+        values.add(i);
+      }
+      continue;
+    }
+
+    // Wildcard
+    if (trimmed === "*") {
+      for (let i = spec.min; i <= spec.max; i++) {
+        values.add(i);
+      }
+      continue;
+    }
+
+    // Single value
+    const val = parseInt(trimmed, 10);
+    if (isNaN(val)) {
+      throw new Error(`Invalid value "${trimmed}" in cron ${spec.name} field`);
+    }
+    validateBounds(val, spec);
+    values.add(val);
+  }
+
+  if (values.size === 0) {
+    throw new Error(`Empty result for cron ${spec.name} field`);
+  }
+
+  return [...values].sort((a, b) => a - b);
+}
+
+function parseCron(expression: string): ParsedCron {
+  const trimmed = expression.trim();
+  if (!trimmed) {
+    throw new Error("Cron expression must not be empty");
+  }
+
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length !== 5) {
+    throw new Error(
+      `Cron expression must have exactly 5 fields, got ${tokens.length}: "${trimmed}"`,
+    );
+  }
+
+  return {
+    minutes: parseField(tokens[0]!, FIELD_SPECS[0]!),
+    hours: parseField(tokens[1]!, FIELD_SPECS[1]!),
+    daysOfMonth: parseField(tokens[2]!, FIELD_SPECS[2]!),
+    months: parseField(tokens[3]!, FIELD_SPECS[3]!),
+    daysOfWeek: parseField(tokens[4]!, FIELD_SPECS[4]!),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a cron expression matches the given date at minute-level
+ * granularity (UTC). Returns `true` if the current minute matches.
+ */
+export function shouldFireAt(cronExpression: string, date: Date): boolean {
+  const parsed = parseCron(cronExpression);
+  return (
+    parsed.minutes.includes(date.getUTCMinutes()) &&
+    parsed.hours.includes(date.getUTCHours()) &&
+    parsed.daysOfMonth.includes(date.getUTCDate()) &&
+    parsed.months.includes(date.getUTCMonth() + 1) &&
+    parsed.daysOfWeek.includes(date.getUTCDay())
+  );
+}
+
+/**
+ * Validate a cron expression string. Returns `null` if valid, or an error
+ * message string if invalid.
+ */
+export function validateCronExpression(expression: string): string | null {
+  try {
+    parseCron(expression);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}

--- a/packages/plugins/examples/plugin-agent-routines/src/cron-match.ts
+++ b/packages/plugins/examples/plugin-agent-routines/src/cron-match.ts
@@ -179,16 +179,34 @@ function parseCron(expression: string): ParsedCron {
 /**
  * Check whether a cron expression matches the given date at minute-level
  * granularity (UTC). Returns `true` if the current minute matches.
+ *
+ * Uses standard vixie-cron OR semantics for the day fields: when both
+ * day-of-month and day-of-week are restricted (non-wildcard), the date
+ * matches if *either* field matches. When only one is restricted, only
+ * that field is checked.
  */
 export function shouldFireAt(cronExpression: string, date: Date): boolean {
   const parsed = parseCron(cronExpression);
-  return (
-    parsed.minutes.includes(date.getUTCMinutes()) &&
-    parsed.hours.includes(date.getUTCHours()) &&
-    parsed.daysOfMonth.includes(date.getUTCDate()) &&
-    parsed.months.includes(date.getUTCMonth() + 1) &&
-    parsed.daysOfWeek.includes(date.getUTCDay())
-  );
+
+  if (
+    !parsed.minutes.includes(date.getUTCMinutes()) ||
+    !parsed.hours.includes(date.getUTCHours()) ||
+    !parsed.months.includes(date.getUTCMonth() + 1)
+  ) {
+    return false;
+  }
+
+  // Vixie-cron OR semantics: when both day-of-month and day-of-week are
+  // restricted (neither is the full wildcard range), match if either matches.
+  const domRestricted = parsed.daysOfMonth.length < 31;
+  const dowRestricted = parsed.daysOfWeek.length < 7;
+  const domMatch = parsed.daysOfMonth.includes(date.getUTCDate());
+  const dowMatch = parsed.daysOfWeek.includes(date.getUTCDay());
+
+  if (domRestricted && dowRestricted) {
+    return domMatch || dowMatch;
+  }
+  return domMatch && dowMatch;
 }
 
 /**

--- a/packages/plugins/examples/plugin-agent-routines/src/index.ts
+++ b/packages/plugins/examples/plugin-agent-routines/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-agent-routines/src/manifest.ts
+++ b/packages/plugins/examples/plugin-agent-routines/src/manifest.ts
@@ -1,0 +1,62 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+/**
+ * Manifest for the Agent Routines Plugin.
+ *
+ * Declares a single dispatcher job on a 1-minute cron that evaluates
+ * configured routines and invokes matching agents. Routines are defined
+ * in the instance config — no code changes needed to add/remove routines.
+ *
+ * @see PLUGIN_SPEC.md §6 — Manifest
+ */
+const manifest: PaperclipPluginManifestV1 = {
+  id: "paperclip.agent-routines",
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Agent Routines",
+  description:
+    "Run agents on cron schedules with specific prompts. Define routines in the plugin config to automatically invoke agents at the right time.",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [
+    "jobs.schedule",
+    "agents.invoke",
+    "agents.read",
+    "activity.log.write",
+    "metrics.write",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      routines: {
+        type: "array",
+        maxItems: 20,
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string", description: "Human-readable label for the routine" },
+            cronExpression: { type: "string", description: "5-field cron (e.g. '0 9 * * 1-5')" },
+            agentId: { type: "string", description: "Target agent UUID" },
+            companyId: { type: "string", description: "Company the agent belongs to" },
+            prompt: { type: "string", description: "What the agent should do on each run" },
+            enabled: { type: "boolean", default: true },
+          },
+          required: ["name", "cronExpression", "agentId", "companyId", "prompt"],
+        },
+      },
+    },
+  },
+  jobs: [
+    {
+      jobKey: "routine-dispatcher",
+      displayName: "Routine Dispatcher",
+      description: "Checks enabled routines every minute and invokes matching agents.",
+      schedule: "* * * * *",
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-agent-routines/src/worker.ts
+++ b/packages/plugins/examples/plugin-agent-routines/src/worker.ts
@@ -1,0 +1,118 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import { shouldFireAt, validateCronExpression } from "./cron-match.js";
+
+/**
+ * Routine configuration — each entry maps a cron schedule to an agent prompt.
+ */
+interface Routine {
+  name: string;
+  cronExpression: string;
+  agentId: string;
+  companyId: string;
+  prompt: string;
+  enabled?: boolean;
+}
+
+/**
+ * Agent Routines Plugin worker.
+ *
+ * Registers a single "routine-dispatcher" job handler. The host fires this
+ * job every minute. On each tick, the handler reads the routines array from
+ * the instance config, evaluates each enabled routine's cron expression
+ * against the current time, and invokes matching agents with their prompt.
+ *
+ * Error isolation: individual routine failures are logged and counted but
+ * never prevent other routines from firing in the same tick.
+ */
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.jobs.register("routine-dispatcher", async (job) => {
+      const config = await ctx.config.get() as { routines?: Routine[] };
+      const routines = config?.routines ?? [];
+      const now = new Date(job.scheduledAt);
+
+      let fired = 0;
+      let skipped = 0;
+      let errors = 0;
+
+      for (const routine of routines) {
+        if (routine.enabled === false) {
+          skipped++;
+          continue;
+        }
+
+        if (!shouldFireAt(routine.cronExpression, now)) continue;
+
+        try {
+          const result = await ctx.agents.invoke(routine.agentId, routine.companyId, {
+            prompt: routine.prompt,
+            reason: `Scheduled routine: ${routine.name}`,
+          });
+
+          await ctx.activity.log({
+            companyId: routine.companyId,
+            message: `Routine "${routine.name}" invoked agent ${routine.agentId} (run: ${result.runId})`,
+            entityType: "agent",
+            entityId: routine.agentId,
+          });
+
+          await ctx.metrics.write("routine_invocation_total", 1, {
+            routine: routine.name,
+            status: "success",
+          });
+
+          fired++;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          ctx.logger.error(`Routine "${routine.name}" failed: ${message}`, {
+            routine: routine.name,
+            agentId: routine.agentId,
+            error: message,
+          });
+
+          await ctx.activity.log({
+            companyId: routine.companyId,
+            message: `Routine "${routine.name}" failed to invoke agent ${routine.agentId}: ${message}`,
+            entityType: "agent",
+            entityId: routine.agentId,
+          });
+
+          await ctx.metrics.write("routine_invocation_total", 1, {
+            routine: routine.name,
+            status: "error",
+          });
+
+          errors++;
+        }
+      }
+
+      if (fired > 0 || errors > 0) {
+        ctx.logger.info("Dispatcher tick complete", { fired, skipped, errors });
+      }
+    });
+  },
+
+  async onValidateConfig(config) {
+    const routines = (config as { routines?: Routine[] })?.routines;
+    if (!routines || !Array.isArray(routines)) return { ok: true };
+
+    const errors: string[] = [];
+
+    for (let i = 0; i < routines.length; i++) {
+      const r = routines[i]!;
+      const cronError = validateCronExpression(r.cronExpression);
+      if (cronError) {
+        errors.push(`Routine "${r.name ?? i}": invalid cron expression — ${cronError}`);
+      }
+    }
+
+    return errors.length > 0 ? { ok: false, errors } : { ok: true };
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Agent routines plugin ready" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-agent-routines/src/worker.ts
+++ b/packages/plugins/examples/plugin-agent-routines/src/worker.ts
@@ -41,9 +41,9 @@ const plugin = definePlugin({
           continue;
         }
 
-        if (!shouldFireAt(routine.cronExpression, now)) continue;
-
         try {
+          if (!shouldFireAt(routine.cronExpression, now)) continue;
+
           const result = await ctx.agents.invoke(routine.agentId, routine.companyId, {
             prompt: routine.prompt,
             reason: `Scheduled routine: ${routine.name}`,
@@ -70,17 +70,23 @@ const plugin = definePlugin({
             error: message,
           });
 
-          await ctx.activity.log({
-            companyId: routine.companyId,
-            message: `Routine "${routine.name}" failed to invoke agent ${routine.agentId}: ${message}`,
-            entityType: "agent",
-            entityId: routine.agentId,
-          });
+          try {
+            await ctx.activity.log({
+              companyId: routine.companyId,
+              message: `Routine "${routine.name}" failed to invoke agent ${routine.agentId}: ${message}`,
+              entityType: "agent",
+              entityId: routine.agentId,
+            });
 
-          await ctx.metrics.write("routine_invocation_total", 1, {
-            routine: routine.name,
-            status: "error",
-          });
+            await ctx.metrics.write("routine_invocation_total", 1, {
+              routine: routine.name,
+              status: "error",
+            });
+          } catch (telemetryErr) {
+            ctx.logger.error(`Failed to write telemetry for routine "${routine.name}"`, {
+              error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+            });
+          }
 
           errors++;
         }

--- a/packages/plugins/examples/plugin-agent-routines/tsconfig.json
+++ b/packages/plugins/examples/plugin-agent-routines/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"]
+  },
+  "include": ["src"]
+}

--- a/server/src/__tests__/plugin-agent-routines.test.ts
+++ b/server/src/__tests__/plugin-agent-routines.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Tests for the Agent Routines Plugin.
+ *
+ * Uses the SDK test harness to verify the plugin's dispatcher job handler,
+ * cron matching, config validation, and error isolation.
+ *
+ * @see packages/plugins/examples/plugin-agent-routines/
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk";
+import type { TestHarness, PluginCapability } from "@paperclipai/plugin-sdk";
+import manifest from "../../../packages/plugins/examples/plugin-agent-routines/src/manifest.js";
+import plugin from "../../../packages/plugins/examples/plugin-agent-routines/src/worker.js";
+import { shouldFireAt, validateCronExpression } from "../../../packages/plugins/examples/plugin-agent-routines/src/cron-match.js";
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+const AGENT_SEED = {
+  id: "agent-1",
+  companyId: "co-1",
+  name: "Health Check Agent",
+  title: null,
+  role: "engineer" as const,
+  reportsTo: null,
+  status: "active" as const,
+  adapterType: "codex-local",
+  adapterConfig: {},
+  runtimeConfig: {},
+  permissions: [],
+  capabilities: null,
+  budgetMonthlyCents: 0,
+  metadata: null,
+  terminatedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  urlKey: "health-check-agent",
+};
+
+function createRoutineHarness(config?: Record<string, unknown>): TestHarness {
+  return createTestHarness({
+    manifest,
+    config,
+  });
+}
+
+/** Build a scheduledAt timestamp matching a specific UTC time. */
+function utcDate(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): string {
+  return new Date(Date.UTC(year, month - 1, day, hour, minute, 0)).toISOString();
+}
+
+// ===========================================================================
+// cron-match unit tests
+// ===========================================================================
+
+describe("cron-match", () => {
+  describe("shouldFireAt", () => {
+    it("matches every-minute wildcard", () => {
+      const date = new Date(Date.UTC(2026, 2, 9, 14, 30)); // Mon March 9 2026 14:30 UTC
+      expect(shouldFireAt("* * * * *", date)).toBe(true);
+    });
+
+    it("matches exact minute and hour", () => {
+      const date = new Date(Date.UTC(2026, 2, 9, 9, 0));
+      expect(shouldFireAt("0 9 * * *", date)).toBe(true);
+    });
+
+    it("rejects non-matching minute", () => {
+      const date = new Date(Date.UTC(2026, 2, 9, 9, 5));
+      expect(shouldFireAt("0 9 * * *", date)).toBe(false);
+    });
+
+    it("matches weekday range (Mon-Fri)", () => {
+      // 2026-03-09 is a Monday (day 1)
+      const monday = new Date(Date.UTC(2026, 2, 9, 9, 0));
+      expect(shouldFireAt("0 9 * * 1-5", monday)).toBe(true);
+
+      // 2026-03-08 is a Sunday (day 0)
+      const sunday = new Date(Date.UTC(2026, 2, 8, 9, 0));
+      expect(shouldFireAt("0 9 * * 1-5", sunday)).toBe(false);
+    });
+
+    it("matches step syntax", () => {
+      const date = new Date(Date.UTC(2026, 2, 9, 14, 15));
+      expect(shouldFireAt("*/15 * * * *", date)).toBe(true);
+      expect(shouldFireAt("*/15 * * * *", new Date(Date.UTC(2026, 2, 9, 14, 7)))).toBe(false);
+    });
+
+    it("matches comma-separated values", () => {
+      const date = new Date(Date.UTC(2026, 2, 9, 9, 0));
+      expect(shouldFireAt("0 9,17 * * *", date)).toBe(true);
+
+      const date2 = new Date(Date.UTC(2026, 2, 9, 17, 0));
+      expect(shouldFireAt("0 9,17 * * *", date2)).toBe(true);
+
+      const date3 = new Date(Date.UTC(2026, 2, 9, 12, 0));
+      expect(shouldFireAt("0 9,17 * * *", date3)).toBe(false);
+    });
+
+    it("matches specific day of month", () => {
+      const first = new Date(Date.UTC(2026, 2, 1, 0, 0));
+      expect(shouldFireAt("0 0 1 * *", first)).toBe(true);
+
+      const second = new Date(Date.UTC(2026, 2, 2, 0, 0));
+      expect(shouldFireAt("0 0 1 * *", second)).toBe(false);
+    });
+  });
+
+  describe("validateCronExpression", () => {
+    it("returns null for valid expressions", () => {
+      expect(validateCronExpression("* * * * *")).toBeNull();
+      expect(validateCronExpression("0 9 * * 1-5")).toBeNull();
+      expect(validateCronExpression("*/15 * * * *")).toBeNull();
+      expect(validateCronExpression("0 2 1 * *")).toBeNull();
+    });
+
+    it("returns error for empty expression", () => {
+      expect(validateCronExpression("")).not.toBeNull();
+    });
+
+    it("returns error for wrong number of fields", () => {
+      expect(validateCronExpression("* * *")).not.toBeNull();
+      expect(validateCronExpression("* * * * * *")).not.toBeNull();
+    });
+
+    it("returns error for out-of-range values", () => {
+      expect(validateCronExpression("60 * * * *")).not.toBeNull();
+      expect(validateCronExpression("* 25 * * *")).not.toBeNull();
+      expect(validateCronExpression("* * 32 * *")).not.toBeNull();
+      expect(validateCronExpression("* * * 13 *")).not.toBeNull();
+      expect(validateCronExpression("* * * * 7")).not.toBeNull();
+    });
+
+    it("returns error for invalid syntax", () => {
+      expect(validateCronExpression("abc * * * *")).not.toBeNull();
+      expect(validateCronExpression("* * * * a-b")).not.toBeNull();
+    });
+  });
+});
+
+// ===========================================================================
+// Plugin dispatcher tests
+// ===========================================================================
+
+describe("agent-routines plugin", () => {
+  let h: TestHarness;
+
+  describe("dispatcher fires matching routines", () => {
+    beforeEach(async () => {
+      h = createRoutineHarness({
+        routines: [
+          {
+            name: "Morning health check",
+            cronExpression: "0 9 * * *",
+            agentId: "agent-1",
+            companyId: "co-1",
+            prompt: "Run a production health check",
+            enabled: true,
+          },
+        ],
+      });
+      h.seed({ agents: [{ ...AGENT_SEED }] });
+      await plugin.definition.setup(h.ctx);
+    });
+
+    it("invokes agent when cron matches", async () => {
+      // 9:00 UTC — should match "0 9 * * *"
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      expect(h.activity).toHaveLength(1);
+      expect(h.activity[0].message).toContain("invoked agent agent-1");
+      expect(h.metrics).toHaveLength(1);
+      expect(h.metrics[0].tags).toEqual({ routine: "Morning health check", status: "success" });
+    });
+
+    it("skips agent when cron does not match", async () => {
+      // 10:00 UTC — should NOT match "0 9 * * *"
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 10, 0),
+      });
+
+      expect(h.activity).toHaveLength(0);
+      expect(h.metrics).toHaveLength(0);
+    });
+  });
+
+  describe("disabled routines", () => {
+    it("skips routines with enabled: false", async () => {
+      h = createRoutineHarness({
+        routines: [
+          {
+            name: "Disabled routine",
+            cronExpression: "* * * * *",
+            agentId: "agent-1",
+            companyId: "co-1",
+            prompt: "Should not fire",
+            enabled: false,
+          },
+        ],
+      });
+      h.seed({ agents: [{ ...AGENT_SEED }] });
+      await plugin.definition.setup(h.ctx);
+
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      expect(h.activity).toHaveLength(0);
+      expect(h.metrics).toHaveLength(0);
+    });
+  });
+
+  describe("error isolation", () => {
+    it("failing routine does not block subsequent routines", async () => {
+      h = createRoutineHarness({
+        routines: [
+          {
+            name: "Bad routine",
+            cronExpression: "* * * * *",
+            agentId: "missing-agent",
+            companyId: "co-1",
+            prompt: "This will fail",
+          },
+          {
+            name: "Good routine",
+            cronExpression: "* * * * *",
+            agentId: "agent-1",
+            companyId: "co-1",
+            prompt: "This should succeed",
+          },
+        ],
+      });
+      h.seed({ agents: [{ ...AGENT_SEED }] });
+      await plugin.definition.setup(h.ctx);
+
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      // Both routines should produce activity entries
+      expect(h.activity).toHaveLength(2);
+      expect(h.activity[0].message).toContain("failed");
+      expect(h.activity[1].message).toContain("invoked");
+
+      // Both should write metrics
+      expect(h.metrics).toHaveLength(2);
+      expect(h.metrics[0].tags).toEqual({ routine: "Bad routine", status: "error" });
+      expect(h.metrics[1].tags).toEqual({ routine: "Good routine", status: "success" });
+    });
+
+    it("logs error for paused agent without crashing", async () => {
+      h = createRoutineHarness({
+        routines: [
+          {
+            name: "Paused agent routine",
+            cronExpression: "* * * * *",
+            agentId: "agent-1",
+            companyId: "co-1",
+            prompt: "Target is paused",
+          },
+        ],
+      });
+      h.seed({ agents: [{ ...AGENT_SEED, status: "paused" as const }] });
+      await plugin.definition.setup(h.ctx);
+
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      expect(h.activity).toHaveLength(1);
+      expect(h.activity[0].message).toContain("failed");
+      expect(h.metrics[0].tags).toEqual({ routine: "Paused agent routine", status: "error" });
+      expect(h.logs.some((l) => l.level === "error")).toBe(true);
+    });
+  });
+
+  describe("empty config", () => {
+    it("handles no routines gracefully", async () => {
+      h = createRoutineHarness({});
+      await plugin.definition.setup(h.ctx);
+
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      expect(h.activity).toHaveLength(0);
+      expect(h.metrics).toHaveLength(0);
+    });
+
+    it("handles undefined config gracefully", async () => {
+      h = createRoutineHarness();
+      await plugin.definition.setup(h.ctx);
+
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      expect(h.activity).toHaveLength(0);
+    });
+  });
+
+  describe("multiple matching routines", () => {
+    it("fires all matching routines in a single tick", async () => {
+      h = createRoutineHarness({
+        routines: [
+          {
+            name: "Routine A",
+            cronExpression: "0 9 * * *",
+            agentId: "agent-1",
+            companyId: "co-1",
+            prompt: "Do task A",
+          },
+          {
+            name: "Routine B",
+            cronExpression: "0 9 * * *",
+            agentId: "agent-1",
+            companyId: "co-1",
+            prompt: "Do task B",
+          },
+        ],
+      });
+      h.seed({ agents: [{ ...AGENT_SEED }] });
+      await plugin.definition.setup(h.ctx);
+
+      await h.runJob("routine-dispatcher", {
+        scheduledAt: utcDate(2026, 3, 9, 9, 0),
+      });
+
+      expect(h.activity).toHaveLength(2);
+      expect(h.metrics).toHaveLength(2);
+    });
+  });
+});
+
+// ===========================================================================
+// Config validation
+// ===========================================================================
+
+describe("agent-routines config validation", () => {
+  it("accepts valid config", async () => {
+    const result = await plugin.definition.onValidateConfig!({
+      routines: [
+        {
+          name: "Daily check",
+          cronExpression: "0 9 * * *",
+          agentId: "agent-1",
+          companyId: "co-1",
+          prompt: "Run health check",
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects invalid cron expression", async () => {
+    const result = await plugin.definition.onValidateConfig!({
+      routines: [
+        {
+          name: "Bad cron",
+          cronExpression: "invalid cron",
+          agentId: "agent-1",
+          companyId: "co-1",
+          prompt: "Won't work",
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+    expect(result.errors![0]).toContain("Bad cron");
+  });
+
+  it("rejects out-of-range cron values", async () => {
+    const result = await plugin.definition.onValidateConfig!({
+      routines: [
+        {
+          name: "Bad range",
+          cronExpression: "60 * * * *",
+          agentId: "agent-1",
+          companyId: "co-1",
+          prompt: "Invalid minute",
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("reports errors for multiple invalid routines", async () => {
+    const result = await plugin.definition.onValidateConfig!({
+      routines: [
+        {
+          name: "Bad 1",
+          cronExpression: "invalid",
+          agentId: "a1",
+          companyId: "c1",
+          prompt: "p1",
+        },
+        {
+          name: "Good",
+          cronExpression: "0 9 * * *",
+          agentId: "a2",
+          companyId: "c1",
+          prompt: "p2",
+        },
+        {
+          name: "Bad 2",
+          cronExpression: "* 25 * * *",
+          agentId: "a3",
+          companyId: "c1",
+          prompt: "p3",
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors![0]).toContain("Bad 1");
+    expect(result.errors![1]).toContain("Bad 2");
+  });
+
+  it("accepts empty routines array", async () => {
+    const result = await plugin.definition.onValidateConfig!({ routines: [] });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts config without routines key", async () => {
+    const result = await plugin.definition.onValidateConfig!({});
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Manifest sanity checks
+// ===========================================================================
+
+describe("agent-routines manifest", () => {
+  it("declares required capabilities", () => {
+    expect(manifest.capabilities).toContain("jobs.schedule");
+    expect(manifest.capabilities).toContain("agents.invoke");
+    expect(manifest.capabilities).toContain("agents.read");
+    expect(manifest.capabilities).toContain("activity.log.write");
+    expect(manifest.capabilities).toContain("metrics.write");
+  });
+
+  it("declares routine-dispatcher job with 1-minute cron", () => {
+    expect(manifest.jobs).toHaveLength(1);
+    expect(manifest.jobs![0].jobKey).toBe("routine-dispatcher");
+    expect(manifest.jobs![0].schedule).toBe("* * * * *");
+  });
+
+  it("has a valid instanceConfigSchema", () => {
+    expect(manifest.instanceConfigSchema).toBeDefined();
+    const schema = manifest.instanceConfigSchema as any;
+    expect(schema.properties.routines.type).toBe("array");
+    expect(schema.properties.routines.maxItems).toBe(20);
+  });
+});
+
+// ===========================================================================
+// Health check
+// ===========================================================================
+
+describe("agent-routines health", () => {
+  it("returns ok status", async () => {
+    const health = await plugin.definition.onHealth!();
+    expect(health.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an example plugin that runs agents on cron schedules with configurable prompts
- Routines are defined in the plugin instance config — no code changes needed to add/remove routines
- Lightweight 5-field cron matching (ranges, steps, comma lists)
- Error isolation: individual routine failures don't block others in the same tick
- Config validation rejects invalid cron expressions before saving

## Files (7 total)

- `packages/plugins/examples/plugin-agent-routines/` — plugin source (worker, manifest, cron matcher)
- `server/src/__tests__/plugin-agent-routines.test.ts` — 481-line test suite

## Test plan

- [x] Cron matching: wildcards, exact times, weekday ranges, steps, comma lists, day-of-month
- [x] Cron validation: empty, wrong field count, out-of-range, invalid syntax
- [x] Dispatcher: fires matching routines, skips non-matching, skips disabled
- [x] Error isolation: failing routine doesn't block subsequent routines
- [x] Empty/undefined config handled gracefully
- [x] Multiple matching routines fire in single tick
- [x] Manifest declares correct capabilities and job schedule
- [x] Health check returns ok

Closes #219
Replaces #409 (which had a bloated 100+ file diff from plugin SDK base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)