### PR TITLE
fix(cli): allow context profile companyId to work

### DIFF
--- a/cli/src/commands/client/activity.ts
+++ b/cli/src/commands/client/activity.ts
@@ -23,7 +23,7 @@ export function registerActivityCommands(program: Command): void {
     activity
       .command("list")
       .description("List company activity log entries")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--agent-id <id>", "Filter by agent ID")
       .option("--entity-type <type>", "Filter by entity type")
       .option("--entity-id <id>", "Filter by entity ID")

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -163,7 +163,7 @@ export function registerAgentCommands(program: Command): void {
     agent
       .command("list")
       .description("List agents for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .action(async (opts: AgentListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -222,7 +222,7 @@ export function registerAgentCommands(program: Command): void {
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",
       )
       .argument("<agentRef>", "Agent ID or shortname/url-key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--key-name <name>", "API key label", "local-cli")
       .option(
         "--no-install-skills",

--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -49,7 +49,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("list")
       .description("List approvals for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--status <status>", "Status filter")
       .action(async (opts: ApprovalListOptions) => {
         try {
@@ -110,7 +110,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("create")
       .description("Create an approval request")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .requiredOption("--type <type>", "Approval type (hire_agent|approve_ceo_strategy)")
       .requiredOption("--payload <json>", "Approval payload as JSON object")
       .option("--requested-by-agent-id <id>", "Requesting agent ID")

--- a/cli/src/commands/client/dashboard.ts
+++ b/cli/src/commands/client/dashboard.ts
@@ -19,7 +19,7 @@ export function registerDashboardCommands(program: Command): void {
     dashboard
       .command("get")
       .description("Get dashboard summary for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .action(async (opts: DashboardGetOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -136,7 +136,7 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("create")
       .description("Create an issue")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .requiredOption("--title <title>", "Issue title")
       .option("--description <text>", "Issue description")
       .option("--status <status>", "Issue status")


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Users interact with Paperclip through the CLI to manage companies, agents, issues, etc.
- The CLI has a context profile system to avoid repeating common flags like `--company-id`
- Users can set defaults via `paperclipai context set --company-id <id>`
- The `resolveCommandContext()` function properly reads context profiles and falls back to CLI args → env vars → profile values
- But several commands used `.requiredOption()` for the `-C, --company-id` flag
- Commander.js's `.requiredOption()` validates **before** the action handler runs, preventing `resolveCommandContext()` from applying the context profile fallback
- This PR changes `.requiredOption()` to `.option()` and relies on `resolveCommandContext()`'s `requireCompany: true` check instead
- The benefit is users can now set `companyId` in their context profile once and avoid repeating `-C <id>` on every command

---

## What Changed

Replaced `.requiredOption("-C, --company-id <id>", "Company ID")` with `.option("-C, --company-id <id>", "Company ID")` in:

- `cli/src/commands/client/dashboard.ts`
- `cli/src/commands/client/activity.ts`
- `cli/src/commands/client/agent.ts` (2 occurrences)
- `cli/src/commands/client/approval.ts` (2 occurrences)
- `cli/src/commands/client/issue.ts`

## Why This Works

The `resolveCommandContext()` function in `cli/src/commands/client/common.ts` already has the correct fallback chain:

```typescript
const companyId =
  options.companyId?.trim() ||
  process.env.PAPERCLIP_COMPANY_ID?.trim() ||
  profile.companyId;

if (opts?.requireCompany && !companyId) {
  throw new Error(
    "Company ID is required. Pass --company-id, set PAPERCLIP_COMPANY_ID, or set context profile companyId via `paperclipai context set`.",
  );
}
```

By removing `.requiredOption()`, we allow the action handler to run and let `resolveCommandContext()` handle validation **after** applying the context profile fallback.

## How to Test

### Before (without this fix):
```bash
pnpm paperclipai context set --company-id <uuid> --profile default
pnpm paperclipai context use default
pnpm paperclipai dashboard get
# Error: required option '-C, --company-id <id>' not specified
```

### After (with this fix):
```bash
pnpm paperclipai context set --company-id <uuid> --profile default
pnpm paperclipai context use default
pnpm paperclipai dashboard get
# Works! Uses companyId from context profile
```

### Validation Still Works:
```bash
pnpm paperclipai context set --profile empty  # Create profile without companyId
pnpm paperclipai context use empty
pnpm paperclipai dashboard get
# Error: Company ID is required. Pass --company-id, set PAPERCLIP_COMPANY_ID, or set context profile companyId via `paperclipai context set`.
```

## Impact

- **No breaking changes** — all existing usage patterns still work
- **No new dependencies**
- **No test changes required** — the validation logic is unchanged, just moved to `resolveCommandContext()`
- Users can now benefit from the context profile system as originally intended

## Related

Fixes #1391

## Checklist

- [x] Focused, small change (6 files, 7 lines changed)
- [x] Clear commit message
- [x] Manual testing performed (verified context profile now works)
- [x] No new lint/test failures (no code logic changed, only Commander.js option type)
