### PR TITLE
fix: clear Claude Code nesting env vars in child agent processes

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -269,6 +269,12 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_API_KEY = authToken;
   }
 
+  // Prevent Claude Code nesting detection from blocking agent runs that are
+  // launched from within an existing Claude Code session.  Applied after
+  // envConfig overrides so user-supplied config cannot re-enable the guard.
+  env.CLAUDECODE = "";
+  env.CLAUDE_CODE_ENTRYPOINT = "";
+
   const runtimeEnv = Object.fromEntries(
     Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",


### PR DESCRIPTION
When launching a claude_local adapter from within an existing Claude Code session, the child process inherits CLAUDECODE and CLAUDE_CODE_ENTRYPOINT env vars, causing it to fail with "Claude Code cannot be launched inside another Claude Code session." Clear these vars in the child env so agent runs work regardless of whether the parent is a Claude Code session.