### PR TITLE
Harden default local-agent bootstrap flow

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -128,6 +128,15 @@ When a local agent run has no resolved project/session workspace, Paperclip fall
 
 This path honors `PAPERCLIP_HOME` and `PAPERCLIP_INSTANCE_ID` in non-default setups.
 
+Paperclip also scaffolds a minimal durable workspace in that location, including:
+
+- `AGENTS.md` for agent-local instructions
+- `.omx/notepad.md`
+- `.omx/project-memory.json`
+- `.omx/{logs,plans,state}/`
+
+For local adapters that support instruction files, new agents default their `instructionsFilePath` to this agent-home `AGENTS.md` unless an explicit path is provided.
+
 ## Worktree-local Instances
 
 When developing from multiple git worktrees, do not point two Paperclip servers at the same embedded PostgreSQL data directory.

--- a/doc/plans/2026-03-19-default-bootstrap-flow.md
+++ b/doc/plans/2026-03-19-default-bootstrap-flow.md
@@ -1,0 +1,52 @@
+# Default Bootstrap Flow
+
+Date: 2026-03-19
+Related issue: `YEO-2`
+
+## Objective
+
+Document the default path from a fresh Paperclip instance to a functioning CEO and first engineer, and record the remaining/manual edges in that flow.
+
+## Current happy path
+
+### 1. Instance bootstrap
+
+1. Run `pnpm paperclipai run` for first-time local setup.
+2. Paperclip creates config if missing, runs doctor, and starts the server.
+3. In `authenticated` mode, generate or consume the bootstrap CEO invite.
+
+### 2. Board onboarding
+
+1. Open the board and complete the onboarding wizard.
+2. Create the first company and optional company goal.
+3. Create the first agent as the CEO.
+4. Launch the default CEO issue from the wizard.
+
+### 3. First CEO run
+
+1. The wizard creates a `todo` issue assigned to the CEO.
+2. Assignment wakeup triggers the first CEO heartbeat.
+3. If no project/session workspace exists yet, the run falls back to the agent-home workspace at:
+   - `~/.paperclip/instances/<instance-id>/workspaces/<agent-id>`
+4. That agent-home workspace is scaffolded with:
+   - `AGENTS.md`
+   - `.omx/notepad.md`
+   - `.omx/project-memory.json`
+   - `.omx/{logs,plans,state}/`
+5. For local instruction-file adapters (`claude_local`, `codex_local`, `gemini_local`, `opencode_local`, `pi_local`, `cursor`), Paperclip now defaults `instructionsFilePath` to the agent-home `AGENTS.md`.
+
+### 4. First engineer handoff
+
+1. The CEO uses the onboarding issue to establish its own durable instructions.
+2. The CEO hires the Founding Engineer through normal Paperclip hiring flows.
+3. The Founding Engineer receives work through standard issue assignment and the same agent-home fallback conventions.
+
+## Rough edge removed in this pass
+
+- New local agents no longer require a separate board-side instructions-path patch before they can persist durable agent instructions. The default path now points at the agent-home `AGENTS.md`.
+
+## Remaining rough edges
+
+- `process` and `http` adapters still require adapter-specific instruction conventions; they do not participate in the default `instructionsFilePath` behavior.
+- `authenticated` bootstrap still depends on invite handling and deployment reachability being correct; this is documented but not fully in-app automated.
+- The default CEO issue still relies on the CEO to write high-quality role instructions; Paperclip now provides the durable location automatically, but not the final persona content.

