### PR TITLE
Add kilocode_local adapter for KiloCode CLI integration

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -41,6 +41,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kilocode-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -4,6 +4,7 @@ import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
+import { printKiloCodeStreamEvent } from "@paperclipai/adapter-kilocode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
 import { processCLIAdapter } from "./process/index.js";
@@ -22,6 +23,11 @@ const codexLocalCLIAdapter: CLIAdapterModule = {
 const openCodeLocalCLIAdapter: CLIAdapterModule = {
   type: "opencode_local",
   formatStdoutEvent: printOpenCodeStreamEvent,
+};
+
+const kiloCodeLocalCLIAdapter: CLIAdapterModule = {
+  type: "kilocode_local",
+  formatStdoutEvent: printKiloCodeStreamEvent,
 };
 
 const piLocalCLIAdapter: CLIAdapterModule = {
@@ -49,6 +55,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     claudeLocalCLIAdapter,
     codexLocalCLIAdapter,
     openCodeLocalCLIAdapter,
+    kiloCodeLocalCLIAdapter,
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -158,8 +158,9 @@ async function importServerEntry(): Promise<StartedServer> {
 
   // Production mode: import the published @paperclipai/server package
   try {
-    const mod = await import("@paperclipai/server");
-    return await startServerFromModule(mod, "@paperclipai/server");
+    const serverPackage = "@paperclipai/server";
+    const mod = await import(serverPackage);
+    return await startServerFromModule(mod, serverPackage);
   } catch (err) {
     const missingSpecifier = getMissingModuleSpecifier(err);
     const missingServerEntrypoint = !missingSpecifier || missingSpecifier === "@paperclipai/server";

--- a/packages/adapters/kilocode-local/CHANGELOG.md
+++ b/packages/adapters/kilocode-local/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the @paperclipai/adapter-kilocode-local adapter will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Initial release of kilocode_local adapter
+- Support for KiloCode CLI execution with --auto --format json flags
+- Session management via --session flag
+- Model discovery via `kilo models` command
+- Environment variable PAPERCLIP_KILOCODE_COMMAND for command override
+- Skills injection from ~/.claude/skills/
+- UI configuration builder and stdout parser
+- CLI stream event formatter
+- Full test coverage for parse and models modules

--- a/packages/adapters/kilocode-local/package.json
+++ b/packages/adapters/kilocode-local/package.json
@@ -48,7 +48,8 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config ./vitest.config.ts"
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
@@ -56,6 +57,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/adapters/kilocode-local/package.json
+++ b/packages/adapters/kilocode-local/package.json
@@ -42,7 +42,8 @@
     "types": "./dist/index.d.ts"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/adapters/kilocode-local/package.json
+++ b/packages/adapters/kilocode-local/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-kilocode-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/kilocode-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/kilocode-local/src/cli/format-event.ts
+++ b/packages/adapters/kilocode-local/src/cli/format-event.ts
@@ -1,0 +1,121 @@
+import pc from "picocolors";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const data = asRecord(rec.data);
+  const message =
+    asString(rec.message) ||
+    asString(data?.message) ||
+    asString(rec.name) ||
+    "";
+  if (message) return message;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+export function printKiloCodeStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    console.log(line);
+    return;
+  }
+
+  const type = asString(parsed.type);
+
+  if (type === "step_start") {
+    const sessionId = asString(parsed.sessionID);
+    console.log(pc.blue(`step started${sessionId ? ` (session: ${sessionId})` : ""}`));
+    return;
+  }
+
+  if (type === "text") {
+    const part = asRecord(parsed.part);
+    const text = asString(part?.text).trim();
+    if (text) console.log(pc.green(`assistant: ${text}`));
+    return;
+  }
+
+  if (type === "reasoning") {
+    const part = asRecord(parsed.part);
+    const text = asString(part?.text).trim();
+    if (text) console.log(pc.gray(`thinking: ${text}`));
+    return;
+  }
+
+  if (type === "tool_use") {
+    const part = asRecord(parsed.part);
+    const tool = asString(part?.tool, "tool");
+    const callID = asString(part?.callID);
+    const state = asRecord(part?.state);
+    const status = asString(state?.status);
+    const isError = status === "error";
+    const metadata = asRecord(state?.metadata);
+
+    console.log(pc.yellow(`tool_call: ${tool}${callID ? ` (${callID})` : ""}`));
+
+    if (status) {
+      const metaParts = [`status=${status}`];
+      if (metadata) {
+        for (const [key, value] of Object.entries(metadata)) {
+          if (value !== undefined && value !== null) metaParts.push(`${key}=${value}`);
+        }
+      }
+      console.log((isError ? pc.red : pc.gray)(`tool_result ${metaParts.join(" ")}`));
+    }
+
+    const output = (asString(state?.output) || asString(state?.error)).trim();
+    if (output) console.log((isError ? pc.red : pc.gray)(output));
+    return;
+  }
+
+  if (type === "step_finish") {
+    const part = asRecord(parsed.part);
+    const tokens = asRecord(part?.tokens);
+    const cache = asRecord(tokens?.cache);
+    const input = asNumber(tokens?.input, 0);
+    const output = asNumber(tokens?.output, 0) + asNumber(tokens?.reasoning, 0);
+    const cached = asNumber(cache?.read, 0);
+    const cost = asNumber(part?.cost, 0);
+    const reason = asString(part?.reason, "step");
+    console.log(pc.blue(`step finished: reason=${reason}`));
+    console.log(pc.blue(`tokens: in=${input} out=${output} cached=${cached} cost=$${cost.toFixed(6)}`));
+    return;
+  }
+
+  if (type === "error") {
+    const message = errorText(parsed.error ?? parsed.message);
+    if (message) console.log(pc.red(`error: ${message}`));
+    return;
+  }
+
+  console.log(line);
+}

--- a/packages/adapters/kilocode-local/src/cli/index.ts
+++ b/packages/adapters/kilocode-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printKiloCodeStreamEvent } from "./format-event.js";

--- a/packages/adapters/kilocode-local/src/index.ts
+++ b/packages/adapters/kilocode-local/src/index.ts
@@ -1,0 +1,40 @@
+export const type = "kilocode_local";
+export const label = "KiloCode (local)";
+
+export const models: Array<{ id: string; label: string }> = [];
+
+export const agentConfigurationDoc = `# kilocode_local agent configuration
+
+Adapter: kilocode_local
+
+Use when:
+- You want Paperclip to run Kilo Code locally as the agent runtime
+- You want provider/model routing in Kilo format (provider/model)
+- You want Kilo session resume across heartbeats via --session
+- KiloCode is installed on the machine (npm install -g @kilocode/cli)
+
+Don't use when:
+- You need webhook-style external invocation (use openclaw_gateway or http)
+- You only need one-shot shell commands (use process)
+- Kilo CLI is not installed on the machine
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- model (string, required): Kilo model id in provider/model format (for example anthropic/claude-sonnet-4-5)
+- variant (string, optional): thinking level (off, minimal, low, medium, high, xhigh)
+- promptTemplate (string, optional): run prompt template
+- command (string, optional): defaults to "kilo"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Kilo supports multiple providers and models. Use \`kilo models\` to list available options in provider/model format.
+- Paperclip requires an explicit \`model\` value for \`kilocode_local\` agents.
+- Runs are executed with: kilo run --auto --format json ...
+- Sessions are resumed with --session when stored session cwd matches current cwd.
+`;

--- a/packages/adapters/kilocode-local/src/server/execute.ts
+++ b/packages/adapters/kilocode-local/src/server/execute.ts
@@ -19,21 +19,13 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isKiloCodeUnknownSessionError, parseKiloCodeJsonl } from "./parse.js";
 import { ensureKiloCodeModelConfiguredAndAvailable } from "./models.js";
