### PR TITLE
feat: use issue_comment_board wake reason for board user comments (QUE-183)

### DIFF
--- a/server/src/__tests__/issues-comment-wakeup.test.ts
+++ b/server/src/__tests__/issues-comment-wakeup.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { commentWakeConfig } from "../routes/issues-comment-wakeup.js";
+
+describe("commentWakeConfig", () => {
+  it("uses issue_comment_board reason for board user comments", () => {
+    const config = commentWakeConfig(false);
+    expect(config.reason).toBe("issue_comment_board");
+    expect(config.source).toBe("issue.comment.board");
+    expect(config.wakeReason).toBe("issue_comment_board");
+  });
+
+  it("uses issue_commented reason for agent comments", () => {
+    const config = commentWakeConfig(true);
+    expect(config.reason).toBe("issue_commented");
+    expect(config.source).toBe("issue.comment");
+    expect(config.wakeReason).toBe("issue_commented");
+  });
+});

--- a/server/src/routes/issues-comment-wakeup.ts
+++ b/server/src/routes/issues-comment-wakeup.ts
@@ -1,0 +1,20 @@
+type CommentWakeConfig = {
+  reason: string;
+  source: string;
+  wakeReason: string;
+};
+
+export function commentWakeConfig(actorIsAgent: boolean): CommentWakeConfig {
+  if (actorIsAgent) {
+    return {
+      reason: "issue_commented",
+      source: "issue.comment",
+      wakeReason: "issue_commented",
+    };
+  }
+  return {
+    reason: "issue_comment_board",
+    source: "issue.comment.board",
+    wakeReason: "issue_comment_board",
+  };
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -34,6 +34,7 @@ import { logger } from "../middleware/logger.js";
 import { forbidden, HttpError, unauthorized } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { commentWakeConfig } from "./issues-comment-wakeup.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 
@@ -1357,10 +1358,11 @@ export function issueRoutes(db: Db, storage: StorageService) {
             },
           });
         } else {
+          const wakeConfig = commentWakeConfig(actorIsAgent);
           wakeups.set(assigneeId, {
             source: "automation",
             triggerDetail: "system",
-            reason: "issue_commented",
+            reason: wakeConfig.reason,
             payload: {
               issueId: currentIssue.id,
               commentId: comment.id,
@@ -1373,8 +1375,9 @@ export function issueRoutes(db: Db, storage: StorageService) {
               issueId: currentIssue.id,
               taskId: currentIssue.id,
               commentId: comment.id,
-              source: "issue.comment",
-              wakeReason: "issue_commented",
+              wakeCommentId: comment.id,
+              source: wakeConfig.source,
+              wakeReason: wakeConfig.wakeReason,
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });


### PR DESCRIPTION
## Summary

When a board user posts a comment on a task with `assigneeAgentId` set, the heartbeat wake reason is now `issue_comment_board` instead of the generic `issue_commented`. This lets agents distinguish board user feedback from other comment wakes and act on it immediately.

**Changes:**
- New `commentWakeConfig()` pure function in `issues-comment-wakeup.ts` (matches pattern from `issues-checkout-wakeup.ts`)
- Board/user actor comments set `reason: "issue_comment_board"` and `wakeReason: "issue_comment_board"`
- Explicitly sets `wakeCommentId: comment.id` in contextSnapshot so `PAPERCLIP_WAKE_COMMENT_ID` is populated for agents
- Agent-originated comments retain existing `issue_commented` reason (no behavior change)

**Acceptance criteria met:**
- Board user comment on a task with `assigneeAgentId` triggers agent wake with `PAPERCLIP_WAKE_REASON=issue_comment_board`
- `PAPERCLIP_WAKE_COMMENT_ID` is set so agents know which comment triggered the wake
- Respects `wakeOnDemand` policy (source remains `"automation"`)
- Unit tests added for `commentWakeConfig`

Fixes: QUE-183

## Test plan
- [x] `pnpm vitest run server/src/__tests__/issues-comment-wakeup.test.ts` passes (2 tests)
- [ ] CI: Backend Tests, Unit Tests, codecov/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)