### PR TITLE
fix(issues): clear executionRunId on release to prevent stale locks

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1021,6 +1021,7 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary
- Fix `release()` endpoint to also clear `executionRunId` when releasing an issue, preventing permanent stale execution locks
- Root cause: `release()` cleared `checkoutRunId` but not `executionRunId`, causing agents to remain locked even after release

## Related
- GitHub Issue: #1245
- Paperclip: QUA-12

## Test plan
- [x] All 268 existing tests pass
- [x] Server typecheck clean
- [ ] Manual verification: release an issue and confirm `executionRunId` is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>