### PR TITLE
fix: include plugin sdk and workspace plugin package manifests in Docker deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+COPY packages/plugins/create-paperclip-plugin/package.json packages/plugins/create-paperclip-plugin/
+COPY packages/plugins/examples/plugin-authoring-smoke-example/package.json packages/plugins/examples/plugin-authoring-smoke-example/
+COPY packages/plugins/examples/plugin-file-browser-example/package.json packages/plugins/examples/plugin-file-browser-example/
+COPY packages/plugins/examples/plugin-hello-world-example/package.json packages/plugins/examples/plugin-hello-world-example/
+COPY packages/plugins/examples/plugin-kitchen-sink-example/package.json packages/plugins/examples/plugin-kitchen-sink-example/
 
 RUN pnpm install --frozen-lockfile
 
@@ -27,6 +33,8 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/shared build
+RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)


### PR DESCRIPTION
## Thinking Path

- Paperclip ships as a Docker image for self-hosted deployments
- The Dockerfile uses a layered build: a `deps` stage copies only `package.json` manifests and runs `pnpm install`, so the dependency install layer is cached separately from source changes
- Paperclip's workspace has grown to include a plugin SDK and several example plugins under `packages/plugins/`
- The `deps` stage was never updated to include those package manifests, so `pnpm install --frozen-lockfile` would fail or produce an incomplete install because the lockfile references packages whose manifests weren't present
- Additionally, the build stage was missing explicit compile steps for `@paperclipai/shared` and `@paperclipai/plugin-sdk`, which are internal deps that must be built before `ui` and `server`
- This PR adds the missing `COPY` entries and build steps so Docker builds work correctly with the full plugin workspace

## Problem

The Docker build uses a two-stage approach: a `deps` stage that copies only `package.json` manifests and runs `pnpm install --frozen-lockfile`, followed by a `build` stage that copies the full source and compiles. The `deps` stage was missing `COPY` entries for all plugin workspace packages. Because pnpm uses a single workspace lockfile that references every package, `pnpm install` fails when those manifests aren't present. Additionally, the `build` stage was missing compile steps for `@paperclipai/shared` and `@paperclipai/plugin-sdk`, which are required before `ui` and `server` can be built.

## What this changes

**`Dockerfile` — `deps` stage**
- Adds `COPY` instructions for the `package.json` of `packages/plugins/sdk`, `packages/plugins/create-paperclip-plugin`, and all four example plugins, so `pnpm install` sees the complete workspace manifest set.

**`Dockerfile` — `build` stage**
- Adds `RUN pnpm --filter @paperclipai/shared build` and `RUN pnpm --filter @paperclipai/plugin-sdk build` before the existing `ui` and `server` build steps, respecting the correct dependency order.

## Verification

Build the image locally: `docker build .` — previously this would fail during `pnpm install` or at the plugin-sdk build step. With this change it completes successfully.

## Impact

No changes to application behavior or runtime. Fixes Docker builds that include the plugin workspace.