### PR TITLE
Fix @mention insertion in Chromium editors

### DIFF
--- a/server/src/__tests__/actor-middleware.test.ts
+++ b/server/src/__tests__/actor-middleware.test.ts
@@ -1,0 +1,137 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { agentApiKeys, agents, heartbeatRuns } from "@paperclipai/db";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import { actorMiddleware } from "../middleware/auth.js";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
+const RUN_ID = "33333333-3333-4333-8333-333333333333";
+
+function makeDb(opts: {
+  keyRows?: unknown[];
+  agentRows?: unknown[];
+  runRows?: unknown[];
+} = {}) {
+  const keyRows = opts.keyRows ?? [];
+  const agentRows = opts.agentRows ?? [];
+  const runRows = opts.runRows ?? [];
+
+  return {
+    select: () => ({
+      from(table: unknown) {
+        const rows =
+          table === agentApiKeys ? keyRows :
+            table === agents ? agentRows :
+              table === heartbeatRuns ? runRows :
+                [];
+        return {
+          where: async () => rows,
+        };
+      },
+    }),
+    update: () => ({
+      set: () => ({
+        where: async () => undefined,
+      }),
+    }),
+  };
+}
+
+function createApp(db: Record<string, unknown>) {
+  const app = express();
+  app.use(actorMiddleware(db as any, { deploymentMode: "authenticated" }));
+  app.get("/actor", (req, res) => {
+    res.json(req.actor);
+  });
+  return app;
+}
+
+describe("actorMiddleware run binding", () => {
+  const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
+  const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
+  const originalSecret = process.env[secretEnv];
+  const originalTtl = process.env[ttlEnv];
+
+  beforeEach(() => {
+    process.env[secretEnv] = "test-secret";
+    process.env[ttlEnv] = "3600";
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env[secretEnv];
+    else process.env[secretEnv] = originalSecret;
+    if (originalTtl === undefined) delete process.env[ttlEnv];
+    else process.env[ttlEnv] = originalTtl;
+  });
+
+  it("binds an active run id for agent key requests", async () => {
+    const app = createApp(makeDb({
+      keyRows: [{ id: "key-1", agentId: AGENT_ID, companyId: COMPANY_ID, revokedAt: null }],
+      agentRows: [{ id: AGENT_ID, companyId: COMPANY_ID, status: "active" }],
+      runRows: [{ id: RUN_ID }],
+    }));
+
+    const res = await request(app)
+      .get("/actor")
+      .set("authorization", "Bearer pcp_test_key")
+      .set("x-paperclip-run-id", RUN_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      agentId: AGENT_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+      source: "agent_key",
+    });
+  });
+
+  it("drops stale or foreign run ids for agent key requests", async () => {
+    const app = createApp(makeDb({
+      keyRows: [{ id: "key-1", agentId: AGENT_ID, companyId: COMPANY_ID, revokedAt: null }],
+      agentRows: [{ id: AGENT_ID, companyId: COMPANY_ID, status: "active" }],
+      runRows: [],
+    }));
+
+    const res = await request(app)
+      .get("/actor")
+      .set("authorization", "Bearer pcp_test_key")
+      .set("x-paperclip-run-id", RUN_ID);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      agentId: AGENT_ID,
+      companyId: COMPANY_ID,
+      source: "agent_key",
+    });
+    expect(res.body.runId).toBeUndefined();
+  });
+
+  it("prefers the JWT run claim over an override header", async () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, "codex_local", RUN_ID);
+    expect(token).toBeTruthy();
+
+    const app = createApp(makeDb({
+      keyRows: [],
+      agentRows: [{ id: AGENT_ID, companyId: COMPANY_ID, status: "active" }],
+      runRows: [{ id: RUN_ID }],
+    }));
+
+    const res = await request(app)
+      .get("/actor")
+      .set("authorization", `Bearer ${token}`)
+      .set("x-paperclip-run-id", "44444444-4444-4444-8444-444444444444");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      agentId: AGENT_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+      source: "agent_jwt",
+    });
+  });
+});

--- a/server/src/__tests__/agent-inbox-lite-routes.test.ts
+++ b/server/src/__tests__/agent-inbox-lite-routes.test.ts
@@ -1,0 +1,82 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { agentRoutes } from "../routes/agents.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({}),
+  agentService: () => ({}),
+  approvalService: () => ({}),
+  budgetService: () => ({}),
+  heartbeatService: () => ({}),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(),
+  secretService: () => ({}),
+  workspaceOperationService: () => ({}),
+}));
+
+function createAgentApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: AGENT_ID,
+      companyId: COMPANY_ID,
+      runId: "33333333-3333-4333-8333-333333333333",
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("agent inbox-lite route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes explicit assignee fields for assigned inbox items", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: "44444444-4444-4444-8444-444444444444",
+        identifier: "NOV-11",
+        title: "Assigned work",
+        status: "in_progress",
+        priority: "high",
+        projectId: "55555555-5555-4555-8555-555555555555",
+        goalId: "66666666-6666-4666-8666-666666666666",
+        parentId: "77777777-7777-4777-8777-777777777777",
+        assigneeAgentId: AGENT_ID,
+        assigneeUserId: null,
+        updatedAt: new Date("2026-03-21T03:05:25.000Z"),
+        activeRun: null,
+      },
+    ]);
+
+    const res = await request(createAgentApp()).get("/api/agents/me/inbox-lite");
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(COMPANY_ID, {
+      assigneeAgentId: AGENT_ID,
+      status: "todo,in_progress,blocked",
+    });
+    expect(res.body).toEqual([
+      expect.objectContaining({
+        identifier: "NOV-11",
+        assigneeAgentId: AGENT_ID,
+        assigneeUserId: null,
+      }),
+    ]);
+  });
+});

--- a/server/src/__tests__/issue-agent-mutation-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-routes.test.ts
@@ -1,0 +1,326 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const ACTOR_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const ISSUE_ID = "44444444-4444-4444-8444-444444444444";
+const RUN_ID = "55555555-5555-4555-8555-555555555555";
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getById: vi.fn(),
+  listAttachments: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockDocumentService = vi.hoisted(() => ({
+  upsertIssueDocument: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  wakeup: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => mockDocumentService,
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  workProductService: () => ({
+    createForIssue: vi.fn(),
+    getById: vi.fn(),
+    remove: vi.fn(),
+    update: vi.fn(),
+  }),
+}));
+
+function createAgentApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: ACTOR_AGENT_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function createAgentAppWithoutRun() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: ACTOR_AGENT_ID,
+      companyId: COMPANY_ID,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function createBoardApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "board-user",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue agent mutation guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("blocks an agent from patching another agent's issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agents can only mutate their own assigned issues" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("requires a live run id for mutating an assigned issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "blocked",
+      assigneeAgentId: ACTOR_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentAppWithoutRun())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Agent run id required" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("requires a live run id for mutating an agent-created draft issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      createdByAgentId: ACTOR_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentAppWithoutRun())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ title: "Updated draft title" });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Agent run id required" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("blocks an agent from overwriting an issue document on someone else's issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .put(`/api/issues/${ISSUE_ID}/documents/plan`)
+      .send({
+        title: "Plan",
+        format: "markdown",
+        body: "# Plan",
+        baseRevisionId: null,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agents can only mutate their own assigned issues" });
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
+  });
+
+  it("allows a mention-triggered agent run to comment on another agent's issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-11",
+      title: "Delegated work",
+      status: "blocked",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+      executionRunId: null,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: RUN_ID,
+      agentId: ACTOR_AGENT_ID,
+      status: "running",
+      contextSnapshot: {
+        issueId: ISSUE_ID,
+        wakeReason: "issue_comment_mentioned",
+        wakeCommentId: "comment-1",
+      },
+    });
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-2",
+      issueId: ISSUE_ID,
+      body: "Here is the requested input.",
+      createdAt: new Date("2026-03-21T03:30:00.000Z"),
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "Here is the requested input." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      ISSUE_ID,
+      "Here is the requested input.",
+      expect.objectContaining({ agentId: ACTOR_AGENT_ID }),
+    );
+  });
+
+  it("blocks a stale mention-triggered run from commenting on another agent's issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-11",
+      title: "Delegated work",
+      status: "blocked",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+      executionRunId: null,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: RUN_ID,
+      agentId: ACTOR_AGENT_ID,
+      status: "succeeded",
+      contextSnapshot: {
+        issueId: ISSUE_ID,
+        wakeReason: "issue_comment_mentioned",
+        wakeCommentId: "comment-1",
+      },
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "Here is the requested input." });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agents can only mutate their own assigned issues" });
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("still blocks a mention-triggered agent run from reopening another agent's issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "done",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "Please reopen this.", reopen: true });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agents can only mutate their own assigned issues" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("blocks agents from deleting issues", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+    });
+
+    const res = await request(createAgentApp()).delete(`/api/issues/${ISSUE_ID}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Board authentication required" });
+    expect(mockIssueService.remove).not.toHaveBeenCalled();
+  });
+
+  it("still allows board users to delete issues", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+    });
+    mockIssueService.listAttachments.mockResolvedValue([]);
+    mockIssueService.remove.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+    });
+
+    const res = await request(createBoardApp()).delete(`/api/issues/${ISSUE_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.remove).toHaveBeenCalledWith(ISSUE_ID);
+  });
+});

