### PR TITLE
fix(cli): context profile companyId ignored due to .requiredOption()

### DIFF
--- a/cli/src/commands/client/activity.ts
+++ b/cli/src/commands/client/activity.ts
@@ -23,7 +23,7 @@ export function registerActivityCommands(program: Command): void {
     activity
       .command("list")
       .description("List company activity log entries")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--agent-id <id>", "Filter by agent ID")
       .option("--entity-type <type>", "Filter by entity type")
       .option("--entity-id <id>", "Filter by entity ID")

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -163,7 +163,7 @@ export function registerAgentCommands(program: Command): void {
     agent
       .command("list")
       .description("List agents for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .action(async (opts: AgentListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -222,7 +222,7 @@ export function registerAgentCommands(program: Command): void {
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",
       )
       .argument("<agentRef>", "Agent ID or shortname/url-key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--key-name <name>", "API key label", "local-cli")
       .option(
         "--no-install-skills",

--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -49,7 +49,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("list")
       .description("List approvals for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--status <status>", "Status filter")
       .action(async (opts: ApprovalListOptions) => {
         try {
@@ -110,7 +110,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("create")
       .description("Create an approval request")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .requiredOption("--type <type>", "Approval type (hire_agent|approve_ceo_strategy)")
       .requiredOption("--payload <json>", "Approval payload as JSON object")
       .option("--requested-by-agent-id <id>", "Requesting agent ID")

--- a/cli/src/commands/client/dashboard.ts
+++ b/cli/src/commands/client/dashboard.ts
@@ -19,7 +19,7 @@ export function registerDashboardCommands(program: Command): void {
     dashboard
       .command("get")
       .description("Get dashboard summary for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .action(async (opts: DashboardGetOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -136,7 +136,7 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("create")
       .description("Create an issue")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .requiredOption("--title <title>", "Issue title")
       .option("--description <text>", "Issue description")
       .option("--status <status>", "Issue status")


### PR DESCRIPTION
## Summary
- Changed `.requiredOption("-C, --company-id <id>", ...)` to `.option("-C, --company-id <id>", ...)` in 5 CLI command files (dashboard, activity, agent, approval, issue)
- Commander's `.requiredOption()` validates before the action handler runs, which prevents `resolveCommandContext()` from applying the context profile fallback for `companyId`
- `resolveCommandContext()` with `requireCompany: true` already handles validation and provides a better error message listing all alternatives (`--company-id`, env var, or context profile)

Fixes #1391

## Test plan
- [ ] Run `paperclip dashboard get` without `--company-id` but with a context profile that has `companyId` set — should succeed instead of erroring
- [ ] Run `paperclip issue create --title test` without `--company-id` and without any profile/env fallback — should get the `resolveCommandContext` error message listing alternatives
- [ ] Existing tests in `cli/src/__tests__/common.test.ts` already cover `resolveCommandContext` profile fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)