### PR TITLE
fix: broaden status-change agent wakes (statusBecameActionable)

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -176,7 +176,7 @@ async function normalizePolicy(input: {
   return normalizeIssueExecutionPolicy(input);
 }
 
-function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress") {
+function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress" | "in_review") {
   return {
     id: "11111111-1111-4111-8111-111111111111",
     companyId: "company-1",
@@ -705,6 +705,62 @@ describe.sequential("issue comment reopen routes", () => {
 
   it("wakes the assignee when an assigned blocked issue moves back to todo", async () => {
     const issue = makeIssue("blocked");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(200);
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_status_changed",
+        payload: expect.objectContaining({
+          issueId: "11111111-1111-4111-8111-111111111111",
+          mutation: "update",
+        }),
+      }),
+    ));
+  });
+
+  it("wakes the assignee when an assigned in_progress issue moves back to todo", async () => {
+    const issue = makeIssue("in_progress");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(200);
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_status_changed",
+        payload: expect.objectContaining({
+          issueId: "11111111-1111-4111-8111-111111111111",
+          mutation: "update",
+        }),
+      }),
+    ));
+  });
+
+  it("wakes the assignee when an assigned in_review issue moves back to todo", async () => {
+    const issue = makeIssue("in_review");
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...issue,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2434,6 +2434,10 @@ export function issueRoutes(
       isClosedIssueStatus(existing.status) &&
       issue.status === "todo" &&
       req.body.status !== undefined;
+    const statusChangedFromActiveToTodo =
+      (existing.status === "in_progress" || existing.status === "in_review") &&
+      issue.status === "todo" &&
+      req.body.status !== undefined;
     const previousExecutionState = parseIssueExecutionState(existing.executionState);
     const nextExecutionState = parseIssueExecutionState(issue.executionState);
     const executionStageWakeup = buildExecutionStageWakeup({
@@ -2491,7 +2495,10 @@ export function issueRoutes(
 
       if (
         !assigneeChanged &&
-        (statusChangedFromBacklog || statusChangedFromBlockedToTodo || statusChangedFromClosedToTodo) &&
+        (statusChangedFromBacklog ||
+          statusChangedFromBlockedToTodo ||
+          statusChangedFromClosedToTodo ||
+          statusChangedFromActiveToTodo) &&
         issue.assigneeAgentId
       ) {
         addWakeup(issue.assigneeAgentId, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Board users (humans) move issues between statuses to drive agent work
> - Upstream already wakes the assigned agent on backlog → todo, blocked → todo, and done/cancelled → todo via `statusChangedFromBacklog`, `statusChangedFromBlockedToTodo`, and `statusChangedFromClosedToTodo`
> - But there is no equivalent path for `in_progress → todo` or `in_review → todo`, so a board user who sets an active or under-review issue back to `todo` (e.g. "please redo this") does not get an agent wake
> - The only workaround was reassigning the issue (off the agent and back), which is unintuitive
> - This pull request adds `statusChangedFromActiveToTodo` to wake the assigned agent on those two transitions, mirroring the existing wake helpers
> - The benefit is that board users can simply set an active issue back to `todo` to re-engage the agent, no reassignment gymnastics

## What Changed

- `server/src/routes/issues.ts`: add `statusChangedFromActiveToTodo` (matches `existing.status === "in_progress" || existing.status === "in_review"` with `issue.status === "todo"`), and OR it into the existing wake condition guarded by `!assigneeChanged`.
- `server/src/__tests__/issue-comment-reopen-routes.test.ts`: extend `makeIssue` to accept `in_review`, add two regression tests covering `in_progress → todo` and `in_review → todo` wake assertions, mirroring the existing blocked/done coverage.

## Verification

- `pnpm --filter server test issue-comment-reopen-routes` — the two new tests pass alongside the existing wake-on-status-change tests.
- Manual: as a board user, set an issue from `in_progress` (or `in_review`) back to `todo` without changing the assignee and confirm the assigned agent receives an `issue_status_changed` wake.

## Risks

- Low risk. Purely additive — the new variable participates in the same wake condition, which is already guarded by `!assigneeChanged` to avoid double-wakes when assignment also changes. No existing behavior is modified.

## Model Used

Anthropic Claude Opus 4.6 (1M context) via Claude Code CLI, with tool use, code execution, and extended-context capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-side wake logic only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge