### PR TITLE
feat: add runtimeConfig.heartbeat.wakeOnComment to control assignee wakes on comments

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -19,6 +19,7 @@ const mockAccessService = vi.hoisted(() => ({
 const mockHeartbeatService = vi.hoisted(() => ({
   wakeup: vi.fn(async () => undefined),
   reportRunActivity: vi.fn(async () => undefined),
+  getHeartbeatPolicy: vi.fn(async () => ({ enabled: true, intervalSec: 0, wakeOnDemand: true, wakeOnComment: true, maxConcurrentRuns: 1 })),
 }));
 
 const mockAgentService = vi.hoisted(() => ({
@@ -113,6 +114,84 @@ describe("issue comment reopen routes", () => {
         details: expect.not.objectContaining({ reopened: true }),
       }),
     );
+  });
+
+  describe("wakeOnComment policy", () => {
+    // The POST /issues/:id/comments route fires assignee wakes in a void async
+    // block after responding. A short flush lets those promises settle.
+    const flush = () => new Promise((r) => setTimeout(r, 50));
+
+    it("suppresses assignee wake when wakeOnComment is false", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+      mockHeartbeatService.getHeartbeatPolicy.mockResolvedValue({
+        enabled: true, intervalSec: 0, wakeOnDemand: true, wakeOnComment: false, maxConcurrentRuns: 1,
+      });
+
+      const res = await request(createApp())
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "looks good, approved" });
+
+      expect(res.status).toBe(201);
+      await flush();
+      // No wake should have been enqueued for the assignee
+      expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    });
+
+    it("still wakes assignee when wakeOnComment is true (default)", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+      mockHeartbeatService.getHeartbeatPolicy.mockResolvedValue({
+        enabled: true, intervalSec: 0, wakeOnDemand: true, wakeOnComment: true, maxConcurrentRuns: 1,
+      });
+
+      const res = await request(createApp())
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "revision needed" });
+
+      expect(res.status).toBe(201);
+      await flush();
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        "22222222-2222-4222-8222-222222222222",
+        expect.objectContaining({ reason: "issue_commented" }),
+      );
+    });
+
+    it("falls back to waking when getHeartbeatPolicy returns null", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+      mockHeartbeatService.getHeartbeatPolicy.mockResolvedValue(null);
+
+      const res = await request(createApp())
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "hello" });
+
+      expect(res.status).toBe(201);
+      await flush();
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        "22222222-2222-4222-8222-222222222222",
+        expect.objectContaining({ reason: "issue_commented" }),
+      );
+    });
+
+    it("still delivers @-mention wakes even when wakeOnComment is false", async () => {
+      const mentionedAgentId = "33333333-3333-4333-8333-333333333333";
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+      mockHeartbeatService.getHeartbeatPolicy.mockResolvedValue({
+        enabled: true, intervalSec: 0, wakeOnDemand: true, wakeOnComment: false, maxConcurrentRuns: 1,
+      });
+      mockIssueService.findMentionedAgents.mockResolvedValue([mentionedAgentId]);
+
+      const res = await request(createApp())
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "hey @SomeAgent check this" });
+
+      expect(res.status).toBe(201);
+      await flush();
+      // Assignee wake suppressed, but @-mention wake fires
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        mentionedAgentId,
+        expect.objectContaining({ reason: "issue_comment_mentioned" }),
+      );
+    });
   });
 
   it("reopens closed issues via the PATCH comment path", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1357,27 +1357,33 @@ export function issueRoutes(db: Db, storage: StorageService) {
             },
           });
         } else {
-          wakeups.set(assigneeId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "issue_commented",
-            payload: {
-              issueId: currentIssue.id,
-              commentId: comment.id,
-              mutation: "comment",
-              ...(interruptedRunId ? { interruptedRunId } : {}),
-            },
-            requestedByActorType: actor.actorType,
-            requestedByActorId: actor.actorId,
-            contextSnapshot: {
-              issueId: currentIssue.id,
-              taskId: currentIssue.id,
-              commentId: comment.id,
-              source: "issue.comment",
-              wakeReason: "issue_commented",
-              ...(interruptedRunId ? { interruptedRunId } : {}),
-            },
-          });
+          // Respect assignee's wakeOnComment policy (defaults to true).
+          // When false, only the automatic "someone commented on your issue" wake
+          // is suppressed — @-mention wakes and assignment wakes still fire.
+          const policy = await heartbeat.getHeartbeatPolicy(assigneeId);
+          if (!policy || policy.wakeOnComment) {
+            wakeups.set(assigneeId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "issue_commented",
+              payload: {
+                issueId: currentIssue.id,
+                commentId: comment.id,
+                mutation: "comment",
+                ...(interruptedRunId ? { interruptedRunId } : {}),
+              },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: currentIssue.id,
+                taskId: currentIssue.id,
+                commentId: comment.id,
+                source: "issue.comment",
+                wakeReason: "issue_commented",
+                ...(interruptedRunId ? { interruptedRunId } : {}),
+              },
+            });
+          }
         }
       }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1519,6 +1519,7 @@ export function heartbeatService(db: Db) {
       enabled: asBoolean(heartbeat.enabled, true),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
+      wakeOnComment: asBoolean(heartbeat.wakeOnComment, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };
   }
