### PR TITLE
fix: create heartbeat run stubs before checkout and wakeup activity writes

### DIFF
--- a/server/src/__tests__/agent-wakeup-run-stub-route.test.ts
+++ b/server/src/__tests__/agent-wakeup-run-stub-route.test.ts
@@ -1,0 +1,102 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+
+const {
+  getByIdMock,
+  wakeupMock,
+  logActivityMock,
+  insertValuesMock,
+} = vi.hoisted(() => ({
+  getByIdMock: vi.fn(),
+  wakeupMock: vi.fn(),
+  logActivityMock: vi.fn(),
+  insertValuesMock: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  agentService: vi.fn(() => ({
+    getById: getByIdMock,
+    list: vi.fn(),
+    update: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    terminate: vi.fn(),
+    remove: vi.fn(),
+    createKey: vi.fn(),
+    listKeys: vi.fn(),
+    revokeKey: vi.fn(),
+    updatePermissions: vi.fn(),
+  })),
+  accessService: vi.fn(() => ({})),
+  approvalService: vi.fn(() => ({})),
+  budgetService: vi.fn(() => ({})),
+  heartbeatService: vi.fn(() => ({
+    wakeup: wakeupMock,
+  })),
+  issueApprovalService: vi.fn(() => ({})),
+  issueService: vi.fn(() => ({})),
+  logActivity: logActivityMock,
+  secretService: vi.fn(() => ({})),
+  workspaceOperationService: vi.fn(() => ({})),
+}));
+
+function createApp() {
+  const db = {
+    insert: vi.fn(() => ({
+      values: vi.fn((values: unknown) => {
+        insertValuesMock(values);
+        return {
+          onConflictDoNothing: vi.fn(async () => undefined),
+        };
+      }),
+    })),
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source: "session",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      isInstanceAdmin: false,
+      runId: "run-123",
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(db as any));
+  return app;
+}
+
+describe("POST /api/agents/:id/wakeup run FK stub", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getByIdMock.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Gateway Agent",
+      adapterType: "openclaw_gateway",
+    });
+    wakeupMock.mockResolvedValue({ id: "heartbeat-run-1", status: "queued" });
+    logActivityMock.mockResolvedValue(undefined);
+  });
+
+  it("upserts a heartbeat run stub when actor runId is provided", async () => {
+    const agentId = "11111111-1111-4111-8111-111111111111";
+    const res = await request(createApp())
+      .post(`/api/agents/${agentId}/wakeup`)
+      .send({ source: "on_demand", triggerDetail: "manual", forceFreshSession: false });
+
+    expect(res.status).toBe(202);
+    expect(insertValuesMock).toHaveBeenCalledWith({
+      id: "run-123",
+      companyId: "company-1",
+      agentId,
+      invocationSource: "on_demand",
+      status: "running",
+    });
+  });
+});

