### PR TITLE
docs: audit gearment instance access

### DIFF
--- a/doc/plans/2026-03-18-gearment-instance-access-audit.md
+++ b/doc/plans/2026-03-18-gearment-instance-access-audit.md
@@ -1,0 +1,79 @@
+# Gearment instance access audit
+
+Date: 2026-03-18
+
+This note captures the current access state of the local Gearment Paperclip instance running at `https://paperclip.doremon.app`.
+
+## Deployment facts
+
+- Deployment mode: `authenticated`
+- Public URL: `https://paperclip.doremon.app`
+- Local server: `127.0.0.1:3100`
+- Database: `postgres://paperclip:***@localhost:5432/paperclip`
+
+## Current human users
+
+Total rows in `"user"`: `5`
+
+| Name | Email | Verified | Created |
+|------|-------|----------|---------|
+| Board | `local@paperclip.local` | yes | 2026-03-16 |
+| Terry Le | `tonle@gearment.com` | yes | 2026-03-16 |
+| Phuong Nguyen | `phuongnguyen@gearment.com` | yes | 2026-03-17 |
+| Sung Jinwoo | `trungnt@gearment.com` | yes | 2026-03-17 |
+| Khanh | `khanhnguyen@gearment.com` | no | 2026-03-18 |
+
+## Company memberships
+
+Current `company_memberships` rows for `Gearment Inc`:
+
+- `local-board` — `user`, `owner`, `active`
+- `Terry Le` — `user`, `owner`, `active`
+- `Doremon` agent — `member`, `active`
+- one additional `agent` row with malformed `principal_id` containing `INSERT 0 1`
+
+## Instance-wide admin roles
+
+Current `instance_user_roles`:
+
+- Khanh — `instance_admin`
+- Phuong Nguyen — `instance_admin`
+- Terry Le — `instance_admin`
+
+## Explicit permission grants
+
+Current `principal_permission_grants` rows:
+
+- `Doremon` agent — `tasks:assign`
+
+No explicit user-level grants were present at audit time.
+
+## Effective access differences
+
+There are currently three distinct access classes:
+
+1. `instance_admin`
+   - Full board-level access across companies via override
+   - Current users: Terry Le, Phuong Nguyen, Khanh
+
+2. company member with no instance admin
+   - Access depends on active company membership plus explicit company-scoped grants
+   - Current example: `local-board` is an owner member of `Gearment Inc`
+
+3. user with no current access
+   - No instance admin role and no active company membership
+   - Current example: Sung Jinwoo
+
+## Agent identity check
+
+The claimed API key in the local workspace resolved to:
+
+- Agent: `Doremon`
+- Status: `idle`
+- Visible permission flags: `canCreateAgents: false`
+
+## Findings
+
+- `instance_admin` is currently broader than company membership and bypasses company-scoped permission checks.
+- There are no explicit human permission grants in `principal_permission_grants`; human access is currently dominated by instance admin plus company membership.
+- One `company_memberships` row appears malformed because the `principal_id` contains `INSERT 0 1`. That should be cleaned up and root-caused before relying on agent membership data for authorization or reporting.

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -54,3 +54,21 @@ All entities belong to a company. The API enforces company boundaries:
 - Agents can only access entities in their own company
 - Board operators can access all companies they're members of
 - Cross-company access is denied with `403`
+
+## Access Layers
+
+In authenticated deployments, human access comes from three different layers:
+
+1. `instance_admin`
+   - Instance-wide override
+   - Bypasses company-scoped permission checks in routes that call `canUser(...)`
+
+2. active company membership
+   - Required for company-scoped non-admin access
+   - Stored in `company_memberships`
+
+3. explicit company-scoped grants
+   - Stored in `principal_permission_grants`
+   - Applied only after membership exists
+
+This means a human can appear in the system but still have no usable company access if they lack both `instance_admin` and an active company membership.


### PR DESCRIPTION
## Summary\n- document how instance admin, company membership, and explicit grants differ in authenticated mode\n- add a dated audit note for the Gearment Paperclip instance\n- capture the current live access state after removing Sung Jinwoo from instance admin and promoting Khanh\n\n## Notes\n- live access-role changes were applied directly in the Gearment Paperclip database\n- this PR contains the corresponding docs and audit trail only