### PR TITLE
fix(plugins): convert manifest path to file URL for Windows ESM compat

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
@@ -926,8 +926,9 @@ export function pluginLoader(
     let raw: unknown;
 
     try {
-      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const mod = await import(manifestPath) as Record<string, unknown>;
+      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests.
+      // On Windows, absolute paths must be converted to file:// URLs for ESM.
+      const mod = await import(pathToFileURL(manifestPath).href) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {


### PR DESCRIPTION
## Summary

- Fixes #1263: Plugin install fails on Windows because `import(absolutePath)` uses raw paths like `C:\Users\...` which Node.js ESM loader rejects
- Converts manifest path to `file://` URL via `pathToFileURL()` before dynamic import
- Matches existing pattern in `cli/src/commands/run.ts:155`

## Changes

- `server/src/services/plugin-loader.ts`: Import `pathToFileURL` from `node:url`, use `pathToFileURL(manifestPath).href` in `loadManifestFromPath()`

## Test plan

- [x] Server typecheck passes
- [x] Plugin worker manager tests pass (5/5)
- [ ] Manual test on Windows with local ESM plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)