### PR TITLE
fix: enforce intervalSec cooldown in releaseIssueExecutionAndPromote

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2760,6 +2760,43 @@ export function heartbeatService(db: Db) {
           continue;
         }
 
+        // Cooldown enforcement: do not promote if agent ran within its intervalSec.
+        // This prevents rapid-fire cascading where each completed run immediately
+        // triggers the next deferred wakeup, ignoring the configured heartbeat interval.
+        const deferredPolicy = parseHeartbeatPolicy(deferredAgent);
+        if (deferredPolicy.intervalSec > 0) {
+          const lastFinished = await tx
+            .select({ finishedAt: heartbeatRuns.finishedAt })
+            .from(heartbeatRuns)
+            .where(
+              and(
+                eq(heartbeatRuns.agentId, deferredAgent.id),
+                sql`${heartbeatRuns.finishedAt} is not null`,
+              ),
+            )
+            .orderBy(desc(heartbeatRuns.finishedAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+
+          if (
+            lastFinished?.finishedAt &&
+            (Date.now() - lastFinished.finishedAt.getTime()) / 1000 < deferredPolicy.intervalSec
+          ) {
+            // Agent ran too recently — leave deferred wakeup in place for the
+            // normal heartbeat timer to pick up at the proper interval.
+            logger.info(
+              {
+                agentId: deferredAgent.id,
+                intervalSec: deferredPolicy.intervalSec,
+                lastFinishedAt: lastFinished.finishedAt.toISOString(),
+                deferredWakeId: deferred.id,
+              },
+              "Skipping deferred wakeup promotion: agent within cooldown interval",
+            );
+            return null;
+          }
+        }
+
         const deferredPayload = parseObject(deferred.payload);
         const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
         const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };


### PR DESCRIPTION
## Problem

When a run completes, `releaseIssueExecutionAndPromote` promotes any `deferred_issue_execution` wakeup to `queued` immediately. This cascades into back-to-back runs because:

1. Run finishes → deferred wakeup promoted → new queued run created
2. `startNextQueuedRunForAgent` has a cooldown, but it caps at `MIN_RUN_COOLDOWN_SEC` (60s)
3. Each completed run triggers new deferred wakeups from status change events
4. Result: runs every ~60s instead of every `intervalSec` (e.g., 3900s for CTO)

**Observed impact:** CTO agent had 220 queued wakeups and 19 runs in 1 hour.

## Fix

Before promoting a deferred wakeup in `releaseIssueExecutionAndPromote`, check the agent's last finished run time against its configured `intervalSec`. If the agent ran within that interval, leave the deferred wakeup in place for the normal heartbeat timer to pick up at the correct cadence.

This is a targeted, minimal change — only the promotion path is gated. On-demand wakes, manual triggers, and the normal heartbeat timer are unaffected.

## Changes

- `server/src/services/heartbeat.ts`: Added cooldown check in `releaseIssueExecutionAndPromote` before promoting deferred wakeups to queued runs.