### PR TITLE
fix: clear execution lock fields on release and PATCH update

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -846,12 +846,18 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionLockedAt = null;
+        patch.executionAgentNameKey = null;
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionLockedAt = null;
+        patch.executionAgentNameKey = null;
       }
 
       return db.transaction(async (tx) => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1126,6 +1126,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
+          executionAgentNameKey: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

- Clears `executionRunId`, `executionLockedAt`, and `executionAgentNameKey` in the `release()` method (original fix from #1015)
- **Also** clears the same fields in the PATCH update path when `checkoutRunId` is nulled due to status transition or assignee reassignment

Without this fix, issues can enter a permanently-blocked 409 state when execution lock fields are orphaned. The `release()` fix alone only covers one trigger path — the PATCH update handler has the identical gap.

Addresses review feedback from Greptile on #1015, which identified the PATCH path as carrying the same orphan-lock bug.

Fixes #1245

## Test plan

- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] Existing tests pass
- [ ] Verify: releasing an issue clears all lock fields
- [ ] Verify: changing status from `in_progress` to `todo` via PATCH clears execution lock fields
- [ ] Verify: reassigning an issue via PATCH clears execution lock fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)