### PR TITLE
feat: add canAssignTasks permission independent of canCreateAgents

### DIFF
--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -11,6 +11,7 @@ import type {
 
 export interface AgentPermissions {
   canCreateAgents: boolean;
+  canAssignTasks: boolean;
 }
 
 export type AgentInstructionsBundleMode = "managed" | "external";

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -9,6 +9,7 @@ import { envConfigSchema } from "./secret.js";
 
 export const agentPermissionsSchema = z.object({
   canCreateAgents: z.boolean().optional().default(false),
+  canAssignTasks: z.boolean().optional().default(false),
 });
 
 export const agentInstructionsBundleModeSchema = z.enum(["managed", "external"]);

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -245,7 +245,7 @@ describe("agent permission routes", () => {
   it("keeps task assignment enabled when agent creation privilege is enabled", async () => {
     mockAgentService.updatePermissions.mockResolvedValue({
       ...baseAgent,
-      permissions: { canCreateAgents: true },
+      permissions: { canCreateAgents: true, canAssignTasks: true },
     });
 
     const app = createApp({
@@ -271,5 +271,36 @@ describe("agent permission routes", () => {
     );
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
+  });
+
+  it("grants tasks:assign independently when canAssignTasks is true without canCreateAgents", async () => {
+    mockAgentService.updatePermissions.mockResolvedValue({
+      ...baseAgent,
+      permissions: { canCreateAgents: false, canAssignTasks: true },
+    });
+
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${agentId}/permissions`)
+      .send({ canCreateAgents: false, canAssignTasks: true });
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "tasks:assign",
+      true,
+      "board-user",
+    );
+    expect(res.body.access.canAssignTasks).toBe(true);
+    expect(res.body.access.taskAssignSource).toBe("explicit_grant");
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -124,7 +124,11 @@ export function agentRoutes(db: Db) {
       };
     }
 
-    if (hasExplicitTaskAssignGrant) {
+    const hasPermissionFlag = Boolean(
+      agent.permissions && (agent.permissions as Record<string, unknown>).canAssignTasks,
+    );
+
+    if (hasExplicitTaskAssignGrant || hasPermissionFlag) {
       return {
         canAssignTasks: true,
         taskAssignSource: "explicit_grant" as const,
@@ -1406,7 +1410,7 @@ export function agentRoutes(db: Db) {
     }
 
     const effectiveCanAssignTasks =
-      agent.role === "ceo" || Boolean(agent.permissions?.canCreateAgents) || req.body.canAssignTasks;
+      agent.role === "ceo" || Boolean(agent.permissions?.canAssignTasks);
     await access.ensureMembership(agent.companyId, "agent", agent.id, "member", "active");
     await access.setPrincipalPermission(
       agent.companyId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -90,10 +90,11 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return false;
   }
 
-  function canCreateAgentsLegacy(agent: { permissions: Record<string, unknown> | null | undefined; role: string }) {
+  function canAssignTasksFromPermissions(agent: { permissions: Record<string, unknown> | null | undefined; role: string }) {
     if (agent.role === "ceo") return true;
     if (!agent.permissions || typeof agent.permissions !== "object") return false;
-    return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
+    const perms = agent.permissions as Record<string, unknown>;
+    return Boolean(perms.canAssignTasks) || Boolean(perms.canCreateAgents);
   }
 
   async function assertCanAssignTasks(req: Request, companyId: string) {
@@ -109,7 +110,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:assign");
       if (allowedByGrant) return;
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
-      if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
+      if (actorAgent && actorAgent.companyId === companyId && canAssignTasksFromPermissions(actorAgent)) return;
       throw forbidden("Missing permission: tasks:assign");
     }
     throw unauthorized();

--- a/server/src/services/agent-permissions.ts
+++ b/server/src/services/agent-permissions.ts
@@ -1,10 +1,12 @@
 export type NormalizedAgentPermissions = Record<string, unknown> & {
   canCreateAgents: boolean;
+  canAssignTasks: boolean;
 };
 
 export function defaultPermissionsForRole(role: string): NormalizedAgentPermissions {
   return {
     canCreateAgents: role === "ceo",
+    canAssignTasks: role === "ceo",
   };
 }
 
@@ -18,10 +20,16 @@ export function normalizeAgentPermissions(
   }
 
   const record = permissions as Record<string, unknown>;
-  return {
-    canCreateAgents:
-      typeof record.canCreateAgents === "boolean"
-        ? record.canCreateAgents
-        : defaults.canCreateAgents,
-  };
+  const canCreateAgents =
+    typeof record.canCreateAgents === "boolean"
+      ? record.canCreateAgents
+      : defaults.canCreateAgents;
+
+  // canCreateAgents implies canAssignTasks (backfill and invariant).
+  // An explicit canAssignTasks: true is also sufficient on its own.
+  const canAssignTasks =
+    canCreateAgents ||
+    (typeof record.canAssignTasks === "boolean" ? record.canAssignTasks : defaults.canAssignTasks);
+
+  return { canCreateAgents, canAssignTasks };
 }

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -504,7 +504,7 @@ export function agentService(db: Db) {
       return updated ? normalizeAgentRow(updated) : null;
     },
 
-    updatePermissions: async (id: string, permissions: { canCreateAgents: boolean }) => {
+    updatePermissions: async (id: string, permissions: { canCreateAgents: boolean; canAssignTasks: boolean }) => {
       const existing = await getById(id);
       if (!existing) return null;
 


### PR DESCRIPTION
## Summary

- Adds `canAssignTasks: boolean` to `AgentPermissions` type and `agentPermissionsSchema` so agents can be granted task routing ability independently of agent creation rights
- Updates `normalizeAgentPermissions` to persist `canAssignTasks`; agents with `canCreateAgents: true` automatically get `canAssignTasks: true` (backfill invariant, no data migration needed)
- Adds `canAssignTasks` check to `buildAgentAccessState` and `assertCanAssignTasks` so the flag is enforced directly from JSONB in addition to the grant-based path
- Simplifies `effectiveCanAssignTasks` in permissions update handler to use persisted normalized value
- Adds test for the independent grant path (`canAssignTasks: true` without `canCreateAgents`)

Closes QUE-185.

## Test plan

- [ ] Existing agent with `canCreateAgents: true` retains task assignment ability (no regression)
- [ ] Agent with `canCreateAgents: false, canAssignTasks: true` can assign tasks independently
- [ ] Agent with neither flag cannot assign tasks
- [ ] `PATCH /api/agents/:id/permissions` with `canAssignTasks: true` sets `tasks:assign` grant
- [ ] `GET /api/agents/:id` reflects correct `access.canAssignTasks` and `taskAssignSource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)