### PR TITLE
Fix migrations not applied for existing databases without journal

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -101,6 +101,82 @@ afterEach(async () => {
   }
 });
 
+describe("applyPendingMigrations — no-migration-journal-non-empty-db", () => {
+  it(
+    "reconciles a fully migrated database that lost its journal table",
+    async () => {
+      const connectionString = await createTempDatabase();
+
+      // Apply all migrations normally first
+      await applyPendingMigrations(connectionString);
+
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        // Drop the entire journal schema to simulate a journal-less database
+        await sql.unsafe(`DROP SCHEMA "drizzle" CASCADE`);
+      } finally {
+        await sql.end();
+      }
+
+      // Verify state is detected correctly
+      const state = await inspectMigrations(connectionString);
+      expect(state).toMatchObject({
+        status: "needsMigrations",
+        reason: "no-migration-journal-non-empty-db",
+      });
+
+      // Reconciliation should bootstrap the journal and record all migrations
+      await applyPendingMigrations(connectionString);
+
+      const finalState = await inspectMigrations(connectionString);
+      expect(finalState.status).toBe("upToDate");
+
+      // Verify journal was recreated with entries
+      const verifySql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const rows = await verifySql.unsafe<{ count: string }[]>(
+          `SELECT count(*)::text AS count FROM "drizzle"."__drizzle_migrations"`,
+        );
+        expect(Number(rows[0].count)).toBeGreaterThan(0);
+      } finally {
+        await verifySql.end();
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "stops reconciliation at the first unconfirmed migration and reports remaining",
+    async () => {
+      const connectionString = await createTempDatabase();
+
+      // Apply all migrations, then drop journal and one table so one migration
+      // can't be confirmed as applied
+      await applyPendingMigrations(connectionString);
+
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        await sql.unsafe(`DROP SCHEMA "drizzle" CASCADE`);
+        // Drop a table created by 0030_rich_magneto.sql so that migration
+        // won't pass the migrationContentAlreadyApplied check
+        await sql.unsafe(`DROP TABLE IF EXISTS "company_logos"`);
+      } finally {
+        await sql.end();
+      }
+
+      const state = await inspectMigrations(connectionString);
+      expect(state.reason).toBe("no-migration-journal-non-empty-db");
+
+      // Should throw because it can't fully reconcile (stopped at the
+      // migration whose table was dropped)
+      await expect(applyPendingMigrations(connectionString)).rejects.toThrow(
+        /Failed to reconcile migrations/,
+      );
+    },
+    30_000,
+  );
+});
+
 describe("applyPendingMigrations", () => {
   it(
     "applies an inserted earlier migration without replaying later legacy migrations",

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -708,19 +708,9 @@ export async function applyPendingMigrations(url: string): Promise<void> {
           continue;
         }
 
-        await runInTransaction(sql, async () => {
-          for (const statement of splitMigrationStatements(migrationContent)) {
-            await sql.unsafe(statement);
-          }
-          await recordMigrationHistoryEntry(
-            sql,
-            qualifiedTable,
-            columnNames,
-            migrationFile,
-            hash,
-            folderMillisByFileName.get(migrationFile) ?? Date.now(),
-          );
-        });
+        // Cannot confirm this migration is already applied via schema inspection.
+        // Stop automatic reconciliation to avoid re-running non-idempotent DDL.
+        break;
       }
     } finally {
       await sql.end();

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -678,8 +678,58 @@ export async function applyPendingMigrations(url: string): Promise<void> {
   }
 
   if (initialState.reason === "no-migration-journal-non-empty-db") {
+    const sql = createUtilitySql(url);
+    try {
+      const { migrationTableSchema, columnNames } = await ensureMigrationJournalTable(sql);
+      const qualifiedTable = `${quoteIdentifier(migrationTableSchema)}.${quoteIdentifier(DRIZZLE_MIGRATIONS_TABLE)}`;
+      const journalEntries = await listJournalMigrationEntries();
+      const folderMillisByFileName = new Map(
+        journalEntries.map((entry) => [entry.fileName, normalizeFolderMillis(entry.folderMillis)]),
+      );
+      const orderedPendingMigrations = await orderMigrationsByJournal(initialState.pendingMigrations);
+
+      for (const migrationFile of orderedPendingMigrations) {
+        const migrationContent = await readMigrationFileContent(migrationFile);
+        const hash = createHash("sha256").update(migrationContent).digest("hex");
+        const alreadyApplied = await migrationContentAlreadyApplied(sql, migrationContent);
+
+        if (alreadyApplied) {
+          const existingEntry = await migrationHistoryEntryExists(sql, qualifiedTable, columnNames, migrationFile, hash);
+          if (!existingEntry) {
+            await recordMigrationHistoryEntry(
+              sql,
+              qualifiedTable,
+              columnNames,
+              migrationFile,
+              hash,
+              folderMillisByFileName.get(migrationFile) ?? Date.now(),
+            );
+          }
+          continue;
+        }
+
+        await runInTransaction(sql, async () => {
+          for (const statement of splitMigrationStatements(migrationContent)) {
+            await sql.unsafe(statement);
+          }
+          await recordMigrationHistoryEntry(
+            sql,
+            qualifiedTable,
+            columnNames,
+            migrationFile,
+            hash,
+            folderMillisByFileName.get(migrationFile) ?? Date.now(),
+          );
+        });
+      }
+    } finally {
+      await sql.end();
+    }
+
+    const reconciledState = await inspectMigrations(url);
+    if (reconciledState.status === "upToDate") return;
     throw new Error(
-      "Database has tables but no migration journal; automatic migration is unsafe. Initialize migration history manually.",
+      `Failed to reconcile migrations for existing database: ${reconciledState.pendingMigrations.join(", ")}`,
     );
   }
 


### PR DESCRIPTION
Fixes #1211

applyPendingMigrations() threw unconditionally when the database had tables but no __drizzle_migrations journal, making it impossible to apply new migrations after a pull+rebuild.

This replaces the hard error with a reconciliation loop that bootstraps the journal table, walks each migration, checks if its DDL is already reflected in the schema, and records or applies accordingly.