### PR TITLE
fix(adapter): add instructions dir to --add-dir to prevent permission auto-reject

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -419,7 +419,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // --add-dir grants Claude read access to sibling files referenced by the
     // instructions. We skip this when the instructions dir is already inside cwd
     // or inside skillsDir to avoid redundant entries.
-    if (instructionsFileDir && instructionsFileDir !== `${skillsDir}/`) {
+    if (instructionsFileDir && !instructionsFileDir.startsWith(`${skillsDir}/`)) {
       const resolvedInstrDir = path.resolve(instructionsFileDir);
       const resolvedCwd = path.resolve(cwd);
       if (!resolvedInstrDir.startsWith(resolvedCwd + path.sep) && resolvedInstrDir !== resolvedCwd) {


### PR DESCRIPTION
## Summary
- Fixes #1362 — When an agent's instructions file lives outside the project cwd (e.g. in `~/.paperclip/instances/.../agents/`), Claude CLI treats that directory as `external_directory` and auto-rejects permission requests, causing a loop.
- Adds the instructions file directory as an additional `--add-dir` argument so Claude has read access to sibling files referenced by the instructions.
- Skips adding when the directory is already within the project cwd to avoid redundant entries.

## Test plan
- [ ] Build passes (`pnpm --filter @paperclipai/adapter-claude-local build`)
- [ ] Verify agent with external instructions file no longer gets permission auto-rejected
- [ ] Verify agents with instructions inside project cwd are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)