### PR TITLE
Add declarative heartbeat hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Every task traces back to the company mission. Agents know <em>what</em> to do a
 </td>
 <td align="center" width="33%">
 <h3>💓 Heartbeats</h3>
-Agents wake on a schedule, check work, and act. Delegation flows up and down the org chart.
+Agents wake on a schedule, check work, and act. Declarative post-run hooks can trigger follow-on automation and delegation across the org chart.
 </td>
 </tr>
 <tr>
@@ -149,6 +149,7 @@ Paperclip handles the hard orchestration details correctly.
 | **Atomic execution.**             | Task checkout and budget enforcement are atomic, so no double-work and no runaway spend.                      |
 | **Persistent agent state.**       | Agents resume the same task context across heartbeats instead of restarting from scratch.                     |
 | **Runtime skill injection.**      | Agents can learn Paperclip workflows and project context at runtime, without retraining.                      |
+| **Declarative handoffs.**         | Heartbeat lifecycle hooks can run commands, call webhooks, wake agents, or reassign issues without replacing the core scheduler. |
 | **Governance with rollback.**     | Approval gates are enforced, config changes are revisioned, and bad changes can be rolled back safely.        |
 | **Goal-aware execution.**         | Tasks carry full goal ancestry so agents consistently see the "why," not just a title.                        |
 | **Portable company templates.**   | Export/import orgs, agents, and skills with secret scrubbing and collision handling.                          |
@@ -211,7 +212,7 @@ Agent orchestration has subtleties in how you coordinate who has work checked ou
 (Bring-your-own-ticket-system is on the Roadmap)
 
 **Do agents run continuously?**
-By default, agents run on scheduled heartbeats and event-based triggers (task assignment, @-mentions). You can also hook in continuous agents like OpenClaw. You bring your agent and Paperclip coordinates.
+By default, agents run on scheduled heartbeats and event-based triggers (task assignment, @-mentions). Agents can also use declarative heartbeat hooks for post-run automation such as waking another agent or calling a webhook. You can still hook in continuous agents like OpenClaw. You bring your agent and Paperclip coordinates.
 
 <br/>
 

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -463,6 +463,14 @@ All endpoints are under `/api` and return JSON.
 - `POST /agents/:agentId/keys` (create API key)
 - `POST /agents/:agentId/heartbeat/invoke`
 
+Agent create/update payloads may include `runtimeConfig.hooks` for declarative post-run automation.
+
+V1 hook constraints:
+
+- only board-managed create/update flows may add, remove, or change hook configuration
+- non-board patches preserve existing hooks when editing other runtime settings
+- non-board config rollbacks are blocked if they would change hooks
+
 ## 10.4 Tasks (Issues)
 
 - `GET /companies/:companyId/issues`
@@ -605,7 +613,35 @@ Behavior:
 - `thin`: send IDs and pointers only; agent fetches context via API
 - `fat`: include current assignments, goal summary, budget snapshot, and recent comments
 
-## 11.5 Scheduler Rules
+## 11.5 Heartbeat Hooks
+
+Per-agent hook config lives in `runtimeConfig.hooks`.
+
+V1 supported events:
+
+- `heartbeat.run.started`
+- `heartbeat.run.finished`
+- `heartbeat.run.succeeded`
+- `heartbeat.run.failed`
+- `heartbeat.run.cancelled`
+- `heartbeat.run.timed_out`
+
+V1 supported actions:
+
+- `command`
+- `webhook`
+- `wake_agent`
+- `assign_issue`
+
+Execution rules:
+
+- hooks dispatch asynchronously after run-status persistence
+- `running` emits `heartbeat.run.started`
+- terminal states emit `heartbeat.run.finished` plus a terminal-specific event
+- `wake_agent` and `assign_issue` targets must resolve to allow-listed agents in the same company
+- hooks cannot wake the originating agent or assign an issue back to that agent
+
+## 11.6 Scheduler Rules
 
 Per-agent schedule fields in `adapter_config`:
 

--- a/doc/SPEC.md
+++ b/doc/SPEC.md
@@ -215,12 +215,25 @@ This is the full adapter contract. `invoke` starts the agent, `status` lets Pape
 - **When** to fire the heartbeat (schedule/frequency, per-agent)
 - **How** to fire it (adapter selection + config)
 - **What context** to include (thin ping vs. fat payload, per-agent)
+- **What follow-on automation** to trigger after run-status transitions via agent-scoped `runtimeConfig.hooks`
 
 ### What Paperclip Does NOT Control
 
 - How long the agent runs
 - What the agent does during its cycle
 - Whether the agent is task-scoped, time-windowed, or continuous
+
+### Declarative Heartbeat Hooks
+
+Agents may also define declarative heartbeat hooks under `runtimeConfig.hooks`.
+
+- hooks are evaluated after heartbeat run-status transitions are persisted
+- initial events: `heartbeat.run.started`, `heartbeat.run.finished`, `heartbeat.run.succeeded`, `heartbeat.run.failed`, `heartbeat.run.cancelled`, `heartbeat.run.timed_out`
+- initial actions: local `command`, outbound `webhook`, cross-agent `wake_agent`, and same-company `assign_issue`
+- hook execution is best-effort and non-blocking relative to the main heartbeat path
+- sensitive actions are permission-gated in agent config and target agents must be explicitly allow-listed
+
+This is a built-in orchestration feature, not a separate plugin-only event bus.
 
 ### Pause Behavior
 

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -1,7 +1,7 @@
 # Agent Runtime Guide
 
 Status: User-facing guide  
-Last updated: 2026-02-17  
+Last updated: 2026-03-20  
 Audience: Operators setting up and running agents in Paperclip
 
 ## 1. What this system does
@@ -69,6 +69,91 @@ You can set:
 
 Templates support variables like `{{agent.id}}`, `{{agent.name}}`, and run context values.
 
+## 3.5 Event-driven hooks
+
+Agents can also declare **hooks** under `runtimeConfig.hooks`.
+
+Hooks are evaluated after meaningful heartbeat lifecycle transitions and let an agent trigger follow-on automation without replacing the existing scheduler, assignment wakeups, or mention/comment wakeups.
+
+Supported hook events in v1:
+
+- `heartbeat.run.started`
+- `heartbeat.run.finished`
+- `heartbeat.run.succeeded`
+- `heartbeat.run.failed`
+- `heartbeat.run.cancelled`
+- `heartbeat.run.timed_out`
+
+Supported hook actions in v1:
+
+- `command`: run a local script/command on the Paperclip host
+- `webhook`: call an HTTP endpoint with JSON payload
+- `wake_agent`: wake one or more other agents in the same company
+- `assign_issue`: reassign the current issue to another agent, optionally waking them
+
+Hooks are declarative and rule-based:
+
+- each rule listens to one or more events
+- optional `match` filters inspect event/run fields such as `run.contextSnapshot.workflow`
+- actions can use templates like `{{run.id}}`, `{{event.issueId}}`, and `{{agent.name}}`
+
+### Permissions and safety
+
+Hook execution is disabled by default unless the relevant permissions are granted in the hook config:
+
+- `allowCommand`: permit local command execution
+- `allowWebhook`: permit outbound webhook calls
+- `allowIssueAssignment`: permit `assign_issue`
+- `allowedAgentRefs`: explicit allow-list for `wake_agent` and `assign_issue` targets
+
+Additional safety rules:
+
+- hook-config changes are board-managed; non-board agent updates and config rollbacks preserve existing hooks but cannot add/remove/change them
+- target agents must belong to the same company
+- hooks cannot wake the same agent that originated the event
+- hooks run best-effort and asynchronously after run status is persisted, so heartbeat scheduling/coalescing behaviour is unchanged
+
+### Example: benchmark finished -> wake CTO
+
+```json
+{
+  "runtimeConfig": {
+    "hooks": {
+      "enabled": true,
+      "permissions": {
+        "allowedAgentRefs": ["CTO"]
+      },
+      "rules": [
+        {
+          "id": "benchmark-finished-wake-cto",
+          "event": "heartbeat.run.succeeded",
+          "match": {
+            "run.contextSnapshot.workflow": "benchmark"
+          },
+          "actions": [
+            {
+              "type": "wake_agent",
+              "agentRefs": ["CTO"],
+              "reason": "benchmark_finished",
+              "payload": {
+                "issueId": "{{event.issueId}}",
+                "sourceRunId": "{{run.id}}",
+                "completedBy": "{{agent.name}}"
+              },
+              "contextSnapshot": {
+                "issueId": "{{event.issueId}}",
+                "source": "agent_hook.benchmark_finished",
+                "wakeReason": "benchmark_finished"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## 4. Session resume behavior
 
 Paperclip stores session IDs for resumable adapters.
@@ -120,7 +205,8 @@ If the connection drops, the UI reconnects automatically.
 
 1. Disable timer or set a long interval
 2. Keep wake-on-assignment enabled
-3. Use on-demand wakeups for manual nudges
+3. Add `runtimeConfig.hooks` rules for handoffs and post-run automation
+4. Use on-demand wakeups for manual nudges
 
 ## 7.3 Safety-first loop
 

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -75,6 +75,83 @@ PATCH /api/agents/{agentId}
 }
 ```
 
