### PR TITLE
fix(server): skip body on HTTP adapter GET/HEAD requests (#1335)

### DIFF
--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -10,7 +10,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const timeoutMs = asNumber(config.timeoutMs, 0);
   const headers = parseObject(config.headers) as Record<string, string>;
   const payloadTemplate = parseObject(config.payloadTemplate);
-  const body = { ...payloadTemplate, agentId: agent.id, runId, context };
+  const payload = { ...payloadTemplate, agentId: agent.id, runId, context };
+  const hasBody = method !== "GET" && method !== "HEAD";
 
   const controller = new AbortController();
   const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
@@ -19,10 +20,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const res = await fetch(url, {
       method,
       headers: {
-        "content-type": "application/json",
+        ...(hasBody ? { "content-type": "application/json" } : {}),
         ...headers,
       },
-      body: JSON.stringify(body),
+      ...(hasBody ? { body: JSON.stringify(payload) } : {}),
       ...(timer ? { signal: controller.signal } : {}),
     });
 


### PR DESCRIPTION
## Summary
- HTTP adapter always sent a JSON body regardless of HTTP method, causing `adapter_failed` on GET/HEAD agents
- Node.js `fetch()` / `undici` throws when GET or HEAD requests include a body
- Fix: conditionally skip body serialization and `content-type` header for GET and HEAD methods

Fixes #1335

## Test plan
- [ ] Create an HTTP agent with `method: "GET"` — heartbeat should succeed without `adapter_failed`
- [ ] Verify POST/PUT/PATCH agents still send body correctly
- [ ] Server typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)