--- a/server/src/__tests__/agent-create-routes.test.ts
+++ b/server/src/__tests__/agent-create-routes.test.ts
@@ -1,0 +1,175 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { agentRoutes } from "../routes/agents.js";
+
+const mockAgentService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+  getChainOfCommand: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+const mockBudgetService = vi.hoisted(() => ({
+  getBudgetSummary: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  listTaskSessions: vi.fn(),
+  resetRuntimeSession: vi.fn(),
+}));
+
+const mockIssueApprovalService = vi.hoisted(() => ({
+  linkManyForApproval: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(),
+  resolveAdapterConfigForRuntime: vi.fn(),
+}));
+
+const mockWorkspaceOperationService = vi.hoisted(() => ({
+  listForAgent: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  accessService: () => mockAccessService,
+  approvalService: () => mockApprovalService,
+  budgetService: () => mockBudgetService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
+  workspaceOperationService: () => mockWorkspaceOperationService,
+}));
+
+function createDbStub(company = { id: "company-1", requireBoardApprovalForNewAgents: false }) {
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([company]),
+      }),
+    }),
+  };
+}
+
+function createApp(db = createDbStub()) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(db as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("agent create routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(
+      async (_companyId: string, adapterConfig: Record<string, unknown>) => adapterConfig,
+    );
+    mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(
+      async (_companyId: string, adapterConfig: Record<string, unknown>) => ({ config: adapterConfig }),
+    );
+    mockLogActivity.mockResolvedValue(undefined);
+    mockAgentService.getById.mockResolvedValue(null);
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.create.mockImplementation(
+      async (companyId: string, data: Record<string, unknown>) => ({
+        id: data.id,
+        companyId,
+        name: data.name,
+        role: data.role ?? "general",
+        status: data.status ?? "idle",
+        adapterType: data.adapterType ?? "process",
+        adapterConfig: data.adapterConfig ?? {},
+        runtimeConfig: data.runtimeConfig ?? {},
+        permissions: data.permissions ?? null,
+        reportsTo: data.reportsTo ?? null,
+        title: data.title ?? null,
+        icon: data.icon ?? null,
+        capabilities: data.capabilities ?? null,
+        budgetMonthlyCents: data.budgetMonthlyCents ?? 0,
+        spentMonthlyCents: data.spentMonthlyCents ?? 0,
+        lastHeartbeatAt: data.lastHeartbeatAt ?? null,
+        updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      }),
+    );
+  });
+
+  it("defaults supported local agents to their agent-home AGENTS.md path", async () => {
+    const res = await request(createApp())
+      .post("/api/companies/company-1/agents")
+      .send({
+        name: "Founding Engineer",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toEqual(expect.any(String));
+    expect(res.body.adapterConfig.instructionsFilePath).toMatch(
+      new RegExp(`workspaces[\\\\/]+${res.body.id}[\\\\/]AGENTS\\.md$`),
+    );
+  });
+
+  it("preserves an explicit instructions path on direct agent creation", async () => {
+    const res = await request(createApp())
+      .post("/api/companies/company-1/agents")
+      .send({
+        name: "CEO",
+        adapterType: "codex_local",
+        adapterConfig: {
+          instructionsFilePath: "/tmp/custom/AGENTS.md",
+        },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.adapterConfig.instructionsFilePath).toBe("/tmp/custom/AGENTS.md");
+  });
+
+  it("defaults hires to the same agent-home AGENTS.md path", async () => {
+    const res = await request(createApp())
+      .post("/api/companies/company-1/agent-hires")
+      .send({
+        name: "Founding Engineer",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.agent.id).toEqual(expect.any(String));
+    expect(res.body.agent.adapterConfig.instructionsFilePath).toMatch(
+      new RegExp(`workspaces[\\\\/]+${res.body.agent.id}[\\\\/]AGENTS\\.md$`),
+    );
+    expect(res.body.approval).toBeNull();
+  });
+});

--- a/server/src/__tests__/agent-home-scaffold.test.ts
+++ b/server/src/__tests__/agent-home-scaffold.test.ts
@@ -27,6 +27,9 @@ describe("ensureAgentHomeScaffold", () => {
 
     await ensureAgentHomeScaffold(dir);
 
+    await expect(fs.readFile(path.join(dir, "AGENTS.md"), "utf8")).resolves.toContain(
+      "durable instructions file",
+    );
     await expect(fs.stat(path.join(dir, ".omx"))).resolves.toMatchObject({ isDirectory: expect.any(Function) });
     await expect(fs.stat(path.join(dir, ".omx", "logs"))).resolves.toMatchObject({
       isDirectory: expect.any(Function),
@@ -45,12 +48,14 @@ describe("ensureAgentHomeScaffold", () => {
 
   it("does not overwrite existing memory files", async () => {
     const dir = await makeTempDir();
+    await fs.writeFile(path.join(dir, "AGENTS.md"), "custom agents\n");
     await fs.mkdir(path.join(dir, ".omx"), { recursive: true });
     await fs.writeFile(path.join(dir, ".omx", "notepad.md"), "custom notepad\n");
     await fs.writeFile(path.join(dir, ".omx", "project-memory.json"), "{\"saved\":true}\n");
 
     await ensureAgentHomeScaffold(dir);
 
+    await expect(fs.readFile(path.join(dir, "AGENTS.md"), "utf8")).resolves.toBe("custom agents\n");
     await expect(fs.readFile(path.join(dir, ".omx", "notepad.md"), "utf8")).resolves.toBe("custom notepad\n");
     await expect(fs.readFile(path.join(dir, ".omx", "project-memory.json"), "utf8")).resolves.toBe(
       "{\"saved\":true}\n",

--- a/server/src/__tests__/agent-home-scaffold.test.ts
+++ b/server/src/__tests__/agent-home-scaffold.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureAgentHomeScaffold } from "../agent-home-scaffold.js";
+
+const tempDirs = new Set<string>();
+
+async function makeTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-"));
+  tempDirs.add(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    Array.from(tempDirs, (dir) =>
+      fs.rm(dir, { recursive: true, force: true }).catch(() => {}),
+    ),
+  );
+  tempDirs.clear();
+});
+
+describe("ensureAgentHomeScaffold", () => {
+  it("creates the OMX memory and state scaffold for a fresh agent home", async () => {
+    const dir = await makeTempDir();
+
+    await ensureAgentHomeScaffold(dir);
+
+    await expect(fs.stat(path.join(dir, ".omx"))).resolves.toMatchObject({ isDirectory: expect.any(Function) });
+    await expect(fs.stat(path.join(dir, ".omx", "logs"))).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+    await expect(fs.stat(path.join(dir, ".omx", "plans"))).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+    await expect(fs.stat(path.join(dir, ".omx", "state"))).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+    await expect(fs.readFile(path.join(dir, ".omx", "notepad.md"), "utf8")).resolves.toContain(
+      "## Priority Context",
+    );
+    await expect(fs.readFile(path.join(dir, ".omx", "project-memory.json"), "utf8")).resolves.toBe("{}\n");
+  });
+
+  it("does not overwrite existing memory files", async () => {
+    const dir = await makeTempDir();
+    await fs.mkdir(path.join(dir, ".omx"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".omx", "notepad.md"), "custom notepad\n");
+    await fs.writeFile(path.join(dir, ".omx", "project-memory.json"), "{\"saved\":true}\n");
+
+    await ensureAgentHomeScaffold(dir);
+
+    await expect(fs.readFile(path.join(dir, ".omx", "notepad.md"), "utf8")).resolves.toBe("custom notepad\n");
+    await expect(fs.readFile(path.join(dir, ".omx", "project-memory.json"), "utf8")).resolves.toBe(
+      "{\"saved\":true}\n",
+    );
+  });
+});

--- a/server/src/__tests__/agent-instructions-path.test.ts
+++ b/server/src/__tests__/agent-instructions-path.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { defaultInstructionsPathKeyForAdapter } from "../routes/agents.js";
+
+describe("defaultInstructionsPathKeyForAdapter", () => {
+  it("maps local instruction-file adapters to instructionsFilePath", () => {
+    expect(defaultInstructionsPathKeyForAdapter("claude_local")).toBe("instructionsFilePath");
+    expect(defaultInstructionsPathKeyForAdapter("codex_local")).toBe("instructionsFilePath");
+    expect(defaultInstructionsPathKeyForAdapter("gemini_local")).toBe("instructionsFilePath");
+    expect(defaultInstructionsPathKeyForAdapter("opencode_local")).toBe("instructionsFilePath");
+    expect(defaultInstructionsPathKeyForAdapter("pi_local")).toBe("instructionsFilePath");
+    expect(defaultInstructionsPathKeyForAdapter("cursor")).toBe("instructionsFilePath");
+  });
+
+  it("returns null when an adapter has no default instructions key", () => {
+    expect(defaultInstructionsPathKeyForAdapter("process")).toBeNull();
+  });
+});

--- a/server/src/__tests__/agent-instructions-path.test.ts
+++ b/server/src/__tests__/agent-instructions-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defaultInstructionsPathKeyForAdapter } from "../routes/agents.js";
+import { defaultInstructionsFilePathForNewAgent, defaultInstructionsPathKeyForAdapter } from "../routes/agents.js";
 
 describe("defaultInstructionsPathKeyForAdapter", () => {
   it("maps local instruction-file adapters to instructionsFilePath", () => {
@@ -13,5 +13,20 @@ describe("defaultInstructionsPathKeyForAdapter", () => {
 
   it("returns null when an adapter has no default instructions key", () => {
     expect(defaultInstructionsPathKeyForAdapter("process")).toBeNull();
+  });
+});
+
+describe("defaultInstructionsFilePathForNewAgent", () => {
+  it("points supported local adapters at the agent-home AGENTS.md file", () => {
+    expect(defaultInstructionsFilePathForNewAgent("claude_local", "agent-123")).toMatch(
+      /workspaces[\\/]+agent-123[\\/]AGENTS\.md$/,
+    );
+    expect(defaultInstructionsFilePathForNewAgent("codex_local", "agent-123")).toMatch(
+      /workspaces[\\/]+agent-123[\\/]AGENTS\.md$/,
+    );
+  });
+
+  it("returns null for adapters without instructions-file support", () => {
+    expect(defaultInstructionsFilePathForNewAgent("process", "agent-123")).toBeNull();
   });
 });

--- a/server/src/agent-home-scaffold.ts
+++ b/server/src/agent-home-scaffold.ts
@@ -10,6 +10,19 @@ const AGENT_HOME_DIRECTORIES = [
 
 const AGENT_HOME_FILES: Array<{ relativePath: string; contents: string }> = [
   {
+    relativePath: "AGENTS.md",
+    contents: `# AGENTS.md
+
+This is the durable instructions file for this agent's fallback home workspace.
+
+Update it with the agent's:
+- role and intent
+- priorities
+- working style
+- boundaries
+`,
+  },
+  {
     relativePath: path.join(".omx", "notepad.md"),
     contents: `# Notepad
 

--- a/server/src/agent-home-scaffold.ts
+++ b/server/src/agent-home-scaffold.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const AGENT_HOME_DIRECTORIES = [
+  ".omx",
+  path.join(".omx", "logs"),
+  path.join(".omx", "plans"),
+  path.join(".omx", "state"),
+];
+
+const AGENT_HOME_FILES: Array<{ relativePath: string; contents: string }> = [
+  {
+    relativePath: path.join(".omx", "notepad.md"),
+    contents: `# Notepad
+
+## Priority Context
+
+## Working Memory
+
+## Manual
+`,
+  },
+  {
+    relativePath: path.join(".omx", "project-memory.json"),
+    contents: "{}\n",
+  },
+];
+
+async function writeFileIfMissing(filePath: string, contents: string) {
+  try {
+    await fs.writeFile(filePath, contents, { flag: "wx" });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code !== "EEXIST") throw error;
+  }
+}
+
+export async function ensureAgentHomeScaffold(cwd: string): Promise<void> {
+  for (const relativeDir of AGENT_HOME_DIRECTORIES) {
+    await fs.mkdir(path.join(cwd, relativeDir), { recursive: true });
+  }
+
+  for (const file of AGENT_HOME_FILES) {
+    await writeFileIfMissing(path.join(cwd, file.relativePath), file.contents);
+  }
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -45,14 +45,20 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
 
+const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
+  claude_local: "instructionsFilePath",
+  codex_local: "instructionsFilePath",
+  gemini_local: "instructionsFilePath",
+  opencode_local: "instructionsFilePath",
+  pi_local: "instructionsFilePath",
+  cursor: "instructionsFilePath",
+};
+
+export function defaultInstructionsPathKeyForAdapter(adapterType: string): string | null {
+  return DEFAULT_INSTRUCTIONS_PATH_KEYS[adapterType] ?? null;
+}
+
 export function agentRoutes(db: Db) {
-  const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
-    claude_local: "instructionsFilePath",
-    codex_local: "instructionsFilePath",
-    gemini_local: "instructionsFilePath",
-    opencode_local: "instructionsFilePath",
-    cursor: "instructionsFilePath",
-  };
   const KNOWN_INSTRUCTIONS_PATH_KEYS = new Set(["instructionsFilePath", "agentsMdPath"]);
 
   const router = Router();
@@ -1016,7 +1022,7 @@ export function agentRoutes(db: Db) {
 
     const existingAdapterConfig = asRecord(existing.adapterConfig) ?? {};
     const explicitKey = asNonEmptyString(req.body.adapterConfigKey);
-    const defaultKey = DEFAULT_INSTRUCTIONS_PATH_KEYS[existing.adapterType] ?? null;
+    const defaultKey = defaultInstructionsPathKeyForAdapter(existing.adapterType);
     const adapterConfigKey = explicitKey ?? defaultKey;
     if (!adapterConfigKey) {
       res.status(422).json({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -44,6 +44,7 @@ import {
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
+import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 
 const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
   claude_local: "instructionsFilePath",
@@ -56,6 +57,33 @@ const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
 
 export function defaultInstructionsPathKeyForAdapter(adapterType: string): string | null {
   return DEFAULT_INSTRUCTIONS_PATH_KEYS[adapterType] ?? null;
+}
+
+export function defaultInstructionsFilePathForNewAgent(
+  adapterType: string | null | undefined,
+  agentId: string,
+): string | null {
+  if (!adapterType) return null;
+  const key = defaultInstructionsPathKeyForAdapter(adapterType);
+  if (!key) return null;
+  return path.join(resolveDefaultAgentWorkspaceDir(agentId), "AGENTS.md");
+}
+
+function applyDefaultInstructionsPathForNewAgent(
+  adapterType: string | null | undefined,
+  agentId: string,
+  adapterConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const key = adapterType ? defaultInstructionsPathKeyForAdapter(adapterType) : null;
+  if (!key) return adapterConfig;
+  const existingPath = adapterConfig[key];
+  if (typeof existingPath === "string" && existingPath.trim().length > 0) return adapterConfig;
+  const instructionsFilePath = defaultInstructionsFilePathForNewAgent(adapterType, agentId);
+  if (!instructionsFilePath) return adapterConfig;
+  return {
+    ...adapterConfig,
+    [key]: instructionsFilePath,
+  };
 }
 
 export function agentRoutes(db: Db) {
@@ -775,9 +803,14 @@ export function agentRoutes(db: Db) {
     await assertCanCreateAgentsForCompany(req, companyId);
     const sourceIssueIds = parseSourceIssueIds(req.body);
     const { sourceIssueId: _sourceIssueId, sourceIssueIds: _sourceIssueIds, ...hireInput } = req.body;
-    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+    const agentId = randomUUID();
+    const requestedAdapterConfig = applyDefaultInstructionsPathForNewAgent(
       hireInput.adapterType,
-      ((hireInput.adapterConfig ?? {}) as Record<string, unknown>),
+      agentId,
+      applyCreateDefaultsByAdapterType(
+        hireInput.adapterType,
+        ((hireInput.adapterConfig ?? {}) as Record<string, unknown>),
+      ),
     );
     const normalizedAdapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
       companyId,
@@ -807,6 +840,7 @@ export function agentRoutes(db: Db) {
     const requiresApproval = company.requireBoardApprovalForNewAgents;
     const status = requiresApproval ? "pending_approval" : "idle";
     const agent = await svc.create(companyId, {
+      id: agentId,
       ...normalizedHireInput,
       status,
       spentMonthlyCents: 0,
@@ -915,9 +949,14 @@ export function agentRoutes(db: Db) {
       assertBoard(req);
     }
 
-    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+    const agentId = randomUUID();
+    const requestedAdapterConfig = applyDefaultInstructionsPathForNewAgent(
       req.body.adapterType,
-      ((req.body.adapterConfig ?? {}) as Record<string, unknown>),
+      agentId,
+      applyCreateDefaultsByAdapterType(
+        req.body.adapterType,
+        ((req.body.adapterConfig ?? {}) as Record<string, unknown>),
+      ),
     );
     const normalizedAdapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
       companyId,
@@ -931,6 +970,7 @@ export function agentRoutes(db: Db) {
     );
 
     const agent = await svc.create(companyId, {
+      id: agentId,
       ...req.body,
       adapterConfig: normalizedAdapterConfig,
       status: "idle",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -27,6 +27,7 @@ import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } fr
 import { costService } from "./costs.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
+import { ensureAgentHomeScaffold } from "../agent-home-scaffold.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
 import {
@@ -1124,6 +1125,7 @@ export function heartbeatService(db: Db) {
 
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
+    await ensureAgentHomeScaffold(cwd);
     const warnings: string[] = [];
     if (sessionCwd) {
       warnings.push(

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -70,7 +70,7 @@ const DEFAULT_TASK_DESCRIPTION = `Setup yourself as the CEO. Use the ceo persona
 
 https://github.com/paperclipai/companies/blob/main/default/ceo/AGENTS.md
 
-Ensure you have a folder agents/ceo and then download this AGENTS.md, and sibling HEARTBEAT.md, SOUL.md, and TOOLS.md. and set that AGENTS.md as the path to your agents instruction file
+If your adapter already has a configured instructions file path, populate that file with the CEO persona. Otherwise create a durable instructions file for yourself and point your adapter at it. If you want companion files, add HEARTBEAT.md, SOUL.md, and TOOLS.md alongside that instructions file.
 
 After that, hire yourself a Founding Engineer agent and then plan the roadmap and tasks for your new company.`;
 


### PR DESCRIPTION
## Summary
- create a durable `.omx` scaffold when Paperclip falls back to agent-home workspaces
- default new local instruction-file agents to the agent-home `AGENTS.md` instead of requiring manual instructions-path setup
- document the default bootstrap flow and lock the behavior with route/scaffold regression tests

## Verification
- pnpm vitest run server/src/__tests__/agent-home-scaffold.test.ts server/src/__tests__/agent-instructions-path.test.ts
- pnpm -r typecheck
- pnpm test:run
- pnpm build

## Internal context
- Related Paperclip issues: YEO-4, YEO-2, YEO-19