### PR TITLE
fix(adapter): change Cursor default model from auto to composer-2

### DIFF
--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -1,9 +1,10 @@
 export const type = "cursor";
 export const label = "Cursor CLI (local)";
-export const DEFAULT_CURSOR_LOCAL_MODEL = "auto";
+export const DEFAULT_CURSOR_LOCAL_MODEL = "composer-2";
 
 const CURSOR_FALLBACK_MODEL_IDS = [
-  "auto",
+  "composer-2",
+  "composer-2-fast",
   "composer-1.5",
   "composer-1",
   "gpt-5.3-codex-low",


### PR DESCRIPTION
## Summary
- Fixes #1357 — Cursor CLI now rejects `auto` as a model selection with "Cannot use this model: auto"
- Changes the default Cursor model from `"auto"` to `"composer-2"`
- Adds `"composer-2"` and `"composer-2-fast"` to the fallback model list

## Test plan
- [ ] Build passes (`pnpm --filter @paperclipai/adapter-cursor-local build`)
- [ ] All cursor adapter tests pass (17/17)
- [ ] Verify new agents default to `composer-2` instead of `auto`
- [ ] Verify existing agents with `auto` model should be updated manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)