### PR TITLE
fix(server): clear execution lock fields in issue release endpoint

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1126,6 +1126,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

- **Bug**: `POST /api/issues/:id/release` cleared `assigneeAgentId` and `checkoutRunId` but left `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` intact
- After unclean agent session ends (crash, timeout), stale execution locks persisted permanently, causing all subsequent checkout attempts to return 409 Conflict
- Only recovery was direct SQL (`UPDATE issues SET execution_run_id = NULL ...`)
- Fix: null all three execution lock fields in the `release()` service method, matching `releaseIssueExecutionAndPromote()` behavior

## Test plan

- [ ] Server builds cleanly (`pnpm --filter @paperclipai/server build` ✅)
- [ ] Verify: call `POST /issues/:id/release` on a locked issue → `executionRunId`, `executionAgentNameKey`, `executionLockedAt` are all null in response
- [ ] Verify: subsequent `POST /issues/:id/checkout` succeeds (no 409)
- [ ] Existing `releaseIssueExecutionAndPromote()` path (heartbeat cleanup) is unchanged

Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)