### PR TITLE
fix: add missing plugin-sdk and plugin packages to Dockerfile deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+COPY packages/plugins/create-paperclip-plugin/package.json packages/plugins/create-paperclip-plugin/
+COPY packages/plugins/examples/plugin-authoring-smoke-example/package.json packages/plugins/examples/plugin-authoring-smoke-example/
+COPY packages/plugins/examples/plugin-file-browser-example/package.json packages/plugins/examples/plugin-file-browser-example/
+COPY packages/plugins/examples/plugin-hello-world-example/package.json packages/plugins/examples/plugin-hello-world-example/
+COPY packages/plugins/examples/plugin-kitchen-sink-example/package.json packages/plugins/examples/plugin-kitchen-sink-example/
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
The @paperclipai/plugin-sdk workspace package was not listed in the Dockerfile's deps stage COPY commands, causing pnpm to not register it as a workspace package. TypeScript then failed to resolve the module during the server build.

https://claude.ai/code/session_01SMNdCdpPW9XNF1gUWaaDED