### PR TITLE
fix(cli): allow -C/--company-id from context profile and env var

### DIFF
--- a/cli/src/commands/client/activity.ts
+++ b/cli/src/commands/client/activity.ts
@@ -23,7 +23,7 @@ export function registerActivityCommands(program: Command): void {
     activity
       .command("list")
       .description("List company activity log entries")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--agent-id <id>", "Filter by agent ID")
       .option("--entity-type <type>", "Filter by entity type")
       .option("--entity-id <id>", "Filter by entity ID")

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -163,7 +163,7 @@ export function registerAgentCommands(program: Command): void {
     agent
       .command("list")
       .description("List agents for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .action(async (opts: AgentListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -222,7 +222,7 @@ export function registerAgentCommands(program: Command): void {
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",
       )
       .argument("<agentRef>", "Agent ID or shortname/url-key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--key-name <name>", "API key label", "local-cli")
       .option(
         "--no-install-skills",

--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -49,7 +49,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("list")
       .description("List approvals for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .option("--status <status>", "Status filter")
       .action(async (opts: ApprovalListOptions) => {
         try {
@@ -110,7 +110,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("create")
       .description("Create an approval request")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .requiredOption("--type <type>", "Approval type (hire_agent|approve_ceo_strategy)")
       .requiredOption("--payload <json>", "Approval payload as JSON object")
       .option("--requested-by-agent-id <id>", "Requesting agent ID")

--- a/cli/src/commands/client/dashboard.ts
+++ b/cli/src/commands/client/dashboard.ts
@@ -19,7 +19,7 @@ export function registerDashboardCommands(program: Command): void {
     dashboard
       .command("get")
       .description("Get dashboard summary for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .action(async (opts: DashboardGetOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -136,7 +136,7 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("create")
       .description("Create an issue")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID")
       .requiredOption("--title <title>", "Issue title")
       .option("--description <text>", "Issue description")
       .option("--status <status>", "Issue status")


### PR DESCRIPTION
## Summary
- Fixes #1391 — CLI context profile's `companyId` is ignored because Commander.js `.requiredOption()` validates before the action handler runs, preventing `resolveCommandContext()` from applying fallbacks.
- Changes `.requiredOption("-C, --company-id <id>")` → `.option("-C, --company-id <id>")` in all 7 occurrences across 5 files.
- `resolveCommandContext({ requireCompany: true })` already provides a clear error when no company ID is available from any source.

## Affected files
- `cli/src/commands/client/dashboard.ts`
- `cli/src/commands/client/activity.ts`
- `cli/src/commands/client/agent.ts` (2 occurrences)
- `cli/src/commands/client/approval.ts` (2 occurrences)
- `cli/src/commands/client/issue.ts`

## Test plan
- [ ] CLI builds cleanly
- [ ] All 66 CLI tests pass (12 test files)
- [ ] `paperclipai context set --company-id <id>` then `paperclipai dashboard get` works without `-C`
- [ ] `-C` flag still works when explicitly provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)