### PR TITLE
fix: sync inbox dismiss with sidebar badge count (#314)

### DIFF
--- a/server/src/__tests__/dismiss-run.test.ts
+++ b/server/src/__tests__/dismiss-run.test.ts
@@ -1,0 +1,203 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockRun = {
+  id: "run-1",
+  companyId: "company-1",
+  agentId: "agent-1",
+  status: "failed",
+  dismissedAt: null,
+};
+
+const mockDismissedRun = {
+  ...mockRun,
+  dismissedAt: new Date("2026-03-08T00:00:00Z"),
+};
+
+const mockSuccessfulRun = {
+  ...mockRun,
+  status: "success",
+};
+
+const mockHeartbeat = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  dismissRun: vi.fn(),
+  listEvents: vi.fn(),
+  cancelRun: vi.fn(),
+  startRun: vi.fn(),
+  getRunLogChunk: vi.fn(),
+  cancelActiveForAgent: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => ({}),
+  accessService: () => ({}),
+  approvalService: () => ({}),
+  heartbeatService: () => mockHeartbeat,
+  issueApprovalService: () => ({}),
+  issueService: () => ({}),
+  secretService: () => ({}),
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../adapters/index.js", () => ({
+  findServerAdapter: vi.fn(),
+  listAdapterModels: vi.fn(),
+}));
+
+vi.mock("../redaction.js", () => ({
+  redactEventPayload: vi.fn((p: unknown) => p),
+}));
+
+vi.mock("@paperclipai/adapter-claude-local/server", () => ({
+  runClaudeLogin: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-codex-local", () => ({
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX: false,
+  DEFAULT_CODEX_LOCAL_MODEL: "codex-mini",
+}));
+
+vi.mock("@paperclipai/adapter-cursor-local", () => ({
+  DEFAULT_CURSOR_LOCAL_MODEL: "cursor-small",
+}));
+
+vi.mock("@paperclipai/adapter-gemini-local", () => ({
+  DEFAULT_GEMINI_LOCAL_MODEL: "gemini-2.5-pro",
+}));
+
+vi.mock("@paperclipai/adapter-opencode-local/server", () => ({
+  ensureOpenCodeModelConfiguredAndAvailable: vi.fn(),
+}));
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use(agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const boardActor = {
+  type: "board",
+  userId: "user-1",
+  companyIds: ["company-1"],
+  source: "session",
+  isInstanceAdmin: false,
+};
+
+const agentActor = {
+  type: "agent",
+  agentId: "agent-1",
+  companyId: "company-1",
+  source: "agent_key",
+};
+
+describe("POST /heartbeat-runs/:runId/dismiss", () => {
+  beforeEach(() => {
+    mockHeartbeat.getRun.mockReset();
+    mockHeartbeat.dismissRun.mockReset();
+    mockLogActivity.mockReset();
+  });
+
+  it("rejects non-board actors with 403", async () => {
+    const app = createApp(agentActor);
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Board access required");
+    expect(mockHeartbeat.getRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when run does not exist", async () => {
+    mockHeartbeat.getRun.mockResolvedValue(null);
+    const app = createApp(boardActor);
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+    expect(res.status).toBe(404);
+    expect(mockHeartbeat.dismissRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-company access with 403", async () => {
+    mockHeartbeat.getRun.mockResolvedValue({ ...mockRun, companyId: "company-other" });
+    const app = createApp(boardActor);
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+    expect(res.status).toBe(403);
+    expect(mockHeartbeat.dismissRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects dismissing non-failed runs", async () => {
+    mockHeartbeat.getRun.mockResolvedValue(mockSuccessfulRun);
+    const app = createApp(boardActor);
+
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("Only failed or timed-out runs can be dismissed");
+    expect(mockHeartbeat.dismissRun).not.toHaveBeenCalled();
+  });
+
+  it("dismisses run for authorized board user", async () => {
+    mockHeartbeat.getRun.mockResolvedValue(mockRun);
+    mockHeartbeat.dismissRun.mockResolvedValue({ run: mockDismissedRun, wasNewlyDismissed: true });
+    mockLogActivity.mockResolvedValue(undefined);
+    const app = createApp(boardActor);
+
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe("run-1");
+    expect(res.body.dismissedAt).toBeTruthy();
+    expect(mockHeartbeat.dismissRun).toHaveBeenCalledWith("run-1");
+  });
+
+  it("is idempotent for already-dismissed runs", async () => {
+    mockHeartbeat.getRun.mockResolvedValue(mockDismissedRun);
+    mockHeartbeat.dismissRun.mockResolvedValue({ run: mockDismissedRun, wasNewlyDismissed: false });
+    mockLogActivity.mockResolvedValue(undefined);
+    const app = createApp(boardActor);
+
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+
+    expect(res.status).toBe(200);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("does not log when another request already dismissed the run", async () => {
+    mockHeartbeat.getRun.mockResolvedValue(mockRun);
+    mockHeartbeat.dismissRun.mockResolvedValue({ run: mockDismissedRun, wasNewlyDismissed: false });
+    mockLogActivity.mockResolvedValue(undefined);
+    const app = createApp(boardActor);
+
+    const res = await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+
+    expect(res.status).toBe(200);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("logs activity only when the dismiss is newly persisted", async () => {
+    mockHeartbeat.getRun.mockResolvedValue(mockRun);
+    mockHeartbeat.dismissRun.mockResolvedValue({ run: mockDismissedRun, wasNewlyDismissed: true });
+    mockLogActivity.mockResolvedValue(undefined);
+    const app = createApp(boardActor);
+
+    await request(app).post("/heartbeat-runs/run-1/dismiss").send({});
+
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId: "company-1",
+        action: "heartbeat.dismissed",
+        entityType: "heartbeat_run",
+        entityId: "run-1",
+      }),
+    );
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1522,6 +1522,32 @@ export function agentRoutes(db: Db) {
     res.json(run);
   });
 
+  router.post("/heartbeat-runs/:runId/dismiss", async (req, res) => {
+    assertBoard(req);
+    const runId = req.params.runId as string;
+    const existing = await heartbeat.getRun(runId);
+    if (!existing) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    if (!existing.dismissedAt && !["failed", "timed_out"].includes(existing.status)) {
+      res.status(422).json({ error: "Only failed or timed-out runs can be dismissed" });
+      return;
+    }
+    const { run, wasNewlyDismissed } = await heartbeat.dismissRun(runId);
+    if (wasNewlyDismissed) {
+      await logActivity(db, {
+        companyId: existing.companyId,
+        actorType: "system",
+        action: "heartbeat.dismissed",
+        entityType: "heartbeat_run",
+        entityId: runId,
+        details: { agentId: existing.agentId, status: existing.status },
+      });
+    }
+    res.json(run);
+  });
+
   router.get("/heartbeat-runs/:runId/events", async (req, res) => {
     const runId = req.params.runId as string;
     const run = await heartbeat.getRun(runId);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1530,6 +1530,7 @@ export function agentRoutes(db: Db) {
       res.status(404).json({ error: "Heartbeat run not found" });
       return;
     }
+    assertCompanyAccess(req, existing.companyId);
     if (!existing.dismissedAt && !["failed", "timed_out"].includes(existing.status)) {
       res.status(422).json({ error: "Only failed or timed-out runs can be dismissed" });
       return;
@@ -1538,7 +1539,8 @@ export function agentRoutes(db: Db) {
     if (wasNewlyDismissed) {
       await logActivity(db, {
         companyId: existing.companyId,
-        actorType: "system",
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
         action: "heartbeat.dismissed",
         entityType: "heartbeat_run",
         entityId: runId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType } from "@paperclipai/shared";
 import {
@@ -3435,6 +3435,18 @@ export function heartbeatService(db: Db) {
     },
 
     cancelRun: (runId: string) => cancelRunInternal(runId),
+
+    dismissRun: async (runId: string) => {
+      const [updated] = await db
+        .update(heartbeatRuns)
+        .set({ dismissedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(heartbeatRuns.id, runId), isNull(heartbeatRuns.dismissedAt)))
+        .returning();
+      return {
+        run: updated ?? (await getRun(runId)),
+        wasNewlyDismissed: !!updated,
+      };
+    },
 
     cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
 

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, not, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, approvals, heartbeatRuns } from "@paperclipai/db";
 import type { SidebarBadges } from "@paperclipai/shared";
@@ -34,6 +34,7 @@ export function sidebarBadgeService(db: Db) {
             eq(heartbeatRuns.companyId, companyId),
             eq(agents.companyId, companyId),
             not(eq(agents.status, "terminated")),
+            isNull(heartbeatRuns.dismissedAt),
           ),
         )
         .orderBy(heartbeatRuns.agentId, desc(heartbeatRuns.createdAt));

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -50,6 +50,7 @@ export const heartbeatsApi = {
       `/workspace-operations/${operationId}/log?offset=${encodeURIComponent(String(offset))}&limitBytes=${encodeURIComponent(String(limitBytes))}`,
     ),
   cancel: (runId: string) => api.post<void>(`/heartbeat-runs/${runId}/cancel`, {}),
+  dismiss: (runId: string) => api.post<HeartbeatRun>(`/heartbeat-runs/${runId}/dismiss`, {}),
   liveRunsForIssue: (issueId: string) =>
     api.get<LiveRunForIssue[]>(`/issues/${issueId}/live-runs`),
   activeRunForIssue: (issueId: string) =>

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -59,9 +59,9 @@ export function saveLastInboxTab(tab: InboxTab) {
 }
 
 export function getLatestFailedRunsByAgent(runs: HeartbeatRun[]): HeartbeatRun[] {
-  const sorted = [...runs].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  );
+  const sorted = [...runs]
+    .filter((run) => !run.dismissedAt)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   const latestByAgent = new Map<string, HeartbeatRun>();
 
   for (const run of sorted) {
@@ -122,9 +122,7 @@ export function computeInboxBadgeData({
   const actionableApprovals = approvals.filter((approval) =>
     ACTIONABLE_APPROVAL_STATUSES.has(approval.status),
   ).length;
-  const failedRuns = getLatestFailedRunsByAgent(heartbeatRuns).filter(
-    (run) => !dismissed.has(`run:${run.id}`),
-  ).length;
+  const failedRuns = getLatestFailedRunsByAgent(heartbeatRuns).length;
   const unreadTouchedIssues = unreadIssues.length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -348,8 +348,8 @@ export function Inbox() {
   }, [issues]);
 
   const failedRuns = useMemo(
-    () => getLatestFailedRunsByAgent(heartbeatRuns ?? []).filter((r) => !dismissed.has(`run:${r.id}`)),
-    [heartbeatRuns, dismissed],
+    () => getLatestFailedRunsByAgent(heartbeatRuns ?? []),
+    [heartbeatRuns],
   );
   const liveIssueIds = useMemo(() => {
     const ids = new Set<string>();
@@ -489,6 +489,20 @@ export function Inbox() {
           return next;
         });
       }, 300);
+    },
+  });
+
+  const dismissRunMutation = useMutation({
+    mutationFn: (runId: string) => heartbeatsApi.dismiss(runId),
+    onSuccess: () => {
+      setActionError(null);
+      if (selectedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(selectedCompanyId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(selectedCompanyId) });
+      }
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to dismiss run");
     },
   });
 
@@ -740,7 +754,7 @@ export function Inbox() {
                   issueById={issueById}
                   agentName={agentName(run.agentId)}
                   issueLinkState={issueLinkState}
-                  onDismiss={() => dismiss(`run:${run.id}`)}
+                  onDismiss={() => dismissRunMutation.mutate(run.id)}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Adds `POST /heartbeat-runs/:runId/dismiss` endpoint with status guard (only failed/timed_out)
- `dismissRun` service method with atomic UPDATE to prevent duplicate activity logs
- Sidebar badge query excludes dismissed runs via `isNull(dismissedAt)`
- UI mutation invalidates heartbeat + badge queries on dismiss
- `dismissed_at` column already exists on upstream (migration 0038) — this PR adds implementation only

## Files (7)

- `server/src/routes/agents.ts` — dismiss endpoint
- `server/src/services/heartbeat.ts` — dismissRun method
- `server/src/services/sidebar-badges.ts` — filter dismissed runs
- `ui/src/api/heartbeats.ts` — dismiss API call
- `ui/src/lib/inbox.ts` — filter by dismissedAt instead of localStorage
- `ui/src/pages/Inbox.tsx` — dismiss mutation
- `server/src/__tests__/dismiss-run.test.ts` — test suite

## Test plan

- [x] Dismiss endpoint returns 422 for non-failed runs
- [x] Dismiss is idempotent (second call is no-op)
- [x] Sidebar badge excludes dismissed runs
- [x] UI invalidates caches after dismiss

Closes #314
Replaces #846 (merge conflicts from migration renumbering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)