### PR TITLE
feat: auto-scroll live transcripts as new entries arrive

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -146,6 +146,7 @@ function AgentRunCard({
           density="compact"
           limit={5}
           streaming={isActive}
+          autoScroll={isActive}
           collapseStdout
           thinkingClassName="!text-[10px] !leading-4"
           emptyMessage={hasOutput ? "Waiting for transcript parsing..." : isActive ? "Waiting for output..." : "No transcript captured."}

--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -147,6 +147,7 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
                   density="compact"
                   limit={8}
                   streaming={isActive}
+                  autoScroll={isActive}
                   collapseStdout
                   emptyMessage={hasOutputForRun(run.id) ? "Waiting for transcript parsing..." : "Waiting for run output..."}
                 />

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -970,7 +970,7 @@ function findScrollAncestor(el: HTMLElement | null): HTMLElement | null {
   while (node) {
     const { overflowY } = window.getComputedStyle(node);
     if (
-      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      (overflowY === "auto" || overflowY === "scroll") &&
       node.scrollHeight > node.clientHeight + 1
     ) {
       return node;
@@ -997,48 +997,62 @@ function useAutoScroll(
 ) {
   const isNearBottom = useRef(true);
   const scrollerRef = useRef<HTMLElement | null>(null);
-  const handlerRef = useRef<(() => void) | null>(null);
+  const listenerRef = useRef<(() => void) | null>(null);
 
-  // (Re-)attach the scroll listener whenever deps change so we always track
-  // the right ancestor, even if overflow only appeared after new entries.
+  const updateNearBottom = (scroller: HTMLElement) => {
+    const distance = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+    isNearBottom.current = distance <= threshold;
+  };
+
+  // 1. Seed isNearBottom synchronously (useLayoutEffect) BEFORE the scroll
+  //    effect fires, so the scroll decision always uses the current ancestor.
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    const sentinel = bottomRef.current;
+    if (!sentinel) return;
+
+    const scroller = findScrollAncestor(sentinel);
+    if (scroller) {
+      updateNearBottom(scroller);
+    } else {
+      // No overflow yet — treat as "at bottom".
+      isNearBottom.current = true;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+
+  // 2. Scroll to sentinel (also useLayoutEffect, but declared after the seed
+  //    above so React processes it second in the same commit).
+  useLayoutEffect(() => {
+    if (!enabled || !isNearBottom.current) return;
+    bottomRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+
+  // 3. (Re-)attach the passive scroll listener so isNearBottom stays current
+  //    between entry updates. Re-runs on deps change to pick up new ancestors.
   useEffect(() => {
     if (!enabled) return;
     const sentinel = bottomRef.current;
     if (!sentinel) return;
 
     // Detach previous listener if the scroller element changed.
-    if (handlerRef.current && scrollerRef.current) {
-      scrollerRef.current.removeEventListener("scroll", handlerRef.current);
+    if (listenerRef.current && scrollerRef.current) {
+      scrollerRef.current.removeEventListener("scroll", listenerRef.current);
     }
 
     const scroller = findScrollAncestor(sentinel);
     scrollerRef.current = scroller;
 
     if (!scroller) {
-      // No overflow yet — treat as "at bottom".
-      isNearBottom.current = true;
-      handlerRef.current = null;
+      listenerRef.current = null;
       return;
     }
 
-    const onScroll = () => {
-      const distance = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
-      isNearBottom.current = distance <= threshold;
-    };
-
-    // Seed with current position so we pick up a mid-scroll state immediately.
-    onScroll();
-
-    handlerRef.current = onScroll;
+    const onScroll = () => updateNearBottom(scroller);
+    listenerRef.current = onScroll;
     scroller.addEventListener("scroll", onScroll, { passive: true });
     return () => scroller.removeEventListener("scroll", onScroll);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, ...deps]);
-
-  // Scroll to sentinel when deps change and user is near bottom.
-  useLayoutEffect(() => {
-    if (!enabled || !isNearBottom.current) return;
-    bottomRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, ...deps]);
 }

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { TranscriptEntry } from "../../adapters";
 import { MarkdownBody } from "../MarkdownBody";
 import { cn, formatTokens } from "../../lib/utils";
@@ -25,6 +25,8 @@ interface RunTranscriptViewProps {
   emptyMessage?: string;
   className?: string;
   thinkingClassName?: string;
+  /** Automatically scroll to bottom when new entries arrive, as long as the user hasn't scrolled up. */
+  autoScroll?: boolean;
 }
 
 type TranscriptBlock =
@@ -959,6 +961,88 @@ function RawTranscriptView({
   );
 }
 
+/**
+ * Find the nearest ancestor that is a scroll container (overflow-y auto/scroll/overlay
+ * and content taller than viewport). Returns null when nothing overflows yet.
+ */
+function findScrollAncestor(el: HTMLElement | null): HTMLElement | null {
+  let node = el?.parentElement ?? null;
+  while (node) {
+    const { overflowY } = window.getComputedStyle(node);
+    if (
+      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      node.scrollHeight > node.clientHeight + 1
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Sticky auto-scroll: scrolls the nearest scrollable ancestor to keep the
+ * bottom sentinel visible whenever `deps` change — but only while the user
+ * is near the bottom (within `threshold` px). Scrolling up to read history
+ * disengages the behaviour; scrolling back down re-engages it.
+ *
+ * The scroll ancestor is re-resolved on every deps change so it works even
+ * when the container starts without overflow and gains it as entries stream in.
+ */
+function useAutoScroll(
+  bottomRef: React.RefObject<HTMLDivElement | null>,
+  enabled: boolean,
+  deps: unknown[],
+  threshold = 80,
+) {
+  const isNearBottom = useRef(true);
+  const scrollerRef = useRef<HTMLElement | null>(null);
+  const handlerRef = useRef<(() => void) | null>(null);
+
+  // (Re-)attach the scroll listener whenever deps change so we always track
+  // the right ancestor, even if overflow only appeared after new entries.
+  useEffect(() => {
+    if (!enabled) return;
+    const sentinel = bottomRef.current;
+    if (!sentinel) return;
+
+    // Detach previous listener if the scroller element changed.
+    if (handlerRef.current && scrollerRef.current) {
+      scrollerRef.current.removeEventListener("scroll", handlerRef.current);
+    }
+
+    const scroller = findScrollAncestor(sentinel);
+    scrollerRef.current = scroller;
+
+    if (!scroller) {
+      // No overflow yet — treat as "at bottom".
+      isNearBottom.current = true;
+      handlerRef.current = null;
+      return;
+    }
+
+    const onScroll = () => {
+      const distance = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      isNearBottom.current = distance <= threshold;
+    };
+
+    // Seed with current position so we pick up a mid-scroll state immediately.
+    onScroll();
+
+    handlerRef.current = onScroll;
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => scroller.removeEventListener("scroll", onScroll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+
+  // Scroll to sentinel when deps change and user is near bottom.
+  useLayoutEffect(() => {
+    if (!enabled || !isNearBottom.current) return;
+    bottomRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+}
+
 export function RunTranscriptView({
   entries,
   mode = "nice",
@@ -969,10 +1053,14 @@ export function RunTranscriptView({
   emptyMessage = "No transcript yet.",
   className,
   thinkingClassName,
+  autoScroll = false,
 }: RunTranscriptViewProps) {
   const blocks = useMemo(() => normalizeTranscript(entries, streaming), [entries, streaming]);
   const visibleBlocks = limit ? blocks.slice(-limit) : blocks;
   const visibleEntries = limit ? entries.slice(-limit) : entries;
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useAutoScroll(bottomRef, autoScroll, [entries.length, visibleBlocks.length]);
 
   if (entries.length === 0) {
     return (
@@ -986,6 +1074,7 @@ export function RunTranscriptView({
     return (
       <div className={className}>
         <RawTranscriptView entries={visibleEntries} density={density} />
+        <div ref={bottomRef} />
       </div>
     );
   }
@@ -1010,6 +1099,7 @@ export function RunTranscriptView({
           {block.type === "event" && <TranscriptEventRow block={block} density={density} />}
         </div>
       ))}
+      <div ref={bottomRef} />
     </div>
   );
 }

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2557,7 +2557,6 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           entries={transcript}
           mode={transcriptMode}
           streaming={isLive}
-          autoScroll={isLive}
           emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
         />
         {logError && (

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2557,6 +2557,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           entries={transcript}
           mode={transcriptMode}
           streaming={isLive}
+          autoScroll={isLive}
           emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
         />
         {logError && (


### PR DESCRIPTION
## Summary
- Adds a sticky `autoScroll` prop to `RunTranscriptView` that keeps the nearest scrollable ancestor pinned to the bottom as transcript entries stream in
- Scrolling up to read history disengages auto-scroll; scrolling back near the bottom re-engages it
- Enabled on all three live transcript surfaces (`LiveRunWidget`, `ActiveAgentsPanel`, `AgentDetail`) only while the run is active

## How it works
A `useAutoScroll` hook places an invisible sentinel `<div>` at the end of the transcript. On each entries change it:
1. Re-resolves the nearest overflow ancestor (handles containers that gain overflow as content grows)
2. Checks if the user is within 80px of the bottom
3. If yes, smooth-scrolls the sentinel into view; if no, does nothing

## Test plan
- [ ] Open a live run in `LiveRunWidget` — transcript should auto-scroll as entries arrive
- [ ] Scroll up mid-stream — auto-scroll should stop
- [ ] Scroll back to bottom — auto-scroll should re-engage
- [ ] Verify same behaviour on `ActiveAgentsPanel` dashboard cards
- [ ] Verify same behaviour on `AgentDetail` run page
- [ ] Finished runs should not auto-scroll