### PR TITLE
feat: display agent title alongside name

### DIFF
--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -31,6 +31,7 @@ export interface CostSummary {
 export interface CostByAgent {
   agentId: string;
   agentName: string | null;
+  agentTitle?: string | null;
   agentStatus: string | null;
   costCents: number;
   inputTokens: number;
@@ -78,6 +79,7 @@ export interface CostByBiller {
 export interface CostByAgentModel {
   agentId: string;
   agentName: string | null;
+  agentTitle?: string | null;
   provider: string;
   biller: string;
   billingType: BillingType;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2045,6 +2045,7 @@ export function agentRoutes(db: Db) {
       createdAt: heartbeatRuns.createdAt,
       agentId: heartbeatRuns.agentId,
       agentName: agentsTable.name,
+      agentTitle: agentsTable.title,
       adapterType: agentsTable.adapterType,
       issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
     };
@@ -2212,6 +2213,7 @@ export function agentRoutes(db: Db) {
         createdAt: heartbeatRuns.createdAt,
         agentId: heartbeatRuns.agentId,
         agentName: agentsTable.name,
+        agentTitle: agentsTable.title,
         adapterType: agentsTable.adapterType,
       })
       .from(heartbeatRuns)
@@ -2267,6 +2269,7 @@ export function agentRoutes(db: Db) {
       ...redactCurrentUserValue(run, await getCurrentUserRedactionOptions()),
       agentId: agent.id,
       agentName: agent.name,
+      agentTitle: agent.title,
       adapterType: agent.adapterType,
     });
   });

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -139,6 +139,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .select({
           agentId: costEvents.agentId,
           agentName: agents.name,
+          agentTitle: agents.title,
           agentStatus: agents.status,
           costCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
           inputTokens: sql<number>`coalesce(sum(${costEvents.inputTokens}), 0)::int`,
@@ -288,6 +289,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .select({
           agentId: costEvents.agentId,
           agentName: agents.name,
+          agentTitle: agents.title,
           provider: costEvents.provider,
           biller: costEvents.biller,
           billingType: costEvents.billingType,

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -9,6 +9,7 @@ import { api } from "./client";
 export interface ActiveRunForIssue extends HeartbeatRun {
   agentId: string;
   agentName: string;
+  agentTitle?: string | null;
   adapterType: string;
 }
 
@@ -22,6 +23,7 @@ export interface LiveRunForIssue {
   createdAt: string;
   agentId: string;
   agentName: string;
+  agentTitle?: string | null;
   adapterType: string;
   issueId?: string | null;
 }

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -108,7 +108,7 @@ function AgentRunCard({
               ) : (
                 <span className="inline-flex h-2.5 w-2.5 rounded-full bg-muted-foreground/35" />
               )}
-              <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
+              <Identity name={run.agentName} title={run.agentTitle} size="sm" className="[&>span:last-child]:!text-[11px]" />
             </div>
             <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
               <span>{isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}</span>

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -95,6 +95,11 @@ export function CommandPalette() {
     return agents.find((a) => a.id === id)?.name ?? null;
   };
 
+  const agentTitle = (id: string | null) => {
+    if (!id) return null;
+    return agents.find((a) => a.id === id)?.title ?? null;
+  };
+
   const visibleIssues = useMemo(
     () => (searchQuery.length > 0 ? searchedIssues : issues),
     [issues, searchedIssues, searchQuery],
@@ -197,7 +202,8 @@ export function CommandPalette() {
                   <span className="flex-1 truncate">{issue.title}</span>
                   {issue.assigneeAgentId && (() => {
                     const name = agentName(issue.assigneeAgentId);
-                    return name ? <Identity name={name} size="sm" className="ml-2 hidden sm:inline-flex" /> : null;
+                    const title = agentTitle(issue.assigneeAgentId);
+                    return name ? <Identity name={name} title={title} size="sm" className="ml-2 hidden sm:inline-flex" /> : null;
                   })()}
                 </CommandItem>
               ))}

--- a/ui/src/components/Identity.tsx
+++ b/ui/src/components/Identity.tsx
@@ -5,6 +5,7 @@ type IdentitySize = "xs" | "sm" | "default" | "lg";
 
 export interface IdentityProps {
   name: string;
+  title?: string | null;
   avatarUrl?: string | null;
   initials?: string;
   size?: IdentitySize;
@@ -24,7 +25,7 @@ const textSize: Record<IdentitySize, string> = {
   lg: "text-sm",
 };
 
-export function Identity({ name, avatarUrl, initials, size = "default", className }: IdentityProps) {
+export function Identity({ name, title, avatarUrl, initials, size = "default", className }: IdentityProps) {
   const displayInitials = initials ?? deriveInitials(name);
 
   return (
@@ -33,7 +34,10 @@ export function Identity({ name, avatarUrl, initials, size = "default", classNam
         {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
         <AvatarFallback>{displayInitials}</AvatarFallback>
       </Avatar>
-      <span className={cn("truncate", textSize[size])}>{name}</span>
+      <span className={cn("truncate", textSize[size])}>
+        {name}
+        {title && <span className="ml-1 text-muted-foreground font-normal">({title})</span>}
+      </span>
     </span>
   );
 }

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -255,6 +255,11 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
     return agent?.name ?? id.slice(0, 8);
   };
 
+  const agentTitle = (id: string | null) => {
+    if (!id || !agents) return null;
+    return agents.find((a) => a.id === id)?.title ?? null;
+  };
+
   const projectName = (id: string | null) => {
     if (!id) return id?.slice(0, 8) ?? "None";
     const project = orderedProjects.find((p) => p.id === id);
@@ -420,7 +425,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
   );
 
   const assigneeTrigger = assignee ? (
-    <Identity name={assignee.name} size="sm" />
+    <Identity name={assignee.name} title={assignee.title} size="sm" />
   ) : assigneeUserLabel ? (
     <>
       <User className="h-3.5 w-3.5 text-muted-foreground" />
@@ -771,7 +776,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
                 to={`/agents/${issue.createdByAgentId}`}
                 className="hover:underline"
               >
-                <Identity name={agentName(issue.createdByAgentId) ?? issue.createdByAgentId.slice(0, 8)} size="sm" />
+                <Identity name={agentName(issue.createdByAgentId) ?? issue.createdByAgentId.slice(0, 8)} title={agentTitle(issue.createdByAgentId)} size="sm" />
               </Link>
             ) : (
               <>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -143,6 +143,7 @@ function countActiveFilters(state: IssueViewState): number {
 interface Agent {
   id: string;
   name: string;
+  title?: string | null;
 }
 
 interface IssuesListProps {
@@ -236,6 +237,11 @@ export function IssuesList({
   const agentName = useCallback((id: string | null) => {
     if (!id || !agents) return null;
     return agents.find((a) => a.id === id)?.name ?? null;
+  }, [agents]);
+
+  const agentTitle = useCallback((id: string | null) => {
+    if (!id || !agents) return null;
+    return agents.find((a) => a.id === id)?.title ?? null;
   }, [agents]);
 
   const filtered = useMemo(() => {
@@ -724,7 +730,7 @@ export function IssuesList({
                             }}
                           >
                             {issue.assigneeAgentId && agentName(issue.assigneeAgentId) ? (
-                              <Identity name={agentName(issue.assigneeAgentId)!} size="sm" />
+                              <Identity name={agentName(issue.assigneeAgentId)!} title={agentTitle(issue.assigneeAgentId)} size="sm" />
                             ) : issue.assigneeUserId ? (
                               <span className="inline-flex items-center gap-1.5 text-xs">
                                 <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-dashed border-muted-foreground/35 bg-muted/30">

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -39,6 +39,7 @@ function statusLabel(status: string): string {
 interface Agent {
   id: string;
   name: string;
+  title?: string | null;
 }
 
 interface KanbanBoardProps {
@@ -130,6 +131,11 @@ function KanbanCard({
     return agents.find((a) => a.id === id)?.name ?? null;
   };
 
+  const agentTitle = (id: string | null) => {
+    if (!id || !agents) return null;
+    return agents.find((a) => a.id === id)?.title ?? null;
+  };
+
   return (
     <div
       ref={setNodeRef}
@@ -164,8 +170,9 @@ function KanbanCard({
           <PriorityIcon priority={issue.priority} />
           {issue.assigneeAgentId && (() => {
             const name = agentName(issue.assigneeAgentId);
+            const title = agentTitle(issue.assigneeAgentId);
             return name ? (
-              <Identity name={name} size="xs" />
+              <Identity name={name} title={title} size="xs" />
             ) : (
               <span className="text-xs text-muted-foreground font-mono">
                 {issue.assigneeAgentId.slice(0, 8)}

--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -106,7 +106,7 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
               <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0">
                   <Link to={`/agents/${run.agentId}`} className="inline-flex hover:underline">
-                    <Identity name={run.agentName} size="sm" />
+                    <Identity name={run.agentName} title={run.agentTitle} size="sm" />
                   </Link>
                   <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     <Link

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -63,6 +63,12 @@ export function ApprovalDetail() {
     return map;
   }, [agents]);
 
+  const agentTitleById = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const agent of agents ?? []) map.set(agent.id, agent.title);
+    return map;
+  }, [agents]);
+
   useEffect(() => {
     setBreadcrumbs([
       { label: "Approvals", href: "/approvals" },
@@ -215,6 +221,7 @@ export function ApprovalDetail() {
               <span className="text-muted-foreground text-xs">Requested by</span>
               <Identity
                 name={agentNameById.get(approval.requestedByAgentId) ?? approval.requestedByAgentId.slice(0, 8)}
+                title={agentTitleById.get(approval.requestedByAgentId)}
                 size="sm"
               />
             </div>
@@ -333,6 +340,7 @@ export function ApprovalDetail() {
                   <Link to={`/agents/${comment.authorAgentId}`} className="hover:underline">
                     <Identity
                       name={agentNameById.get(comment.authorAgentId) ?? comment.authorAgentId.slice(0, 8)}
+                      title={agentTitleById.get(comment.authorAgentId)}
                       size="sm"
                     />
                   </Link>

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -741,7 +741,7 @@ export function Costs() {
                                 ) : (
                                   <span className="h-3 w-3 shrink-0" />
                                 )}
-                                <Identity name={row.agentName ?? row.agentId} size="sm" />
+                                <Identity name={row.agentName ?? row.agentId} title={row.agentTitle} size="sm" />
                                 {row.agentStatus === "terminated" ? <StatusBadge status="terminated" /> : null}
                               </div>
                               <div className="text-right text-sm tabular-nums">

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -163,6 +163,11 @@ export function Dashboard() {
     return agents.find((a) => a.id === id)?.name ?? null;
   };
 
+  const agentTitle = (id: string | null) => {
+    if (!id || !agents) return null;
+    return agents.find((a) => a.id === id)?.title ?? null;
+  };
+
   if (!selectedCompanyId) {
     if (companies.length === 0) {
       return (
@@ -363,8 +368,9 @@ export function Dashboard() {
                             </span>
                             {issue.assigneeAgentId && (() => {
                               const name = agentName(issue.assigneeAgentId);
+                              const title = agentTitle(issue.assigneeAgentId);
                               return name
-                                ? <span className="hidden sm:inline-flex"><Identity name={name} size="sm" /></span>
+                                ? <span className="hidden sm:inline-flex"><Identity name={name} title={title} size="sm" /></span>
                                 : null;
                             })()}
                             <span className="text-xs text-muted-foreground sm:hidden">&middot;</span>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -186,7 +186,7 @@ function ActorIdentity({ evt, agentMap }: { evt: ActivityEvent; agentMap: Map<st
   const id = evt.actorId;
   if (evt.actorType === "agent") {
     const agent = agentMap.get(id);
-    return <Identity name={agent?.name ?? id.slice(0, 8)} size="sm" />;
+    return <Identity name={agent?.name ?? id.slice(0, 8)} title={agent?.title} size="sm" />;
   }
   if (evt.actorType === "system") return <Identity name="System" size="sm" />;
   if (evt.actorType === "user") return <Identity name="Board" size="sm" />;
@@ -1059,9 +1059,9 @@ export function IssueDetail() {
                     <span className="truncate">{child.title}</span>
                   </div>
                   {child.assigneeAgentId && (() => {
-                    const name = agentMap.get(child.assigneeAgentId)?.name;
-                    return name
-                      ? <Identity name={name} size="sm" />
+                    const agent = agentMap.get(child.assigneeAgentId);
+                    return agent?.name
+                      ? <Identity name={agent.name} title={agent.title} size="sm" />
                       : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
                   })()}
                 </Link>


### PR DESCRIPTION
## Summary

- Adds optional `title` prop to the `Identity` component, rendering the agent's job title in parentheses next to their name (e.g. "Jordan (Chief Executive Officer)")
- Updates all `Identity` call sites across the UI to pass the agent title
- Adds `agentTitle` field to live-runs and cost API responses so run-based views also show titles
- Adds `agentTitle` to `CostByAgent` and `CostByAgentModel` shared types

## Test plan

- [ ] Verify agent titles appear next to names in issue list, kanban board, dashboard, command palette
- [ ] Verify titles show on issue detail (activity feed, subtask assignees, created-by)
- [ ] Verify titles show on approval detail (requester, comment authors)
- [ ] Verify titles show on active agents panel and live run widget
- [ ] Verify titles show on costs page
- [ ] Verify agents without titles display name only (no empty parens)
- [ ] Run `pnpm typecheck` — passes clean
- [ ] Run `pnpm build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)