### PR TITLE
fix: auto-generate PAPERCLIP_API_KEY when creating agents via API

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -807,6 +807,33 @@ export function agentRoutes(db: Db) {
       lastHeartbeatAt: null,
     });
 
+    // Auto-generate API key for the new agent so it can authenticate with
+    // the Paperclip API immediately. Agents created via the hire flow (e.g.
+    // by a CEO agent) previously had no key injected, causing every run to
+    // fail with "Agent authentication required".
+    if (!requiresApproval) {
+      try {
+        const autoKey = await svc.createApiKey(agent.id, "auto-generated-run-key");
+        const currentEnv =
+          (agent.adapterConfig as Record<string, unknown> | null)?.env ?? {};
+        await svc.update(
+          agent.id,
+          {
+            adapterConfig: {
+              ...(agent.adapterConfig as Record<string, unknown>),
+              env: {
+                ...(currentEnv as Record<string, unknown>),
+                PAPERCLIP_API_KEY: { type: "plain", value: autoKey.token },
+              },
+            },
+          },
+          {},
+        );
+      } catch (e) {
+        console.warn("[auto-key] Failed to create agent API key:", (e as Error)?.message);
+      }
+    }
+
     let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
     const actor = getActorInfo(req);
 
@@ -931,6 +958,28 @@ export function agentRoutes(db: Db) {
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,
     });
+
+    // Auto-generate API key (same as hire flow above).
+    try {
+      const autoKey = await svc.createApiKey(agent.id, "auto-generated-run-key");
+      const currentEnv =
+        (agent.adapterConfig as Record<string, unknown> | null)?.env ?? {};
+      await svc.update(
+        agent.id,
+        {
+          adapterConfig: {
+            ...(agent.adapterConfig as Record<string, unknown>),
+            env: {
+              ...(currentEnv as Record<string, unknown>),
+              PAPERCLIP_API_KEY: { type: "plain", value: autoKey.token },
+            },
+          },
+        },
+        {},
+      );
+    } catch (e) {
+      console.warn("[auto-key] Failed to create agent API key:", (e as Error)?.message);
+    }
 
     const actor = getActorInfo(req);
     await logActivity(db, {


### PR DESCRIPTION
## Problem

Agents created programmatically — for example by a CEO agent using `POST /companies/:id/agent-hires` — receive no `PAPERCLIP_API_KEY` in their adapter config. Every run then fails immediately with:

```
{"error": "Agent authentication required"}
```

This is a silent failure: the agent starts, tries to call the Paperclip API, gets a 401, and the run is marked as failed. The user has no obvious way to diagnose it.

## Root cause

Both agent creation routes (`/agent-hires` and `/agents`) call `svc.create()` but never call `svc.createApiKey()`. The key is only generated when explicitly requested via `POST /agents/:id/keys` (e.g. through `paperclipai agent local-cli`). When an agent hires another agent via the API, this step is skipped.

## Fix

After a successful `svc.create()` in both endpoints, automatically:
1. Generate an API key via `svc.createApiKey(agent.id, "auto-generated-run-key")`
2. Inject it as `PAPERCLIP_API_KEY` into `adapterConfig.env`

Errors during key creation are caught and logged as warnings — agent creation is never blocked by a key generation failure.

The fix does not apply to `pending_approval` agents since `createApiKey` already rejects them.

## Test plan

- [ ] Create a company and let CEO hire a new agent via the hire endpoint
- [ ] Verify the new agent has `PAPERCLIP_API_KEY` set in its adapter config immediately after creation
- [ ] Trigger a run on the new agent — confirm it authenticates successfully
- [ ] Create an agent requiring board approval — confirm key is NOT pre-generated (pending approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)