### PR TITLE
fix: provision agent task assignment grants

### DIFF
--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -7,10 +7,19 @@ const mockAgentService = vi.hoisted(() => ({
   terminate: vi.fn(),
 }));
 
+const mockAccessService = vi.hoisted(() => ({
+  ensureMembership: vi.fn(),
+  setPrincipalGrants: vi.fn(),
+}));
+
 const mockNotifyHireApproved = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/agents.js", () => ({
   agentService: vi.fn(() => mockAgentService),
+}));
+
+vi.mock("../services/access.js", () => ({
+  accessService: vi.fn(() => mockAccessService),
 }));
 
 vi.mock("../services/hire-hook.js", () => ({
@@ -61,6 +70,8 @@ describe("approvalService resolution idempotency", () => {
     mockAgentService.activatePendingApproval.mockResolvedValue(undefined);
     mockAgentService.create.mockResolvedValue({ id: "agent-1" });
     mockAgentService.terminate.mockResolvedValue(undefined);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalGrants.mockResolvedValue(undefined);
     mockNotifyHireApproved.mockResolvedValue(undefined);
   });
 
@@ -102,6 +113,20 @@ describe("approvalService resolution idempotency", () => {
 
     expect(result.applied).toBe(true);
     expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1");
+    expect(mockAccessService.ensureMembership).toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-1",
+      "member",
+      "active",
+    );
+    expect(mockAccessService.setPrincipalGrants).toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-1",
+      [{ permissionKey: "tasks:assign", scope: null }],
+      "board",
+    );
     expect(mockNotifyHireApproved).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/src/__tests__/invite-default-grants.test.ts
+++ b/server/src/__tests__/invite-default-grants.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { grantsFromDefaults } from "../routes/access.js";
+
+describe("grantsFromDefaults", () => {
+  it("adds tasks:assign for agents when invite defaults omit grants", () => {
+    expect(grantsFromDefaults(null, "agent")).toEqual([
+      { permissionKey: "tasks:assign", scope: null },
+    ]);
+  });
+
+  it("preserves explicit agent grants without duplicating tasks:assign", () => {
+    expect(
+      grantsFromDefaults(
+        {
+          agent: {
+            grants: [
+              { permissionKey: "tasks:assign", scope: null },
+              { permissionKey: "joins:approve", scope: { team: "ops" } },
+            ],
+          },
+        },
+        "agent",
+      ),
+    ).toEqual([
+      { permissionKey: "tasks:assign", scope: null },
+      { permissionKey: "joins:approve", scope: { team: "ops" } },
+    ]);
+  });
+
+  it("does not add tasks:assign defaults for human invite grants", () => {
+    expect(grantsFromDefaults(null, "human")).toEqual([]);
+  });
+});

--- a/server/src/__tests__/issues-company-scoped-routes.test.ts
+++ b/server/src/__tests__/issues-company-scoped-routes.test.ts
@@ -1,0 +1,192 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  getAncestors: vi.fn(),
+  findMentionedProjectIds: vi.fn(),
+  update: vi.fn(),
+  listComments: vi.fn(),
+  checkout: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+}));
+
+const mockProjectService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  listByIds: vi.fn(),
+}));
+
+const mockGoalService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getDefaultCompanyGoal: vi.fn(),
+}));
+
+const mockDocumentService = vi.hoisted(() => ({
+  getIssueDocumentPayload: vi.fn(),
+}));
+
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockWorkProductService = vi.hoisted(() => ({
+  listForIssue: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockIssueApprovalService = vi.hoisted(() => ({
+  listApprovalsForIssue: vi.fn(),
+  link: vi.fn(),
+  unlink: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  issueService: () => mockIssueService,
+  accessService: () => mockAccessService,
+  heartbeatService: () => mockHeartbeatService,
+  agentService: () => mockAgentService,
+  projectService: () => mockProjectService,
+  goalService: () => mockGoalService,
+  issueApprovalService: () => mockIssueApprovalService,
+  executionWorkspaceService: () => mockExecutionWorkspaceService,
+  workProductService: () => mockWorkProductService,
+  documentService: () => mockDocumentService,
+  logActivity: mockLogActivity,
+}));
+
+const companyId = "company-1";
+const issueId = "11111111-1111-4111-8111-111111111111";
+const agentId = "22222222-2222-4222-8222-222222222222";
+const otherAgentId = "33333333-3333-4333-8333-333333333333";
+
+function createBoardApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      runId: null,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function createAgentApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("company-scoped issue route aliases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProjectService.listByIds.mockResolvedValue([]);
+    mockDocumentService.getIssueDocumentPayload.mockResolvedValue({});
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+  });
+
+  it("supports company-scoped PATCH for issue assignment updates", async () => {
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId,
+      identifier: "PAP-1",
+      status: "todo",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      title: "Test issue",
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: issueId,
+      companyId,
+      identifier: "PAP-1",
+      status: "todo",
+      assigneeAgentId: otherAgentId,
+      assigneeUserId: null,
+      title: "Test issue",
+    });
+
+    const res = await request(createBoardApp())
+      .patch(`/api/companies/${companyId}/issues/${issueId}`)
+      .send({ assigneeAgentId: otherAgentId });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(issueId, { assigneeAgentId: otherAgentId });
+  });
+
+  it("supports company-scoped checkout aliases for agents", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: issueId,
+      companyId,
+      identifier: "PAP-1",
+      projectId: null,
+    });
+    mockIssueService.checkout.mockResolvedValue({
+      id: issueId,
+      companyId,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${companyId}/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo", "in_review"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(issueId, agentId, ["todo", "in_review"], "run-1");
+  });
+
+  it("supports company-scoped comment listing aliases", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: issueId,
+      companyId,
+      identifier: "PAP-1",
+    });
+    mockIssueService.listComments.mockResolvedValue([{ id: "comment-1", issueId, body: "hi" }]);
+
+    const res = await request(createBoardApp()).get(`/api/companies/${companyId}/issues/${issueId}/comments`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(issueId, {
+      afterCommentId: null,
+      order: "desc",
+      limit: null,
+    });
+    expect(res.body).toEqual([{ id: "comment-1", issueId, body: "hi" }]);
+  });
+});

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1369,36 +1369,45 @@ async function resolveActorEmail(db: Db, req: Request): Promise<string | null> {
   return user?.email ?? null;
 }
 