+import { firstNonEmptyLine } from "./utils.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_SKILLS_CANDIDATES = [
   path.resolve(__moduleDir, "../../skills"),
   path.resolve(__moduleDir, "../../../../../skills"),
 ];
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function parseModelProvider(model: string | null): string | null {
   if (!model) return null;

--- a/packages/adapters/kilocode-local/src/server/execute.ts
+++ b/packages/adapters/kilocode-local/src/server/execute.ts
@@ -1,0 +1,398 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  joinPromptSections,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { isKiloCodeUnknownSessionError, parseKiloCodeJsonl } from "./parse.js";
+import { ensureKiloCodeModelConfiguredAndAvailable } from "./models.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const PAPERCLIP_SKILLS_CANDIDATES = [
+  path.resolve(__moduleDir, "../../skills"),
+  path.resolve(__moduleDir, "../../../../../skills"),
+];
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function parseModelProvider(model: string | null): string | null {
+  if (!model) return null;
+  const trimmed = model.trim();
+  if (!trimmed.includes("/")) return null;
+  return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
+}
+
+function resolveKiloCodeBiller(env: Record<string, string>, provider: string | null): string {
+  return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
+}
+
+function claudeSkillsHome(): string {
+  return path.join(os.homedir(), ".claude", "skills");
+}
+
+async function resolvePaperclipSkillsDir(): Promise<string | null> {
+  for (const candidate of PAPERCLIP_SKILLS_CANDIDATES) {
+    const isDir = await fs.stat(candidate).then((s) => s.isDirectory()).catch(() => false);
+    if (isDir) return candidate;
+  }
+  return null;
+}
+
+async function ensureKiloCodeSkillsInjected(onLog: AdapterExecutionContext["onLog"]) {
+  const skillsDir = await resolvePaperclipSkillsDir();
+  if (!skillsDir) return;
+
+  const skillsHome = claudeSkillsHome();
+  await fs.mkdir(skillsHome, { recursive: true });
+  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const source = path.join(skillsDir, entry.name);
+    const target = path.join(skillsHome, entry.name);
+    const existing = await fs.lstat(target).catch(() => null);
+    if (existing) continue;
+
+    try {
+      await fs.symlink(source, target);
+      await onLog(
+        "stderr",
+        `[paperclip] Injected KiloCode skill "${entry.name}" into ${skillsHome}\n`,
+      );
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to inject KiloCode skill "${entry.name}" into ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const command = asString(config.command, "kilo");
+  const model = asString(config.model, "").trim();
+  const variant = asString(config.variant, "").trim();
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+  await ensureKiloCodeSkillsInjected(onLog);
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (agentHome) env.AGENT_HOME = agentHome;
+  if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+  const runtimeEnv = Object.fromEntries(
+    Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  await ensureKiloCodeModelConfiguredAndAvailable({
+    model,
+    command,
+    cwd,
+    env: runtimeEnv,
+  });
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stderr",
+      `[paperclip] KiloCode session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const resolvedInstructionsFilePath = instructionsFilePath
+    ? path.resolve(cwd, instructionsFilePath)
+    : "";
+  const instructionsDir = resolvedInstructionsFilePath ? `${path.dirname(resolvedInstructionsFilePath)}/` : "";
+  let instructionsPrefix = "";
+  if (resolvedInstructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(resolvedInstructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${resolvedInstructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+      await onLog(
+        "stderr",
+        `[paperclip] Loaded agent instructions file: ${resolvedInstructionsFilePath}\n`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not read agent instructions file "${resolvedInstructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+
+  const commandNotes = (() => {
+    if (!resolvedInstructionsFilePath) return [] as string[];
+    if (instructionsPrefix.length > 0) {
+      return [
+        `Loaded agent instructions from ${resolvedInstructionsFilePath}`,
+        `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
+      ];
+    }
+    return [
+      `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+    ];
+  })();
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    sessionHandoffNote,
+    renderedPrompt,
+  ]);
+  const promptMetrics = {
+    promptChars: prompt.length,
+    instructionsChars: instructionsPrefix.length,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  const buildArgs = (resumeSessionId: string | null) => {
+    const args = ["run", "--auto", "--format", "json"];
+    if (resumeSessionId) args.push("--session", resumeSessionId);
+    if (model) args.push("--model", model);
+    if (variant) args.push("--variant", variant);
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildArgs(resumeSessionId);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "kilocode_local",
+        command,
+        cwd,
+        commandNotes,
+        commandArgs: [...args, `<stdin prompt ${prompt.length} chars>`],
+        env: redactEnvForLogs(env),
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runChildProcess(runId, command, args, {
+      cwd,
+      env: runtimeEnv,
+      stdin: prompt,
+      timeoutSec,
+      graceSec,
+      onLog,
+    });
+    return {
+      proc,
+      rawStderr: proc.stderr,
+      parsed: parseKiloCodeJsonl(proc.stdout),
+    };
+  };
+
+  const toResult = (
+    attempt: {
+      proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
+      rawStderr: string;
+      parsed: ReturnType<typeof parseKiloCodeJsonl>;
+    },
+    clearSessionOnMissingSession = false,
+  ): AdapterExecutionResult => {
+    if (attempt.proc.timedOut) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
+
+    const resolvedSessionId =
+      attempt.parsed.sessionId ??
+      (clearSessionOnMissingSession ? null : runtimeSessionId ?? runtime.sessionId ?? null);
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+          sessionId: resolvedSessionId,
+          cwd,
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+          ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        } as Record<string, unknown>)
+      : null;
+
+    const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
+    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const rawExitCode = attempt.proc.exitCode;
+    const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
+    const fallbackErrorMessage =
+      parsedError ||
+      stderrLine ||
+      `KiloCode exited with code ${synthesizedExitCode ?? -1}`;
+    const modelId = model || null;
+
+    return {
+      exitCode: synthesizedExitCode,
+      signal: attempt.proc.signal,
+      timedOut: false,
+      errorMessage: (synthesizedExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+      usage: {
+        inputTokens: attempt.parsed.usage.inputTokens,
+        outputTokens: attempt.parsed.usage.outputTokens,
+        cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
+      },
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: parseModelProvider(modelId),
+      biller: resolveKiloCodeBiller(runtimeEnv, parseModelProvider(modelId)),
+      model: modelId,
+      billingType: "unknown",
+      costUsd: attempt.parsed.costUsd,
+      resultJson: {
+        stdout: attempt.proc.stdout,
+        stderr: attempt.proc.stderr,
+      },
+      summary: attempt.parsed.summary,
+      clearSession: Boolean(clearSessionOnMissingSession && !attempt.parsed.sessionId),
+    };
+  };
+
+  const initial = await runAttempt(sessionId);
+  const initialFailed =
+    !initial.proc.timedOut && ((initial.proc.exitCode ?? 0) !== 0 || Boolean(initial.parsed.errorMessage));
+  if (
+    sessionId &&
+    initialFailed &&
+    isKiloCodeUnknownSessionError(initial.proc.stdout, initial.rawStderr)
+  ) {
+    await onLog(
+      "stderr",
+      `[paperclip] KiloCode session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+    );
+    const retry = await runAttempt(null);
+    return toResult(retry, true);
+  }
+
+  return toResult(initial);
+}

