### PR TITLE
feat: add delete issue UI with confirmation and loading states

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -18,6 +18,8 @@ import {
   labels,
   projectWorkspaces,
   projects,
+  costEvents,
+  financeEvents,
 } from "@paperclipai/db";
 import { extractProjectMentionIds } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
@@ -888,6 +890,13 @@ export function issueService(db: Db) {
           .select({ documentId: issueDocuments.documentId })
           .from(issueDocuments)
           .where(eq(issueDocuments.issueId, id));
+
+        // Clean up non-cascading FK references before deleting the issue
+        await tx.delete(issueReadStates).where(eq(issueReadStates.issueId, id));
+        await tx.delete(issueComments).where(eq(issueComments.issueId, id));
+        await tx.update(issues).set({ parentId: null }).where(eq(issues.parentId, id));
+        await tx.update(costEvents).set({ issueId: null }).where(eq(costEvents.issueId, id));
+        await tx.update(financeEvents).set({ issueId: null }).where(eq(financeEvents.issueId, id));
 
         const removedIssue = await tx
           .delete(issues)

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -44,7 +44,7 @@ export function IssueRow({
       to={`/issues/${issuePathId}`}
       state={issueLinkState}
       className={cn(
-        "flex items-start gap-2 border-b border-border py-2.5 pl-2 pr-3 text-sm no-underline text-inherit transition-colors hover:bg-accent/50 last:border-b-0 sm:items-center sm:py-2 sm:pl-1",
+        "group/row flex items-start gap-2 border-b border-border py-2.5 pl-2 pr-3 text-sm no-underline text-inherit transition-colors hover:bg-accent/50 last:border-b-0 sm:items-center sm:py-2 sm:pl-1",
         className,
       )}
     >

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
-import { CircleDot, Plus, Filter, ArrowUpDown, Layers, Check, X, ChevronRight, List, Columns3, User, Search } from "lucide-react";
+import { CircleDot, Plus, Filter, ArrowUpDown, Layers, Check, X, ChevronRight, List, Columns3, User, Search, Trash2, Loader2 } from "lucide-react";
 import { KanbanBoard } from "./KanbanBoard";
 import type { Issue } from "@paperclipai/shared";
 
@@ -158,6 +158,7 @@ interface IssuesListProps {
   initialSearch?: string;
   onSearchChange?: (search: string) => void;
   onUpdateIssue: (id: string, data: Record<string, unknown>) => void;
+  onDeleteIssue?: (id: string) => Promise<unknown>;
 }
 
 export function IssuesList({
@@ -173,6 +174,7 @@ export function IssuesList({
   initialSearch,
   onSearchChange,
   onUpdateIssue,
+  onDeleteIssue,
 }: IssuesListProps) {
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
@@ -193,6 +195,8 @@ export function IssuesList({
   });
   const [assigneePickerIssueId, setAssigneePickerIssueId] = useState<string | null>(null);
   const [assigneeSearch, setAssigneeSearch] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [issueSearch, setIssueSearch] = useState(initialSearch ?? "");
   const [debouncedIssueSearch, setDebouncedIssueSearch] = useState(issueSearch);
   const normalizedIssueSearch = debouncedIssueSearch.trim();
@@ -813,7 +817,68 @@ export function IssuesList({
                       </Popover>
                     </>
                   )}
-                  trailingMeta={formatDate(issue.createdAt)}
+                  trailingMeta={(
+                    <span className="flex items-center gap-2">
+                      <span>{formatDate(issue.createdAt)}</span>
+                      {onDeleteIssue && (
+                        deletingId === issue.id ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                        ) : (
+                        <Popover
+                          open={confirmDeleteId === issue.id}
+                          onOpenChange={(open) => setConfirmDeleteId(open ? issue.id : null)}
+                        >
+                          <PopoverTrigger asChild>
+                            <button
+                              className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover/row:opacity-100"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                setConfirmDeleteId(issue.id);
+                              }}
+                              title="Delete issue"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </PopoverTrigger>
+                          <PopoverContent
+                            className="w-64 p-3"
+                            align="end"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <p className="mb-3 text-sm font-medium">Delete this issue? This cannot be undone.</p>
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setConfirmDeleteId(null);
+                                }}
+                              >
+                                Cancel
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setDeletingId(issue.id);
+                                  setConfirmDeleteId(null);
+                                  onDeleteIssue(issue.id).finally(() => setDeletingId(null));
+                                }}
+                              >
+                                Delete
+                              </Button>
+                            </div>
+                          </PopoverContent>
+                        </Popover>
+                        )
+                      )}
+                    </span>
+                  )}
                 />
               ))}
             </CollapsibleContent>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -44,6 +44,7 @@ import {
   EyeOff,
   Hexagon,
   ListTree,
+  Loader2,
   MessageSquare,
   MoreHorizontal,
   Paperclip,
@@ -201,6 +202,7 @@ export function IssueDetail() {
   const location = useLocation();
   const { pushToast } = useToast();
   const [moreOpen, setMoreOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [copied, setCopied] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
   const [detailTab, setDetailTab] = useState("comments");
@@ -474,6 +476,14 @@ export function IssueDetail() {
     mutationFn: (data: Record<string, unknown>) => issuesApi.update(issueId!, data),
     onSuccess: () => {
       invalidateIssue();
+    },
+  });
+
+  const deleteIssue = useMutation({
+    mutationFn: () => issuesApi.remove(issueId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(selectedCompanyId!) });
+      navigate("/issues/all");
     },
   });
 