--- a/server/src/__tests__/issue-checkout-run-stub.test.ts
+++ b/server/src/__tests__/issue-checkout-run-stub.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { issueService } from "../services/issues.ts";
+
+type Row = Record<string, unknown>;
+
+function createSelectSequenceDb(results: unknown[]) {
+  const pending = [...results];
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    then: vi.fn((resolve: (rows: Row[]) => unknown) => Promise.resolve(resolve((pending.shift() as Row[]) ?? []))),
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => chain),
+    },
+  };
+}
+
+describe("issueService.checkout run FK stub", () => {
+  it("upserts a heartbeat run stub before writing checkoutRunId", async () => {
+    const dbStub = createSelectSequenceDb([
+      [{ companyId: "company-1" }],
+      [{ id: "agent-1", companyId: "company-1", status: "idle" }],
+    ]);
+
+    const insertValues = vi.fn();
+    const db = {
+      ...dbStub.db,
+      insert: vi.fn(() => ({
+        values: vi.fn((values: unknown) => {
+          insertValues(values);
+          return {
+            onConflictDoNothing: vi.fn(async () => undefined),
+          };
+        }),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => {
+          throw new Error("stop-after-fk-stub");
+        }),
+      })),
+    };
+
+    const svc = issueService(db as any);
+
+    await expect(
+      svc.checkout("issue-1", "agent-1", ["todo", "backlog", "blocked"], "run-123"),
+    ).rejects.toThrow("stop-after-fk-stub");
+
+    expect(insertValues).toHaveBeenCalledWith({
+      id: "run-123",
+      companyId: "company-1",
+      agentId: "agent-1",
+      invocationSource: "on_demand",
+      status: "running",
+    });
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1330,6 +1330,18 @@ export function agentRoutes(db: Db) {
     }
 
     const actor = getActorInfo(req);
+    if (actor.runId) {
+      await db
+        .insert(heartbeatRuns)
+        .values({
+          id: actor.runId,
+          companyId: agent.companyId,
+          agentId: actor.agentId ?? id,
+          invocationSource: "on_demand",
+          status: "running",
+        })
+        .onConflictDoNothing();
+    }
     await logActivity(db, {
       companyId: agent.companyId,
       actorType: actor.actorType,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -921,6 +921,20 @@ export function issueService(db: Db) {
       if (!issueCompany) throw notFound("Issue not found");
       await assertAssignableAgent(issueCompany.companyId, agentId);
 
+      // Ensure checkoutRunId always has a corresponding heartbeat_runs row before FK write.
+      if (checkoutRunId) {
+        await db
+          .insert(heartbeatRuns)
+          .values({
+            id: checkoutRunId,
+            companyId: issueCompany.companyId,
+            agentId,
+            invocationSource: "on_demand",
+            status: "running",
+          })
+          .onConflictDoNothing();
+      }
+
       const now = new Date();
       const sameRunAssigneeCondition = checkoutRunId
         ? and(


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Every time an agent runs, that run is tracked as a `heartbeat_runs` row with a unique ID
- Two write paths stamp a run ID onto the work the agent does: issue checkout (stores `checkoutRunId`) and the wakeup route (logs activity against the run)
- Both paths receive the run ID from the actor's JWT, but the `heartbeat_runs` row itself may not exist yet at that moment
- When the FK target row is missing, the database raises a constraint error and the write fails
- This PR upserts a minimal run stub before either write, so the FK target always exists
- The stub uses `onConflictDoNothing` so it is a no-op if the scheduler has already created the row

## Problem

Two write paths reference `heartbeat_runs.id` as a foreign key:

1. **Issue checkout** — `checkoutRunId` is written to the issue row when an agent checks out a task.
2. **Agent wakeup** — the wakeup route records run activity tied to a run ID.

In both cases, the run ID comes from the actor context (e.g. the JWT claim), but the corresponding `heartbeat_runs` row may not exist yet at the time of the write. When the row is missing, the FK constraint fires and the operation fails.

## What this changes

**`server/src/services/issues.ts`**
- Before writing `checkoutRunId` to the issue, upserts a minimal `heartbeat_runs` stub (`id`, `companyId`, `agentId`, `invocationSource`, `status: "running"`) using `onConflictDoNothing`, ensuring the FK target exists.

**`server/src/routes/agents.ts`**
- Applies the same stub upsert in the wakeup route before any activity is logged against the run ID.

**Tests**
- `issue-checkout-run-stub.test.ts` — unit test asserting the stub insert is called with the correct shape before the checkout write proceeds.
- `agent-wakeup-run-stub-route.test.ts` — integration-style route test asserting the stub is upserted with the actor's `runId` when `POST /api/agents/:id/wakeup` is called.

## Why a stub rather than a full run row

The full run record is created by the heartbeat scheduler. The stub is intentionally minimal and uses `onConflictDoNothing` so it is a no-op if the scheduler has already created the row — there is no risk of overwriting real run data.