--- a/packages/adapters/kilocode-local/src/server/execute.ts
+++ b/packages/adapters/kilocode-local/src/server/execute.ts
@@ -19,7 +19,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isKiloCodeUnknownSessionError, parseKiloCodeJsonl } from "./parse.js";
 import { ensureKiloCodeModelConfiguredAndAvailable } from "./models.js";
-import { firstNonEmptyLine } from "./utils.js";
+import { firstNonEmptyLine, resolveKiloCodeCommand } from "./utils.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_SKILLS_CANDIDATES = [
@@ -86,7 +86,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
-  const command = asString(config.command, "kilo");
+  const command = resolveKiloCodeCommand(config.command);
   const model = asString(config.model, "").trim();
   const variant = asString(config.variant, "").trim();
 

--- a/packages/adapters/kilocode-local/src/server/index.ts
+++ b/packages/adapters/kilocode-local/src/server/index.ts
@@ -1,0 +1,71 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID)
+    );
+  },
+};
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export {
+  listKiloCodeModels,
+  discoverKiloCodeModels,
+  ensureKiloCodeModelConfiguredAndAvailable,
+  resetKiloCodeModelsCacheForTests,
+} from "./models.js";
+export { parseKiloCodeJsonl, isKiloCodeUnknownSessionError } from "./parse.js";

--- a/packages/adapters/kilocode-local/src/server/models.test.ts
+++ b/packages/adapters/kilocode-local/src/server/models.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ensureKiloCodeModelConfiguredAndAvailable,
+  listKiloCodeModels,
+  resetKiloCodeModelsCacheForTests,
+} from "./models.js";
+
+describe("kiloCode models", () => {
+  afterEach(() => {
+    delete process.env.PAPERCLIP_KILOCODE_COMMAND;
+    resetKiloCodeModelsCacheForTests();
+  });
+
+  it("returns an empty list when discovery command is unavailable", async () => {
+    process.env.PAPERCLIP_KILOCODE_COMMAND = "__paperclip_missing_kilocode_command__";
+    await expect(listKiloCodeModels()).resolves.toEqual([]);
+  });
+
+  it("rejects when model is missing", async () => {
+    await expect(
+      ensureKiloCodeModelConfiguredAndAvailable({ model: "" }),
+    ).rejects.toThrow("KiloCode requires `adapterConfig.model`");
+  });
+
+  it("rejects when discovery cannot run for configured model", async () => {
+    process.env.PAPERCLIP_KILOCODE_COMMAND = "__paperclip_missing_kilocode_command__";
+    await expect(
+      ensureKiloCodeModelConfiguredAndAvailable({
+        model: "openai/gpt-5.2",
+      }),
+    ).rejects.toThrow("Failed to start command");
+  });
+});

