### PR TITLE
fix(ci): skip auto-merge step when lockfile is unchanged

### DIFF
--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -51,11 +51,13 @@ jobs:
           fi
 
       - name: Create or update pull request
+        id: upsert-pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- pnpm-lock.yaml; then
             echo "Lockfile unchanged, nothing to do."
+            echo "pr_created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -79,8 +81,10 @@ jobs:
           else
             echo "PR #$existing already exists, branch updated via force push."
           fi
+          echo "pr_created=true" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge for lockfile PR
+        if: steps.upsert-pr.outputs.pr_created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses a CI workflow to keep the pnpm lockfile up to date
> - The workflow creates a PR when the lockfile changes and then enables auto-merge on it
> - But the auto-merge step ran unconditionally — even when the lockfile was unchanged and no PR existed
> - This caused the workflow to fail with `Error: lockfile PR was not found.` (e.g. [this run](https://github.com/paperclipai/paperclip/actions/runs/23312804385/job/67804283724))
> - This PR adds a `pr_created` step output and gates the auto-merge step behind an `if` condition
> - The benefit is that the workflow now exits cleanly when there is nothing to do, avoiding false failures

## Summary
- Adds `id: upsert-pr` and a `pr_created` output to the "Create or update pull request" step
- Gates the "Enable auto-merge" step with `if: steps.upsert-pr.outputs.pr_created == 'true'`
- No risks — the happy path (lockfile changed → create PR → auto-merge) is unchanged

## Test plan
- [x] Verified the failing run logs to confirm the root cause
- [ ] Next push to master with no lockfile changes should pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)