### PR TITLE
(fix): Docker: Add SDK plugin package and build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
 
 RUN pnpm install --frozen-lockfile
 
@@ -27,6 +28,8 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/shared build
+RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)


### PR DESCRIPTION
This pull request updates the Docker build process to ensure that the `@paperclipai/plugin-sdk` package is included and built alongside other core packages. The changes improve the reliability and completeness of the build by explicitly copying and building the plugin SDK.

Build process improvements:

* Added a `COPY` command for `packages/plugins/sdk/package.json` to ensure the plugin SDK is available during dependency installation.
* Added a build step for `@paperclipai/plugin-sdk` using `pnpm --filter`, so the SDK is properly built as part of the Docker image creation.

This fixes #1264