### PR TITLE
fix(heartbeat): align agent-home workspace with adapter execution cwd

### DIFF
--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -13,6 +13,9 @@ const payload = {
   argv: process.argv.slice(2),
   prompt: fs.readFileSync(0, "utf8"),
   codexHome: process.env.CODEX_HOME || null,
+  agentHome: process.env.AGENT_HOME || null,
+  workspaceCwd: process.env.PAPERCLIP_WORKSPACE_CWD || null,
+  cwd: process.cwd(),
   paperclipEnvKeys: Object.keys(process.env)
     .filter((key) => key.startsWith("PAPERCLIP_"))
     .sort(),
@@ -32,6 +35,9 @@ type CapturePayload = {
   argv: string[];
   prompt: string;
   codexHome: string | null;
+  agentHome: string | null;
+  workspaceCwd: string | null;
+  cwd: string;
   paperclipEnvKeys: string[];
 };
 
@@ -222,6 +228,66 @@ describe("codex execute", () => {
       else process.env.PAPERCLIP_IN_WORKTREE = previousPaperclipInWorktree;
       if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
       else process.env.CODEX_HOME = previousCodexHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps AGENT_HOME aligned with the configured agent-home workspace", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-agent-home-"));
+    const agentHomeCwd = path.join(root, "agent-home");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(agentHomeCwd, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-agent-home",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: agentHomeCwd,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            cwd: agentHomeCwd,
+            source: "agent_home",
+            agentHome: agentHomeCwd,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.cwd).toBe(agentHomeCwd);
+      expect(capture.agentHome).toBe(agentHomeCwd);
+      expect(capture.workspaceCwd).toBeNull();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { agents } from "@paperclipai/db";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  applyExecutionWorkspaceCwdToAdapterConfig,
   formatRuntimeWorkspaceWarningLog,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  resolveAgentHomePathForExecutionWorkspace,
+  resolveConfiguredAgentHomeWorkspaceForRun,
   resolveRuntimeSessionParamsForWorkspace,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -115,6 +121,105 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
       workspaceId: "workspace-1",
     });
     expect(result.warning).toBeNull();
