### PR TITLE
fix: recover local agent jwt from instance env

### DIFF
--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 
@@ -12,6 +15,7 @@ describe("agent local JWT", () => {
     ttl: process.env[ttlEnv],
     issuer: process.env[issuerEnv],
     audience: process.env[audienceEnv],
+    home: process.env.PAPERCLIP_HOME,
   };
 
   beforeEach(() => {
@@ -32,6 +36,8 @@ describe("agent local JWT", () => {
     else process.env[issuerEnv] = originalEnv.issuer;
     if (originalEnv.audience === undefined) delete process.env[audienceEnv];
     else process.env[audienceEnv] = originalEnv.audience;
+    if (originalEnv.home === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalEnv.home;
   });
 
   it("creates and verifies a token", () => {
@@ -51,10 +57,39 @@ describe("agent local JWT", () => {
   });
 
   it("returns null when secret is missing", () => {
+    const paperclipHome = path.join(os.tmpdir(), `paperclip-agent-jwt-missing-${Date.now()}`);
+    process.env.PAPERCLIP_HOME = paperclipHome;
     process.env[secretEnv] = "";
     const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
     expect(token).toBeNull();
     expect(verifyLocalAgentJwt("abc.def.ghi")).toBeNull();
+  });
+
+  it("falls back to the instance env file when the process secret is blank", async () => {
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-jwt-home-"));
+    const envFilePath = path.join(paperclipHome, "instances", "default", ".env");
+    await fs.mkdir(path.dirname(envFilePath), { recursive: true });
+    await fs.writeFile(
+      envFilePath,
+      "# Paperclip environment variables\nPAPERCLIP_AGENT_JWT_SECRET=file-secret\n",
+      "utf8",
+    );
+
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env[secretEnv] = "";
+
+    try {
+      const token = createLocalAgentJwt("agent-1", "company-1", "codex_local", "run-1");
+      expect(typeof token).toBe("string");
+      expect(verifyLocalAgentJwt(token!)).toMatchObject({
+        sub: "agent-1",
+        company_id: "company-1",
+        adapter_type: "codex_local",
+        run_id: "run-1",
+      });
+    } finally {
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+    }
   });
 
   it("rejects expired tokens", () => {

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -1,4 +1,7 @@
+import { existsSync, readFileSync } from "node:fs";
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { parse as parseEnvFileContents } from "dotenv";
+import { resolvePaperclipEnvPath } from "./paths.js";
 
 interface JwtHeader {
   alg: string;
@@ -25,8 +28,25 @@ function parseNumber(value: string | undefined, fallback: number) {
   return Math.floor(parsed);
 }
 
+function readAgentJwtSecretFromEnvFile(): string | null {
+  const envFilePath = resolvePaperclipEnvPath();
+  if (!existsSync(envFilePath)) return null;
+
+  try {
+    const parsed = parseEnvFileContents(readFileSync(envFilePath, "utf-8"));
+    const value =
+      typeof parsed.PAPERCLIP_AGENT_JWT_SECRET === "string"
+        ? parsed.PAPERCLIP_AGENT_JWT_SECRET.trim()
+        : "";
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 function jwtConfig() {
-  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  const envSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim();
+  const secret = envSecret || readAgentJwtSecretFromEnvFile();
   if (!secret) return null;
 
   return {


### PR DESCRIPTION
## Summary
- fall back to the instance `.env` when `PAPERCLIP_AGENT_JWT_SECRET` is present in the process environment but blank
- keep the true-missing case returning `null`
- add regression coverage for the blank-process-env fallback path

## Root cause
Local heartbeat shells were starting without `PAPERCLIP_API_KEY` when `PAPERCLIP_AGENT_JWT_SECRET` reached the server process as an empty string. In that state, dotenv would not overwrite the blank process value from the instance `.env`, so `createLocalAgentJwt()` returned `null` and local adapters launched without an auth token.

## Why this fixes it
`server/src/agent-auth-jwt.ts` now treats a blank process-level secret as missing and falls back to the Paperclip instance `.env`. That restores JWT minting for local heartbeat sessions while preserving the existing true-missing behavior.

## Verification
- `cd server && pnpm exec vitest run src/__tests__/agent-auth-jwt.test.ts`
- `cd server && pnpm exec vitest run src/__tests__/codex-local-execute.test.ts`
- `cd server && pnpm run build`

## Acceptance target
After this lands, a fresh local heartbeat should have `PAPERCLIP_API_KEY` present without manual recovery, and `GET /api/agents/me` should succeed from the heartbeat shell.
