### PR TITLE
feat: humans & permissions — full implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tests/e2e/test-results/
 tests/e2e/playwright-report/
 .superset/
 .claude/worktrees/
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,14 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
-
-RUN pnpm install --frozen-lockfile
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+RUN pnpm install --no-frozen-lockfile
 
 FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
 COPY packages/plugins/sdk/package.json packages/plugins/sdk/
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 FROM base AS build
 WORKDIR /app

--- a/doc/plans/2026-03-17-humans-permissions-completion.md
+++ b/doc/plans/2026-03-17-humans-permissions-completion.md
@@ -1,0 +1,247 @@
+# Humans & Permissions — Completion PR
+
+Status: Ready to implement
+Date: 2026-03-17
+Branch: feature/human-invite-ui
+Companion plans: `doc/plans/2026-02-21-humans-and-permissions.md`,
+                 `doc/plans/2026-02-21-humans-and-permissions-implementation.md`
+
+## Scope
+
+This PR closes the remaining open items from the humans-and-permissions plan that are
+required before the feature is considered complete enough for upstream PR submission.
+
+The existing branch already delivers:
+- Better Auth integration and `authenticated` deployment mode
+- All DB schema: `invites`, `join_requests`, `principal_permission_grants`,
+  `instance_user_roles`, `company_memberships` extensions, `issues.assignee_user_id`,
+  `agents.reports_to_user_id`
+- Full invite → accept → pending join → approve/reject backend
+- `tasks:assign`, `agents:create`, `users:invite`, `joins:approve` permission checks
+  on their respective routes
+- Auth UI (`Auth.tsx`), bootstrap pending screen, invite landing, inbox join approvals
+- CLI `auth-bootstrap-ceo` and `onboard` commands
+- Human pages (`Humans`, `HumanDetail`, `SidebarHumans`)
+
+The four remaining items are delivered together in this PR.
+
+---
+
+## Tasks
+
+Tasks marked **[parallel]** have no dependency on each other and can be done
+simultaneously. Tasks marked **[requires: N]** must wait for task N to complete first.
+
+---
+
+### Task 1 — Add XOR single-assignee refine to issue validators [parallel]
+
+**File:** `packages/shared/src/validators/issue.ts`
+
+Extract the assignee fields into a base schema and add a `.superRefine()` that errors
+when both `assigneeAgentId` and `assigneeUserId` are non-null. Apply the refine to
+both `createIssueSchema` and `updateIssueSchema` (via the shared base before
+`.partial()`).
+
+Error shape: `ZodIssueCode.custom`, path `["assigneeUserId"]`, message
+`"assigneeAgentId and assigneeUserId are mutually exclusive"`.
+
+Acceptance criteria:
+- Both fields set → ZodError with path `assigneeUserId`
+- Either field set alone → parses correctly
+- Neither field set → parses correctly
+
+---
+
+### Task 2 — Add local trusted mode badge to sidebar [parallel]
+
+**File:** `ui/src/components/Layout.tsx`
+
+`Layout.tsx` already has `health?.deploymentMode` in scope. Add a small pill near the
+sidebar footer that renders only when `deploymentMode === "local_trusted"`. The pill
+should contain a green dot and the text "Local trusted mode". Follow existing sidebar
+footer styling conventions. Must not appear in `authenticated` mode.
+
+Acceptance criteria:
+- Badge visible in `local_trusted` build
+- Badge absent in `authenticated` build
+- No layout shift or overflow on narrow sidebar widths
+
+---
+
+### Task 3 — Add `parseAssignmentScope` and `evaluateAssignmentScope` pure functions [parallel]
+
+**File:** `server/src/services/access.ts`
+
+Add as module-level exports (outside the `accessService` factory):
+
+```ts
+export type AssignmentScopeRule =
+  | { type: "subtree"; anchorId: string }
+  | { type: "exclude"; targetId: string };
+
+export function parseAssignmentScope(
+  raw: Record<string, unknown> | null | undefined,
+): AssignmentScopeRule[]
+
+export function evaluateAssignmentScope(
+  rules: AssignmentScopeRule[],
+  assigneeId: string,
+  ancestors: string[],
+): { allowed: boolean; reason?: string }
+```
+
+`parseAssignmentScope`: expects `{ rules: [...] }` shape; returns `[]` on null,
+undefined, or unrecognised input — never throws.
+
+`evaluateAssignmentScope`: empty rules → allowed. `subtree` rule passes if
+`anchorId === assigneeId` or `anchorId` is in `ancestors`. `exclude` rule fails if
+`targetId === assigneeId`. All subtree rules must pass; any exclude failure denies.
+
+No DB access — pure functions only.
+
+---
+
+### Task 4 — Add `resolveAssigneeAncestors` and `getPermissionGrant` to `accessService` [requires: 3]
+
+**File:** `server/src/services/access.ts`
+
+Add to the `accessService` factory and include in its return object:
+
+`resolveAssigneeAncestors(companyId, assigneeType: "agent" | "user", assigneeId)`:
+- Agent: walk `agents.reports_to` upward, capped at 20 hops to prevent cycles.
+- User: walk `company_memberships.supervisor_agent_id` / `supervisor_user_id` upward,
+  same cap.
+- Returns ancestor IDs ordered from direct parent to root. Returns `[]` when no
+  hierarchy data exists.
+
+`getPermissionGrant(companyId, principalType, principalId, permissionKey)`:
+- Returns the full `principal_permission_grants` row (including `scope`) or `null`.
+- Used by the route to read the scope payload without a separate query.
+
+---
+
+### Task 5 — Wire scope enforcement into `assertCanAssignTasks` [requires: 4]
+
+**File:** `server/src/routes/issues.ts`
+
+After the existing grant-existence check passes in `assertCanAssignTasks`, fetch the
+full grant row via `access.getPermissionGrant`. If `grant.scope` is non-null, call
+`parseAssignmentScope` then `evaluateAssignmentScope` with the ancestors resolved via
+`access.resolveAssigneeAncestors`. Throw `forbidden` with the evaluator's reason on
+denial.
+
+Scope enforcement only triggers when the grant row has a non-null `scope` payload with
+parseable rules. Null-scope grants are unaffected. The existing local-implicit and
+instance-admin short-circuits at the top of `assertCanAssignTasks` remain and bypass
+scope entirely.
+
+Acceptance criteria:
+- `subtree:X` scope: can assign to X and X's reports → 200; outside subtree → 403
+- `exclude:CEO-id`: cannot assign to CEO → 403
+- Null-scope `tasks:assign`: can assign anywhere → 200
+- Local implicit admin and instance admin bypass scope → 200
+
+---
+
+### Task 6 — Write test: issue assignee XOR validator [requires: 1]
+
+**File:** `server/src/__tests__/issue-assignee-xor.test.ts`
+
+Unit tests against the shared validator (no HTTP, no DB):
+
+- `createIssueSchema` with both assignee fields → ZodError, path `assigneeUserId`
+- `createIssueSchema` with only `assigneeAgentId` → succeeds
+- `createIssueSchema` with only `assigneeUserId` → succeeds
+- `updateIssueSchema` with both assignee fields → ZodError
+
+---
+
+### Task 7 — Write test: assignment scope pure functions [requires: 3]
+
+**File:** `server/src/__tests__/assignment-scope.test.ts`
+
+Unit tests against `parseAssignmentScope` and `evaluateAssignmentScope` (no HTTP,
+no DB):
+
+- `parseAssignmentScope(null)` → `[]`
+- `parseAssignmentScope` with valid shape → typed rules
+- `parseAssignmentScope` with unrecognised shape → `[]` (no throw)
+- `evaluateAssignmentScope([], ...)` → allowed
+- `subtree` rule: assignee is anchor → allowed
+- `subtree` rule: anchor in ancestors → allowed
+- `subtree` rule: anchor not in ancestors and not assignee → denied
+- `exclude` rule: targetId matches assignee → denied
+- `exclude` rule: targetId does not match → allowed
+- Combined: subtree passes, exclude fails → denied
+
+---
+
+### Task 8 — Write test: auth mode guard [parallel]
+
+**File:** `server/src/__tests__/auth-mode-guard.test.ts`
+
+Tests `actorMiddleware` + `boardMutationGuard` in `authenticated` mode using
+in-process express stubs (follow pattern in `board-mutation-guard.test.ts`):
+
+- No bearer, no session → mutation endpoint returns 401 or 403
+- Valid agent bearer → actor resolves, company access check passes
+- Valid session with matching `companyIds` → actor resolves, passes
+- Session user accessing a company not in their `companyIds` → 403
+
+---
+
+### Task 9 — Write test: cross-company access guard [parallel]
+
+**File:** `server/src/__tests__/cross-company-access.test.ts`
+
+Tests `assertCompanyAccess` via in-process express stubs:
+
+- Board actor (`source: "session"`, `companyIds: ["co-1"]`) accessing `co-2` → 403
+- Board actor with `isInstanceAdmin: true` accessing any company → passes
+- Agent actor with `companyId: "co-1"` accessing `co-1` → passes
+- Agent actor with `companyId: "co-1"` accessing `co-2` → 403
+
+---
+
+## Dependency graph
+
+```
+Task 1 ──────────────────────────────► Task 6
+Task 2 (no dependents)
+Task 3 ──► Task 4 ──► Task 5
+       └──────────────────────────────► Task 7
+Task 8 (no dependencies)
+Task 9 (no dependencies)
+```
+
+Tasks 1, 2, 3, 8, 9 can all start at the same time.
+Task 4 starts after Task 3 completes.
+Task 5 starts after Task 4 completes.
+Task 6 starts after Task 1 completes.
+Task 7 starts after Task 3 completes.
+
+---
+
+## Verification gate
+
+Before marking the PR ready:
+
+```sh
+pnpm -r typecheck
+pnpm test:run
+pnpm build
+```
+
+All three must pass clean. No skips without documented justification.
+
+---
+
+## Done criteria (maps to plan acceptance criteria)
+
+- Passing both `assigneeAgentId` and `assigneeUserId` returns a validation error.
+- UI shows "Local trusted mode" badge in local builds; badge absent in authenticated builds.
+- Principal with scoped `tasks:assign` grant cannot assign outside their permitted subtree.
+- Unauthenticated mutations in `authenticated` mode return 401/403.
+- Cross-company access returns 403 for non-admin user actors.
+- All new code passes typecheck, existing tests remain green.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       timeout: 5s
       retries: 30
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5442:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 
@@ -29,6 +29,8 @@ services:
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
     volumes:
       - paperclip-data:/paperclip
+      - ~/paperclip-projects:/paperclip/projects
+    command: ["pnpm", "paperclipai", "run"]
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
     volumes:
       - paperclip-data:/paperclip
-      - ~/paperclip-projects:/paperclip/projects
+      - ${HOME}/paperclip-projects:/paperclip/projects
     command: ["pnpm", "paperclipai", "run"]
     depends_on:
       db:

--- a/packages/db/src/migrations/0038_human_profile_fields.sql
+++ b/packages/db/src/migrations/0038_human_profile_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "company_memberships" ADD COLUMN "job_title" text;--> statement-breakpoint
+ALTER TABLE "company_memberships" ADD COLUMN "supervisor_user_id" text;--> statement-breakpoint
+ALTER TABLE "company_memberships" ADD COLUMN "hourly_rate_cents" integer;

--- a/packages/db/src/migrations/0039_unified_org_hierarchy.sql
+++ b/packages/db/src/migrations/0039_unified_org_hierarchy.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agents" ADD COLUMN "reports_to_user_id" text;
+ALTER TABLE "company_memberships" ADD COLUMN "supervisor_agent_id" text;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -267,6 +267,20 @@
       "when": 1773756922363,
       "tag": "0037_friendly_eddie_brock",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1742169600000,
+      "tag": "0038_human_profile_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1742256000000,
+      "tag": "0039_unified_org_hierarchy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -21,6 +21,7 @@ export const agents = pgTable(
     icon: text("icon"),
     status: text("status").notNull().default("idle"),
     reportsTo: uuid("reports_to").references((): AnyPgColumn => agents.id),
+    reportsToUserId: text("reports_to_user_id"),
     capabilities: text("capabilities"),
     adapterType: text("adapter_type").notNull().default("process"),
     adapterConfig: jsonb("adapter_config").$type<Record<string, unknown>>().notNull().default({}),

