### PR TITLE
Redesign issue detail page layout and comment UX

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -49,6 +49,8 @@ interface CommentThreadProps {
   mentions?: MentionOption[];
   /** Timestamp of the user's last interaction with the issue. Comments from others after this are "unread". */
   myLastTouchAt?: Date | string | null;
+  /** Current user's ID, used to determine which comments are "unread" (not authored by this user). */
+  currentUserId?: string | null;
 }
 
 const CLOSED_STATUSES = new Set(["done", "cancelled"]);
@@ -127,6 +129,7 @@ const TimelineList = memo(function TimelineList({
   projectId,
   highlightCommentId,
   unreadAfterMs,
+  currentUserId,
 }: {
   timeline: TimelineItem[];
   agentMap?: Map<string, Agent>;
@@ -135,6 +138,8 @@ const TimelineList = memo(function TimelineList({
   highlightCommentId?: string | null;
   /** Epoch ms: comments from others created after this time get an unread dot. */
   unreadAfterMs?: number | null;
+  /** Current user's ID — comments authored by this user are never marked unread. */
+  currentUserId?: string | null;
 }) {
   if (timeline.length === 0) {
     return <p className="text-sm text-muted-foreground">No comments or runs yet.</p>;
@@ -178,7 +183,7 @@ const TimelineList = memo(function TimelineList({
         // and was created after the user's last interaction with the issue.
         const isUnread = Boolean(
           unreadAfterMs &&
-          !comment.authorUserId &&
+          comment.authorUserId !== currentUserId &&
           item.createdAtMs > unreadAfterMs
         );
         return (
@@ -288,6 +293,7 @@ export function CommentThread({
   currentAssigneeValue = "",
   mentions: providedMentions,
   myLastTouchAt,
+  currentUserId,
 }: CommentThreadProps) {
   const unreadAfterMs = useMemo(() => {
     if (!myLastTouchAt) return null;
@@ -446,7 +452,7 @@ export function CommentThread({
               <input
                 ref={attachInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif"
+                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf,.pdf,text/markdown,.md,.markdown"
                 className="hidden"
                 onChange={handleAttachFile}
               />
@@ -455,7 +461,7 @@ export function CommentThread({
                 size="icon-sm"
                 onClick={() => attachInputRef.current?.click()}
                 disabled={attaching}
-                title="Attach image"
+                title="Attach file"
               >
                 <Paperclip className="h-4 w-4" />
               </Button>
@@ -523,6 +529,7 @@ export function CommentThread({
         projectId={projectId}
         highlightCommentId={highlightCommentId}
         unreadAfterMs={unreadAfterMs}
+        currentUserId={currentUserId}
       />
 
       {liveRunSlot}

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type ChangeEvent } from "re
 import { Link, useLocation } from "react-router-dom";
 import type { IssueComment, Agent } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
-import { Check, Copy, Paperclip } from "lucide-react";
+import { ArrowDownUp, Check, Copy, Paperclip } from "lucide-react";
 import { Identity } from "./Identity";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
 import { MarkdownBody } from "./MarkdownBody";
@@ -47,6 +47,8 @@ interface CommentThreadProps {
   reassignOptions?: InlineEntityOption[];
   currentAssigneeValue?: string;
   mentions?: MentionOption[];
+  /** Timestamp of the user's last interaction with the issue. Comments from others after this are "unread". */
+  myLastTouchAt?: Date | string | null;
 }
 
 const CLOSED_STATUSES = new Set(["done", "cancelled"]);
@@ -124,12 +126,15 @@ const TimelineList = memo(function TimelineList({
   companyId,
   projectId,
   highlightCommentId,
+  unreadAfterMs,
 }: {
   timeline: TimelineItem[];
   agentMap?: Map<string, Agent>;
   companyId?: string | null;
   projectId?: string | null;
   highlightCommentId?: string | null;
+  /** Epoch ms: comments from others created after this time get an unread dot. */
+  unreadAfterMs?: number | null;
 }) {
   if (timeline.length === 0) {
     return <p className="text-sm text-muted-foreground">No comments or runs yet.</p>;
@@ -169,6 +174,13 @@ const TimelineList = memo(function TimelineList({
 
         const comment = item.comment;
         const isHighlighted = highlightCommentId === comment.id;
+        // A comment is "unread" if it's from someone other than the current user
+        // and was created after the user's last interaction with the issue.
+        const isUnread = Boolean(
+          unreadAfterMs &&
+          !comment.authorUserId &&
+          item.createdAtMs > unreadAfterMs
+        );
         return (
           <div
             key={comment.id}
@@ -176,16 +188,21 @@ const TimelineList = memo(function TimelineList({
             className={`border p-3 overflow-hidden min-w-0 rounded-sm transition-colors duration-1000 ${isHighlighted ? "border-primary/50 bg-primary/5" : "border-border"}`}
           >
             <div className="flex items-center justify-between mb-1">
-              {comment.authorAgentId ? (
-                <Link to={`/agents/${comment.authorAgentId}`} className="hover:underline">
-                  <Identity
-                    name={agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)}
-                    size="sm"
-                  />
-                </Link>
-              ) : (
-                <Identity name="You" size="sm" />
-              )}
+              <div className="flex items-center gap-1.5">
+                {isUnread && (
+                  <span className="block h-2 w-2 rounded-full bg-blue-600 dark:bg-blue-400 shrink-0" />
+                )}
+                {comment.authorAgentId ? (
+                  <Link to={`/agents/${comment.authorAgentId}`} className="hover:underline">
+                    <Identity
+                      name={agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)}
+                      size="sm"
+                    />
+                  </Link>
+                ) : (
+                  <Identity name="You" size="sm" />
+                )}
+              </div>
               <span className="flex items-center gap-1.5">
                 {companyId ? (
                   <PluginSlotOutlet
@@ -270,13 +287,19 @@ export function CommentThread({
   reassignOptions = [],
   currentAssigneeValue = "",
   mentions: providedMentions,
+  myLastTouchAt,
 }: CommentThreadProps) {
+  const unreadAfterMs = useMemo(() => {
+    if (!myLastTouchAt) return null;
+    return new Date(myLastTouchAt).getTime();
+  }, [myLastTouchAt]);
   const [body, setBody] = useState("");
   const [reopen, setReopen] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [attaching, setAttaching] = useState(false);
   const [reassignTarget, setReassignTarget] = useState(currentAssigneeValue);
   const [highlightCommentId, setHighlightCommentId] = useState<string | null>(null);
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const editorRef = useRef<MarkdownEditorRef>(null);
   const attachInputRef = useRef<HTMLInputElement | null>(null);
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -298,12 +321,13 @@ export function CommentThread({
       createdAtMs: new Date(run.startedAt ?? run.createdAt).getTime(),
       run,
     }));
+    const dir = sortOrder === "asc" ? 1 : -1;
     return [...commentItems, ...runItems].sort((a, b) => {
-      if (a.createdAtMs !== b.createdAtMs) return a.createdAtMs - b.createdAtMs;
-      if (a.kind === b.kind) return a.id.localeCompare(b.id);
-      return a.kind === "comment" ? -1 : 1;
+      if (a.createdAtMs !== b.createdAtMs) return (a.createdAtMs - b.createdAtMs) * dir;
+      if (a.kind === b.kind) return a.id.localeCompare(b.id) * dir;
+      return (a.kind === "comment" ? -1 : 1) * dir;
     });
-  }, [comments, linkedRuns]);
+  }, [comments, linkedRuns, sortOrder]);
 
   // Build mention options from agent map (exclude terminated agents)
   const mentions = useMemo<MentionOption[]>(() => {
@@ -392,17 +416,18 @@ export function CommentThread({
 
   return (
     <div className="space-y-4">
-      <h3 className="text-sm font-semibold">Comments &amp; Runs ({timeline.length})</h3>
-
-      <TimelineList
-        timeline={timeline}
-        agentMap={agentMap}
-        companyId={companyId}
-        projectId={projectId}
-        highlightCommentId={highlightCommentId}
-      />
-
-      {liveRunSlot}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Comments &amp; Runs ({timeline.length})</h3>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 text-xs text-muted-foreground"
+          onClick={() => setSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
+        >
+          <ArrowDownUp className="h-3.5 w-3.5" />
+          {sortOrder === "desc" ? "Newest first" : "Oldest first"}
+        </Button>
+      </div>
 
       <div className="space-y-2">
         <MarkdownEditor
@@ -490,6 +515,17 @@ export function CommentThread({
           </Button>
         </div>
       </div>
+
+      <TimelineList
+        timeline={timeline}
+        agentMap={agentMap}
+        companyId={companyId}
+        projectId={projectId}
+        highlightCommentId={highlightCommentId}
+        unreadAfterMs={unreadAfterMs}
+      />
+
+      {liveRunSlot}
     </div>
   );
 }

--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Issue, IssueDocument } from "@paperclipai/shared";
 import { useLocation } from "@/lib/router";
@@ -39,15 +39,17 @@ const DOCUMENT_AUTOSAVE_DEBOUNCE_MS = 900;
 const DOCUMENT_KEY_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
 const getFoldedDocumentsStorageKey = (issueId: string) => `paperclip:issue-document-folds:${issueId}`;
 
-function loadFoldedDocumentKeys(issueId: string) {
-  if (typeof window === "undefined") return [];
+const NO_STORED_PREFERENCE = Symbol("no-stored-preference");
+
+function loadFoldedDocumentKeys(issueId: string): string[] | typeof NO_STORED_PREFERENCE {
+  if (typeof window === "undefined") return NO_STORED_PREFERENCE;
   try {
     const raw = window.localStorage.getItem(getFoldedDocumentsStorageKey(issueId));
-    if (!raw) return [];
+    if (!raw) return NO_STORED_PREFERENCE;
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : NO_STORED_PREFERENCE;
   } catch {
-    return [];
+    return NO_STORED_PREFERENCE;
   }
 }
 
@@ -84,26 +86,40 @@ function downloadDocumentFile(key: string, body: string) {
   URL.revokeObjectURL(url);
 }
 
-export function IssueDocumentsSection({
-  issue,
-  canDeleteDocuments,
-  mentions,
-  imageUploadHandler,
-  extraActions,
-}: {
+export interface IssueDocumentsSectionHandle {
+  beginNewDocument: () => void;
+}
+
+export const IssueDocumentsSection = forwardRef<IssueDocumentsSectionHandle, {
   issue: Issue;
   canDeleteDocuments: boolean;
   mentions?: MentionOption[];
   imageUploadHandler?: (file: File) => Promise<string>;
   extraActions?: ReactNode;
-}) {
+  /** When true, hides the "New document" and extra action buttons. The section is only rendered when documents exist. */
+  hideActions?: boolean;
+  /** When true, all documents start collapsed unless the user has explicitly expanded them. */
+  defaultCollapsed?: boolean;
+}>(function IssueDocumentsSection({
+  issue,
+  canDeleteDocuments,
+  mentions,
+  imageUploadHandler,
+  extraActions,
+  hideActions = false,
+  defaultCollapsed = false,
+}, ref) {
   const queryClient = useQueryClient();
   const location = useLocation();
   const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [draft, setDraft] = useState<DraftState | null>(null);
   const [documentConflict, setDocumentConflict] = useState<DocumentConflictState | null>(null);
-  const [foldedDocumentKeys, setFoldedDocumentKeys] = useState<string[]>(() => loadFoldedDocumentKeys(issue.id));
+  const [hasStoredPreference] = useState(() => loadFoldedDocumentKeys(issue.id) !== NO_STORED_PREFERENCE);
+  const [foldedDocumentKeys, setFoldedDocumentKeys] = useState<string[]>(() => {
+    const stored = loadFoldedDocumentKeys(issue.id);
+    return stored === NO_STORED_PREFERENCE ? [] : stored;
+  });
   const [autosaveDocumentKey, setAutosaveDocumentKey] = useState<string | null>(null);
   const [copiedDocumentKey, setCopiedDocumentKey] = useState<string | null>(null);
   const [highlightDocumentKey, setHighlightDocumentKey] = useState<string | null>(null);
@@ -186,6 +202,8 @@ export function IssueDocumentsSection({
     });
     setError(null);
   };
+
+  useImperativeHandle(ref, () => ({ beginNewDocument }), []);
 
   const beginEdit = (key: string) => {
     const doc = sortedDocuments.find((entry) => entry.key === key);
@@ -415,23 +433,29 @@ export function IssueDocumentsSection({
   };
 
   useEffect(() => {
-    setFoldedDocumentKeys(loadFoldedDocumentKeys(issue.id));
+    const stored = loadFoldedDocumentKeys(issue.id);
+    setFoldedDocumentKeys(stored === NO_STORED_PREFERENCE ? [] : stored);
   }, [issue.id]);
 
   useEffect(() => {
     hasScrolledToHashRef.current = false;
   }, [issue.id, location.hash]);
 
+  // When defaultCollapsed and no stored user preference, fold all documents.
+  // Also prune folded keys that reference deleted documents.
   useEffect(() => {
     const validKeys = new Set(sortedDocuments.map((doc) => doc.key));
     setFoldedDocumentKeys((current) => {
+      if (defaultCollapsed && !hasStoredPreference && sortedDocuments.length > 0) {
+        return sortedDocuments.map((doc) => doc.key);
+      }
       const next = current.filter((key) => validKeys.has(key));
       if (next.length !== current.length) {
         saveFoldedDocumentKeys(issue.id, next);
       }
       return next;
     });
-  }, [issue.id, sortedDocuments]);
+  }, [issue.id, sortedDocuments, defaultCollapsed, hasStoredPreference]);
 
   useEffect(() => {
     saveFoldedDocumentKeys(issue.id, foldedDocumentKeys);
@@ -516,9 +540,17 @@ export function IssueDocumentsSection({
     );
   };
 
+  // When actions are hidden and there's nothing to show, render nothing.
+  if (hideActions && isEmpty && !draft?.isNew) return null;
+
   return (
     <div className="space-y-3">
-      {isEmpty && !draft?.isNew ? (
+      {hideActions ? (
+        /* Actions hidden — just show the "Documents" heading when there are documents */
+        !isEmpty || draft?.isNew ? (
+          <h3 className="text-sm font-medium text-muted-foreground">Documents</h3>
+        ) : null
+      ) : isEmpty && !draft?.isNew ? (
         <div className="flex items-center justify-end gap-2">
           {extraActions}
           <Button variant="outline" size="sm" onClick={beginNewDocument}>
@@ -886,4 +918,4 @@ export function IssueDocumentsSection({
       </div>
     </div>
   );
-}
+});

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -781,7 +781,7 @@ export function IssueDetail() {
         <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
           <TabsList variant="line" className="w-full justify-start gap-1">
             <TabsTrigger value="comments" className="gap-1.5">
-              Comments{comments ? ` (${comments.length})` : ""}
+              Comments{comments ? ` (${comments.length + (timelineRuns?.length ?? 0)})` : ""}
             </TabsTrigger>
             <TabsTrigger value="subissues" className="gap-1.5">
               Sub-issues{childIssues.length > 0 ? ` (${childIssues.length})` : ""}
@@ -831,6 +831,7 @@ export function IssueDetail() {
                 }
               }}
               myLastTouchAt={issue.myLastTouchAt}
+              currentUserId={currentUserId}
               liveRunSlot={<LiveRunWidget issueId={issueId!} companyId={issue.companyId} />}
             />
           </TabsContent>
@@ -880,31 +881,32 @@ export function IssueDetail() {
               defaultCollapsed
             />
 
-            {hasAttachments ? (
-              <div
-                className={cn(
-                  "space-y-3 rounded-lg transition-colors mt-4",
-                )}
-                onDragEnter={(evt) => {
-                  evt.preventDefault();
-                  setAttachmentDragActive(true);
-                }}
-                onDragOver={(evt) => {
-                  evt.preventDefault();
-                  setAttachmentDragActive(true);
-                }}
-                onDragLeave={(evt) => {
-                  if (evt.currentTarget.contains(evt.relatedTarget as Node | null)) return;
-                  setAttachmentDragActive(false);
-                }}
-                onDrop={(evt) => void handleAttachmentDrop(evt)}
-              >
-                <h3 className="text-sm font-medium text-muted-foreground">Attachments</h3>
+            <div
+              className={cn(
+                "space-y-3 rounded-lg transition-colors mt-4",
+                attachmentDragActive && "ring-2 ring-primary/40 bg-primary/5",
+              )}
+              onDragEnter={(evt) => {
+                evt.preventDefault();
+                setAttachmentDragActive(true);
+              }}
+              onDragOver={(evt) => {
+                evt.preventDefault();
+                setAttachmentDragActive(true);
+              }}
+              onDragLeave={(evt) => {
+                if (evt.currentTarget.contains(evt.relatedTarget as Node | null)) return;
+                setAttachmentDragActive(false);
+              }}
+              onDrop={(evt) => void handleAttachmentDrop(evt)}
+            >
+              <h3 className="text-sm font-medium text-muted-foreground">Attachments</h3>
 
-                {attachmentError && (
-                  <p className="text-xs text-destructive">{attachmentError}</p>
-                )}
+              {attachmentError && (
+                <p className="text-xs text-destructive">{attachmentError}</p>
+              )}
 
+              {hasAttachments ? (
                 <div className="space-y-2">
                   {attachmentList.map((attachment) => (
                     <div key={attachment.id} className="border border-border rounded-md p-2">
@@ -944,8 +946,12 @@ export function IssueDetail() {
                     </div>
                   ))}
                 </div>
-              </div>
-            ) : null}
+              ) : (
+                <p className="text-xs text-muted-foreground py-4 text-center border border-dashed border-border rounded-md">
+                  Drop files here to attach them to this issue.
+                </p>
+              )}
+            </div>
           </TabsContent>
 
           <TabsContent value="activity">

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ChangeEvent, type DragEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { issuesApi } from "../api/issues";
@@ -17,7 +17,7 @@ import { useProjectOrder } from "../hooks/useProjectOrder";
 import { relativeTime, cn, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { InlineEditor } from "../components/InlineEditor";
 import { CommentThread } from "../components/CommentThread";
-import { IssueDocumentsSection } from "../components/IssueDocumentsSection";
+import { IssueDocumentsSection, type IssueDocumentsSectionHandle } from "../components/IssueDocumentsSection";
 import { IssueProperties } from "../components/IssueProperties";
 import { LiveRunWidget } from "../components/LiveRunWidget";
 import type { MentionOption } from "../components/MarkdownEditor";
@@ -28,7 +28,7 @@ import { StatusBadge } from "../components/StatusBadge";
 import { Identity } from "../components/Identity";
 import { PluginSlotMount, PluginSlotOutlet, usePluginSlots } from "@/plugins/slots";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
-import { Separator } from "@/components/ui/separator";
+
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -36,17 +36,11 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
-  Activity as ActivityIcon,
-  Check,
   ChevronDown,
   ChevronRight,
   Copy,
   EyeOff,
-  Hexagon,
-  ListTree,
-  MessageSquare,
   MoreHorizontal,
-  Paperclip,
   SlidersHorizontal,
   Trash2,
 } from "lucide-react";
@@ -194,7 +188,6 @@ function ActorIdentity({ evt, agentMap }: { evt: ActivityEvent; agentMap: Map<st
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
   const { selectedCompanyId } = useCompany();
-  const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -210,7 +203,7 @@ export function IssueDetail() {
   });
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [attachmentDragActive, setAttachmentDragActive] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const documentsRef = useRef<IssueDocumentsSectionHandle>(null);
   const lastMarkedReadIssueIdRef = useRef<string | null>(null);
 
   const { data: issue, isLoading, error } = useQuery({
@@ -581,14 +574,11 @@ export function IssueDetail() {
     markIssueRead.mutate(issue.id);
   }, [issue?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Close any previously opened panel (this page renders properties inline now)
+  const { closePanel } = usePanel();
   useEffect(() => {
-    if (issue) {
-      openPanel(
-        <IssueProperties issue={issue} onUpdate={(data) => updateIssue.mutate(data)} />
-      );
-    }
-    return () => closePanel();
-  }, [issue]); // eslint-disable-line react-hooks/exhaustive-deps
+    closePanel();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const copyIssueToClipboard = async () => {
     if (!issue) return;
@@ -612,20 +602,6 @@ export function IssueDetail() {
 
   // Ancestors are returned oldest-first from the server (root at end, immediate parent at start)
   const ancestors = issue.ancestors ?? [];
-  const handleFilePicked = async (evt: ChangeEvent<HTMLInputElement>) => {
-    const files = evt.target.files;
-    if (!files || files.length === 0) return;
-    for (const file of Array.from(files)) {
-      if (isMarkdownFile(file)) {
-        await importMarkdownDocument.mutateAsync(file);
-      } else {
-        await uploadAttachment.mutateAsync(file);
-      }
-    }
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
 
   const handleAttachmentDrop = async (evt: DragEvent<HTMLDivElement>) => {
     evt.preventDefault();
@@ -644,522 +620,450 @@ export function IssueDetail() {
   const isImageAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("image/");
   const attachmentList = attachments ?? [];
   const hasAttachments = attachmentList.length > 0;
-  const attachmentUploadButton = (
-    <>
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*,application/pdf,text/plain,text/markdown,application/json,text/csv,text/html,.md,.markdown"
-        className="hidden"
-        onChange={handleFilePicked}
-        multiple
-      />
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={uploadAttachment.isPending || importMarkdownDocument.isPending}
-        className={cn(
-          "shadow-none",
-          attachmentDragActive && "border-primary bg-primary/5",
-        )}
-      >
-        <Paperclip className="h-3.5 w-3.5 mr-1.5" />
-        {uploadAttachment.isPending || importMarkdownDocument.isPending ? "Uploading..." : "Upload attachment"}
-      </Button>
-    </>
-  );
 
   return (
-    <div className="max-w-2xl space-y-6">
-      {/* Parent chain breadcrumb */}
-      {ancestors.length > 0 && (
-        <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">
-          {[...ancestors].reverse().map((ancestor, i) => (
-            <span key={ancestor.id} className="flex items-center gap-1">
-              {i > 0 && <ChevronRight className="h-3 w-3 shrink-0" />}
-              <Link
-                to={`/issues/${ancestor.identifier ?? ancestor.id}`}
-                state={location.state}
-                className="hover:text-foreground transition-colors truncate max-w-[200px]"
-                title={ancestor.title}
-              >
-                {ancestor.title}
-              </Link>
-            </span>
-          ))}
-          <ChevronRight className="h-3 w-3 shrink-0" />
-          <span className="text-foreground/60 truncate max-w-[200px]">{issue.title}</span>
-        </nav>
-      )}
-
-      {issue.hiddenAt && (
-        <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          <EyeOff className="h-4 w-4 shrink-0" />
-          This issue is hidden
-        </div>
-      )}
-
-      <div className="space-y-3">
-        <div className="flex items-center gap-2 min-w-0 flex-wrap">
-          <StatusIcon
-            status={issue.status}
-            onChange={(status) => updateIssue.mutate({ status })}
-          />
-          <PriorityIcon
-            priority={issue.priority}
-            onChange={(priority) => updateIssue.mutate({ priority })}
-          />
-          <span className="text-sm font-mono text-muted-foreground shrink-0">{issue.identifier ?? issue.id.slice(0, 8)}</span>
-
-          {hasLiveRuns && (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400 shrink-0">
-              <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-cyan-400" />
-              </span>
-              Live
-            </span>
-          )}
-
-          {issue.projectId ? (
-            <Link
-              to={`/projects/${issue.projectId}`}
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded px-1 -mx-1 py-0.5 min-w-0"
-            >
-              <Hexagon className="h-3 w-3 shrink-0" />
-              <span className="truncate">{(projects ?? []).find((p) => p.id === issue.projectId)?.name ?? issue.projectId.slice(0, 8)}</span>
-            </Link>
-          ) : (
-            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground opacity-50 px-1 -mx-1 py-0.5">
-              <Hexagon className="h-3 w-3 shrink-0" />
-              No project
-            </span>
-          )}
-
-          {(issue.labels ?? []).length > 0 && (
-            <div className="hidden sm:flex items-center gap-1">
-              {(issue.labels ?? []).slice(0, 4).map((label) => (
-                <span
-                  key={label.id}
-                  className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium"
-                  style={{
-                    borderColor: label.color,
-                    color: label.color,
-                    backgroundColor: `${label.color}1f`,
-                  }}
+    <div className="flex gap-8">
+      {/* ── Left column: main content ── */}
+      <div className="flex-1 min-w-0 space-y-6">
+        {/* Parent chain breadcrumb */}
+        {ancestors.length > 0 && (
+          <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">
+            {[...ancestors].reverse().map((ancestor, i) => (
+              <span key={ancestor.id} className="flex items-center gap-1">
+                {i > 0 && <ChevronRight className="h-3 w-3 shrink-0" />}
+                <Link
+                  to={`/issues/${ancestor.identifier ?? ancestor.id}`}
+                  state={location.state}
+                  className="hover:text-foreground transition-colors truncate max-w-[200px]"
+                  title={ancestor.title}
                 >
-                  {label.name}
-                </span>
-              ))}
-              {(issue.labels ?? []).length > 4 && (
-                <span className="text-[10px] text-muted-foreground">+{(issue.labels ?? []).length - 4}</span>
-              )}
-            </div>
-          )}
+                  {ancestor.title}
+                </Link>
+              </span>
+            ))}
+            <ChevronRight className="h-3 w-3 shrink-0" />
+            <span className="text-foreground/60 truncate max-w-[200px]">{issue.title}</span>
+          </nav>
+        )}
 
-          <div className="ml-auto flex items-center gap-0.5 md:hidden shrink-0">
+        {issue.hiddenAt && (
+          <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <EyeOff className="h-4 w-4 shrink-0" />
+            This issue is hidden
+          </div>
+        )}
+
+        {/* Header: title + meta */}
+        <div className="space-y-2">
+          <InlineEditor
+            value={issue.title}
+            onSave={(title) => updateIssue.mutateAsync({ title })}
+            as="h2"
+            className="text-2xl font-bold"
+          />
+          <div className="flex items-center gap-2 flex-wrap text-sm">
+            <span className="font-mono text-xs text-muted-foreground bg-accent/40 border border-border rounded px-1.5 py-0.5">{issue.identifier ?? issue.id.slice(0, 8)}</span>
+            <StatusIcon
+              status={issue.status}
+              onChange={(status) => updateIssue.mutate({ status })}
+            />
+
+            {hasLiveRuns && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400 shrink-0">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-cyan-400" />
+                </span>
+                Live
+              </span>
+            )}
+
+            <span className="text-xs text-muted-foreground">
+              Created {relativeTime(issue.createdAt)}
+              {issue.createdByUserId ? " by you" : issue.createdByAgentId ? ` by ${agentMap.get(issue.createdByAgentId)?.name ?? issue.createdByAgentId.slice(0, 8)}` : ""}
+            </span>
+
             <Button
               variant="ghost"
               size="icon-xs"
-              onClick={copyIssueToClipboard}
-              title="Copy issue as markdown"
-            >
-              {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-xs"
+              className="ml-auto lg:hidden shrink-0"
               onClick={() => setMobilePropsOpen(true)}
               title="Properties"
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-            </Button>
-          </div>
-
-          <div className="hidden md:flex items-center md:ml-auto shrink-0">
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={copyIssueToClipboard}
-              title="Copy issue as markdown"
-            >
-              {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              className={cn(
-                "shrink-0 transition-opacity duration-200",
-                panelVisible ? "opacity-0 pointer-events-none w-0 overflow-hidden" : "opacity-100",
-              )}
-              onClick={() => setPanelVisible(true)}
-              title="Show properties"
             >
               <SlidersHorizontal className="h-4 w-4" />
             </Button>
 
             <Popover open={moreOpen} onOpenChange={setMoreOpen}>
               <PopoverTrigger asChild>
-                <Button variant="ghost" size="icon-xs" className="shrink-0">
+                <Button variant="ghost" size="icon-xs" className="shrink-0 lg:ml-auto">
                   <MoreHorizontal className="h-4 w-4" />
                 </Button>
               </PopoverTrigger>
-            <PopoverContent className="w-44 p-1" align="end">
-              <button
-                className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
-                onClick={() => {
-                  updateIssue.mutate(
-                    { hiddenAt: new Date().toISOString() },
-                    { onSuccess: () => navigate("/issues/all") },
-                  );
-                  setMoreOpen(false);
-                }}
-              >
-                <EyeOff className="h-3 w-3" />
-                Hide this Issue
-              </button>
-            </PopoverContent>
+              <PopoverContent className="w-44 p-1" align="end">
+                <button
+                  className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
+                  onClick={() => {
+                    updateIssue.mutate(
+                      { hiddenAt: new Date().toISOString() },
+                      { onSuccess: () => navigate("/issues/all") },
+                    );
+                    setMoreOpen(false);
+                  }}
+                >
+                  <EyeOff className="h-3 w-3" />
+                  Hide this Issue
+                </button>
+              </PopoverContent>
             </Popover>
           </div>
         </div>
 
-        <InlineEditor
-          value={issue.title}
-          onSave={(title) => updateIssue.mutateAsync({ title })}
-          as="h2"
-          className="text-xl font-bold"
-        />
-
-        <InlineEditor
-          value={issue.description ?? ""}
-          onSave={(description) => updateIssue.mutateAsync({ description })}
-          as="p"
-          className="text-[15px] leading-7 text-foreground"
-          placeholder="Add a description..."
-          multiline
-          mentions={mentionOptions}
-          imageUploadHandler={async (file) => {
-            const attachment = await uploadAttachment.mutateAsync(file);
-            return attachment.contentPath;
-          }}
-        />
-      </div>
-
-      <PluginSlotOutlet
-        slotTypes={["toolbarButton", "contextMenuItem"]}
-        entityType="issue"
-        context={{
-          companyId: issue.companyId,
-          projectId: issue.projectId ?? null,
-          entityId: issue.id,
-          entityType: "issue",
-        }}
-        className="flex flex-wrap gap-2"
-        itemClassName="inline-flex"
-        missingBehavior="placeholder"
-      />
-
-      <PluginLauncherOutlet
-        placementZones={["toolbarButton"]}
-        entityType="issue"
-        context={{
-          companyId: issue.companyId,
-          projectId: issue.projectId ?? null,
-          entityId: issue.id,
-          entityType: "issue",
-        }}
-        className="flex flex-wrap gap-2"
-        itemClassName="inline-flex"
-      />
-
-      <PluginSlotOutlet
-        slotTypes={["taskDetailView"]}
-        entityType="issue"
-        context={{
-          companyId: issue.companyId,
-          projectId: issue.projectId ?? null,
-          entityId: issue.id,
-          entityType: "issue",
-        }}
-        className="space-y-3"
-        itemClassName="rounded-lg border border-border p-3"
-        missingBehavior="placeholder"
-      />
-
-      <IssueDocumentsSection
-        issue={issue}
-        canDeleteDocuments={Boolean(session?.user?.id)}
-        mentions={mentionOptions}
-        imageUploadHandler={async (file) => {
-          const attachment = await uploadAttachment.mutateAsync(file);
-          return attachment.contentPath;
-        }}
-        extraActions={!hasAttachments ? attachmentUploadButton : undefined}
-      />
-
-      {hasAttachments ? (
-        <div
-        className={cn(
-          "space-y-3 rounded-lg transition-colors",
-        )}
-        onDragEnter={(evt) => {
-          evt.preventDefault();
-          setAttachmentDragActive(true);
-        }}
-        onDragOver={(evt) => {
-          evt.preventDefault();
-          setAttachmentDragActive(true);
-        }}
-        onDragLeave={(evt) => {
-          if (evt.currentTarget.contains(evt.relatedTarget as Node | null)) return;
-          setAttachmentDragActive(false);
-        }}
-        onDrop={(evt) => void handleAttachmentDrop(evt)}
-      >
-        <div className="flex items-center justify-between gap-2">
-          <h3 className="text-sm font-medium text-muted-foreground">Attachments</h3>
-          {attachmentUploadButton}
-        </div>
-
-        {attachmentError && (
-          <p className="text-xs text-destructive">{attachmentError}</p>
-        )}
-
-        <div className="space-y-2">
-          {attachmentList.map((attachment) => (
-            <div key={attachment.id} className="border border-border rounded-md p-2">
-              <div className="flex items-center justify-between gap-2">
-                <a
-                  href={attachment.contentPath}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-xs hover:underline truncate"
-                  title={attachment.originalFilename ?? attachment.id}
-                >
-                  {attachment.originalFilename ?? attachment.id}
-                </a>
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-destructive"
-                  onClick={() => deleteAttachment.mutate(attachment.id)}
-                  disabled={deleteAttachment.isPending}
-                  title="Delete attachment"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </div>
-              <p className="text-[11px] text-muted-foreground">
-                {attachment.contentType} · {(attachment.byteSize / 1024).toFixed(1)} KB
-              </p>
-              {isImageAttachment(attachment) && (
-                <a href={attachment.contentPath} target="_blank" rel="noreferrer">
-                  <img
-                    src={attachment.contentPath}
-                    alt={attachment.originalFilename ?? "attachment"}
-                    className="mt-2 max-h-56 rounded border border-border object-contain bg-accent/10"
-                    loading="lazy"
-                  />
-                </a>
-              )}
-            </div>
-          ))}
-        </div>
-        </div>
-      ) : null}
-
-      <Separator />
-
-      <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
-        <TabsList variant="line" className="w-full justify-start gap-1">
-          <TabsTrigger value="comments" className="gap-1.5">
-            <MessageSquare className="h-3.5 w-3.5" />
-            Comments
-          </TabsTrigger>
-          <TabsTrigger value="subissues" className="gap-1.5">
-            <ListTree className="h-3.5 w-3.5" />
-            Sub-issues
-          </TabsTrigger>
-          <TabsTrigger value="activity" className="gap-1.5">
-            <ActivityIcon className="h-3.5 w-3.5" />
-            Activity
-          </TabsTrigger>
-          {issuePluginTabItems.map((item) => (
-            <TabsTrigger key={item.value} value={item.value}>
-              {item.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-
-        <TabsContent value="comments">
-          <CommentThread
-            comments={commentsWithRunMeta}
-            linkedRuns={timelineRuns}
-            companyId={issue.companyId}
-            projectId={issue.projectId}
-            issueStatus={issue.status}
-            agentMap={agentMap}
-            draftKey={`paperclip:issue-comment-draft:${issue.id}`}
-            enableReassign
-            reassignOptions={commentReassignOptions}
-            currentAssigneeValue={currentAssigneeValue}
+        {/* Description card */}
+        <div className="rounded-lg border border-border p-5 space-y-3">
+          <h3 className="text-base font-semibold">Description</h3>
+          <InlineEditor
+            value={issue.description ?? ""}
+            onSave={(description) => updateIssue.mutateAsync({ description })}
+            as="p"
+            className="text-[15px] leading-7 text-foreground"
+            placeholder="Add a description..."
+            multiline
             mentions={mentionOptions}
-            onAdd={async (body, reopen, reassignment) => {
-              if (reassignment) {
-                await addCommentAndReassign.mutateAsync({ body, reopen, reassignment });
-                return;
-              }
-              await addComment.mutateAsync({ body, reopen });
-            }}
             imageUploadHandler={async (file) => {
               const attachment = await uploadAttachment.mutateAsync(file);
               return attachment.contentPath;
             }}
-            onAttachImage={async (file) => {
-              await uploadAttachment.mutateAsync(file);
-            }}
-            liveRunSlot={<LiveRunWidget issueId={issueId!} companyId={issue.companyId} />}
           />
-        </TabsContent>
+        </div>
 
-        <TabsContent value="subissues">
-          {childIssues.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No sub-issues.</p>
-          ) : (
-            <div className="border border-border rounded-lg divide-y divide-border">
-              {childIssues.map((child) => (
-                <Link
-                  key={child.id}
-                  to={`/issues/${child.identifier ?? child.id}`}
-                  state={location.state}
-                  className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <StatusIcon status={child.status} />
-                    <PriorityIcon priority={child.priority} />
-                    <span className="font-mono text-muted-foreground shrink-0">
-                      {child.identifier ?? child.id.slice(0, 8)}
-                    </span>
-                    <span className="truncate">{child.title}</span>
-                  </div>
-                  {child.assigneeAgentId && (() => {
-                    const name = agentMap.get(child.assigneeAgentId)?.name;
-                    return name
-                      ? <Identity name={name} size="sm" />
-                      : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
-                  })()}
-                </Link>
-              ))}
-            </div>
-          )}
-        </TabsContent>
+        <PluginSlotOutlet
+          slotTypes={["toolbarButton", "contextMenuItem"]}
+          entityType="issue"
+          context={{
+            companyId: issue.companyId,
+            projectId: issue.projectId ?? null,
+            entityId: issue.id,
+            entityType: "issue",
+          }}
+          className="flex flex-wrap gap-2"
+          itemClassName="inline-flex"
+          missingBehavior="placeholder"
+        />
 
-        <TabsContent value="activity">
-          {!activity || activity.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No activity yet.</p>
-          ) : (
-            <div className="space-y-1.5">
-              {activity.slice(0, 20).map((evt) => (
-                <div key={evt.id} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <ActorIdentity evt={evt} agentMap={agentMap} />
-                  <span>{formatAction(evt.action, evt.details)}</span>
-                  <span className="ml-auto shrink-0">{relativeTime(evt.createdAt)}</span>
-                </div>
-              ))}
-            </div>
-          )}
-        </TabsContent>
+        <PluginLauncherOutlet
+          placementZones={["toolbarButton"]}
+          entityType="issue"
+          context={{
+            companyId: issue.companyId,
+            projectId: issue.projectId ?? null,
+            entityId: issue.id,
+            entityType: "issue",
+          }}
+          className="flex flex-wrap gap-2"
+          itemClassName="inline-flex"
+        />
 
-        {activePluginTab && (
-          <TabsContent value={activePluginTab.value}>
-            <PluginSlotMount
-              slot={activePluginTab.slot}
-              context={{
-                companyId: issue.companyId,
-                projectId: issue.projectId ?? null,
-                entityId: issue.id,
-                entityType: "issue",
+        <PluginSlotOutlet
+          slotTypes={["taskDetailView"]}
+          entityType="issue"
+          context={{
+            companyId: issue.companyId,
+            projectId: issue.projectId ?? null,
+            entityId: issue.id,
+            entityType: "issue",
+          }}
+          className="space-y-3"
+          itemClassName="rounded-lg border border-border p-3"
+          missingBehavior="placeholder"
+        />
+
+        {/* Tabs: Comments / Sub-issues / Documents / Activity */}
+        <Tabs value={detailTab} onValueChange={setDetailTab} className="space-y-3">
+          <TabsList variant="line" className="w-full justify-start gap-1">
+            <TabsTrigger value="comments" className="gap-1.5">
+              Comments{comments ? ` (${comments.length})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="subissues" className="gap-1.5">
+              Sub-issues{childIssues.length > 0 ? ` (${childIssues.length})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="documents" className="gap-1.5">
+              Documents
+            </TabsTrigger>
+            <TabsTrigger value="activity" className="gap-1.5">
+              Activity
+            </TabsTrigger>
+            {issuePluginTabItems.map((item) => (
+              <TabsTrigger key={item.value} value={item.value}>
+                {item.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          <TabsContent value="comments">
+            <CommentThread
+              comments={commentsWithRunMeta}
+              linkedRuns={timelineRuns}
+              companyId={issue.companyId}
+              projectId={issue.projectId}
+              issueStatus={issue.status}
+              agentMap={agentMap}
+              draftKey={`paperclip:issue-comment-draft:${issue.id}`}
+              enableReassign
+              reassignOptions={commentReassignOptions}
+              currentAssigneeValue={currentAssigneeValue}
+              mentions={mentionOptions}
+              onAdd={async (body, reopen, reassignment) => {
+                if (reassignment) {
+                  await addCommentAndReassign.mutateAsync({ body, reopen, reassignment });
+                  return;
+                }
+                await addComment.mutateAsync({ body, reopen });
               }}
-              missingBehavior="placeholder"
+              imageUploadHandler={async (file) => {
+                const attachment = await uploadAttachment.mutateAsync(file);
+                return attachment.contentPath;
+              }}
+              onAttachImage={async (file) => {
+                if (isMarkdownFile(file)) {
+                  await importMarkdownDocument.mutateAsync(file);
+                } else {
+                  await uploadAttachment.mutateAsync(file);
+                }
+              }}
+              myLastTouchAt={issue.myLastTouchAt}
+              liveRunSlot={<LiveRunWidget issueId={issueId!} companyId={issue.companyId} />}
             />
           </TabsContent>
-        )}
-      </Tabs>
 
-      {linkedApprovals && linkedApprovals.length > 0 && (
-        <Collapsible
-          open={secondaryOpen.approvals}
-          onOpenChange={(open) => setSecondaryOpen((prev) => ({ ...prev, approvals: open }))}
-          className="rounded-lg border border-border"
-        >
-          <CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2 text-left">
-            <span className="text-sm font-medium text-muted-foreground">
-              Linked Approvals ({linkedApprovals.length})
-            </span>
-            <ChevronDown
-              className={cn("h-4 w-4 text-muted-foreground transition-transform", secondaryOpen.approvals && "rotate-180")}
-            />
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="border-t border-border divide-y divide-border">
-              {linkedApprovals.map((approval) => (
-                <Link
-                  key={approval.id}
-                  to={`/approvals/${approval.id}`}
-                  className="flex items-center justify-between px-3 py-2 text-xs hover:bg-accent/20 transition-colors"
-                >
-                  <div className="flex items-center gap-2">
-                    <StatusBadge status={approval.status} />
-                    <span className="font-medium">
-                      {approval.type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
-                    </span>
-                    <span className="font-mono text-muted-foreground">{approval.id.slice(0, 8)}</span>
-                  </div>
-                  <span className="text-muted-foreground">{relativeTime(approval.createdAt)}</span>
-                </Link>
-              ))}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+          <TabsContent value="subissues">
+            {childIssues.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No sub-issues.</p>
+            ) : (
+              <div className="border border-border rounded-lg divide-y divide-border">
+                {childIssues.map((child) => (
+                  <Link
+                    key={child.id}
+                    to={`/issues/${child.identifier ?? child.id}`}
+                    state={location.state}
+                    className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <StatusIcon status={child.status} />
+                      <PriorityIcon priority={child.priority} />
+                      <span className="font-mono text-muted-foreground shrink-0">
+                        {child.identifier ?? child.id.slice(0, 8)}
+                      </span>
+                      <span className="truncate">{child.title}</span>
+                    </div>
+                    {child.assigneeAgentId && (() => {
+                      const name = agentMap.get(child.assigneeAgentId)?.name;
+                      return name
+                        ? <Identity name={name} size="sm" />
+                        : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
+                    })()}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </TabsContent>
 
-      {linkedRuns && linkedRuns.length > 0 && (
-        <Collapsible
-          open={secondaryOpen.cost}
-          onOpenChange={(open) => setSecondaryOpen((prev) => ({ ...prev, cost: open }))}
-          className="rounded-lg border border-border"
-        >
-          <CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2 text-left">
-            <span className="text-sm font-medium text-muted-foreground">Cost Summary</span>
-            <ChevronDown
-              className={cn("h-4 w-4 text-muted-foreground transition-transform", secondaryOpen.cost && "rotate-180")}
+          <TabsContent value="documents">
+            <IssueDocumentsSection
+              ref={documentsRef}
+              issue={issue}
+              canDeleteDocuments={Boolean(session?.user?.id)}
+              mentions={mentionOptions}
+              imageUploadHandler={async (file) => {
+                const attachment = await uploadAttachment.mutateAsync(file);
+                return attachment.contentPath;
+              }}
+              defaultCollapsed
             />
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="border-t border-border px-3 py-2">
-              {!issueCostSummary.hasCost && !issueCostSummary.hasTokens ? (
-                <div className="text-xs text-muted-foreground">No cost data yet.</div>
-              ) : (
-                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground tabular-nums">
-                  {issueCostSummary.hasCost && (
-                    <span className="font-medium text-foreground">
-                      ${issueCostSummary.cost.toFixed(4)}
-                    </span>
-                  )}
-                  {issueCostSummary.hasTokens && (
-                    <span>
-                      Tokens {formatTokens(issueCostSummary.totalTokens)}
-                      {issueCostSummary.cached > 0
-                        ? ` (in ${formatTokens(issueCostSummary.input)}, out ${formatTokens(issueCostSummary.output)}, cached ${formatTokens(issueCostSummary.cached)})`
-                        : ` (in ${formatTokens(issueCostSummary.input)}, out ${formatTokens(issueCostSummary.output)})`}
-                    </span>
-                  )}
+
+            {hasAttachments ? (
+              <div
+                className={cn(
+                  "space-y-3 rounded-lg transition-colors mt-4",
+                )}
+                onDragEnter={(evt) => {
+                  evt.preventDefault();
+                  setAttachmentDragActive(true);
+                }}
+                onDragOver={(evt) => {
+                  evt.preventDefault();
+                  setAttachmentDragActive(true);
+                }}
+                onDragLeave={(evt) => {
+                  if (evt.currentTarget.contains(evt.relatedTarget as Node | null)) return;
+                  setAttachmentDragActive(false);
+                }}
+                onDrop={(evt) => void handleAttachmentDrop(evt)}
+              >
+                <h3 className="text-sm font-medium text-muted-foreground">Attachments</h3>
+
+                {attachmentError && (
+                  <p className="text-xs text-destructive">{attachmentError}</p>
+                )}
+
+                <div className="space-y-2">
+                  {attachmentList.map((attachment) => (
+                    <div key={attachment.id} className="border border-border rounded-md p-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <a
+                          href={attachment.contentPath}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-xs hover:underline truncate"
+                          title={attachment.originalFilename ?? attachment.id}
+                        >
+                          {attachment.originalFilename ?? attachment.id}
+                        </a>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-destructive"
+                          onClick={() => deleteAttachment.mutate(attachment.id)}
+                          disabled={deleteAttachment.isPending}
+                          title="Delete attachment"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                      <p className="text-[11px] text-muted-foreground">
+                        {attachment.contentType} · {(attachment.byteSize / 1024).toFixed(1)} KB
+                      </p>
+                      {isImageAttachment(attachment) && (
+                        <a href={attachment.contentPath} target="_blank" rel="noreferrer">
+                          <img
+                            src={attachment.contentPath}
+                            alt={attachment.originalFilename ?? "attachment"}
+                            className="mt-2 max-h-56 rounded border border-border object-contain bg-accent/10"
+                            loading="lazy"
+                          />
+                        </a>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              )}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+              </div>
+            ) : null}
+          </TabsContent>
+
+          <TabsContent value="activity">
+            {!activity || activity.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No activity yet.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {activity.slice(0, 20).map((evt) => (
+                  <div key={evt.id} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <ActorIdentity evt={evt} agentMap={agentMap} />
+                    <span>{formatAction(evt.action, evt.details)}</span>
+                    <span className="ml-auto shrink-0">{relativeTime(evt.createdAt)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+
+          {activePluginTab && (
+            <TabsContent value={activePluginTab.value}>
+              <PluginSlotMount
+                slot={activePluginTab.slot}
+                context={{
+                  companyId: issue.companyId,
+                  projectId: issue.projectId ?? null,
+                  entityId: issue.id,
+                  entityType: "issue",
+                }}
+                missingBehavior="placeholder"
+              />
+            </TabsContent>
+          )}
+        </Tabs>
+
+        {linkedApprovals && linkedApprovals.length > 0 && (
+          <Collapsible
+            open={secondaryOpen.approvals}
+            onOpenChange={(open) => setSecondaryOpen((prev) => ({ ...prev, approvals: open }))}
+            className="rounded-lg border border-border"
+          >
+            <CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2 text-left">
+              <span className="text-sm font-medium text-muted-foreground">
+                Linked Approvals ({linkedApprovals.length})
+              </span>
+              <ChevronDown
+                className={cn("h-4 w-4 text-muted-foreground transition-transform", secondaryOpen.approvals && "rotate-180")}
+              />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="border-t border-border divide-y divide-border">
+                {linkedApprovals.map((approval) => (
+                  <Link
+                    key={approval.id}
+                    to={`/approvals/${approval.id}`}
+                    className="flex items-center justify-between px-3 py-2 text-xs hover:bg-accent/20 transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      <StatusBadge status={approval.status} />
+                      <span className="font-medium">
+                        {approval.type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                      </span>
+                      <span className="font-mono text-muted-foreground">{approval.id.slice(0, 8)}</span>
+                    </div>
+                    <span className="text-muted-foreground">{relativeTime(approval.createdAt)}</span>
+                  </Link>
+                ))}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+
+        {linkedRuns && linkedRuns.length > 0 && (
+          <Collapsible
+            open={secondaryOpen.cost}
+            onOpenChange={(open) => setSecondaryOpen((prev) => ({ ...prev, cost: open }))}
+            className="rounded-lg border border-border"
+          >
+            <CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2 text-left">
+              <span className="text-sm font-medium text-muted-foreground">Cost Summary</span>
+              <ChevronDown
+                className={cn("h-4 w-4 text-muted-foreground transition-transform", secondaryOpen.cost && "rotate-180")}
+              />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="border-t border-border px-3 py-2">
+                {!issueCostSummary.hasCost && !issueCostSummary.hasTokens ? (
+                  <div className="text-xs text-muted-foreground">No cost data yet.</div>
+                ) : (
+                  <div className="flex flex-wrap gap-3 text-xs text-muted-foreground tabular-nums">
+                    {issueCostSummary.hasCost && (
+                      <span className="font-medium text-foreground">
+                        ${issueCostSummary.cost.toFixed(4)}
+                      </span>
+                    )}
+                    {issueCostSummary.hasTokens && (
+                      <span>
+                        Tokens {formatTokens(issueCostSummary.totalTokens)}
+                        {issueCostSummary.cached > 0
+                          ? ` (in ${formatTokens(issueCostSummary.input)}, out ${formatTokens(issueCostSummary.output)}, cached ${formatTokens(issueCostSummary.cached)})`
+                          : ` (in ${formatTokens(issueCostSummary.input)}, out ${formatTokens(issueCostSummary.output)})`}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+      </div>
+
+      {/* ── Right column: sidebar (hidden on mobile, shown on lg+) ── */}
+      <aside className="hidden lg:block w-72 xl:w-80 shrink-0">
+        <div className="sticky top-6 space-y-4">
+          <div className="rounded-lg border border-border p-4">
+            <IssueProperties issue={issue} onUpdate={(data) => updateIssue.mutate(data)} />
+          </div>
+        </div>
+      </aside>
 
       {/* Mobile properties drawer */}
       <Sheet open={mobilePropsOpen} onOpenChange={setMobilePropsOpen}>


### PR DESCRIPTION
## Thinking

The issue page is a core feature used to check status and communicate with agents. The previous design had several UX pain points:

- **Scroll fatigue**: Users had to scroll to the very bottom of the page to see the latest agent activity and leave new comments. For an issue with a long comment history, this made it hard to quickly parse what is new.
- **Cluttered UI**: Multiple separate buttons for uploads, documents, and attachments created visual noise. These could be better organized into existing UI affordances.
- **Property panel friction**: The side panel for issue properties was a separate overlay rather than always-visible context, requiring extra clicks to reference issue metadata while reading comments.

## Summary

Improves the layout and UX of the issues page by making the following changes:

- **Two-column layout**: main content on the left, issue properties in a sticky right sidebar (replaces the separate panel). Mobile retains bottom sheet.
- **Comment UX overhaul**: default sort newest-first with toggle, comment input moved above the timeline, blue unread dot on new comments from others since your last interaction.
- **Documents tab**: documents and attachments moved from the main flow into a dedicated "Documents" tab alongside Comments, Sub-issues, and Activity. Documents default to collapsed.
- **Consolidated uploads**: the paperclip button in the comment form handles file attachments (images, PDFs) and markdown document imports. Removed duplicate/disruptive upload buttons.
- **Cleaner header**: prominent title, identifier badge, status icon, and creation metadata on one line.

## Screenshots

#Before
<img width="1058" height="754" alt="Screenshot 2026-03-20 at 1 01 11 PM" src="https://github.com/user-attachments/assets/52354b80-d191-477b-9bd9-3fcc49dd8185" />

# After
<img width="1107" height="773" alt="Screenshot 2026-03-20 at 10 09 41 AM" src="https://github.com/user-attachments/assets/ea9feed0-6437-4feb-8c54-c091e4d84bf3" />

## Risks

- Layout shift on smaller desktop widths (1024-1280px) where two-column may feel cramped — mitigated by the responsive breakpoint falling back to single-column.
- Changing default comment sort to newest-first is a behavior change for existing users — mitigated by the toggle being prominently visible.

## Test plan
- [ ] Open an issue detail page — verify two-column layout with properties sidebar on desktop
- [ ] Resize to mobile width — verify properties accessible via bottom sheet (slider icon)
- [ ] Leave a comment, navigate away, have another user/agent comment, return — verify blue dot appears on new comments
- [ ] Toggle comment sort order between newest/oldest first
- [ ] Switch to Documents tab — verify documents render (collapsed by default), attachments listed below
- [ ] Use paperclip button to upload an image, a PDF, and a .md file — verify correct routing (attachment vs document import)
- [ ] Verify all existing functionality preserved: inline title/description editing, sub-issues tab, activity tab, plugin tabs, approvals collapsible, cost summary collapsible, drag-and-drop attachments
- [ ] Drag-and-drop a file onto the Documents tab when no attachments exist — verify it uploads successfully