### PR TITLE
fix: restore post-merge route verification

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -38,6 +38,9 @@ vi.mock("../services/index.js", () => ({
   issueService: () => mockIssueService,
   logActivity: mockLogActivity,
   projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
   workProductService: () => ({}),
 }));
 

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -103,9 +103,9 @@ export function costRoutes(db: Db) {
   }
 
   function parseLimit(query: Record<string, unknown>) {
-    const raw = query.limit as string | undefined;
-    if (!raw) return 100;
-    const limit = Number.parseInt(raw, 10);
+    const raw = Array.isArray(query.limit) ? query.limit[0] : query.limit;
+    if (raw == null || raw === "") return 100;
+    const limit = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
     if (!Number.isFinite(limit) || limit <= 0 || limit > 500) {
       throw badRequest("invalid 'limit' value");
     }


### PR DESCRIPTION
### Thinking Path
- Paperclip orchestrates AI agents for zero-human companies.
- The control plane depends on route and service contracts staying synchronized after upstream merges.
- This branch had already merged into `master`, but one follow-up verification pass exposed a few post-merge regressions.
- Two of those regressions were in route-level behavior and test coverage rather than new product logic.
- One was a finance event limit parsing edge case that only showed up in the full suite.
- The other was an older issue-route test mock that no longer matched the current service barrel after `routineService` became a route dependency.
- This PR fixes those verification regressions so the branch remains clean on top of current `master`.

## What Changed
- Fixed finance event `limit` parsing in `server/src/routes/costs.ts` so invalid values like `0` are rejected consistently instead of being treated like an omitted limit.
- Updated `server/src/__tests__/issue-comment-reopen-routes.test.ts` to mock the newer `routineService.syncRunStatusForIssue` dependency required by `issueRoutes`.

## Why It Matters
- Restores expected request validation for finance event listing.
- Keeps the issue comment reopen route tests aligned with the live route dependency graph.
- Preserves a green verification state after the branch was rebased onto current `master`.

## Verification
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`

## Risks
- Low risk.
- The route change is narrowly scoped to query parsing for `limit`.
- The test change only updates mocked surface area to match the route's current dependencies.

## Screenshots
- Not applicable; no visible UI change.
