### PR TITLE
fix: clear executionRunId on release and status-leaving-in_progress

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -846,12 +846,14 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
       }
 
       return db.transaction(async (tx) => {
@@ -1126,6 +1128,7 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Problem

When an issue is released (or its status moves away from `in_progress`), `checkoutRunId` was correctly cleared, but `executionRunId` was not.

The checkout logic blocks on **both** fields:
```ts
const executionLockCondition = checkoutRunId
  ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
  : isNull(issues.executionRunId);
```

So a stale `executionRunId` causes permanent 409 conflicts on any subsequent checkout of that issue — the issue becomes permanently stuck and invisible to agents.

## Fix

Clear `executionRunId` alongside `checkoutRunId` in both:
- `release()`: explicit release path
- `update()`: when status transitions away from `in_progress`, or when assignee changes

## Impact

3 lines added. Unblocks issues that previously got stuck in a ghost checkout state.