+  });
+});
+
+describe("resolveConfiguredAgentHomeWorkspaceForRun", () => {
+  it("uses adapterConfig.cwd as the agent-home fallback for timer runs and creates it if missing", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-fallback-"));
+    const configuredCwd = path.join(root, "agent-home");
+
+    try {
+      const result = await resolveConfiguredAgentHomeWorkspaceForRun({
+        adapterConfig: { cwd: configuredCwd },
+        resolvedProjectId: null,
+        sessionCwd: null,
+        workspaceHints: [],
+      });
+
+      expect(result).toEqual({
+        cwd: configuredCwd,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        workspaceHints: [],
+        warnings: [],
+      });
+      const stats = await fs.stat(configuredCwd);
+      expect(stats.isDirectory()).toBe(true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when a saved session cwd is unavailable and falls back to configured agent home", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-session-fallback-"));
+    const configuredCwd = path.join(root, "agent-home");
+    const missingSessionCwd = path.join(root, "missing-session");
+
+    try {
+      const result = await resolveConfiguredAgentHomeWorkspaceForRun({
+        adapterConfig: { cwd: configuredCwd },
+        resolvedProjectId: null,
+        sessionCwd: missingSessionCwd,
+        workspaceHints: [],
+      });
+
+      expect(result?.warnings).toEqual([
+        `Saved session workspace "${missingSessionCwd}" is not available. Using configured agent home workspace "${configuredCwd}" for this run.`,
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for non-absolute configured cwd values", async () => {
+    await expect(
+      resolveConfiguredAgentHomeWorkspaceForRun({
+        adapterConfig: { cwd: "relative/path" },
+        resolvedProjectId: null,
+        sessionCwd: null,
+        workspaceHints: [],
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("resolveAgentHomePathForExecutionWorkspace", () => {
+  it("uses the execution workspace cwd for agent-home runs", () => {
+    expect(
+      resolveAgentHomePathForExecutionWorkspace({
+        agentId: "agent-1",
+        executionWorkspaceSource: "agent_home",
+        executionWorkspaceCwd: "/tmp/configured-agent-home",
+      }),
+    ).toBe("/tmp/configured-agent-home");
+  });
+
+  it("keeps the synthetic default agent home for project workspaces", () => {
+    expect(
+      resolveAgentHomePathForExecutionWorkspace({
+        agentId: "agent-1",
+        executionWorkspaceSource: "project_primary",
+        executionWorkspaceCwd: "/tmp/project-workspace",
+      }),
+    ).toBe(resolveDefaultAgentWorkspaceDir("agent-1"));
+  });
+});
+
+describe("applyExecutionWorkspaceCwdToAdapterConfig", () => {
+  it("overrides config.cwd with the execution workspace cwd", () => {
+    expect(
+      applyExecutionWorkspaceCwdToAdapterConfig(
+        { cwd: "/tmp/static-cwd", command: "echo" },
+        "/tmp/execution-workspace",
+      ),
+    ).toEqual({
+      cwd: "/tmp/execution-workspace",
+      command: "echo",
+    });
   });
 });
 

--- a/server/src/__tests__/process-adapter-execute.test.ts
+++ b/server/src/__tests__/process-adapter-execute.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "../adapters/process/execute.ts";
+import { applyExecutionWorkspaceCwdToAdapterConfig } from "../services/heartbeat.ts";
+
+async function writeFakeProcessCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({ cwd: process.cwd() }), "utf8");
+}
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+describe("process adapter execute", () => {
+  it("runs in the execution workspace cwd when heartbeat overrides config.cwd", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-execute-"));
+    const staticCwd = path.join(root, "static-config-cwd");
+    const executionWorkspaceCwd = path.join(root, "execution-workspace");
+    const commandPath = path.join(root, "process-command");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(staticCwd, { recursive: true });
+    await fs.mkdir(executionWorkspaceCwd, { recursive: true });
+    await writeFakeProcessCommand(commandPath);
+
+    let metaCwd: string | null = null;
+    try {
+      const result = await execute({
+        runId: "run-1",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Process Agent",
+          adapterType: "process",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: applyExecutionWorkspaceCwdToAdapterConfig(
+          {
+            command: commandPath,
+            cwd: staticCwd,
+            env: {
+              PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            },
+          },
+          executionWorkspaceCwd,
+        ),
+        context: {},
+        onLog: async () => {},
+        onMeta: async (meta) => {
+          metaCwd = meta.cwd ?? null;
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeUndefined();
+      expect(metaCwd).toBe(executionWorkspaceCwd);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as { cwd: string };
+      expect(capture.cwd).toBe(executionWorkspaceCwd);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -23,7 +23,14 @@ import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
-import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import {
+  parseObject,
+  asBoolean,
+  asNumber,
+  appendWithCap,
+  ensureAbsoluteDirectory,
+  MAX_EXCERPT_BYTES,
+} from "../adapters/utils.js";
 import { costService } from "./costs.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
@@ -256,6 +263,70 @@ export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWork
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export async function resolveConfiguredAgentHomeWorkspaceForRun(input: {
+  adapterConfig: unknown;
+  resolvedProjectId: string | null;
+  sessionCwd: string | null;
+  workspaceHints: ResolvedWorkspaceForRun["workspaceHints"];
+}): Promise<ResolvedWorkspaceForRun | null> {
+  const configuredCwd = readNonEmptyString(parseObject(input.adapterConfig).cwd);
+  if (!configuredCwd || !path.isAbsolute(configuredCwd)) {
+    return null;
+  }
+
+  try {
+    await ensureAbsoluteDirectory(configuredCwd, { createIfMissing: true });
+  } catch {
+    return null;
+  }
+
+  const warnings: string[] = [];
+  if (input.sessionCwd) {
+    warnings.push(
+      `Saved session workspace "${input.sessionCwd}" is not available. Using configured agent home workspace "${configuredCwd}" for this run.`,
+    );
+  } else if (input.resolvedProjectId) {
+    warnings.push(
+      `No project workspace directory is currently available for this issue. Using configured agent home workspace "${configuredCwd}" for this run.`,
+    );
+  }
+
+  return {
+    cwd: configuredCwd,
+    source: "agent_home" as const,
+    projectId: input.resolvedProjectId,
+    workspaceId: null,
+    repoUrl: null,
+    repoRef: null,
+    workspaceHints: input.workspaceHints,
+    warnings,
+  };
+}
+
+export function resolveAgentHomePathForExecutionWorkspace(input: {
+  agentId: string;
+  executionWorkspaceSource: ResolvedWorkspaceForRun["source"];
+  executionWorkspaceCwd: string;
+}) {
+  if (
+    input.executionWorkspaceSource === "agent_home" &&
+    readNonEmptyString(input.executionWorkspaceCwd)
+  ) {
+    return input.executionWorkspaceCwd;
+  }
+  return resolveDefaultAgentWorkspaceDir(input.agentId);
+}
+
+export function applyExecutionWorkspaceCwdToAdapterConfig(
+  config: Record<string, unknown>,
+  executionWorkspaceCwd: string,
+): Record<string, unknown> {
+  return {
+    ...config,
+    cwd: executionWorkspaceCwd,
+  };
 }
 
 function normalizeLedgerBillingType(value: unknown): BillingType {
@@ -1122,6 +1193,16 @@ export function heartbeatService(db: Db) {
       }
     }
 
+    const configuredAgentHomeWorkspace = await resolveConfiguredAgentHomeWorkspaceForRun({
+      adapterConfig: agent.adapterConfig,
+      resolvedProjectId,
+      sessionCwd,
+      workspaceHints,
+    });
+    if (configuredAgentHomeWorkspace) {
+      return configuredAgentHomeWorkspace;
+    }
+
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
@@ -1908,7 +1989,11 @@ export function heartbeatService(db: Db) {
       repoRef: executionWorkspace.repoRef,
       branchName: executionWorkspace.branchName,
       worktreePath: executionWorkspace.worktreePath,
-      agentHome: resolveDefaultAgentWorkspaceDir(agent.id),
+      agentHome: resolveAgentHomePathForExecutionWorkspace({
+        agentId: agent.id,
+        executionWorkspaceSource: executionWorkspace.source,
+        executionWorkspaceCwd: executionWorkspace.cwd,
+      }),
     };
     context.paperclipWorkspaces = resolvedWorkspace.workspaceHints;
     const runtimeServiceIntents = (() => {
@@ -2144,11 +2229,15 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+      const adapterConfigForExecution = applyExecutionWorkspaceCwdToAdapterConfig(
+        resolvedConfig,
+        executionWorkspace.cwd,
+      );
       const adapterResult = await adapter.execute({
         runId: run.id,
         agent,
         runtime: runtimeForAdapter,
-        config: resolvedConfig,
+        config: adapterConfigForExecution,
         context,
         onLog,
         onMeta: onAdapterMeta,


### PR DESCRIPTION
## Thinking Path

- We kept seeing `No project or prior session workspace was available. Using fallback workspace...` on recurring heartbeats in the logs.
- That pointed to Paperclip resolving one workspace path for the run while the adapter process was still using another.
- In timer heartbeats with no issue/project/session context, `resolveWorkspaceForRun()` fell back to the synthetic Paperclip agent-home directory.
- At the same time, local adapters could still execute from `adapterConfig.cwd`, and the plain `process` adapter always executed from `config.cwd`.
- That meant a single run could end up with:
  - `paperclipWorkspace.cwd` pointing at the Paperclip fallback dir
  - the actual child process running in the configured adapter cwd
  - `AGENT_HOME` still pointing at the synthetic fallback path
- The result was a split-brain workspace model: misleading fallback warnings, inconsistent run context, and data potentially written to two different locations.
- This PR aligns those paths so agent-home runs resolve, execute, and export the same workspace consistently.

## What Changed

### `server/src/services/heartbeat.ts`

- Use `adapterConfig.cwd` as the `agent_home` fallback when there is no project workspace and no resumable session workspace.
- Require that fallback cwd to be absolute and create it if it does not exist yet.
- Override the adapter runtime config with `executionWorkspace.cwd` before `adapter.execute(...)` so execution always happens in the resolved workspace.
- Set `context.paperclipWorkspace.agentHome` to the execution workspace cwd for `agent_home` runs so local adapters do not keep a second synthetic home path alive.

### Tests

- `server/src/__tests__/heartbeat-workspace-session.test.ts`
  - Added coverage for configured agent-home fallback resolution.
  - Added coverage for agent-home path selection and execution cwd override helpers.
- `server/src/__tests__/process-adapter-execute.test.ts`
  - Added coverage that the `process` adapter actually runs in the execution workspace cwd after the heartbeat override.
- `server/src/__tests__/codex-local-execute.test.ts`
  - Added coverage that `AGENT_HOME` stays aligned with the configured agent-home workspace for local adapter runs.

## How to Verify

1. Configure a local agent with an absolute `adapterConfig.cwd`.
2. Trigger a timer heartbeat with no issue/project/session context.
3. Confirm the recurring fallback warning no longer appears for that agent.
4. Confirm `context.paperclipWorkspace.cwd` matches the configured agent-home workspace.
5. Confirm `AGENT_HOME` matches that same workspace during the run.
6. Confirm the adapter process runs in that same directory instead of splitting state across two locations.

## Verification

- `pnpm -s vitest run server/src/__tests__/heartbeat-workspace-session.test.ts server/src/__tests__/process-adapter-execute.test.ts server/src/__tests__/codex-local-execute.test.ts`
- `pnpm -r typecheck`
- `pnpm build`

## Risks

- Low.
- This changes fallback behavior for agent-home runs so an absolute `adapterConfig.cwd` now wins over the synthetic Paperclip fallback workspace.
- Session migration behavior is unchanged: migration to a project workspace still only recognizes the synthetic fallback path.
- Relative `adapterConfig.cwd` values are intentionally ignored here to avoid ambiguous runtime path resolution.
