### PR TITLE
fix(adapters): fall back to directory junctions on Windows when symlink fails with EPERM

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -330,11 +330,32 @@ export async function readPaperclipSkillMarkdown(
   }
 }
 
+/**
+ * Creates a symlink, falling back to a directory junction on Windows when the
+ * caller lacks the SeCreateSymbolicLinkPrivilege (EPERM).  Junctions don't
+ * require elevated privileges and work for directory targets on NTFS.
+ */
+export async function robustLink(source: string, target: string): Promise<void> {
+  try {
+    await fs.symlink(source, target);
+  } catch (err: unknown) {
+    if (
+      process.platform === "win32" &&
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "EPERM"
+    ) {
+      await fs.symlink(source, target, "junction");
+    } else {
+      throw err;
+    }
+  }
+}
+
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
-  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+  linkSkill: (source: string, target: string) => Promise<void> = robustLink,
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -19,6 +19,7 @@ import {
   ensurePathInEnv,
   renderTemplate,
   runChildProcess,
+  robustLink,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
@@ -56,7 +57,7 @@ async function buildSkillsDir(): Promise<string> {
   const entries = await fs.readdir(skillsDir, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      await fs.symlink(
+      await robustLink(
         path.join(skillsDir, entry.name),
         path.join(target, entry.name),
       );

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -40,11 +40,28 @@ async function ensureParentDir(target: string): Promise<void> {
   await fs.mkdir(path.dirname(target), { recursive: true });
 }
 
+async function symlinkOrCopy(source: string, target: string): Promise<void> {
+  try {
+    await fs.symlink(source, target);
+  } catch (err: unknown) {
+    if (
+      process.platform === "win32" &&
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "EPERM"
+    ) {
+      await fs.copyFile(source, target);
+    } else {
+      throw err;
+    }
+  }
+}
+
 async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(source, target);
+    await symlinkOrCopy(source, target);
     return;
   }
 
@@ -59,7 +76,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === source) return;
 
   await fs.unlink(target);
-  await fs.symlink(source, target);
+  await symlinkOrCopy(source, target);
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePathInEnv,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
+  robustLink,
   renderTemplate,
   joinPromptSections,
   runChildProcess,
@@ -140,7 +141,7 @@ export async function ensureCodexSkillsInjected(
           if (linkSkill) {
             await linkSkill(entry.source, target);
           } else {
-            await fs.symlink(entry.source, target);
+            await robustLink(entry.source, target);
           }
           await onLog(
             "stdout",

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePathInEnv,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
+  robustLink,
   renderTemplate,
   joinPromptSections,
   runChildProcess,
@@ -131,7 +132,7 @@ export async function ensureCursorSkillsInjected(
       `[paperclip] Removed maintainer-only Cursor skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target));
+  const linkSkill = options.linkSkill ?? robustLink;
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.name);
     try {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePathInEnv,
   renderTemplate,
   runChildProcess,
+  robustLink,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
@@ -73,7 +74,7 @@ async function ensureOpenCodeSkillsInjected(onLog: AdapterExecutionContext["onLo
     if (existing) continue;
 
     try {
-      await fs.symlink(source, target);
+      await robustLink(source, target);
       await onLog(
         "stderr",
         `[paperclip] Injected OpenCode skill "${entry.name}" into ${skillsHome}\n`,

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
+  robustLink,
+  ensurePaperclipSkillSymlink,
 } from "@paperclipai/adapter-utils/server-utils";
 
 async function makeTempDir(prefix: string): Promise<string> {
@@ -57,5 +59,91 @@ describe("paperclip skill utils", () => {
     await expect(fs.lstat(path.join(skillsHome, "release"))).rejects.toThrow();
     expect((await fs.lstat(path.join(skillsHome, "paperclip"))).isSymbolicLink()).toBe(true);
     expect((await fs.lstat(path.join(skillsHome, "release-notes"))).isSymbolicLink()).toBe(true);
+  });
+
+  describe("robustLink", () => {
+    it("creates a symlink for a directory", async () => {
+      const root = await makeTempDir("robust-link-");
+      cleanupDirs.add(root);
+
+      const source = path.join(root, "source-dir");
+      const target = path.join(root, "link");
+      await fs.mkdir(source, { recursive: true });
+      await fs.writeFile(path.join(source, "file.txt"), "hello");
+
+      await robustLink(source, target);
+
+      const stat = await fs.lstat(target);
+      expect(stat.isSymbolicLink()).toBe(true);
+      const content = await fs.readFile(path.join(target, "file.txt"), "utf8");
+      expect(content).toBe("hello");
+    });
+
+    it("propagates non-EPERM errors", async () => {
+      const root = await makeTempDir("robust-link-err-");
+      cleanupDirs.add(root);
+
+      await expect(
+        robustLink(path.join(root, "nonexistent"), path.join(root, "sub", "deep", "link")),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("ensurePaperclipSkillSymlink", () => {
+    it("creates a new symlink when target does not exist", async () => {
+      const root = await makeTempDir("skill-symlink-create-");
+      cleanupDirs.add(root);
+
+      const source = path.join(root, "skill");
+      const target = path.join(root, "link");
+      await fs.mkdir(source, { recursive: true });
+
+      const result = await ensurePaperclipSkillSymlink(source, target);
+      expect(result).toBe("created");
+      expect((await fs.lstat(target)).isSymbolicLink()).toBe(true);
+    });
+
+    it("repairs a broken symlink pointing to a stale location", async () => {
+      const root = await makeTempDir("skill-symlink-repair-");
+      cleanupDirs.add(root);
+
+      const source = path.join(root, "skill");
+      const stale = path.join(root, "stale");
+      const target = path.join(root, "link");
+      await fs.mkdir(source, { recursive: true });
+      await fs.symlink(stale, target);
+
+      const result = await ensurePaperclipSkillSymlink(source, target);
+      expect(result).toBe("repaired");
+      const linkedPath = await fs.readlink(target);
+      expect(path.resolve(path.dirname(target), linkedPath)).toBe(source);
+    });
+
+    it("skips when target already points to source", async () => {
+      const root = await makeTempDir("skill-symlink-skip-");
+      cleanupDirs.add(root);
+
+      const source = path.join(root, "skill");
+      const target = path.join(root, "link");
+      await fs.mkdir(source, { recursive: true });
+      await fs.symlink(source, target);
+
+      const result = await ensurePaperclipSkillSymlink(source, target);
+      expect(result).toBe("skipped");
+    });
+
+    it("uses robustLink as default linker", async () => {
+      const root = await makeTempDir("skill-symlink-robust-");
+      cleanupDirs.add(root);
+
+      const source = path.join(root, "skill");
+      const target = path.join(root, "link");
+      await fs.mkdir(source, { recursive: true });
+
+      // default linkSkill should be robustLink
+      const result = await ensurePaperclipSkillSymlink(source, target);
+      expect(result).toBe("created");
+      expect((await fs.lstat(target)).isSymbolicLink()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #1320 — Windows users without elevated privileges get EPERM crashes during skill installation
- Adds `robustLink()` helper that tries `fs.symlink()` first, falls back to `junction` type on Windows EPERM
- Updates all 5 adapter skill injection sites (claude-local, codex-local, cursor-local, opencode-local, adapter-utils)
- Adds `symlinkOrCopy` fallback in codex-home for file symlinks (auth.json)
- 4 new tests + all existing skill injection tests pass

## Test plan

- [x] `robustLink` creates symlinks on non-Windows (macOS/Linux)
- [x] `robustLink` propagates non-EPERM errors
- [x] `ensurePaperclipSkillSymlink` creates/repairs/skips correctly with robustLink default
- [x] Existing codex-local and cursor-local skill injection tests pass
- [x] Full server typecheck clean
- [ ] Manual verification on Windows without Developer Mode enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)