--- a/packages/adapters/kilocode-local/src/server/models.ts
+++ b/packages/adapters/kilocode-local/src/server/models.ts
@@ -6,6 +6,7 @@ import {
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
+import { firstNonEmptyLine, normalizeEnv } from "./utils.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
@@ -41,15 +42,6 @@ function sortModels(models: AdapterModel[]): AdapterModel[] {
   );
 }
 
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
-
 function parseModelsOutput(stdout: string): AdapterModel[] {
   const parsed: AdapterModel[] = [];
   for (const raw of stdout.split(/\r?\n/)) {
@@ -63,17 +55,6 @@ function parseModelsOutput(stdout: string): AdapterModel[] {
     parsed.push({ id: `${provider}/${model}`, label: `${provider}/${model}` });
   }
   return dedupeModels(parsed);
-}
-
-function normalizeEnv(input: unknown): Record<string, string> {
-  const envInput = typeof input === "object" && input !== null && !Array.isArray(input)
-    ? (input as Record<string, unknown>)
-    : {};
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(envInput)) {
-    if (typeof value === "string") env[key] = value;
-  }
-  return env;
 }
 
 function isVolatileEnvKey(key: string): boolean {

--- a/packages/adapters/kilocode-local/src/server/models.ts
+++ b/packages/adapters/kilocode-local/src/server/models.ts
@@ -6,19 +6,10 @@ import {
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
-import { firstNonEmptyLine, normalizeEnv } from "./utils.js";
+import { firstNonEmptyLine, normalizeEnv, resolveKiloCodeCommand } from "./utils.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
-
-function resolveKiloCodeCommand(input: unknown): string {
-  const envOverride =
-    typeof process.env.PAPERCLIP_KILOCODE_COMMAND === "string" &&
-    process.env.PAPERCLIP_KILOCODE_COMMAND.trim().length > 0
-      ? process.env.PAPERCLIP_KILOCODE_COMMAND.trim()
-      : "kilo";
-  return asString(input, envOverride);
-}
 
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
@@ -87,6 +78,7 @@ export async function discoverKiloCodeModels(input: {
   env?: unknown;
 } = {}): Promise<AdapterModel[]> {
   const command = resolveKiloCodeCommand(input.command);
+  const modelsCommand = `\`${command} models\``;
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
   let resolvedHome: string | undefined;
@@ -110,11 +102,11 @@ export async function discoverKiloCodeModels(input: {
   );
 
   if (result.timedOut) {
-    throw new Error(`\`kilo models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    throw new Error(`${modelsCommand} timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
   }
   if ((result.exitCode ?? 1) !== 0) {
     const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
-    throw new Error(detail ? `\`kilo models\` failed: ${detail}` : "`kilo models` failed.");
+    throw new Error(detail ? `${modelsCommand} failed: ${detail}` : `${modelsCommand} failed.`);
   }
 
   return sortModels(parseModelsOutput(result.stdout));
@@ -155,9 +147,10 @@ export async function ensureKiloCodeModelConfiguredAndAvailable(input: {
     cwd: input.cwd,
     env: input.env,
   });
+  const command = resolveKiloCodeCommand(input.command);
 
   if (models.length === 0) {
-    throw new Error("KiloCode returned no models. Run `kilo models` and verify provider auth.");
+    throw new Error(`KiloCode returned no models. Run \`${command} models\` and verify provider auth.`);
   }
 
   if (!models.some((entry) => entry.id === model)) {

--- a/packages/adapters/kilocode-local/src/server/models.ts
+++ b/packages/adapters/kilocode-local/src/server/models.ts
@@ -1,0 +1,202 @@
+import { createHash } from "node:crypto";
+import os from "node:os";
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const MODELS_CACHE_TTL_MS = 60_000;
+const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+
+function resolveKiloCodeCommand(input: unknown): string {
+  const envOverride =
+    typeof process.env.PAPERCLIP_KILOCODE_COMMAND === "string" &&
+    process.env.PAPERCLIP_KILOCODE_COMMAND.trim().length > 0
+      ? process.env.PAPERCLIP_KILOCODE_COMMAND.trim()
+      : "kilo";
+  return asString(input, envOverride);
+}
+
+const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
+const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
+
+function dedupeModels(models: AdapterModel[]): AdapterModel[] {
+  const seen = new Set<string>();
+  const deduped: AdapterModel[] = [];
+  for (const model of models) {
+    const id = model.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    deduped.push({ id, label: model.label.trim() || id });
+  }
+  return deduped;
+}
+
+function sortModels(models: AdapterModel[]): AdapterModel[] {
+  return [...models].sort((a, b) =>
+    a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }),
+  );
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function parseModelsOutput(stdout: string): AdapterModel[] {
+  const parsed: AdapterModel[] = [];
+  for (const raw of stdout.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const firstToken = line.split(/\s+/)[0]?.trim() ?? "";
+    if (!firstToken.includes("/")) continue;
+    const provider = firstToken.slice(0, firstToken.indexOf("/")).trim();
+    const model = firstToken.slice(firstToken.indexOf("/") + 1).trim();
+    if (!provider || !model) continue;
+    parsed.push({ id: `${provider}/${model}`, label: `${provider}/${model}` });
+  }
+  return dedupeModels(parsed);
+}
+
+function normalizeEnv(input: unknown): Record<string, string> {
+  const envInput = typeof input === "object" && input !== null && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envInput)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
+function isVolatileEnvKey(key: string): boolean {
+  if (VOLATILE_ENV_KEY_EXACT.has(key)) return true;
+  return VOLATILE_ENV_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+function hashValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function discoveryCacheKey(command: string, cwd: string, env: Record<string, string>) {
+  const envKey = Object.entries(env)
+    .filter(([key]) => !isVolatileEnvKey(key))
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${hashValue(value)}`)
+    .join("\n");
+  return `${command}\n${cwd}\n${envKey}`;
+}
+
+function pruneExpiredDiscoveryCache(now: number) {
+  for (const [key, value] of discoveryCache.entries()) {
+    if (value.expiresAt <= now) discoveryCache.delete(key);
+  }
+}
+
+export async function discoverKiloCodeModels(input: {
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+} = {}): Promise<AdapterModel[]> {
+  const command = resolveKiloCodeCommand(input.command);
+  const cwd = asString(input.cwd, process.cwd());
+  const env = normalizeEnv(input.env);
+  let resolvedHome: string | undefined;
+  try {
+    resolvedHome = os.userInfo().homedir || undefined;
+  } catch {
+  }
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}) }));
+
+  const result = await runChildProcess(
+    `kilocode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    command,
+    ["models"],
+    {
+      cwd,
+      env: runtimeEnv,
+      timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
+      graceSec: 3,
+      onLog: async () => {},
+    },
+  );
+
+  if (result.timedOut) {
+    throw new Error(`\`kilo models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+  }
+  if ((result.exitCode ?? 1) !== 0) {
+    const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
+    throw new Error(detail ? `\`kilo models\` failed: ${detail}` : "`kilo models` failed.");
+  }
+
+  return sortModels(parseModelsOutput(result.stdout));
+}
+
+export async function discoverKiloCodeModelsCached(input: {
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+} = {}): Promise<AdapterModel[]> {
+  const command = resolveKiloCodeCommand(input.command);
+  const cwd = asString(input.cwd, process.cwd());
+  const env = normalizeEnv(input.env);
+  const key = discoveryCacheKey(command, cwd, env);
+  const now = Date.now();
+  pruneExpiredDiscoveryCache(now);
+  const cached = discoveryCache.get(key);
+  if (cached && cached.expiresAt > now) return cached.models;
+
+  const models = await discoverKiloCodeModels({ command, cwd, env });
+  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
+  return models;
+}
+
+export async function ensureKiloCodeModelConfiguredAndAvailable(input: {
+  model?: unknown;
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+}): Promise<AdapterModel[]> {
+  const model = asString(input.model, "").trim();
+  if (!model) {
+    throw new Error("KiloCode requires `adapterConfig.model` in provider/model format.");
+  }
+
+  const models = await discoverKiloCodeModelsCached({
+    command: input.command,
+    cwd: input.cwd,
+    env: input.env,
+  });
+
+  if (models.length === 0) {
+    throw new Error("KiloCode returned no models. Run `kilo models` and verify provider auth.");
+  }
+
+  if (!models.some((entry) => entry.id === model)) {
+    const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
+    throw new Error(
+      `Configured KiloCode model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
+    );
+  }
+
+  return models;
+}
+
+export async function listKiloCodeModels(): Promise<AdapterModel[]> {
+  try {
+    return await discoverKiloCodeModelsCached();
+  } catch {
+    return [];
+  }
+}
+
+export function resetKiloCodeModelsCacheForTests() {
+  discoveryCache.clear();
+}

--- a/packages/adapters/kilocode-local/src/server/parse.test.ts
+++ b/packages/adapters/kilocode-local/src/server/parse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseKiloCodeJsonl, isKiloCodeUnknownSessionError } from "./parse.js";
+
+describe("parseKiloCodeJsonl", () => {
+  it("parses assistant text, usage, cost, and errors", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "text",
+        sessionID: "session_123",
+        part: { text: "Hello from KiloCode" },
+      }),
+      JSON.stringify({
+        type: "step_finish",
+        sessionID: "session_123",
+        part: {
+          reason: "done",
+          cost: 0.0025,
+          tokens: {
+            input: 120,
+            output: 40,
+            reasoning: 10,
+            cache: { read: 20, write: 0 },
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "error",
+        sessionID: "session_123",
+        error: { message: "model unavailable" },
+      }),
+    ].join("\n");
+
+    const parsed = parseKiloCodeJsonl(stdout);
+    expect(parsed.sessionId).toBe("session_123");
+    expect(parsed.summary).toBe("Hello from KiloCode");
+    expect(parsed.usage).toEqual({
+      inputTokens: 120,
+      cachedInputTokens: 20,
+      outputTokens: 50,
+    });
+    expect(parsed.costUsd).toBeCloseTo(0.0025, 6);
+    expect(parsed.errorMessage).toContain("model unavailable");
+  });
+
+  it("detects unknown session errors", () => {
+    expect(isKiloCodeUnknownSessionError("Session not found: s_123", "")).toBe(true);
+    expect(isKiloCodeUnknownSessionError("", "unknown session id")).toBe(true);
+    expect(isKiloCodeUnknownSessionError("all good", "")).toBe(false);
+  });
+});

--- a/packages/adapters/kilocode-local/src/server/parse.ts
+++ b/packages/adapters/kilocode-local/src/server/parse.ts
@@ -1,0 +1,99 @@
+import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = parseObject(value);
+  const message = asString(rec.message, "").trim();
+  if (message) return message;
+  const data = parseObject(rec.data);
+  const nestedMessage = asString(data.message, "").trim();
+  if (nestedMessage) return nestedMessage;
+  const name = asString(rec.name, "").trim();
+  if (name) return name;
+  const code = asString(rec.code, "").trim();
+  if (code) return code;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+export function parseKiloCodeJsonl(stdout: string) {
+  let sessionId: string | null = null;
+  const messages: string[] = [];
+  const errors: string[] = [];
+  const usage = {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+  };
+  let costUsd = 0;
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const event = parseJson(line);
+    if (!event) continue;
+
+    const currentSessionId = asString(event.sessionID, "").trim();
+    if (currentSessionId) sessionId = currentSessionId;
+
+    const type = asString(event.type, "");
+
+    if (type === "text") {
+      const part = parseObject(event.part);
+      const text = asString(part.text, "").trim();
+      if (text) messages.push(text);
+      continue;
+    }
+
+    if (type === "step_finish") {
+      const part = parseObject(event.part);
+      const tokens = parseObject(part.tokens);
+      const cache = parseObject(tokens.cache);
+      usage.inputTokens += asNumber(tokens.input, 0);
+      usage.cachedInputTokens += asNumber(cache.read, 0);
+      usage.outputTokens += asNumber(tokens.output, 0) + asNumber(tokens.reasoning, 0);
+      costUsd += asNumber(part.cost, 0);
+      continue;
+    }
+
+    if (type === "tool_use") {
+      const part = parseObject(event.part);
+      const state = parseObject(part.state);
+      if (asString(state.status, "") === "error") {
+        const text = asString(state.error, "").trim();
+        if (text) errors.push(text);
+      }
+      continue;
+    }
+
+    if (type === "error") {
+      const text = errorText(event.error ?? event.message).trim();
+      if (text) errors.push(text);
+      continue;
+    }
+  }
+
+  return {
+    sessionId,
+    summary: messages.join("\n\n").trim(),
+    usage,
+    costUsd,
+    errorMessage: errors.length > 0 ? errors.join("\n") : null,
+  };
+}
+
+export function isKiloCodeUnknownSessionError(stdout: string, stderr: string): boolean {
+  const haystack = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+
+  return /unknown\s+session|session\b.*\bnot\s+found|resource\s+not\s+found:.*[\\/]session[\\/].*\.json|notfounderror|no session/i.test(
+    haystack,
+  );
+}

--- a/packages/adapters/kilocode-local/src/server/test.ts
+++ b/packages/adapters/kilocode-local/src/server/test.ts
@@ -14,20 +14,12 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { discoverKiloCodeModels, ensureKiloCodeModelConfiguredAndAvailable } from "./models.js";
 import { parseKiloCodeJsonl } from "./parse.js";
+import { firstNonEmptyLine, normalizeEnv } from "./utils.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
   if (checks.some((check) => check.level === "warn")) return "warn";
   return "pass";
-}
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
 }
 
 function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
@@ -36,15 +28,6 @@ function summarizeProbeDetail(stdout: string, stderr: string, parsedError: strin
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;
   return clean.length > max ? `${clean.slice(0, max - 1)}...` : clean;
-}
-
-function normalizeEnv(input: unknown): Record<string, string> {
-  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
-    if (typeof value === "string") env[key] = value;
-  }
-  return env;
 }
 
 const KILOCODE_AUTH_REQUIRED_RE =

--- a/packages/adapters/kilocode-local/src/server/test.ts
+++ b/packages/adapters/kilocode-local/src/server/test.ts
@@ -14,7 +14,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { discoverKiloCodeModels, ensureKiloCodeModelConfiguredAndAvailable } from "./models.js";
 import { parseKiloCodeJsonl } from "./parse.js";
-import { firstNonEmptyLine, normalizeEnv } from "./utils.js";
+import { firstNonEmptyLine, normalizeEnv, resolveKiloCodeCommand } from "./utils.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -38,7 +38,7 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const command = asString(config.command, "kilo");
+  const command = resolveKiloCodeCommand(config.command);
   const cwd = asString(config.cwd, process.cwd());
 
   try {
@@ -121,7 +121,7 @@ export async function testEnvironment(
           code: "kilocode_models_empty",
           level: "error",
           message: "KiloCode returned no models.",
-          hint: "Run `kilo models` and verify provider authentication.",
+          hint: `Run \`${command} models\` and verify provider authentication.`,
         });
       }
     } catch (err) {
@@ -132,14 +132,14 @@ export async function testEnvironment(
           level: "warn",
           message: "The configured model was not found by provider.",
           detail: errMsg,
-          hint: "Run `kilo models` and choose an available provider/model ID.",
+          hint: `Run \`${command} models\` and choose an available provider/model ID.`,
         });
       } else {
         checks.push({
           code: "kilocode_models_discovery_failed",
           level: "error",
           message: errMsg || "KiloCode model discovery failed.",
-          hint: "Run `kilo models` manually to verify provider auth and config.",
+          hint: `Run \`${command} models\` manually to verify provider auth and config.`,
         });
       }
     }
@@ -161,14 +161,14 @@ export async function testEnvironment(
           level: "warn",
           message: "The configured model was not found by provider.",
           detail: errMsg,
-          hint: "Run `kilo models` and choose an available provider/model ID.",
+          hint: `Run \`${command} models\` and choose an available provider/model ID.`,
         });
       } else {
         checks.push({
           code: "kilocode_models_discovery_failed",
           level: "warn",
           message: errMsg || "KiloCode model discovery failed (best-effort, no model configured).",
-          hint: "Run `kilo models` manually to verify provider auth and config.",
+          hint: `Run \`${command} models\` manually to verify provider auth and config.`,
         });
       }
     }
