### PR TITLE
fix(shared): register `gemini_local` in AGENT_ADAPTER_TYPES

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -26,6 +26,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "gemini_local",
   "opencode_local",
   "pi_local",
   "cursor",


### PR DESCRIPTION
## Summary

- Add missing `"gemini_local"` entry to the `AGENT_ADAPTER_TYPES` tuple in `packages/shared/src/constants.ts`

## Problem

The `gemini-local` adapter is fully implemented:
- **Server registry** (`server/src/adapters/registry.ts`) registers `geminiLocalAdapter` with `type: "gemini_local"`
- **CLI registry** (`cli/src/adapters/registry.ts`) registers `geminiLocalCLIAdapter` with `type: "gemini_local"`
- **UI components** (`OnboardingWizard.tsx`, `AgentConfigForm.tsx`, `NewAgent.tsx`) reference `adapterType === "gemini_local"` throughout

However, the shared `AGENT_ADAPTER_TYPES` constant omits `"gemini_local"`. Since the Zod schema in `validators/agent.ts` uses `z.enum(AGENT_ADAPTER_TYPES)` for `adapterType`, any attempt to create an agent with `adapterType: "gemini_local"` is rejected by validation. The adapter never appears in the UI dropdown.

## Root Cause

`"gemini_local"` was never added to the `AGENT_ADAPTER_TYPES` array when the adapter package was created.

## Fix

Add `"gemini_local"` to the `AGENT_ADAPTER_TYPES` tuple, positioned alphabetically after `"codex_local"` and before `"opencode_local"`.

## Testing

- Verified the server adapter registry already maps `"gemini_local"` to `geminiLocalAdapter`
- Verified the CLI adapter registry already maps `"gemini_local"` to `geminiLocalCLIAdapter`
- The Zod validator `z.enum(AGENT_ADAPTER_TYPES)` will now accept `"gemini_local"` as a valid adapter type
- UI components already handle `gemini_local` in their switch/conditional logic

Closes #1195