### PR TITLE
fix(onboarding): gemini_local adapter, null-safe markdown, config merge

### DIFF
--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -244,11 +244,12 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
     ),
   );
 
+  let existingConfig: PaperclipConfig | null = null;
   if (configExists(opts.config)) {
     p.log.message(pc.dim(`${configPath} exists, updating config`));
 
     try {
-      readConfig(opts.config);
+      existingConfig = readConfig(opts.config);
     } catch (err) {
       p.log.message(
         pc.yellow(
@@ -406,20 +407,27 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
     p.log.info(`Using existing ${pc.cyan("PAPERCLIP_AGENT_JWT_SECRET")} in ${pc.dim(envFilePath)}`);
   }
 
-  const config: PaperclipConfig = {
+  // When --yes and existing config present, merge: preserve user overrides,
+  // only fill in missing fields from quickstart defaults.
+  const mergedConfig: PaperclipConfig = {
     $meta: {
       version: 1,
       updatedAt: new Date().toISOString(),
       source: "onboard",
     },
     ...(llm && { llm }),
-    database,
-    logging,
-    server,
-    auth,
-    storage,
-    secrets,
+    database: existingConfig?.database ? { ...database, ...existingConfig.database } : database,
+    logging: existingConfig?.logging ? { ...logging, ...existingConfig.logging } : logging,
+    server: existingConfig?.server ? { ...server, ...existingConfig.server } : server,
+    auth: existingConfig?.auth ? { ...auth, ...existingConfig.auth } : auth,
+    storage: existingConfig?.storage ? { ...storage, ...existingConfig.storage } : storage,
+    secrets: existingConfig?.secrets ? { ...secrets, ...existingConfig.secrets } : secrets,
   };
+  // Preserve existing LLM config if not set by env/prompts
+  if (!llm && existingConfig?.llm) {
+    mergedConfig.llm = existingConfig.llm;
+  }
+  const config = mergedConfig;
 
   const keyResult = ensureLocalSecretsKeyFile(config, configPath);
   if (keyResult.status === "created") {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -26,6 +26,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "gemini_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -603,7 +603,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             <>
               <Field label="Prompt Template" hint={help.promptTemplate}>
                 <MarkdownEditor
-                  value={val!.promptTemplate}
+                  value={val!.promptTemplate ?? ""}
                   onChange={(v) => set!({ promptTemplate: v })}
                   placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
                   contentClassName="min-h-[88px] text-sm font-mono"

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -304,7 +304,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
 
   useEffect(() => {
     if (value !== latestValueRef.current) {
-      ref.current?.setMarkdown(value);
+      ref.current?.setMarkdown(value ?? "");
       latestValueRef.current = value;
     }
   }, [value]);


### PR DESCRIPTION
## Summary

- **#1195**: Add `gemini_local` to `AGENT_ADAPTER_TYPES` constant — the adapter was already used in the UI but not registered in the shared type, preventing it from appearing in dropdowns and causing type mismatches.
- **#1227**: Add null guard to `MarkdownEditor` `value` prop and `AgentConfigForm.promptTemplate` — `setMarkdown(null)` crashes MDXEditor. Now falls back to `""`.
- **#1196**: Merge existing `config.json` during `onboard --yes` — previously overwrote the entire file, losing user customizations (e.g., `server.host: "0.0.0.0"`, `deploymentMode: "authenticated"`). Now shallow-merges each config section, preserving user overrides.

## Test plan

- [x] All 421 tests pass (85 test files)
- [x] TypeScript typecheck clean (shared, cli, ui)
- [ ] Manual: create `config.json` with `server.host: "0.0.0.0"`, run `onboard --yes`, verify host preserved
- [ ] Manual: open agent config page with null prompt template, verify no crash
- [ ] Manual: verify `gemini_local` appears in adapter type dropdown

## Risk notes

- Config merge uses shallow merge per section (`{ ...defaults, ...existing }`). Nested sub-objects within a section are replaced as a whole by user overrides, not deep-merged. This matches current config structure where sections are flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)