### PR TITLE
fix(adapter): resolve openclaw_gateway claimed API key path from agent config

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -335,8 +335,22 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+const DEFAULT_CLAIMED_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+
+export function resolveClaimedApiKeyPath(config: Record<string, unknown>): string {
+  const explicit = nonEmpty(config.claimedApiKeyPath);
+  if (explicit) return explicit;
+
+  const workspace = nonEmpty(config.openclawWorkspace);
+  if (workspace) {
+    const base = workspace.endsWith("/") ? workspace.slice(0, -1) : workspace;
+    return `${base}/paperclip-claimed-api-key.json`;
+  }
+
+  return DEFAULT_CLAIMED_API_KEY_PATH;
+}
+
+function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>, claimedApiKeyPath: string): string {
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1053,7 +1067,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
-  const wakeText = buildWakeText(wakePayload, paperclipEnv);
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config);
+  const wakeText = buildWakeText(wakePayload, paperclipEnv, claimedApiKeyPath);
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);

--- a/packages/adapters/openclaw-gateway/src/server/index.ts
+++ b/packages/adapters/openclaw-gateway/src/server/index.ts
@@ -1,2 +1,2 @@
-export { execute } from "./execute.js";
+export { execute, resolveClaimedApiKeyPath } from "./execute.js";
 export { testEnvironment } from "./test.js";

--- a/server/src/__tests__/openclaw-gateway-claimed-key-path.test.ts
+++ b/server/src/__tests__/openclaw-gateway-claimed-key-path.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { resolveClaimedApiKeyPath } from "@paperclipai/adapter-openclaw-gateway/server";
+
+describe("resolveClaimedApiKeyPath", () => {
+  it("returns default path when no config is set", () => {
+    expect(resolveClaimedApiKeyPath({})).toBe(
+      "~/.openclaw/workspace/paperclip-claimed-api-key.json",
+    );
+  });
+
+  it("returns explicit claimedApiKeyPath when set", () => {
+    const path = "/custom/path/to/key.json";
+    expect(resolveClaimedApiKeyPath({ claimedApiKeyPath: path })).toBe(path);
+  });
+
+  it("derives path from openclawWorkspace", () => {
+    expect(
+      resolveClaimedApiKeyPath({ openclawWorkspace: "~/.openclaw/workspace-nora" }),
+    ).toBe("~/.openclaw/workspace-nora/paperclip-claimed-api-key.json");
+  });
+
+  it("strips trailing slash from openclawWorkspace", () => {
+    expect(
+      resolveClaimedApiKeyPath({ openclawWorkspace: "~/.openclaw/workspace-nora/" }),
+    ).toBe("~/.openclaw/workspace-nora/paperclip-claimed-api-key.json");
+  });
+
+  it("prefers claimedApiKeyPath over openclawWorkspace", () => {
+    expect(
+      resolveClaimedApiKeyPath({
+        claimedApiKeyPath: "/explicit/key.json",
+        openclawWorkspace: "~/.openclaw/workspace-nora",
+      }),
+    ).toBe("/explicit/key.json");
+  });
+
+  it("ignores empty string config values", () => {
+    expect(
+      resolveClaimedApiKeyPath({ claimedApiKeyPath: "", openclawWorkspace: "" }),
+    ).toBe("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - There are many types of adapters for each LLM model provider, including the openclaw_gateway adapter
> - Each agent can have its own openclaw workspace and claimed API key file
> - But the `buildWakeText` function had a hardcoded default path (`~/.openclaw/workspace/paperclip-claimed-api-key.json`) for the claimed API key
> - Named agents (e.g. `workspace-nora`) that use a different workspace directory were receiving the wrong claimed API key path in their wake prompt
> - This PR adds `resolveClaimedApiKeyPath()` which checks `config.claimedApiKeyPath` (explicit) or `config.openclawWorkspace` (derives path) before falling back to the default
> - That way each agent resolves its own correct claimed API key path, while agents without custom config remain backward-compatible

## Summary

- Fixes the hardcoded `~/.openclaw/workspace/paperclip-claimed-api-key.json` path in the openclaw_gateway wake prompt that caused named agents (e.g. `workspace-nora`) to receive the wrong claimed API key file path
- Adds `resolveClaimedApiKeyPath()` that checks `config.claimedApiKeyPath` (explicit) or `config.openclawWorkspace` (derives path) before falling back to the default
- Backward-compatible: agents without these config fields continue using the default path

Closes #1371

## Test plan

- [x] 6 unit tests covering all resolution paths (default, explicit, derived, trailing slash, priority, empty values)
- [x] Full test suite passes (90 files, 444 tests)
- [x] Typecheck passes across all packages
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)