### PR TITLE
fix: prevent UI reload storms and workspace warning spam

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -72,6 +72,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+const lastWorkspaceWarningsByAgent = new Map<string, Set<string>>();
 
 function deriveRepoNameFromRepoUrl(repoUrl: string | null): string | null {
   const trimmed = repoUrl?.trim() ?? "";
@@ -2055,6 +2056,10 @@ export function heartbeatService(db: Db) {
         });
       };
       for (const warning of runtimeWorkspaceWarnings) {
+        const seen = lastWorkspaceWarningsByAgent.get(run.agentId);
+        if (seen?.has(warning)) continue;
+        if (!seen) lastWorkspaceWarningsByAgent.set(run.agentId, new Set([warning]));
+        else seen.add(warning);
         await onLog("stderr", `[paperclip] ${warning}\n`);
       }
       const adapterEnv = Object.fromEntries(

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -530,6 +530,46 @@ export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
     let reconnectTimer: number | null = null;
     let socket: WebSocket | null = null;
 
+    // --- Event batching to prevent query invalidation storms ---
+    const BATCH_WINDOW_MS = 100;
+    let pendingEvents: LiveEvent[] = [];
+    let flushTimer: number | null = null;
+
+    const dedupeKey = (event: LiveEvent): string => {
+      const p = event.payload ?? {};
+      const runId = readString(p.runId);
+      const agentId = readString(p.agentId);
+      const entityId = readString(p.entityId);
+      const action = readString(p.action);
+      // Build a key from event type + the most specific identifier available
+      return `${event.type}:${runId ?? entityId ?? agentId ?? ""}:${action ?? ""}`;
+    };
+
+    const flushEvents = () => {
+      flushTimer = null;
+      if (pendingEvents.length === 0) return;
+
+      // Deduplicate: for each key, keep only the LAST event (most recent state)
+      const seen = new Map<string, LiveEvent>();
+      for (const event of pendingEvents) {
+        seen.set(dedupeKey(event), event);
+      }
+      pendingEvents = [];
+
+      for (const event of seen.values()) {
+        handleLiveEvent(queryClient, selectedCompanyId, event, pushToast, gateRef.current, {
+          userId: currentUserId,
+          agentId: null,
+        });
+      }
+    };
+
+    const scheduleFlush = () => {
+      if (flushTimer === null) {
+        flushTimer = window.setTimeout(flushEvents, BATCH_WINDOW_MS);
+      }
+    };
+
     const clearReconnect = () => {
       if (reconnectTimer !== null) {
         window.clearTimeout(reconnectTimer);
@@ -566,10 +606,8 @@ export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
 
         try {
           const parsed = JSON.parse(raw) as LiveEvent;
-          handleLiveEvent(queryClient, selectedCompanyId, parsed, pushToast, gateRef.current, {
-            userId: currentUserId,
-            agentId: null,
-          });
+          pendingEvents.push(parsed);
+          scheduleFlush();
         } catch {
           // Ignore non-JSON payloads.
         }
@@ -590,6 +628,11 @@ export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
     return () => {
       closed = true;
       clearReconnect();
+      if (flushTimer !== null) {
+        window.clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      pendingEvents = [];
       if (socket) {
         socket.onopen = null;
         socket.onmessage = null;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -32,6 +32,20 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 30_000,
       refetchOnWindowFocus: true,
+      retry: (failureCount, error) => {
+        // Don't retry network errors — server is unreachable
+        if (
+          error instanceof TypeError &&
+          (error.message.includes("Failed to fetch") || error.message.includes("NetworkError"))
+        ) {
+          return false;
+        }
+        // Max 2 retries for transient server errors
+        if (failureCount >= 2) return false;
+        return true;
+      },
+      retryDelay: (failureCount) =>
+        Math.min(5000, 1000 * 2 ** failureCount),
     },
   },
 });


### PR DESCRIPTION
## Summary
- **React Query retry config**: Skip retries on network errors (`Failed to fetch` / `NetworkError`), cap server error retries at 2 with exponential backoff — prevents 3x request amplification during server pressure
- **WebSocket event batching**: Buffer incoming WS events for 100ms and deduplicate by type+entity before triggering query invalidations — prevents bursts of 6-15+ simultaneous refetches
- **Workspace warning dedup**: Track previously-logged fallback workspace warnings per agent so identical messages only appear once per server process lifetime

## Test plan
- [ ] Start Paperclip with an agent that has no project workspace configured — verify the fallback workspace warning appears once in stderr, not on every heartbeat cycle
- [ ] Open the UI and monitor network tab — verify no retry storms on transient server errors
- [ ] With multiple agents active, verify WebSocket events still update the UI within ~100ms and that query invalidations are batched

🤖 Generated with [Claude Code](https://claude.com/claude-code)