### PR TITLE
fix(gemini-local): enable adapter, add v3 models, and support new schema

### DIFF
--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,11 +4,11 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
-  { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
-  { id: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
 ];
 
 export const agentConfigurationDoc = `# gemini_local agent configuration

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -7,16 +7,23 @@ function collectMessageText(message: unknown): string[] {
   }
 
   const record = parseObject(message);
-  const direct = asString(record.text, "").trim();
-  const lines: string[] = direct ? [direct] : [];
-  const content = Array.isArray(record.content) ? record.content : [];
+  const lines: string[] = [];
 
-  for (const partRaw of content) {
-    const part = parseObject(partRaw);
-    const type = asString(part.type, "").trim();
-    if (type === "output_text" || type === "text" || type === "content") {
-      const text = asString(part.text, "").trim() || asString(part.content, "").trim();
-      if (text) lines.push(text);
+  const directText = asString(record.text, "").trim();
+  if (directText) lines.push(directText);
+
+  if (typeof record.content === "string") {
+    const trimmedContent = record.content.trim();
+    if (trimmedContent) lines.push(trimmedContent);
+  } else if (Array.isArray(record.content)) {
+    for (const partRaw of record.content) {
+      const part = parseObject(partRaw);
+      const type = asString(part.type, "").trim();
+
+      if (type === "output_text" || type === "text" || type === "content" || !type) {
+        const text = asString(part.text, "").trim() || asString(part.content, "").trim();
+        if (text) lines.push(text);
+      }
     }
   }
 
@@ -96,11 +103,18 @@ export function parseGeminiJsonl(stdout: string) {
     if (foundSessionId) sessionId = foundSessionId;
 
     const type = asString(event.type, "").trim();
+    const role = asString(event.role, "").trim(); // Grab the role for the new schema
 
-    if (type === "assistant") {
-      messages.push(...collectMessageText(event.message));
-      const messageObj = parseObject(event.message);
+    // Match legacy `type === "assistant"` OR the new `type === "message" && role === "assistant"`
+    if (type === "assistant" || (type === "message" && role === "assistant")) {
+      // Normalize: use event.message if it exists (old format), otherwise use the event itself (new flat format)
+      const messageData = event.message ?? event;
+
+      messages.push(...collectMessageText(messageData));
+
+      const messageObj = parseObject(messageData);
       const content = Array.isArray(messageObj.content) ? messageObj.content : [];
+
       for (const partRaw of content) {
         const part = parseObject(partRaw);
         if (asString(part.type, "").trim() === "question") {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "gemini_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 


### PR DESCRIPTION
Registers `gemini_local` as a supported agent adapter type in shared constants.
- Updates the supported model list by replacing Gemini 2.0 models with Gemini 3 and 3.1 preview models.
- Enhances JSONL message parsing to accommodate the latest Gemini API schema, seamlessly handling flat event structures (`type: "message"`, `role: "assistant"`) alongside the legacy format.
- Hardens message text extraction to safely process varied payload shapes, including when `content` is a string instead of an array.