### PR TITLE
fix: add missing assertCompanyAccess checks for multi-tenant isolation

### DIFF
--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -142,6 +142,8 @@ async function authorizeUpgrade(
         ),
     ]);
 
+    // NOTE: This membership check mirrors assertCompanyAccess() in routes/authz.ts.
+    // If the access model changes there, update this check to match.
     const hasCompanyMembership = memberships.some((row) => row.companyId === companyId);
     if (!roleRow && !hasCompanyMembership) return null;
 

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { z } from "zod";
 import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
 import { validate } from "../middleware/validate.js";
 import { activityService } from "../services/activity.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
@@ -46,6 +48,7 @@ export function activityRoutes(db: Db) {
   router.post("/companies/:companyId/activity", validate(createActivitySchema), async (req, res) => {
     assertBoard(req);
     const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
     const event = await svc.create({
       companyId,
       ...req.body,
@@ -80,6 +83,16 @@ export function activityRoutes(db: Db) {
 
   router.get("/heartbeat-runs/:runId/issues", async (req, res) => {
     const runId = req.params.runId as string;
+    const run = await db
+      .select({ companyId: heartbeatRuns.companyId })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    if (!run) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    assertCompanyAccess(req, run.companyId);
     const result = await svc.issuesForRun(runId);
     res.json(result);
   });

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -82,6 +82,7 @@ export function activityRoutes(db: Db) {
   });
 
   router.get("/heartbeat-runs/:runId/issues", async (req, res) => {
+    assertBoard(req);
     const runId = req.params.runId as string;
     const run = await db
       .select({ companyId: heartbeatRuns.companyId })

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1897,17 +1897,15 @@ export function agentRoutes(db: Db) {
     assertCompanyAccess(req, agent.companyId);
     const key = await svc.createApiKey(id, req.body.name);
 
-    if (agent) {
-      await logActivity(db, {
-        companyId: agent.companyId,
-        actorType: "user",
-        actorId: req.actor.userId ?? "board",
-        action: "agent.key_created",
-        entityType: "agent",
-        entityId: agent.id,
-        details: { keyId: key.id, name: key.name },
-      });
-    }
+    await logActivity(db, {
+      companyId: agent.companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "agent.key_created",
+      entityType: "agent",
+      entityId: agent.id,
+      details: { keyId: key.id, name: key.name },
+    });
 
     res.status(201).json(key);
   });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1764,6 +1764,12 @@ export function agentRoutes(db: Db) {
   router.post("/agents/:id/pause", async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
     const agent = await svc.pause(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -1787,6 +1793,12 @@ export function agentRoutes(db: Db) {
   router.post("/agents/:id/resume", async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
     const agent = await svc.resume(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -1808,6 +1820,12 @@ export function agentRoutes(db: Db) {
   router.post("/agents/:id/terminate", async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
     const agent = await svc.terminate(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -1831,6 +1849,12 @@ export function agentRoutes(db: Db) {
   router.delete("/agents/:id", async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
     const agent = await svc.remove(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -1852,6 +1876,12 @@ export function agentRoutes(db: Db) {
   router.get("/agents/:id/keys", async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
     const keys = await svc.listKeys(id);
     res.json(keys);
   });
@@ -1859,9 +1889,14 @@ export function agentRoutes(db: Db) {
   router.post("/agents/:id/keys", validate(createAgentKeySchema), async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
     const key = await svc.createApiKey(id, req.body.name);
 
-    const agent = await svc.getById(id);
     if (agent) {
       await logActivity(db, {
         companyId: agent.companyId,
@@ -1879,7 +1914,20 @@ export function agentRoutes(db: Db) {
 
   router.delete("/agents/:id/keys/:keyId", async (req, res) => {
     assertBoard(req);
+    const id = req.params.id as string;
     const keyId = req.params.keyId as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+    // Verify the key belongs to this agent to prevent cross-agent key revocation
+    const keys = await svc.listKeys(id);
+    if (!keys.some((k) => k.id === keyId)) {
+      res.status(404).json({ error: "Key not found for this agent" });
+      return;
+    }
     const revoked = await svc.revokeKey(keyId);
     if (!revoked) {
       res.status(404).json({ error: "Key not found" });
@@ -2098,6 +2146,12 @@ export function agentRoutes(db: Db) {
   router.post("/heartbeat-runs/:runId/cancel", async (req, res) => {
     assertBoard(req);
     const runId = req.params.runId as string;
+    const existing = await heartbeat.getRun(runId);
+    if (!existing) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
     const run = await heartbeat.cancelRun(runId);
 
     if (run) {

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -7,6 +7,14 @@ export function assertBoard(req: Request) {
   }
 }
 
+export function assertInstanceAdmin(req: Request) {
+  assertBoard(req);
+  if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) {
+    return;
+  }
+  throw forbidden("Instance admin access required");
+}
+
 export function assertCompanyAccess(req: Request, companyId: string) {
   if (req.actor.type === "none") {
     throw unauthorized();

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -48,6 +48,7 @@ import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js
 import type { ToolRunContext } from "@paperclipai/plugin-sdk";
 import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { forbidden } from "../errors.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -313,6 +314,14 @@ export function pluginRoutes(
     loader,
     workerManager: bridgeDeps?.workerManager ?? webhookDeps?.workerManager,
   });
+
+  function assertInstanceAdmin(req: Request) {
+    assertBoard(req);
+    if (req.actor.type === "board" && (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin)) {
+      return;
+    }
+    throw forbidden("Instance admin access required");
+  }
 
   async function resolvePluginAuditCompanyIds(req: Request): Promise<string[]> {
     if (typeof (db as { select?: unknown }).select === "function") {
@@ -601,7 +610,7 @@ export function pluginRoutes(
    * - `500` — installation succeeded but manifest is missing (indicates a loader bug)
    */
   router.post("/plugins/install", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { packageName, version, isLocalPath } = req.body as PluginInstallRequest;
 
     // Input validation
@@ -1228,7 +1237,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.delete("/plugins/:pluginId", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
     const purge = req.query.purge === "true";
 
@@ -1264,7 +1273,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.post("/plugins/:pluginId/enable", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);
@@ -1302,7 +1311,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.post("/plugins/:pluginId/disable", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
     const body = req.body as { reason?: string } | undefined;
     const reason = body?.reason;
@@ -1461,7 +1470,7 @@ export function pluginRoutes(
    * Errors: 404 if plugin not found, 400 for lifecycle errors
    */
   router.post("/plugins/:pluginId/upgrade", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
     const body = req.body as { version?: string } | undefined;
     const version = body?.version;
@@ -1540,7 +1549,7 @@ export function pluginRoutes(
    * - 404 if plugin not found
    */
   router.post("/plugins/:pluginId/config", async (req, res) => {
-    assertBoard(req);
+    assertInstanceAdmin(req);
     const { pluginId } = req.params;
 
     const plugin = await resolvePlugin(registry, pluginId);

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -47,8 +47,7 @@ import type { PluginStreamBus } from "../services/plugin-stream-bus.js";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 import type { ToolRunContext } from "@paperclipai/plugin-sdk";
 import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
-import { forbidden } from "../errors.js";
+import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -314,14 +313,6 @@ export function pluginRoutes(
     loader,
     workerManager: bridgeDeps?.workerManager ?? webhookDeps?.workerManager,
   });
-
-  function assertInstanceAdmin(req: Request) {
-    assertBoard(req);
-    if (req.actor.type === "board" && (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin)) {
-      return;
-    }
-    throw forbidden("Instance admin access required");
-  }
 
   async function resolvePluginAuditCompanyIds(req: Request): Promise<string[]> {
     if (typeof (db as { select?: unknown }).select === "function") {


### PR DESCRIPTION
## Summary

Security audit of multi-tenant authorization found **8 routes** missing `assertCompanyAccess` checks, allowing cross-tenant data access in `authenticated` (shared hosting) deployments.

### HIGH severity (3)
- **`GET /heartbeat-runs/:runId/issues`** — no authentication or authorization at all; any actor could enumerate issues for any company's heartbeat runs
- **`POST /agents/:id/pause|resume|terminate`, `DELETE /agents/:id`** — only checked `assertBoard`, not company membership; a user in Company A could control agents in Company B
- **`GET/POST/DELETE /agents/:id/keys`** — same missing check; **most critical** because creating an API key for another company's agent grants full agent-level access to that company's data. Additionally, `DELETE /agents/:id/keys/:keyId` ignored the `:id` param entirely, allowing any key to be revoked by ID alone

### MEDIUM severity (3)
- **`POST /heartbeat-runs/:runId/cancel`** — missing company access check; cross-tenant heartbeat cancellation
- **`POST /companies/:companyId/activity`** — missing company access check; could inject fake audit log entries into another company
- **`DELETE /agents/:id/keys/:keyId`** — `:id` param was ignored; now validates the key belongs to the specified agent

### LOW severity (2)
- **Plugin mutation routes** (install, uninstall, enable, disable, upgrade, config) — now require `isInstanceAdmin` instead of any board user
- **WebSocket `authorizeUpgrade`** — added cross-reference comment to `assertCompanyAccess` to flag maintenance coupling risk

### Fix pattern

All fixes follow the existing fetch-then-authorize pattern used elsewhere in the codebase:
1. Fetch the resource by ID
2. Extract its `companyId`
3. Call `assertCompanyAccess(req, resource.companyId)` before proceeding

### Files changed
- `server/src/routes/activity.ts` — Findings 1, 5
- `server/src/routes/agents.ts` — Findings 2, 3, 4, 8
- `server/src/routes/plugins.ts` — Finding 6
- `server/src/realtime/live-events-ws.ts` — Finding 7

## Test plan

- [ ] Verify existing tests pass (no behavioral change for authorized users)
- [ ] In `authenticated` mode with two companies: confirm a user in Company A gets 403 when calling the patched routes with Company B's resource IDs
- [ ] Confirm instance admins can still access all companies (bypass preserved)
- [ ] Confirm `local_trusted` mode is unaffected (implicit access preserved)
- [ ] Verify plugin install/uninstall/enable/disable/upgrade/config now require instance admin
- [ ] Verify `DELETE /agents/:id/keys/:keyId` rejects keys that don't belong to agent `:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)