@@ -3652,6 +3653,12 @@ export function heartbeatService(db: Db) {
       }),
 
     wakeup: enqueueWakeup,
+
+    /** Returns the parsed heartbeat policy for an agent, or null if not found. */
+    getHeartbeatPolicy: async (agentId: string) => {
+      const agent = await getAgent(agentId);
+      return agent ? parseHeartbeatPolicy(agent) : null;
+    },
 
     reportRunActivity: clearDetachedRunWarning,
 


### PR DESCRIPTION
## Thinking path

Paperclip orchestrates AI agents via adapters (Claude, OpenClaw, etc.) → agents collaborate on issues by posting comments → when a comment is posted, the assignee is unconditionally woken with reason `issue_commented` → in hierarchical orgs (IC → Manager → Director), a reviewer approving work by commenting triggers the submitter to wake, read "approved," find nothing to do, and exit → this burns a full adapter session (model startup, context loading, tool init) for zero value → the fix is a per-agent policy flag that gates this specific wake path while preserving all other wake mechanisms.

## Problem

When any agent posts a comment on an issue, Paperclip unconditionally wakes the assignee with reason `issue_commented`. In multi-layer orgs (IC → Manager → C-Suite → CEO), this creates wasteful wakes: when a reviewer approves work by commenting, the submitting agent wakes up, reads "approved," has nothing to do, and exits — burning a full adapter session for zero value.

With 20 agents in a 4-layer hierarchy, every review cycle generates at least one wasted wake. On expensive models, this adds up fast.

## Solution

Adds `runtimeConfig.heartbeat.wakeOnComment` (boolean, default: `true`) that gates the automatic assignee-comment wake. When `false`, the assignee is **not** woken when someone comments on their issue.

All other wake paths are unaffected:
- `@-mention` wakes (`issue_comment_mentioned`) still fire
- Assignment wakes (`issue_assigned`) still fire
- Reopen-via-comment wakes (`issue_reopened_via_comment`) still fire

This is fully backward-compatible — existing agents behave identically unless `wakeOnComment` is explicitly set to `false`.

## Risks

- **Agent misses a revision request posted as a plain comment (no @-mention, no status change):** Mitigated by the fact that `@-mention` wakes are unaffected. Teams using `wakeOnComment: false` should adopt the convention of `@-mentioning` agents when action is needed, which is already the natural pattern for most workflows.
- **Agent misses state changes communicated only via comments:** If an agent's only signal for new work is a comment on an already-assigned issue (no status transition, no `@-mention`), disabling `wakeOnComment` means they won't see it until their next timer heartbeat. This is an acceptable tradeoff for teams that opt in, and the default (`true`) preserves current behavior for everyone else.
- **`getHeartbeatPolicy` DB lookup adds latency:** The lookup is placed inside the existing `void (async () => { ... })()` fire-and-forget block, so it does not affect HTTP response latency.

## Changes

- **`heartbeat.ts`**: Read `wakeOnComment` in `parseHeartbeatPolicy`, expose `getHeartbeatPolicy()` on the heartbeat service
- **`issues.ts`**: Check `policy.wakeOnComment` before enqueuing assignee wake in `POST /issues/:id/comments`
- **`issue-comment-reopen-routes.test.ts`**: 4 new test cases covering:
  1. Wake suppressed when `wakeOnComment: false`
  2. Wake fires normally when `wakeOnComment: true` (default)
  3. Null-policy fallback (agent not found) correctly enqueues the wake
  4. `@-mention` wake still fires even when `wakeOnComment: false`

## Testing

- All 86 server test files pass (432 tests, 0 failures, 1 pre-existing skip)
- Manually verified: agent with `wakeOnComment: false` no longer wakes on non-mention comments, but still wakes on `@-mention` and assignment