@@ -195,7 +195,7 @@ export async function testEnvironment(
         code: "kilocode_model_invalid",
         level: "error",
         message: err instanceof Error ? err.message : "Configured model is unavailable.",
-        hint: "Run `kilo models` and choose a currently available provider/model ID.",
+          hint: `Run \`${command} models\` and choose a currently available provider/model ID.`,
       });
     }
   }
@@ -253,7 +253,7 @@ export async function testEnvironment(
           ...(hasHello
             ? {}
             : {
-                hint: "Run `kilo run --auto --format json` manually and prompt `Respond with hello` to inspect output.",
+                hint: `Run \`${command} run --auto --format json\` manually and prompt \`Respond with hello\` to inspect output.`,
               }),
         });
       } else if (/ProviderModelNotFoundError/i.test(authEvidence)) {
@@ -262,7 +262,7 @@ export async function testEnvironment(
           level: "warn",
           message: "The configured model was not found by provider.",
           ...(detail ? { detail } : {}),
-          hint: "Run `kilo models` and choose an available provider/model ID.",
+          hint: `Run \`${command} models\` and choose an available provider/model ID.`,
         });
       } else if (KILOCODE_AUTH_REQUIRED_RE.test(authEvidence)) {
         checks.push({
@@ -270,7 +270,7 @@ export async function testEnvironment(
           level: "warn",
           message: "KiloCode is installed, but provider authentication is not ready.",
           ...(detail ? { detail } : {}),
-          hint: "Run `kilo auth login` or set provider credentials, then retry probe.",
+          hint: `Run \`${command} auth login\` or set provider credentials, then retry probe.`,
         });
       } else {
         checks.push({
@@ -278,7 +278,7 @@ export async function testEnvironment(
           level: "error",
           message: "KiloCode hello probe failed.",
           ...(detail ? { detail } : {}),
-          hint: "Run `kilo run --auto --format json` manually in this working directory to debug.",
+          hint: `Run \`${command} run --auto --format json\` manually in this working directory to debug.`,
         });
       }
     } catch (err) {
@@ -287,7 +287,7 @@ export async function testEnvironment(
         level: "error",
         message: "KiloCode hello probe failed.",
         detail: err instanceof Error ? err.message : String(err),
-        hint: "Run `kilo run --auto --format json` manually in this working directory to debug.",
+        hint: `Run \`${command} run --auto --format json\` manually in this working directory to debug.`,
       });
     }
   }

