### PR TITLE
fix: use origin for github release creation in actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
         default: master
       stable_date:
-        description: Stable release date in UTC (YYYY-MM-DD). First stable that day is .0, then .1, and so on.
+        description: Enter a UTC date in YYYY-MM-DD format, for example 2026-03-18. Do not enter a version string. The workflow will resolve that date to a stable version such as 2026.318.0, then 2026.318.1 for the next same-day stable.
         required: false
         type: string
       dry_run:
@@ -251,6 +251,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          PUBLISH_REMOTE: origin
         run: |
           version="$(git tag --points-at HEAD | grep '^v' | head -1 | sed 's/^v//')"
           if [ -z "$version" ]; then

--- a/doc/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/RELEASE-AUTOMATION-SETUP.md
@@ -222,7 +222,8 @@ After at least one good canary exists:
 3. open `Actions` -> `Release`
 4. run it with:
    - `source_ref`: the tested commit SHA or canary tag source commit
-   - `stable_date`: leave blank or set the intended UTC date
+   - `stable_date`: leave blank or set the intended UTC date like `2026-03-18`
+     do not enter a version like `2026.318.0`; the workflow computes that from the date
    - `dry_run`: `true`
 5. confirm the dry-run succeeds
 6. rerun with `dry_run: false`
@@ -230,6 +231,11 @@ After at least one good canary exists:
 8. confirm npm `latest` points to the new stable version
 9. confirm git tag `vYYYY.MDD.P` exists
 10. confirm the GitHub Release was created
+
+Implementation note:
+
+- the GitHub Actions stable workflow calls `create-github-release.sh` with `PUBLISH_REMOTE=origin`
+- local maintainer usage can still pass `PUBLISH_REMOTE=public-gh` explicitly when needed
 
 ## 13. Suggested Maintainer Policy
 

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -77,21 +77,30 @@ npx paperclipai@canary onboard --data-dir "$(mktemp -d /tmp/paperclip-canary.XXX
 
 Use [`.github/workflows/release.yml`](../.github/workflows/release.yml) from the Actions tab with the manual `workflow_dispatch` inputs.
 
+[Run the action here](https://github.com/paperclipai/paperclip/actions/workflows/release.yml)
+
 Inputs:
 
 - `source_ref`
   - commit SHA, branch, or tag
 - `stable_date`
   - optional UTC date override in `YYYY-MM-DD`
+  - enter a date like `2026-03-18`, not a version like `2026.318.0`
 - `dry_run`
   - preview only when true
 
 Before running stable:
 
 1. pick the canary commit or tag you trust
-2. resolve the target stable version with `./scripts/release.sh stable --date YYYY-MM-DD --print-version`
+2. resolve the target stable version with `./scripts/release.sh stable --date "$(date +%F)" --print-version`
 3. create or update `releases/vYYYY.MDD.P.md` on that source ref
 4. run the stable workflow from that source ref
+
+Example:
+
+- `source_ref`: `master`
+- `stable_date`: `2026-03-18`
+- resulting stable version: `2026.318.0`
 
 The workflow:
 
@@ -122,7 +131,7 @@ This is mainly for emergency/manual use. The normal path is the GitHub workflow.
 ```bash
 ./scripts/release.sh stable
 git push public-gh refs/tags/vYYYY.MDD.P
-./scripts/create-github-release.sh YYYY.MDD.P
+PUBLISH_REMOTE=public-gh ./scripts/create-github-release.sh YYYY.MDD.P
 ```
 
 ## Stable Changelog Workflow
@@ -217,7 +226,7 @@ This is a partial release. npm is already live.
 Do this immediately:
 
 1. push the missing tag
-2. rerun `./scripts/create-github-release.sh YYYY.MDD.P`
+2. rerun `PUBLISH_REMOTE=public-gh ./scripts/create-github-release.sh YYYY.MDD.P`
 3. verify the GitHub Release notes point at `releases/vYYYY.MDD.P.md`
 
 Do not republish the same version.

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -19,7 +19,8 @@ Examples:
 
 Notes:
   - Run this after pushing the stable tag.
-  - Defaults to git remote public-gh.
+  - Resolves the git remote automatically.
+  - In GitHub Actions, origin is used explicitly.
   - If the release already exists, this script updates its title and notes.
 EOF
 }
@@ -54,7 +55,9 @@ fi
 
 tag="v$version"
 notes_file="$REPO_ROOT/releases/${tag}.md"
-PUBLISH_REMOTE="${PUBLISH_REMOTE:-public-gh}"
+if [ "${GITHUB_ACTIONS:-}" = "true" ] && [ -z "${PUBLISH_REMOTE:-}" ] && git_remote_exists origin; then
+  PUBLISH_REMOTE=origin
+fi
 PUBLISH_REMOTE="$(resolve_release_remote)"
 if ! command -v gh >/dev/null 2>&1; then
   echo "Error: gh CLI is required to create GitHub releases." >&2


### PR DESCRIPTION
## Summary
- stop assuming the public-gh remote exists inside GitHub Actions
- pass PUBLISH_REMOTE=origin in the stable release workflow
- clarify the stable_date input and local recovery commands in release docs

## Why
The stable publish for v2026.318.0 succeeded, but the GitHub Release step failed because create-github-release.sh forced public-gh in Actions, where only origin exists.