--- a/server/src/__tests__/issue-manager-control-routes.test.ts
+++ b/server/src/__tests__/issue-manager-control-routes.test.ts
@@ -1,0 +1,231 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const CEO_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const MANAGER_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const WORKER_AGENT_ID = "44444444-4444-4444-8444-444444444444";
+const ISSUE_ID = "55555555-5555-4555-8555-555555555555";
+const RUN_ID = "66666666-6666-4666-8666-666666666666";
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getById: vi.fn(),
+  release: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  wakeup: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  workProductService: () => ({}),
+}));
+
+function createAgentApp({
+  agentId = CEO_AGENT_ID,
+  runId = RUN_ID,
+}: {
+  agentId?: string;
+  runId?: string | null;
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId,
+      companyId: COMPANY_ID,
+      ...(runId ? { runId } : {}),
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue manager control routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("allows a CEO agent to reprioritize another agent's assigned backlog issue", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: CEO_AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "ceo",
+      permissions: null,
+    });
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "backlog",
+      assigneeAgentId: WORKER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: WORKER_AGENT_ID,
+      createdByUserId: null,
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: WORKER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: WORKER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      ISSUE_ID,
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
+  it("requires a live run id for CEO queue-control mutations", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: CEO_AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "ceo",
+      permissions: null,
+    });
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "backlog",
+      assigneeAgentId: WORKER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: WORKER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentApp({ runId: null }))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Agent run id required" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent with tasks:assign permission to reprioritize another agent's issue", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue({
+      id: MANAGER_AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "manager",
+      permissions: null,
+    });
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "backlog",
+      assigneeAgentId: WORKER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: WORKER_AGENT_ID,
+      createdByUserId: null,
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: WORKER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: WORKER_AGENT_ID,
+      createdByUserId: null,
+    });
+
+    const res = await request(createAgentApp({ agentId: MANAGER_AGENT_ID }))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      MANAGER_AGENT_ID,
+      "tasks:assign",
+    );
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      ISSUE_ID,
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
+  it("allows a CEO agent to release another agent's checked-out issue", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      id: CEO_AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "ceo",
+      permissions: null,
+    });
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: WORKER_AGENT_ID,
+      assigneeUserId: null,
+      createdByAgentId: WORKER_AGENT_ID,
+      createdByUserId: null,
+    });
+    mockIssueService.release.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/issues/${ISSUE_ID}/release`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith(
+      ISSUE_ID,
+      {
+        actorAgentId: CEO_AGENT_ID,
+        actorRunId: RUN_ID,
+        bypassAssigneeCheck: true,
+      },
+    );
+  });
+});

--- a/server/src/__tests__/issue-mentions-and-locks.test.ts
+++ b/server/src/__tests__/issue-mentions-and-locks.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  findMentionedAgentIdsInBody,
+  shouldClearIssueExecutionLockForUpdate,
+} from "../services/issues.ts";
+
+describe("findMentionedAgentIdsInBody", () => {
+  it("resolves multi-word agent mentions", () => {
+    const mentioned = findMentionedAgentIdsInBody(
+      "Escalating to @Trade Analyst, then handing off to @Founding Engineer.",
+      [
+        { id: "agent-1", name: "Trade Analyst" },
+        { id: "agent-2", name: "Founding Engineer" },
+      ],
+    );
+
+    expect(mentioned).toEqual(["agent-1", "agent-2"]);
+  });
+
+  it("prefers the longest matching agent name when names share a prefix", () => {
+    const mentioned = findMentionedAgentIdsInBody(
+      "Please ask @Trade Analyst for the next step.",
+      [
+        { id: "agent-short", name: "Trade" },
+        { id: "agent-long", name: "Trade Analyst" },
+      ],
+    );
+
+    expect(mentioned).toEqual(["agent-long"]);
+  });
+
+  it("does not treat email addresses as mentions", () => {
+    const mentioned = findMentionedAgentIdsInBody(
+      "ops@trade-analyst.example.com is not the same as @Trade Analyst.",
+      [
+        { id: "agent-1", name: "Trade Analyst" },
+      ],
+    );
+
+    expect(mentioned).toEqual(["agent-1"]);
+  });
+});
+
+describe("shouldClearIssueExecutionLockForUpdate", () => {
+  const existing = {
+    status: "in_progress",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+  } as const;
+
+  it("clears execution lock when status leaves in_progress", () => {
+    expect(
+      shouldClearIssueExecutionLockForUpdate(existing, { status: "blocked" }),
+    ).toBe(true);
+  });
+
+  it("clears execution lock when the assignee changes", () => {
+    expect(
+      shouldClearIssueExecutionLockForUpdate(existing, { assigneeAgentId: "agent-2" }),
+    ).toBe(true);
+  });
+
+  it("keeps execution lock for non-ownership metadata changes", () => {
+    expect(
+      shouldClearIssueExecutionLockForUpdate(existing, { priority: "high" }),
+    ).toBe(false);
+  });
+});

--- a/server/src/__tests__/issue-self-assignment-routes.test.ts
+++ b/server/src/__tests__/issue-self-assignment-routes.test.ts
@@ -8,6 +8,7 @@ const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
 const ACTOR_AGENT_ID = "22222222-2222-4222-8222-222222222222";
 const OTHER_AGENT_ID = "33333333-3333-4333-8333-333333333333";
 const ISSUE_ID = "44444444-4444-4444-8444-444444444444";
+const PARENT_ISSUE_ID = "66666666-6666-4666-8666-666666666666";
 const RUN_ID = "55555555-5555-4555-8555-555555555555";
 
 const mockIssueService = vi.hoisted(() => ({
@@ -62,7 +63,23 @@ function createAgentApp() {
   return app;
 }
 
-describe("issue self-assignment permissions", () => {
+function createAgentAppWithoutRun() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: ACTOR_AGENT_ID,
+      companyId: COMPANY_ID,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue assignment permissions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccessService.canUser.mockResolvedValue(false);
@@ -77,17 +94,7 @@ describe("issue self-assignment permissions", () => {
     mockLogActivity.mockResolvedValue(undefined);
   });
 
-  it("allows an agent to create a self-assigned issue without tasks:assign", async () => {
-    mockIssueService.create.mockResolvedValue({
-      id: ISSUE_ID,
-      companyId: COMPANY_ID,
-      identifier: "NOV-101",
-      title: "Self assigned follow-up",
-      status: "todo",
-      assigneeAgentId: ACTOR_AGENT_ID,
-      assigneeUserId: null,
-    });
-
+  it("blocks an agent from creating a self-assigned issue without tasks:assign", async () => {
     const res = await request(createAgentApp())
       .post(`/api/companies/${COMPANY_ID}/issues`)
       .send({
@@ -97,19 +104,105 @@ describe("issue self-assignment permissions", () => {
         assigneeUserId: null,
       });
 
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("requires a live run id for agent-created issues", async () => {
+    const res = await request(createAgentAppWithoutRun())
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({
+        parentId: PARENT_ISSUE_ID,
+        title: "Delegated follow-up",
+        status: "todo",
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Agent run id required" });
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent to create a delegated subtask without tasks:assign", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: PARENT_ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-90",
+      title: "Parent issue",
+      status: "todo",
+      assigneeAgentId: ACTOR_AGENT_ID,
+      assigneeUserId: null,
+    });
+    mockIssueService.create.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-104",
+      title: "Delegated follow-up",
+      status: "todo",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({
+        parentId: PARENT_ISSUE_ID,
+        title: "Delegated follow-up",
+        status: "todo",
+        assigneeAgentId: OTHER_AGENT_ID,
+        assigneeUserId: null,
+      });
+
     expect(res.status).toBe(201);
-    expect(mockAccessService.hasPermission).not.toHaveBeenCalled();
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      ACTOR_AGENT_ID,
+      "tasks:assign",
+    );
     expect(mockIssueService.create).toHaveBeenCalledWith(
       COMPANY_ID,
       expect.objectContaining({
-        title: "Self assigned follow-up",
-        assigneeAgentId: ACTOR_AGENT_ID,
+        parentId: PARENT_ISSUE_ID,
+        title: "Delegated follow-up",
+        assigneeAgentId: OTHER_AGENT_ID,
         createdByAgentId: ACTOR_AGENT_ID,
       }),
     );
   });
 
-  it("allows an agent to self-assign its own unassigned issue without tasks:assign", async () => {
+  it("blocks an agent from creating a top-level issue without tasks:assign", async () => {
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({
+        title: "Top-level draft issue",
+        status: "todo",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("still blocks an agent from creating a top-level issue assigned to another agent", async () => {
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({
+        title: "Top-level delegated issue",
+        status: "todo",
+        assigneeAgentId: OTHER_AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("blocks an agent from self-assigning its own unassigned issue without tasks:assign", async () => {
     mockIssueService.getById.mockResolvedValue({
       id: ISSUE_ID,
       companyId: COMPANY_ID,
@@ -138,15 +231,120 @@ describe("issue self-assignment permissions", () => {
         assigneeUserId: null,
       });
 
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent to assign its own unassigned subtask to another agent without tasks:assign", async () => {
+    mockIssueService.getById
+      .mockResolvedValueOnce({
+        id: ISSUE_ID,
+        companyId: COMPANY_ID,
+        identifier: "NOV-105",
+        title: "Delegated follow-up",
+        status: "todo",
+        parentId: PARENT_ISSUE_ID,
+        createdByAgentId: ACTOR_AGENT_ID,
+        createdByUserId: null,
+        assigneeAgentId: null,
+        assigneeUserId: null,
+      })
+      .mockResolvedValueOnce({
+        id: PARENT_ISSUE_ID,
+        companyId: COMPANY_ID,
+        identifier: "NOV-90",
+        title: "Parent issue",
+        status: "todo",
+        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeUserId: null,
+      });
+    mockIssueService.update.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-105",
+      title: "Delegated follow-up",
+      status: "todo",
+      assigneeAgentId: OTHER_AGENT_ID,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({
+        assigneeAgentId: OTHER_AGENT_ID,
+        assigneeUserId: null,
+      });
+
     expect(res.status).toBe(200);
-    expect(mockAccessService.hasPermission).not.toHaveBeenCalled();
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      ACTOR_AGENT_ID,
+      "tasks:assign",
+    );
     expect(mockIssueService.update).toHaveBeenCalledWith(
       ISSUE_ID,
       expect.objectContaining({
-        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeAgentId: OTHER_AGENT_ID,
         assigneeUserId: null,
       }),
     );
+  });
+
+  it("blocks an agent from assigning its own unassigned child issue to itself", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-105",
+      title: "Delegated follow-up",
+      status: "todo",
+      parentId: PARENT_ISSUE_ID,
+      createdByAgentId: ACTOR_AGENT_ID,
+      createdByUserId: null,
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({
+        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("still blocks an agent from assigning its own top-level unassigned issue to another agent", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-106",
+      title: "Top-level delegated issue",
+      status: "todo",
+      parentId: null,
+      createdByAgentId: ACTOR_AGENT_ID,
+      createdByUserId: null,
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({
+        assigneeAgentId: OTHER_AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("still blocks an agent from self-assigning someone else's unassigned issue", async () => {
@@ -167,11 +365,16 @@ describe("issue self-assignment permissions", () => {
       .send({
         assigneeAgentId: ACTOR_AGENT_ID,
         assigneeUserId: null,
-      });
+    });
 
     expect(res.status).toBe(403);
-    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
-    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(res.body).toEqual({ error: "Agents can only mutate their own assigned issues" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      COMPANY_ID,
+      "agent",
+      ACTOR_AGENT_ID,
+      "tasks:assign",
+    );
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issue-self-assignment-routes.test.ts
+++ b/server/src/__tests__/issue-self-assignment-routes.test.ts
@@ -1,0 +1,177 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const ACTOR_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const ISSUE_ID = "44444444-4444-4444-8444-444444444444";
+const RUN_ID = "55555555-5555-4555-8555-555555555555";
+
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  workProductService: () => ({}),
+}));
+
+function createAgentApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: ACTOR_AGENT_ID,
+      companyId: COMPANY_ID,
+      runId: RUN_ID,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue self-assignment permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue({
+      id: ACTOR_AGENT_ID,
+      companyId: COMPANY_ID,
+      role: "researcher",
+      permissions: null,
+    });
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("allows an agent to create a self-assigned issue without tasks:assign", async () => {
+    mockIssueService.create.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-101",
+      title: "Self assigned follow-up",
+      status: "todo",
+      assigneeAgentId: ACTOR_AGENT_ID,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({
+        title: "Self assigned follow-up",
+        status: "todo",
+        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockAccessService.hasPermission).not.toHaveBeenCalled();
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({
+        title: "Self assigned follow-up",
+        assigneeAgentId: ACTOR_AGENT_ID,
+        createdByAgentId: ACTOR_AGENT_ID,
+      }),
+    );
+  });
+
+  it("allows an agent to self-assign its own unassigned issue without tasks:assign", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-102",
+      title: "Agent-created follow-up",
+      status: "todo",
+      createdByAgentId: ACTOR_AGENT_ID,
+      createdByUserId: null,
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-102",
+      title: "Agent-created follow-up",
+      status: "todo",
+      assigneeAgentId: ACTOR_AGENT_ID,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({
+        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.hasPermission).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      ISSUE_ID,
+      expect.objectContaining({
+        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeUserId: null,
+      }),
+    );
+  });
+
+  it("still blocks an agent from self-assigning someone else's unassigned issue", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: ISSUE_ID,
+      companyId: COMPANY_ID,
+      identifier: "NOV-103",
+      title: "Someone else's follow-up",
+      status: "todo",
+      createdByAgentId: OTHER_AGENT_ID,
+      createdByUserId: null,
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createAgentApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({
+        assigneeAgentId: ACTOR_AGENT_ID,
+        assigneeUserId: null,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Missing permission: tasks:assign" });
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(COMPANY_ID, "agent", ACTOR_AGENT_ID, "tasks:assign");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import type { Request, RequestHandler } from "express";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agentApiKeys, agents, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import { agentApiKeys, agents, companyMemberships, heartbeatRuns, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
@@ -18,6 +18,29 @@ interface ActorMiddlewareOptions {
 }
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
+  async function resolveActiveAgentRunId(
+    agentId: string,
+    companyId: string,
+    runId: string | null | undefined,
+  ) {
+    const normalizedRunId = runId?.trim();
+    if (!normalizedRunId) return undefined;
+    const run = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.id, normalizedRunId),
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.status, "running"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    if (!run) return undefined;
+    return run.id;
+  }
+
   return async (req, _res, next) => {
     req.actor =
       opts.deploymentMode === "local_trusted"
@@ -110,12 +133,30 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         return;
       }
 
+      if (claims.run_id && runIdHeader && runIdHeader !== claims.run_id) {
+        logger.warn(
+          {
+            agentId: claims.sub,
+            companyId: claims.company_id,
+            claimedRunId: claims.run_id,
+            headerRunId: runIdHeader,
+          },
+          "Ignoring agent JWT run id override header",
+        );
+      }
+
+      const runId = await resolveActiveAgentRunId(
+        claims.sub,
+        claims.company_id,
+        claims.run_id || runIdHeader || undefined,
+      );
+
       req.actor = {
         type: "agent",
         agentId: claims.sub,
         companyId: claims.company_id,
         keyId: undefined,
-        runId: runIdHeader || claims.run_id || undefined,
+        runId,
         source: "agent_jwt",
       };
       next();
@@ -138,12 +179,14 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       return;
     }
 
+    const runId = await resolveActiveAgentRunId(key.agentId, key.companyId, runIdHeader);
+
     req.actor = {
       type: "agent",
       agentId: key.agentId,
       companyId: key.companyId,
       keyId: key.id,
-      runId: runIdHeader || undefined,
+      runId,
       source: "agent_key",
     };
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -601,6 +601,8 @@ export function agentRoutes(db: Db) {
         projectId: issue.projectId,
         goalId: issue.goalId,
         parentId: issue.parentId,
+        assigneeAgentId: issue.assigneeAgentId,
+        assigneeUserId: issue.assigneeUserId,
         updatedAt: issue.updatedAt,
         activeRun: issue.activeRun,
       })),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -87,56 +87,109 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return false;
   }
 
-  function canCreateAgentsLegacy(agent: { permissions: Record<string, unknown> | null | undefined; role: string }) {
+  function hasManagerAgentPrivileges(agent: { permissions: Record<string, unknown> | null | undefined; role: string }) {
     if (agent.role === "ceo") return true;
     if (!agent.permissions || typeof agent.permissions !== "object") return false;
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
-  async function assertCanAssignTasks(req: Request, companyId: string) {
+  async function actorCanManageCompanyTasks(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
-      if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
-      const allowed = await access.canUser(companyId, req.actor.userId, "tasks:assign");
-      if (!allowed) throw forbidden("Missing permission: tasks:assign");
-      return;
+      if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return true;
+      return access.canUser(companyId, req.actor.userId, "tasks:assign");
     }
     if (req.actor.type === "agent") {
-      if (!req.actor.agentId) throw forbidden("Agent authentication required");
+      if (!req.actor.agentId) return false;
       const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:assign");
-      if (allowedByGrant) return;
+      if (allowedByGrant) return true;
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
-      if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
+      return Boolean(actorAgent && actorAgent.companyId === companyId && hasManagerAgentPrivileges(actorAgent));
+    }
+    return false;
+  }
+
+  async function actorCanAssignTasks(req: Request, companyId: string) {
+    return actorCanManageCompanyTasks(req, companyId);
+  }
+
+  async function actorCanManageAnyIssueInCompany(req: Request, companyId: string) {
+    assertCompanyAccess(req, companyId);
+    if (req.actor.type === "board") return true;
+    return actorCanManageCompanyTasks(req, companyId);
+  }
+
+  async function assertCanAssignTasks(req: Request, companyId: string) {
+    if (await actorCanAssignTasks(req, companyId)) return;
+    if (req.actor.type === "board" || req.actor.type === "agent") {
       throw forbidden("Missing permission: tasks:assign");
     }
     throw unauthorized();
   }
 
-  function isAgentAssigningToSelf(
+  function hasParentIssue(parentId: string | null | undefined): parentId is string {
+    return typeof parentId === "string" && parentId.length > 0;
+  }
+
+  function isAgentAssigningToOtherAgent(
     req: Request,
     assigneeAgentId: string | null | undefined,
     assigneeUserId: string | null | undefined,
   ) {
     return req.actor.type === "agent"
       && !!req.actor.agentId
-      && assigneeAgentId === req.actor.agentId
+      && typeof assigneeAgentId === "string"
+      && assigneeAgentId.length > 0
+      && assigneeAgentId !== req.actor.agentId
       && (assigneeUserId === null || assigneeUserId === undefined);
   }
 
-  function canAgentSelfAssignOwnUnassignedIssue(
+  async function getValidatedParentIssue(
+    res: Response,
+    companyId: string,
+    parentId: string,
+  ) {
+    const parentIssue = await svc.getById(parentId);
+    if (!parentIssue || parentIssue.companyId !== companyId) {
+      res.status(422).json({ error: "Parent issue does not belong to company" });
+      return null;
+    }
+    return parentIssue;
+  }
+
+  async function assertAgentCanDelegateFromParentIssue(
+    req: Request,
+    res: Response,
+    companyId: string,
+    parentId: string,
+  ) {
+    const parentIssue = await getValidatedParentIssue(res, companyId, parentId);
+    if (!parentIssue) return null;
+    if (!(await assertCanMutateAssignedIssue(req, res, parentIssue))) return null;
+    return parentIssue;
+  }
+
+  function canAgentAssignOwnUnassignedChildIssueWithoutAssignPermission(
     req: Request,
     issue: {
       createdByAgentId: string | null;
+      parentId: string | null;
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
     assigneeAgentId: string | null | undefined,
     assigneeUserId: string | null | undefined,
   ) {
-    return isAgentAssigningToSelf(req, assigneeAgentId, assigneeUserId)
-      && issue.createdByAgentId === req.actor.agentId
-      && issue.assigneeAgentId === null
-      && issue.assigneeUserId === null;
+    if (req.actor.type !== "agent" || !req.actor.agentId) return false;
+    if (
+      issue.createdByAgentId !== req.actor.agentId
+      || issue.assigneeAgentId !== null
+      || issue.assigneeUserId !== null
+    ) {
+      return false;
+    }
+    return hasParentIssue(issue.parentId)
+      && isAgentAssigningToOtherAgent(req, assigneeAgentId, assigneeUserId);
   }
 
   function requireAgentRunId(req: Request, res: Response) {
@@ -145,6 +198,11 @@ export function issueRoutes(db: Db, storage: StorageService) {
     if (runId) return runId;
     res.status(401).json({ error: "Agent run id required" });
     return null;
+  }
+
+  function assertAgentMutationRunContext(req: Request, res: Response) {
+    if (req.actor.type !== "agent") return true;
+    return Boolean(requireAgentRunId(req, res));
   }
 
   async function assertAgentRunCheckoutOwnership(
@@ -158,11 +216,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
-    if (issue.status !== "in_progress" || issue.assigneeAgentId !== actorAgentId) {
+    if (issue.assigneeAgentId !== actorAgentId) {
       return true;
     }
     const runId = requireAgentRunId(req, res);
     if (!runId) return false;
+    if (issue.status !== "in_progress") {
+      return true;
+    }
     const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId);
     if (ownership.adoptedFromRunId) {
       const actor = getActorInfo(req);
@@ -183,6 +244,102 @@ export function issueRoutes(db: Db, storage: StorageService) {
       });
     }
     return true;
+  }
+
+  function isAgentAssignedIssue(
+    req: Request,
+    issue: { assigneeAgentId: string | null },
+  ) {
+    return req.actor.type === "agent"
+      && !!req.actor.agentId
+      && issue.assigneeAgentId === req.actor.agentId;
+  }
+
+  function isAgentCreatedUnassignedIssue(
+    req: Request,
+    issue: {
+      createdByAgentId: string | null;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+    },
+  ) {
+    return req.actor.type === "agent"
+      && !!req.actor.agentId
+      && issue.createdByAgentId === req.actor.agentId
+      && issue.assigneeAgentId === null
+      && issue.assigneeUserId === null;
+  }
+
+  async function isMentionWakeForIssue(req: Request, issueId: string) {
+    if (req.actor.type !== "agent" || !req.actor.agentId) return false;
+    const runId = req.actor.runId?.trim();
+    if (!runId) return false;
+    const run = await heartbeat.getRun(runId);
+    if (!run || run.agentId !== req.actor.agentId) return false;
+    const context = run.contextSnapshot;
+    if (!context || typeof context !== "object" || Array.isArray(context)) return false;
+    const snapshot = context as Record<string, unknown>;
+    const contextIssueId = typeof snapshot.issueId === "string" ? snapshot.issueId : null;
+    const wakeReason = typeof snapshot.wakeReason === "string" ? snapshot.wakeReason : null;
+    const wakeCommentId = typeof snapshot.wakeCommentId === "string" ? snapshot.wakeCommentId : null;
+    return run.status === "running"
+      && contextIssueId === issueId
+      && wakeReason === "issue_comment_mentioned"
+      && Boolean(wakeCommentId);
+  }
+
+  async function assertCanMutateIssue(
+    req: Request,
+    res: Response,
+    issue: {
+      id: string;
+      companyId: string;
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+      createdByAgentId: string | null;
+    },
+    options?: {
+      allowCreatedUnassignedIssue?: boolean;
+      allowMentionComment?: boolean;
+    },
+  ) {
+    if (req.actor.type === "board") return true;
+    if (isAgentAssignedIssue(req, issue)) {
+      return assertAgentRunCheckoutOwnership(req, res, issue);
+    }
+    if (await actorCanManageAnyIssueInCompany(req, issue.companyId)) {
+      return assertAgentMutationRunContext(req, res);
+    }
+    if (options?.allowCreatedUnassignedIssue && isAgentCreatedUnassignedIssue(req, issue)) {
+      return assertAgentMutationRunContext(req, res);
+    }
+    if (options?.allowMentionComment && await isMentionWakeForIssue(req, issue.id)) {
+      return true;
+    }
+    res.status(403).json({ error: "Agents can only mutate their own assigned issues" });
+    return false;
+  }
+
+  async function assertCanMutateAssignedIssue(
+    req: Request,
+    res: Response,
+    issue: {
+      id: string;
+      companyId: string;
+      status: string;
+      assigneeAgentId: string | null;
+    },
+  ) {
+    if (req.actor.type === "board") return true;
+    if (isAgentAssignedIssue(req, issue)) {
+      return assertAgentRunCheckoutOwnership(req, res, issue);
+    }
+    if (await actorCanManageAnyIssueInCompany(req, issue.companyId)) {
+      return assertAgentMutationRunContext(req, res);
+    }
+    res.status(403).json({ error: "Agents can only mutate their own assigned issues" });
+    return false;
   }
 
   async function normalizeIssueIdentifier(rawId: string): Promise<string> {
@@ -492,6 +649,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
       return;
     }
+    if (!(await assertCanMutateIssue(req, res, issue, { allowCreatedUnassignedIssue: true }))) return;
 
     const actor = getActorInfo(req);
     const result = await documentsSvc.upsertIssueDocument({
@@ -594,6 +752,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    if (!(await assertCanMutateIssue(req, res, issue, { allowCreatedUnassignedIssue: true }))) return;
     const product = await workProductsSvc.createForIssue(issue.id, issue.companyId, {
       ...req.body,
       projectId: req.body.projectId ?? issue.projectId ?? null,
@@ -625,6 +784,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    const issue = await svc.getById(existing.issueId);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    if (!(await assertCanMutateIssue(req, res, issue, { allowCreatedUnassignedIssue: true }))) return;
     const product = await workProductsSvc.update(id, req.body);
     if (!product) {
       res.status(404).json({ error: "Work product not found" });
@@ -653,6 +818,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    const issue = await svc.getById(existing.issueId);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    if (!(await assertCanMutateIssue(req, res, issue, { allowCreatedUnassignedIssue: true }))) return;
     const removed = await workProductsSvc.remove(id);
     if (!removed) {
       res.status(404).json({ error: "Work product not found" });
@@ -779,13 +950,28 @@ export function issueRoutes(db: Db, storage: StorageService) {
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const isAgentCreatingIssueAssignedToSelf = isAgentAssigningToSelf(
-      req,
-      req.body.assigneeAgentId,
-      req.body.assigneeUserId,
-    );
-    if ((req.body.assigneeAgentId || req.body.assigneeUserId) && !isAgentCreatingIssueAssignedToSelf) {
-      await assertCanAssignTasks(req, companyId);
+    if (!assertAgentMutationRunContext(req, res)) return;
+    const canAssignTasks = await actorCanAssignTasks(req, companyId);
+    let canAgentCreateDelegatedChildIssueWithoutAssignPermission = false;
+
+    if (req.actor.type === "agent" && !canAssignTasks) {
+      if (!hasParentIssue(req.body.parentId)) {
+        res.status(403).json({ error: "Missing permission: tasks:assign" });
+        return;
+      }
+      if (!(await assertAgentCanDelegateFromParentIssue(req, res, companyId, req.body.parentId))) return;
+      canAgentCreateDelegatedChildIssueWithoutAssignPermission = true;
+    }
+
+    if (!canAssignTasks && (req.body.assigneeAgentId || req.body.assigneeUserId)) {
+      const validDelegatedChildAssignee = isAgentAssigningToOtherAgent(
+        req,
+        req.body.assigneeAgentId,
+        req.body.assigneeUserId,
+      );
+      if (!canAgentCreateDelegatedChildIssueWithoutAssignPermission || !validDelegatedChildAssignee) {
+        throw forbidden("Missing permission: tasks:assign");
+      }
     }
 
     const actor = getActorInfo(req);
@@ -832,9 +1018,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    if (!(await assertCanMutateIssue(req, res, existing, { allowCreatedUnassignedIssue: true }))) return;
     const assigneeWillChange =
       (req.body.assigneeAgentId !== undefined && req.body.assigneeAgentId !== existing.assigneeAgentId) ||
       (req.body.assigneeUserId !== undefined && req.body.assigneeUserId !== existing.assigneeUserId);
+    const canAssignTasks = assigneeWillChange
+      ? await actorCanAssignTasks(req, existing.companyId)
+      : false;
 
     const isAgentReturningIssueToCreator =
       req.actor.type === "agent" &&
@@ -844,19 +1034,26 @@ export function issueRoutes(db: Db, storage: StorageService) {
       typeof req.body.assigneeUserId === "string" &&
       !!existing.createdByUserId &&
       req.body.assigneeUserId === existing.createdByUserId;
-    const isAgentSelfAssigningOwnUnassignedIssue = canAgentSelfAssignOwnUnassignedIssue(
+    const canAgentAssignOwnUnassignedChildIssue = canAgentAssignOwnUnassignedChildIssueWithoutAssignPermission(
       req,
       existing,
       req.body.assigneeAgentId,
       req.body.assigneeUserId,
     );
+    if (canAgentAssignOwnUnassignedChildIssue) {
+      if (!(await assertAgentCanDelegateFromParentIssue(
+        req,
+        res,
+        existing.companyId,
+        existing.parentId!,
+      ))) return;
+    }
 
     if (assigneeWillChange) {
-      if (!isAgentReturningIssueToCreator && !isAgentSelfAssigningOwnUnassignedIssue) {
-        await assertCanAssignTasks(req, existing.companyId);
+      if (!isAgentReturningIssueToCreator && !canAssignTasks && !canAgentAssignOwnUnassignedChildIssue) {
+        throw forbidden("Missing permission: tasks:assign");
       }
     }
-    if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
 
     const { comment: commentBody, hiddenAt: hiddenAtRaw, ...updateFields } = req.body;
     if (hiddenAtRaw !== undefined) {
@@ -1030,6 +1227,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    if (req.actor.type !== "board") {
+      res.status(403).json({ error: "Board authentication required" });
+      return;
+    }
     const attachments = await svc.listAttachments(id);
 
     const issue = await svc.remove(id);
@@ -1137,14 +1338,22 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
+    if (!(await assertCanMutateAssignedIssue(req, res, existing))) return;
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;
+    const bypassAssigneeCheck =
+      req.actor.type === "agent"
+      && !!req.actor.agentId
+      && existing.assigneeAgentId !== req.actor.agentId
+      && await actorCanManageAnyIssueInCompany(req, existing.companyId);
 
     const released = await svc.release(
       id,
-      req.actor.type === "agent" ? req.actor.agentId : undefined,
-      actorRunId,
+      {
+        actorAgentId: req.actor.type === "agent" ? req.actor.agentId : undefined,
+        actorRunId,
+        bypassAssigneeCheck,
+      },
     );
     if (!released) {
       res.status(404).json({ error: "Issue not found" });
@@ -1225,11 +1434,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentRunCheckoutOwnership(req, res, issue))) return;
 
     const actor = getActorInfo(req);
     const reopenRequested = req.body.reopen === true;
     const interruptRequested = req.body.interrupt === true;
+    if (reopenRequested) {
+      if (!(await assertCanMutateAssignedIssue(req, res, issue))) return;
+    } else if (!(await assertCanMutateIssue(req, res, issue, {
+      allowCreatedUnassignedIssue: true,
+      allowMentionComment: true,
+    }))) {
+      return;
+    }
     const isClosed = issue.status === "done" || issue.status === "cancelled";
     let reopened = false;
     let reopenFromStatus: string | null = null;
@@ -1455,6 +1671,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(422).json({ error: "Issue does not belong to company" });
       return;
     }
+    if (!(await assertCanMutateIssue(req, res, issue, { allowCreatedUnassignedIssue: true }))) return;
 
     try {
       await runSingleFileUpload(req, res);
@@ -1563,6 +1780,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, attachment.companyId);
+    const issue = await svc.getById(attachment.issueId);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    if (!(await assertCanMutateIssue(req, res, issue, { allowCreatedUnassignedIssue: true }))) return;
 
     try {
       await storage.deleteObject(attachment.companyId, attachment.objectKey);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -112,6 +112,33 @@ export function issueRoutes(db: Db, storage: StorageService) {
     throw unauthorized();
   }
 
+  function isAgentAssigningToSelf(
+    req: Request,
+    assigneeAgentId: string | null | undefined,
+    assigneeUserId: string | null | undefined,
+  ) {
+    return req.actor.type === "agent"
+      && !!req.actor.agentId
+      && assigneeAgentId === req.actor.agentId
+      && (assigneeUserId === null || assigneeUserId === undefined);
+  }
+
+  function canAgentSelfAssignOwnUnassignedIssue(
+    req: Request,
+    issue: {
+      createdByAgentId: string | null;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+    },
+    assigneeAgentId: string | null | undefined,
+    assigneeUserId: string | null | undefined,
+  ) {
+    return isAgentAssigningToSelf(req, assigneeAgentId, assigneeUserId)
+      && issue.createdByAgentId === req.actor.agentId
+      && issue.assigneeAgentId === null
+      && issue.assigneeUserId === null;
+  }
+
   function requireAgentRunId(req: Request, res: Response) {
     if (req.actor.type !== "agent") return null;
     const runId = req.actor.runId?.trim();
@@ -752,7 +779,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    if (req.body.assigneeAgentId || req.body.assigneeUserId) {
+    const isAgentCreatingIssueAssignedToSelf = isAgentAssigningToSelf(
+      req,
+      req.body.assigneeAgentId,
+      req.body.assigneeUserId,
+    );
+    if ((req.body.assigneeAgentId || req.body.assigneeUserId) && !isAgentCreatingIssueAssignedToSelf) {
       await assertCanAssignTasks(req, companyId);
     }
 
@@ -812,9 +844,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
       typeof req.body.assigneeUserId === "string" &&
       !!existing.createdByUserId &&
       req.body.assigneeUserId === existing.createdByUserId;
+    const isAgentSelfAssigningOwnUnassignedIssue = canAgentSelfAssignOwnUnassignedIssue(
+      req,
+      existing,
+      req.body.assigneeAgentId,
+      req.body.assigneeUserId,
+    );
 
     if (assigneeWillChange) {
-      if (!isAgentReturningIssueToCreator) {
+      if (!isAgentReturningIssueToCreator && !isAgentSelfAssigningOwnUnassignedIssue) {
         await assertCanAssignTasks(req, existing.companyId);
       }
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2442,21 +2442,20 @@ export function heartbeatService(db: Db) {
   }
 
   async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
-    const promotedRun = await db.transaction(async (tx) => {
+    const promotedRuns = await db.transaction(async (tx) => {
       await tx.execute(
         sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
       );
 
-      const issue = await tx
+      const affectedIssues = await tx
         .select({
           id: issues.id,
           companyId: issues.companyId,
         })
         .from(issues)
-        .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
-        .then((rows) => rows[0] ?? null);
+        .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
 
-      if (!issue) return;
+      if (affectedIssues.length === 0) return [];
 
       await tx
         .update(issues)
@@ -2466,131 +2465,138 @@ export function heartbeatService(db: Db) {
           executionLockedAt: null,
           updatedAt: new Date(),
         })
-        .where(eq(issues.id, issue.id));
+        .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
 
-      while (true) {
-        const deferred = await tx
-          .select()
-          .from(agentWakeupRequests)
-          .where(
-            and(
-              eq(agentWakeupRequests.companyId, issue.companyId),
-              eq(agentWakeupRequests.status, "deferred_issue_execution"),
-              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
-            ),
-          )
-          .orderBy(asc(agentWakeupRequests.requestedAt))
-          .limit(1)
-          .then((rows) => rows[0] ?? null);
+      const queuedRuns: (typeof heartbeatRuns.$inferSelect)[] = [];
 
-        if (!deferred) return null;
+      for (const issue of affectedIssues) {
+        while (true) {
+          const deferred = await tx
+            .select()
+            .from(agentWakeupRequests)
+            .where(
+              and(
+                eq(agentWakeupRequests.companyId, issue.companyId),
+                eq(agentWakeupRequests.status, "deferred_issue_execution"),
+                sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
+              ),
+            )
+            .orderBy(asc(agentWakeupRequests.requestedAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
 
-        const deferredAgent = await tx
-          .select()
-          .from(agents)
-          .where(eq(agents.id, deferred.agentId))
-          .then((rows) => rows[0] ?? null);
+          if (!deferred) break;
 
-        if (
-          !deferredAgent ||
-          deferredAgent.companyId !== issue.companyId ||
-          deferredAgent.status === "paused" ||
-          deferredAgent.status === "terminated" ||
-          deferredAgent.status === "pending_approval"
-        ) {
+          const deferredAgent = await tx
+            .select()
+            .from(agents)
+            .where(eq(agents.id, deferred.agentId))
+            .then((rows) => rows[0] ?? null);
+
+          if (
+            !deferredAgent ||
+            deferredAgent.companyId !== issue.companyId ||
+            deferredAgent.status === "paused" ||
+            deferredAgent.status === "terminated" ||
+            deferredAgent.status === "pending_approval"
+          ) {
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                status: "failed",
+                finishedAt: new Date(),
+                error: "Deferred wake could not be promoted: agent is not invokable",
+                updatedAt: new Date(),
+              })
+              .where(eq(agentWakeupRequests.id, deferred.id));
+            continue;
+          }
+
+          const deferredPayload = parseObject(deferred.payload);
+          const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
+          const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
+          const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
+          const promotedSource =
+            (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
+          const promotedTriggerDetail =
+            (readNonEmptyString(deferred.triggerDetail) as WakeupOptions["triggerDetail"]) ?? null;
+          const promotedPayload = deferredPayload;
+          delete promotedPayload[DEFERRED_WAKE_CONTEXT_KEY];
+
+          const {
+            contextSnapshot: promotedContextSnapshot,
+            taskKey: promotedTaskKey,
+          } = enrichWakeContextSnapshot({
+            contextSnapshot: promotedContextSeed,
+            reason: promotedReason,
+            source: promotedSource,
+            triggerDetail: promotedTriggerDetail,
+            payload: promotedPayload,
+          });
+
+          const sessionBefore = await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
+          const now = new Date();
+          const newRun = await tx
+            .insert(heartbeatRuns)
+            .values({
+              companyId: deferredAgent.companyId,
+              agentId: deferredAgent.id,
+              invocationSource: promotedSource,
+              triggerDetail: promotedTriggerDetail,
+              status: "queued",
+              wakeupRequestId: deferred.id,
+              contextSnapshot: promotedContextSnapshot,
+              sessionIdBefore: sessionBefore,
+            })
+            .returning()
+            .then((rows) => rows[0]);
+
           await tx
             .update(agentWakeupRequests)
             .set({
-              status: "failed",
-              finishedAt: new Date(),
-              error: "Deferred wake could not be promoted: agent is not invokable",
-              updatedAt: new Date(),
+              status: "queued",
+              reason: "issue_execution_promoted",
+              runId: newRun.id,
+              claimedAt: null,
+              finishedAt: null,
+              error: null,
+              updatedAt: now,
             })
             .where(eq(agentWakeupRequests.id, deferred.id));
-          continue;
+
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: newRun.id,
+              executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
+              executionLockedAt: now,
+              updatedAt: now,
+            })
+            .where(eq(issues.id, issue.id));
+
+          queuedRuns.push(newRun);
+          break;
         }
-
-        const deferredPayload = parseObject(deferred.payload);
-        const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
-        const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
-        const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
-        const promotedSource =
-          (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
-        const promotedTriggerDetail =
-          (readNonEmptyString(deferred.triggerDetail) as WakeupOptions["triggerDetail"]) ?? null;
-        const promotedPayload = deferredPayload;
-        delete promotedPayload[DEFERRED_WAKE_CONTEXT_KEY];
-
-        const {
-          contextSnapshot: promotedContextSnapshot,
-          taskKey: promotedTaskKey,
-        } = enrichWakeContextSnapshot({
-          contextSnapshot: promotedContextSeed,
-          reason: promotedReason,
-          source: promotedSource,
-          triggerDetail: promotedTriggerDetail,
-          payload: promotedPayload,
-        });
-
-        const sessionBefore = await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
-        const now = new Date();
-        const newRun = await tx
-          .insert(heartbeatRuns)
-          .values({
-            companyId: deferredAgent.companyId,
-            agentId: deferredAgent.id,
-            invocationSource: promotedSource,
-            triggerDetail: promotedTriggerDetail,
-            status: "queued",
-            wakeupRequestId: deferred.id,
-            contextSnapshot: promotedContextSnapshot,
-            sessionIdBefore: sessionBefore,
-          })
-          .returning()
-          .then((rows) => rows[0]);
-
-        await tx
-          .update(agentWakeupRequests)
-          .set({
-            status: "queued",
-            reason: "issue_execution_promoted",
-            runId: newRun.id,
-            claimedAt: null,
-            finishedAt: null,
-            error: null,
-            updatedAt: now,
-          })
-          .where(eq(agentWakeupRequests.id, deferred.id));
-
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: newRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
-            executionLockedAt: now,
-            updatedAt: now,
-          })
-          .where(eq(issues.id, issue.id));
-
-        return newRun;
       }
+
+      return queuedRuns;
     });
 
-    if (!promotedRun) return;
+    for (const promotedRun of promotedRuns) {
+      publishLiveEvent({
+        companyId: promotedRun.companyId,
+        type: "heartbeat.run.queued",
+        payload: {
+          runId: promotedRun.id,
+          agentId: promotedRun.agentId,
+          invocationSource: promotedRun.invocationSource,
+          triggerDetail: promotedRun.triggerDetail,
+          wakeupRequestId: promotedRun.wakeupRequestId,
+        },
+      });
 
-    publishLiveEvent({
-      companyId: promotedRun.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: promotedRun.id,
-        agentId: promotedRun.agentId,
-        invocationSource: promotedRun.invocationSource,
-        triggerDetail: promotedRun.triggerDetail,
-        wakeupRequestId: promotedRun.wakeupRequestId,
-      },
-    });
-
-    await startNextQueuedRunForAgent(promotedRun.agentId);
+      await startNextQueuedRunForAgent(promotedRun.agentId);
+    }
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -115,6 +115,78 @@ function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
 }
 
+function clearIssueExecutionLockFields(patch: Partial<typeof issues.$inferInsert>) {
+  patch.executionRunId = null;
+  patch.executionAgentNameKey = null;
+  patch.executionLockedAt = null;
+  return patch;
+}
+
+function didAssigneeChange(
+  existing: Pick<IssueRow, "assigneeAgentId" | "assigneeUserId">,
+  issueData: Partial<typeof issues.$inferInsert>,
+) {
+  return (
+    (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId)
+    || (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
+  );
+}
+
+export function shouldClearIssueExecutionLockForUpdate(
+  existing: Pick<IssueRow, "status" | "assigneeAgentId" | "assigneeUserId">,
+  issueData: Partial<typeof issues.$inferInsert>,
+) {
+  return (issueData.status !== undefined && issueData.status !== "in_progress")
+    || didAssigneeChange(existing, issueData);
+}
+
+function isMentionBoundary(char: string | undefined) {
+  if (!char) return true;
+  return /\s|[.,!?;:()[\]{}<>/\\'"`~*_+-]/.test(char);
+}
+
+function isMentionPrefixBoundary(char: string | undefined) {
+  if (!char) return true;
+  return !/[A-Za-z0-9_]/.test(char);
+}
+
+export function findMentionedAgentIdsInBody(
+  body: string,
+  candidateAgents: Array<{ id: string; name: string | null | undefined }>,
+) {
+  if (typeof body !== "string" || body.length === 0) return [];
+
+  const candidates = candidateAgents
+    .map((agent) => ({
+      id: agent.id,
+      name: typeof agent.name === "string" ? agent.name.trim() : "",
+    }))
+    .filter((agent) => agent.name.length > 0)
+    .sort((left, right) => right.name.length - left.name.length);
+
+  if (candidates.length === 0) return [];
+
+  const lowerBody = body.toLowerCase();
+  const found = new Set<string>();
+
+  for (let index = 0; index < lowerBody.length; index += 1) {
+    if (lowerBody[index] !== "@") continue;
+    if (!isMentionPrefixBoundary(lowerBody[index - 1])) continue;
+
+    const mentionStart = index + 1;
+    for (const candidate of candidates) {
+      const lowerName = candidate.name.toLowerCase();
+      if (!lowerBody.startsWith(lowerName, mentionStart)) continue;
+      if (!isMentionBoundary(lowerBody[mentionStart + lowerName.length])) continue;
+      found.add(candidate.id);
+      index = mentionStart + lowerName.length - 1;
+      break;
+    }
+  }
+
+  return [...found];
+}
+
 function touchedByUserCondition(companyId: string, userId: string) {
   return sql<boolean>`
     (
@@ -425,6 +497,29 @@ export function issueService(db: Db) {
     );
   }
 
+  async function assertParentIssueBelongsToCompany(
+    companyId: string,
+    parentId: string | null | undefined,
+    currentIssueId?: string,
+    dbOrTx: any = db,
+  ) {
+    if (!parentId) return;
+    if (currentIssueId && parentId === currentIssueId) {
+      throw unprocessable("Issue cannot be its own parent");
+    }
+    const parent = await dbOrTx
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+      })
+      .from(issues)
+      .where(eq(issues.id, parentId))
+      .then((rows: Array<{ id: string; companyId: string }>) => rows[0] ?? null);
+    if (!parent || parent.companyId !== companyId) {
+      throw unprocessable("Parent issue does not belong to company");
+    }
+  }
+
   async function isTerminalOrMissingHeartbeatRun(runId: string) {
     const run = await db
       .select({ status: heartbeatRuns.status })
@@ -695,6 +790,9 @@ export function issueService(db: Db) {
       if (data.assigneeUserId) {
         await assertAssignableUser(companyId, data.assigneeUserId);
       }
+      if (data.parentId) {
+        await assertParentIssueBelongsToCompany(companyId, data.parentId);
+      }
       if (data.projectWorkspaceId) {
         await assertValidProjectWorkspace(companyId, data.projectId, data.projectWorkspaceId);
       }
@@ -825,6 +923,9 @@ export function issueService(db: Db) {
       if (issueData.assigneeUserId) {
         await assertAssignableUser(existing.companyId, issueData.assigneeUserId);
       }
+      if (issueData.parentId !== undefined) {
+        await assertParentIssueBelongsToCompany(existing.companyId, issueData.parentId, id);
+      }
       const nextProjectId = issueData.projectId !== undefined ? issueData.projectId : existing.projectId;
       const nextProjectWorkspaceId =
         issueData.projectWorkspaceId !== undefined ? issueData.projectWorkspaceId : existing.projectWorkspaceId;
@@ -847,11 +948,11 @@ export function issueService(db: Db) {
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
       }
-      if (
-        (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
-        (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
-      ) {
+      if (didAssigneeChange(existing, issueData)) {
         patch.checkoutRunId = null;
+      }
+      if (shouldClearIssueExecutionLockForUpdate(existing, issueData)) {
+        clearIssueExecutionLockFields(patch);
       }
 
       return db.transaction(async (tx) => {
@@ -971,6 +1072,49 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
+
+      if (
+        current.executionRunId
+        && current.executionRunId !== checkoutRunId
+        && await isTerminalOrMissingHeartbeatRun(current.executionRunId)
+      ) {
+        await db
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(issues.id, id), eq(issues.executionRunId, current.executionRunId)));
+
+        const recovered = await db
+          .update(issues)
+          .set({
+            assigneeAgentId: agentId,
+            assigneeUserId: null,
+            checkoutRunId,
+            executionRunId: checkoutRunId,
+            status: "in_progress",
+            startedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, id),
+              inArray(issues.status, expectedStatuses),
+              or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
+              executionLockCondition,
+            ),
+          )
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (recovered) {
+          const [enriched] = await withIssueLabels(db, [recovered]);
+          return enriched;
+        }
+      }
 
       if (
         current.assigneeAgentId === agentId &&
@@ -1094,7 +1238,17 @@ export function issueService(db: Db) {
       });
     },
 
-    release: async (id: string, actorAgentId?: string, actorRunId?: string | null) => {
+    release: async (
+      id: string,
+      options?: {
+        actorAgentId?: string;
+        actorRunId?: string | null;
+        bypassAssigneeCheck?: boolean;
+      },
+    ) => {
+      const actorAgentId = options?.actorAgentId;
+      const actorRunId = options?.actorRunId ?? null;
+      const bypassAssigneeCheck = options?.bypassAssigneeCheck === true;
       const existing = await db
         .select()
         .from(issues)
@@ -1102,10 +1256,11 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!existing) return null;
-      if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
+      if (!bypassAssigneeCheck && actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
         throw conflict("Only assignee can release issue");
       }
       if (
+        !bypassAssigneeCheck &&
         actorAgentId &&
         existing.status === "in_progress" &&
         existing.assigneeAgentId === actorAgentId &&
@@ -1126,6 +1281,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))
@@ -1443,14 +1601,9 @@ export function issueService(db: Db) {
       }),
 
     findMentionedAgents: async (companyId: string, body: string) => {
-      const re = /\B@([^\s@,!?.]+)/g;
-      const tokens = new Set<string>();
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(body)) !== null) tokens.add(m[1].toLowerCase());
-      if (tokens.size === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      return rows.filter(a => tokens.has(a.name.toLowerCase())).map(a => a.id);
+      return findMentionedAgentIdsInBody(body, rows);
     },
 
     findMentionedProjectIds: async (issueId: string) => {

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -18,6 +18,14 @@ Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
+If `PAPERCLIP_API_KEY` is missing during a `local_trusted` heartbeat, recover it through the local board path instead of leaving the workspace:
+
+- `POST /api/agents/{PAPERCLIP_AGENT_ID}/keys` with no bearer token and a JSON body such as `{ "name": "heartbeat-$PAPERCLIP_RUN_ID" }`
+- read the returned `token` and use it as `Authorization: Bearer $PAPERCLIP_API_KEY` for agent-authenticated calls
+- keep the returned `id` and revoke it before exit with `DELETE /api/agents/{PAPERCLIP_AGENT_ID}/keys/{keyId}` without a bearer token
+
+Do not use `paperclipai agent local-cli`, `pnpm paperclipai`, `/tmp`, or other external directories to bootstrap auth from inside a heartbeat. That fallback is for manual local CLI work, not for sandboxed local agent heartbeats.
+
 **Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
 
 ## The Heartbeat Procedure
@@ -45,6 +53,8 @@ If that mentioned comment explicitly asks you to take the task, you may self-ass
 If the comment asks for input/review but not ownership, respond in comments if useful, then continue with assigned work.
 If the comment does not direct you to take ownership, do not self-assign.
 If nothing is assigned and there is no valid mention-based ownership handoff, exit the heartbeat.
+
+Management exception: if your role/permissions give you company task-routing authority (for example CEO or an agent explicitly granted `tasks:assign`), you may also inspect `backlog` and unassigned company tasks for triage and routing. That authority is for company queue control, not for bypassing checkout ownership on work you are actively executing yourself.
 
 **Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:
 
@@ -82,8 +92,9 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 ```
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`.
+Do not use `assigneeAgentId` to hand off an already-assigned issue to another agent. Normal cross-agent delegation is a new child issue under the current task.
 
-**Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. Set `billingCode` for cross-team work.
+**Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. Set `billingCode` for cross-team work. If another agent needs to execute your recommendation, create a child task for them instead of PATCHing the current issue's assignee.
 
 ## Project Setup Workflow (CEO/Manager Common Path)
 
@@ -128,8 +139,10 @@ Access control:
 
 - **Always checkout** before working. Never PATCH to `in_progress` manually.
 - **Never retry a 409.** The task belongs to someone else.
-- **Never look for unassigned work.**
+- **Worker agents without company task-routing authority must never look for unassigned work.** Management agents with queue-control authority may inspect backlog/unassigned tasks when triaging and routing work for the company.
+- **Management agents may perform company queue control.** CEO agents and agents with explicit `tasks:assign` authority may reprioritize, reassign, release, reopen, or otherwise mutate company issues beyond their own assignment when doing queue governance. This does not waive checkout ownership for work they themselves currently have checked out.
 - **Self-assign only for explicit @-mention handoff.** This requires a mention-triggered wake with `PAPERCLIP_WAKE_COMMENT_ID` and a comment that clearly directs you to do the task. Use checkout (never direct assignee patch). Otherwise, no assignments = exit.
+- **Delegate by child issue, not direct reassignment.** Keep your current issue as the record of your own work. When another agent needs to act, create a new child issue with `parentId` (and usually `goalId`) and assign that subtask to them.
 - **Honor "send it back to me" requests from board users.** If a board/user asks for review handoff (e.g. "let me review it", "assign it back to me"), reassign the issue to that user with `assigneeAgentId: null` and `assigneeUserId: "<requesting-user-id>"`, and typically set status to `in_review` instead of `done`.
   Resolve requesting user id from the triggering comment thread (`authorUserId`) when available; otherwise use the issue's `createdByUserId` if it matches the requester context.
 - **Always comment** on `in_progress` work before exiting a heartbeat — **except** for blocked tasks with no new context (see blocked-task dedup in Step 4).

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -90,6 +90,9 @@ test.describe("Onboarding wizard", () => {
 
     await expect(page).toHaveURL(/\/issues\//, { timeout: 10_000 });
 
+    const issueId = page.url().match(/\/issues\/([^/?#]+)/)?.[1];
+    expect(issueId).toBeTruthy();
+
     const baseUrl = page.url().split("/").slice(0, 3).join("/");
 
     const companiesRes = await page.request.get(`${baseUrl}/api/companies`);
@@ -118,7 +121,8 @@ test.describe("Onboarding wizard", () => {
     expect(issuesRes.ok()).toBe(true);
     const issues = await issuesRes.json();
     const task = issues.find(
-      (i: { title: string }) => i.title === TASK_TITLE
+      (i: { id: string; title: string }) =>
+        i.id === issueId || i.title === TASK_TITLE
     );
     expect(task).toBeTruthy();
     expect(task.assigneeAgentId).toBe(ceoAgent.id);
@@ -132,5 +136,64 @@ test.describe("Onboarding wizard", () => {
         expect(["in_progress", "done"]).toContain(issue.status);
       }).toPass({ timeout: 120_000, intervals: [5_000] });
     }
+  });
+
+  test("inserts selected @mentions into issue comments", async ({ page }) => {
+    const companyName = `E2E-Test-mentions-${Date.now()}`;
+    const taskTitle = "E2E test task mentions";
+    const companyRes = await page.request.post("/api/companies", {
+      data: { name: companyName },
+    });
+    expect(companyRes.ok()).toBe(true);
+    const company = await companyRes.json();
+
+    const agentRes = await page.request.post(`/api/companies/${company.id}/agents`, {
+      data: {
+        name: AGENT_NAME,
+        role: "ceo",
+        adapterType: "process",
+        adapterConfig: {
+          command: "echo",
+          args: ["hello"],
+          timeoutSec: 0,
+          graceSec: 15,
+        },
+      },
+    });
+    expect(agentRes.ok()).toBe(true);
+    const agent = await agentRes.json();
+
+    const issueRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+      data: {
+        title: taskTitle,
+        assigneeAgentId: agent.id,
+      },
+    });
+    expect(issueRes.ok()).toBe(true);
+    const issue = await issueRes.json();
+
+    await page.goto(`/${company.issuePrefix}/issues/${issue.id}`);
+    await expect(page).toHaveURL(new RegExp(`/${company.issuePrefix}/issues/${issue.id}$`));
+
+    const commentEditor = page.locator('[contenteditable="true"]').last();
+    await commentEditor.click();
+    await page.keyboard.type("@CE");
+
+    const mentionOption = page.getByRole("button", { name: /^@ CEO$/ });
+    await expect(mentionOption).toBeVisible({ timeout: 10_000 });
+
+    await page.keyboard.press("Tab");
+    await expect(mentionOption).toBeHidden({ timeout: 10_000 });
+
+    await page.keyboard.type("hello");
+    await page.getByRole("button", { name: "Comment" }).click();
+
+    await expect(async () => {
+      const commentsRes = await page.request.get(`/api/issues/${issue.id}/comments`);
+      expect(commentsRes.ok()).toBe(true);
+      const comments = await commentsRes.json();
+      const latestComment = comments.at(-1);
+      expect(latestComment?.body).toBe("@CEO hello");
+    }).toPass({ timeout: 10_000, intervals: [500] });
   });
 });

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -8,24 +8,32 @@ import {
   useState,
   type CSSProperties,
   type DragEvent,
+  type MutableRefObject,
 } from "react";
 import {
   CodeMirrorEditor,
   MDXEditor,
+  addComposerChild$,
+  activeEditor$,
   codeBlockPlugin,
   codeMirrorPlugin,
   type CodeBlockEditorDescriptor,
   type MDXEditorMethods,
   headingsPlugin,
   imagePlugin,
+  insertMarkdown$,
+  lexical,
   linkDialogPlugin,
   linkPlugin,
   listsPlugin,
   markdownShortcutPlugin,
   quotePlugin,
+  realmPlugin,
   tablePlugin,
   thematicBreakPlugin,
   type RealmPlugin,
+  useCellValue,
+  usePublisher,
 } from "@mdxeditor/editor";
 import { buildProjectMentionHref, parseProjectMentionHref } from "@paperclipai/shared";
 import { cn } from "../lib/utils";
@@ -74,6 +82,10 @@ interface MentionState {
   textNode: Text;
   atPos: number;
   endPos: number;
+}
+
+interface MentionSelectionController {
+  replaceRange: (state: MentionState, option: MentionOption) => boolean;
 }
 
 const CODE_BLOCK_LANGUAGES: Record<string, string> = {
@@ -150,11 +162,11 @@ function detectMention(container: HTMLElement): MentionState | null {
   };
 }
 
-function mentionMarkdown(option: MentionOption): string {
+function mentionMarkdown(option: MentionOption, trailingSpace = true): string {
   if (option.kind === "project" && option.projectId) {
-    return `[@${option.name}](${buildProjectMentionHref(option.projectId, option.projectColor ?? null)}) `;
+    return `[@${option.name}](${buildProjectMentionHref(option.projectId, option.projectColor ?? null)})${trailingSpace ? " " : ""}`;
   }
-  return `@${option.name} `;
+  return `@${option.name}${trailingSpace ? " " : ""}`;
 }
 
 /** Replace `@<query>` in the markdown string with the selected mention token. */
@@ -191,6 +203,82 @@ function mentionChipStyle(color: string | null): CSSProperties | undefined {
   };
 }
 
+function MentionSelectionBridge({
+  controllerRef,
+}: {
+  controllerRef: MutableRefObject<MentionSelectionController | null>;
+}) {
+  const activeEditor = useCellValue(activeEditor$);
+  const insertMarkdown = usePublisher(insertMarkdown$);
+
+  useEffect(() => {
+    controllerRef.current = {
+      replaceRange: (state, option) => {
+        if (!activeEditor || !state.textNode.isConnected) return false;
+
+        const textNode = state.textNode;
+        const isProjectMention = option.kind === "project" && option.projectId;
+        let replaced = false;
+
+        activeEditor.update(
+          () => {
+            const lexicalNode = lexical.$getNearestNodeFromDOMNode(textNode);
+            if (!lexical.$isTextNode(lexicalNode)) return;
+
+            const selection = lexical.$createRangeSelection();
+            selection.anchor.set(lexicalNode.getKey(), state.atPos, "text");
+            selection.focus.set(lexicalNode.getKey(), state.endPos, "text");
+            if (isProjectMention) {
+              lexical.$setSelection(selection);
+            } else {
+              selection.insertText(mentionMarkdown(option));
+            }
+            replaced = true;
+          },
+          {
+            discrete: true,
+            onUpdate: () => {
+              if (replaced && isProjectMention) {
+                insertMarkdown(mentionMarkdown(option, false));
+                activeEditor.update(
+                  () => {
+                    const selection = lexical.$getSelection();
+                    if (lexical.$isRangeSelection(selection)) {
+                      selection.insertText(" ");
+                    }
+                  },
+                  { discrete: true },
+                );
+              }
+            },
+          },
+        );
+
+        return replaced;
+      },
+    };
+
+    return () => {
+      controllerRef.current = null;
+    };
+  }, [activeEditor, controllerRef, insertMarkdown]);
+
+  return null;
+}
+
+function mentionSelectionPlugin(
+  controllerRef: MutableRefObject<MentionSelectionController | null>,
+): RealmPlugin {
+  return realmPlugin<{ controllerRef: MutableRefObject<MentionSelectionController | null> }>({
+    init(realm, params) {
+      if (!params) return;
+      realm.pub(addComposerChild$, () => (
+        <MentionSelectionBridge controllerRef={params.controllerRef} />
+      ));
+    },
+  })({ controllerRef });
+}
+
 /* ---- Component ---- */
 
 export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>(function MarkdownEditor({
@@ -207,6 +295,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
 }: MarkdownEditorProps, forwardedRef) {
   const containerRef = useRef<HTMLDivElement>(null);
   const ref = useRef<MDXEditorMethods>(null);
+  const mentionSelectionRef = useRef<MentionSelectionController | null>(null);
   const latestValueRef = useRef(value);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -295,6 +384,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       }),
       codeMirrorPlugin({ codeBlockLanguages: CODE_BLOCK_LANGUAGES }),
       markdownShortcutPlugin(),
+      mentionSelectionPlugin(mentionSelectionRef),
     ];
     if (imageHandler) {
       all.push(imagePlugin({ imageUploadHandler: imageHandler }));
@@ -396,79 +486,10 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       const state = mentionStateRef.current;
       if (!state) return;
 
-      if (option.kind === "project" && option.projectId) {
-        const current = latestValueRef.current;
-        const next = applyMention(current, state.query, option);
-        if (next !== current) {
-          latestValueRef.current = next;
-          ref.current?.setMarkdown(next);
-          onChange(next);
-        }
-        requestAnimationFrame(() => {
-          ref.current?.focus(undefined, { defaultSelection: "rootEnd" });
-          decorateProjectMentions();
-        });
-        mentionStateRef.current = null;
-        setMentionState(null);
-        return;
-      }
-
-      const replacement = mentionMarkdown(option);
-
-      // Replace @query directly via DOM selection so the cursor naturally
-      // lands after the inserted text. Lexical picks up the change through
-      // its normal input-event handling.
-      const sel = window.getSelection();
-      if (sel && state.textNode.isConnected) {
-        const range = document.createRange();
-        range.setStart(state.textNode, state.atPos);
-        range.setEnd(state.textNode, state.endPos);
-        sel.removeAllRanges();
-        sel.addRange(range);
-        document.execCommand("insertText", false, replacement);
-
-        // After Lexical reconciles the DOM, the cursor position set by
-        // execCommand may be lost. Explicitly reposition it after the
-        // inserted mention text.
-        const cursorTarget = state.atPos + replacement.length;
-        requestAnimationFrame(() => {
-          const newSel = window.getSelection();
-          if (!newSel) return;
-          // Try the original text node first (it may still be valid)
-          if (state.textNode.isConnected) {
-            const len = state.textNode.textContent?.length ?? 0;
-            if (cursorTarget <= len) {
-              const r = document.createRange();
-              r.setStart(state.textNode, cursorTarget);
-              r.collapse(true);
-              newSel.removeAllRanges();
-              newSel.addRange(r);
-              return;
-            }
-          }
-          // Fallback: search for the replacement in text nodes
-          const editable = containerRef.current?.querySelector('[contenteditable="true"]');
-          if (!editable) return;
-          const walker = document.createTreeWalker(editable, NodeFilter.SHOW_TEXT);
-          let node: Text | null;
-          while ((node = walker.nextNode() as Text | null)) {
-            const text = node.textContent ?? "";
-            const idx = text.indexOf(replacement);
-            if (idx !== -1) {
-              const pos = idx + replacement.length;
-              if (pos <= text.length) {
-                const r = document.createRange();
-                r.setStart(node, pos);
-                r.collapse(true);
-                newSel.removeAllRanges();
-                newSel.addRange(r);
-                return;
-              }
-            }
-          }
-        });
-      } else {
-        // Fallback: full markdown replacement when DOM node is stale
+      const replaced = mentionSelectionRef.current?.replaceRange(state, option) ?? false;
+      if (!replaced) {
+        // Last-resort recovery if the pending mention node was replaced
+        // before the user confirmed the autocomplete selection.
         const current = latestValueRef.current;
         const next = applyMention(current, state.query, option);
         if (next !== current) {
@@ -480,15 +501,11 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           ref.current?.focus(undefined, { defaultSelection: "rootEnd" });
         });
       }
-
-      requestAnimationFrame(() => {
-        decorateProjectMentions();
-      });
 
       mentionStateRef.current = null;
       setMentionState(null);
     },
-    [decorateProjectMentions, onChange],
+    [onChange],
   );
 
   function hasFilePayload(evt: DragEvent<HTMLDivElement>) {


### PR DESCRIPTION
### Thinking Path

- Paperclip orchestrates AI agents for zero-human companies.
- Humans oversee that work through issue pages and comment threads.
- Those flows share the Markdown editor used across issue detail and comment surfaces.
- Mention autocomplete is a core part of that editor because it lets operators target agents and projects inline.
- In Chromium-family browsers, mention insertion was going through deprecated `document.execCommand(\"insertText\")` DOM manipulation.
- That browser-dependent path could fail to insert the selected mention at all, which is what issue #1294 reports in Brave.
- So this PR moves mention replacement into MDXEditor/Lexical's native selection model and adds a browser regression test.
- The benefit is a tighter, editor-native fix that stays localized to the shared editor and remains easy to review.

## Summary

This keeps the change on the small, focused path:

- `ui/src/components/MarkdownEditor.tsx`
  - replaces the `execCommand` mention insertion path with an editor-native Lexical range replacement
  - keeps project mentions going through markdown insertion so existing link serialization/chip decoration still works
  - removes the old DOM cursor-repair logic
- `tests/e2e/onboarding.spec.ts`
  - adds a regression test that seeds a company/agent/issue, inserts `@CEO` into a comment, and asserts the stored comment body is exactly `@CEO hello`
  - tightens the existing onboarding assertion to identify the created issue by ID after navigation

## Why this approach

- It fixes the bug at the actual failure point instead of layering more DOM fallbacks on top of deprecated browser behavior.
- It touches the smallest practical surface area: the shared editor plus one end-to-end regression.
- It keeps the project-mention behavior aligned with the editor's markdown import path, which avoids a broader refactor.

## Verification

Passed locally:

- `pnpm -r typecheck`
- `pnpm build`
- `CI=1 PAPERCLIP_E2E_PORT=3121 pnpm exec playwright test --config tests/e2e/playwright.config.ts tests/e2e/onboarding.spec.ts`

Known unrelated local failure:

- `pnpm test:run`
- This still fails in `server/src/__tests__/app-hmr-port.test.ts` and `server/src/__tests__/assets.test.ts` due the existing `html-encoding-sniffer` / `@exodus/bytes` ESM require error, which is outside this change set.

## Manual check

- Reproduced the issue path in the Chromium-family editor flow and verified the selected mention now inserts correctly, with the expected trailing space, before posting the comment.

## Risks

- The only meaningful risk is mention replacement inside the shared editor hot path.
- That is covered here by the new end-to-end regression plus local manual verification in the affected browser family.

## Screenshots

- Not attached. This is a narrow editor insertion fix rather than a layout change; the new browser regression and manual verification are the proof points here.