### PR TITLE
fix(codex_local): support codex experimental-json and new event schema

### DIFF
--- a/packages/adapters/codex-local/src/cli/format-event.ts
+++ b/packages/adapters/codex-local/src/cli/format-event.ts
@@ -31,7 +31,7 @@ function errorText(value: unknown): string {
 }
 
 function printItemStarted(item: Record<string, unknown>): boolean {
-  const itemType = asString(item.type);
+  const itemType = asString(item.type) || asString(item.item_type);
   if (itemType === "command_execution") {
     const command = asString(item.command);
     console.log(pc.yellow("tool_call: command_execution"));
@@ -56,9 +56,9 @@ function printItemStarted(item: Record<string, unknown>): boolean {
 }
 
 function printItemCompleted(item: Record<string, unknown>): boolean {
-  const itemType = asString(item.type);
+  const itemType = asString(item.type) || asString(item.item_type);
 
-  if (itemType === "agent_message") {
+  if (itemType === "agent_message" || itemType === "assistant_message") {
     const text = asString(item.text);
     if (text) console.log(pc.green(`assistant: ${text}`));
     return true;
@@ -153,8 +153,8 @@ export function printCodexStreamEvent(raw: string, _debug: boolean): void {
 
   const type = asString(parsed.type);
 
-  if (type === "thread.started") {
-    const threadId = asString(parsed.thread_id);
+  if (type === "thread.started" || type === "session.created") {
+    const threadId = asString(parsed.thread_id) || asString(parsed.session_id) || asString(parsed.sessionId);
     const model = asString(parsed.model);
     const details = [threadId ? `session: ${threadId}` : "", model ? `model: ${model}` : ""].filter(Boolean).join(", ");
     console.log(pc.blue(`Codex thread started${details ? ` (${details})` : ""}`));

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -474,7 +474,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const buildArgs = (resumeSessionId: string | null) => {
-    const args = ["exec", "--json"];
+    const args = ["exec", "--experimental-json", "--skip-git-repo-check"];
     if (search) args.unshift("--search");
     if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
     if (model) args.push("--model", model);

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -18,8 +18,12 @@ export function parseCodexJsonl(stdout: string) {
     if (!event) continue;
 
     const type = asString(event.type, "");
-    if (type === "thread.started") {
-      sessionId = asString(event.thread_id, sessionId ?? "") || sessionId;
+    if (type === "thread.started" || type === "session.created") {
+      sessionId =
+        asString(event.thread_id, "") ||
+        asString(event.session_id, "") ||
+        asString(event.sessionId, sessionId ?? "") ||
+        sessionId;
       continue;
     }
 
@@ -31,7 +35,8 @@ export function parseCodexJsonl(stdout: string) {
 
     if (type === "item.completed") {
       const item = parseObject(event.item);
-      if (asString(item.type, "") === "agent_message") {
+      const itemType = asString(item.type, "") || asString(item.item_type, "");
+      if (itemType === "agent_message" || itemType === "assistant_message") {
         const text = asString(item.text, "");
         if (text) messages.push(text);
       }

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -156,7 +156,7 @@ export async function testEnvironment(
         return asStringArray(config.args);
       })();
 
-      const args = ["exec", "--json"];
+      const args = ["exec", "--experimental-json", "--skip-git-repo-check"];
       if (search) args.unshift("--search");
       if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
       if (model) args.push("--model", model);
@@ -203,7 +203,7 @@ export async function testEnvironment(
           ...(hasHello
             ? {}
             : {
-                hint: "Try the probe manually (`codex exec --json -` then prompt: Respond with hello) to inspect full output.",
+                hint: "Try the probe manually (`codex exec --experimental-json --skip-git-repo-check -` then prompt: Respond with hello) to inspect full output.",
               }),
         });
       } else if (CODEX_AUTH_REQUIRED_RE.test(authEvidence)) {

--- a/packages/adapters/codex-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/codex-local/src/ui/parse-stdout.ts
@@ -123,9 +123,9 @@ function parseCodexItem(
   ts: string,
   phase: "started" | "completed",
 ): TranscriptEntry[] {
-  const itemType = asString(item.type);
+  const itemType = asString(item.type) || asString(item.item_type);
 
-  if (itemType === "agent_message") {
+  if (itemType === "agent_message" || itemType === "assistant_message") {
     const text = asString(item.text);
     if (text) return [{ kind: "assistant", ts, text }];
     return [];
@@ -189,8 +189,8 @@ export function parseCodexStdoutLine(line: string, ts: string): TranscriptEntry[
 
   const type = asString(parsed.type);
 
-  if (type === "thread.started") {
-    const threadId = asString(parsed.thread_id);
+  if (type === "thread.started" || type === "session.created") {
+    const threadId = asString(parsed.thread_id) || asString(parsed.session_id) || asString(parsed.sessionId);
     return [{
       kind: "init",
       ts,

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -265,7 +265,9 @@ describe("codex execute", () => {
 
       const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
       expect(capture.codexHome).toBe(isolatedCodexHome);
-      expect(capture.argv).toEqual(expect.arrayContaining(["exec", "--json", "-"]));
+      expect(capture.argv).toEqual(
+        expect.arrayContaining(["exec", "--experimental-json", "--skip-git-repo-check", "-"]),
+      );
       expect(capture.prompt).toContain("Follow the paperclip heartbeat.");
       expect(capture.paperclipEnvKeys).toEqual(
         expect.arrayContaining([


### PR DESCRIPTION
## Summary
This updates `codex_local` for Codex CLI 0.42.0 behavior:

- use `--experimental-json` instead of deprecated `--json`
- add `--skip-git-repo-check` for non-trusted cwd execution
- support new event shape variants in parser/formatters:
  - `session.created` (alongside `thread.started`)
  - `item.item_type` (fallback when `item.type` is absent)
  - `assistant_message` (alongside `agent_message`)

## Why
Without these updates, users can see:
- deprecation warnings/errors around `--json`
- failures when cwd is not a trusted git repo
- transcript events rendered as `Unknown` in UI for valid Codex output

## Validation
- local install and run on macOS arm64
- reproduced Codex 0.42.0 outputs including `session.created` and `assistant_message`
- adapter builds successfully

Closes #1343
