### PR TITLE
[Bug Fix] Orphaned run reaper race condition — activeRunExecutions not shared across heartbeatService instances

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -551,7 +551,7 @@ export async function startServer(): Promise<StartedServer> {
       // still being driven forward.  Use a 2-hour threshold so long-running
       // adapter executions (timeouts up to 3600 s) are not incorrectly reaped.
       void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 120 * 60 * 1000 })
+        .reapOrphanedRuns({ staleThresholdMs: 60 * 60 * 1000 })
         .then(() => heartbeat.resumeQueuedRuns())
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -547,10 +547,11 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "heartbeat timer tick failed");
         });
   
-      // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-      // persisted queued work is still being driven forward.
+      // Periodically reap orphaned runs and make sure persisted queued work is
+      // still being driven forward.  Use a 2-hour threshold so long-running
+      // adapter executions (timeouts up to 3600 s) are not incorrectly reaped.
       void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .reapOrphanedRuns({ staleThresholdMs: 120 * 60 * 1000 })
         .then(() => heartbeat.resumeQueuedRuns())
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -693,6 +693,12 @@ function resolveNextSessionState(input: {
   };
 }
 
+// Module-level Set shared across all heartbeatService() call-sites.
+// Prevents a race condition where the reaper (running in the scheduler's
+// heartbeatService instance) cannot see runs tracked by the executor's
+// separate heartbeatService instance, causing active runs to be reaped.
+const activeRunExecutions = new Set<string>();
+
 export function heartbeatService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
 
@@ -701,7 +707,6 @@ export function heartbeatService(db: Db) {
   const issuesSvc = issueService(db);
   const executionWorkspacesSvc = executionWorkspaceService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
-  const activeRunExecutions = new Set<string>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };


### PR DESCRIPTION
## Bug Description

`heartbeatService(db)` is called from multiple sites -- the scheduler in `index.ts` and the routes in `routes/issues.ts` -- and each call creates a **separate** `activeRunExecutions` Set because the Set is declared inside the function body.

The reaper (running in the scheduler's `heartbeatService` instance) checks its own `activeRunExecutions` to decide which runs are still alive. But actual run executions are tracked in the executor's instance. Since these are different `Set` objects, **the reaper never sees active runs** and incorrectly marks them as orphaned.

### Race condition flow

1. Route handler calls `heartbeatService(db)` -> gets **instance A** with its own `activeRunExecutions` Set
2. Instance A starts a run -> adds run ID to **Set A**
3. Scheduler calls `heartbeatService(db)` -> gets **instance B** with its own `activeRunExecutions` Set
4. Instance B runs `reapOrphanedRuns()` -> checks **Set B** (empty!) -> concludes the run is orphaned -> reaps it

### Additional issue: 5-minute stale threshold

The stale threshold is hardcoded to `5 * 60 * 1000` (5 minutes). Adapters can configure timeouts up to **3600 seconds** (1 hour) via `adapterConfig.timeoutSec`. Any run exceeding 5 minutes gets reaped even when it is still legitimately executing.

This is especially problematic for:
- Long-running Hermes agent tasks (common timeout: 3600s)
- Complex multi-step agent workflows
- Slow local LLM inference

## Fixes

### Fix 1: Move `activeRunExecutions` to module scope (`heartbeat.ts`)

The `activeRunExecutions` Set is moved from inside the `heartbeatService()` function body to module scope. Since ES modules are singletons, all call-sites now share the same Set instance. The reaper can correctly see which runs are actively executing.

### Fix 2: Increase stale threshold to 2 hours (`index.ts`)

Changed `staleThresholdMs` from `5 * 60 * 1000` (5 min) to `120 * 60 * 1000` (2 hours). This accommodates the maximum adapter timeout (3600s / 1 hour) with comfortable margin.

## How to reproduce

1. Configure an agent with a Hermes adapter (`adapterConfig.timeoutSec: 3600`)
2. Assign an issue that triggers a long-running run
3. Wait 5+ minutes -- the run gets reaped by the periodic reaper
4. Agent output is lost; run shows as "failed" with no result

## Files changed

- `server/src/services/heartbeat.ts` -- move `activeRunExecutions` to module scope
- `server/src/index.ts` -- increase reaper stale threshold from 5 min to 2 hours
