### PR TITLE
fix(server): clear execution lock on assignee change to prevent orphaned deferred wakes

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -852,6 +852,9 @@ export function issueService(db: Db) {
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary

- **Bug**: When an agent reassigns an issue via PATCH, `checkoutRunId` was cleared but `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` were left intact
- The new assignee's wakeup was deferred (waiting for old execution lock to release), but `releaseIssueExecutionAndPromote` couldn't find the issue post-reassign, leaving the deferred wake permanently orphaned
- Fix: clear all three execution lock fields when the assignee changes in `svc.update()`

## Test plan

- [ ] Server builds cleanly (`pnpm --filter @paperclipai/server build` ✅)
- [ ] Agent A checks out issue, reassigns to Agent B via PATCH → Agent B gets woken immediately (not deferred)
- [ ] `GET /issues/:id` after reassign shows `executionRunId: null`
- [ ] Existing assignee-unchanged PATCH flows are unaffected

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)