### PR TITLE
feat: implement issue due dates

### DIFF
--- a/packages/db/src/migrations/0026_issue_due_date.sql
+++ b/packages/db/src/migrations/0026_issue_due_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "issues" ADD COLUMN "due_at" timestamp with time zone;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1772807461603,
       "tag": "0025_nasty_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1773936000000,
+      "tag": "0026_issue_due_date",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -44,6 +44,7 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    dueAt: timestamp("due_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -77,6 +77,7 @@ export interface Issue {
   completedAt: Date | null;
   cancelledAt: Date | null;
   hiddenAt: Date | null;
+  dueAt: Date | null;
   labelIds?: string[];
   labels?: IssueLabel[];
   project?: Project | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -22,6 +22,7 @@ export const createIssueSchema = z.object({
   billingCode: z.string().optional().nullable(),
   assigneeAdapterOverrides: issueAssigneeAdapterOverridesSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
+  dueAt: z.string().datetime().nullable().optional(),
 });
 
 export type CreateIssue = z.infer<typeof createIssueSchema>;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -421,8 +421,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
 
     const actor = getActorInfo(req);
+    const { dueAt: dueAtRaw, ...createFields } = req.body;
     const issue = await svc.create(companyId, {
-      ...req.body,
+      ...createFields,
+      ...(dueAtRaw !== undefined ? { dueAt: dueAtRaw ? new Date(dueAtRaw) : null } : {}),
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
     });
@@ -484,9 +486,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
 
-    const { comment: commentBody, hiddenAt: hiddenAtRaw, ...updateFields } = req.body;
+    const { comment: commentBody, hiddenAt: hiddenAtRaw, dueAt: dueAtRaw, ...updateFields } = req.body;
     if (hiddenAtRaw !== undefined) {
       updateFields.hiddenAt = hiddenAtRaw ? new Date(hiddenAtRaw) : null;
+    }
+    if (dueAtRaw !== undefined) {
+      updateFields.dueAt = dueAtRaw ? new Date(dueAtRaw) : null;
     }
     let issue;
     try {

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -17,7 +17,7 @@ import { formatDate, cn, projectUrl } from "../lib/utils";
 import { timeAgo } from "../lib/timeAgo";
 import { Separator } from "@/components/ui/separator";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { User, Hexagon, ArrowUpRight, Tag, Plus, Trash2 } from "lucide-react";
+import { User, Hexagon, ArrowUpRight, Tag, Plus, Trash2, Calendar } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
 
 interface IssuePropertiesProps {
@@ -107,6 +107,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
   const [projectSearch, setProjectSearch] = useState("");
   const [labelsOpen, setLabelsOpen] = useState(false);
   const [labelSearch, setLabelSearch] = useState("");
+  const [dueOpen, setDueOpen] = useState(false);
   const [newLabelName, setNewLabelName] = useState("");
   const [newLabelColor, setNewLabelColor] = useState("#6366f1");
 
@@ -502,6 +503,60 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
           ) : undefined}
         >
           {projectContent}
+        </PropertyPicker>
+
+        <PropertyPicker
+          inline={inline}
+          label="Due date"
+          open={dueOpen}
+          onOpenChange={setDueOpen}
+          triggerContent={
+            issue.dueAt ? (
+              <>
+                <Calendar className={cn(
+                  "h-3.5 w-3.5",
+                  new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
+                    ? "text-red-500"
+                    : "text-orange-500",
+                )} />
+                <span className={cn(
+                  "text-sm",
+                  new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
+                    ? "text-red-500"
+                    : "text-foreground",
+                )}>
+                  {new Date(issue.dueAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                </span>
+              </>
+            ) : (
+              <>
+                <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">No due date</span>
+              </>
+            )
+          }
+          popoverClassName="w-56"
+        >
+          <div className="space-y-2 p-1">
+            <input
+              type="datetime-local"
+              className="w-full px-2 py-1.5 text-xs bg-transparent outline-none rounded border border-border"
+              value={issue.dueAt ? new Date(new Date(issue.dueAt).getTime() - new Date(issue.dueAt).getTimezoneOffset() * 60000).toISOString().slice(0, 16) : ""}
+              onChange={(e) => {
+                onUpdate({ dueAt: e.target.value ? new Date(e.target.value).toISOString() : null });
+                setDueOpen(false);
+              }}
+              autoFocus={!inline}
+            />
+            {issue.dueAt && (
+              <button
+                className="text-[11px] text-destructive hover:underline"
+                onClick={() => { onUpdate({ dueAt: null }); setDueOpen(false); }}
+              >
+                Clear due date
+              </button>
+            )}
+          </div>
         </PropertyPicker>
 
         {issue.parentId && (

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -108,6 +108,9 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
   const [labelsOpen, setLabelsOpen] = useState(false);
   const [labelSearch, setLabelSearch] = useState("");
   const [dueOpen, setDueOpen] = useState(false);
+  const [localDueAt, setLocalDueAt] = useState(
+    issue.dueAt ? new Date(new Date(issue.dueAt).getTime() - new Date(issue.dueAt).getTimezoneOffset() * 60000).toISOString().slice(0, 16) : "",
+  );
   const [newLabelName, setNewLabelName] = useState("");
   const [newLabelColor, setNewLabelColor] = useState("#6366f1");
 
@@ -511,29 +514,24 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
           open={dueOpen}
           onOpenChange={setDueOpen}
           triggerContent={
-            issue.dueAt ? (
-              <>
-                <Calendar className={cn(
-                  "h-3.5 w-3.5",
-                  new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
-                    ? "text-red-500"
-                    : "text-orange-500",
-                )} />
-                <span className={cn(
-                  "text-sm",
-                  new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
-                    ? "text-red-500"
-                    : "text-foreground",
-                )}>
-                  {new Date(issue.dueAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
-                </span>
-              </>
-            ) : (
-              <>
-                <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-sm text-muted-foreground">No due date</span>
-              </>
-            )
+            (() => {
+              if (!issue.dueAt) return (
+                <>
+                  <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">No due date</span>
+                </>
+              );
+              const dueDate = new Date(issue.dueAt);
+              const isOverdue = dueDate < new Date() && !["done", "cancelled"].includes(issue.status);
+              return (
+                <>
+                  <Calendar className={cn("h-3.5 w-3.5", isOverdue ? "text-red-500" : "text-orange-500")} />
+                  <span className={cn("text-sm", isOverdue ? "text-red-500" : "text-foreground")}>
+                    {dueDate.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                  </span>
+                </>
+              );
+            })()
           }
           popoverClassName="w-56"
         >
@@ -541,21 +539,30 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
             <input
               type="datetime-local"
               className="w-full px-2 py-1.5 text-xs bg-transparent outline-none rounded border border-border"
-              value={issue.dueAt ? new Date(new Date(issue.dueAt).getTime() - new Date(issue.dueAt).getTimezoneOffset() * 60000).toISOString().slice(0, 16) : ""}
-              onChange={(e) => {
-                onUpdate({ dueAt: e.target.value ? new Date(e.target.value).toISOString() : null });
-                setDueOpen(false);
-              }}
+              value={localDueAt}
+              onChange={(e) => setLocalDueAt(e.target.value)}
               autoFocus={!inline}
             />
-            {issue.dueAt && (
+            <div className="flex items-center gap-2">
               <button
-                className="text-[11px] text-destructive hover:underline"
-                onClick={() => { onUpdate({ dueAt: null }); setDueOpen(false); }}
+                className="flex-1 px-2 py-1.5 text-xs rounded border border-border hover:bg-accent/50 disabled:opacity-50"
+                disabled={!localDueAt}
+                onClick={() => {
+                  onUpdate({ dueAt: localDueAt ? new Date(localDueAt).toISOString() : null });
+                  setDueOpen(false);
+                }}
               >
-                Clear due date
+                Apply
               </button>
-            )}
+              {issue.dueAt && (
+                <button
+                  className="text-[11px] text-destructive hover:underline"
+                  onClick={() => { onUpdate({ dueAt: null }); setLocalDueAt(""); setDueOpen(false); }}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
           </div>
         </PropertyPicker>
 

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -660,6 +660,18 @@ export function IssuesList({
                         )}
                       </span>
                     )}
+                    {issue.dueAt && (
+                      <span className={cn(
+                        "text-[11px] font-medium shrink-0",
+                        new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
+                          ? "text-red-500"
+                          : "text-muted-foreground",
+                      )}>
+                        {new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
+                          ? "Overdue"
+                          : `Due ${new Date(issue.dueAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
+                      </span>
+                    )}
                     <Popover
                       open={assigneePickerIssueId === issue.id}
                       onOpenChange={(open) => {

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -660,18 +660,15 @@ export function IssuesList({
                         )}
                       </span>
                     )}
-                    {issue.dueAt && (
-                      <span className={cn(
-                        "text-[11px] font-medium shrink-0",
-                        new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
-                          ? "text-red-500"
-                          : "text-muted-foreground",
-                      )}>
-                        {new Date(issue.dueAt) < new Date() && !["done", "cancelled"].includes(issue.status)
-                          ? "Overdue"
-                          : `Due ${new Date(issue.dueAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
-                      </span>
-                    )}
+                    {issue.dueAt && (() => {
+                      const due = new Date(issue.dueAt as string);
+                      const isOverdue = due < new Date() && !["done", "cancelled"].includes(issue.status);
+                      return (
+                        <span className={cn("text-[11px] font-medium shrink-0", isOverdue ? "text-red-500" : "text-muted-foreground")}>
+                          {isOverdue ? "Overdue" : `Due ${due.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
+                        </span>
+                      );
+                    })()}
                     <Popover
                       open={assigneePickerIssueId === issue.id}
                       onOpenChange={(open) => {

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -183,6 +183,7 @@ export function NewIssueDialog() {
   const [assigneeUseProjectWorkspace, setAssigneeUseProjectWorkspace] = useState(true);
   const [expanded, setExpanded] = useState(false);
   const [dialogCompanyId, setDialogCompanyId] = useState<string | null>(null);
+  const [dueAt, setDueAt] = useState("");
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const effectiveCompanyId = dialogCompanyId ?? selectedCompanyId;
@@ -400,6 +401,7 @@ export function NewIssueDialog() {
     setExpanded(false);
     setDialogCompanyId(null);
     setCompanyOpen(false);
+    setDueAt("");
   }
 
   function handleCompanyChange(companyId: string) {
@@ -437,6 +439,7 @@ export function NewIssueDialog() {
       ...(assigneeId ? { assigneeAgentId: assigneeId } : {}),
       ...(projectId ? { projectId } : {}),
       ...(assigneeAdapterOverrides ? { assigneeAdapterOverrides } : {}),
+      ...(dueAt ? { dueAt: new Date(dueAt).toISOString() } : {}),
     });
   }
 
@@ -923,22 +926,37 @@ export function NewIssueDialog() {
             {uploadDescriptionImage.isPending ? "Uploading..." : "Image"}
           </button>
 
-          {/* More (dates) */}
+          {/* Due date */}
           <Popover open={moreOpen} onOpenChange={setMoreOpen}>
             <PopoverTrigger asChild>
-              <button className="inline-flex items-center justify-center rounded-md border border-border p-1 text-xs hover:bg-accent/50 transition-colors text-muted-foreground">
-                <MoreHorizontal className="h-3 w-3" />
+              <button className={cn(
+                "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs hover:bg-accent/50 transition-colors",
+                dueAt ? "border-orange-500/40 text-orange-600 dark:text-orange-400" : "border-border text-muted-foreground",
+              )}>
+                <Calendar className="h-3 w-3" />
+                {dueAt
+                  ? new Date(dueAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+                  : "Due date"}
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-44 p-1" align="start">
-              <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
-                <Calendar className="h-3 w-3" />
-                Start date
-              </button>
-              <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
-                <Calendar className="h-3 w-3" />
-                Due date
-              </button>
+            <PopoverContent className="w-56 p-3" align="start">
+              <div className="space-y-2">
+                <label className="text-xs text-muted-foreground">Due date</label>
+                <input
+                  type="datetime-local"
+                  className="w-full px-2 py-1.5 text-xs bg-transparent outline-none rounded border border-border"
+                  value={dueAt}
+                  onChange={(e) => setDueAt(e.target.value)}
+                />
+                {dueAt && (
+                  <button
+                    className="text-[11px] text-destructive hover:underline"
+                    onClick={() => { setDueAt(""); setMoreOpen(false); }}
+                  >
+                    Clear due date
+                  </button>
+                )}
+              </div>
             </PopoverContent>
           </Popover>
         </div>


### PR DESCRIPTION
## Summary
Implements the `dueDate` field documented in [TASKS.md](doc/TASKS.md) (line 41) and [TASKS-mcp.md](doc/TASKS-mcp.md) (line 72) but not yet wired up. The "Due date" button in the new issue dialog was a placeholder with no click handler — this PR makes it functional.

- Add `due_at` timestamp column to issues table with migration
- Add `dueAt` to Issue type interface and create/update Zod validators
- Parse `dueAt` ISO string to Date in create and update route handlers (same pattern as `hiddenAt`)
- Replace placeholder "Due date" button in NewIssueDialog with a working datetime picker
- Add "Due date" PropertyPicker in IssueProperties sidebar for editing on existing issues
- Show "Due Mar 20" or red "Overdue" indicator in issue list rows

## Test plan
- [ ] Create a new issue with a due date set → date persists and shows in issue detail
- [ ] Open an existing issue → "Due date" row appears in properties, click to set/edit
- [ ] Clear due date on an existing issue → field returns to null
- [ ] Issue list shows "Due Mar 20" for future dates, red "Overdue" for past dates on open issues
- [ ] Completed/cancelled issues with past due dates don't show "Overdue"
- [ ] All existing tests pass (`vitest run` — 143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)