### PR TITLE
fix(server): expire stale queued runs that permanently lock issues

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -532,6 +532,7 @@ export async function startServer(): Promise<StartedServer> {
     // then resume any persisted queued runs that were waiting on the previous process.
     void heartbeat
       .reapOrphanedRuns()
+      .then(() => heartbeat.reapStaleQueuedRuns())
       .then(() => heartbeat.resumeQueuedRuns())
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");
@@ -563,6 +564,7 @@ export async function startServer(): Promise<StartedServer> {
       // persisted queued work is still being driven forward.
       void heartbeat
         .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .then(() => heartbeat.reapStaleQueuedRuns())
         .then(() => heartbeat.resumeQueuedRuns())
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType } from "@paperclipai/shared";
 import {
@@ -1732,6 +1732,50 @@ export function heartbeatService(db: Db) {
     return { reaped: reaped.length, runIds: reaped };
   }
 
+  /**
+   * Expire queued runs that never transitioned to running within 5 minutes.
+   * These stale queued runs hold `executionRunId` on their target issues,
+   * permanently blocking all subsequent mutations (GH #1390).
+   */
+  async function reapStaleQueuedRuns() {
+    const staleThresholdMs = 5 * 60 * 1000;
+    const cutoff = new Date(Date.now() - staleThresholdMs);
+    const staleRuns = await db
+      .select({ id: heartbeatRuns.id, agentId: heartbeatRuns.agentId })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "queued"),
+          isNull(heartbeatRuns.startedAt),
+          lt(heartbeatRuns.createdAt, cutoff),
+        ),
+      );
+
+    const expired: string[] = [];
+    for (const run of staleRuns) {
+      const finalized = await setRunStatus(run.id, "failed", {
+        error: "Queued run expired: never started within timeout (5m)",
+        errorCode: "queued_run_expired",
+      });
+      if (finalized) {
+        await releaseIssueExecutionAndPromote(finalized);
+        await appendRunEvent(finalized, await nextRunEventSeq(finalized.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: "Queued run expired: never started within 5 minutes",
+        });
+        await finalizeAgentStatus(run.agentId, "failed");
+        expired.push(run.id);
+      }
+    }
+
+    if (expired.length > 0) {
+      logger.warn({ expiredCount: expired.length, runIds: expired }, "expired stale queued heartbeat runs");
+    }
+    return { expired: expired.length, runIds: expired };
+  }
+
   async function resumeQueuedRuns() {
     const queuedRuns = await db
       .select({ agentId: heartbeatRuns.agentId })
@@ -2974,6 +3018,15 @@ export function heartbeatService(db: Db) {
         if (activeExecutionRun && activeExecutionRun.status !== "queued" && activeExecutionRun.status !== "running") {
           activeExecutionRun = null;
         }
+        // A queued run that never started within 5 minutes is stale (GH #1390).
+        if (
+          activeExecutionRun &&
+          activeExecutionRun.status === "queued" &&
+          !activeExecutionRun.startedAt &&
+          Date.now() - new Date(activeExecutionRun.createdAt).getTime() > 5 * 60 * 1000
+        ) {
+          activeExecutionRun = null;
+        }
 
         if (!activeExecutionRun && issue.executionRunId) {
           await tx
@@ -3656,6 +3709,8 @@ export function heartbeatService(db: Db) {
     reportRunActivity: clearDetachedRunWarning,
 
     reapOrphanedRuns,
+
+    reapStaleQueuedRuns,
 
     resumeQueuedRuns,
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -106,6 +106,8 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 }
 
 const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
+/** Queued runs older than this are considered stale and their issue lock can be superseded (GH #1390). */
+const STALE_QUEUED_RUN_THRESHOLD_MS = 5 * 60 * 1000;
 
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
@@ -430,12 +432,20 @@ export function issueService(db: Db) {
 
   async function isTerminalOrMissingHeartbeatRun(runId: string) {
     const run = await db
-      .select({ status: heartbeatRuns.status })
+      .select({ status: heartbeatRuns.status, createdAt: heartbeatRuns.createdAt })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
     if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+    // A queued run that never started within 5 minutes is considered stale.
+    // This prevents permanently locked issues when a queued run is orphaned
+    // due to adapter timeout, server restart, or scheduling race (GH #1390).
+    if (run.status === "queued") {
+      const ageMs = Date.now() - new Date(run.createdAt).getTime();
+      if (ageMs > STALE_QUEUED_RUN_THRESHOLD_MS) return true;
+    }
+    return false;
   }
 
   async function adoptStaleCheckoutRun(input: {


### PR DESCRIPTION
## Summary
- Fixes #1390 — Queued runs that never transition to `running` permanently lock their target issues via `executionRunId`, blocking all subsequent agent mutations (checkout, PATCH, comments, release).
- Three-layer fix:
  1. **Checkout adoption**: `isTerminalOrMissingHeartbeatRun()` now treats queued runs older than 5 minutes as stale, allowing checkout to supersede them.
  2. **Wakeup gate**: `enqueueWakeup()` stale lock check also expires old queued runs, clearing the execution lock.
  3. **Periodic reaper**: New `reapStaleQueuedRuns()` function runs on the main interval to fail-out orphaned queued runs, release issue locks, and promote deferred wakeups.

## Test plan
- [ ] TypeScript compiles cleanly (only pre-existing `sharp` module error)
- [ ] `heartbeat-process-recovery.test.ts` passes (4/4)
- [ ] Manual: create a queued run, wait >5 min, verify it gets expired and issue lock is released
- [ ] Verify normal queued runs (<5 min) are not affected

## Risk notes
- 5-minute threshold is conservative but may need tuning for slow environments
- Expired runs are marked as `failed` with error code `queued_run_expired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)