### PR TITLE
fix(ui): guard MarkdownEditor against null values in setMarkdown

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -450,7 +450,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             <Field label="Capabilities" hint={help.capabilities}>
               <MarkdownEditor
                 value={eff("identity", "capabilities", props.agent.capabilities ?? "")}
-                onChange={(v) => mark("identity", "capabilities", v || null)}
+                onChange={(v) => mark("identity", "capabilities", v ?? null)}
                 placeholder="Describe what this agent can do..."
                 contentClassName="min-h-[44px] text-sm font-mono"
                 imageUploadHandler={async (file) => {
@@ -716,7 +716,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                         String(config.bootstrapPromptTemplate ?? ""),
                       )}
                       onChange={(v) =>
-                        mark("adapterConfig", "bootstrapPromptTemplate", v || undefined)
+                        mark("adapterConfig", "bootstrapPromptTemplate", v ?? undefined)
                       }
                       placeholder="Optional initial setup prompt for the first run"
                       contentClassName="min-h-[44px] text-sm font-mono"

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -266,7 +266,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
               );
               if (updated !== current) {
                 latestValueRef.current = updated;
-                ref.current?.setMarkdown(updated);
+                ref.current?.setMarkdown(updated ?? "");
                 onChange(updated);
                 requestAnimationFrame(() => {
                   ref.current?.focus(undefined, { defaultSelection: "rootEnd" });
@@ -304,7 +304,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
 
   useEffect(() => {
     if (value !== latestValueRef.current) {
-      ref.current?.setMarkdown(value);
+      ref.current?.setMarkdown(value ?? "");
       latestValueRef.current = value;
     }
   }, [value]);
@@ -401,7 +401,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         const next = applyMention(current, state.query, option);
         if (next !== current) {
           latestValueRef.current = next;
-          ref.current?.setMarkdown(next);
+          ref.current?.setMarkdown(next ?? "");
           onChange(next);
         }
         requestAnimationFrame(() => {
@@ -473,7 +473,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         const next = applyMention(current, state.query, option);
         if (next !== current) {
           latestValueRef.current = next;
-          ref.current?.setMarkdown(next);
+          ref.current?.setMarkdown(next ?? "");
           onChange(next);
         }
         requestAnimationFrame(() => {
@@ -576,7 +576,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     >
       <MDXEditor
         ref={ref}
-        markdown={value}
+        markdown={value ?? ""}
         placeholder={placeholder}
         onChange={(next) => {
           latestValueRef.current = next;


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of null (reading 'trim')` crash on the agent configuration page when MDXEditor's `setMarkdown()` receives `null`.

- Adds `?? ""` defensive guard at all 5 `setMarkdown()` call sites and the initial `markdown={}` prop in `MarkdownEditor.tsx`
- Changes `v || null` → `v ?? null` in `AgentConfigForm.tsx` for markdown-backed `onChange` handlers (`capabilities`, `bootstrapPromptTemplate`)

Closes #1227

## Root Cause

`onChange` handlers use `v || null`, which converts empty string `""` to `null` (since `""` is falsy). This `null` flows back into `MarkdownEditor` → `setMarkdown(null)` → MDXEditor calls `.trim()` on null → crash.

## Changes

**`ui/src/components/MarkdownEditor.tsx`** (5 guards):
- L269: `setMarkdown(updated ?? "")`
- L307: `setMarkdown(value ?? "")`
- L404: `setMarkdown(next ?? "")`
- L476: `setMarkdown(next ?? "")`
- L579: `markdown={value ?? ""}`

**`ui/src/components/AgentConfigForm.tsx`** (2 fixes):
- L453: `v || null` → `v ?? null` (capabilities)
- L719: `v || undefined` → `v ?? undefined` (bootstrapPromptTemplate)

Non-markdown fields (`title`, `cwd`, `command`, `model`, `thinkingEffort`) unchanged — they feed `<input>` elements that handle null natively.

## Test plan
- [ ] Open agent config page — no crash
- [ ] Clear capabilities field — no crash
- [ ] Clear bootstrap prompt template — no crash
- [ ] Save with empty markdown fields — saves correctly
- [ ] `pnpm -r typecheck` passes
- [ ] `pnpm build` passes