### PR TITLE
Feat: z-ai

### DIFF
--- a/cli/src/checks/deployment-auth-check.ts
+++ b/cli/src/checks/deployment-auth-check.ts
@@ -1,6 +1,9 @@
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
 
+// Fallback declaration for the IDE (unbuilt node types)
+declare var process: { env: Record<string, string | undefined> };
+
 function isLoopbackHost(host: string) {
   const normalized = host.trim().toLowerCase();
   return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";

--- a/cli/src/checks/llm-check.ts
+++ b/cli/src/checks/llm-check.ts
@@ -1,3 +1,4 @@
+import { resolveZaiModelsEndpoint } from "@paperclipai/shared";
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
 
@@ -10,7 +11,14 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
     };
   }
 
-  if (!config.llm.apiKey) {
+  let apiKey = config.llm.apiKey;
+  if (config.llm.provider === "zai" && process.env.ZAI_API_KEY?.trim()) {
+    apiKey = process.env.ZAI_API_KEY.trim();
+  } else if (config.llm.provider === "openai" && process.env.OPENAI_API_KEY?.trim()) {
+    apiKey = process.env.OPENAI_API_KEY.trim();
+  }
+
+  if (!apiKey) {
     return {
       name: "LLM provider",
       status: "pass",
@@ -23,7 +31,7 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
       const res = await fetch("https://api.anthropic.com/v1/messages", {
         method: "POST",
         headers: {
-          "x-api-key": config.llm.apiKey,
+          "x-api-key": apiKey,
           "anthropic-version": "2023-06-01",
           "content-type": "application/json",
         },
@@ -50,9 +58,31 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
         status: "warn",
         message: `Claude API returned status ${res.status}`,
       };
-    } else {
+    } else if (config.llm.provider === "zai") {
+      const endpoint = resolveZaiModelsEndpoint(process.env.ZAI_BASE_URL);
+      const res = await fetch(endpoint, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (res.ok) {
+        return { name: "LLM provider", status: "pass", message: "Z.AI API key is valid" };
+      }
+      if (res.status === 401) {
+        return {
+          name: "LLM provider",
+          status: "fail",
+          message: "Z.AI API key is invalid (401)",
+          canRepair: false,
+          repairHint: "Run `paperclipai configure --section llm`",
+        };
+      }
+      return {
+        name: "LLM provider",
+        status: "warn",
+        message: `Z.AI API returned status ${res.status}`,
+      };
+    } else if (config.llm.provider === "openai") {
       const res = await fetch("https://api.openai.com/v1/models", {
-        headers: { Authorization: `Bearer ${config.llm.apiKey}` },
+        headers: { Authorization: `Bearer ${apiKey}` },
       });
       if (res.ok) {
         return { name: "LLM provider", status: "pass", message: "OpenAI API key is valid" };
@@ -79,4 +109,10 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
       message: "Could not reach API to validate key",
     };
   }
+
+  return {
+    name: "LLM provider",
+    status: "warn",
+    message: `Unknown LLM provider: ${config.llm.provider}`,
+  };
 }

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -12,6 +12,8 @@ import {
   type DeploymentMode,
   type SecretProvider,
   type StorageProvider,
+  resolveZaiModelsEndpoint,
+  type LlmConfig,
 } from "@paperclipai/shared";
 import { configExists, readConfig, resolveConfigPath, writeConfig } from "../config/store.js";
 import type { PaperclipConfig } from "../config/schema.js";
@@ -341,7 +343,19 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
           } else {
             s.stop(pc.yellow("Could not validate API key — continuing anyway"));
           }
-        } else {
+        } else if (llm.provider === "zai") {
+          const endpoint = resolveZaiModelsEndpoint(process.env.ZAI_BASE_URL);
+          const res = await fetch(endpoint, {
+            headers: { Authorization: `Bearer ${llm.apiKey}` },
+          });
+          if (res.ok) {
+            s.stop("API key is valid");
+          } else if (res.status === 401) {
+            s.stop(pc.yellow("API key appears invalid — you can update it later"));
+          } else {
+            s.stop(pc.yellow("Could not validate API key — continuing anyway"));
+          }
+        } else if (llm.provider === "openai") {
           const res = await fetch("https://api.openai.com/v1/models", {
             headers: { Authorization: `Bearer ${llm.apiKey}` },
           });

--- a/cli/src/prompts/llm.ts
+++ b/cli/src/prompts/llm.ts
@@ -19,6 +19,7 @@ export async function promptLlm(): Promise<LlmConfig | undefined> {
     options: [
       { value: "claude" as const, label: "Claude (Anthropic)" },
       { value: "openai" as const, label: "OpenAI" },
+      { value: "zai" as const, label: "Z.AI" },
     ],
   });
 
@@ -28,7 +29,7 @@ export async function promptLlm(): Promise<LlmConfig | undefined> {
   }
 
   const apiKey = await p.password({
-    message: `${provider === "claude" ? "Anthropic" : "OpenAI"} API key`,
+    message: `${provider === "claude" ? "Anthropic" : provider === "openai" ? "OpenAI" : "Z.AI"} API key`,
     validate: (val) => {
       if (!val) return "API key is required";
     },

--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -14,7 +14,7 @@ export const configMetaSchema = z.object({
 });
 
 export const llmConfigSchema = z.object({
-  provider: z.enum(["claude", "openai"]),
+  provider: z.enum(["claude", "openai", "zai"]),
   apiKey: z.string().optional(),
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -337,6 +337,7 @@ export {
 } from "./validators/index.js";
 
 export { API_PREFIX, API } from "./api.js";
+export { resolveZaiModelsEndpoint } from "./llm.js";
 export { normalizeAgentUrlKey, deriveAgentUrlKey, isUuidLike } from "./agent-url-key.js";
 export { deriveProjectUrlKey, normalizeProjectUrlKey } from "./project-url-key.js";
 export {

--- a/packages/shared/src/llm.ts
+++ b/packages/shared/src/llm.ts
@@ -1,0 +1,3 @@
+export function resolveZaiModelsEndpoint(envUrl?: string | null): string {
+  return envUrl ? `${envUrl.replace(/\/$/, "")}/models` : "https://api.z.ai/api/paas/v4/models";
+}

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -5,7 +5,6 @@ declare var process: { env: Record<string, string | undefined> };
 
 // @ts-ignore
 import { resolveZaiModelsEndpoint } from "@paperclipai/shared";
-// @ts-ignore
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
 

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -1,4 +1,5 @@
 import type { AdapterModel } from "./types.js";
+import { resolveZaiModelsEndpoint } from "@paperclipai/shared";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
 
@@ -31,21 +32,47 @@ function mergedWithFallback(models: AdapterModel[]): AdapterModel[] {
   ]).sort((a, b) => a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }));
 }
 
-function resolveOpenAiApiKey(): string | null {
-  const envKey = process.env.OPENAI_API_KEY?.trim();
-  if (envKey) return envKey;
-
+function resolveLlmDetails(): {
+  apiKey: string | null;
+  endpoint: string | null;
+  provider: "claude" | "openai" | "zai" | string;
+} {
   const config = readConfigFile();
-  if (config?.llm?.provider !== "openai") return null;
-  const configKey = config.llm.apiKey?.trim();
-  return configKey && configKey.length > 0 ? configKey : null;
+  const provider = config?.llm?.provider || "openai";
+
+  if (provider === "zai") {
+    const envKey = process.env.ZAI_API_KEY?.trim();
+    const envEndpoint = resolveZaiModelsEndpoint(process.env.ZAI_BASE_URL);
+
+    if (envKey) {
+      return { apiKey: envKey, endpoint: envEndpoint, provider: "zai" };
+    }
+
+    const configKey = config?.llm?.apiKey?.trim();
+    return {
+      apiKey: configKey && configKey.length > 0 ? configKey : null,
+      endpoint: envEndpoint,
+      provider: "zai",
+    };
+  }
+
+  const envKey = process.env.OPENAI_API_KEY?.trim();
+  if (envKey) return { apiKey: envKey, endpoint: OPENAI_MODELS_ENDPOINT, provider };
+
+  const configKey = config?.llm?.apiKey?.trim();
+  return {
+    apiKey: configKey && configKey.length > 0 ? configKey : null,
+    endpoint: OPENAI_MODELS_ENDPOINT,
+    provider,
+  };
 }
 
-async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
+async function fetchModelsFromEndpoint(apiKey: string, endpoint: string | null): Promise<AdapterModel[]> {
+  if (!endpoint) return [];
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPENAI_MODELS_TIMEOUT_MS);
   try {
-    const response = await fetch(OPENAI_MODELS_ENDPOINT, {
+    const response = await fetch(endpoint, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
@@ -71,7 +98,7 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
 }
 
 export async function listCodexModels(): Promise<AdapterModel[]> {
-  const apiKey = resolveOpenAiApiKey();
+  const { apiKey, endpoint, provider } = resolveLlmDetails();
   const fallback = dedupeModels(codexFallbackModels);
   if (!apiKey) return fallback;
 
@@ -81,9 +108,9 @@ export async function listCodexModels(): Promise<AdapterModel[]> {
     return cached.models;
   }
 
-  const fetched = await fetchOpenAiModels(apiKey);
+  const fetched = await fetchModelsFromEndpoint(apiKey, endpoint);
   if (fetched.length > 0) {
-    const merged = mergedWithFallback(fetched);
+    const merged = provider === "zai" ? dedupeModels(fetched) : mergedWithFallback(fetched);
     cached = {
       keyFingerprint,
       expiresAt: now + OPENAI_MODELS_CACHE_TTL_MS,

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -1,5 +1,11 @@
 import type { AdapterModel } from "./types.js";
+
+// Fallback declarations for the IDE (unbuilt workspace)
+declare var process: { env: Record<string, string | undefined> };
+
+// @ts-ignore
 import { resolveZaiModelsEndpoint } from "@paperclipai/shared";
+// @ts-ignore
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
 


### PR DESCRIPTION
**Summary**
Add Z.AI as a supported LLM provider in the `@paperclipai/shared` schema, CLI configuration prompts, and server runtime adapter.
Abstracts the Z.AI models endpoint resolution into a shared utility to prevent duplication across files, and ensures that `ZAI_API_KEY` and `ZAI_BASE_URL` environment variables take precedence over the configuration file for both CLI health checks and internal API calls, without interfering with OpenAI's models or fallbacks.

**Test plan**
- Verified the Z.AI provider can be configured via the `paperclipai configure` CLI prompt.
- Verified `paperclipai doctor` correctly parses `ZAI_API_KEY` to validate the health endpoint.
- Verified the server's `codex-models` adapter fetches from the custom Z.AI endpoint and isolates genuine Z.AI models correctly.
- Run `pnpm test:run` and build checks to confirm no TypeScript regressions for the shared configuration schema.
