### PR TITLE
feat: add PAPERCLIP_PLUGIN_ALLOWED_HOSTS for self-hosted plugin access to local services

### DIFF
--- a/server/src/__tests__/plugin-allowed-hosts.test.ts
+++ b/server/src/__tests__/plugin-allowed-hosts.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import {
+  getAllowedPrivateHosts,
+  _resetAllowedPrivateHostsCache,
+  isPrivateIP,
+  validateAndResolveFetchUrl,
+} from "../services/plugin-host-services.js";
+
+// ---------------------------------------------------------------------------
+// getAllowedPrivateHosts
+// ---------------------------------------------------------------------------
+
+describe("getAllowedPrivateHosts", () => {
+  beforeEach(() => {
+    _resetAllowedPrivateHostsCache();
+  });
+
+  it("returns empty set when envValue is empty string", () => {
+    const hosts = getAllowedPrivateHosts("");
+    expect(hosts.size).toBe(0);
+  });
+
+  it("parses a single hostname", () => {
+    const hosts = getAllowedPrivateHosts("localhost");
+    expect(hosts.size).toBe(1);
+    expect(hosts.has("localhost")).toBe(true);
+  });
+
+  it("parses multiple comma-separated hostnames", () => {
+    const hosts = getAllowedPrivateHosts("localhost,127.0.0.1,myapi.local");
+    expect(hosts.size).toBe(3);
+    expect(hosts.has("localhost")).toBe(true);
+    expect(hosts.has("127.0.0.1")).toBe(true);
+    expect(hosts.has("myapi.local")).toBe(true);
+  });
+
+  it("trims whitespace around hostnames", () => {
+    const hosts = getAllowedPrivateHosts("  localhost , 127.0.0.1 ");
+    expect(hosts.has("localhost")).toBe(true);
+    expect(hosts.has("127.0.0.1")).toBe(true);
+  });
+
+  it("normalises hostnames to lowercase", () => {
+    const hosts = getAllowedPrivateHosts("LocalHost,MY-SERVER.Local");
+    expect(hosts.has("localhost")).toBe(true);
+    expect(hosts.has("my-server.local")).toBe(true);
+  });
+
+  it("filters out empty segments from trailing commas", () => {
+    const hosts = getAllowedPrivateHosts("localhost,,,,127.0.0.1,");
+    expect(hosts.size).toBe(2);
+  });
+
+  it("reads from process.env when no envValue is provided", () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "from-env.local";
+    _resetAllowedPrivateHostsCache();
+    const hosts = getAllowedPrivateHosts();
+    expect(hosts.has("from-env.local")).toBe(true);
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("caches the result from process.env on subsequent calls", () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "cached.local";
+    _resetAllowedPrivateHostsCache();
+    const first = getAllowedPrivateHosts();
+    // Change env — should still return cached value
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "different.local";
+    const second = getAllowedPrivateHosts();
+    expect(first).toBe(second); // same Set instance
+    expect(second.has("cached.local")).toBe(true);
+    expect(second.has("different.local")).toBe(false);
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("bypasses cache when explicit envValue is provided", () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "from-env.local";
+    _resetAllowedPrivateHostsCache();
+    const hosts = getAllowedPrivateHosts("explicit.local");
+    expect(hosts.has("explicit.local")).toBe(true);
+    expect(hosts.has("from-env.local")).toBe(false);
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPrivateIP
+// ---------------------------------------------------------------------------
+
+describe("isPrivateIP", () => {
+  it.each([
+    ["10.0.0.1", true],
+    ["10.255.255.255", true],
+    ["172.16.0.1", true],
+    ["172.31.255.255", true],
+    ["172.15.0.1", false],
+    ["172.32.0.1", false],
+    ["192.168.0.1", true],
+    ["192.168.255.255", true],
+    ["127.0.0.1", true],
+    ["127.255.255.255", true],
+    ["169.254.1.1", true],
+    ["0.0.0.0", true],
+    ["8.8.8.8", false],
+    ["1.1.1.1", false],
+    ["142.250.80.46", false],
+  ])("IPv4 %s → private=%s", (ip, expected) => {
+    expect(isPrivateIP(ip)).toBe(expected);
+  });
+
+  it.each([
+    ["::1", true],
+    ["fc00::1", true],
+    ["fd12:3456::1", true],
+    ["fe80::1", true],
+    ["::", true],
+    ["2001:4860:4860::8888", false],
+  ])("IPv6 %s → private=%s", (ip, expected) => {
+    expect(isPrivateIP(ip)).toBe(expected);
+  });
+
+  it.each([
+    ["::ffff:127.0.0.1", true],
+    ["::ffff:10.0.0.1", true],
+    ["::ffff:8.8.8.8", false],
+    ["::ffff:192.168.1.1", true],
+  ])("IPv4-mapped IPv6 %s → private=%s", (ip, expected) => {
+    expect(isPrivateIP(ip)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAndResolveFetchUrl — protocol & SSRF checks
+// ---------------------------------------------------------------------------
+
+describe("validateAndResolveFetchUrl", () => {
+  beforeEach(() => {
+    _resetAllowedPrivateHostsCache();
+  });
+
+  it("rejects invalid URLs", async () => {
+    await expect(validateAndResolveFetchUrl("not-a-url")).rejects.toThrow("Invalid URL");
+  });
+
+  it("rejects disallowed protocols", async () => {
+    await expect(validateAndResolveFetchUrl("ftp://example.com/file")).rejects.toThrow(
+      /Disallowed protocol.*ftp/,
+    );
+  });
+
+  it("rejects file:// protocol", async () => {
+    await expect(validateAndResolveFetchUrl("file:///etc/passwd")).rejects.toThrow(
+      /Disallowed protocol.*file/,
+    );
+  });
+
+  it("resolves a public hostname and returns pinned target", async () => {
+    // example.com is IANA-reserved and should resolve to a public IP
+    const target = await validateAndResolveFetchUrl("https://example.com/path?q=1");
+    expect(target.parsedUrl.hostname).toBe("example.com");
+    expect(target.resolvedAddress).toBeTruthy();
+    expect(target.hostHeader).toBe("example.com");
+    expect(target.useTls).toBe(true);
+    expect(target.tlsServername).toBe("example.com");
+    expect(isPrivateIP(target.resolvedAddress)).toBe(false);
+  });
+
+  it("blocks localhost by default (no allowlist)", async () => {
+    await expect(validateAndResolveFetchUrl("http://localhost:3000/api")).rejects.toThrow(
+      /private\/reserved/,
+    );
+  });
+
+  it("blocks 127.0.0.1 by default (no allowlist)", async () => {
+    await expect(validateAndResolveFetchUrl("http://127.0.0.1:8080/")).rejects.toThrow(
+      /private\/reserved/,
+    );
+  });
+
+  it("allows localhost when in PAPERCLIP_PLUGIN_ALLOWED_HOSTS", async () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "localhost";
+    _resetAllowedPrivateHostsCache();
+    const target = await validateAndResolveFetchUrl("http://localhost:3000/api");
+    expect(target.parsedUrl.hostname).toBe("localhost");
+    // Resolved IP should be loopback — pinned for DNS rebinding prevention
+    expect(target.resolvedAddress).toMatch(/^127\.|^::1$/);
+    expect(target.useTls).toBe(false);
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("allows 127.0.0.1 when in PAPERCLIP_PLUGIN_ALLOWED_HOSTS", async () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "127.0.0.1";
+    _resetAllowedPrivateHostsCache();
+    const target = await validateAndResolveFetchUrl("http://127.0.0.1:18890/api/tasks");
+    expect(target.resolvedAddress).toMatch(/^127\./);
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("still applies DNS pinning to allowed private hosts", async () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "localhost";
+    _resetAllowedPrivateHostsCache();
+    const target = await validateAndResolveFetchUrl("http://localhost:3000/test");
+    // The resolved address should be set (DNS pinning happened)
+    expect(target.resolvedAddress).toBeTruthy();
+    // Host header preserved for correct routing
+    expect(target.hostHeader).toBe("localhost:3000");
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("hostname matching is case-insensitive", async () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "LOCALHOST";
+    _resetAllowedPrivateHostsCache();
+    // URL hostname is normalised to lowercase by URL constructor
+    const target = await validateAndResolveFetchUrl("http://localhost:3000/");
+    expect(target.resolvedAddress).toBeTruthy();
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("does not allow unlisted private hosts even when allowlist is non-empty", async () => {
+    process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS = "localhost";
+    _resetAllowedPrivateHostsCache();
+    // 127.0.0.2 resolves to private IP but isn't "localhost"
+    await expect(validateAndResolveFetchUrl("http://127.0.0.2:3000/")).rejects.toThrow(
+      /private\/reserved/,
+    );
+    delete process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS;
+  });
+
+  it("preserves path and query string in parsed URL", async () => {
+    const target = await validateAndResolveFetchUrl(
+      "https://example.com/api/v1/tasks?status=open&limit=10",
+    );
+    expect(target.parsedUrl.pathname).toBe("/api/v1/tasks");
+    expect(target.parsedUrl.search).toBe("?status=open&limit=10");
+  });
+});

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -61,16 +61,39 @@ const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
  *
  * Allowed hosts still go through DNS pinning to prevent rebinding attacks;
  * only the private-IP filter is bypassed.
+ *
+ * **Security note:** Adding a hostname to this allowlist permits plugins to
+ * reach *any* port and path on that host (e.g. `localhost` opens access to
+ * every local service — Postgres, Redis, etc.). Only add hosts you trust all
+ * installed plugins to contact.
  */
 let _allowedPrivateHosts: Set<string> | undefined;
-function getAllowedPrivateHosts(): Set<string> {
+
+function getAllowedPrivateHosts(envValue?: string): Set<string> {
+  if (envValue !== undefined) {
+    // Explicit value passed (e.g. from tests) — bypass cache.
+    return new Set(
+      envValue.split(",").map((h) => h.trim().toLowerCase()).filter(Boolean),
+    );
+  }
   if (!_allowedPrivateHosts) {
     const raw = process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS ?? "";
     _allowedPrivateHosts = new Set(
       raw.split(",").map((h) => h.trim().toLowerCase()).filter(Boolean),
     );
+    if (_allowedPrivateHosts.size > 0) {
+      logger.warn(
+        { allowedHosts: [..._allowedPrivateHosts] },
+        "PAPERCLIP_PLUGIN_ALLOWED_HOSTS is set — plugins may reach private/local IPs on these hosts",
+      );
+    }
   }
   return _allowedPrivateHosts;
+}
+
+/** Reset the cached allowlist. Exported for test isolation only. */
+export function _resetAllowedPrivateHostsCache(): void {
+  _allowedPrivateHosts = undefined;
 }
 
 /**
@@ -174,6 +197,7 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
     // Hosts listed in PAPERCLIP_PLUGIN_ALLOWED_HOSTS bypass private-IP
     // filtering so that self-hosted plugins can reach local services.
     // DNS pinning still applies to prevent rebinding.
+    // Note: allowed hosts can be reached on ANY port — see JSDoc above.
     const allowedHosts = getAllowedPrivateHosts();
     const hostIsAllowed = allowedHosts.has(originalHostname.toLowerCase());
     const safeResults = hostIsAllowed

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -49,6 +49,31 @@ const DNS_LOOKUP_TIMEOUT_MS = 5_000;
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 
 /**
+ * Hostnames that plugins are allowed to reach even when they resolve to
+ * private/reserved IP addresses.
+ *
+ * Self-hosted deployments often run plugins alongside local services (databases,
+ * APIs, other agents) on the same machine or LAN. Without an allowlist, all
+ * plugin HTTP requests to these services are blocked by SSRF protection.
+ *
+ * Set via the `PAPERCLIP_PLUGIN_ALLOWED_HOSTS` environment variable as a
+ * comma-separated list of hostnames (e.g. `localhost,127.0.0.1,myapi.local`).
+ *
+ * Allowed hosts still go through DNS pinning to prevent rebinding attacks;
+ * only the private-IP filter is bypassed.
+ */
+let _allowedPrivateHosts: Set<string> | undefined;
+function getAllowedPrivateHosts(): Set<string> {
+  if (!_allowedPrivateHosts) {
+    const raw = process.env.PAPERCLIP_PLUGIN_ALLOWED_HOSTS ?? "";
+    _allowedPrivateHosts = new Set(
+      raw.split(",").map((h) => h.trim().toLowerCase()).filter(Boolean),
+    );
+  }
+  return _allowedPrivateHosts;
+}
+
+/**
  * Check if an IP address is in a private/reserved range (RFC 1918, loopback,
  * link-local, etc.) that plugins should never be able to reach.
  *
@@ -145,7 +170,15 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
     // Filter to only non-private IPs instead of rejecting the entire request
     // when some IPs are private. This handles multi-homed hosts that resolve
     // to both private and public addresses.
-    const safeResults = results.filter((entry) => !isPrivateIP(entry.address));
+    //
+    // Hosts listed in PAPERCLIP_PLUGIN_ALLOWED_HOSTS bypass private-IP
+    // filtering so that self-hosted plugins can reach local services.
+    // DNS pinning still applies to prevent rebinding.
+    const allowedHosts = getAllowedPrivateHosts();
+    const hostIsAllowed = allowedHosts.has(originalHostname.toLowerCase());
+    const safeResults = hostIsAllowed
+      ? results
+      : results.filter((entry) => !isPrivateIP(entry.address));
     if (safeResults.length === 0) {
       throw new Error(
         `All resolved IPs for ${originalHostname} are in private/reserved ranges`,

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -69,7 +69,8 @@ const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
  */
 let _allowedPrivateHosts: Set<string> | undefined;
 
-function getAllowedPrivateHosts(envValue?: string): Set<string> {
+/** @internal Exported for testing only. */
+export function getAllowedPrivateHosts(envValue?: string): Set<string> {
   if (envValue !== undefined) {
     // Explicit value passed (e.g. from tests) — bypass cache.
     return new Set(
@@ -103,7 +104,8 @@ export function _resetAllowedPrivateHostsCache(): void {
  * Handles IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) which Node's
  * dns.lookup may return depending on OS configuration.
  */
-function isPrivateIP(ip: string): boolean {
+/** @internal Exported for testing only. */
+export function isPrivateIP(ip: string): boolean {
   const lower = ip.toLowerCase();
 
   // Unwrap IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) and re-check as IPv4
@@ -146,7 +148,8 @@ function isPrivateIP(ip: string): boolean {
  * @returns Request-routing metadata used to connect directly to the resolved IP
  *          while preserving the original hostname for HTTP Host and TLS SNI.
  */
-interface ValidatedFetchTarget {
+/** @internal Exported for testing only. */
+export interface ValidatedFetchTarget {
   parsedUrl: URL;
   resolvedAddress: string;
   hostHeader: string;
@@ -154,7 +157,8 @@ interface ValidatedFetchTarget {
   useTls: boolean;
 }
 
-async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedFetchTarget> {
+/** @internal Exported for testing only. */
+export async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedFetchTarget> {
   let parsed: URL;
   try {
     parsed = new URL(urlString);


### PR DESCRIPTION
### Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend Paperclip by integrating with external services via `ctx.http.fetch`
> - But `plugin-host-services.ts` blocks ALL HTTP requests that resolve to private/reserved IPs (SSRF protection)
> - Self-hosted deployments often run plugins alongside local services (databases, APIs, other agents) on the same machine or LAN
> - So plugins cannot reach local services at all in self-hosted mode
> - This PR adds an opt-in `PAPERCLIP_PLUGIN_ALLOWED_HOSTS` env var that bypasses the private-IP filter for explicitly listed hostnames
> - DNS pinning, protocol whitelisting, and fetch timeouts are all preserved for allowed hosts
> - The benefit is self-hosted operators can use plugins that integrate with local services without weakening SSRF protection for cloud deployments

## What

Adds `PAPERCLIP_PLUGIN_ALLOWED_HOSTS` environment variable (comma-separated hostnames) that permits plugin HTTP requests to reach private/local IPs for explicitly listed hosts.

```
PAPERCLIP_PLUGIN_ALLOWED_HOSTS=localhost,127.0.0.1
```

## Why

I built [paperclip-delega](https://github.com/delega-dev/paperclip-delega), a plugin that syncs Paperclip issues with a local [Delega](https://github.com/delega-dev/delega) task server. Every `ctx.http.fetch` call to `localhost:18890` was rejected by the SSRF filter. This affects any plugin that talks to a co-located service in self-hosted deployments.

## What stays safe

- **DNS pinning preserved** — allowed hosts still get pinned to their resolved IP (prevents rebinding)
- **Protocol whitelist** — only http/https (unchanged)
- **Fetch timeout** — 30s limit (unchanged)
- **Non-allowed hosts** — fully protected, zero behavior change
- **Cloud deployments** — env var defaults to empty, zero behavior change
- **Startup warning** — server logs a warning when the allowlist is active so operators see what is exposed

## Risks

- **Port exposure:** Adding a hostname (e.g. `localhost`) opens ALL ports on that host to every installed plugin, including third-party ones. This is documented in JSDoc and logged at startup, but operators should only add hosts they trust all plugins to contact.
- **No per-plugin scoping:** The allowlist is global, not per-plugin. A future enhancement could scope allowed hosts per plugin in the manifest.

## How to verify

1. Start Paperclip without `PAPERCLIP_PLUGIN_ALLOWED_HOSTS` — confirm plugins still cannot fetch private IPs (existing behavior)
2. Set `PAPERCLIP_PLUGIN_ALLOWED_HOSTS=localhost` — confirm plugins can fetch `http://localhost:*` and a startup warning is logged
3. Confirm plugins still cannot reach other private IPs not in the allowlist (e.g. `192.168.1.100`)
4. Use `_resetAllowedPrivateHostsCache()` in tests to verify cache reset between test cases

## Changes

- 1 file: `server/src/services/plugin-host-services.ts`
- `getAllowedPrivateHosts()` — reads and caches env var, accepts optional param for test injection, logs warning when non-empty
- `_resetAllowedPrivateHostsCache()` — exported test helper to clear module-level cache
- `validateAndResolveFetchUrl()` — checks allowlist before filtering private IPs
- JSDoc security notes about port/path exposure