### PR TITLE
fix(inbox): mark-all-as-read not persisting for agent-created issues

### DIFF
--- a/server/src/__tests__/issues-user-context.test.ts
+++ b/server/src/__tests__/issues-user-context.test.ts
@@ -92,6 +92,51 @@ describe("deriveIssueUserContext", () => {
     expect(context.isUnreadForMe).toBe(false);
   });
 
+  it("agent-created issue with no user interaction returns myLastTouchAt null and not unread", () => {
+    const context = deriveIssueUserContext(
+      makeIssue(), // createdByUserId=null, assigneeUserId=null
+      "user-1",
+      {
+        myLastCommentAt: null,
+        myLastReadAt: null,
+        lastExternalCommentAt: new Date("2026-03-06T12:00:00.000Z"),
+      },
+    );
+
+    expect(context.myLastTouchAt).toBeNull();
+    expect(context.isUnreadForMe).toBe(false);
+  });
+
+  it("agent-created issue marked as read clears unread state", () => {
+    const context = deriveIssueUserContext(
+      makeIssue(), // createdByUserId=null, assigneeUserId=null
+      "user-1",
+      {
+        myLastCommentAt: null,
+        myLastReadAt: new Date("2026-03-06T14:00:00.000Z"),
+        lastExternalCommentAt: new Date("2026-03-06T12:00:00.000Z"),
+      },
+    );
+
+    expect(context.myLastTouchAt?.toISOString()).toBe("2026-03-06T14:00:00.000Z");
+    expect(context.isUnreadForMe).toBe(false);
+  });
+
+  it("agent-created issue with new comment after mark-read shows unread", () => {
+    const context = deriveIssueUserContext(
+      makeIssue(), // createdByUserId=null, assigneeUserId=null
+      "user-1",
+      {
+        myLastCommentAt: null,
+        myLastReadAt: new Date("2026-03-06T14:00:00.000Z"),
+        lastExternalCommentAt: new Date("2026-03-06T15:00:00.000Z"),
+      },
+    );
+
+    expect(context.myLastTouchAt?.toISOString()).toBe("2026-03-06T14:00:00.000Z");
+    expect(context.isUnreadForMe).toBe(true);
+  });
+
   it("handles SQL timestamp strings without throwing", () => {
     const context = deriveIssueUserContext(
       makeIssue({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -167,10 +167,10 @@ function myLastTouchAtExpr(companyId: string, userId: string) {
   const myLastReadAt = myLastReadAtExpr(companyId, userId);
   return sql<Date | null>`
     GREATEST(
-      COALESCE(${myLastCommentAt}, to_timestamp(0)),
-      COALESCE(${myLastReadAt}, to_timestamp(0)),
-      COALESCE(CASE WHEN ${issues.createdByUserId} = ${userId} THEN ${issues.createdAt} ELSE NULL END, to_timestamp(0)),
-      COALESCE(CASE WHEN ${issues.assigneeUserId} = ${userId} THEN ${issues.updatedAt} ELSE NULL END, to_timestamp(0))
+      ${myLastCommentAt},
+      ${myLastReadAt},
+      CASE WHEN ${issues.createdByUserId} = ${userId} THEN ${issues.createdAt} ELSE NULL END,
+      CASE WHEN ${issues.assigneeUserId} = ${userId} THEN ${issues.updatedAt} ELSE NULL END
     )
   `;
 }

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -361,6 +361,7 @@ function invalidateActivityQueries(
 
   if (entityType === "issue") {
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(companyId) });
     if (entityId) {
       const details = readRecord(payload.details);
       const issueRefs = resolveIssueQueryRefs(queryClient, companyId, entityId, details);


### PR DESCRIPTION
## Summary

Fixes #1247 — "Mark all as read" in Inbox doesn't persist for agent-created issues.

**Two root causes:**

- **SQL/JS divergence in `myLastTouchAtExpr`**: `COALESCE(..., to_timestamp(0))` made SQL treat untouched issues as "seen at epoch 1970", so any comment appeared unread. JS used `null` → `isUnreadForMe=false`. Fix: remove COALESCE wrappers — PostgreSQL `GREATEST` naturally ignores NULLs.
- **Missing cache invalidation**: `LiveUpdatesProvider` didn't invalidate `listTouchedByMe` on issue activity events, causing stale unread indicators after mark-read.

## Changes

- `server/src/services/issues.ts`: Remove epoch fallbacks from `myLastTouchAtExpr` SQL
- `ui/src/context/LiveUpdatesProvider.tsx`: Add `listTouchedByMe` invalidation on issue activity
- `server/src/__tests__/issues-user-context.test.ts`: 3 new test cases for agent-created issues

## Test plan

- [x] All 9 `issues-user-context` tests pass (6 existing + 3 new)
- [x] Server TypeScript type-check passes
- [x] UI TypeScript type-check passes
- [ ] Manual: create agent-spawned issue, post agent comments, mark read, verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)