### PR TITLE
feat: add global Docs hub for browsing Paperclip documents

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -164,6 +164,7 @@ export type {
   LegacyPlanDocument,
   IssueAttachment,
   IssueLabel,
+  CompanyDocumentListItem,
   Goal,
   Approval,
   ApprovalComment,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -50,6 +50,7 @@ export type {
   IssueAncestorGoal,
   IssueAttachment,
   IssueLabel,
+  CompanyDocumentListItem,
 } from "./issue.js";
 export type { Goal } from "./goal.js";
 export type { Approval, ApprovalComment } from "./approval.js";

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -88,6 +88,19 @@ export interface DocumentRevision {
   createdAt: Date;
 }
 
+export interface CompanyDocumentListItem {
+  id: string;
+  companyId: string;
+  issueId: string;
+  issueIdentifier: string | null;
+  issueTitle: string;
+  key: string;
+  title: string | null;
+  format: DocumentFormat;
+  latestRevisionNumber: number;
+  updatedAt: Date;
+}
+
 export interface LegacyPlanDocument {
   key: "plan";
   body: string;

--- a/server/src/__tests__/company-documents.test.ts
+++ b/server/src/__tests__/company-documents.test.ts
@@ -1,0 +1,115 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const mockDocumentService = vi.hoisted(() => ({
+  listCompanyDocuments: vi.fn(),
+  listIssueDocuments: vi.fn(),
+  getIssueDocumentByKey: vi.fn(),
+  getIssueDocumentPayload: vi.fn(),
+  upsertIssueDocument: vi.fn(),
+  deleteIssueDocument: vi.fn(),
+  listIssueDocumentRevisions: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  listComments: vi.fn(),
+  checkout: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  issueService: () => mockIssueService,
+  documentService: () => mockDocumentService,
+  accessService: () => ({ ensureCompanyAccess: vi.fn() }),
+  heartbeatService: () => ({ findActiveRun: vi.fn() }),
+  agentService: () => ({ getById: vi.fn() }),
+  projectService: () => ({ getById: vi.fn() }),
+  goalService: () => ({ getById: vi.fn() }),
+  issueApprovalService: () => ({ list: vi.fn() }),
+  executionWorkspaceService: () => ({ getById: vi.fn() }),
+  workProductService: () => ({ listForIssue: vi.fn() }),
+  logActivity: vi.fn(),
+}));
+
+vi.mock("../routes/issues-checkout-wakeup.js", () => ({
+  shouldWakeAssigneeOnCheckout: vi.fn().mockReturnValue(false),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /api/companies/:companyId/documents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns company-wide document list", async () => {
+    const docs = [
+      {
+        id: "doc-1",
+        companyId: "company-1",
+        issueId: "issue-1",
+        issueIdentifier: "PAP-1",
+        issueTitle: "Test Issue",
+        key: "plan",
+        title: "Plan",
+        format: "markdown",
+        latestRevisionNumber: 2,
+        updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      },
+    ];
+    mockDocumentService.listCompanyDocuments.mockResolvedValue(docs);
+
+    const res = await request(createApp()).get("/api/companies/company-1/documents");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({
+      id: "doc-1",
+      issueIdentifier: "PAP-1",
+      issueTitle: "Test Issue",
+      key: "plan",
+    });
+    expect(mockDocumentService.listCompanyDocuments).toHaveBeenCalledWith("company-1");
+  });
+
+  it("returns empty array when no documents exist", async () => {
+    mockDocumentService.listCompanyDocuments.mockResolvedValue([]);
+
+    const res = await request(createApp()).get("/api/companies/company-1/documents");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("rejects access to other company documents", async () => {
+    const res = await request(createApp()).get("/api/companies/other-company/documents");
+
+    expect(res.status).toBe(403);
+    expect(mockDocumentService.listCompanyDocuments).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -419,6 +419,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(workProducts);
   });
 
+  router.get("/companies/:companyId/documents", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const docs = await documentsSvc.listCompanyDocuments(companyId);
+    res.json(docs);
+  });
+
   router.get("/issues/:id/documents", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -66,6 +66,28 @@ function mapIssueDocumentRow(
 
 export function documentService(db: Db) {
   return {
+    listCompanyDocuments: async (companyId: string) => {
+      const rows = await db
+        .select({
+          id: documents.id,
+          companyId: documents.companyId,
+          issueId: issueDocuments.issueId,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+          key: issueDocuments.key,
+          title: documents.title,
+          format: documents.format,
+          latestRevisionNumber: documents.latestRevisionNumber,
+          updatedAt: documents.updatedAt,
+        })
+        .from(issueDocuments)
+        .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+        .innerJoin(issues, eq(issueDocuments.issueId, issues.id))
+        .where(eq(issueDocuments.companyId, companyId))
+        .orderBy(desc(documents.updatedAt));
+      return rows;
+    },
+
     getIssueDocumentPayload: async (issue: { id: string; description: string | null }) => {
       const [planDocument, documentSummaries] = await Promise.all([
         db

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import { ProjectDetail } from "./pages/ProjectDetail";
 import { Issues } from "./pages/Issues";
 import { IssueDetail } from "./pages/IssueDetail";
 import { ExecutionWorkspaceDetail } from "./pages/ExecutionWorkspaceDetail";
+import { Docs } from "./pages/Docs";
 import { Goals } from "./pages/Goals";
 import { GoalDetail } from "./pages/GoalDetail";
 import { Approvals } from "./pages/Approvals";
@@ -144,6 +145,7 @@ function boardRoutes() {
       <Route path="issues/recent" element={<Navigate to="/issues" replace />} />
       <Route path="issues/:issueId" element={<IssueDetail />} />
       <Route path="execution-workspaces/:workspaceId" element={<ExecutionWorkspaceDetail />} />
+      <Route path="docs" element={<Docs />} />
       <Route path="goals" element={<Goals />} />
       <Route path="goals/:goalId" element={<GoalDetail />} />
       <Route path="approvals" element={<Navigate to="/approvals/pending" replace />} />
@@ -320,6 +322,7 @@ export function App() {
           <Route path="projects/:projectId/issues" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/issues/:filter" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/configuration" element={<UnprefixedBoardRedirect />} />
+          <Route path="docs" element={<UnprefixedBoardRedirect />} />
           <Route path="tests/ux/runs" element={<UnprefixedBoardRedirect />} />
           <Route path=":companyPrefix" element={<Layout />}>
             {boardRoutes()}

--- a/ui/src/api/docs.ts
+++ b/ui/src/api/docs.ts
@@ -1,0 +1,7 @@
+import type { CompanyDocumentListItem } from "@paperclipai/shared";
+import { api } from "./client";
+
+export const docsApi = {
+  list: (companyId: string) =>
+    api.get<CompanyDocumentListItem[]>(`/companies/${companyId}/documents`),
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Target,
   LayoutDashboard,
   DollarSign,
+  FileText,
   History,
   Search,
   SquarePen,
@@ -98,6 +99,7 @@ export function Sidebar() {
         <SidebarSection label="Work">
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          <SidebarNavItem to="/docs" label="Docs" icon={FileText} />
         </SidebarSection>
 
         <SidebarProjects />

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -41,6 +41,9 @@ export const queryKeys = {
       ["execution-workspaces", companyId, filters ?? {}] as const,
     detail: (id: string) => ["execution-workspaces", "detail", id] as const,
   },
+  docs: {
+    list: (companyId: string) => ["docs", companyId] as const,
+  },
   projects: {
     list: (companyId: string) => ["projects", companyId] as const,
     detail: (id: string) => ["projects", "detail", id] as const,

--- a/ui/src/pages/Docs.tsx
+++ b/ui/src/pages/Docs.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { docsApi } from "../api/docs";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EntityRow } from "../components/EntityRow";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { formatDate, issueUrl } from "../lib/utils";
+import { FileText } from "lucide-react";
+
+export function Docs() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Docs" }]);
+  }, [setBreadcrumbs]);
+
+  const { data: docs, isLoading, error } = useQuery({
+    queryKey: queryKeys.docs.list(selectedCompanyId!),
+    queryFn: () => docsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={FileText} message="Select a company to view documents." />;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton variant="list" />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && <p className="text-sm text-destructive">{error.message}</p>}
+
+      {!isLoading && (!docs || docs.length === 0) && (
+        <EmptyState
+          icon={FileText}
+          message="No documents yet. Documents created on issues will appear here."
+        />
+      )}
+
+      {docs && docs.length > 0 && (
+        <div className="border border-border">
+          {docs.map((doc) => (
+            <EntityRow
+              key={doc.id}
+              identifier={doc.issueIdentifier ?? undefined}
+              title={doc.title || doc.key}
+              subtitle={doc.issueTitle}
+              to={`${issueUrl({ id: doc.issueId, identifier: doc.issueIdentifier })}#document-${doc.key}`}
+              trailing={
+                <div className="flex items-center gap-3">
+                  <span className="text-xs text-muted-foreground font-mono">
+                    {doc.key}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatDate(doc.updatedAt)}
+                  </span>
+                </div>
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add company-wide `GET /api/companies/:companyId/documents` endpoint listing all issue-linked Paperclip documents
- New `/docs` page in sidebar under Work section showing document title/key, linked issue, and update time
- Clicking a doc navigates to the existing issue document deep link (`#document-<key>`)
- Read-only first release — no new editing flows, no repo/workspace markdown browsing

## Changes
- `packages/shared`: `CompanyDocumentListItem` type
- `server/src/services/documents.ts`: `listCompanyDocuments` service method
- `server/src/routes/issues.ts`: `GET /companies/:companyId/documents` route
- `ui/src/pages/Docs.tsx`: Docs page component
- `ui/src/api/docs.ts`: API client
- `ui/src/components/Sidebar.tsx`: FileText nav entry
- `ui/src/App.tsx`: Route + unprefixed redirect
- `ui/src/lib/queryKeys.ts`: `docs.list` query key
- `server/src/__tests__/company-documents.test.ts`: Backend route tests

## Test plan
- [x] `pnpm -r typecheck` passes
- [x] Server tests: 64 files, 324 passed
- [x] UI tests: 8 files, 39 passed
- [x] `pnpm build` passes
- [ ] Manual: verify Docs link appears in sidebar
- [ ] Manual: verify docs list loads and clicking navigates to issue document

🤖 Generated with [Claude Code](https://claude.com/claude-code)