### PR TITLE
fix(cli): preserve existing config values during quickstart onboard

### DIFF
--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -406,6 +406,29 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
     p.log.info(`Using existing ${pc.cyan("PAPERCLIP_AGENT_JWT_SECRET")} in ${pc.dim(envFilePath)}`);
   }
 
+  const existingConfig = configExists(opts.config) ? readConfig(opts.config) : null;
+
+  if (existingConfig && setupMode === "quickstart") {
+    database = { ...database, ...(existingConfig.database ?? {}) };
+    logging = { ...logging, ...(existingConfig.logging ?? {}) };
+    server = { ...server, ...(existingConfig.server ?? {}) };
+    auth = { ...auth, ...(existingConfig.auth ?? {}) };
+    storage = {
+      ...storage,
+      ...(existingConfig.storage ?? {}),
+      localDisk: { ...storage.localDisk, ...(existingConfig.storage?.localDisk ?? {}) },
+      s3: { ...storage.s3, ...(existingConfig.storage?.s3 ?? {}) },
+    };
+    secrets = {
+      ...secrets,
+      ...(existingConfig.secrets ?? {}),
+      localEncrypted: { ...secrets.localEncrypted, ...(existingConfig.secrets?.localEncrypted ?? {}) },
+    };
+    if (!llm && existingConfig.llm) {
+      llm = existingConfig.llm;
+    }
+  }
+
   const config: PaperclipConfig = {
     $meta: {
       version: 1,

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -406,10 +406,23 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
     p.log.info(`Using existing ${pc.cyan("PAPERCLIP_AGENT_JWT_SECRET")} in ${pc.dim(envFilePath)}`);
   }
 
-  const existingConfig = configExists(opts.config) ? readConfig(opts.config) : null;
+  let existingConfig: PaperclipConfig | null = null;
+  if (configExists(opts.config)) {
+    try {
+      existingConfig = readConfig(opts.config);
+    } catch {
+      // Invalid or corrupted config — skip merging, fall back to defaults
+    }
+  }
 
   if (existingConfig && setupMode === "quickstart") {
-    database = { ...database, ...(existingConfig.database ?? {}) };
+    database = {
+      ...database,
+      ...(existingConfig.database ?? {}),
+      ...(existingConfig.database?.backup != null
+        ? { backup: { ...database.backup, ...existingConfig.database.backup } }
+        : {}),
+    };
     logging = { ...logging, ...(existingConfig.logging ?? {}) };
     server = { ...server, ...(existingConfig.server ?? {}) };
     auth = { ...auth, ...(existingConfig.auth ?? {}) };


### PR DESCRIPTION
## Summary

- Merge existing config values over quickstart defaults during `onboard --yes` so manual changes survive re-onboarding

## Problem

Running `paperclipai onboard --yes` (or any quickstart re-onboard) unconditionally overwrites the entire `config.json` with fresh defaults. Users who manually set `server.host: "0.0.0.0"` or `server.deploymentMode: "authenticated"` find their changes reverted to `"127.0.0.1"` and `"local_trusted"` after every restart or re-onboard.

## Root Cause

The `onboard` command builds a complete `PaperclipConfig` from quickstart defaults and writes it via `writeConfig()` without reading the existing config. Any manually-configured fields are silently replaced.

## Fix

When an existing config exists and the setup mode is `quickstart`, read the existing config via `readConfig()` and shallow-merge each section so that existing values take precedence over defaults:

```typescript
server = { ...server, ...(existingConfig.server ?? {}) };
```

This preserves user-set fields like `host`, `deploymentMode`, and `exposure` while still filling in any missing defaults. Nested objects like `storage.s3` and `secrets.localEncrypted` are also merged at their level.

## Testing

- When config.json has `server.host: "0.0.0.0"`, re-running `onboard --yes` preserves it
- When config.json is missing a field, the quickstart default fills it in
- When no config.json exists, behavior is identical to before (pure defaults)
- Advanced mode is unaffected (user explicitly chooses all values via prompts)

Closes #1196