### PR TITLE
fix(build): inline external workspace package deps into published CLI (#1340)

### DIFF
--- a/scripts/generate-npm-package-json.mjs
+++ b/scripts/generate-npm-package-json.mjs
@@ -53,11 +53,20 @@ for (const pkgPath of workspacePaths) {
 
   for (const [name, version] of Object.entries(deps)) {
     if (name.startsWith("@paperclipai/") && !externalWorkspacePackages.has(name)) continue;
-    // For external workspace packages, read their version directly
+    // For external workspace packages, add the package itself AND its dependencies
     if (externalWorkspacePackages.has(name)) {
       const pkgDirMap = { "@paperclipai/server": "server" };
       const wsPkg = readPkg(pkgDirMap[name]);
       allDeps[name] = wsPkg.version;
+      // Inline the external workspace package's own dependencies so they are
+      // installed when the published CLI package is `npm install`-ed.
+      const wsDeps = wsPkg.dependencies || {};
+      for (const [wsDepName, wsDepVersion] of Object.entries(wsDeps)) {
+        if (wsDepName.startsWith("@paperclipai/")) continue; // skip internal workspace refs
+        if (!allDeps[wsDepName] || !wsDepVersion.startsWith("^")) {
+          allDeps[wsDepName] = wsDepVersion;
+        }
+      }
       continue;
     }
     // Keep the more specific (pinned) version if conflict


### PR DESCRIPTION
## Summary
- Fixed `generate-npm-package-json.mjs` to include dependencies from external workspace packages (like `@paperclipai/server`) in the published CLI `package.json`
- Root cause: script added `@paperclipai/server` as a dep but skipped its own deps (`@aws-sdk/client-s3`, `express`, etc.), causing "Cannot find module '@aws-sdk/core'" after install
- Now merges all non-workspace dependencies from external packages into the published dependency list

## Test plan
- [x] Run `node scripts/generate-npm-package-json.mjs` — confirms `@aws-sdk/client-s3` now appears in generated deps (25 deps vs previous ~15)
- [ ] Publish to npm staging and verify `npx paperclipai` launches with S3 storage enabled

Closes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)