### PR TITLE
feat(shared): Add gemini_local to AGENT_ADAPTER_TYPES

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "gemini_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 


### PR DESCRIPTION
## Summary
- Register `gemini_local` in `AGENT_ADAPTER_TYPES` constant so the API validator accepts it when creating/updating agents
- The adapter implementation already exists in `packages/adapters/gemini-local` but was missing from the shared enum, causing 422 validation errors on agent creation

## Test plan
- [x] Verified `gemini_local` agents can be created via API after this change
- [x] Existing adapters unaffected (additive change only)
- [ ] Run `pnpm test:run` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)