+## Hook configuration
+
+Hooks live under `runtimeConfig.hooks` and are intended for event-driven handoffs.
+
+Supported lifecycle events:
+
+- `heartbeat.run.started`
+- `heartbeat.run.finished`
+- `heartbeat.run.succeeded`
+- `heartbeat.run.failed`
+- `heartbeat.run.cancelled`
+- `heartbeat.run.timed_out`
+
+Supported actions:
+
+- `command`
+- `webhook`
+- `wake_agent`
+- `assign_issue`
+
+Security model:
+
+- only board-managed create/update flows — including config rollbacks that would change hooks — can add, remove, or change `runtimeConfig.hooks`
+- `wake_agent` and `assign_issue` targets must be explicitly allow-listed via `permissions.allowedAgentRefs`
+- `command`, `webhook`, and `assign_issue` each require explicit permission flags
+
+Example: benchmark finished -> wake CTO.
+
+```json
+POST /api/companies/{companyId}/agents
+{
+  "name": "BenchWorker",
+  "role": "engineer",
+  "adapterType": "process",
+  "adapterConfig": {
+    "command": "./bin/bench-worker"
+  },
+  "runtimeConfig": {
+    "heartbeat": {
+      "intervalSec": 0
+    },
+    "hooks": {
+      "enabled": true,
+      "permissions": {
+        "allowedAgentRefs": ["CTO"]
+      },
+      "rules": [
+        {
+          "id": "benchmark-finished-wake-cto",
+          "event": "heartbeat.run.succeeded",
+          "match": {
+            "run.contextSnapshot.workflow": "benchmark"
+          },
+          "actions": [
+            {
+              "type": "wake_agent",
+              "agentRefs": ["CTO"],
+              "reason": "benchmark_finished",
+              "payload": {
+                "issueId": "{{event.issueId}}",
+                "sourceRunId": "{{run.id}}",
+                "completedBy": "{{agent.name}}"
+              },
+              "contextSnapshot": {
+                "issueId": "{{event.issueId}}",
+                "source": "agent_hook.benchmark_finished",
+                "wakeReason": "benchmark_finished"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Pause Agent
 
 ```

--- a/docs/guides/agent-developer/heartbeat-protocol.md
+++ b/docs/guides/agent-developer/heartbeat-protocol.md
@@ -5,6 +5,8 @@ summary: Step-by-step heartbeat procedure for agents
 
 Every agent follows the same heartbeat procedure on each wake. This is the core contract between agents and Paperclip.
 
+After Paperclip persists the run result, declarative `runtimeConfig.hooks` may fire follow-on automation such as webhooks, cross-agent wakeups, or issue handoffs. Those hooks do not change the steps below; they run after the heartbeat itself has been recorded.
+
 ## The Steps
 
 ### Step 1: Identity