-function grantsFromDefaults(
+export function grantsFromDefaults(
   defaultsPayload: Record<string, unknown> | null | undefined,
   key: "human" | "agent"
 ): Array<{
   permissionKey: (typeof PERMISSION_KEYS)[number];
   scope: Record<string, unknown> | null;
 }> {
-  if (!defaultsPayload || typeof defaultsPayload !== "object") return [];
-  const scoped = defaultsPayload[key];
-  if (!scoped || typeof scoped !== "object") return [];
-  const grants = (scoped as Record<string, unknown>).grants;
-  if (!Array.isArray(grants)) return [];
   const validPermissionKeys = new Set<string>(PERMISSION_KEYS);
   const result: Array<{
     permissionKey: (typeof PERMISSION_KEYS)[number];
     scope: Record<string, unknown> | null;
   }> = [];
-  for (const item of grants) {
-    if (!item || typeof item !== "object") continue;
-    const record = item as Record<string, unknown>;
-    if (typeof record.permissionKey !== "string") continue;
-    if (!validPermissionKeys.has(record.permissionKey)) continue;
+  if (defaultsPayload && typeof defaultsPayload === "object") {
+    const scoped = defaultsPayload[key];
+    if (scoped && typeof scoped === "object") {
+      const grants = (scoped as Record<string, unknown>).grants;
+      if (Array.isArray(grants)) {
+        for (const item of grants) {
+          if (!item || typeof item !== "object") continue;
+          const record = item as Record<string, unknown>;
+          if (typeof record.permissionKey !== "string") continue;
+          if (!validPermissionKeys.has(record.permissionKey)) continue;
+          result.push({
+            permissionKey: record.permissionKey as (typeof PERMISSION_KEYS)[number],
+            scope:
+              record.scope &&
+              typeof record.scope === "object" &&
+              !Array.isArray(record.scope)
+                ? (record.scope as Record<string, unknown>)
+                : null
+          });
+        }
+      }
+    }
+  }
+  if (key === "agent" && !result.some((grant) => grant.permissionKey === "tasks:assign")) {
     result.push({
-      permissionKey: record.permissionKey as (typeof PERMISSION_KEYS)[number],
-      scope:
-        record.scope &&
-        typeof record.scope === "object" &&
-        !Array.isArray(record.scope)
-          ? (record.scope as Record<string, unknown>)
-          : null
+      permissionKey: "tasks:assign",
+      scope: null,
     });
   }
   return result;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -71,6 +71,21 @@ export function agentRoutes(db: Db) {
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
+  async function ensureAgentCompanyAccessDefaults(
+    companyId: string,
+    agentId: string,
+    grantedByUserId: string | null,
+  ) {
+    await access.ensureMembership(companyId, "agent", agentId, "member", "active");
+    await access.setPrincipalGrants(
+      companyId,
+      "agent",
+      agentId,
+      [{ permissionKey: "tasks:assign", scope: null }],
+      grantedByUserId,
+    );
+  }
+
   async function assertCanCreateAgentsForCompany(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
@@ -809,6 +824,11 @@ export function agentRoutes(db: Db) {
 
     let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
     const actor = getActorInfo(req);
+    await ensureAgentCompanyAccessDefaults(
+      companyId,
+      agent.id,
+      actor.actorType === "user" ? actor.actorId : null,
+    );
 
     if (requiresApproval) {
       const requestedAdapterType = normalizedHireInput.adapterType ?? agent.adapterType;
@@ -933,6 +953,11 @@ export function agentRoutes(db: Db) {
     });
 
     const actor = getActorInfo(req);
+    await ensureAgentCompanyAccessDefaults(
+      companyId,
+      agent.id,
+      actor.actorType === "user" ? actor.actorId : null,
+    );
     await logActivity(db, {
       companyId,
       actorType: actor.actorType,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -168,6 +168,19 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return rawId;
   }
 
+  function routeIssueId(req: Request): string {
+    return (req.params.id as string | undefined) ?? (req.params.issueId as string | undefined) ?? "";
+  }
+
+  function assertIssueCompanyPathMatches(req: Request, res: Response, companyId: string) {
+    const pathCompanyId = typeof req.params.companyId === "string" ? req.params.companyId : "";
+    if (pathCompanyId && pathCompanyId !== companyId) {
+      res.status(422).json({ error: "Issue does not belong to company" });
+      return false;
+    }
+    return true;
+  }
+
   // Resolve issue identifiers (e.g. "PAP-39") to UUIDs for all /issues/:id routes
   router.param("id", async (req, res, next, rawId) => {
     try {
@@ -295,13 +308,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(removed);
   });
 
-  router.get("/issues/:id", async (req, res) => {
-    const id = req.params.id as string;
+  router.get(["/issues/:id", "/companies/:companyId/issues/:issueId"], async (req, res) => {
+    const id = routeIssueId(req);
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, issue.companyId)) return;
     assertCompanyAccess(req, issue.companyId);
     const [ancestors, project, goal, mentionedProjectIds, documentPayload] = await Promise.all([
       svc.getAncestors(issue.id),
@@ -792,13 +806,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.status(201).json(issue);
   });
 
-  router.patch("/issues/:id", validate(updateIssueSchema), async (req, res) => {
-    const id = req.params.id as string;
+  router.patch(["/issues/:id", "/companies/:companyId/issues/:issueId"], validate(updateIssueSchema), async (req, res) => {
+    const id = routeIssueId(req);
     const existing = await svc.getById(id);
     if (!existing) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, existing.companyId)) return;
     assertCompanyAccess(req, existing.companyId);
     const assigneeWillChange =
       (req.body.assigneeAgentId !== undefined && req.body.assigneeAgentId !== existing.assigneeAgentId) ||
@@ -1023,13 +1038,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(issue);
   });
 
-  router.post("/issues/:id/checkout", validate(checkoutIssueSchema), async (req, res) => {
-    const id = req.params.id as string;
+  router.post(["/issues/:id/checkout", "/companies/:companyId/issues/:issueId/checkout"], validate(checkoutIssueSchema), async (req, res) => {
+    const id = routeIssueId(req);
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, issue.companyId)) return;
     assertCompanyAccess(req, issue.companyId);
 
     if (issue.projectId) {
@@ -1091,13 +1107,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(updated);
   });
 
-  router.post("/issues/:id/release", async (req, res) => {
-    const id = req.params.id as string;
+  router.post(["/issues/:id/release", "/companies/:companyId/issues/:issueId/release"], async (req, res) => {
+    const id = routeIssueId(req);
     const existing = await svc.getById(id);
     if (!existing) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, existing.companyId)) return;
     assertCompanyAccess(req, existing.companyId);
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
     const actorRunId = requireAgentRunId(req, res);
@@ -1128,13 +1145,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(released);
   });
 
-  router.get("/issues/:id/comments", async (req, res) => {
-    const id = req.params.id as string;
+  router.get(["/issues/:id/comments", "/companies/:companyId/issues/:issueId/comments"], async (req, res) => {
+    const id = routeIssueId(req);
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, issue.companyId)) return;
     assertCompanyAccess(req, issue.companyId);
     const afterCommentId =
       typeof req.query.after === "string" && req.query.after.trim().length > 0
@@ -1162,14 +1180,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(comments);
   });
 
-  router.get("/issues/:id/comments/:commentId", async (req, res) => {
-    const id = req.params.id as string;
+  router.get(["/issues/:id/comments/:commentId", "/companies/:companyId/issues/:issueId/comments/:commentId"], async (req, res) => {
+    const id = routeIssueId(req);
     const commentId = req.params.commentId as string;
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, issue.companyId)) return;
     assertCompanyAccess(req, issue.companyId);
     const comment = await svc.getComment(commentId);
     if (!comment || comment.issueId !== id) {
@@ -1179,13 +1198,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(comment);
   });
 
-  router.post("/issues/:id/comments", validate(addIssueCommentSchema), async (req, res) => {
-    const id = req.params.id as string;
+  router.post(["/issues/:id/comments", "/companies/:companyId/issues/:issueId/comments"], validate(addIssueCommentSchema), async (req, res) => {
+    const id = routeIssueId(req);
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (!assertIssueCompanyPathMatches(req, res, issue.companyId)) return;
     assertCompanyAccess(req, issue.companyId);
     if (!(await assertAgentRunCheckoutOwnership(req, res, issue))) return;
 

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { redactCurrentUserText } from "../log-redaction.js";
+import { accessService } from "./access.js";
 import { agentService } from "./agents.js";
 import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
@@ -15,12 +16,28 @@ function redactApprovalComment<T extends { body: string }>(comment: T): T {
 }
 
 export function approvalService(db: Db) {
+  const access = accessService(db);
   const agentsSvc = agentService(db);
   const budgets = budgetService(db);
   const canResolveStatuses = new Set(["pending", "revision_requested"]);
   const resolvableStatuses = Array.from(canResolveStatuses);
   type ApprovalRecord = typeof approvals.$inferSelect;
   type ResolutionResult = { approval: ApprovalRecord; applied: boolean };
+
+  async function ensureAgentCompanyAccessDefaults(
+    companyId: string,
+    agentId: string,
+    grantedByUserId: string | null,
+  ) {
+    await access.ensureMembership(companyId, "agent", agentId, "member", "active");
+    await access.setPrincipalGrants(
+      companyId,
+      "agent",
+      agentId,
+      [{ permissionKey: "tasks:assign", scope: null }],
+      grantedByUserId,
+    );
+  }
 
   async function getExistingApproval(id: string) {
     const existing = await db
@@ -112,6 +129,11 @@ export function approvalService(db: Db) {
         const payloadAgentId = typeof payload.agentId === "string" ? payload.agentId : null;
         if (payloadAgentId) {
           await agentsSvc.activatePendingApproval(payloadAgentId);
+          await ensureAgentCompanyAccessDefaults(
+            updated.companyId,
+            payloadAgentId,
+            decidedByUserId,
+          );
           hireApprovedAgentId = payloadAgentId;
         } else {
           const created = await agentsSvc.create(updated.companyId, {
@@ -136,6 +158,7 @@ export function approvalService(db: Db) {
             permissions: undefined,
             lastHeartbeatAt: null,
           });
+          await ensureAgentCompanyAccessDefaults(updated.companyId, created.id, decidedByUserId);
           hireApprovedAgentId = created?.id ?? null;
         }
         if (hireApprovedAgentId) {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -483,6 +483,17 @@ export function companyPortabilityService(db: Db) {
   const agents = agentService(db);
   const access = accessService(db);
 
+  async function ensureAgentCompanyAccessDefaults(companyId: string, agentId: string) {
+    await access.ensureMembership(companyId, "agent", agentId, "member", "active");
+    await access.setPrincipalGrants(
+      companyId,
+      "agent",
+      agentId,
+      [{ permissionKey: "tasks:assign", scope: null }],
+      null,
+    );
+  }
+
   async function resolveSource(source: CompanyPortabilityPreview["source"]): Promise<ResolvedSource> {
     if (source.type === "inline") {
       return {
@@ -942,6 +953,7 @@ export function companyPortabilityService(db: Db) {
             });
             continue;
           }
+          await ensureAgentCompanyAccessDefaults(targetCompany.id, updated.id);
           importedSlugToAgentId.set(planAgent.slug, updated.id);
           existingSlugToAgentId.set(normalizeAgentUrlKey(updated.name) ?? updated.id, updated.id);
           resultAgents.push({
@@ -955,6 +967,7 @@ export function companyPortabilityService(db: Db) {
         }
 
         const created = await agents.create(targetCompany.id, patch);
+        await ensureAgentCompanyAccessDefaults(targetCompany.id, created.id);
         importedSlugToAgentId.set(planAgent.slug, created.id);
         existingSlugToAgentId.set(normalizeAgentUrlKey(created.name) ?? created.id, created.id);
         resultAgents.push({


### PR DESCRIPTION
## Summary
- enroll newly created, approved, and imported agents into company memberships and grant them `tasks:assign`
- make agent join/invite defaults include `tasks:assign` when no explicit agent grants are provided
- add focused tests for approval side effects and default invite grants

## Why
Agent-to-agent reassignment was blocked in practice because many agents were never added to `company_memberships`, so grant checks in the issues route could never succeed even after assignment-related permissions were modeled.

## Verification
- `pnpm exec vitest run server/src/__tests__/approvals-service.test.ts server/src/__tests__/invite-default-grants.test.ts`
- `pnpm --filter @paperclipai/server typecheck`