### PR TITLE
Handle stale heartbeat run IDs in activity logging

### DIFF
--- a/server/src/__tests__/activity-log.test.ts
+++ b/server/src/__tests__/activity-log.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { logActivity } from "../services/activity-log.js";
+
+const mockPublishLiveEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/live-events.js", () => ({
+  publishLiveEvent: mockPublishLiveEvent,
+}));
+
+describe("logActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries without runId when the referenced heartbeat run is missing", async () => {
+    const values = vi.fn()
+      .mockRejectedValueOnce({
+        code: "23503",
+        constraint_name: "activity_log_run_id_heartbeat_runs_id_fk",
+      })
+      .mockResolvedValueOnce(undefined);
+    const insert = vi.fn(() => ({ values }));
+    const db = { insert } as any;
+
+    await logActivity(db, {
+      companyId: "company-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "agent.updated",
+      entityType: "agent",
+      entityId: "agent-2",
+      runId: "missing-run",
+      details: { ok: true },
+    });
+
+    expect(values).toHaveBeenCalledTimes(2);
+    expect(values.mock.calls[0][0]).toMatchObject({ runId: "missing-run" });
+    expect(values.mock.calls[1][0]).toMatchObject({ runId: null });
+    expect(mockPublishLiveEvent).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({ runId: null }),
+    }));
+  });
+
+  it("retries without runId when the driver reports the constraint under constraint", async () => {
+    const values = vi.fn()
+      .mockRejectedValueOnce({
+        code: "23503",
+        constraint: "activity_log_run_id_heartbeat_runs_id_fk",
+      })
+      .mockResolvedValueOnce(undefined);
+    const insert = vi.fn(() => ({ values }));
+    const db = { insert } as any;
+
+    await logActivity(db, {
+      companyId: "company-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "agent.updated",
+      entityType: "agent",
+      entityId: "agent-2",
+      runId: "missing-run",
+    });
+
+    expect(values).toHaveBeenCalledTimes(2);
+    expect(values.mock.calls[0][0]).toMatchObject({ runId: "missing-run" });
+    expect(values.mock.calls[1][0]).toMatchObject({ runId: null });
+    expect(mockPublishLiveEvent).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({ runId: null }),
+    }));
+  });
+
+  it("rethrows unrelated insert failures", async () => {
+    const values = vi.fn().mockRejectedValueOnce(new Error("boom"));
+    const insert = vi.fn(() => ({ values }));
+    const db = { insert } as any;
+
+    await expect(logActivity(db, {
+      companyId: "company-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "agent.updated",
+      entityType: "agent",
+      entityId: "agent-2",
+      runId: "run-1",
+    })).rejects.toThrow("boom");
+
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(mockPublishLiveEvent).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -10,6 +10,7 @@ import { logger } from "../middleware/logger.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
 
 const PLUGIN_EVENT_SET: ReadonlySet<string> = new Set(PLUGIN_EVENT_TYPES);
+const ACTIVITY_RUN_ID_FK_CONSTRAINT = "activity_log_run_id_heartbeat_runs_id_fk";
 
 let _pluginEventBus: PluginEventBus | null = null;
 
@@ -33,10 +34,17 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+function isMissingHeartbeatRunReferenceError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const record = err as { code?: unknown; constraint?: unknown; constraint_name?: unknown };
+  const constraint = record.constraint ?? record.constraint_name;
+  return record.code === "23503" && constraint === ACTIVITY_RUN_ID_FK_CONSTRAINT;
+}
+
 export async function logActivity(db: Db, input: LogActivityInput) {
   const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
   const redactedDetails = sanitizedDetails ? redactCurrentUserValue(sanitizedDetails) : null;
-  await db.insert(activityLog).values({
+  const insertRecord = async (runId: string | null) => db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
     actorId: input.actorId,
@@ -44,9 +52,18 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId,
     details: redactedDetails,
   });
+
+  let persistedRunId = input.runId ?? null;
+  try {
+    await insertRecord(persistedRunId);
+  } catch (err) {
+    if (!persistedRunId || !isMissingHeartbeatRunReferenceError(err)) throw err;
+    persistedRunId = null;
+    await insertRecord(null);
+  }
 
   publishLiveEvent({
     companyId: input.companyId,
@@ -58,7 +75,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
+      runId: persistedRunId,
       details: redactedDetails,
     },
   });
@@ -76,7 +93,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       payload: {
         ...redactedDetails,
         agentId: input.agentId ?? null,
-        runId: input.runId ?? null,
+        runId: persistedRunId,
       },
     };
     void _pluginEventBus.emit(event).then(({ errors }) => {


### PR DESCRIPTION
## Summary
- retry activity-log inserts without `runId` only for the specific stale heartbeat FK violation
- keep persisted payloads aligned with the retried `runId` value
- add focused coverage for both driver error shapes and the unrelated-error path

## Verification
- pnpm -r typecheck
- pnpm test:run
- pnpm build

Related: YEO-22