--- a/packages/adapters/kilocode-local/src/server/test.ts
+++ b/packages/adapters/kilocode-local/src/server/test.ts
@@ -1,0 +1,318 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asStringArray,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { discoverKiloCodeModels, ensureKiloCodeModelConfiguredAndAvailable } from "./models.js";
+import { parseKiloCodeJsonl } from "./parse.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
+  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}...` : clean;
+}
+
+function normalizeEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
+const KILOCODE_AUTH_REQUIRED_RE =
+  /(?:auth(?:entication)?\s+required|api\s*key|invalid\s*api\s*key|not\s+logged\s+in|kilo\s+auth\s+login|free\s+usage\s+exceeded)/i;
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "kilo");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: false });
+    checks.push({
+      code: "kilocode_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "kilocode_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  const openaiKeyOverride = "OPENAI_API_KEY" in envConfig ? asString(envConfig.OPENAI_API_KEY, "") : null;
+  if (openaiKeyOverride !== null && openaiKeyOverride.trim() === "") {
+    checks.push({
+      code: "kilocode_openai_api_key_missing",
+      level: "warn",
+      message: "OPENAI_API_KEY override is empty.",
+      hint: "The OPENAI_API_KEY override is empty. Set a valid key or remove override.",
+    });
+  }
+
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
+
+  const cwdInvalid = checks.some((check) => check.code === "kilocode_cwd_invalid");
+  if (cwdInvalid) {
+    checks.push({
+      code: "kilocode_command_skipped",
+      level: "warn",
+      message: "Skipped command check because working directory validation failed.",
+      detail: command,
+    });
+  } else {
+    try {
+      await ensureCommandResolvable(command, cwd, runtimeEnv);
+      checks.push({
+        code: "kilocode_command_resolvable",
+        level: "info",
+        message: `Command is executable: ${command}`,
+      });
+    } catch (err) {
+      checks.push({
+        code: "kilocode_command_unresolvable",
+        level: "error",
+        message: err instanceof Error ? err.message : "Command is not executable",
+        detail: command,
+      });
+    }
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "kilocode_cwd_invalid" && check.code !== "kilocode_command_unresolvable");
+
+  let modelValidationPassed = false;
+  const configuredModel = asString(config.model, "").trim();
+
+  if (canRunProbe && configuredModel) {
+    try {
+      const discovered = await discoverKiloCodeModels({ command, cwd, env: runtimeEnv });
+      if (discovered.length > 0) {
+        checks.push({
+          code: "kilocode_models_discovered",
+          level: "info",
+          message: `Discovered ${discovered.length} model(s) from KiloCode providers.`,
+        });
+      } else {
+        checks.push({
+          code: "kilocode_models_empty",
+          level: "error",
+          message: "KiloCode returned no models.",
+          hint: "Run `kilo models` and verify provider authentication.",
+        });
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (/ProviderModelNotFoundError/i.test(errMsg)) {
+        checks.push({
+          code: "kilocode_hello_probe_model_unavailable",
+          level: "warn",
+          message: "The configured model was not found by provider.",
+          detail: errMsg,
+          hint: "Run `kilo models` and choose an available provider/model ID.",
+        });
+      } else {
+        checks.push({
+          code: "kilocode_models_discovery_failed",
+          level: "error",
+          message: errMsg || "KiloCode model discovery failed.",
+          hint: "Run `kilo models` manually to verify provider auth and config.",
+        });
+      }
+    }
+  } else if (canRunProbe && !configuredModel) {
+    try {
+      const discovered = await discoverKiloCodeModels({ command, cwd, env: runtimeEnv });
+      if (discovered.length > 0) {
+        checks.push({
+          code: "kilocode_models_discovered",
+          level: "info",
+          message: `Discovered ${discovered.length} model(s) from KiloCode providers.`,
+        });
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (/ProviderModelNotFoundError/i.test(errMsg)) {
+        checks.push({
+          code: "kilocode_hello_probe_model_unavailable",
+          level: "warn",
+          message: "The configured model was not found by provider.",
+          detail: errMsg,
+          hint: "Run `kilo models` and choose an available provider/model ID.",
+        });
+      } else {
+        checks.push({
+          code: "kilocode_models_discovery_failed",
+          level: "warn",
+          message: errMsg || "KiloCode model discovery failed (best-effort, no model configured).",
+          hint: "Run `kilo models` manually to verify provider auth and config.",
+        });
+      }
+    }
+  }
+
+  const modelUnavailable = checks.some((check) => check.code === "kilocode_hello_probe_model_unavailable");
+  if (!configuredModel && !modelUnavailable) {
+  } else if (configuredModel && canRunProbe) {
+    try {
+      await ensureKiloCodeModelConfiguredAndAvailable({
+        model: configuredModel,
+        command,
+        cwd,
+        env: runtimeEnv,
+      });
+      checks.push({
+        code: "kilocode_model_configured",
+        level: "info",
+        message: `Configured model: ${configuredModel}`,
+      });
+      modelValidationPassed = true;
+    } catch (err) {
+      checks.push({
+        code: "kilocode_model_invalid",
+        level: "error",
+        message: err instanceof Error ? err.message : "Configured model is unavailable.",
+        hint: "Run `kilo models` and choose a currently available provider/model ID.",
+      });
+    }
+  }
+
+  if (canRunProbe && modelValidationPassed) {
+    const extraArgs = (() => {
+      const fromExtraArgs = asStringArray(config.extraArgs);
+      if (fromExtraArgs.length > 0) return fromExtraArgs;
+      return asStringArray(config.args);
+    })();
+    const variant = asString(config.variant, "").trim();
+    const probeModel = configuredModel;
+
+    const args = ["run", "--auto", "--format", "json"];
+    args.push("--model", probeModel);
+    if (variant) args.push("--variant", variant);
+    if (extraArgs.length > 0) args.push(...extraArgs);
+
+    try {
+      const probe = await runChildProcess(
+        `kilocode-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        args,
+        {
+          cwd,
+          env: runtimeEnv,
+          timeoutSec: 60,
+          graceSec: 5,
+          stdin: "Respond with hello.",
+          onLog: async () => {},
+        },
+      );
+
+      const parsed = parseKiloCodeJsonl(probe.stdout);
+      const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
+      const authEvidence = `${parsed.errorMessage ?? ""}\n${probe.stdout}\n${probe.stderr}`.trim();
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "kilocode_hello_probe_timed_out",
+          level: "warn",
+          message: "KiloCode hello probe timed out.",
+          hint: "Retry probe. If this persists, run KiloCode manually in this working directory.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0 && !parsed.errorMessage) {
+        const summary = parsed.summary.trim();
+        const hasHello = /\bhello\b/i.test(summary);
+        checks.push({
+          code: hasHello ? "kilocode_hello_probe_passed" : "kilocode_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "KiloCode hello probe succeeded."
+            : "KiloCode probe ran but did not return `hello` as expected.",
+          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+          ...(hasHello
+            ? {}
+            : {
+                hint: "Run `kilo run --auto --format json` manually and prompt `Respond with hello` to inspect output.",
+              }),
+        });
+      } else if (/ProviderModelNotFoundError/i.test(authEvidence)) {
+        checks.push({
+          code: "kilocode_hello_probe_model_unavailable",
+          level: "warn",
+          message: "The configured model was not found by provider.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `kilo models` and choose an available provider/model ID.",
+        });
+      } else if (KILOCODE_AUTH_REQUIRED_RE.test(authEvidence)) {
+        checks.push({
+          code: "kilocode_hello_probe_auth_required",
+          level: "warn",
+          message: "KiloCode is installed, but provider authentication is not ready.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `kilo auth login` or set provider credentials, then retry probe.",
+        });
+      } else {
+        checks.push({
+          code: "kilocode_hello_probe_failed",
+          level: "error",
+          message: "KiloCode hello probe failed.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `kilo run --auto --format json` manually in this working directory to debug.",
+        });
+      }
+    } catch (err) {
+      checks.push({
+        code: "kilocode_hello_probe_failed",
+        level: "error",
+        message: "KiloCode hello probe failed.",
+        detail: err instanceof Error ? err.message : String(err),
+        hint: "Run `kilo run --auto --format json` manually in this working directory to debug.",
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/kilocode-local/src/server/utils.ts
+++ b/packages/adapters/kilocode-local/src/server/utils.ts
@@ -1,0 +1,18 @@
+export function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+export function normalizeEnv(input: unknown): Record<string, string> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return {};
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}

--- a/packages/adapters/kilocode-local/src/server/utils.ts
+++ b/packages/adapters/kilocode-local/src/server/utils.ts
@@ -1,3 +1,5 @@
+import { asString } from "@paperclipai/adapter-utils/server-utils";
+
 export function firstNonEmptyLine(text: string): string {
   return (
     text
@@ -15,4 +17,13 @@ export function normalizeEnv(input: unknown): Record<string, string> {
     if (typeof value === "string") env[key] = value;
   }
   return env;
+}
+
+export function resolveKiloCodeCommand(input: unknown): string {
+  const envOverride =
+    typeof process.env.PAPERCLIP_KILOCODE_COMMAND === "string" &&
+    process.env.PAPERCLIP_KILOCODE_COMMAND.trim().length > 0
+      ? process.env.PAPERCLIP_KILOCODE_COMMAND.trim()
+      : "kilo";
+  return asString(input, envOverride);
 }

--- a/packages/adapters/kilocode-local/src/ui/build-config.ts
+++ b/packages/adapters/kilocode-local/src/ui/build-config.ts
@@ -1,0 +1,74 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildKiloCodeLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
+  if (v.model) ac.model = v.model;
+  if (v.thinkingEffort) ac.variant = v.thinkingEffort;
+  ac.timeoutSec = 0;
+  ac.graceSec = 20;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/kilocode-local/src/ui/index.ts
+++ b/packages/adapters/kilocode-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseKiloCodeStdoutLine } from "./parse-stdout.js";
+export { buildKiloCodeLocalConfig } from "./build-config.js";

--- a/packages/adapters/kilocode-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/kilocode-local/src/ui/parse-stdout.ts
@@ -1,0 +1,154 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const data = asRecord(rec.data);
+  const msg =
+    asString(rec.message) ||
+    asString(data?.message) ||
+    asString(rec.name) ||
+    "";
+  if (msg) return msg;
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+function parseToolUse(parsed: Record<string, unknown>, ts: string): TranscriptEntry[] {
+  const part = asRecord(parsed.part);
+  if (!part) return [{ kind: "system", ts, text: "tool event" }];
+
+  const toolName = asString(part.tool, "tool");
+  const state = asRecord(part.state);
+  const input = state?.input ?? {};
+  const callEntry: TranscriptEntry = {
+    kind: "tool_call",
+    ts,
+    name: toolName,
+    toolUseId: asString(part.callID) || asString(part.id) || undefined,
+    input,
+  };
+
+  const status = asString(state?.status);
+  if (status !== "completed" && status !== "error") return [callEntry];
+
+  const rawOutput =
+    asString(state?.output) ||
+    asString(state?.error) ||
+    asString(part.title) ||
+    `${toolName} ${status}`;
+
+  const metadata = asRecord(state?.metadata);
+  const headerParts: string[] = [`status: ${status}`];
+  if (metadata) {
+    for (const [key, value] of Object.entries(metadata)) {
+      if (value !== undefined && value !== null) headerParts.push(`${key}: ${value}`);
+    }
+  }
+  const content = `${headerParts.join("\n")}\n\n${rawOutput}`.trim();
+
+  return [
+    callEntry,
+    {
+      kind: "tool_result",
+      ts,
+      toolUseId: asString(part.callID) || asString(part.id, toolName),
+      content,
+      isError: status === "error",
+    },
+  ];
+}
+
+export function parseKiloCodeStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type);
+
+  if (type === "text") {
+    const part = asRecord(parsed.part);
+    const text = asString(part?.text).trim();
+    if (!text) return [];
+    return [{ kind: "assistant", ts, text }];
+  }
+
+  if (type === "reasoning") {
+    const part = asRecord(parsed.part);
+    const text = asString(part?.text).trim();
+    if (!text) return [];
+    return [{ kind: "thinking", ts, text }];
+  }
+
+  if (type === "tool_use") {
+    return parseToolUse(parsed, ts);
+  }
+
+  if (type === "step_start") {
+    const sessionId = asString(parsed.sessionID);
+    return [
+      {
+        kind: "system",
+        ts,
+        text: `step started${sessionId ? ` (${sessionId})` : ""}`,
+      },
+    ];
+  }
+
+  if (type === "step_finish") {
+    const part = asRecord(parsed?.part);
+    const tokens = asRecord(part?.tokens);
+    const cache = asRecord(tokens?.cache);
+    const reason = asString(part?.reason, "step");
+    const output = asNumber(tokens?.output, 0) + asNumber(tokens?.reasoning, 0);
+    return [
+      {
+        kind: "result",
+        ts,
+        text: reason,
+        inputTokens: asNumber(tokens?.input, 0),
+        outputTokens: output,
+        cachedTokens: asNumber(cache?.read, 0),
+        costUsd: asNumber(part?.cost, 0),
+        subtype: reason,
+        isError: false,
+        errors: [],
+      },
+    ];
+  }
+
+  if (type === "error") {
+    const text = errorText(parsed.error ?? parsed.message);
+    return [{ kind: "stderr", ts, text: text || line }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}
+
+export { buildKiloCodeLocalConfig } from "./build-config.js";

--- a/packages/adapters/kilocode-local/tsconfig.json
+++ b/packages/adapters/kilocode-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/kilocode-local/vitest.config.ts
+++ b/packages/adapters/kilocode-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kilocode-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kilocode-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -160,6 +163,25 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+
+  packages/adapters/kilocode-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/adapters/openclaw-gateway:
     dependencies:
@@ -447,6 +469,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kilocode-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kilocode-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -592,6 +617,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kilocode-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/kilocode-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -5629,46 +5657,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -9065,21 +9053,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -11794,41 +11782,11 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.2.3
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -11846,7 +11804,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -11871,7 +11829,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -11889,7 +11847,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kilocode-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -36,6 +36,15 @@ import {
   agentConfigurationDoc as openCodeAgentConfigurationDoc,
 } from "@paperclipai/adapter-opencode-local";
 import {
+  agentConfigurationDoc as kiloCodeAgentConfigurationDoc,
+} from "@paperclipai/adapter-kilocode-local";
+import {
+  execute as kiloCodeExecute,
+  testEnvironment as kiloCodeTestEnvironment,
+  sessionCodec as kiloCodeSessionCodec,
+  listKiloCodeModels,
+} from "@paperclipai/adapter-kilocode-local/server";
+import {
   execute as openclawGatewayExecute,
   testEnvironment as openclawGatewayTestEnvironment,
 } from "@paperclipai/adapter-openclaw-gateway/server";
@@ -135,6 +144,18 @@ const openCodeLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openCodeAgentConfigurationDoc,
 };
 
+const kiloCodeLocalAdapter: ServerAdapterModule = {
+  type: "kilocode_local",
+  execute: kiloCodeExecute,
+  testEnvironment: kiloCodeTestEnvironment,
+  sessionCodec: kiloCodeSessionCodec,
+  sessionManagement: getAdapterSessionManagement("kilocode_local") ?? undefined,
+  models: [],
+  listModels: listKiloCodeModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: kiloCodeAgentConfigurationDoc,
+};
+
 const piLocalAdapter: ServerAdapterModule = {
   type: "pi_local",
   execute: piExecute,
@@ -162,6 +183,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     claudeLocalAdapter,
     codexLocalAdapter,
     openCodeLocalAdapter,
+    kiloCodeLocalAdapter,
     piLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kilocode-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/ui/src/adapters/kilocode-local/config-fields.tsx
+++ b/ui/src/adapters/kilocode-local/config-fields.tsx
@@ -1,0 +1,47 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime.";
+
+export function KiloCodeLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <Field label="Agent instructions file" hint={instructionsFileHint}>
+      <div className="flex items-center gap-2">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.instructionsFilePath ?? ""
+              : eff(
+                  "adapterConfig",
+                  "instructionsFilePath",
+                  String(config.instructionsFilePath ?? ""),
+                )
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="/absolute/path/to/AGENTS.md"
+        />
+        <ChoosePathButton />
+      </div>
+    </Field>
+  );
+}