@@ -799,7 +809,7 @@ export function IssueDetail() {
               <SlidersHorizontal className="h-4 w-4" />
             </Button>
 
-            <Popover open={moreOpen} onOpenChange={setMoreOpen}>
+            <Popover open={moreOpen} onOpenChange={(open) => { setMoreOpen(open); if (!open) setConfirmDelete(false); }}>
               <PopoverTrigger asChild>
                 <Button variant="ghost" size="icon-xs" className="shrink-0">
                   <MoreHorizontal className="h-4 w-4" />
@@ -819,6 +829,36 @@ export function IssueDetail() {
                 <EyeOff className="h-3 w-3" />
                 Hide this Issue
               </button>
+              {!confirmDelete ? (
+                <button
+                  className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
+                  onClick={() => setConfirmDelete(true)}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Delete Issue
+                </button>
+              ) : (
+                <div className="border-t border-border mt-1 pt-1 space-y-1">
+                  <p className="px-2 py-1 text-xs text-destructive font-medium">Delete this issue? This cannot be undone.</p>
+                  <div className="flex items-center gap-1 px-1">
+                    <button
+                      className="flex-1 px-2 py-1 text-xs rounded hover:bg-accent/50 disabled:opacity-50"
+                      disabled={deleteIssue.isPending}
+                      onClick={() => setConfirmDelete(false)}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="flex-1 px-2 py-1 text-xs rounded bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 inline-flex items-center justify-center gap-1"
+                      disabled={deleteIssue.isPending}
+                      onClick={() => deleteIssue.mutate()}
+                    >
+                      {deleteIssue.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+                      {deleteIssue.isPending ? "Deleting..." : "Delete"}
+                    </button>
+                  </div>
+                </div>
+              )}
             </PopoverContent>
             </Popover>
           </div>

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -92,6 +92,13 @@ export function Issues() {
     },
   });
 
+  const deleteIssue = useMutation({
+    mutationFn: (id: string) => issuesApi.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(selectedCompanyId!) });
+    },
+  });
+
   if (!selectedCompanyId) {
     return <EmptyState icon={CircleDot} message="Select a company to view issues." />;
   }
@@ -109,6 +116,7 @@ export function Issues() {
       initialSearch={initialSearch}
       onSearchChange={handleSearchChange}
       onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
+      onDeleteIssue={(id) => deleteIssue.mutateAsync(id)}
     />
   );
 }

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -186,6 +186,14 @@ function ProjectIssuesList({ projectId, companyId }: { projectId: string; compan
     },
   });
 
+  const deleteIssue = useMutation({
+    mutationFn: (id: string) => issuesApi.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listByProject(companyId, projectId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
+    },
+  });
+
   return (
     <IssuesList
       issues={issues ?? []}
@@ -196,6 +204,7 @@ function ProjectIssuesList({ projectId, companyId }: { projectId: string; compan
       projectId={projectId}
       viewStateKey={`paperclip:project-view:${projectId}`}
       onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
+      onDeleteIssue={(id) => deleteIssue.mutateAsync(id)}
     />
   );
 }


### PR DESCRIPTION
Add the ability to delete issues from both the issues list and the issue detail page. The backend delete endpoint already existed but had two gaps: no UI to trigger it, and missing cleanup of non-cascading FK references (issue_read_states, issue_comments, etc.) which caused a 500 error.

Backend: clean up all non-cascading foreign key references inside the existing transaction before deleting the issue row.

Frontend: add a trash icon on each issue row (visible on hover) with a confirmation popover, and a "Delete Issue" option in the issue detail more-menu. Both surfaces show a spinner/loading state while the delete is in flight.