@@ -96,6 +98,10 @@ POST /api/companies/{companyId}/issues
 ```
 
 Always set `parentId` and `goalId` on subtasks.
+
+### Step 10: Exit Cleanly
+
+Finish the heartbeat with enough task state and comments for any follow-on wake, manual review, or hook-driven handoff to make sense.
 
 ## Critical Rules
 

--- a/docs/guides/agent-developer/how-agents-work.md
+++ b/docs/guides/agent-developer/how-agents-work.md
@@ -13,6 +13,7 @@ Agents in Paperclip are AI employees that wake up, do work, and go back to sleep
 4. **Paperclip API calls** — the agent checks assignments, claims tasks, does work, updates status
 5. **Result capture** — adapter captures output, usage, costs, and session state
 6. **Run record** — Paperclip stores the run result for audit and debugging
+7. **Post-run hooks** — if the agent has `runtimeConfig.hooks`, Paperclip may trigger declarative follow-on automation after the run state is stored
 
 ## Agent Identity
 
@@ -35,6 +36,8 @@ Additional context variables are set when the wake has a specific trigger:
 | `PAPERCLIP_WAKE_COMMENT_ID` | Specific comment that triggered this wake |
 | `PAPERCLIP_APPROVAL_ID` | Approval that was resolved |
 | `PAPERCLIP_APPROVAL_STATUS` | Approval decision (`approved`, `rejected`) |
+
+Some wakes may be created by another agent's heartbeat hook. In those cases, the wake reason and context snapshot describe the handoff source, for example a completed benchmark run that wakes a manager for review.
 
 ## Session Persistence
 

--- a/docs/guides/board-operator/managing-agents.md
+++ b/docs/guides/board-operator/managing-agents.md
@@ -45,9 +45,12 @@ Edit an agent's configuration from the agent detail page:
 
 - **Adapter config** — change model, prompt template, working directory, environment variables
 - **Heartbeat settings** — interval, cooldown, max concurrent runs, wake triggers
+- **Heartbeat hooks** — declarative post-run actions such as `webhook`, `wake_agent`, and `assign_issue`
 - **Budget** — monthly spend limit
 
 Use the "Test Environment" button to validate that the agent's adapter config is correct before running.
+
+Hook changes are board-managed. Non-board agent updates and config rollbacks can preserve existing hooks, but they cannot add, remove, or modify them.
 
 ## Pausing and Resuming
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -289,6 +289,24 @@ export const LIVE_EVENT_TYPES = [
 ] as const;
 export type LiveEventType = (typeof LIVE_EVENT_TYPES)[number];
 
+export const AGENT_HOOK_EVENT_TYPES = [
+  "heartbeat.run.started",
+  "heartbeat.run.finished",
+  "heartbeat.run.succeeded",
+  "heartbeat.run.failed",
+  "heartbeat.run.cancelled",
+  "heartbeat.run.timed_out",
+] as const;
+export type AgentHookEventType = (typeof AGENT_HOOK_EVENT_TYPES)[number];
+
+export const AGENT_HOOK_ACTION_TYPES = [
+  "command",
+  "webhook",
+  "wake_agent",
+  "assign_issue",
+] as const;
+export type AgentHookActionType = (typeof AGENT_HOOK_ACTION_TYPES)[number];
+
 export const PRINCIPAL_TYPES = ["user", "agent"] as const;
 export type PrincipalType = (typeof PRINCIPAL_TYPES)[number];
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,6 +34,8 @@ export {
   WAKEUP_TRIGGER_DETAILS,
   WAKEUP_REQUEST_STATUSES,
   LIVE_EVENT_TYPES,
+  AGENT_HOOK_EVENT_TYPES,
+  AGENT_HOOK_ACTION_TYPES,
   PRINCIPAL_TYPES,
   MEMBERSHIP_STATUSES,
   INSTANCE_USER_ROLES,
@@ -92,6 +94,8 @@ export {
   type WakeupTriggerDetail,
   type WakeupRequestStatus,
   type LiveEventType,
+  type AgentHookEventType,
+  type AgentHookActionType,
   type PrincipalType,
   type MembershipStatus,
   type InstanceUserRole,
@@ -130,6 +134,16 @@ export type {
   AdapterEnvironmentTestStatus,
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestResult,
+  AgentHookMatchValue,
+  AgentHooksPermissions,
+  AgentHookBaseAction,
+  AgentHookCommandAction,
+  AgentHookWebhookAction,
+  AgentHookWakeAgentAction,
+  AgentHookAssignIssueAction,
+  AgentHookAction,
+  AgentHookRule,
+  AgentHooksConfig,
   AssetImage,
   Project,
   ProjectCodebase,
@@ -243,6 +257,13 @@ export type {
   QuotaWindow,
   ProviderQuotaResult,
 } from "./types/index.js";
+
+export {
+  agentHooksPermissionsSchema,
+  agentHookActionSchema,
+  agentHookRuleSchema,
+  agentHooksConfigSchema,
+} from "./validators/agent-hooks.js";
 
 export {
   instanceExperimentalSettingsSchema,

--- a/packages/shared/src/types/agent-hooks.ts
+++ b/packages/shared/src/types/agent-hooks.ts
@@ -1,0 +1,78 @@
+import type {
+  AgentHookActionType,
+  AgentHookEventType,
+  IssueStatus,
+} from "../constants.js";
+
+export type AgentHookMatchValue =
+  | string
+  | number
+  | boolean
+  | Array<string | number | boolean>;
+
+export interface AgentHooksPermissions {
+  allowCommand: boolean;
+  allowWebhook: boolean;
+  allowIssueAssignment: boolean;
+  allowedAgentRefs: string[];
+}
+
+export interface AgentHookBaseAction {
+  type: AgentHookActionType;
+}
+
+export interface AgentHookCommandAction extends AgentHookBaseAction {
+  type: "command";
+  command: string;
+  args?: string[];
+  cwd?: string | null;
+  env?: Record<string, string>;
+  timeoutSec?: number;
+}
+
+export interface AgentHookWebhookAction extends AgentHookBaseAction {
+  type: "webhook";
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+export interface AgentHookWakeAgentAction extends AgentHookBaseAction {
+  type: "wake_agent";
+  agentRefs: string[];
+  reason?: string | null;
+  payload?: Record<string, unknown> | null;
+  contextSnapshot?: Record<string, unknown> | null;
+  forceFreshSession?: boolean;
+}
+
+export interface AgentHookAssignIssueAction extends AgentHookBaseAction {
+  type: "assign_issue";
+  agentRef: string;
+  issueId?: string | null;
+  status?: IssueStatus | null;
+  wakeAssignee?: boolean;
+}
+
+export type AgentHookAction =
+  | AgentHookCommandAction
+  | AgentHookWebhookAction
+  | AgentHookWakeAgentAction
+  | AgentHookAssignIssueAction;
+
+export interface AgentHookRule {
+  id: string;
+  description?: string | null;
+  enabled: boolean;
+  event: AgentHookEventType | AgentHookEventType[];
+  match?: Record<string, AgentHookMatchValue>;
+  actions: AgentHookAction[];
+}
+
+export interface AgentHooksConfig {
+  enabled: boolean;
+  permissions: AgentHooksPermissions;
+  rules: AgentHookRule[];
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,6 +10,18 @@ export type {
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestResult,
 } from "./agent.js";
+export type {
+  AgentHookMatchValue,
+  AgentHooksPermissions,
+  AgentHookBaseAction,
+  AgentHookCommandAction,
+  AgentHookWebhookAction,
+  AgentHookWakeAgentAction,
+  AgentHookAssignIssueAction,
+  AgentHookAction,
+  AgentHookRule,
+  AgentHooksConfig,
+} from "./agent-hooks.js";
 export type { AssetImage } from "./asset.js";
 export type { Project, ProjectCodebase, ProjectCodebaseOrigin, ProjectGoalRef, ProjectWorkspace } from "./project.js";
 export type {

--- a/packages/shared/src/validators/agent-hooks.ts
+++ b/packages/shared/src/validators/agent-hooks.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import {
+  AGENT_HOOK_ACTION_TYPES,
+  AGENT_HOOK_EVENT_TYPES,
+  ISSUE_STATUSES,
+} from "../constants.js";
+
+const hookMatchScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
+const hookMatchValueSchema = z.union([
+  hookMatchScalarSchema,
+  z.array(hookMatchScalarSchema).min(1),
+]);
+
+const hookCommandActionSchema = z.object({
+  type: z.literal(AGENT_HOOK_ACTION_TYPES[0]),
+  command: z.string().trim().min(1),
+  args: z.array(z.string()).optional().default([]),
+  cwd: z.string().trim().min(1).optional().nullable(),
+  env: z.record(z.string()).optional().default({}),
+  timeoutSec: z.number().int().positive().optional().default(60),
+});
+
+const hookWebhookActionSchema = z.object({
+  type: z.literal(AGENT_HOOK_ACTION_TYPES[1]),
+  url: z.string().trim().min(1),
+  method: z.string().trim().min(1).optional().default("POST"),
+  headers: z.record(z.string()).optional().default({}),
+  body: z.record(z.unknown()).optional().default({}),
+  timeoutMs: z.number().int().positive().optional().default(10000),
+});
+
+const hookWakeAgentActionSchema = z.object({
+  type: z.literal(AGENT_HOOK_ACTION_TYPES[2]),
+  agentRefs: z.array(z.string().trim().min(1)).min(1),
+  reason: z.string().trim().min(1).optional().nullable(),
+  payload: z.record(z.unknown()).optional().nullable().default(null),
+  contextSnapshot: z.record(z.unknown()).optional().nullable().default(null),
+  forceFreshSession: z.boolean().optional().default(false),
+});
+
+const hookAssignIssueActionSchema = z.object({
+  type: z.literal(AGENT_HOOK_ACTION_TYPES[3]),
+  agentRef: z.string().trim().min(1),
+  issueId: z.string().trim().min(1).optional().nullable(),
+  status: z.enum(ISSUE_STATUSES).optional().nullable(),
+  wakeAssignee: z.boolean().optional().default(false),
+});
+
+export const agentHooksPermissionsSchema = z.object({
+  allowCommand: z.boolean().optional().default(false),
+  allowWebhook: z.boolean().optional().default(false),
+  allowIssueAssignment: z.boolean().optional().default(false),
+  allowedAgentRefs: z.array(z.string().trim().min(1)).optional().default([]),
+});
+
+export const agentHookActionSchema = z.discriminatedUnion("type", [
+  hookCommandActionSchema,
+  hookWebhookActionSchema,
+  hookWakeAgentActionSchema,
+  hookAssignIssueActionSchema,
+]);
+
+const hookEventSchema = z.enum(AGENT_HOOK_EVENT_TYPES);
+
+export const agentHookRuleSchema = z.object({
+  id: z.string().trim().min(1),
+  description: z.string().trim().min(1).optional().nullable(),
+  enabled: z.boolean().optional().default(true),
+  event: z.union([hookEventSchema, z.array(hookEventSchema).min(1)]),
+  match: z.record(hookMatchValueSchema).optional(),
+  actions: z.array(agentHookActionSchema).min(1),
+});
+
+export const agentHooksConfigSchema = z.object({
+  enabled: z.boolean().optional().default(true),
+  permissions: agentHooksPermissionsSchema.optional().default({}),
+  rules: z.array(agentHookRuleSchema).optional().default([]),
+});
+
+export type AgentHooksPermissions = z.infer<typeof agentHooksPermissionsSchema>;
+export type AgentHookAction = z.infer<typeof agentHookActionSchema>;
+export type AgentHookRule = z.infer<typeof agentHookRuleSchema>;
+export type AgentHooksConfig = z.infer<typeof agentHooksConfigSchema>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,4 +1,15 @@
 export {
+  agentHooksPermissionsSchema,
+  agentHookActionSchema,
+  agentHookRuleSchema,
+  agentHooksConfigSchema,
+  type AgentHooksPermissions,
+  type AgentHookAction,
+  type AgentHookRule,
+  type AgentHooksConfig,
+} from "./agent-hooks.js";
+
+export {
   instanceExperimentalSettingsSchema,
   patchInstanceExperimentalSettingsSchema,
   type InstanceExperimentalSettings,

--- a/server/src/__tests__/agent-hooks-runtime-config.test.ts
+++ b/server/src/__tests__/agent-hooks-runtime-config.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeRuntimeConfigForCreate,
+  normalizeRuntimeConfigForPatch,
+  runtimeConfigHooksDiffer,
+} from "../routes/agent-hooks-runtime-config.js";
+
+describe("agent hooks runtimeConfig normalisation", () => {
+  it("rejects hook configuration from non-board create flows", () => {
+    expect(() =>
+      normalizeRuntimeConfigForCreate({
+        runtimeConfig: {
+          hooks: {
+            rules: [],
+          },
+        },
+        allowHooksConfig: false,
+      }),
+    ).toThrowError("Only board can configure agent hooks");
+  });
+
+  it("preserves existing hooks when a non-board patch updates other runtime settings", () => {
+    const next = normalizeRuntimeConfigForPatch({
+      runtimeConfig: {
+        heartbeat: {
+          intervalSec: 300,
+        },
+      },
+      existingRuntimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowedAgentRefs: ["CTO"],
+          },
+          rules: [
+            {
+              id: "wake-cto",
+              event: "heartbeat.run.succeeded",
+              actions: [
+                {
+                  type: "wake_agent",
+                  agentRefs: ["CTO"],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      allowHooksConfig: false,
+    });
+
+    expect(next).toMatchObject({
+      heartbeat: {
+        intervalSec: 300,
+      },
+      hooks: {
+        enabled: true,
+        permissions: {
+          allowedAgentRefs: ["CTO"],
+        },
+      },
+    });
+  });
+
+  it("rejects explicit non-board hook edits on patch", () => {
+    expect(() =>
+      normalizeRuntimeConfigForPatch({
+        runtimeConfig: {
+          hooks: {
+            enabled: false,
+          },
+        },
+        existingRuntimeConfig: {
+          hooks: {
+            enabled: true,
+            permissions: {
+              allowedAgentRefs: ["CTO"],
+            },
+            rules: [],
+          },
+        },
+        allowHooksConfig: false,
+      }),
+    ).toThrowError("Only board can modify agent hook configuration");
+  });
+
+  it("canonicalises board-managed hook configs with schema defaults", () => {
+    const next = normalizeRuntimeConfigForCreate({
+      runtimeConfig: {
+        hooks: {
+          rules: [
+            {
+              id: "notify",
+              event: "heartbeat.run.finished",
+              actions: [
+                {
+                  type: "webhook",
+                  url: "https://example.test/hook",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      allowHooksConfig: true,
+    });
+
+    expect(next).toEqual({
+      hooks: {
+        enabled: true,
+        permissions: {
+          allowCommand: false,
+          allowWebhook: false,
+          allowIssueAssignment: false,
+          allowedAgentRefs: [],
+        },
+        rules: [
+          {
+            id: "notify",
+            enabled: true,
+            event: "heartbeat.run.finished",
+            actions: [
+              {
+                type: "webhook",
+                url: "https://example.test/hook",
+                method: "POST",
+                headers: {},
+                body: {},
+                timeoutMs: 10000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it("compares hook configs using canonical defaults", () => {
+    expect(
+      runtimeConfigHooksDiffer(
+        {
+          hooks: {
+            rules: [
+              {
+                id: "notify",
+                event: "heartbeat.run.finished",
+                actions: [
+                  {
+                    type: "webhook",
+                    url: "https://example.test/hook",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          hooks: {
+            enabled: true,
+            permissions: {
+              allowCommand: false,
+              allowWebhook: false,
+              allowIssueAssignment: false,
+              allowedAgentRefs: [],
+            },
+            rules: [
+              {
+                id: "notify",
+                enabled: true,
+                event: "heartbeat.run.finished",
+                actions: [
+                  {
+                    type: "webhook",
+                    url: "https://example.test/hook",
+                    method: "POST",
+                    headers: {},
+                    body: {},
+                    timeoutMs: 10000,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ),
+    ).toBe(false);
+
+    expect(
+      runtimeConfigHooksDiffer(
+        {
+          hooks: {
+            rules: [
+              {
+                id: "notify",
+                event: "heartbeat.run.finished",
+                actions: [
+                  {
+                    type: "webhook",
+                    url: "https://example.test/hook",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          hooks: {
+            rules: [
+              {
+                id: "notify",
+                event: "heartbeat.run.finished",
+                actions: [
+                  {
+                    type: "webhook",
+                    url: "https://example.test/other-hook",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ),
+    ).toBe(true);
+  });
+});

--- a/server/src/__tests__/agent-hooks.test.ts
+++ b/server/src/__tests__/agent-hooks.test.ts
@@ -1,0 +1,607 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { agents, issues } from "@paperclipai/db";
+
+const mockLogActivity = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockIssueService = vi.hoisted(() => ({
+  update: vi.fn(),
+}));
+const mockLogger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../services/issues.js", () => ({
+  issueService: () => mockIssueService,
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: mockLogger,
+}));
+
+const { runAgentHooksForEvent } = await import("../services/agent-hooks.js");
+
+type AgentRow = typeof agents.$inferSelect;
+type IssueRow = typeof issues.$inferSelect;
+
+function buildAgent(overrides: Partial<AgentRow> = {}): AgentRow {
+  return {
+    id: "agent-source",
+    companyId: "company-1",
+    name: "Benchmark Worker",
+    role: "engineer",
+    title: "Benchmark Worker",
+    icon: null,
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "process",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    permissions: {},
+    lastHeartbeatAt: null,
+    pauseReason: null,
+    pausedAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as AgentRow;
+}
+
+function buildIssue(overrides: Partial<IssueRow> = {}): IssueRow {
+  return {
+    id: "issue-1",
+    companyId: "company-1",
+    issueNumber: 1,
+    identifier: "PAP-1",
+    title: "Benchmark issue",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    goalId: null,
+    projectId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    createdByUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionLockedAt: null,
+    projectWorkspaceId: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    assigneeAdapterOverrides: null,
+    issueType: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as IssueRow;
+}
+
+function createDbMock(input: {
+  sourceAgent: AgentRow;
+  directoryAgents?: AgentRow[];
+  issuesById?: Record<string, IssueRow>;
+}): Db {
+  let agentSelectCount = 0;
+
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          if (table === agents) {
+            agentSelectCount += 1;
+            return Promise.resolve(
+              agentSelectCount === 1
+                ? [input.sourceAgent]
+                : (input.directoryAgents ?? [input.sourceAgent]),
+            );
+          }
+          if (table === issues) {
+            return Promise.resolve(Object.values(input.issuesById ?? {}));
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+  } as unknown as Db;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLogActivity.mockResolvedValue(undefined);
+  mockIssueService.update.mockReset();
+  mockLogger.warn.mockReset();
+  mockLogger.error.mockReset();
+  mockLogger.info.mockReset();
+  mockLogger.debug.mockReset();
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("runAgentHooksForEvent", () => {
+  it("wakes allow-listed target agents when a matching run succeeds", async () => {
+    const sourceAgent = buildAgent({
+      runtimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowedAgentRefs: ["CTO"],
+          },
+          rules: [
+            {
+              id: "benchmark-finished",
+              event: "heartbeat.run.succeeded",
+              match: {
+                "run.contextSnapshot.workflow": "benchmark",
+              },
+              actions: [
+                {
+                  type: "wake_agent",
+                  agentRefs: ["CTO"],
+                  reason: "benchmark_finished",
+                  payload: {
+                    issueId: "{{event.issueId}}",
+                    sourceRunId: "{{run.id}}",
+                    completedBy: "{{agent.name}}",
+                  },
+                  contextSnapshot: {
+                    issueId: "{{event.issueId}}",
+                    workflow: "{{run.contextSnapshot.workflow}}",
+                  },
+                  forceFreshSession: true,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const targetAgent = buildAgent({
+      id: "agent-cto",
+      name: "CTO",
+      role: "cto",
+      title: "CTO",
+    });
+    const wakeAgent = vi.fn().mockResolvedValue(undefined);
+    const db = createDbMock({
+      sourceAgent,
+      directoryAgents: [sourceAgent, targetAgent],
+    });
+
+    await runAgentHooksForEvent(
+      db,
+      {
+        eventType: "heartbeat.run.succeeded",
+        companyId: "company-1",
+        sourceAgentId: sourceAgent.id,
+        issueId: "issue-123",
+        run: {
+          id: "run-1",
+          status: "succeeded",
+          invocationSource: "automation",
+          triggerDetail: "callback",
+          contextSnapshot: {
+            workflow: "benchmark",
+            issueId: "issue-123",
+          },
+          usageJson: null,
+          resultJson: null,
+        },
+      },
+      { wakeAgent },
+    );
+
+    expect(wakeAgent).toHaveBeenCalledTimes(1);
+    expect(wakeAgent).toHaveBeenCalledWith(
+      "agent-cto",
+      expect.objectContaining({
+        source: "automation",
+        triggerDetail: "callback",
+        reason: "benchmark_finished",
+        payload: {
+          issueId: "issue-123",
+          sourceRunId: "run-1",
+          completedBy: "Benchmark Worker",
+        },
+        contextSnapshot: {
+          issueId: "issue-123",
+          workflow: "benchmark",
+          forceFreshSession: true,
+        },
+        requestedByActorType: "system",
+        requestedByActorId: "agent_hook:agent-source:benchmark-finished:0",
+        idempotencyKey: "hook:run-1:benchmark-finished:0:agent-cto",
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent_hook.wake_requested",
+        entityId: "agent-cto",
+        details: expect.objectContaining({
+          ruleId: "benchmark-finished",
+          targetAgentId: "agent-cto",
+          reason: "benchmark_finished",
+        }),
+      }),
+    );
+  });
+
+  it("denies command hooks unless allowCommand is enabled", async () => {
+    const sourceAgent = buildAgent({
+      runtimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowCommand: false,
+          },
+          rules: [
+            {
+              id: "run-local-script",
+              event: "heartbeat.run.finished",
+              actions: [
+                {
+                  type: "command",
+                  command: "./scripts/post-run.sh",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const db = createDbMock({ sourceAgent });
+
+    await runAgentHooksForEvent(
+      db,
+      {
+        eventType: "heartbeat.run.finished",
+        companyId: "company-1",
+        sourceAgentId: sourceAgent.id,
+        run: {
+          id: "run-2",
+          status: "succeeded",
+          invocationSource: "automation",
+          triggerDetail: "callback",
+          contextSnapshot: {},
+        },
+      },
+      { wakeAgent: vi.fn().mockResolvedValue(undefined) },
+    );
+
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent_hook.permission_denied",
+        details: expect.objectContaining({
+          ruleId: "run-local-script",
+          actionType: "command",
+          reason: "hooks.permissions.allowCommand is false",
+        }),
+      }),
+    );
+  });
+
+  it("posts webhooks with rendered payloads when enabled", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: vi.fn().mockResolvedValue("accepted"),
+    } as any);
+
+    const sourceAgent = buildAgent({
+      runtimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowWebhook: true,
+          },
+          rules: [
+            {
+              id: "notify-api",
+              event: "heartbeat.run.finished",
+              actions: [
+                {
+                  type: "webhook",
+                  url: "https://example.test/hooks/run-finished",
+                  method: "POST",
+                  headers: {
+                    "x-hook-event": "{{event.name}}",
+                  },
+                  body: {
+                    runId: "{{run.id}}",
+                    status: "{{run.status}}",
+                    issueId: "{{event.issueId}}",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const db = createDbMock({ sourceAgent });
+
+    await runAgentHooksForEvent(
+      db,
+      {
+        eventType: "heartbeat.run.finished",
+        companyId: "company-1",
+        sourceAgentId: sourceAgent.id,
+        issueId: "issue-9",
+        run: {
+          id: "run-3",
+          status: "failed",
+          invocationSource: "automation",
+          triggerDetail: "callback",
+          contextSnapshot: {},
+        },
+      },
+      { wakeAgent: vi.fn().mockResolvedValue(undefined) },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/hooks/run-finished",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "content-type": "application/json",
+          "x-hook-event": "heartbeat.run.finished",
+        }),
+        body: JSON.stringify({
+          runId: "run-3",
+          status: "failed",
+          issueId: "issue-9",
+        }),
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent_hook.webhook_succeeded",
+        details: expect.objectContaining({
+          ruleId: "notify-api",
+          url: "https://example.test/hooks/run-finished",
+          statusCode: 202,
+        }),
+      }),
+    );
+  });
+
+  it("assigns the issue to an allow-listed agent and can wake them", async () => {
+    const sourceAgent = buildAgent({
+      runtimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowIssueAssignment: true,
+            allowedAgentRefs: ["CTO"],
+          },
+          rules: [
+            {
+              id: "handoff-to-cto",
+              event: "heartbeat.run.succeeded",
+              actions: [
+                {
+                  type: "assign_issue",
+                  agentRef: "CTO",
+                  status: "in_review",
+                  wakeAssignee: true,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const targetAgent = buildAgent({
+      id: "agent-cto",
+      name: "CTO",
+      role: "cto",
+      title: "CTO",
+    });
+    const issue = buildIssue({ id: "issue-77" });
+    mockIssueService.update.mockResolvedValue({
+      id: issue.id,
+      companyId: issue.companyId,
+    });
+    const wakeAgent = vi.fn().mockResolvedValue(undefined);
+    const db = createDbMock({
+      sourceAgent,
+      directoryAgents: [sourceAgent, targetAgent],
+      issuesById: { [issue.id]: issue },
+    });
+
+    await runAgentHooksForEvent(
+      db,
+      {
+        eventType: "heartbeat.run.succeeded",
+        companyId: "company-1",
+        sourceAgentId: sourceAgent.id,
+        issueId: issue.id,
+        run: {
+          id: "run-4",
+          status: "succeeded",
+          invocationSource: "automation",
+          triggerDetail: "callback",
+          contextSnapshot: {
+            issueId: issue.id,
+          },
+        },
+      },
+      { wakeAgent },
+    );
+
+    expect(mockIssueService.update).toHaveBeenCalledWith(issue.id, {
+      assigneeAgentId: "agent-cto",
+      status: "in_review",
+    });
+    expect(wakeAgent).toHaveBeenCalledWith(
+      "agent-cto",
+      expect.objectContaining({
+        reason: "issue_assigned_by_hook",
+        payload: {
+          issueId: issue.id,
+          mutation: "hook.assign_issue",
+        },
+        contextSnapshot: {
+          issueId: issue.id,
+          source: "agent_hook.assign_issue",
+          wakeReason: "issue_assigned_by_hook",
+        },
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent_hook.issue_assigned",
+        entityType: "issue",
+        entityId: issue.id,
+      }),
+    );
+  });
+
+  it("refuses to wake the originating agent even when it is allow-listed", async () => {
+    const sourceAgent = buildAgent({
+      runtimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowedAgentRefs: ["Benchmark Worker"],
+          },
+          rules: [
+            {
+              id: "self-wake",
+              event: "heartbeat.run.succeeded",
+              actions: [
+                {
+                  type: "wake_agent",
+                  agentRefs: ["Benchmark Worker"],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const wakeAgent = vi.fn().mockResolvedValue(undefined);
+    const db = createDbMock({
+      sourceAgent,
+      directoryAgents: [sourceAgent],
+    });
+
+    await runAgentHooksForEvent(
+      db,
+      {
+        eventType: "heartbeat.run.succeeded",
+        companyId: "company-1",
+        sourceAgentId: sourceAgent.id,
+        run: {
+          id: "run-5",
+          status: "succeeded",
+          invocationSource: "automation",
+          triggerDetail: "callback",
+          contextSnapshot: {},
+        },
+      },
+      { wakeAgent },
+    );
+
+    expect(wakeAgent).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent_hook.permission_denied",
+        details: expect.objectContaining({
+          ruleId: "self-wake",
+          actionType: "wake_agent",
+          reason: "Hooks cannot wake the originating agent",
+        }),
+      }),
+    );
+  });
+
+  it("refuses to assign issues back to the originating agent", async () => {
+    const sourceAgent = buildAgent({
+      runtimeConfig: {
+        hooks: {
+          enabled: true,
+          permissions: {
+            allowIssueAssignment: true,
+            allowedAgentRefs: ["Benchmark Worker"],
+          },
+          rules: [
+            {
+              id: "self-assign",
+              event: "heartbeat.run.succeeded",
+              actions: [
+                {
+                  type: "assign_issue",
+                  agentRef: "Benchmark Worker",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const issue = buildIssue({ id: "issue-88" });
+    const db = createDbMock({
+      sourceAgent,
+      directoryAgents: [sourceAgent],
+      issuesById: { [issue.id]: issue },
+    });
+
+    await runAgentHooksForEvent(
+      db,
+      {
+        eventType: "heartbeat.run.succeeded",
+        companyId: "company-1",
+        sourceAgentId: sourceAgent.id,
+        issueId: issue.id,
+        run: {
+          id: "run-6",
+          status: "succeeded",
+          invocationSource: "automation",
+          triggerDetail: "callback",
+          contextSnapshot: {
+            issueId: issue.id,
+          },
+        },
+      },
+      { wakeAgent: vi.fn().mockResolvedValue(undefined) },
+    );
+
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent_hook.permission_denied",
+        details: expect.objectContaining({
+          ruleId: "self-assign",
+          actionType: "assign_issue",
+          reason: "Hooks cannot assign issues back to the originating agent",
+        }),
+      }),
+    );
+  });
+});

--- a/server/src/routes/agent-hooks-runtime-config.ts
+++ b/server/src/routes/agent-hooks-runtime-config.ts
@@ -1,0 +1,77 @@
+import { agentHooksConfigSchema } from "@paperclipai/shared";
+import { forbidden, unprocessable } from "../errors.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function normalizeRuntimeConfigHooks(value: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...value };
+
+  if (!Object.prototype.hasOwnProperty.call(normalized, "hooks")) {
+    return normalized;
+  }
+
+  const parsedHooks = agentHooksConfigSchema.safeParse(normalized.hooks);
+  if (!parsedHooks.success) {
+    const issue = parsedHooks.error.issues[0];
+    throw unprocessable(issue?.message ?? "Invalid runtimeConfig.hooks configuration");
+  }
+
+  normalized.hooks = parsedHooks.data;
+  return normalized;
+}
+
+function normalizedHooksForComparison(runtimeConfig: unknown): unknown {
+  const record = asRecord(runtimeConfig);
+  if (!record || !Object.prototype.hasOwnProperty.call(record, "hooks")) {
+    return null;
+  }
+
+  const parsedHooks = agentHooksConfigSchema.safeParse(record.hooks);
+  return parsedHooks.success ? parsedHooks.data : record.hooks;
+}
+
+export function runtimeConfigHooksDiffer(leftRuntimeConfig: unknown, rightRuntimeConfig: unknown): boolean {
+  return JSON.stringify(normalizedHooksForComparison(leftRuntimeConfig)) !== JSON.stringify(normalizedHooksForComparison(rightRuntimeConfig));
+}
+
+export function normalizeRuntimeConfigForCreate(input: {
+  runtimeConfig: unknown;
+  allowHooksConfig: boolean;
+}): Record<string, unknown> {
+  const runtimeConfig = asRecord(input.runtimeConfig) ?? {};
+  if (!input.allowHooksConfig && Object.prototype.hasOwnProperty.call(runtimeConfig, "hooks")) {
+    throw forbidden("Only board can configure agent hooks");
+  }
+  return normalizeRuntimeConfigHooks(runtimeConfig);
+}
+
+export function normalizeRuntimeConfigForPatch(input: {
+  runtimeConfig: unknown;
+  existingRuntimeConfig: unknown;
+  allowHooksConfig: boolean;
+}): Record<string, unknown> {
+  const runtimeConfig = asRecord(input.runtimeConfig);
+  if (!runtimeConfig) {
+    throw unprocessable("runtimeConfig must be an object");
+  }
+
+  if (!input.allowHooksConfig && Object.prototype.hasOwnProperty.call(runtimeConfig, "hooks")) {
+    throw forbidden("Only board can modify agent hook configuration");
+  }
+
+  const normalized = normalizeRuntimeConfigHooks(runtimeConfig);
+  const existingRuntimeConfig = asRecord(input.existingRuntimeConfig) ?? {};
+
+  if (
+    !input.allowHooksConfig &&
+    Object.prototype.hasOwnProperty.call(existingRuntimeConfig, "hooks") &&
+    !Object.prototype.hasOwnProperty.call(normalized, "hooks")
+  ) {
+    normalized.hooks = existingRuntimeConfig.hooks;
+  }
+
+  return normalized;
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -33,6 +33,11 @@ import {
 } from "../services/index.js";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import {
+  normalizeRuntimeConfigForCreate,
+  normalizeRuntimeConfigForPatch,
+  runtimeConfigHooksDiffer,
+} from "./agent-hooks-runtime-config.js";
 import { findServerAdapter, listAdapterModels } from "../adapters/index.js";
 import { redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
@@ -677,6 +682,17 @@ export function agentRoutes(db: Db) {
     }
     await assertCanUpdateAgent(req, existing);
 
+    const revision = await svc.getConfigRevision(id, revisionId);
+    if (!revision) {
+      res.status(404).json({ error: "Revision not found" });
+      return;
+    }
+
+    const targetRuntimeConfig = asRecord(revision.afterConfig)?.runtimeConfig;
+    if (req.actor.type !== "board" && runtimeConfigHooksDiffer(existing.runtimeConfig, targetRuntimeConfig)) {
+      throw forbidden("Only board can modify agent hook configuration");
+    }
+
     const actor = getActorInfo(req);
     const updated = await svc.rollbackConfigRevision(id, revisionId, {
       agentId: actor.agentId,
@@ -783,9 +799,14 @@ export function agentRoutes(db: Db) {
       hireInput.adapterType,
       normalizedAdapterConfig,
     );
+    const normalizedRuntimeConfig = normalizeRuntimeConfigForCreate({
+      runtimeConfig: hireInput.runtimeConfig ?? {},
+      allowHooksConfig: req.actor.type === "board",
+    });
     const normalizedHireInput = {
       ...hireInput,
       adapterConfig: normalizedAdapterConfig,
+      runtimeConfig: normalizedRuntimeConfig,
     };
 
     const company = await db
@@ -924,9 +945,15 @@ export function agentRoutes(db: Db) {
       normalizedAdapterConfig,
     );
 
+    const normalizedRuntimeConfig = normalizeRuntimeConfigForCreate({
+      runtimeConfig: req.body.runtimeConfig ?? {},
+      allowHooksConfig: req.actor.type === "board",
+    });
+
     const agent = await svc.create(companyId, {
       ...req.body,
       adapterConfig: normalizedAdapterConfig,
+      runtimeConfig: normalizedRuntimeConfig,
       status: "idle",
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,
@@ -1109,6 +1136,14 @@ export function agentRoutes(db: Db) {
         await assertCanManageInstructionsPath(req, existing);
       }
       patchData.adapterConfig = adapterConfig;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patchData, "runtimeConfig")) {
+      patchData.runtimeConfig = normalizeRuntimeConfigForPatch({
+        runtimeConfig: patchData.runtimeConfig,
+        existingRuntimeConfig: existing.runtimeConfig,
+        allowHooksConfig: req.actor.type === "board",
+      });
     }
 
     const requestedAdapterType =

--- a/server/src/services/agent-hooks.ts
+++ b/server/src/services/agent-hooks.ts
@@ -1,0 +1,905 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, issues } from "@paperclipai/db";
+import {
+  agentHooksConfigSchema,
+  normalizeAgentUrlKey,
+  type AgentHookAction,
+  type AgentHookAssignIssueAction,
+  type AgentHookCommandAction,
+  type AgentHookEventType,
+  type AgentHookRule,
+  type AgentHookWebhookAction,
+  type AgentHookWakeAgentAction,
+  type IssueStatus,
+} from "@paperclipai/shared";
+import { buildPaperclipEnv, renderTemplate } from "../adapters/utils.js";
+import { logger } from "../middleware/logger.js";
+import { logActivity } from "./activity-log.js";
+import { issueService } from "./issues.js";
+
+const execFile = promisify(execFileCallback);
+const MAX_ACTIVITY_EXCERPT_CHARS = 500;
+const DEFAULT_COMMAND_TIMEOUT_SEC = 60;
+const DEFAULT_WEBHOOK_TIMEOUT_MS = 10_000;
+
+type SourceAgent = typeof agents.$inferSelect;
+type WakeAgentFn = (
+  agentId: string,
+  opts: {
+    source: "automation";
+    triggerDetail: "system" | "callback";
+    reason?: string | null;
+    payload?: Record<string, unknown> | null;
+    idempotencyKey?: string | null;
+    requestedByActorType?: "system";
+    requestedByActorId?: string | null;
+    contextSnapshot?: Record<string, unknown>;
+  },
+) => Promise<unknown>;
+
+export interface AgentHookDispatchEvent {
+  eventType: AgentHookEventType;
+  companyId: string;
+  sourceAgentId: string;
+  occurredAt?: Date | string | null;
+  issueId?: string | null;
+  projectId?: string | null;
+  run: {
+    id: string;
+    status: string;
+    invocationSource: string;
+    triggerDetail: string | null;
+    error?: string | null;
+    errorCode?: string | null;
+    startedAt?: Date | string | null;
+    finishedAt?: Date | string | null;
+    contextSnapshot?: Record<string, unknown> | null;
+    usageJson?: Record<string, unknown> | null;
+    resultJson?: Record<string, unknown> | null;
+  };
+}
+
+interface RunAgentHooksOptions {
+  wakeAgent: WakeAgentFn;
+}
+
+interface AgentDirectoryEntry {
+  id: string;
+  companyId: string;
+  name: string;
+  status: string;
+  urlKey: string;
+}
+
+interface AgentDirectory {
+  byId: Map<string, AgentDirectoryEntry>;
+  byReference: Map<string, AgentDirectoryEntry>;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function coerceText(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
+  return null;
+}
+
+function truncateForActivity(value: unknown): string | null {
+  const text = coerceText(value);
+  if (!text) return null;
+  return text.length > MAX_ACTIVITY_EXCERPT_CHARS ? text.slice(0, MAX_ACTIVITY_EXCERPT_CHARS) : text;
+}
+
+function coerceIsoString(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function resolvePathValue(input: unknown, dottedPath: string): unknown {
+  if (!dottedPath) return input;
+  const parts = dottedPath.split(".");
+  let cursor: unknown = input;
+
+  for (const part of parts) {
+    if (!isPlainRecord(cursor)) {
+      return undefined;
+    }
+    cursor = cursor[part];
+  }
+
+  return cursor;
+}
+
+function primitiveComparable(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return null;
+}
+
+function matchExpectedValue(actual: unknown, expected: string | number | boolean): boolean {
+  if (Array.isArray(actual)) {
+    return actual.some((entry) => matchExpectedValue(entry, expected));
+  }
+  return primitiveComparable(actual) === primitiveComparable(expected);
+}
+
+function ruleMatchesTemplateData(rule: AgentHookRule, templateData: Record<string, unknown>): boolean {
+  const ruleEvents = Array.isArray(rule.event) ? rule.event : [rule.event];
+  const eventName = readNonEmptyString(resolvePathValue(templateData, "event.name"));
+  if (!eventName || !ruleEvents.includes(eventName as AgentHookEventType)) return false;
+
+  const conditions = (rule.match ?? {}) as Record<string, string | number | boolean | Array<string | number | boolean>>;
+  for (const [path, expected] of Object.entries(conditions)) {
+    const actual = resolvePathValue(templateData, path);
+    const matches = Array.isArray(expected)
+      ? expected.some((value) => matchExpectedValue(actual, value))
+      : matchExpectedValue(actual, expected);
+    if (!matches) return false;
+  }
+
+  return true;
+}
+
+function renderTemplateValue<T>(value: T, data: Record<string, unknown>): T {
+  if (typeof value === "string") {
+    return renderTemplate(value, data) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => renderTemplateValue(entry, data)) as T;
+  }
+  if (isPlainRecord(value)) {
+    const rendered: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      rendered[key] = renderTemplateValue(entry, data);
+    }
+    return rendered as T;
+  }
+  return value;
+}
+
+function buildTemplateData(
+  sourceAgent: SourceAgent,
+  event: AgentHookDispatchEvent,
+  rule: AgentHookRule,
+): Record<string, unknown> {
+  const contextSnapshot = isPlainRecord(event.run.contextSnapshot) ? event.run.contextSnapshot : {};
+  const issueId = event.issueId ?? readNonEmptyString(contextSnapshot.issueId);
+  const projectId = event.projectId ?? readNonEmptyString(contextSnapshot.projectId);
+
+  return {
+    event: {
+      name: event.eventType,
+      occurredAt: coerceIsoString(event.occurredAt) ?? new Date().toISOString(),
+      companyId: event.companyId,
+      sourceAgentId: sourceAgent.id,
+      issueId,
+      projectId,
+    },
+    agent: {
+      id: sourceAgent.id,
+      name: sourceAgent.name,
+      urlKey: normalizeAgentUrlKey(sourceAgent.name) ?? sourceAgent.id,
+      role: sourceAgent.role,
+      title: sourceAgent.title,
+      status: sourceAgent.status,
+    },
+    run: {
+      id: event.run.id,
+      status: event.run.status,
+      invocationSource: event.run.invocationSource,
+      triggerDetail: event.run.triggerDetail,
+      error: event.run.error ?? null,
+      errorCode: event.run.errorCode ?? null,
+      startedAt: coerceIsoString(event.run.startedAt),
+      finishedAt: coerceIsoString(event.run.finishedAt),
+      contextSnapshot,
+      context: contextSnapshot,
+      usageJson: event.run.usageJson ?? null,
+      resultJson: event.run.resultJson ?? null,
+      issueId,
+      projectId,
+    },
+    hook: {
+      ruleId: rule.id,
+    },
+  };
+}
+
+function buildHookRequestedById(sourceAgentId: string, ruleId: string, actionIndex: number) {
+  return `agent_hook:${sourceAgentId}:${ruleId}:${actionIndex}`;
+}
+
+async function loadSourceAgent(
+  db: Db,
+  input: Pick<AgentHookDispatchEvent, "companyId" | "sourceAgentId">,
+): Promise<SourceAgent | null> {
+  return db
+    .select()
+    .from(agents)
+    .where(and(eq(agents.id, input.sourceAgentId), eq(agents.companyId, input.companyId)))
+    .then((rows) => rows[0] ?? null);
+}
+
+async function loadAgentDirectory(db: Db, companyId: string): Promise<AgentDirectory> {
+  const rows = await db
+    .select({
+      id: agents.id,
+      companyId: agents.companyId,
+      name: agents.name,
+      status: agents.status,
+    })
+    .from(agents)
+    .where(eq(agents.companyId, companyId));
+
+  const byId = new Map<string, AgentDirectoryEntry>();
+  const byReference = new Map<string, AgentDirectoryEntry>();
+
+  for (const row of rows) {
+    const entry: AgentDirectoryEntry = {
+      ...row,
+      urlKey: normalizeAgentUrlKey(row.name) ?? row.id,
+    };
+    byId.set(entry.id, entry);
+    byReference.set(entry.id, entry);
+    byReference.set(entry.name.toLowerCase(), entry);
+    byReference.set(entry.urlKey, entry);
+  }
+
+  return { byId, byReference };
+}
+
+function resolveAgentReference(directory: AgentDirectory, reference: string): AgentDirectoryEntry | null {
+  const trimmed = reference.trim();
+  if (!trimmed) return null;
+  return directory.byReference.get(trimmed) ?? directory.byReference.get(trimmed.toLowerCase()) ?? null;
+}
+
+async function logPermissionDenied(
+  db: Db,
+  sourceAgent: SourceAgent,
+  event: AgentHookDispatchEvent,
+  ruleId: string,
+  actionType: AgentHookAction["type"],
+  detail: Record<string, unknown>,
+) {
+  await logActivity(db, {
+    companyId: event.companyId,
+    actorType: "system",
+    actorId: "agent_hook",
+    agentId: sourceAgent.id,
+    runId: event.run.id,
+    action: "agent_hook.permission_denied",
+    entityType: "agent",
+    entityId: sourceAgent.id,
+    details: {
+      hookEventType: event.eventType,
+      ruleId,
+      actionType,
+      ...detail,
+    },
+  });
+}
+
+async function executeCommandAction(
+  db: Db,
+  sourceAgent: SourceAgent,
+  event: AgentHookDispatchEvent,
+  rule: AgentHookRule,
+  action: AgentHookCommandAction,
+  templateData: Record<string, unknown>,
+) {
+  const rendered: AgentHookCommandAction = renderTemplateValue(action, templateData);
+  const env = {
+    ...buildPaperclipEnv({ id: sourceAgent.id, companyId: sourceAgent.companyId }),
+    PAPERCLIP_HOOK_EVENT: event.eventType,
+    PAPERCLIP_HOOK_RUN_ID: event.run.id,
+    ...(rendered.env ?? {}),
+  };
+
+  try {
+    const result = await execFile(rendered.command, rendered.args ?? [], {
+      cwd: rendered.cwd ?? process.cwd(),
+      env: {
+        ...process.env,
+        ...env,
+      },
+      timeout: Math.max(1, rendered.timeoutSec ?? DEFAULT_COMMAND_TIMEOUT_SEC) * 1000,
+      maxBuffer: 1024 * 1024,
+    });
+
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.command_succeeded",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        command: rendered.command,
+        args: rendered.args ?? [],
+        cwd: rendered.cwd ?? process.cwd(),
+        stdoutExcerpt: truncateForActivity(result.stdout),
+        stderrExcerpt: truncateForActivity(result.stderr),
+      },
+    });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.command_failed",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        command: rendered.command,
+        args: rendered.args ?? [],
+        cwd: rendered.cwd ?? process.cwd(),
+        error: err.message,
+        stdoutExcerpt: truncateForActivity(err.stdout),
+        stderrExcerpt: truncateForActivity(err.stderr),
+      },
+    });
+  }
+}
+
+async function executeWebhookAction(
+  db: Db,
+  sourceAgent: SourceAgent,
+  event: AgentHookDispatchEvent,
+  rule: AgentHookRule,
+  action: AgentHookWebhookAction,
+  templateData: Record<string, unknown>,
+) {
+  const rendered: AgentHookWebhookAction = renderTemplateValue(action, templateData);
+  const method = (rendered.method ?? "POST").toUpperCase();
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    Math.max(1, rendered.timeoutMs ?? DEFAULT_WEBHOOK_TIMEOUT_MS),
+  );
+
+  try {
+    const response = await fetch(rendered.url, {
+      method,
+      headers: {
+        "content-type": "application/json",
+        ...(rendered.headers ?? {}),
+      },
+      body:
+        method === "GET" || method === "HEAD"
+          ? undefined
+          : JSON.stringify(rendered.body ?? {}),
+      signal: controller.signal,
+    });
+    const responseText = truncateForActivity(await response.text().catch(() => ""));
+
+    if (!response.ok) {
+      throw new Error(`Webhook returned ${response.status}`);
+    }
+
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.webhook_succeeded",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        url: rendered.url,
+        method,
+        statusCode: response.status,
+        responseExcerpt: responseText,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.webhook_failed",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        url: rendered.url,
+        method,
+        error: message,
+      },
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function executeWakeAgentAction(
+  db: Db,
+  sourceAgent: SourceAgent,
+  event: AgentHookDispatchEvent,
+  rule: AgentHookRule,
+  action: AgentHookWakeAgentAction,
+  templateData: Record<string, unknown>,
+  directory: AgentDirectory,
+  allowedTargetIds: Set<string>,
+  wakeAgent: WakeAgentFn,
+  actionIndex: number,
+) {
+  const rendered: AgentHookWakeAgentAction = renderTemplateValue(action, templateData);
+  const renderedAgentRefs = Array.isArray(rendered.agentRefs)
+    ? rendered.agentRefs.map((value) => String(value))
+    : [];
+  const uniqueAgentRefs = [...new Set(renderedAgentRefs.map((value) => value.trim()).filter((value) => value.length > 0))];
+  const processedTargetAgentIds = new Set<string>();
+
+  for (const agentRef of uniqueAgentRefs) {
+    const targetAgent = resolveAgentReference(directory, agentRef);
+    if (!targetAgent) {
+      await logActivity(db, {
+        companyId: event.companyId,
+        actorType: "system",
+        actorId: "agent_hook",
+        agentId: sourceAgent.id,
+        runId: event.run.id,
+        action: "agent_hook.wake_failed",
+        entityType: "agent",
+        entityId: sourceAgent.id,
+        details: {
+          hookEventType: event.eventType,
+          ruleId: rule.id,
+          actionType: rendered.type,
+          agentRef,
+          error: "Target agent not found in company",
+        },
+      });
+      continue;
+    }
+
+    if (targetAgent.id === sourceAgent.id) {
+      await logPermissionDenied(db, sourceAgent, event, rule.id, rendered.type, {
+        agentRef,
+        reason: "Hooks cannot wake the originating agent",
+      });
+      continue;
+    }
+
+    if (!allowedTargetIds.has(targetAgent.id)) {
+      await logPermissionDenied(db, sourceAgent, event, rule.id, rendered.type, {
+        agentRef,
+        targetAgentId: targetAgent.id,
+        reason: "Target agent is not allow-listed for hooks.permissions.allowedAgentRefs",
+      });
+      continue;
+    }
+
+    if (processedTargetAgentIds.has(targetAgent.id)) {
+      continue;
+    }
+    processedTargetAgentIds.add(targetAgent.id);
+
+    try {
+      const contextSnapshot = isPlainRecord(rendered.contextSnapshot)
+        ? { ...rendered.contextSnapshot }
+        : {};
+      if (rendered.forceFreshSession) {
+        contextSnapshot.forceFreshSession = true;
+      }
+
+      await wakeAgent(targetAgent.id, {
+        source: "automation",
+        triggerDetail: "callback",
+        reason: rendered.reason ?? event.eventType,
+        payload: isPlainRecord(rendered.payload) ? rendered.payload : null,
+        contextSnapshot,
+        requestedByActorType: "system",
+        requestedByActorId: buildHookRequestedById(sourceAgent.id, rule.id, actionIndex),
+        idempotencyKey: `hook:${event.run.id}:${rule.id}:${actionIndex}:${targetAgent.id}`,
+      });
+
+      await logActivity(db, {
+        companyId: event.companyId,
+        actorType: "system",
+        actorId: "agent_hook",
+        agentId: sourceAgent.id,
+        runId: event.run.id,
+        action: "agent_hook.wake_requested",
+        entityType: "agent",
+        entityId: targetAgent.id,
+        details: {
+          hookEventType: event.eventType,
+          ruleId: rule.id,
+          actionType: rendered.type,
+          targetAgentId: targetAgent.id,
+          targetAgentName: targetAgent.name,
+          reason: rendered.reason ?? event.eventType,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await logActivity(db, {
+        companyId: event.companyId,
+        actorType: "system",
+        actorId: "agent_hook",
+        agentId: sourceAgent.id,
+        runId: event.run.id,
+        action: "agent_hook.wake_failed",
+        entityType: "agent",
+        entityId: targetAgent.id,
+        details: {
+          hookEventType: event.eventType,
+          ruleId: rule.id,
+          actionType: rendered.type,
+          targetAgentId: targetAgent.id,
+          targetAgentName: targetAgent.name,
+          error: message,
+        },
+      });
+    }
+  }
+}
+
+async function executeAssignIssueAction(
+  db: Db,
+  sourceAgent: SourceAgent,
+  event: AgentHookDispatchEvent,
+  rule: AgentHookRule,
+  action: AgentHookAssignIssueAction,
+  templateData: Record<string, unknown>,
+  directory: AgentDirectory,
+  allowedTargetIds: Set<string>,
+  wakeAgent: WakeAgentFn,
+  actionIndex: number,
+) {
+  const rendered: AgentHookAssignIssueAction = renderTemplateValue(action, templateData);
+  const renderedAgentRef = readNonEmptyString(rendered.agentRef);
+  if (!renderedAgentRef) {
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.issue_assignment_failed",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        error: "assign_issue rendered an empty agentRef",
+      },
+    });
+    return;
+  }
+
+  const targetAgent = resolveAgentReference(directory, renderedAgentRef);
+  if (!targetAgent) {
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.issue_assignment_failed",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        agentRef: renderedAgentRef,
+        error: "Target agent not found in company",
+      },
+    });
+    return;
+  }
+
+  if (targetAgent.id === sourceAgent.id) {
+    await logPermissionDenied(db, sourceAgent, event, rule.id, rendered.type, {
+      agentRef: renderedAgentRef,
+      reason: "Hooks cannot assign issues back to the originating agent",
+    });
+    return;
+  }
+
+  if (!allowedTargetIds.has(targetAgent.id)) {
+    await logPermissionDenied(db, sourceAgent, event, rule.id, rendered.type, {
+      agentRef: renderedAgentRef,
+      targetAgentId: targetAgent.id,
+      reason: "Target agent is not allow-listed for hooks.permissions.allowedAgentRefs",
+    });
+    return;
+  }
+
+  const eventIssueId = readNonEmptyString(resolvePathValue(templateData, "event.issueId"));
+  const issueId = readNonEmptyString(rendered.issueId) ?? eventIssueId;
+  if (!issueId) {
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.issue_assignment_failed",
+      entityType: "agent",
+      entityId: sourceAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        targetAgentId: targetAgent.id,
+        error: "No issueId available for assign_issue action",
+      },
+    });
+    return;
+  }
+
+  const issuesSvc = issueService(db);
+  let updatedIssue: Awaited<ReturnType<typeof issuesSvc.update>> | null = null;
+
+  try {
+    const issueRow = await db
+      .select({ id: issues.id, companyId: issues.companyId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    if (!issueRow || issueRow.companyId !== event.companyId) {
+      throw new Error("Issue not found in company");
+    }
+
+    updatedIssue = await issuesSvc.update(issueId, {
+      assigneeAgentId: targetAgent.id,
+      ...(rendered.status ? { status: rendered.status as IssueStatus } : {}),
+    });
+
+    if (!updatedIssue || updatedIssue.companyId !== event.companyId) {
+      throw new Error("Issue not found in company");
+    }
+
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.issue_assigned",
+      entityType: "issue",
+      entityId: updatedIssue.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        issueId: updatedIssue.id,
+        targetAgentId: targetAgent.id,
+        targetAgentName: targetAgent.name,
+        status: rendered.status ?? null,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.issue_assignment_failed",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        targetAgentId: targetAgent.id,
+        targetAgentName: targetAgent.name,
+        error: message,
+      },
+    });
+    return;
+  }
+
+  if (!rendered.wakeAssignee || !updatedIssue) {
+    return;
+  }
+
+  try {
+    await wakeAgent(targetAgent.id, {
+      source: "automation",
+      triggerDetail: "callback",
+      reason: "issue_assigned_by_hook",
+      payload: { issueId: updatedIssue.id, mutation: "hook.assign_issue" },
+      contextSnapshot: {
+        issueId: updatedIssue.id,
+        source: "agent_hook.assign_issue",
+        wakeReason: "issue_assigned_by_hook",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: buildHookRequestedById(sourceAgent.id, rule.id, actionIndex),
+      idempotencyKey: `hook:${event.run.id}:${rule.id}:${actionIndex}:${updatedIssue.id}:${targetAgent.id}`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await logActivity(db, {
+      companyId: event.companyId,
+      actorType: "system",
+      actorId: "agent_hook",
+      agentId: sourceAgent.id,
+      runId: event.run.id,
+      action: "agent_hook.wake_failed",
+      entityType: "agent",
+      entityId: targetAgent.id,
+      details: {
+        hookEventType: event.eventType,
+        ruleId: rule.id,
+        actionType: rendered.type,
+        issueId: updatedIssue.id,
+        targetAgentId: targetAgent.id,
+        targetAgentName: targetAgent.name,
+        error: message,
+      },
+    });
+  }
+}
+
+export async function runAgentHooksForEvent(
+  db: Db,
+  event: AgentHookDispatchEvent,
+  options: RunAgentHooksOptions,
+): Promise<void> {
+  const sourceAgent = await loadSourceAgent(db, event);
+  if (!sourceAgent) return;
+
+  const runtimeConfig = isPlainRecord(sourceAgent.runtimeConfig) ? sourceAgent.runtimeConfig : {};
+  const hooksRaw = runtimeConfig.hooks;
+  if (!hooksRaw) return;
+
+  const parsedHooks = agentHooksConfigSchema.safeParse(hooksRaw);
+  if (!parsedHooks.success) {
+    logger.warn(
+      { companyId: event.companyId, sourceAgentId: event.sourceAgentId, issues: parsedHooks.error.issues },
+      "agent hook config is invalid at dispatch time",
+    );
+    return;
+  }
+
+  const hooks = parsedHooks.data;
+  if (!hooks.enabled || hooks.rules.length === 0) return;
+
+  let directoryPromise: Promise<AgentDirectory> | null = null;
+  let allowedTargetIdsPromise: Promise<Set<string>> | null = null;
+
+  const getDirectory = () => {
+    if (!directoryPromise) directoryPromise = loadAgentDirectory(db, event.companyId);
+    return directoryPromise;
+  };
+
+  const getAllowedTargetIds = async () => {
+    if (!allowedTargetIdsPromise) {
+      allowedTargetIdsPromise = (async () => {
+        const directory = await getDirectory();
+        const ids = new Set<string>();
+        for (const reference of hooks.permissions.allowedAgentRefs) {
+          const targetAgent = resolveAgentReference(directory, reference);
+          if (targetAgent) ids.add(targetAgent.id);
+        }
+        return ids;
+      })();
+    }
+    return allowedTargetIdsPromise;
+  };
+
+  for (const rule of hooks.rules) {
+    if (!rule.enabled) continue;
+
+    const templateData = buildTemplateData(sourceAgent, event, rule);
+    if (!ruleMatchesTemplateData(rule, templateData)) continue;
+
+    for (const [actionIndex, action] of rule.actions.entries()) {
+      try {
+        if (action.type === "command") {
+          if (!hooks.permissions.allowCommand) {
+            await logPermissionDenied(db, sourceAgent, event, rule.id, action.type, {
+              reason: "hooks.permissions.allowCommand is false",
+            });
+            continue;
+          }
+          await executeCommandAction(db, sourceAgent, event, rule, action, templateData);
+          continue;
+        }
+
+        if (action.type === "webhook") {
+          if (!hooks.permissions.allowWebhook) {
+            await logPermissionDenied(db, sourceAgent, event, rule.id, action.type, {
+              reason: "hooks.permissions.allowWebhook is false",
+            });
+            continue;
+          }
+          await executeWebhookAction(db, sourceAgent, event, rule, action, templateData);
+          continue;
+        }
+
+        const directory = await getDirectory();
+        const allowedTargetIds = await getAllowedTargetIds();
+
+        if (action.type === "wake_agent") {
+          await executeWakeAgentAction(
+            db,
+            sourceAgent,
+            event,
+            rule,
+            action,
+            templateData,
+            directory,
+            allowedTargetIds,
+            options.wakeAgent,
+            actionIndex,
+          );
+          continue;
+        }
+
+        if (!hooks.permissions.allowIssueAssignment) {
+          await logPermissionDenied(db, sourceAgent, event, rule.id, action.type, {
+            reason: "hooks.permissions.allowIssueAssignment is false",
+          });
+          continue;
+        }
+
+        await executeAssignIssueAction(
+          db,
+          sourceAgent,
+          event,
+          rule,
+          action,
+          templateData,
+          directory,
+          allowedTargetIds,
+          options.wakeAgent,
+          actionIndex,
+        );
+      } catch (error) {
+        logger.warn(
+          {
+            err: error,
+            companyId: event.companyId,
+            sourceAgentId: event.sourceAgentId,
+            runId: event.run.id,
+            hookEventType: event.eventType,
+            ruleId: rule.id,
+            actionType: action.type,
+          },
+          "agent hook action failed unexpectedly",
+        );
+      }
+    }
+  }
+}

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -12,7 +12,7 @@ import {
   heartbeatRunEvents,
   heartbeatRuns,
 } from "@paperclipai/db";
-import { isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
+import { agentHooksConfigSchema, isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { normalizeAgentPermissions } from "./agent-permissions.js";
 import { REDACTED_EVENT_VALUE, sanitizeRecord } from "../redaction.js";
@@ -97,6 +97,23 @@ function buildConfigSnapshot(
     budgetMonthlyCents: row.budgetMonthlyCents,
     metadata,
   };
+}
+
+function normalizeRuntimeConfigValue(value: unknown): Record<string, unknown> {
+  const normalized = isPlainRecord(value) ? { ...value } : {};
+
+  if (!Object.prototype.hasOwnProperty.call(normalized, "hooks")) {
+    return normalized;
+  }
+
+  const parsedHooks = agentHooksConfigSchema.safeParse(normalized.hooks);
+  if (!parsedHooks.success) {
+    const issue = parsedHooks.error.issues[0];
+    throw unprocessable(issue?.message ?? "Invalid runtimeConfig.hooks configuration");
+  }
+
+  normalized.hooks = parsedHooks.data;
+  return normalized;
 }
 
 function containsRedactedMarker(value: unknown): boolean {
@@ -335,6 +352,9 @@ export function agentService(db: Db) {
       const role = (data.role ?? existing.role) as string;
       normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
     }
+    if (Object.prototype.hasOwnProperty.call(data, "runtimeConfig")) {
+      normalizedPatch.runtimeConfig = normalizeRuntimeConfigValue(data.runtimeConfig);
+    }
 
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
     const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
@@ -394,9 +414,17 @@ export function agentService(db: Db) {
 
       const role = data.role ?? "general";
       const normalizedPermissions = normalizeAgentPermissions(data.permissions, role);
+      const normalizedRuntimeConfig = normalizeRuntimeConfigValue(data.runtimeConfig);
       const created = await db
         .insert(agents)
-        .values({ ...data, name: uniqueName, companyId, role, permissions: normalizedPermissions })
+        .values({
+          ...data,
+          name: uniqueName,
+          companyId,
+          role,
+          permissions: normalizedPermissions,
+          runtimeConfig: normalizedRuntimeConfig,
+        })
         .returning()
         .then((rows) => rows[0]);
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -41,6 +41,7 @@ import {
 import { issueService } from "./issues.js";
 import { executionWorkspaceService } from "./execution-workspaces.js";
 import { workspaceOperationService } from "./workspace-operations.js";
+import { runAgentHooksForEvent } from "./agent-hooks.js";
 import {
   buildExecutionWorkspaceAdapterConfig,
   gateProjectExecutionWorkspacePolicy,
@@ -1236,6 +1237,60 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0]);
   }
 
+  async function dispatchHookEventsForRunStatus(run: typeof heartbeatRuns.$inferSelect) {
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const eventTypes =
+      run.status === "running"
+        ? (["heartbeat.run.started"] as const)
+        : run.status === "succeeded"
+          ? (["heartbeat.run.finished", "heartbeat.run.succeeded"] as const)
+          : run.status === "failed"
+            ? (["heartbeat.run.finished", "heartbeat.run.failed"] as const)
+            : run.status === "cancelled"
+              ? (["heartbeat.run.finished", "heartbeat.run.cancelled"] as const)
+              : run.status === "timed_out"
+                ? (["heartbeat.run.finished", "heartbeat.run.timed_out"] as const)
+                : ([] as const);
+
+    if (eventTypes.length === 0) return;
+
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const projectId = readNonEmptyString(contextSnapshot.projectId);
+    const usageJson = parseObject(run.usageJson);
+    const summarizedResult = summarizeHeartbeatRunResultJson(run.resultJson);
+    const resultJson = summarizedResult ?? parseObject(run.resultJson);
+
+    for (const eventType of eventTypes) {
+      await runAgentHooksForEvent(
+        db,
+        {
+          eventType,
+          companyId: run.companyId,
+          sourceAgentId: run.agentId,
+          occurredAt: run.finishedAt ?? run.startedAt ?? run.updatedAt,
+          issueId,
+          projectId,
+          run: {
+            id: run.id,
+            status: run.status,
+            invocationSource: run.invocationSource,
+            triggerDetail: run.triggerDetail,
+            error: run.error ?? null,
+            errorCode: run.errorCode ?? null,
+            startedAt: run.startedAt,
+            finishedAt: run.finishedAt,
+            contextSnapshot,
+            usageJson: Object.keys(usageJson).length > 0 ? usageJson : null,
+            resultJson: Object.keys(resultJson).length > 0 ? resultJson : null,
+          },
+        },
+        {
+          wakeAgent: enqueueWakeup,
+        },
+      );
+    }
+  }
+
   async function setRunStatus(
     runId: string,
     status: string,
@@ -1263,6 +1318,9 @@ export function heartbeatService(db: Db) {
           startedAt: updated.startedAt ? new Date(updated.startedAt).toISOString() : null,
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
+      });
+      void dispatchHookEventsForRunStatus(updated).catch((err) => {
+        logger.warn({ err, runId: updated.id, status: updated.status }, "agent hook dispatch failed");
       });
     }
 
@@ -1395,6 +1453,9 @@ export function heartbeatService(db: Db) {
         startedAt: claimed.startedAt ? new Date(claimed.startedAt).toISOString() : null,
         finishedAt: claimed.finishedAt ? new Date(claimed.finishedAt).toISOString() : null,
       },
+    });
+    void dispatchHookEventsForRunStatus(claimed).catch((err) => {
+      logger.warn({ err, runId: claimed.id, status: claimed.status }, "agent hook dispatch failed");
     });
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });


### PR DESCRIPTION
## Summary

Adds a first-class declarative heartbeat hooks system so agents can trigger follow-on automation from heartbeat lifecycle events without changing the existing scheduler or wakeup flows.

This includes:
- shared hook event/action constants, types, and validators
- server-side hook dispatch/execution for `command`, `webhook`, `wake_agent`, and `assign_issue`
- hook dispatch from heartbeat run status transitions
- board-managed runtime config normalization and protections for hook edits/rollbacks
- focused tests for hook execution and runtime config behavior
- docs updates across API docs, runtime docs, guides, README, and specs

## Verification

Passed:
- `pnpm -r typecheck`
- `pnpm build`
- new hook tests in `server/src/__tests__/agent-hooks.test.ts`
- new hook config tests in `server/src/__tests__/agent-hooks-runtime-config.test.ts`

`pnpm test:run` still fails in this repo for unrelated pre-existing issues:
- `server/src/__tests__/app-hmr-port.test.ts` (`@paperclipai/plugin-sdk` package entry resolution failure)
- `server/src/__tests__/plugin-worker-manager.test.ts` (same `@paperclipai/plugin-sdk` resolution failure)
- `server/src/__tests__/cursor-local-adapter-environment.test.ts` (timeout)
- `server/src/__tests__/workspace-runtime.test.ts` (timeout)
- `packages/db/src/client.test.ts` (embedded Postgres init/migration failure)