--- a/ui/src/adapters/kilocode-local/index.ts
+++ b/ui/src/adapters/kilocode-local/index.ts
@@ -1,8 +1,12 @@
-import { parseKiloCodeStdoutLine, buildKiloCodeLocalConfig } from "@paperclipai/adapter-kilocode-local/ui";
+import type { UIAdapterModule } from "../types";
+import { parseKiloCodeStdoutLine } from "@paperclipai/adapter-kilocode-local/ui";
+import { KiloCodeLocalConfigFields } from "./config-fields";
+import { buildKiloCodeLocalConfig } from "@paperclipai/adapter-kilocode-local/ui";
 
 export const kiloCodeLocalUIAdapter: UIAdapterModule = {
   type: "kilocode_local",
-  buildConfig: buildKiloCodeLocalConfig,
+  label: "KiloCode (local)",
   parseStdoutLine: parseKiloCodeStdoutLine,
-  supportsLocalAgentJwt: true,
+  ConfigFields: KiloCodeLocalConfigFields,
+  buildAdapterConfig: buildKiloCodeLocalConfig,
 };

--- a/ui/src/adapters/kilocode-local/index.ts
+++ b/ui/src/adapters/kilocode-local/index.ts
@@ -1,0 +1,8 @@
+import { parseKiloCodeStdoutLine, buildKiloCodeLocalConfig } from "@paperclipai/adapter-kilocode-local/ui";
+
+export const kiloCodeLocalUIAdapter: UIAdapterModule = {
+  type: "kilocode_local",
+  buildConfig: buildKiloCodeLocalConfig,
+  parseStdoutLine: parseKiloCodeStdoutLine,
+  supportsLocalAgentJwt: true,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -4,6 +4,7 @@ import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
+import { kiloCodeLocalUIAdapter } from "./kilocode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { processUIAdapter } from "./process";
@@ -15,6 +16,7 @@ const adaptersByType = new Map<string, UIAdapterModule>(
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
     openCodeLocalUIAdapter,
+    kiloCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,
     openClawGatewayUIAdapter,


### PR DESCRIPTION
## Summary
Implements full adapter support for KiloCode CLI, a fork of OpenCode.

## Changes
- Added `packages/adapters/kilocode-local` package with server/ui/cli implementations
- Registered adapter in server, ui, and cli registries
- Full test coverage for parse and models modules

## Features
- Execution: `kilo run --auto --format json` with stdin prompt
- Model discovery: Via `kilo models` command
- Session management: Resume with `--session` flag
- Skills injection: From `~/.claude/skills/` directory
- Environment override: `PAPERCLIP_KILOCODE_COMMAND` variable

## Key Differences from opencode-local
- Command name: `kilo` instead of `opencode`
- Additional `--auto` flag for autonomous mode
- Environment variable: `PAPERCLIP_KILOCODE_COMMAND`
- Adapter type: `kilocode_local` instead of `opencode_local`

## Testing
Run tests with:
```bash
cd packages/adapters/kilocode-local
pnpm test
```