### PR TITLE
fix(auth): prevent privilege escalation with invalid bearer tokens in local_trusted mode

### DIFF
--- a/server/src/__tests__/auth-privilege-escalation.test.ts
+++ b/server/src/__tests__/auth-privilege-escalation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { actorMiddleware } from "../middleware/auth.js";
+import type { Db } from "@paperclipai/db";
+
+/**
+ * Regression test for GH #1314: in local_trusted mode, an invalid bearer token
+ * must NOT inherit the default board actor. Without the fix, expired/invalid agent
+ * JWTs would fall through to the local_trusted board default, granting full
+ * board-level access (including agent deletion).
+ */
+describe("auth privilege escalation prevention", () => {
+  function createApp(deploymentMode: "local_trusted" | "authenticated") {
+    const app = express();
+    // Stub DB: all queries return empty results
+    const fakeDb = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            then: (cb: (rows: unknown[]) => unknown) => Promise.resolve(cb([])),
+          }),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => Promise.resolve(),
+        }),
+      }),
+    } as unknown as Db;
+
+    app.use(actorMiddleware(fakeDb, { deploymentMode }));
+    app.get("/test", (req, res) => {
+      res.json({ actorType: req.actor.type, source: req.actor.source });
+    });
+    return app;
+  }
+
+  it("local_trusted without bearer token keeps board actor", async () => {
+    const app = createApp("local_trusted");
+    const res = await request(app).get("/test");
+    expect(res.body.actorType).toBe("board");
+    expect(res.body.source).toBe("local_implicit");
+  });
+
+  it("local_trusted with invalid bearer token clears board actor to none", async () => {
+    const app = createApp("local_trusted");
+    const res = await request(app)
+      .get("/test")
+      .set("Authorization", "Bearer invalid-or-expired-token");
+    expect(res.body.actorType).toBe("none");
+    expect(res.body.source).toBe("none");
+  });
+
+  it("local_trusted with empty bearer token keeps board actor", async () => {
+    const app = createApp("local_trusted");
+    const res = await request(app)
+      .get("/test")
+      .set("Authorization", "Bearer ");
+    expect(res.body.actorType).toBe("board");
+    expect(res.body.source).toBe("local_implicit");
+  });
+
+  it("authenticated mode with invalid bearer token stays none", async () => {
+    const app = createApp("authenticated");
+    const res = await request(app)
+      .get("/test")
+      .set("Authorization", "Bearer invalid-token");
+    expect(res.body.actorType).toBe("none");
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -80,6 +80,14 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       return;
     }
 
+    // When a bearer token is present, clear the default actor to prevent
+    // privilege escalation in local_trusted mode. If the token is invalid,
+    // the request should be unauthenticated, not board-level.
+    const savedRunId = req.actor.runId;
+    req.actor = { type: "none", source: "none" };
+    if (savedRunId) req.actor.runId = savedRunId;
+    if (runIdHeader) req.actor.runId = runIdHeader;
+
     const tokenHash = hashToken(token);
     const key = await db
       .select()


### PR DESCRIPTION
## Summary

- **Security fix**: In `local_trusted` deployment mode, invalid/expired bearer tokens (e.g. after device idle) fell through to the default board actor, granting full board-level access
- Agents with expired auth could perform destructive operations like deleting other agents (GH #1314)
- Fix clears the actor to `{ type: "none" }` when a bearer token is present before attempting validation

## Changes

- `server/src/middleware/auth.ts`: Clear default actor when bearer token is present but before validation
- `server/src/__tests__/auth-privilege-escalation.test.ts`: 4 regression tests covering the privilege escalation scenario

## Test plan

- [x] New regression tests: invalid bearer in local_trusted → `none` actor (not `board`)
- [x] Empty bearer still keeps default board actor
- [x] All 425 existing tests pass
- [x] TypeScript typecheck clean

Fixes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)