### PR TITLE
fix(ui): guard MarkdownEditor against null value to prevent crash

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -303,9 +303,10 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
   }, [hasImageUpload]);
 
   useEffect(() => {
-    if (value !== latestValueRef.current) {
-      ref.current?.setMarkdown(value);
-      latestValueRef.current = value;
+    const safeValue = value ?? "";
+    if (safeValue !== latestValueRef.current) {
+      ref.current?.setMarkdown(safeValue);
+      latestValueRef.current = safeValue;
     }
   }, [value]);
 
@@ -576,7 +577,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     >
       <MDXEditor
         ref={ref}
-        markdown={value}
+        markdown={value ?? ""}
         placeholder={placeholder}
         onChange={(next) => {
           latestValueRef.current = next;


### PR DESCRIPTION
## Summary

- **Bug**: Agent config page crashes with `TypeError: Cannot read properties of null (reading 'trim')` when `capabilities` or other markdown fields are null in the database
- MDXEditor's `setMarkdown()` doesn't accept null — it calls `.trim()` internally
- Fix: add `?? ""` null guards in `MarkdownEditor.tsx` at the `setMarkdown()` call and the initial `markdown={}` prop

## Test plan

- [ ] UI builds cleanly (`pnpm --filter @paperclipai/ui build` ✅)
- [ ] Navigate to agent config page with null capabilities → no crash
- [ ] Clear capabilities field → no crash on re-render
- [ ] Normal markdown editing still works

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)