--- a/packages/db/src/schema/company_memberships.ts
+++ b/packages/db/src/schema/company_memberships.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, integer, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 
 export const companyMemberships = pgTable(
@@ -10,6 +10,10 @@ export const companyMemberships = pgTable(
     principalId: text("principal_id").notNull(),
     status: text("status").notNull().default("active"),
     membershipRole: text("membership_role"),
+    jobTitle: text("job_title"),
+    supervisorUserId: text("supervisor_user_id"),
+    supervisorAgentId: text("supervisor_agent_id"),
+    hourlyRateCents: integer("hourly_rate_cents"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -19,6 +19,7 @@ export interface Agent {
   icon: string | null;
   status: AgentStatus;
   reportsTo: string | null;
+  reportsToUserId: string | null;
   capabilities: string | null;
   adapterType: AgentAdapterType;
   adapterConfig: Record<string, unknown>;

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -30,6 +30,7 @@ export const createAgentSchema = z.object({
   title: z.string().optional().nullable(),
   icon: z.enum(AGENT_ICON_NAMES).optional().nullable(),
   reportsTo: z.string().uuid().optional().nullable(),
+  reportsToUserId: z.string().optional().nullable(),
   capabilities: z.string().optional().nullable(),
   adapterType: z.enum(AGENT_ADAPTER_TYPES).optional().default("process"),
   adapterConfig: adapterConfigSchema.optional().default({}),

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -27,7 +27,20 @@ export const issueAssigneeAdapterOverridesSchema = z
   })
   .strict();
 
-export const createIssueSchema = z.object({
+function assigneeXorCheck(
+  data: { assigneeAgentId?: string | null | undefined; assigneeUserId?: string | null | undefined },
+  ctx: z.RefinementCtx,
+) {
+  if (data.assigneeAgentId != null && data.assigneeUserId != null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["assigneeUserId"],
+      message: "assigneeAgentId and assigneeUserId are mutually exclusive",
+    });
+  }
+}
+
+const issueBaseObject = z.object({
   projectId: z.string().uuid().optional().nullable(),
   projectWorkspaceId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
@@ -54,6 +67,8 @@ export const createIssueSchema = z.object({
   labelIds: z.array(z.string().uuid()).optional(),
 });
 
+export const createIssueSchema = issueBaseObject.superRefine(assigneeXorCheck);
+
 export type CreateIssue = z.infer<typeof createIssueSchema>;
 
 export const createIssueLabelSchema = z.object({
@@ -63,10 +78,10 @@ export const createIssueLabelSchema = z.object({
 
 export type CreateIssueLabel = z.infer<typeof createIssueLabelSchema>;
 
-export const updateIssueSchema = createIssueSchema.partial().extend({
+export const updateIssueSchema = issueBaseObject.partial().extend({
   comment: z.string().min(1).optional(),
   hiddenAt: z.string().datetime().nullable().optional(),
-});
+}).superRefine(assigneeXorCheck);
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
 export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorkspaceSettingsSchema>;

--- a/server/src/__tests__/assignment-scope.test.ts
+++ b/server/src/__tests__/assignment-scope.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAssignmentScope,
+  evaluateAssignmentScope,
+} from "../services/access.ts";
+
+describe("parseAssignmentScope", () => {
+  it("returns [] for null", () => {
+    expect(parseAssignmentScope(null)).toEqual([]);
+  });
+
+  it("returns [] for undefined", () => {
+    expect(parseAssignmentScope(undefined)).toEqual([]);
+  });
+
+  it("returns [] for unrecognised shape (no rules key)", () => {
+    expect(parseAssignmentScope({ something: "else" })).toEqual([]);
+  });
+
+  it("returns [] when rules is not an array", () => {
+    expect(parseAssignmentScope({ rules: "bad" })).toEqual([]);
+  });
+
+  it("parses a valid subtree rule", () => {
+    expect(
+      parseAssignmentScope({ rules: [{ type: "subtree", anchorId: "agent-1" }] }),
+    ).toEqual([{ type: "subtree", anchorId: "agent-1" }]);
+  });
+
+  it("parses a valid exclude rule", () => {
+    expect(
+      parseAssignmentScope({ rules: [{ type: "exclude", targetId: "agent-ceo" }] }),
+    ).toEqual([{ type: "exclude", targetId: "agent-ceo" }]);
+  });
+
+  it("parses multiple rules of mixed types", () => {
+    expect(
+      parseAssignmentScope({
+        rules: [
+          { type: "subtree", anchorId: "agent-1" },
+          { type: "exclude", targetId: "agent-2" },
+        ],
+      }),
+    ).toEqual([
+      { type: "subtree", anchorId: "agent-1" },
+      { type: "exclude", targetId: "agent-2" },
+    ]);
+  });
+
+  it("skips items with unrecognised type without throwing", () => {
+    expect(
+      parseAssignmentScope({
+        rules: [{ type: "unknown", anchorId: "agent-1" }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("skips items missing required string fields without throwing", () => {
+    expect(
+      parseAssignmentScope({
+        rules: [{ type: "subtree", anchorId: 42 }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not throw on completely malformed input", () => {
+    expect(parseAssignmentScope({ rules: [null, undefined, 42, "str"] })).toEqual([]);
+  });
+});
+
+describe("evaluateAssignmentScope", () => {
+  it("allows when rules is empty", () => {
+    expect(evaluateAssignmentScope([], "agent-1", [])).toEqual({ allowed: true });
+  });
+
+  it("subtree rule: allowed when assignee is the anchor", () => {
+    const rules = [{ type: "subtree" as const, anchorId: "agent-1" }];
+    expect(evaluateAssignmentScope(rules, "agent-1", [])).toEqual({ allowed: true });
+  });
+
+  it("subtree rule: allowed when anchor is in ancestors", () => {
+    const rules = [{ type: "subtree" as const, anchorId: "agent-root" }];
+    expect(evaluateAssignmentScope(rules, "agent-leaf", ["agent-root", "agent-mid"])).toEqual({ allowed: true });
+  });
+
+  it("subtree rule: denied when anchor is not assignee and not in ancestors", () => {
+    const rules = [{ type: "subtree" as const, anchorId: "agent-root" }];
+    const result = evaluateAssignmentScope(rules, "agent-other", ["agent-x"]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/outside permitted subtree/);
+  });
+
+  it("exclude rule: denied when targetId matches assignee", () => {
+    const rules = [{ type: "exclude" as const, targetId: "agent-ceo" }];
+    const result = evaluateAssignmentScope(rules, "agent-ceo", []);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/explicitly excluded/);
+  });
+
+  it("exclude rule: allowed when targetId does not match assignee", () => {
+    const rules = [{ type: "exclude" as const, targetId: "agent-ceo" }];
+    expect(evaluateAssignmentScope(rules, "agent-other", [])).toEqual({ allowed: true });
+  });
+
+  it("subtree rule: second subtree rule failing denies even when first passes", () => {
+    const rules = [
+      { type: "subtree" as const, anchorId: "agent-root" },
+      { type: "subtree" as const, anchorId: "agent-mid" },
+    ];
+    // assignee is under agent-root but not under agent-mid
+    const result = evaluateAssignmentScope(rules, "agent-leaf", ["agent-root"]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/outside permitted subtree/);
+  });
+
+  it("combined: subtree passes but exclude fails → denied", () => {
+    const rules = [
+      { type: "subtree" as const, anchorId: "agent-root" },
+      { type: "exclude" as const, targetId: "agent-leaf" },
+    ];
+    const result = evaluateAssignmentScope(rules, "agent-leaf", ["agent-root"]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/explicitly excluded/);
+  });
+
+  it("combined: both subtree and exclude pass → allowed", () => {
+    const rules = [
+      { type: "subtree" as const, anchorId: "agent-root" },
+      { type: "exclude" as const, targetId: "agent-ceo" },
+    ];
+    expect(evaluateAssignmentScope(rules, "agent-leaf", ["agent-root"])).toEqual({ allowed: true });
+  });
+});

--- a/server/src/__tests__/auth-mode-guard.test.ts
+++ b/server/src/__tests__/auth-mode-guard.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express, { type Request } from "express";
+import request from "supertest";
+import { actorMiddleware } from "../middleware/auth.js";
+import { boardMutationGuard } from "../middleware/board-mutation-guard.js";
+import { assertCompanyAccess } from "../routes/authz.js";
+import { errorHandler } from "../middleware/error-handler.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+
+const JWT_SECRET_ENV = "PAPERCLIP_AGENT_JWT_SECRET";
+
+function makeMockDb(selects: Array<unknown[]> = []) {
+  const selectQueue = [...selects];
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(selectQueue.shift() ?? []),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => Promise.resolve([]),
+      }),
+    }),
+  };
+}
+
+function createApp(
+  opts: {
+    resolveSession?: (req: Request) => Promise<{ user: { id: string } } | null>;
+    dbSelects?: Array<unknown[]>;
+    companyId?: string;
+  } = {},
+) {
+  const app = express();
+  app.use(express.json());
+
+  const db = makeMockDb(opts.dbSelects);
+  app.use(
+    actorMiddleware(db as any, {
+      deploymentMode: "authenticated",
+      resolveSession: opts.resolveSession as any,
+    }),
+  );
+  app.use(boardMutationGuard());
+
+  const companyId = opts.companyId ?? "co-1";
+  app.post("/mutate", (req, res, next) => {
+    try {
+      assertCompanyAccess(req, companyId);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.use(errorHandler);
+  return app;
+}
+
+describe("actorMiddleware + boardMutationGuard in authenticated mode", () => {
+  let originalSecret: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env[JWT_SECRET_ENV];
+    process.env[JWT_SECRET_ENV] = "test-jwt-secret";
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env[JWT_SECRET_ENV];
+    } else {
+      process.env[JWT_SECRET_ENV] = originalSecret;
+    }
+  });
+
+  it("no bearer, no session → mutation returns 401", async () => {
+    const app = createApp({ resolveSession: async () => null });
+    const res = await request(app).post("/mutate").send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("valid agent bearer → actor resolves, company access passes", async () => {
+    const token = createLocalAgentJwt("agent-1", "co-1", "claude_local", "run-1");
+    expect(token).toBeTruthy();
+    const app = createApp({
+      dbSelects: [
+        [], // agentApiKeys lookup → no matching key
+        [{ id: "agent-1", companyId: "co-1", status: "active" }], // agents lookup → found
+      ],
+    });
+    const res = await request(app)
+      .post("/mutate")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(204);
+  });
+
+  it("valid session with matching companyIds → actor resolves, passes", async () => {
+    const app = createApp({
+      resolveSession: async () => ({ user: { id: "user-1" } }),
+      dbSelects: [
+        [], // instanceUserRoles → not an instance admin
+        [{ companyId: "co-1" }], // companyMemberships → active member of co-1
+      ],
+    });
+    const res = await request(app)
+      .post("/mutate")
+      .set("Origin", "http://localhost:3100")
+      .send({});
+    expect(res.status).toBe(204);
+  });
+
+  it("session user accessing company not in companyIds → 403", async () => {
+    const app = createApp({
+      resolveSession: async () => ({ user: { id: "user-1" } }),
+      dbSelects: [
+        [], // instanceUserRoles → not an instance admin
+        [{ companyId: "co-1" }], // companyMemberships → member of co-1 only
+      ],
+      companyId: "co-2", // route resource belongs to co-2
+    });
+    const res = await request(app)
+      .post("/mutate")
+      .set("Origin", "http://localhost:3100")
+      .send({});
+    expect(res.status).toBe(403);
+  });
+});

--- a/server/src/__tests__/cross-company-access.test.ts
+++ b/server/src/__tests__/cross-company-access.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { assertCompanyAccess } from "../routes/authz.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+function createApp(actor: Express.Request["actor"], targetCompanyId: string) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.get("/resource", (req, res) => {
+    assertCompanyAccess(req, targetCompanyId);
+    res.status(200).json({ ok: true });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe("assertCompanyAccess", () => {
+  it("denies unauthenticated (none) actor with 401", async () => {
+    const actor: Express.Request["actor"] = { type: "none", source: "none" };
+    const res = await request(createApp(actor, "co-1")).get("/resource");
+    expect(res.status).toBe(401);
+  });
+
+  it("denies board session actor accessing a company not in their companyIds", async () => {
+    const actor: Express.Request["actor"] = {
+      type: "board",
+      userId: "user-1",
+      source: "session",
+      companyIds: ["co-1"],
+      isInstanceAdmin: false,
+    };
+    const res = await request(createApp(actor, "co-2")).get("/resource");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "User does not have access to this company" });
+  });
+
+  it("allows board session actor accessing a company in their companyIds", async () => {
+    const actor: Express.Request["actor"] = {
+      type: "board",
+      userId: "user-1",
+      source: "session",
+      companyIds: ["co-1", "co-2"],
+      isInstanceAdmin: false,
+    };
+    const res = await request(createApp(actor, "co-2")).get("/resource");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows instance admin board actor to access any company", async () => {
+    const actor: Express.Request["actor"] = {
+      type: "board",
+      userId: "user-admin",
+      source: "session",
+      companyIds: ["co-1"],
+      isInstanceAdmin: true,
+    };
+    const res = await request(createApp(actor, "co-999")).get("/resource");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows local_implicit board actor to access any company regardless of companyIds", async () => {
+    const actor: Express.Request["actor"] = {
+      type: "board",
+      userId: "local-board",
+      source: "local_implicit",
+      companyIds: [],
+      isInstanceAdmin: true,
+    };
+    const res = await request(createApp(actor, "co-any")).get("/resource");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows agent actor accessing its own company", async () => {
+    const actor: Express.Request["actor"] = {
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "co-1",
+      source: "agent_key",
+    };
+    const res = await request(createApp(actor, "co-1")).get("/resource");
+    expect(res.status).toBe(200);
+  });
+
+  it("denies agent actor accessing a different company", async () => {
+    const actor: Express.Request["actor"] = {
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "co-1",
+      source: "agent_key",
+    };
+    const res = await request(createApp(actor, "co-2")).get("/resource");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agent key cannot access another company" });
+  });
+});

--- a/server/src/__tests__/issue-assignee-xor.test.ts
+++ b/server/src/__tests__/issue-assignee-xor.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createIssueSchema, updateIssueSchema } from "@paperclipai/shared/validators/issue";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+describe("issue assignee XOR validator", () => {
+  describe("createIssueSchema", () => {
+    it("errors when both assigneeAgentId and assigneeUserId are set", () => {
+      const result = createIssueSchema.safeParse({
+        title: "test issue",
+        assigneeAgentId: AGENT_ID,
+        assigneeUserId: "user-1",
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      const issue = result.error.issues.find((i) => i.path[0] === "assigneeUserId");
+      expect(issue).toBeDefined();
+      expect(issue!.code).toBe(z.ZodIssueCode.custom);
+      expect(issue!.message).toBe("assigneeAgentId and assigneeUserId are mutually exclusive");
+    });
+
+    it("succeeds with only assigneeAgentId", () => {
+      const result = createIssueSchema.safeParse({
+        title: "test issue",
+        assigneeAgentId: AGENT_ID,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("succeeds with only assigneeUserId", () => {
+      const result = createIssueSchema.safeParse({
+        title: "test issue",
+        assigneeUserId: "user-1",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("succeeds with neither assignee field", () => {
+      const result = createIssueSchema.safeParse({ title: "test issue" });
+      expect(result.success).toBe(true);
+    });
+
+    it("succeeds when assigneeAgentId is null and assigneeUserId is set", () => {
+      const result = createIssueSchema.safeParse({
+        title: "test issue",
+        assigneeAgentId: null,
+        assigneeUserId: "user-1",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("succeeds when assigneeUserId is null and assigneeAgentId is set", () => {
+      const result = createIssueSchema.safeParse({
+        title: "test issue",
+        assigneeAgentId: AGENT_ID,
+        assigneeUserId: null,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("updateIssueSchema", () => {
+    it("errors when both assigneeAgentId and assigneeUserId are set", () => {
+      const result = updateIssueSchema.safeParse({
+        assigneeAgentId: AGENT_ID,
+        assigneeUserId: "user-1",
+      });
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      const issue = result.error.issues.find((i) => i.path[0] === "assigneeUserId");
+      expect(issue).toBeDefined();
+      expect(issue!.code).toBe(z.ZodIssueCode.custom);
+      expect(issue!.message).toBe("assigneeAgentId and assigneeUserId are mutually exclusive");
+    });
+
+    it("succeeds with only assigneeAgentId", () => {
+      const result = updateIssueSchema.safeParse({ assigneeAgentId: AGENT_ID });
+      expect(result.success).toBe(true);
+    });
+
+    it("succeeds with only assigneeUserId", () => {
+      const result = updateIssueSchema.safeParse({ assigneeUserId: "user-1" });
+      expect(result.success).toBe(true);
+    });
+
+    it("succeeds with no fields at all (empty partial update)", () => {
+      const result = updateIssueSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -26,7 +26,7 @@ function parseNumber(value: string | undefined, fallback: number) {
 }
 
 function jwtConfig() {
-  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET ?? process.env.BETTER_AUTH_SECRET;
   if (!secret) return null;
 
   return {

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -26,7 +26,7 @@ function parseNumber(value: string | undefined, fallback: number) {
 }
 
 function jwtConfig() {
-  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET ?? process.env.BETTER_AUTH_SECRET;
+  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
   if (!secret) return null;
 
   return {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,7 +2,8 @@ import express, { Router, type Request as ExpressRequest } from "express";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import type { Db } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { type Db, authUsers } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import type { StorageService } from "./storage/types.js";
 import { httpLogger, errorHandler } from "./middleware/index.js";
@@ -101,10 +102,23 @@ export async function createApp(
       resolveSession: opts.resolveSession,
     }),
   );
-  app.get("/api/auth/get-session", (req, res) => {
+  app.get("/api/auth/get-session", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {
       res.status(401).json({ error: "Unauthorized" });
       return;
+    }
+    let name: string | null = null;
+    let email: string | null = null;
+    if (req.actor.source === "local_implicit") {
+      name = "Local Board";
+    } else {
+      const user = await db
+        .select({ name: authUsers.name, email: authUsers.email })
+        .from(authUsers)
+        .where(eq(authUsers.id, req.actor.userId))
+        .then((rows) => rows[0] ?? null);
+      name = user?.name ?? null;
+      email = user?.email ?? null;
     }
     res.json({
       session: {
@@ -113,8 +127,8 @@ export async function createApp(
       },
       user: {
         id: req.actor.userId,
-        email: null,
-        name: req.actor.source === "local_implicit" ? "Local Board" : null,
+        email,
+        name,
       },
     });
   });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -14,6 +14,7 @@ import type { Db } from "@paperclipai/db";
 import {
   agentApiKeys,
   authUsers,
+  companyMemberships,
   invites,
   joinRequests
 } from "@paperclipai/db";
@@ -2629,6 +2630,81 @@ export function accessRoutes(
       });
     }
   );
+
+  router.get("/companies/:companyId/human-members", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    await assertCompanyAccess(req, companyId);
+    const members = await db
+      .select({
+        id: companyMemberships.principalId,
+        name: authUsers.name,
+        email: authUsers.email,
+        membershipRole: companyMemberships.membershipRole,
+        jobTitle: companyMemberships.jobTitle,
+        supervisorUserId: companyMemberships.supervisorUserId,
+        supervisorAgentId: companyMemberships.supervisorAgentId,
+        hourlyRateCents: companyMemberships.hourlyRateCents,
+      })
+      .from(companyMemberships)
+      .innerJoin(authUsers, eq(authUsers.id, companyMemberships.principalId))
+      .where(
+        and(
+          eq(companyMemberships.companyId, companyId),
+          eq(companyMemberships.principalType, "user"),
+          eq(companyMemberships.status, "active"),
+        )
+      );
+    res.json(members);
+  });
+
+  router.get("/companies/:companyId/human-member-config", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    await assertCompanyAccess(req, companyId);
+    const canManageMembers =
+      isLocalImplicit(req) ||
+      (req.actor.type === "board" &&
+        (await access.canUser(companyId, req.actor.userId ?? null, "users:manage_permissions")));
+    res.json({ canManageMembers });
+  });
+
+  router.patch("/companies/:companyId/human-members/:userId", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const userId = req.params.userId as string;
+    await assertCompanyPermission(req, companyId, "users:manage_permissions");
+    const { jobTitle, supervisorUserId, supervisorAgentId, hourlyRateCents } = req.body as {
+      jobTitle?: string | null;
+      supervisorUserId?: string | null;
+      supervisorAgentId?: string | null;
+      hourlyRateCents?: number | null;
+    };
+    const updated = await db
+      .update(companyMemberships)
+      .set({
+        jobTitle: jobTitle ?? null,
+        supervisorUserId: supervisorUserId ?? null,
+        supervisorAgentId: supervisorAgentId ?? null,
+        hourlyRateCents: typeof hourlyRateCents === "number" ? hourlyRateCents : null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(companyMemberships.companyId, companyId),
+          eq(companyMemberships.principalType, "user"),
+          eq(companyMemberships.principalId, userId),
+          eq(companyMemberships.status, "active"),
+        )
+      )
+      .returning({
+        id: companyMemberships.principalId,
+        jobTitle: companyMemberships.jobTitle,
+        supervisorUserId: companyMemberships.supervisorUserId,
+        supervisorAgentId: companyMemberships.supervisorAgentId,
+        hourlyRateCents: companyMemberships.hourlyRateCents,
+      })
+      .then((rows) => rows[0] ?? null);
+    if (!updated) throw notFound("Member not found");
+    res.json(updated);
+  });
 
   router.get("/companies/:companyId/members", async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -13,6 +13,7 @@ import { and, eq, isNull, desc } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agentApiKeys,
+  agents as agentsTable,
   authUsers,
   companyMemberships,
   invites,
@@ -2677,6 +2678,36 @@ export function accessRoutes(
       supervisorAgentId?: string | null;
       hourlyRateCents?: number | null;
     };
+
+    if (supervisorUserId != null && supervisorUserId === userId) {
+      throw badRequest("A user cannot be their own supervisor");
+    }
+
+    if (supervisorUserId != null) {
+      const supervisorMembership = await db
+        .select({ id: companyMemberships.id })
+        .from(companyMemberships)
+        .where(
+          and(
+            eq(companyMemberships.companyId, companyId),
+            eq(companyMemberships.principalType, "user"),
+            eq(companyMemberships.principalId, supervisorUserId),
+            eq(companyMemberships.status, "active"),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      if (!supervisorMembership) throw badRequest("Supervisor user is not an active member of this company");
+    }
+
+    if (supervisorAgentId != null) {
+      const supervisorAgent = await db
+        .select({ id: agentsTable.id })
+        .from(agentsTable)
+        .where(and(eq(agentsTable.id, supervisorAgentId), eq(agentsTable.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!supervisorAgent) throw badRequest("Supervisor agent does not belong to this company");
+    }
+
     const updated = await db
       .update(companyMemberships)
       .set({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2,7 +2,7 @@ import { Router, type Request } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
-import { agents as agentsTable, companies, heartbeatRuns } from "@paperclipai/db";
+import { agents as agentsTable, companies, companyMemberships, heartbeatRuns } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
 import {
   createAgentKeySchema,
@@ -406,6 +406,7 @@ export function agentRoutes(db: Db) {
       name: String(node.name),
       role: String(node.role),
       status: String(node.status),
+      kind: node.kind === "human" ? "human" : "agent",
       reports,
     };
   }
@@ -783,7 +784,7 @@ export function agentRoutes(db: Db) {
       hireInput.adapterType,
       normalizedAdapterConfig,
     );
-    const normalizedHireInput = {
+    let normalizedHireInput = {
       ...hireInput,
       adapterConfig: normalizedAdapterConfig,
     };
@@ -796,6 +797,33 @@ export function agentRoutes(db: Db) {
     if (!company) {
       res.status(404).json({ error: "Company not found" });
       return;
+    }
+
+    // If no manager is specified and this is the first agent for the company,
+    // auto-assign it to the company owner so it appears under them in the org chart.
+    const explicitManager = normalizedHireInput.reportsTo || normalizedHireInput.reportsToUserId;
+    if (!explicitManager) {
+      const existingAgents = await db
+        .select({ id: agentsTable.id })
+        .from(agentsTable)
+        .where(and(eq(agentsTable.companyId, companyId), not(eq(agentsTable.status, "terminated"))));
+      if (existingAgents.length === 0) {
+        const owner = await db
+          .select({ principalId: companyMemberships.principalId })
+          .from(companyMemberships)
+          .where(
+            and(
+              eq(companyMemberships.companyId, companyId),
+              eq(companyMemberships.principalType, "user"),
+              eq(companyMemberships.status, "active"),
+              eq(companyMemberships.membershipRole, "owner"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (owner) {
+          normalizedHireInput = { ...normalizedHireInput, reportsToUserId: owner.principalId };
+        }
+      }
     }
 
     const requiresApproval = company.requireBoardApprovalForNewAgents;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -802,6 +802,7 @@ export function agentRoutes(db: Db) {
     // If no manager is specified and this is the first agent for the company,
     // auto-assign it to the company owner so it appears under them in the org chart.
     const explicitManager = normalizedHireInput.reportsTo || normalizedHireInput.reportsToUserId;
+    let autoAssignedManagerId: string | null = null;
     if (!explicitManager) {
       const existingAgents = await db
         .select({ id: agentsTable.id })
@@ -821,6 +822,7 @@ export function agentRoutes(db: Db) {
           )
           .then((rows) => rows[0] ?? null);
         if (owner) {
+          autoAssignedManagerId = owner.principalId;
           normalizedHireInput = { ...normalizedHireInput, reportsToUserId: owner.principalId };
         }
       }
@@ -926,7 +928,7 @@ export function agentRoutes(db: Db) {
       });
     }
 
-    res.status(201).json({ agent, approval });
+    res.status(201).json({ agent, approval, autoAssignedManagerId });
   });
 
   router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -19,6 +19,7 @@ import { validate } from "../middleware/validate.js";
 import {
   accessService,
   agentService,
+  evaluateAssignmentScope,
   executionWorkspaceService,
   goalService,
   heartbeatService,
@@ -26,6 +27,7 @@ import {
   issueService,
   documentService,
   logActivity,
+  parseAssignmentScope,
   projectService,
   workProductService,
 } from "../services/index.js";
@@ -93,18 +95,42 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
-  async function assertCanAssignTasks(req: Request, companyId: string) {
+  async function assertCanAssignTasks(
+    req: Request,
+    companyId: string,
+    assignee: { type: "agent" | "user"; id: string } | null,
+  ) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
       if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
       const allowed = await access.canUser(companyId, req.actor.userId, "tasks:assign");
       if (!allowed) throw forbidden("Missing permission: tasks:assign");
+      if (assignee) {
+        const grant = await access.getPermissionGrant(companyId, "user", req.actor.userId!, "tasks:assign");
+        if (grant?.scope != null) {
+          const rules = parseAssignmentScope(grant.scope as Record<string, unknown>);
+          const ancestors = await access.resolveAssigneeAncestors(companyId, assignee.type, assignee.id);
+          const result = evaluateAssignmentScope(rules, assignee.id, ancestors);
+          if (!result.allowed) throw forbidden(result.reason ?? "Assignment outside permitted scope");
+        }
+      }
       return;
     }
     if (req.actor.type === "agent") {
       if (!req.actor.agentId) throw forbidden("Agent authentication required");
       const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:assign");
-      if (allowedByGrant) return;
+      if (allowedByGrant) {
+        if (assignee) {
+          const grant = await access.getPermissionGrant(companyId, "agent", req.actor.agentId, "tasks:assign");
+          if (grant?.scope != null) {
+            const rules = parseAssignmentScope(grant.scope as Record<string, unknown>);
+            const ancestors = await access.resolveAssigneeAncestors(companyId, assignee.type, assignee.id);
+            const result = evaluateAssignmentScope(rules, assignee.id, ancestors);
+            if (!result.allowed) throw forbidden(result.reason ?? "Assignment outside permitted scope");
+          }
+        }
+        return;
+      }
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
       if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
       throw forbidden("Missing permission: tasks:assign");
@@ -753,7 +779,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
-      await assertCanAssignTasks(req, companyId);
+      const assignee = req.body.assigneeAgentId
+        ? { type: "agent" as const, id: req.body.assigneeAgentId as string }
+        : { type: "user" as const, id: req.body.assigneeUserId as string };
+      await assertCanAssignTasks(req, companyId, assignee);
     }
 
     const actor = getActorInfo(req);
@@ -815,7 +844,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
     if (assigneeWillChange) {
       if (!isAgentReturningIssueToCreator) {
-        await assertCanAssignTasks(req, existing.companyId);
+        const assignee =
+          req.body.assigneeAgentId != null
+            ? { type: "agent" as const, id: req.body.assigneeAgentId as string }
+            : req.body.assigneeUserId != null
+              ? { type: "user" as const, id: req.body.assigneeUserId as string }
+              : null;
+        await assertCanAssignTasks(req, existing.companyId, assignee);
       }
     }
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
+  agents,
   companyMemberships,
   instanceUserRoles,
   principalPermissionGrants,
@@ -12,6 +13,56 @@ type GrantInput = {
   permissionKey: PermissionKey;
   scope?: Record<string, unknown> | null;
 };
+
+export type AssignmentScopeRule =
+  | { type: "subtree"; anchorId: string }
+  | { type: "exclude"; targetId: string };
+
+export function parseAssignmentScope(
+  raw: Record<string, unknown> | null | undefined,
+): AssignmentScopeRule[] {
+  try {
+    if (raw == null) return [];
+    const rules = raw["rules"];
+    if (!Array.isArray(rules)) return [];
+    const parsed: AssignmentScopeRule[] = [];
+    for (const item of rules) {
+      if (item == null || typeof item !== "object") continue;
+      const r = item as Record<string, unknown>;
+      if (r["type"] === "subtree" && typeof r["anchorId"] === "string") {
+        parsed.push({ type: "subtree", anchorId: r["anchorId"] });
+      } else if (r["type"] === "exclude" && typeof r["targetId"] === "string") {
+        parsed.push({ type: "exclude", targetId: r["targetId"] });
+      }
+    }
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export function evaluateAssignmentScope(
+  rules: AssignmentScopeRule[],
+  assigneeId: string,
+  ancestors: string[],
+): { allowed: boolean; reason?: string } {
+  if (rules.length === 0) return { allowed: true };
+  for (const rule of rules) {
+    if (rule.type === "subtree") {
+      if (rule.anchorId !== assigneeId && !ancestors.includes(rule.anchorId)) {
+        return { allowed: false, reason: `assignee is outside permitted subtree (anchor: ${rule.anchorId})` };
+      }
+    } else if (rule.type === "exclude") {
+      if (rule.targetId === assigneeId) {
+        return { allowed: false, reason: `assignee is explicitly excluded (target: ${rule.targetId})` };
+      }
+    } else {
+      const _exhaustive: never = rule;
+      void _exhaustive;
+    }
+  }
+  return { allowed: true };
+}
 
 export function accessService(db: Db) {
   async function isInstanceAdmin(userId: string | null | undefined): Promise<boolean> {
@@ -218,6 +269,92 @@ export function accessService(db: Db) {
       .then((rows) => rows[0]);
   }
 
+  async function resolveAssigneeAncestors(
+    companyId: string,
+    assigneeType: "agent" | "user",
+    assigneeId: string,
+  ): Promise<string[]> {
+    const MAX_HOPS = 20;
+    const ancestors: string[] = [];
+    const visited = new Set<string>();
+    let currentId = assigneeId;
+
+    for (let hop = 0; hop < MAX_HOPS; hop++) {
+      if (visited.has(currentId)) break;
+      visited.add(currentId);
+
+      if (assigneeType === "agent") {
+        const row = await db
+          .select({ reportsTo: agents.reportsTo, reportsToUserId: agents.reportsToUserId })
+          .from(agents)
+          .where(and(eq(agents.id, currentId), eq(agents.companyId, companyId)))
+          .then((rows) => rows[0] ?? null);
+        if (!row) break;
+        // Agent hierarchy: reportsTo is another agent, reportsToUserId is a user
+        if (row.reportsTo) {
+          ancestors.push(row.reportsTo);
+          currentId = row.reportsTo;
+        } else if (row.reportsToUserId) {
+          ancestors.push(row.reportsToUserId);
+          // Switch to user walk so we continue up the user's supervisor chain
+          assigneeType = "user";
+          currentId = row.reportsToUserId;
+        } else {
+          break;
+        }
+      } else {
+        const row = await db
+          .select({
+            supervisorAgentId: companyMemberships.supervisorAgentId,
+            supervisorUserId: companyMemberships.supervisorUserId,
+          })
+          .from(companyMemberships)
+          .where(
+            and(
+              eq(companyMemberships.companyId, companyId),
+              eq(companyMemberships.principalType, "user"),
+              eq(companyMemberships.principalId, currentId),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (!row) break;
+        if (row.supervisorAgentId) {
+          ancestors.push(row.supervisorAgentId);
+          // Supervisor is an agent — switch to agent walk
+          assigneeType = "agent";
+          currentId = row.supervisorAgentId;
+        } else if (row.supervisorUserId) {
+          ancestors.push(row.supervisorUserId);
+          currentId = row.supervisorUserId;
+        } else {
+          break;
+        }
+      }
+    }
+
+    return ancestors;
+  }
+
+  async function getPermissionGrant(
+    companyId: string,
+    principalType: PrincipalType,
+    principalId: string,
+    permissionKey: PermissionKey,
+  ) {
+    return db
+      .select()
+      .from(principalPermissionGrants)
+      .where(
+        and(
+          eq(principalPermissionGrants.companyId, companyId),
+          eq(principalPermissionGrants.principalType, principalType),
+          eq(principalPermissionGrants.principalId, principalId),
+          eq(principalPermissionGrants.permissionKey, permissionKey),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function setPrincipalGrants(
     companyId: string,
     principalType: PrincipalType,
@@ -264,5 +401,7 @@ export function accessService(db: Db) {
     listUserCompanyAccess,
     setUserCompanyAccess,
     setPrincipalGrants,
+    resolveAssigneeAncestors,
+    getPermissionGrant,
   };
 }

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -280,8 +280,9 @@ export function accessService(db: Db) {
     let currentId = assigneeId;
 
     for (let hop = 0; hop < MAX_HOPS; hop++) {
-      if (visited.has(currentId)) break;
-      visited.add(currentId);
+      const visitedKey = `${assigneeType}:${currentId}`;
+      if (visited.has(visitedKey)) break;
+      visited.add(visitedKey);
 
       if (assigneeType === "agent") {
         const row = await db

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -8,6 +8,8 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  authUsers,
+  companyMemberships,
   costEvents,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -613,24 +615,97 @@ export function agentService(db: Db) {
     },
 
     orgForCompany: async (companyId: string) => {
-      const rows = await db
+      const agentRows = await db
         .select()
         .from(agents)
         .where(and(eq(agents.companyId, companyId), ne(agents.status, "terminated")));
-      const normalizedRows = rows.map(normalizeAgentRow);
-      const byManager = new Map<string | null, typeof normalizedRows>();
-      for (const row of normalizedRows) {
-        const key = row.reportsTo ?? null;
-        const group = byManager.get(key) ?? [];
-        group.push(row);
-        byManager.set(key, group);
+
+      const humanRows = await db
+        .select({
+          id: companyMemberships.principalId,
+          name: authUsers.name,
+          jobTitle: companyMemberships.jobTitle,
+          supervisorUserId: companyMemberships.supervisorUserId,
+          supervisorAgentId: companyMemberships.supervisorAgentId,
+        })
+        .from(companyMemberships)
+        .innerJoin(authUsers, eq(authUsers.id, companyMemberships.principalId))
+        .where(
+          and(
+            eq(companyMemberships.companyId, companyId),
+            eq(companyMemberships.principalType, "user"),
+            eq(companyMemberships.status, "active"),
+          ),
+        );
+
+      const validAgentIds = new Set(agentRows.map((a) => a.id));
+      const validUserIds = new Set(humanRows.map((h) => h.id));
+
+      type OrgEntry = {
+        key: string;
+        parentKey: string | null;
+        id: string;
+        name: string;
+        role: string;
+        status: string;
+        kind: "agent" | "human";
+      };
+
+      const entries: OrgEntry[] = [];
+
+      for (const row of agentRows) {
+        const normalized = normalizeAgentRow(row);
+        let parentKey: string | null = null;
+        if (normalized.reportsToUserId && validUserIds.has(normalized.reportsToUserId)) {
+          parentKey = `user:${normalized.reportsToUserId}`;
+        } else if (normalized.reportsTo && validAgentIds.has(normalized.reportsTo)) {
+          parentKey = `agent:${normalized.reportsTo}`;
+        }
+        entries.push({
+          key: `agent:${normalized.id}`,
+          parentKey,
+          id: normalized.id,
+          name: normalized.name,
+          role: normalized.role,
+          status: normalized.status,
+          kind: "agent",
+        });
       }
 
-      const build = (managerId: string | null): Array<Record<string, unknown>> => {
-        const members = byManager.get(managerId) ?? [];
-        return members.map((member) => ({
-          ...member,
-          reports: build(member.id),
+      for (const row of humanRows) {
+        let parentKey: string | null = null;
+        if (row.supervisorAgentId && validAgentIds.has(row.supervisorAgentId)) {
+          parentKey = `agent:${row.supervisorAgentId}`;
+        } else if (row.supervisorUserId && validUserIds.has(row.supervisorUserId)) {
+          parentKey = `user:${row.supervisorUserId}`;
+        }
+        entries.push({
+          key: `user:${row.id}`,
+          parentKey,
+          id: row.id,
+          name: row.name ?? "",
+          role: row.jobTitle ?? "Human",
+          status: "active",
+          kind: "human",
+        });
+      }
+
+      const byParent = new Map<string | null, OrgEntry[]>();
+      for (const entry of entries) {
+        const group = byParent.get(entry.parentKey) ?? [];
+        group.push(entry);
+        byParent.set(entry.parentKey, group);
+      }
+
+      const build = (parentKey: string | null): Array<Record<string, unknown>> => {
+        const children = byParent.get(parentKey) ?? [];
+        return children.map((child) => ({
+          id: child.id,
+          name: child.name,
+          role: child.role,
+          status: child.status,
+          kind: child.kind,
+          reports: build(child.key),
         }));
       };
 

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -15,7 +15,7 @@ export { financeService } from "./finance.js";
 export { heartbeatService } from "./heartbeat.js";
 export { dashboardService } from "./dashboard.js";
 export { sidebarBadgeService } from "./sidebar-badges.js";
-export { accessService } from "./access.js";
+export { accessService, parseAssignmentScope, evaluateAssignmentScope, type AssignmentScopeRule } from "./access.js";
 export { instanceSettingsService } from "./instance-settings.js";
 export { companyPortabilityService } from "./company-portability.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -32,6 +32,8 @@ import { PluginPage } from "./pages/PluginPage";
 import { RunTranscriptUxLab } from "./pages/RunTranscriptUxLab";
 import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
+import { Humans } from "./pages/Humans";
+import { HumanDetail } from "./pages/HumanDetail";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
 import { InviteLandingPage } from "./pages/InviteLanding";
@@ -129,6 +131,9 @@ function boardRoutes() {
       <Route path="agents/:agentId" element={<AgentDetail />} />
       <Route path="agents/:agentId/:tab" element={<AgentDetail />} />
       <Route path="agents/:agentId/runs/:runId" element={<AgentDetail />} />
+      <Route path="humans" element={<Humans />} />
+      <Route path="humans/:userId" element={<HumanDetail />} />
+      <Route path="humans/:userId/:tab" element={<HumanDetail />} />
       <Route path="projects" element={<Projects />} />
       <Route path="projects/:projectId" element={<ProjectDetail />} />
       <Route path="projects/:projectId/overview" element={<ProjectDetail />} />
@@ -322,6 +327,9 @@ export function App() {
           <Route path="agents/:agentId" element={<UnprefixedBoardRedirect />} />
           <Route path="agents/:agentId/:tab" element={<UnprefixedBoardRedirect />} />
           <Route path="agents/:agentId/runs/:runId" element={<UnprefixedBoardRedirect />} />
+          <Route path="humans" element={<UnprefixedBoardRedirect />} />
+          <Route path="humans/:userId" element={<UnprefixedBoardRedirect />} />
+          <Route path="humans/:userId/:tab" element={<UnprefixedBoardRedirect />} />
           <Route path="projects" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/overview" element={<UnprefixedBoardRedirect />} />

--- a/ui/src/api/access.ts
+++ b/ui/src/api/access.ts
@@ -107,6 +107,42 @@ export const accessApi = {
       input,
     ),
 
+  listHumanMembers: (companyId: string) =>
+    api.get<Array<{
+      id: string;
+      name: string | null;
+      email: string | null;
+      membershipRole: string | null;
+      jobTitle: string | null;
+      supervisorUserId: string | null;
+      supervisorAgentId: string | null;
+      hourlyRateCents: number | null;
+    }>>(`/companies/${companyId}/human-members`),
+
+  getHumanMemberConfig: (companyId: string) =>
+    api.get<{ canManageMembers: boolean }>(`/companies/${companyId}/human-member-config`),
+
+  updateHumanMemberProfile: (
+    companyId: string,
+    userId: string,
+    input: {
+      jobTitle?: string | null;
+      supervisorUserId?: string | null;
+      supervisorAgentId?: string | null;
+      hourlyRateCents?: number | null;
+    },
+  ) =>
+    api.patch<{
+      id: string;
+      jobTitle: string | null;
+      supervisorUserId: string | null;
+      supervisorAgentId: string | null;
+      hourlyRateCents: number | null;
+    }>(
+      `/companies/${companyId}/human-members/${userId}`,
+      input,
+    ),
+
   listJoinRequests: (companyId: string, status: "pending_approval" | "approved" | "rejected" = "pending_approval") =>
     api.get<JoinRequest[]>(`/companies/${companyId}/join-requests?status=${status}`),
 

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -37,6 +37,7 @@ export interface OrgNode {
   name: string;
   role: string;
   status: string;
+  kind: "agent" | "human";
   reports: OrgNode[];
 }
 

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@/lib/router";
 import { AGENT_ROLE_LABELS, type Agent, type AgentRuntimeState } from "@paperclipai/shared";
 import { agentsApi } from "../api/agents";
+import { accessApi } from "../api/access";
 import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "./StatusBadge";
@@ -45,7 +46,16 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
     enabled: !!selectedCompanyId && !!agent.reportsTo,
   });
 
+  const { data: humanMembers } = useQuery({
+    queryKey: queryKeys.access.humanMembers(selectedCompanyId!),
+    queryFn: () => accessApi.listHumanMembers(selectedCompanyId!),
+    enabled: !!selectedCompanyId && !!agent.reportsToUserId,
+  });
+
   const reportsToAgent = agent.reportsTo ? agents?.find((a) => a.id === agent.reportsTo) : null;
+  const reportsToHuman = agent.reportsToUserId
+    ? humanMembers?.find((m) => m.id === agent.reportsToUserId) ?? null
+    : null;
 
   return (
     <div className="space-y-4">
@@ -86,14 +96,22 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
             <span className="text-sm">{formatDate(agent.lastHeartbeatAt)}</span>
           </PropertyRow>
         )}
-        {agent.reportsTo && (
+        {(agent.reportsTo || agent.reportsToUserId) && (
           <PropertyRow label="Reports To">
-            {reportsToAgent ? (
+            {agent.reportsToUserId ? (
+              reportsToHuman ? (
+                <Link to={`/humans/${reportsToHuman.id}/dashboard`} className="hover:underline">
+                  <Identity name={reportsToHuman.name ?? reportsToHuman.email ?? reportsToHuman.id} size="sm" />
+                </Link>
+              ) : (
+                <span className="text-sm font-mono">{agent.reportsToUserId.slice(0, 8)}</span>
+              )
+            ) : reportsToAgent ? (
               <Link to={agentUrl(reportsToAgent)} className="hover:underline">
                 <Identity name={reportsToAgent.name} size="sm" />
               </Link>
             ) : (
-              <span className="text-sm font-mono">{agent.reportsTo.slice(0, 8)}</span>
+              <span className="text-sm font-mono">{agent.reportsTo!.slice(0, 8)}</span>
             )}
           </PropertyRow>
         )}

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -3,6 +3,7 @@ import { Link } from "@/lib/router";
 import type { Issue } from "@paperclipai/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { agentsApi } from "../api/agents";
+import { accessApi } from "../api/access";
 import { authApi } from "../api/auth";
 import { executionWorkspacesApi } from "../api/execution-workspaces";
 import { instanceSettingsApi } from "../api/instanceSettings";
@@ -12,7 +13,7 @@ import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
 import { useProjectOrder } from "../hooks/useProjectOrder";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
-import { formatAssigneeUserLabel } from "../lib/assignees";
+import { formatAssigneeUserLabel, humanMemberAssigneeOptions, parseAssigneeValue } from "../lib/assignees";
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
@@ -202,6 +203,12 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
     enabled: !!companyId,
   });
 
+  const { data: humanMembers = [] } = useQuery({
+    queryKey: queryKeys.access.humanMembers(companyId!),
+    queryFn: () => accessApi.listHumanMembers(companyId!),
+    enabled: !!companyId,
+  });
+
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(companyId!),
     queryFn: () => projectsApi.list(companyId!),
@@ -316,7 +323,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
   const assignee = issue.assigneeAgentId
     ? agents?.find((a) => a.id === issue.assigneeAgentId)
     : null;
-  const userLabel = (userId: string | null | undefined) => formatAssigneeUserLabel(userId, currentUserId);
+  const userLabel = (userId: string | null | undefined) => formatAssigneeUserLabel(userId, currentUserId, humanMembers);
   const assigneeUserLabel = userLabel(issue.assigneeUserId);
   const creatorUserLabel = userLabel(issue.createdByUserId);
 
@@ -482,6 +489,25 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
             {creatorUserLabel ? `Assign to ${creatorUserLabel}` : "Assign to requester"}
           </button>
         )}
+        {humanMemberAssigneeOptions(humanMembers, currentUserId)
+          .filter((m) => {
+            if (!assigneeSearch.trim()) return true;
+            const q = assigneeSearch.toLowerCase();
+            return m.label.toLowerCase().includes(q) || (m.searchText ?? "").toLowerCase().includes(q);
+          })
+          .map((m) => (
+            <button
+              key={m.id}
+              className={cn(
+                "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50",
+                issue.assigneeUserId === parseAssigneeValue(m.id).assigneeUserId && "bg-accent",
+              )}
+              onClick={() => { onUpdate({ ...parseAssigneeValue(m.id), assigneeAgentId: null }); setAssigneeOpen(false); }}
+            >
+              <User className="h-3 w-3 shrink-0 text-muted-foreground" />
+              {m.label}
+            </button>
+          ))}
         {sortedAgents
           .filter((a) => {
             if (!assigneeSearch.trim()) return true;

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { BookOpen, Moon, Settings, Sun } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { BookOpen, LogOut, Moon, Settings, Sun } from "lucide-react";
 import { Link, Outlet, useLocation, useNavigate, useParams } from "@/lib/router";
 import { CompanyRail } from "./CompanyRail";
 import { Sidebar } from "./Sidebar";
@@ -23,6 +23,7 @@ import { useTheme } from "../context/ThemeContext";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useCompanyPageMemory } from "../hooks/useCompanyPageMemory";
 import { healthApi } from "../api/health";
+import { authApi } from "../api/auth";
 import { shouldSyncCompanySelectionFromRoute } from "../lib/company-selection";
 import {
   DEFAULT_INSTANCE_SETTINGS_PATH,
@@ -32,6 +33,15 @@ import { queryKeys } from "../lib/queryKeys";
 import { cn } from "../lib/utils";
 import { NotFoundPage } from "../pages/NotFound";
 import { Button } from "@/components/ui/button";
+import { Identity } from "./Identity";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 const INSTANCE_SETTINGS_MEMORY_KEY = "paperclip.lastInstanceSettingsPath";
 
@@ -78,6 +88,20 @@ export function Layout() {
     queryFn: () => healthApi.get(),
     retry: false,
   });
+  const queryClient = useQueryClient();
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    enabled: health?.deploymentMode === "authenticated",
+    retry: false,
+  });
+  const isAuthenticated = health?.deploymentMode === "authenticated";
+
+  async function handleSignOut() {
+    await authApi.signOut();
+    await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
+    navigate("/auth");
+  }
 
   useEffect(() => {
     if (companiesLoading || onboardingTriggered.current) return;
@@ -287,6 +311,14 @@ export function Layout() {
               {isInstanceSettingsRoute ? <InstanceSidebar /> : <Sidebar />}
             </div>
             <div className="border-t border-r border-border px-3 py-2 bg-background">
+              {health?.deploymentMode === "local_trusted" && (
+                <div className="mb-1.5">
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">
+                    <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+                    Local trusted mode
+                  </span>
+                </div>
+              )}
               <div className="flex items-center gap-1">
                 <a
                   href="https://docs.paperclip.ing/"
@@ -299,6 +331,31 @@ export function Layout() {
                 </a>
                 {health?.version && (
                   <span className="px-2 text-xs text-muted-foreground shrink-0">v{health.version}</span>
+                )}
+                {isAuthenticated && session?.user && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon-sm" className="shrink-0" aria-label="User menu">
+                        <Identity
+                          name={session.user.name ?? session.user.email ?? "User"}
+                          size="xs"
+                        />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent side="top" align="end" className="w-52">
+                      <DropdownMenuLabel className="font-normal">
+                        <p className="text-sm font-medium leading-none truncate">{session.user.name ?? session.user.email ?? "User"}</p>
+                        {session.user.name && session.user.email && (
+                          <p className="text-xs text-muted-foreground truncate mt-1">{session.user.email}</p>
+                        )}
+                      </DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={handleSignOut}>
+                        <LogOut className="h-4 w-4 mr-2" />
+                        Sign out
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 )}
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link
@@ -340,6 +397,14 @@ export function Layout() {
               </div>
             </div>
             <div className="border-t border-r border-border px-3 py-2">
+              {health?.deploymentMode === "local_trusted" && (
+                <div className="mb-1.5">
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">
+                    <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+                    Local trusted mode
+                  </span>
+                </div>
+              )}
               <div className="flex items-center gap-1">
                 <a
                   href="https://docs.paperclip.ing/"
@@ -352,6 +417,31 @@ export function Layout() {
                 </a>
                 {health?.version && (
                   <span className="px-2 text-xs text-muted-foreground shrink-0">v{health.version}</span>
+                )}
+                {isAuthenticated && session?.user && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon-sm" className="shrink-0" aria-label="User menu">
+                        <Identity
+                          name={session.user.name ?? session.user.email ?? "User"}
+                          size="xs"
+                        />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent side="top" align="end" className="w-52">
+                      <DropdownMenuLabel className="font-normal">
+                        <p className="text-sm font-medium leading-none truncate">{session.user.name ?? session.user.email ?? "User"}</p>
+                        {session.user.name && session.user.email && (
+                          <p className="text-xs text-muted-foreground truncate mt-1">{session.user.email}</p>
+                        )}
+                      </DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={handleSignOut}>
+                        <LogOut className="h-4 w-4 mr-2" />
+                        Sign out
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 )}
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -35,7 +35,7 @@ import { cn } from "../lib/utils";
 export interface MentionOption {
   id: string;
   name: string;
-  kind?: "agent" | "project";
+  kind?: "agent" | "human" | "project";
   projectId?: string;
   projectColor?: string | null;
 }

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -16,8 +16,10 @@ import { useToast } from "../context/ToastContext";
 import {
   assigneeValueFromSelection,
   currentUserAssigneeOption,
+  humanMemberAssigneeOptions,
   parseAssigneeValue,
 } from "../lib/assignees";
+import { accessApi } from "../api/access";
 import {
   Dialog,
   DialogContent,
@@ -348,6 +350,11 @@ export function NewIssueDialog() {
     enabled: newIssueOpen,
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  const { data: humanMembers = [] } = useQuery({
+    queryKey: queryKeys.access.humanMembers(effectiveCompanyId!),
+    queryFn: () => accessApi.listHumanMembers(effectiveCompanyId!),
+    enabled: !!effectiveCompanyId,
+  });
   const activeProjects = useMemo(
     () => (projects ?? []).filter((p) => !p.archivedAt),
     [projects],
@@ -672,6 +679,7 @@ export function NewIssueDialog() {
         ? { executionWorkspaceId: selectedExecutionWorkspaceId }
         : {}),
       ...(executionWorkspaceSettings ? { executionWorkspaceSettings } : {}),
+      ...(newIssueDefaults.parentId ? { parentId: newIssueDefaults.parentId } : {}),
     });
   }
 
@@ -790,6 +798,7 @@ export function NewIssueDialog() {
   const assigneeOptions = useMemo<InlineEntityOption[]>(
     () => [
       ...currentUserAssigneeOption(currentUserId),
+      ...humanMemberAssigneeOptions(humanMembers, currentUserId),
       ...sortAgentsByRecency(
         (agents ?? []).filter((agent) => agent.status !== "terminated"),
         recentAssigneeIds,
@@ -799,7 +808,7 @@ export function NewIssueDialog() {
         searchText: `${agent.name} ${agent.role} ${agent.title ?? ""}`,
       })),
     ],
-    [agents, currentUserId, recentAssigneeIds],
+    [agents, currentUserId, humanMembers, recentAssigneeIds],
   );
   const projectOptions = useMemo<InlineEntityOption[]>(
     () =>
@@ -953,7 +962,7 @@ export function NewIssueDialog() {
               </PopoverContent>
             </Popover>
             <span className="text-muted-foreground/60">&rsaquo;</span>
-            <span>New issue</span>
+            <span>{newIssueDefaults.parentId ? "New sub-issue" : "New issue"}</span>
           </div>
           <div className="flex items-center gap-1">
             <Button

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import { SidebarSection } from "./SidebarSection";
 import { SidebarNavItem } from "./SidebarNavItem";
 import { SidebarProjects } from "./SidebarProjects";
 import { SidebarAgents } from "./SidebarAgents";
+import { SidebarHumans } from "./SidebarHumans";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { heartbeatsApi } from "../api/heartbeats";
@@ -103,6 +104,8 @@ export function Sidebar() {
         <SidebarProjects />
 
         <SidebarAgents />
+
+        <SidebarHumans />
 
         <SidebarSection label="Company">
           <SidebarNavItem to="/org" label="Org" icon={Network} />

--- a/ui/src/components/SidebarHumans.tsx
+++ b/ui/src/components/SidebarHumans.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { NavLink, useLocation } from "@/lib/router";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronRight, User } from "lucide-react";
+import { useCompany } from "../context/CompanyContext";
+import { useSidebar } from "../context/SidebarContext";
+import { accessApi } from "../api/access";
+import { queryKeys } from "../lib/queryKeys";
+import { cn } from "../lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+export function SidebarHumans() {
+  const [open, setOpen] = useState(true);
+  const { selectedCompanyId } = useCompany();
+  const { isMobile, setSidebarOpen } = useSidebar();
+  const location = useLocation();
+
+  const { data: members = [] } = useQuery({
+    queryKey: queryKeys.access.humanMembers(selectedCompanyId!),
+    queryFn: () => accessApi.listHumanMembers(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  if (members.length === 0) return null;
+
+  const humanMatch = location.pathname.match(/^\/(?:[^/]+\/)?humans\/([^/]+)/);
+  const activeUserId = humanMatch?.[1] ?? null;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="group">
+        <div className="flex items-center px-3 py-1.5">
+          <CollapsibleTrigger className="flex items-center gap-1 flex-1 min-w-0">
+            <ChevronRight
+              className={cn(
+                "h-3 w-3 text-muted-foreground/60 transition-transform opacity-0 group-hover:opacity-100",
+                open && "rotate-90"
+              )}
+            />
+            <span className="text-[10px] font-medium uppercase tracking-widest font-mono text-muted-foreground/60">
+              Humans
+            </span>
+          </CollapsibleTrigger>
+        </div>
+      </div>
+
+      <CollapsibleContent>
+        <div className="flex flex-col gap-0.5 mt-0.5">
+          {members.map((member) => {
+            const label = member.name ?? member.email ?? member.id.slice(0, 8);
+            return (
+              <NavLink
+                key={member.id}
+                to={`/humans/${member.id}/dashboard`}
+                onClick={() => {
+                  if (isMobile) setSidebarOpen(false);
+                }}
+                className={cn(
+                  "flex items-center gap-2.5 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                  activeUserId === member.id
+                    ? "bg-accent text-foreground"
+                    : "text-foreground/80 hover:bg-accent/50 hover:text-foreground"
+                )}
+              >
+                <User className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
+                <span className="flex-1 truncate">{label}</span>
+              </NavLink>
+            );
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/ui/src/context/DialogContext.tsx
+++ b/ui/src/context/DialogContext.tsx
@@ -8,6 +8,7 @@ interface NewIssueDefaults {
   assigneeUserId?: string;
   title?: string;
   description?: string;
+  parentId?: string;
 }
 
 interface NewGoalDefaults {

--- a/ui/src/lib/assignees.ts
+++ b/ui/src/lib/assignees.ts
@@ -40,12 +40,28 @@ export function currentUserAssigneeOption(currentUserId: string | null | undefin
   }];
 }
 
+export function humanMemberAssigneeOptions(
+  members: Array<{ id: string; name: string | null; email: string | null }>,
+  currentUserId: string | null | undefined,
+): AssigneeOption[] {
+  return members
+    .filter((m) => m.id !== currentUserId)
+    .map((m) => ({
+      id: assigneeValueFromSelection({ assigneeUserId: m.id }),
+      label: m.name ?? m.email ?? m.id.slice(0, 8),
+      searchText: `${m.name ?? ""} ${m.email ?? ""} human`,
+    }));
+}
+
 export function formatAssigneeUserLabel(
   userId: string | null | undefined,
   currentUserId: string | null | undefined,
+  members?: Array<{ id: string; name: string | null; email: string | null }>,
 ): string | null {
   if (!userId) return null;
   if (currentUserId && userId === currentUserId) return "Me";
   if (userId === "local-board") return "Board";
+  const member = members?.find((m) => m.id === userId);
+  if (member) return member.name ?? member.email ?? userId.slice(0, 5);
   return userId.slice(0, 5);
 }

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -63,6 +63,8 @@ export const queryKeys = {
     joinRequests: (companyId: string, status: string = "pending_approval") =>
       ["access", "join-requests", companyId, status] as const,
     invite: (token: string) => ["access", "invite", token] as const,
+    humanMembers: (companyId: string) => ["access", "human-members", companyId] as const,
+    humanMemberConfig: (companyId: string) => ["access", "human-member-config", companyId] as const,
   },
   auth: {
     session: ["auth", "session"] as const,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { useParams, useNavigate, Link, Navigate, useBeforeUnload } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { agentsApi, type AgentKey, type ClaudeLoginResult, type AvailableSkill } from "../api/agents";
+import { accessApi } from "../api/access";
 import { budgetsApi } from "../api/budgets";
 import { heartbeatsApi } from "../api/heartbeats";
 import { ApiError } from "../api/client";
@@ -1389,6 +1390,49 @@ function ConfigurationTab({
     onSavingChange(isConfigSaving);
   }, [onSavingChange, isConfigSaving]);
 
+  // ---- Hierarchy (Reports To) ----
+
+  const { data: allAgents = [] } = useQuery({
+    queryKey: queryKeys.agents.list(agent.companyId),
+    queryFn: () => agentsApi.list(agent.companyId),
+  });
+
+  const { data: humanMembers = [] } = useQuery({
+    queryKey: queryKeys.access.humanMembers(agent.companyId),
+    queryFn: () => accessApi.listHumanMembers(agent.companyId),
+  });
+
+  function encodeReportsTo(a: Agent): string {
+    if (a.reportsToUserId) return `user:${a.reportsToUserId}`;
+    if (a.reportsTo) return `agent:${a.reportsTo}`;
+    return "";
+  }
+
+  const [supervisorRef, setSupervisorRef] = useState(() => encodeReportsTo(agent));
+
+  // Sync if agent data refreshes (after save or external change)
+  useEffect(() => {
+    setSupervisorRef(encodeReportsTo(agent));
+  }, [agent.reportsTo, agent.reportsToUserId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const savedSupervisorRef = encodeReportsTo(agent);
+  const hierarchyDirty = supervisorRef !== savedSupervisorRef;
+
+  const updateHierarchy = useMutation({
+    mutationFn: () => {
+      const reportsTo = supervisorRef.startsWith("agent:") ? supervisorRef.slice(6) : null;
+      const reportsToUserId = supervisorRef.startsWith("user:") ? supervisorRef.slice(5) : null;
+      return agentsApi.update(agent.id, { reportsTo, reportsToUserId }, companyId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.org(agent.companyId) });
+    },
+  });
+
+  const otherAgents = allAgents.filter((a) => a.id !== agent.id && a.status !== "terminated");
+
   return (
     <div className="space-y-6">
       <AgentConfigForm
@@ -1403,6 +1447,68 @@ function ConfigurationTab({
         hideInlineSave
         sectionLayout="cards"
       />
+
+      <div>
+        <h3 className="text-sm font-medium mb-3">Hierarchy</h3>
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <div className="flex items-end gap-3">
+            <div className="flex-1 space-y-1.5">
+              <label className="text-xs text-muted-foreground">Reports To</label>
+              <select
+                value={supervisorRef}
+                onChange={(e) => setSupervisorRef(e.target.value)}
+                className="w-full h-8 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="">— None —</option>
+                {otherAgents.length > 0 && (
+                  <optgroup label="Agents">
+                    {otherAgents.map((a) => (
+                      <option key={a.id} value={`agent:${a.id}`}>
+                        {a.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                )}
+                {humanMembers.length > 0 && (
+                  <optgroup label="Humans">
+                    {humanMembers.map((m) => (
+                      <option key={m.id} value={`user:${m.id}`}>
+                        {m.name ?? m.email ?? m.id.slice(0, 8)}
+                      </option>
+                    ))}
+                  </optgroup>
+                )}
+              </select>
+            </div>
+            {hierarchyDirty && (
+              <div className="flex gap-2 shrink-0">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8"
+                  onClick={() => setSupervisorRef(savedSupervisorRef)}
+                  disabled={updateHierarchy.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-8"
+                  onClick={() => updateHierarchy.mutate()}
+                  disabled={updateHierarchy.isPending}
+                >
+                  {updateHierarchy.isPending ? "Saving…" : "Save"}
+                </Button>
+              </div>
+            )}
+          </div>
+          {updateHierarchy.isError && (
+            <p className="text-xs text-destructive">
+              {updateHierarchy.error instanceof Error ? updateHierarchy.error.message : "Failed to save"}
+            </p>
+          )}
+        </div>
+      </div>
 
       <div>
         <h3 className="text-sm font-medium mb-3">Permissions</h3>

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -52,6 +52,11 @@ export function CompanySettings() {
   const [snippetCopied, setSnippetCopied] = useState(false);
   const [snippetCopyDelightId, setSnippetCopyDelightId] = useState(0);
 
+  const [humanInviteLink, setHumanInviteLink] = useState<string | null>(null);
+  const [humanInviteError, setHumanInviteError] = useState<string | null>(null);
+  const [humanInviteLinkCopied, setHumanInviteLinkCopied] = useState(false);
+  const [humanInviteRole, setHumanInviteRole] = useState<"member" | "board">("member");
+
   const generalDirty =
     !!selectedCompany &&
     (companyName !== selectedCompany.name ||
@@ -132,6 +137,32 @@ export function CompanySettings() {
     }
   });
 
+  const humanInviteMutation = useMutation({
+    mutationFn: () =>
+      accessApi.createCompanyInvite(selectedCompanyId!, {
+        allowedJoinTypes: "human",
+        defaultsPayload: {
+          human: {
+            grants: humanInviteRole === "board"
+              ? [
+                  { permissionKey: "tasks:assign", scope: null },
+                  { permissionKey: "users:manage_permissions", scope: null },
+                ]
+              : [{ permissionKey: "tasks:assign", scope: null }],
+          },
+        },
+      }),
+    onSuccess: (invite) => {
+      const base = window.location.origin.replace(/\/+$/, "");
+      setHumanInviteLink(`${base}/invite/${invite.token}`);
+      setHumanInviteError(null);
+      setHumanInviteLinkCopied(false);
+    },
+    onError: (err) => {
+      setHumanInviteError(err instanceof Error ? err.message : "Failed to create invite");
+    },
+  });
+
   const syncLogoState = (nextLogoUrl: string | null) => {
     setLogoUrl(nextLogoUrl ?? "");
     void queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
@@ -173,6 +204,10 @@ export function CompanySettings() {
     setInviteSnippet(null);
     setSnippetCopied(false);
     setSnippetCopyDelightId(0);
+    setHumanInviteLink(null);
+    setHumanInviteError(null);
+    setHumanInviteLinkCopied(false);
+    setHumanInviteRole("member");
   }, [selectedCompanyId]);
   const archiveMutation = useMutation({
     mutationFn: ({
@@ -453,6 +488,99 @@ export function CompanySettings() {
                     }}
                   >
                     {snippetCopied ? "Copied snippet" : "Copy snippet"}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-3 rounded-md border border-border px-4 py-4">
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">
+              Invite a human member to this company.
+            </span>
+            <HintIcon text="Generates a short-lived invite link. Share it with the person you want to add — they will join as pending until approved." />
+          </div>
+          <div className="space-y-2">
+            <div className="text-xs font-medium text-foreground">Role</div>
+            <div className="flex gap-2">
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="humanInviteRole"
+                  value="member"
+                  checked={humanInviteRole === "member"}
+                  onChange={() => { setHumanInviteRole("member"); setHumanInviteLink(null); }}
+                  className="mt-0.5"
+                />
+                <div>
+                  <div className="text-sm font-medium">Team Member</div>
+                  <div className="text-xs text-muted-foreground">Can be assigned issues and comment. Cannot manage approvals or other members.</div>
+                </div>
+              </label>
+            </div>
+            <div className="flex gap-2">
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="humanInviteRole"
+                  value="board"
+                  checked={humanInviteRole === "board"}
+                  onChange={() => { setHumanInviteRole("board"); setHumanInviteLink(null); }}
+                  className="mt-0.5"
+                />
+                <div>
+                  <div className="text-sm font-medium">Board Member</div>
+                  <div className="text-xs text-muted-foreground">Full access: can manage approvals, join requests, and other members.</div>
+                </div>
+              </label>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              onClick={() => humanInviteMutation.mutate()}
+              disabled={humanInviteMutation.isPending}
+            >
+              {humanInviteMutation.isPending ? "Generating..." : "Generate Human Invite Link"}
+            </Button>
+          </div>
+          {humanInviteError && (
+            <p className="text-sm text-destructive">{humanInviteError}</p>
+          )}
+          {humanInviteLink && (
+            <div className="rounded-md border border-border bg-muted/30 p-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs text-muted-foreground">Invite link (expires in 10 minutes)</div>
+                {humanInviteLinkCopied && (
+                  <span className="flex items-center gap-1 text-xs text-green-600 animate-pulse">
+                    <Check className="h-3 w-3" />
+                    Copied
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 space-y-1.5">
+                <input
+                  className="w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs outline-none"
+                  value={humanInviteLink}
+                  readOnly
+                />
+                <div className="flex justify-end">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(humanInviteLink);
+                        setHumanInviteLinkCopied(true);
+                        setTimeout(() => setHumanInviteLinkCopied(false), 2000);
+                      } catch {
+                        /* clipboard may not be available */
+                      }
+                    }}
+                  >
+                    {humanInviteLinkCopied ? "Copied" : "Copy link"}
                   </Button>
                 </div>
               </div>

--- a/ui/src/pages/HumanDetail.tsx
+++ b/ui/src/pages/HumanDetail.tsx
@@ -1,0 +1,642 @@
+import { useEffect, useMemo, useCallback, useRef, useState } from "react";
+import { useParams, useNavigate, Navigate } from "@/lib/router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  User,
+  Plus,
+  Copy,
+  MoreHorizontal,
+  Briefcase,
+  DollarSign,
+  Users,
+} from "lucide-react";
+import { accessApi } from "../api/access";
+import { agentsApi } from "../api/agents";
+import { issuesApi } from "../api/issues";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useDialog } from "../context/DialogContext";
+import { useSidebar } from "../context/SidebarContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { Identity } from "../components/Identity";
+import { EntityRow } from "../components/EntityRow";
+import { PageTabBar } from "../components/PageTabBar";
+import { StatusBadge } from "../components/StatusBadge";
+import { ChartCard, PriorityChart, IssueStatusChart } from "../components/ActivityCharts";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Tabs } from "@/components/ui/tabs";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Field } from "../components/agent-config-primitives";
+import { cn } from "../lib/utils";
+
+type HumanDetailView = "dashboard" | "configuration";
+
+function parseHumanDetailView(value: string | null): HumanDetailView {
+  if (value === "configuration") return "configuration";
+  return "dashboard";
+}
+
+function formatHourlyRate(cents: number | null | undefined): string {
+  if (cents == null) return "—";
+  const dollars = cents / 100;
+  return `$${dollars % 1 === 0 ? dollars.toFixed(0) : dollars.toFixed(2)}/hr`;
+}
+
+/* ---- Profile Configuration Form ---- */
+
+type HumanMember = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  membershipRole: string | null;
+  jobTitle: string | null;
+  supervisorUserId: string | null;
+  supervisorAgentId: string | null;
+  hourlyRateCents: number | null;
+};
+
+/** Encodes supervisor as "user:xxx", "agent:xxx", or "" */
+function encodeSupervisorRef(member: Pick<HumanMember, "supervisorAgentId" | "supervisorUserId">): string {
+  if (member.supervisorAgentId) return `agent:${member.supervisorAgentId}`;
+  if (member.supervisorUserId) return `user:${member.supervisorUserId}`;
+  return "";
+}
+
+function HumanConfigurationPage({
+  member,
+  companyId,
+  allMembers,
+  allAgents,
+  canManage,
+  onDirtyChange,
+  onSaveActionChange,
+  onCancelActionChange,
+  onSavingChange,
+}: {
+  member: HumanMember;
+  companyId: string;
+  allMembers: HumanMember[];
+  allAgents: Array<{ id: string; name: string; role: string; status: string }>;
+  canManage: boolean;
+  onDirtyChange: (dirty: boolean) => void;
+  onSaveActionChange: (save: (() => void) | null) => void;
+  onCancelActionChange: (cancel: (() => void) | null) => void;
+  onSavingChange: (saving: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const [jobTitle, setJobTitle] = useState(member.jobTitle ?? "");
+  const [supervisorRef, setSupervisorRef] = useState(() => encodeSupervisorRef(member));
+  const [hourlyRate, setHourlyRate] = useState(
+    member.hourlyRateCents != null ? String(member.hourlyRateCents / 100) : "",
+  );
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const originalRef = useRef({
+    jobTitle: member.jobTitle ?? "",
+    supervisorRef: encodeSupervisorRef(member),
+    hourlyRate: member.hourlyRateCents != null ? String(member.hourlyRateCents / 100) : "",
+  });
+
+  const isDirty =
+    jobTitle !== originalRef.current.jobTitle ||
+    supervisorRef !== originalRef.current.supervisorRef ||
+    hourlyRate !== originalRef.current.hourlyRate;
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      const rateRaw = parseFloat(hourlyRate);
+      const hourlyRateCents =
+        hourlyRate.trim() === "" || isNaN(rateRaw) ? null : Math.round(rateRaw * 100);
+      const supervisorUserId = supervisorRef.startsWith("user:") ? supervisorRef.slice(5) : null;
+      const supervisorAgentId = supervisorRef.startsWith("agent:") ? supervisorRef.slice(6) : null;
+      return accessApi.updateHumanMemberProfile(companyId, member.id, {
+        jobTitle: jobTitle.trim() || null,
+        supervisorUserId,
+        supervisorAgentId,
+        hourlyRateCents,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.access.humanMembers(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.org(companyId) });
+      setSaveError(null);
+      originalRef.current = { jobTitle, supervisorRef, hourlyRate };
+      onDirtyChange(false);
+      onSavingChange(false);
+    },
+    onError: (err) => {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+      onSavingChange(false);
+    },
+  });
+
+  const doSave = useCallback(() => {
+    onSavingChange(true);
+    saveMutation.mutate();
+  }, [saveMutation, onSavingChange]);
+
+  const doCancel = useCallback(() => {
+    setJobTitle(originalRef.current.jobTitle);
+    setSupervisorRef(originalRef.current.supervisorRef);
+    setHourlyRate(originalRef.current.hourlyRate);
+    setSaveError(null);
+  }, []);
+
+  useEffect(() => {
+    onSaveActionChange(doSave);
+    onCancelActionChange(doCancel);
+    return () => {
+      onSaveActionChange(null);
+      onCancelActionChange(null);
+    };
+  }, [doSave, doCancel, onSaveActionChange, onCancelActionChange]);
+
+  const otherMembers = allMembers.filter((m) => m.id !== member.id);
+  const activeAgents = allAgents.filter((a) => a.status !== "terminated");
+
+  // Resolve display name for read-only supervisor view
+  const supervisorDisplayName = useMemo(() => {
+    if (member.supervisorAgentId) {
+      const a = allAgents.find((a) => a.id === member.supervisorAgentId);
+      return a ? `${a.name} (Agent)` : null;
+    }
+    if (member.supervisorUserId) {
+      const u = allMembers.find((m) => m.id === member.supervisorUserId);
+      return u ? (u.name ?? u.email ?? null) : null;
+    }
+    return null;
+  }, [member, allMembers, allAgents]);
+
+  if (!canManage) {
+    return (
+      <div className="max-w-3xl space-y-6">
+        <div className="rounded-xl border border-border p-4 space-y-4">
+          <ProfileReadRow label="Job Title" icon={Briefcase} value={member.jobTitle} />
+          <ProfileReadRow label="Reports To" icon={Users} value={supervisorDisplayName} />
+          <ProfileReadRow
+            label="Hourly Rate"
+            icon={DollarSign}
+            value={formatHourlyRate(member.hourlyRateCents)}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div className="rounded-xl border border-border p-4 space-y-4">
+        <Field label="Job Title" hint="This person's role or title at the company">
+          <Input
+            value={jobTitle}
+            onChange={(e) => setJobTitle(e.target.value)}
+            placeholder="e.g. Senior Engineer"
+            className="h-8 text-sm"
+          />
+        </Field>
+
+        <Field label="Reports To" hint="Supervisor or manager — can be a human or an agent">
+          <select
+            value={supervisorRef}
+            onChange={(e) => setSupervisorRef(e.target.value)}
+            className="w-full h-8 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <option value="">— None —</option>
+            {otherMembers.length > 0 && (
+              <optgroup label="Humans">
+                {otherMembers.map((m) => (
+                  <option key={m.id} value={`user:${m.id}`}>
+                    {m.name ?? m.email ?? m.id.slice(0, 8)}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {activeAgents.length > 0 && (
+              <optgroup label="Agents">
+                {activeAgents.map((a) => (
+                  <option key={a.id} value={`agent:${a.id}`}>
+                    {a.name}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+        </Field>
+
+        <Field label="Hourly Rate ($/hr)" hint="Used for budget planning and cost tracking">
+          <Input
+            type="number"
+            min="0"
+            step="0.01"
+            value={hourlyRate}
+            onChange={(e) => setHourlyRate(e.target.value)}
+            placeholder="e.g. 75.00"
+            className="h-8 text-sm"
+          />
+        </Field>
+
+        {saveError && <p className="text-xs text-destructive">{saveError}</p>}
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium mb-2">Member Info</h3>
+        <div className="rounded-xl border border-border divide-y divide-border px-4">
+          <ProfileReadRow label="Email" icon={User} value={member.email} />
+          <ProfileReadRow
+            label="Member ID"
+            icon={User}
+            value={member.id.slice(0, 8)}
+            mono
+          />
+          <ProfileReadRow
+            label="Role"
+            icon={User}
+            value={member.membershipRole ?? "member"}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProfileReadRow({
+  label,
+  icon: Icon,
+  value,
+  mono,
+}: {
+  label: string;
+  icon?: typeof User;
+  value: string | null | undefined;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between py-2.5 gap-4">
+      <span className="text-xs text-muted-foreground shrink-0">{label}</span>
+      <span
+        className={cn(
+          "text-sm text-right truncate",
+          !value && "text-muted-foreground/60 italic",
+          mono && "font-mono text-xs",
+        )}
+      >
+        {value ?? "—"}
+      </span>
+    </div>
+  );
+}
+
+/* ---- Dashboard Tab ---- */
+
+function HumanDashboard({
+  assignedIssues,
+  userId,
+}: {
+  assignedIssues: Array<{
+    id: string;
+    title: string;
+    status: string;
+    priority: string;
+    identifier?: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  userId: string;
+}) {
+  const openIssues = assignedIssues.filter(
+    (i) => i.status !== "done" && i.status !== "cancelled",
+  );
+  const closedIssues = assignedIssues.filter(
+    (i) => i.status === "done" || i.status === "cancelled",
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        <StatCard label="Open Issues" value={openIssues.length} />
+        <StatCard label="Completed" value={closedIssues.length} />
+        <StatCard
+          label="Total Assigned"
+          value={assignedIssues.length}
+          className="hidden sm:block"
+        />
+      </div>
+
+      {/* Charts */}
+      <div className="grid grid-cols-2 gap-4">
+        <ChartCard title="Issues by Priority">
+          <PriorityChart issues={assignedIssues} />
+        </ChartCard>
+        <ChartCard title="Issues by Status">
+          <IssueStatusChart issues={assignedIssues} />
+        </ChartCard>
+      </div>
+
+      {/* Assigned Issues */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Assigned Issues</h3>
+          <a
+            href={`/issues?assignee=__user:${userId}`}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            See All &rarr;
+          </a>
+        </div>
+        {assignedIssues.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No assigned issues.</p>
+        ) : (
+          <div className="border border-border rounded-lg">
+            {assignedIssues.slice(0, 10).map((issue) => (
+              <EntityRow
+                key={issue.id}
+                identifier={issue.identifier ?? issue.id.slice(0, 8)}
+                title={issue.title}
+                to={`/issues/${issue.identifier ?? issue.id}`}
+                trailing={<StatusBadge status={issue.status} />}
+              />
+            ))}
+            {assignedIssues.length > 10 && (
+              <div className="px-3 py-2 text-xs text-muted-foreground text-center border-t border-border">
+                +{assignedIssues.length - 10} more issues
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("rounded-xl border border-border p-4", className)}>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold tabular-nums mt-1">{value}</p>
+    </div>
+  );
+}
+
+/* ---- Main export ---- */
+
+export function HumanDetail() {
+  const { userId, tab: urlTab } = useParams<{ userId: string; tab?: string }>();
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const { openNewIssue } = useDialog();
+  const { isMobile } = useSidebar();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const activeView = parseHumanDetailView(urlTab ?? null);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [configDirty, setConfigDirty] = useState(false);
+  const [configSaving, setConfigSaving] = useState(false);
+  const saveConfigActionRef = useRef<(() => void) | null>(null);
+  const cancelConfigActionRef = useRef<(() => void) | null>(null);
+  const setSaveConfigAction = useCallback((fn: (() => void) | null) => { saveConfigActionRef.current = fn; }, []);
+  const setCancelConfigAction = useCallback((fn: (() => void) | null) => { cancelConfigActionRef.current = fn; }, []);
+
+  const { data: members, isLoading: isMembersLoading } = useQuery({
+    queryKey: queryKeys.access.humanMembers(selectedCompanyId!),
+    queryFn: () => accessApi.listHumanMembers(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const { data: memberConfig } = useQuery({
+    queryKey: queryKeys.access.humanMemberConfig(selectedCompanyId!),
+    queryFn: () => accessApi.getHumanMemberConfig(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const { data: allAgents = [] } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const member = useMemo(
+    () => members?.find((m) => m.id === userId) ?? null,
+    [members, userId],
+  );
+
+  const label = member?.name ?? member?.email ?? userId?.slice(0, 8) ?? "Human";
+
+  const { data: assignedIssues = [], isLoading: isIssuesLoading } = useQuery({
+    queryKey: ["issues", selectedCompanyId!, "assigned-to-user", userId!] as const,
+    queryFn: () => issuesApi.list(selectedCompanyId!, { assigneeUserId: userId }),
+    enabled: !!selectedCompanyId && !!userId,
+  });
+
+  const sortedIssues = useMemo(
+    () =>
+      [...assignedIssues].sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      ),
+    [assignedIssues],
+  );
+
+  useEffect(() => {
+    const crumbs: { label: string; href?: string }[] = [
+      { label: "Humans", href: "/humans" },
+    ];
+    if (activeView === "dashboard") {
+      crumbs.push({ label });
+    } else {
+      crumbs.push({ label, href: `/humans/${userId}/dashboard` });
+      crumbs.push({ label: "Configuration" });
+    }
+    setBreadcrumbs(crumbs);
+  }, [setBreadcrumbs, label, activeView, userId]);
+
+  const showConfigActionBar = activeView === "configuration" && (configDirty || configSaving);
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={User} message="Select a company to view this member." />;
+  }
+
+  if (isMembersLoading || isIssuesLoading) return <PageSkeleton variant="detail" />;
+
+  if (!member && !isMembersLoading) {
+    return <EmptyState icon={User} message="Member not found." />;
+  }
+
+  if (!urlTab) {
+    return <Navigate to={`/humans/${userId}/dashboard`} replace />;
+  }
+
+  const roleLabel =
+    member?.membershipRole === "owner"
+      ? "Owner"
+      : member?.membershipRole
+        ? member.membershipRole.charAt(0).toUpperCase() + member.membershipRole.slice(1)
+        : null;
+
+  const canManage = memberConfig?.canManageMembers ?? false;
+
+  return (
+    <div className={cn("space-y-6", isMobile && showConfigActionBar && "pb-24")}>
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="shrink-0 flex items-center justify-center h-12 w-12 rounded-lg bg-accent">
+            <Identity name={label} size="sm" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="text-2xl font-bold truncate">{label}</h2>
+              {roleLabel && (
+                <Badge variant="secondary" className="text-xs shrink-0">
+                  {roleLabel}
+                </Badge>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground truncate">
+              {member?.jobTitle
+                ? member.jobTitle
+                : (member?.name && member?.email
+                  ? member.email
+                  : null) ?? "Human Member"}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => openNewIssue({ assigneeUserId: userId })}
+          >
+            <Plus className="h-3.5 w-3.5 sm:mr-1" />
+            <span className="hidden sm:inline">Assign Task</span>
+          </Button>
+
+          <Popover open={moreOpen} onOpenChange={setMoreOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="icon-xs">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-44 p-1" align="end">
+              <button
+                className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
+                onClick={() => {
+                  navigator.clipboard.writeText(userId ?? "");
+                  setMoreOpen(false);
+                }}
+              >
+                <Copy className="h-3 w-3" />
+                Copy Member ID
+              </button>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      {/* Tab bar */}
+      <Tabs
+        value={activeView}
+        onValueChange={(value) => navigate(`/humans/${userId}/${value}`)}
+      >
+        <PageTabBar
+          items={[
+            { value: "dashboard", label: "Dashboard" },
+            { value: "configuration", label: "Configuration" },
+          ]}
+          value={activeView}
+          onValueChange={(value) => navigate(`/humans/${userId}/${value}`)}
+        />
+      </Tabs>
+
+      {/* Floating Save/Cancel bar — desktop */}
+      {!isMobile && showConfigActionBar && (
+        <div className="sticky top-6 z-10 float-right transition-opacity duration-150">
+          <div className="flex items-center gap-2 bg-background/90 backdrop-blur-sm border border-border rounded-lg px-3 py-1.5 shadow-lg">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => cancelConfigActionRef.current?.()}
+              disabled={configSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => saveConfigActionRef.current?.()}
+              disabled={configSaving}
+            >
+              {configSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Mobile bottom bar */}
+      {isMobile && showConfigActionBar && (
+        <div className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/95 backdrop-blur-sm">
+          <div
+            className="flex items-center justify-end gap-2 px-3 py-2"
+            style={{ paddingBottom: "max(env(safe-area-inset-bottom), 0.5rem)" }}
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => cancelConfigActionRef.current?.()}
+              disabled={configSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => saveConfigActionRef.current?.()}
+              disabled={configSaving}
+            >
+              {configSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Tab content */}
+      {activeView === "dashboard" && (
+        <HumanDashboard assignedIssues={sortedIssues} userId={userId!} />
+      )}
+
+      {activeView === "configuration" && member && (
+        <HumanConfigurationPage
+          member={member}
+          companyId={selectedCompanyId}
+          allMembers={members ?? []}
+          allAgents={allAgents}
+          canManage={canManage}
+          onDirtyChange={setConfigDirty}
+          onSaveActionChange={setSaveConfigAction}
+          onCancelActionChange={setCancelConfigAction}
+          onSavingChange={setConfigSaving}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/Humans.tsx
+++ b/ui/src/pages/Humans.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { Link } from "@/lib/router";
+import { useQuery } from "@tanstack/react-query";
+import { User, Users } from "lucide-react";
+import { accessApi } from "../api/access";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { Identity } from "../components/Identity";
+
+export function Humans() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Humans" }]);
+  }, [setBreadcrumbs]);
+
+  const { data: members, isLoading, error } = useQuery({
+    queryKey: queryKeys.access.humanMembers(selectedCompanyId!),
+    queryFn: () => accessApi.listHumanMembers(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={Users} message="Select a company to view human members." />;
+  }
+
+  if (isLoading) return <PageSkeleton variant="list" />;
+
+  if (error) {
+    return (
+      <p className="text-sm text-destructive">
+        {error instanceof Error ? error.message : "Failed to load members."}
+      </p>
+    );
+  }
+
+  if (!members || members.length === 0) {
+    return (
+      <EmptyState
+        icon={Users}
+        message="No human members yet. Generate an invite link in Company Settings to add humans."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Humans</h1>
+      <div className="divide-y divide-border rounded-xl border border-border">
+        {members.map((member) => {
+          const label = member.name ?? member.email ?? member.id.slice(0, 8);
+          return (
+            <Link
+              key={member.id}
+              to={`/humans/${member.id}`}
+              className="flex items-center gap-3 px-4 py-3 no-underline text-inherit transition-colors hover:bg-accent/50"
+            >
+              <Identity name={label} size="sm" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{label}</p>
+                {member.name && member.email && (
+                  <p className="text-xs text-muted-foreground truncate">{member.email}</p>
+                )}
+              </div>
+              <User className="h-4 w-4 shrink-0 text-muted-foreground" />
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -53,6 +53,7 @@ import { useDismissedInboxItems } from "../hooks/useInboxBadge";
 type InboxCategoryFilter =
   | "everything"
   | "issues_i_touched"
+  | "assigned_issues"
   | "join_requests"
   | "approvals"
   | "failed_runs"
@@ -60,6 +61,7 @@ type InboxCategoryFilter =
 type InboxApprovalFilter = "all" | "actionable" | "resolved";
 type SectionKey =
   | "issues_i_touched"
+  | "assigned_issues"
   | "join_requests"
   | "approvals"
   | "failed_runs"
@@ -283,21 +285,19 @@ export function Inbox() {
   const {
     data: joinRequests = [],
     isLoading: isJoinRequestsLoading,
+    error: joinRequestsError,
   } = useQuery({
     queryKey: queryKeys.access.joinRequests(selectedCompanyId!),
-    queryFn: async () => {
-      try {
-        return await accessApi.listJoinRequests(selectedCompanyId!, "pending_approval");
-      } catch (err) {
-        if (err instanceof ApiError && (err.status === 403 || err.status === 401)) {
-          return [];
-        }
-        throw err;
-      }
-    },
+    queryFn: () => accessApi.listJoinRequests(selectedCompanyId!, "pending_approval"),
     enabled: !!selectedCompanyId,
     retry: false,
   });
+
+  // 403/401 on join requests = regular human member, not a board-level admin
+  const isAdminUser = !(
+    joinRequestsError instanceof ApiError &&
+    (joinRequestsError.status === 403 || joinRequestsError.status === 401)
+  );
 
   const { data: dashboard, isLoading: isDashboardLoading } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),
@@ -310,6 +310,12 @@ export function Inbox() {
     queryFn: () => issuesApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
+  const { data: assignedIssues = [], isLoading: isAssignedLoading } = useQuery({
+    queryKey: queryKeys.issues.listAssignedToMe(selectedCompanyId!),
+    queryFn: () => issuesApi.list(selectedCompanyId!, { assigneeUserId: "me" }),
+    enabled: !!selectedCompanyId,
+  });
+
   const {
     data: touchedIssuesRaw = [],
     isLoading: isTouchedIssuesLoading,
@@ -329,7 +335,14 @@ export function Inbox() {
     enabled: !!selectedCompanyId,
   });
 
-  const touchedIssues = useMemo(() => getRecentTouchedIssues(touchedIssuesRaw), [touchedIssuesRaw]);
+  const assignedIssueIds = useMemo(
+    () => new Set(assignedIssues.map((i) => i.id)),
+    [assignedIssues],
+  );
+  const touchedIssues = useMemo(
+    () => getRecentTouchedIssues(touchedIssuesRaw).filter((i) => !assignedIssueIds.has(i.id)),
+    [touchedIssuesRaw, assignedIssueIds],
+  );
   const unreadTouchedIssues = useMemo(
     () => touchedIssues.filter((issue) => issue.isUnreadForMe),
     [touchedIssues],
@@ -511,12 +524,18 @@ export function Inbox() {
     allCategoryFilter === "everything" || allCategoryFilter === "join_requests";
   const showTouchedCategory =
     allCategoryFilter === "everything" || allCategoryFilter === "issues_i_touched";
+  const showAssignedCategory =
+    allCategoryFilter === "everything" || allCategoryFilter === "assigned_issues";
   const showApprovalsCategory = allCategoryFilter === "everything" || allCategoryFilter === "approvals";
   const showFailedRunsCategory =
     allCategoryFilter === "everything" || allCategoryFilter === "failed_runs";
   const showAlertsCategory = allCategoryFilter === "everything" || allCategoryFilter === "alerts";
 
   const approvalsToRender = tab === "all" ? filteredAllApprovals : actionableApprovals;
+  const showAssignedSection =
+    tab === "all"
+      ? showAssignedCategory && assignedIssues.length > 0
+      : assignedIssues.length > 0;
   const showTouchedSection =
     tab === "all"
       ? showTouchedCategory && hasTouchedIssues
@@ -524,29 +543,30 @@ export function Inbox() {
         ? unreadTouchedIssues.length > 0
         : hasTouchedIssues;
   const showJoinRequestsSection =
-    tab === "all" ? showJoinRequestsCategory && hasJoinRequests : tab === "unread" && hasJoinRequests;
-  const showApprovalsSection = tab === "all"
+    isAdminUser && (tab === "all" ? showJoinRequestsCategory && hasJoinRequests : hasJoinRequests);
+  const showApprovalsSection = isAdminUser && (tab === "all"
     ? showApprovalsCategory && filteredAllApprovals.length > 0
-    : actionableApprovals.length > 0;
+    : actionableApprovals.length > 0);
   const showFailedRunsSection =
-    tab === "all" ? showFailedRunsCategory && hasRunFailures : tab === "unread" && hasRunFailures;
-  const showAlertsSection = tab === "all" ? showAlertsCategory && hasAlerts : tab === "unread" && hasAlerts;
+    isAdminUser && (tab === "all" ? showFailedRunsCategory && hasRunFailures : tab === "unread" && hasRunFailures);
+  const showAlertsSection = isAdminUser && (tab === "all" ? showAlertsCategory && hasAlerts : tab === "unread" && hasAlerts);
 
   const visibleSections = [
     showFailedRunsSection ? "failed_runs" : null,
     showAlertsSection ? "alerts" : null,
     showApprovalsSection ? "approvals" : null,
     showJoinRequestsSection ? "join_requests" : null,
+    showAssignedSection ? "assigned_issues" : null,
     showTouchedSection ? "issues_i_touched" : null,
   ].filter((key): key is SectionKey => key !== null);
 
   const allLoaded =
     !isJoinRequestsLoading &&
-    !isApprovalsLoading &&
-    !isDashboardLoading &&
-    !isIssuesLoading &&
+    (isAdminUser
+      ? !isApprovalsLoading && !isDashboardLoading && !isIssuesLoading && !isRunsLoading
+      : true) &&
     !isTouchedIssuesLoading &&
-    !isRunsLoading;
+    !isAssignedLoading;
 
   const showSeparatorBefore = (key: SectionKey) => visibleSections.indexOf(key) > 0;
   const unreadIssueIds = unreadTouchedIssues
@@ -597,14 +617,15 @@ export function Inbox() {
               <SelectContent>
                 <SelectItem value="everything">All categories</SelectItem>
                 <SelectItem value="issues_i_touched">My recent issues</SelectItem>
-                <SelectItem value="join_requests">Join requests</SelectItem>
-                <SelectItem value="approvals">Approvals</SelectItem>
-                <SelectItem value="failed_runs">Failed runs</SelectItem>
-                <SelectItem value="alerts">Alerts</SelectItem>
+                <SelectItem value="assigned_issues">Assigned to me</SelectItem>
+                {isAdminUser && <SelectItem value="join_requests">Join requests</SelectItem>}
+                {isAdminUser && <SelectItem value="approvals">Approvals</SelectItem>}
+                {isAdminUser && <SelectItem value="failed_runs">Failed runs</SelectItem>}
+                {isAdminUser && <SelectItem value="alerts">Alerts</SelectItem>}
               </SelectContent>
             </Select>
 
-            {showApprovalsCategory && (
+            {isAdminUser && showApprovalsCategory && (
               <Select
                 value={allApprovalFilter}
                 onValueChange={(value) => setAllApprovalFilter(value as InboxApprovalFilter)}
@@ -623,7 +644,7 @@ export function Inbox() {
         )}
       </div>
 
-      {approvalsError && <p className="text-sm text-destructive">{approvalsError.message}</p>}
+      {isAdminUser && approvalsError && <p className="text-sm text-destructive">{approvalsError.message}</p>}
       {actionError && <p className="text-sm text-destructive">{actionError}</p>}
 
       {!allLoaded && visibleSections.length === 0 && (
@@ -806,10 +827,48 @@ export function Inbox() {
         </>
       )}
 
+      {showAssignedSection && (
+        <>
+          {showSeparatorBefore("assigned_issues") && <Separator />}
+          <div>
+            <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Assigned to Me
+            </h3>
+            <div>
+              {assignedIssues.map((issue) => (
+                <IssueRow
+                  key={issue.id}
+                  issue={issue}
+                  issueLinkState={issueLinkState}
+                  desktopMetaLeading={(
+                    <>
+                      <span className="hidden sm:inline-flex">
+                        <PriorityIcon priority={issue.priority} />
+                      </span>
+                      <span className="hidden shrink-0 sm:inline-flex">
+                        <StatusIcon status={issue.status} />
+                      </span>
+                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                        {issue.identifier ?? issue.id.slice(0, 8)}
+                      </span>
+                    </>
+                  )}
+                  mobileMeta={`updated ${timeAgo(issue.updatedAt)}`}
+                  trailingMeta={`updated ${timeAgo(issue.updatedAt)}`}
+                />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
       {showTouchedSection && (
         <>
           {showSeparatorBefore("issues_i_touched") && <Separator />}
           <div>
+            <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {tab === "unread" ? "Unread" : "My Recent Issues"}
+            </h3>
             <div>
               {(tab === "unread" ? unreadTouchedIssues : touchedIssues).map((issue) => {
                 const isUnread = issue.isUnreadForMe && !fadingOutIssues.has(issue.id);

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -293,11 +293,9 @@ export function Inbox() {
     retry: false,
   });
 
-  // 403/401 on join requests = regular human member, not a board-level admin
-  const isAdminUser = !(
-    joinRequestsError instanceof ApiError &&
-    (joinRequestsError.status === 403 || joinRequestsError.status === 401)
-  );
+  // Any error fetching join requests means the user lacks access or the call failed;
+  // only treat a successful response (no error) as proof of admin rights.
+  const isAdminUser = joinRequestsError == null;
 
   const { data: dashboard, isLoading: isDashboardLoading } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -229,7 +229,7 @@ export function InviteLandingPage() {
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">Invite expires {dateTime(invite.expiresAt)}.</p>
 
-        {invite.inviteType !== "bootstrap_ceo" && (
+        {invite.inviteType !== "bootstrap_ceo" && availableJoinTypes.length > 1 && (
           <div className="mt-5 flex gap-2">
             {availableJoinTypes.map((type) => (
               <button

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -5,9 +5,11 @@ import { issuesApi } from "../api/issues";
 import { activityApi } from "../api/activity";
 import { heartbeatsApi } from "../api/heartbeats";
 import { agentsApi } from "../api/agents";
+import { accessApi } from "../api/access";
 import { authApi } from "../api/auth";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
+import { useDialog } from "../context/DialogContext";
 import { usePanel } from "../context/PanelContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
@@ -44,6 +46,7 @@ import {
   MessageSquare,
   MoreHorizontal,
   Paperclip,
+  Plus,
   SlidersHorizontal,
   Trash2,
 } from "lucide-react";
@@ -191,6 +194,7 @@ function ActorIdentity({ evt, agentMap }: { evt: ActivityEvent; agentMap: Map<st
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
   const { selectedCompanyId } = useCompany();
+  const { openNewIssue } = useDialog();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
@@ -287,6 +291,12 @@ export function IssueDetail() {
     enabled: !!selectedCompanyId,
   });
 
+  const { data: humanMembers = [] } = useQuery({
+    queryKey: queryKeys.access.humanMembers(selectedCompanyId!),
+    queryFn: () => accessApi.listHumanMembers(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
   const { data: session } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -337,6 +347,13 @@ export function IssueDetail() {
         kind: "agent",
       });
     }
+    for (const member of [...humanMembers].sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""))) {
+      options.push({
+        id: `user:${member.id}`,
+        name: member.name ?? member.email ?? member.id.slice(0, 8),
+        kind: "human",
+      });
+    }
     for (const project of orderedProjects) {
       options.push({
         id: `project:${project.id}`,
@@ -347,7 +364,7 @@ export function IssueDetail() {
       });
     }
     return options;
-  }, [agents, orderedProjects]);
+  }, [agents, humanMembers, orderedProjects]);
 
   const childIssues = useMemo(() => {
     if (!allIssues || !issue) return [];
@@ -367,8 +384,16 @@ export function IssueDetail() {
     if (currentUserId) {
       options.push({ id: `user:${currentUserId}`, label: "Me" });
     }
+    for (const member of humanMembers) {
+      if (member.id === currentUserId) continue;
+      options.push({
+        id: `user:${member.id}`,
+        label: member.name ?? member.email ?? member.id.slice(0, 8),
+        searchText: `${member.name ?? ""} ${member.email ?? ""} human`,
+      });
+    }
     return options;
-  }, [agents, currentUserId]);
+  }, [agents, currentUserId, humanMembers]);
 
   const currentAssigneeValue = useMemo(() => {
     if (issue?.assigneeAgentId) return `agent:${issue.assigneeAgentId}`;
@@ -985,6 +1010,17 @@ export function IssueDetail() {
         </TabsContent>
 
         <TabsContent value="subissues">
+          <div className="flex justify-end mb-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => openNewIssue({ parentId: issue.id })}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Create sub-issue
+            </Button>
+          </div>
           {childIssues.length === 0 ? (
             <p className="text-xs text-muted-foreground">No sub-issues.</p>
           ) : (

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -9,6 +9,7 @@ import { agentUrl } from "../lib/utils";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
+import { Identity } from "../components/Identity";
 import { Network } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
 
@@ -19,21 +20,21 @@ const GAP_X = 32;
 const GAP_Y = 80;
 const PADDING = 60;
 
-// ── Tree layout types ───────────────────────────────────────────────────
+// ── Layout types ─────────────────────────────────────────────────────────
 
 interface LayoutNode {
   id: string;
   name: string;
-  role: string;
+  subtitle: string;
   status: string;
+  kind: "agent" | "human";
   x: number;
   y: number;
   children: LayoutNode[];
 }
 
-// ── Layout algorithm ────────────────────────────────────────────────────
+// ── Layout algorithm ─────────────────────────────────────────────────────
 
-/** Compute the width each subtree needs. */
 function subtreeWidth(node: OrgNode): number {
   if (node.reports.length === 0) return CARD_W;
   const childrenW = node.reports.reduce((sum, c) => sum + subtreeWidth(c), 0);
@@ -41,7 +42,6 @@ function subtreeWidth(node: OrgNode): number {
   return Math.max(CARD_W, childrenW + gaps);
 }
 
-/** Recursively assign x,y positions. */
 function layoutTree(node: OrgNode, x: number, y: number): LayoutNode {
   const totalW = subtreeWidth(node);
   const layoutChildren: LayoutNode[] = [];
@@ -50,7 +50,6 @@ function layoutTree(node: OrgNode, x: number, y: number): LayoutNode {
     const childrenW = node.reports.reduce((sum, c) => sum + subtreeWidth(c), 0);
     const gaps = (node.reports.length - 1) * GAP_X;
     let cx = x + (totalW - childrenW - gaps) / 2;
-
     for (const child of node.reports) {
       const cw = subtreeWidth(child);
       layoutChildren.push(layoutTree(child, cx, y + CARD_H + GAP_Y));
@@ -61,35 +60,26 @@ function layoutTree(node: OrgNode, x: number, y: number): LayoutNode {
   return {
     id: node.id,
     name: node.name,
-    role: node.role,
+    subtitle: node.role,
     status: node.status,
+    kind: node.kind,
     x: x + (totalW - CARD_W) / 2,
     y,
     children: layoutChildren,
   };
 }
 
-/** Layout all root nodes side by side. */
 function layoutForest(roots: OrgNode[]): LayoutNode[] {
   if (roots.length === 0) return [];
-
-  const totalW = roots.reduce((sum, r) => sum + subtreeWidth(r), 0);
-  const gaps = (roots.length - 1) * GAP_X;
   let x = PADDING;
-  const y = PADDING;
-
-  const result: LayoutNode[] = [];
-  for (const root of roots) {
+  return roots.map((root) => {
     const w = subtreeWidth(root);
-    result.push(layoutTree(root, x, y));
+    const node = layoutTree(root, x, PADDING);
     x += w + GAP_X;
-  }
-
-  // Compute bounds and return
-  return result;
+    return node;
+  });
 }
 
-/** Flatten layout tree to list of nodes. */
 function flattenLayout(nodes: LayoutNode[]): LayoutNode[] {
   const result: LayoutNode[] = [];
   function walk(n: LayoutNode) {
@@ -100,7 +90,6 @@ function flattenLayout(nodes: LayoutNode[]): LayoutNode[] {
   return result;
 }
 
-/** Collect all parent→child edges. */
 function collectEdges(nodes: LayoutNode[]): Array<{ parent: LayoutNode; child: LayoutNode }> {
   const edges: Array<{ parent: LayoutNode; child: LayoutNode }> = [];
   function walk(n: LayoutNode) {
@@ -113,18 +102,7 @@ function collectEdges(nodes: LayoutNode[]): Array<{ parent: LayoutNode; child: L
   return edges;
 }
 
-// ── Status dot colors (raw hex for SVG) ─────────────────────────────────
-
-const adapterLabels: Record<string, string> = {
-  claude_local: "Claude",
-  codex_local: "Codex",
-  gemini_local: "Gemini",
-  opencode_local: "OpenCode",
-  cursor: "Cursor",
-  openclaw_gateway: "OpenClaw Gateway",
-  process: "Process",
-  http: "HTTP",
-};
+// ── Status dot colors ─────────────────────────────────────────────────────
 
 const statusDotColor: Record<string, string> = {
   running: "#22d3ee",
@@ -135,8 +113,9 @@ const statusDotColor: Record<string, string> = {
   terminated: "#a3a3a3",
 };
 const defaultDotColor = "#a3a3a3";
+const humanDotColor = "#818cf8"; // indigo for humans
 
-// ── Main component ──────────────────────────────────────────────────────
+// ── Main component ────────────────────────────────────────────────────────
 
 export function OrgChart() {
   const { selectedCompanyId } = useCompany();
@@ -165,12 +144,17 @@ export function OrgChart() {
     setBreadcrumbs([{ label: "Org Chart" }]);
   }, [setBreadcrumbs]);
 
-  // Layout computation
-  const layout = useMemo(() => layoutForest(orgTree ?? []), [orgTree]);
-  const allNodes = useMemo(() => flattenLayout(layout), [layout]);
-  const edges = useMemo(() => collectEdges(layout), [layout]);
+  const layoutRoots = useMemo(
+    () => layoutForest(orgTree ?? []),
+    [orgTree],
+  );
+  const allNodes = useMemo(() => flattenLayout(layoutRoots), [layoutRoots]);
+  const edges = useMemo(() => collectEdges(layoutRoots), [layoutRoots]);
 
-  // Compute SVG bounds
+  const hasHumans = allNodes.some((n) => n.kind === "human");
+  const hasAgents = allNodes.some((n) => n.kind === "agent");
+
+  // SVG bounds
   const bounds = useMemo(() => {
     if (allNodes.length === 0) return { width: 800, height: 600 };
     let maxX = 0, maxY = 0;
@@ -181,88 +165,67 @@ export function OrgChart() {
     return { width: maxX + PADDING, height: maxY + PADDING };
   }, [allNodes]);
 
-  // Pan & zoom state
+  // Pan & zoom
   const containerRef = useRef<HTMLDivElement>(null);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [dragging, setDragging] = useState(false);
   const dragStart = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
-
-  // Center the chart on first load
   const hasInitialized = useRef(false);
+
   useEffect(() => {
     if (hasInitialized.current || allNodes.length === 0 || !containerRef.current) return;
     hasInitialized.current = true;
-
     const container = containerRef.current;
     const containerW = container.clientWidth;
     const containerH = container.clientHeight;
-
-    // Fit chart to container
     const scaleX = (containerW - 40) / bounds.width;
     const scaleY = (containerH - 40) / bounds.height;
     const fitZoom = Math.min(scaleX, scaleY, 1);
-
     const chartW = bounds.width * fitZoom;
     const chartH = bounds.height * fitZoom;
-
     setZoom(fitZoom);
-    setPan({
-      x: (containerW - chartW) / 2,
-      y: (containerH - chartH) / 2,
-    });
+    setPan({ x: (containerW - chartW) / 2, y: (containerH - chartH) / 2 });
   }, [allNodes, bounds]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
-    // Don't drag if clicking a card
-    const target = e.target as HTMLElement;
-    if (target.closest("[data-org-card]")) return;
+    if ((e.target as HTMLElement).closest("[data-org-card]")) return;
     setDragging(true);
     dragStart.current = { x: e.clientX, y: e.clientY, panX: pan.x, panY: pan.y };
   }, [pan]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     if (!dragging) return;
-    const dx = e.clientX - dragStart.current.x;
-    const dy = e.clientY - dragStart.current.y;
-    setPan({ x: dragStart.current.panX + dx, y: dragStart.current.panY + dy });
+    setPan({
+      x: dragStart.current.panX + (e.clientX - dragStart.current.x),
+      y: dragStart.current.panY + (e.clientY - dragStart.current.y),
+    });
   }, [dragging]);
 
-  const handleMouseUp = useCallback(() => {
-    setDragging(false);
-  }, []);
+  const handleMouseUp = useCallback(() => setDragging(false), []);
 
   const handleWheel = useCallback((e: React.WheelEvent) => {
     e.preventDefault();
     const container = containerRef.current;
     if (!container) return;
-
     const rect = container.getBoundingClientRect();
     const mouseX = e.clientX - rect.left;
     const mouseY = e.clientY - rect.top;
-
     const factor = e.deltaY < 0 ? 1.1 : 0.9;
     const newZoom = Math.min(Math.max(zoom * factor, 0.2), 2);
-
-    // Zoom toward mouse position
     const scale = newZoom / zoom;
-    setPan({
-      x: mouseX - scale * (mouseX - pan.x),
-      y: mouseY - scale * (mouseY - pan.y),
-    });
+    setPan({ x: mouseX - scale * (mouseX - pan.x), y: mouseY - scale * (mouseY - pan.y) });
     setZoom(newZoom);
   }, [zoom, pan]);
 
   if (!selectedCompanyId) {
     return <EmptyState icon={Network} message="Select a company to view the org chart." />;
   }
-
   if (isLoading) {
     return <PageSkeleton variant="org-chart" />;
   }
-
-  if (orgTree && orgTree.length === 0) {
+  if (allNodes.length === 0) {
     return <EmptyState icon={Network} message="No organizational hierarchy defined." />;
   }
 
@@ -279,69 +242,52 @@ export function OrgChart() {
     >
       {/* Zoom controls */}
       <div className="absolute top-3 right-3 z-10 flex flex-col gap-1">
-        <button
-          className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
-          onClick={() => {
-            const newZoom = Math.min(zoom * 1.2, 2);
-            const container = containerRef.current;
-            if (container) {
-              const cx = container.clientWidth / 2;
-              const cy = container.clientHeight / 2;
-              const scale = newZoom / zoom;
-              setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
-            }
-            setZoom(newZoom);
-          }}
-          aria-label="Zoom in"
-        >
-          +
-        </button>
-        <button
-          className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
-          onClick={() => {
-            const newZoom = Math.max(zoom * 0.8, 0.2);
-            const container = containerRef.current;
-            if (container) {
-              const cx = container.clientWidth / 2;
-              const cy = container.clientHeight / 2;
-              const scale = newZoom / zoom;
-              setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
-            }
-            setZoom(newZoom);
-          }}
-          aria-label="Zoom out"
-        >
-          &minus;
-        </button>
-        <button
-          className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-[10px] hover:bg-accent transition-colors"
-          onClick={() => {
-            if (!containerRef.current) return;
-            const cW = containerRef.current.clientWidth;
-            const cH = containerRef.current.clientHeight;
-            const scaleX = (cW - 40) / bounds.width;
-            const scaleY = (cH - 40) / bounds.height;
-            const fitZoom = Math.min(scaleX, scaleY, 1);
-            const chartW = bounds.width * fitZoom;
-            const chartH = bounds.height * fitZoom;
-            setZoom(fitZoom);
-            setPan({ x: (cW - chartW) / 2, y: (cH - chartH) / 2 });
-          }}
-          title="Fit to screen"
-          aria-label="Fit chart to screen"
-        >
-          Fit
-        </button>
+        {(["zoom-in", "zoom-out", "fit"] as const).map((action) => (
+          <button
+            key={action}
+            className="w-7 h-7 flex items-center justify-center bg-background border border-border rounded text-sm hover:bg-accent transition-colors"
+            onClick={() => {
+              const container = containerRef.current;
+              if (!container) return;
+              if (action === "fit") {
+                const cW = container.clientWidth;
+                const cH = container.clientHeight;
+                const fitZoom = Math.min((cW - 40) / bounds.width, (cH - 40) / bounds.height, 1);
+                setZoom(fitZoom);
+                setPan({ x: (cW - bounds.width * fitZoom) / 2, y: (cH - bounds.height * fitZoom) / 2 });
+              } else {
+                const factor = action === "zoom-in" ? 1.2 : 0.8;
+                const newZoom = Math.min(Math.max(zoom * factor, 0.2), 2);
+                const cx = container.clientWidth / 2;
+                const cy = container.clientHeight / 2;
+                const scale = newZoom / zoom;
+                setPan({ x: cx - scale * (cx - pan.x), y: cy - scale * (cy - pan.y) });
+                setZoom(newZoom);
+              }
+            }}
+            aria-label={action}
+          >
+            {action === "zoom-in" ? "+" : action === "zoom-out" ? "−" : "Fit"}
+          </button>
+        ))}
       </div>
 
-      {/* SVG layer for edges */}
-      <svg
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          width: "100%",
-          height: "100%",
-        }}
-      >
+      {/* Legend */}
+      {hasHumans && hasAgents && (
+        <div className="absolute bottom-3 left-3 z-10 flex items-center gap-3 bg-background/90 border border-border rounded-lg px-3 py-1.5 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: humanDotColor }} />
+            Humans
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-400" />
+            Agents
+          </span>
+        </div>
+      )}
+
+      {/* SVG edge layer */}
+      <svg className="absolute inset-0 pointer-events-none" style={{ width: "100%", height: "100%" }}>
         <g transform={`translate(${pan.x}, ${pan.y}) scale(${zoom})`}>
           {edges.map(({ parent, child }) => {
             const x1 = parent.x + CARD_W / 2;
@@ -349,7 +295,6 @@ export function OrgChart() {
             const x2 = child.x + CARD_W / 2;
             const y2 = child.y;
             const midY = (y1 + y2) / 2;
-
             return (
               <path
                 key={`${parent.id}-${child.id}`}
@@ -372,42 +317,50 @@ export function OrgChart() {
         }}
       >
         {allNodes.map((node) => {
-          const agent = agentMap.get(node.id);
-          const dotColor = statusDotColor[node.status] ?? defaultDotColor;
+          const isHuman = node.kind === "human";
+          const agent = isHuman ? undefined : agentMap.get(node.id);
+          const dotColor = isHuman
+            ? humanDotColor
+            : (statusDotColor[node.status] ?? defaultDotColor);
 
           return (
             <div
               key={node.id}
               data-org-card
               className="absolute bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-foreground/20 transition-[box-shadow,border-color] duration-150 cursor-pointer select-none"
-              style={{
-                left: node.x,
-                top: node.y,
-                width: CARD_W,
-                minHeight: CARD_H,
-              }}
-              onClick={() => navigate(agent ? agentUrl(agent) : `/agents/${node.id}`)}
+              style={{ left: node.x, top: node.y, width: CARD_W, minHeight: CARD_H }}
+              onClick={() =>
+                navigate(
+                  isHuman
+                    ? `/humans/${node.id}/dashboard`
+                    : agent
+                      ? agentUrl(agent)
+                      : `/agents/${node.id}`,
+                )
+              }
             >
               <div className="flex items-center px-4 py-3 gap-3">
-                {/* Agent icon + status dot */}
                 <div className="relative shrink-0">
-                  <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center">
-                    <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />
+                  <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center overflow-hidden">
+                    {isHuman ? (
+                      <Identity name={node.name} size="sm" />
+                    ) : (
+                      <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />
+                    )}
                   </div>
                   <span
                     className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"
                     style={{ backgroundColor: dotColor }}
                   />
                 </div>
-                {/* Name + role + adapter type */}
                 <div className="flex flex-col items-start min-w-0 flex-1">
-                  <span className="text-sm font-semibold text-foreground leading-tight">
+                  <span className="text-sm font-semibold text-foreground leading-tight truncate w-full">
                     {node.name}
                   </span>
-                  <span className="text-[11px] text-muted-foreground leading-tight mt-0.5">
-                    {agent?.title ?? roleLabel(node.role)}
+                  <span className="text-[11px] text-muted-foreground leading-tight mt-0.5 truncate w-full">
+                    {isHuman ? node.subtitle : (agent?.title ?? roleLabel(node.subtitle))}
                   </span>
-                  {agent && (
+                  {!isHuman && agent && (
                     <span className="text-[10px] text-muted-foreground/60 font-mono leading-tight mt-1">
                       {adapterLabels[agent.adapterType] ?? agent.adapterType}
                     </span>
@@ -422,8 +375,18 @@ export function OrgChart() {
   );
 }
 
-const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;
-
+const roleLabelsMap = AGENT_ROLE_LABELS as Record<string, string>;
 function roleLabel(role: string): string {
-  return roleLabels[role] ?? role;
+  return roleLabelsMap[role] ?? role;
 }
+
+const adapterLabels: Record<string, string> = {
+  claude_local: "Claude",
+  codex_local: "Codex",
+  gemini_local: "Gemini",
+  opencode_local: "OpenCode",
+  cursor: "Cursor",
+  openclaw_gateway: "OpenClaw Gateway",
+  process: "Process",
+  http: "HTTP",
+};


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- But real companies have human operators who collaborate alongside agents and need their own logins, roles, and permissions
- Agents and humans also need a shared org hierarchy so that task delegation, assignment scope, and approval authority can follow the chain of command
- So we need first-class human users — with authenticated sessions, invite/join flows, company memberships, and a normalized permission grant model that applies equally to humans and agents
- Without this, Paperclip can only ever be a single-operator tool; with it, teams can onboard, govern access, and delegate work across both humans and AI
- This PR delivers the complete implementation: schema, backend, UI, CLI, and a full test suite covering auth guards, cross-company access, scoped assignment enforcement, and the assignee XOR invariant

---

## What changed

### DB / Schema
- Two new migrations: `0038_human_profile_fields` and `0039_unified_org_hierarchy`
- `company_memberships` extended with `supervisor_agent_id` and `supervisor_user_id` for org-hierarchy walks
- `agents` extended with `reports_to_user_id` so agents can report to a human
- `issues` extended with `assignee_user_id` (nullable); XOR invariant enforced at the validator layer
- New tables: `instance_user_roles`, `principal_permission_grants`, `invites`, `join_requests`

### Deployment modes
- Two explicit modes: `local_trusted` and `authenticated`
- `local_trusted`: no login UI, implicit instance-admin actor, loopback-only server binding enforced at startup
- `authenticated`: Better Auth email/password sessions required for all human mutations; fails startup if auth is not configured
- Health endpoint surfaces `deploymentMode`, `authReady`, and `bootstrapStatus`

### Auth & actor model
- `actorMiddleware` resolves three actor types: `local_implicit_admin`, `user` (session), `agent` (bearer JWT)
- `boardMutationGuard` blocks unauthenticated mutations in `authenticated` mode
- Session resolution is injected so the middleware is testable without a live DB

### Invite → join → approval workflow
- `POST /companies/:companyId/invites` — creates a one-time share link (copy-link only; no outbound email)
- `GET /invites/:token` / `POST /invites/:token/accept` — landing and accept endpoints; acceptance creates a `pending_approval` join request with no access granted yet
- `POST /companies/:companyId/join-requests/:id/approve|reject` — admin approval activates the membership and applies permission grants; rejection is recorded
- Human and agent join paths share the same link; join type is selected on the invite landing page

### Permission system
- `principal_permission_grants` table — one normalized grants table for both humans and agents
- `accessService` — `hasPermission`, `canUser`, `isInstanceAdmin`, `getMembership`, `ensureMembership`, `setMemberPermissions`, `promoteInstanceAdmin`, `demoteInstanceAdmin`, `listUserCompanyAccess`, `setUserCompanyAccess`, `setPrincipalGrants`
- Core grants implemented: `agents:create`, `users:invite`, `tasks:assign`, `joins:approve`
- Instance admins bypass all company-scoped permission checks

### Scoped assignment enforcement
- `parseAssignmentScope` — pure function, parses `{ rules: [...] }` JSON from the grant's `scope` column; returns `[]` on null/unrecognised input, never throws
- `evaluateAssignmentScope` — pure function, evaluates `subtree` (assignee must be at or below anchor) and `exclude` (assignee must not match target) rules
- `resolveAssigneeAncestors` — walks the org hierarchy upward for both agent (`reports_to` / `reports_to_user_id`) and user (`supervisor_agent_id` / `supervisor_user_id`) chains, capped at 20 hops to prevent cycles
- `getPermissionGrant` — returns the full grant row including `scope`, used by the route to avoid a second query
- `assertCanAssignTasks` in `issues.ts` — fetches the grant, parses scope, resolves ancestors, and throws `403` with the evaluator's reason on denial; `local_implicit` and instance-admin actors bypass scope entirely

### Assignee XOR validator
- `assigneeXorCheck` superRefine added to both `createIssueSchema` and `updateIssueSchema` in `packages/shared/src/validators/issue.ts`
- Error: `ZodIssueCode.custom`, path `["assigneeUserId"]`, message `"assigneeAgentId and assigneeUserId are mutually exclusive"`

### Bootstrap flow
- If no instance admin exists, instance is in `bootstrap_pending` state
- `pnpm paperclipai auth bootstrap-ceo` creates a single-use, short-lived bootstrap invite URL
- `pnpm paperclipai onboard` auto-detects bootstrap state and prints the invite URL
- UI blocks with a setup screen when `bootstrapStatus === "bootstrap_pending"`

### UI
- `Auth.tsx` — email/password login and signup for `authenticated` mode
- `BootstrapPending` screen — shown when no admin exists yet
- `InviteLanding` — choose human vs agent join path, respects `allowedJoinTypes`
- `Humans` / `HumanDetail` / `SidebarHumans` — human member listing, detail view, and sidebar nav
- `Layout.tsx` — "Local trusted mode" pill (green dot) shown in the sidebar footer when `deploymentMode === "local_trusted"`; absent in `authenticated` mode
- `Inbox` — join request approval cards with inline approve/reject actions; shows requester email and source IP
- `CompanySettings` — member list with permission grant management
- `OrgChart` — extended to show human nodes alongside agents

### CLI
- `paperclipai auth bootstrap-ceo` — creates bootstrap invite
- `paperclipai onboard` — checks bootstrap state and prints invite URL when pending

---

## Testing

Four new test files added:

| File | Coverage |
|------|----------|
| `server/src/__tests__/issue-assignee-xor.test.ts` | XOR validator — both fields set → ZodError; each alone → passes; null fields → passes (10 tests) |
| `server/src/__tests__/assignment-scope.test.ts` | `parseAssignmentScope` and `evaluateAssignmentScope` — null/undefined/malformed input, subtree, exclude, combined rules (19 tests) |
| `server/src/__tests__/auth-mode-guard.test.ts` | `actorMiddleware` + `boardMutationGuard` in `authenticated` mode — no auth → 401, agent bearer → 204, valid session → 204, wrong company → 403 (4 tests) |
| `server/src/__tests__/cross-company-access.test.ts` | `assertCompanyAccess` — board actor wrong company → 403, instance admin → any company passes, agent own company → 200, agent cross-company → 403 (7 tests) |

Verification gate (all passing locally):

```
pnpm -r typecheck   ✓  19/19 packages
pnpm test:run       ✓  88 files, 448 passed, 1 pre-existing skip
pnpm build          ✓  all packages including UI bundle
```

No `pnpm-lock.yaml` — intentionally excluded per repo lockfile policy.

---

## Risks / notes

- The scoped assignment rules (`subtree`, `exclude`) are evaluated purely in application code against the resolved ancestor chain. If the hierarchy data is stale or circular (the 20-hop cap handles the latter), scope evaluation could give unexpected results — this is acceptable for V1.
- `local_trusted` does not show a login UI in V1; the implicit local admin actor is the only human actor in that mode. Adding login UX to local mode is explicitly a post-V1 decision.
- Agent API keys are indefinite by default in V1 with explicit revoke/regenerate controls — no automatic expiry.
- Bootstrap invite is single-use with a short TTL; only one active bootstrap invite exists at a time per instance (regeneration revokes the prior token).