### PR TITLE
fix: Docker plugin build, Railway deploy compatibility, per-agent API key paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+COPY packages/plugins/create-paperclip-plugin/package.json packages/plugins/create-paperclip-plugin/
+COPY packages/plugins/examples/plugin-authoring-smoke-example/package.json packages/plugins/examples/plugin-authoring-smoke-example/
+COPY packages/plugins/examples/plugin-file-browser-example/package.json packages/plugins/examples/plugin-file-browser-example/
+COPY packages/plugins/examples/plugin-hello-world-example/package.json packages/plugins/examples/plugin-hello-world-example/
+COPY packages/plugins/examples/plugin-kitchen-sink-example/package.json packages/plugins/examples/plugin-kitchen-sink-example/
 
 RUN pnpm install --frozen-lockfile
 
@@ -27,6 +33,8 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/shared build
+RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)


### PR DESCRIPTION
## Summary

- Fix Docker build to include plugin SDK and workspace plugin package manifests in deps stage
- Resolve Railway deployment compatibility issues (railwayignore, railway.toml, unblock deploy)
- Add per-agent API key paths and `PAPERCLIP_PUBLIC_URL` support
- Add `request-actor` middleware and clean up express type declarations

## Test plan

- [ ] Docker build completes without missing plugin package errors
- [ ] Railway deployment succeeds
- [ ] Per-agent API keys resolve correctly via new path logic
- [ ] `PAPERCLIP_PUBLIC_URL` env var respected when set
- [ ] Existing auth middleware tests pass (`pnpm test`)