### PR TITLE
fix(codex-local): prevent server crash when codex CLI is missing

### DIFF
--- a/packages/adapters/codex-local/src/server/quota.ts
+++ b/packages/adapters/codex-local/src/server/quota.ts
@@ -424,6 +424,10 @@ class CodexRpcClient {
       this.startupError = error;
       this.rejectPending(error);
     });
+    this.proc.stdin.on("error", (error) => {
+      if (!this.startupError) this.startupError = error;
+      this.rejectPending(error);
+    });
     this.proc.stdout.setEncoding("utf8");
     this.proc.stderr.setEncoding("utf8");
     this.proc.stdout.on("data", (chunk: string) => this.onStdout(chunk));

--- a/packages/adapters/codex-local/src/server/quota.ts
+++ b/packages/adapters/codex-local/src/server/quota.ts
@@ -417,8 +417,13 @@ class CodexRpcClient {
   private buffer = "";
   private pending = new Map<number, PendingRequest>();
   private stderr = "";
+  private startupError: Error | null = null;
 
   constructor() {
+    this.proc.on("error", (error) => {
+      this.startupError = error;
+      this.rejectPending(error);
+    });
     this.proc.stdout.setEncoding("utf8");
     this.proc.stderr.setEncoding("utf8");
     this.proc.stdout.on("data", (chunk: string) => this.onStdout(chunk));
@@ -426,12 +431,16 @@ class CodexRpcClient {
       this.stderr += chunk;
     });
     this.proc.on("exit", () => {
-      for (const request of this.pending.values()) {
-        clearTimeout(request.timer);
-        request.reject(new Error(this.stderr.trim() || "codex app-server closed unexpectedly"));
-      }
-      this.pending.clear();
+      this.rejectPending(new Error(this.stderr.trim() || "codex app-server closed unexpectedly"));
     });
+  }
+
+  private rejectPending(error: Error) {
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(error);
+    }
+    this.pending.clear();
   }
 
   private onStdout(chunk: string) {
@@ -459,6 +468,7 @@ class CodexRpcClient {
   }
 
   private request(method: string, params: Record<string, unknown> = {}, timeoutMs = 6_000): Promise<Record<string, unknown>> {
+    if (this.startupError) return Promise.reject(this.startupError);
     const id = this.nextId++;
     const payload = JSON.stringify({ id, method, params }) + "\n";
     return new Promise<Record<string, unknown>>((resolve, reject) => {


### PR DESCRIPTION
Fixes #1268

## Thinking path

The quota-windows flow asks each provider adapter for quota data. The Codex adapter starts a local RPC subprocess to collect that information. If the `codex` binary is missing, that failure should stay isolated to the Codex adapter instead of crashing the whole Paperclip server. This change makes the Codex quota RPC startup path fail gracefully.

## Summary

Prevent a server crash when the `codex` CLI is not installed.

Paperclip could crash while loading quota windows because the Codex adapter starts `codex app-server`.  
If the binary is missing, Node emits a child-process `error` (`ENOENT`). That event was not handled, so the server terminated.

## Root cause

In `CodexRpcClient`, process startup failures from `spawn("codex", ...)` were not handled via `proc.on("error")`.  
This allowed an unhandled child-process error to crash the process.

## Changes

- Added child-process `error` handling in `CodexRpcClient`.
- Reject all pending RPC requests and clear their timers on process startup failure.
- Added fast-fail behavior so subsequent requests reject immediately after startup/spawn failure.
- Kept existing fallback behavior so quota collection continues gracefully.

## Result

If `codex` is unavailable, the server no longer crashes.  
`/costs/quota-windows` now returns a structured provider error/fallback response instead of terminating the process.

## Test plan

- Run Paperclip without Codex CLI installed.
- Call `GET /api/companies/:companyId/costs/quota-windows`.
- Repeat the request multiple times.
- Verify:
  - server remains running
  - endpoint returns `200` with provider-level error/fallback data
  - no unhandled child-process crash appears in logs