### PR TITLE
fix(openclaw-gateway): prefix session keys with agent id for multi-agent routing

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -131,11 +131,16 @@ function resolveSessionKey(input: {
   configuredSessionKey: string | null;
   runId: string;
   issueId: string | null;
+  agentId?: string | null;
 }): string {
   const fallback = input.configuredSessionKey ?? "paperclip";
-  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
-  if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
-  return fallback;
+  let baseKey: string;
+  if (input.strategy === "run") baseKey = `paperclip:run:${input.runId}`;
+  else if (input.strategy === "issue" && input.issueId) baseKey = `paperclip:issue:${input.issueId}`;
+  else baseKey = fallback;
+
+  if (input.agentId) return `agent:${input.agentId}:${baseKey}`;
+  return baseKey;
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -1056,11 +1061,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
+  const configuredAgentId = nonEmpty(ctx.config.agentId);
   const sessionKey = resolveSessionKey({
     strategy: sessionKeyStrategy,
     configuredSessionKey,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
+    agentId: configuredAgentId,
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
@@ -1075,7 +1082,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
   delete agentParams.text;
 
-  const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;
   }


### PR DESCRIPTION
## Summary

When `agentId` is configured in the OpenClaw gateway adapter, `resolveSessionKey()` now prefixes the generated session key with `agent:{agentId}:` so the OpenClaw gateway can correctly route sessions in multi-agent deployments.

## Changes

- Added optional `agentId` parameter to `resolveSessionKey()` function signature
- When `agentId` is provided, the session key is prefixed with `agent:{agentId}:`
- Moved `configuredAgentId` declaration earlier in `execute()` so it can be passed to `resolveSessionKey()`

## Example

Before: `paperclip:run:abc123`
After (with agentId `my-agent`): `agent:my-agent:paperclip:run:abc123`

Without `agentId` configured, behaviour is unchanged.

Closes #1205