### PR TITLE
fix: improve embedded PostgreSQL startup resilience

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -318,8 +318,30 @@ export async function startServer(): Promise<StartedServer> {
     };
   
     const runningPid = getRunningPid();
+    let pidReusable = false;
     if (runningPid) {
-      logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
+      // Verify the process is actually accepting connections before trusting the PID
+      const verifyConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+      for (let verifyAttempt = 1; verifyAttempt <= 10; verifyAttempt++) {
+        try {
+          await getPostgresDataDirectory(verifyConnectionString);
+          pidReusable = true;
+          break;
+        } catch {
+          if (verifyAttempt === 1) logger.info(`Verifying embedded PostgreSQL (pid=${runningPid}) is accepting connections...`);
+          await new Promise((r) => setTimeout(r, 1000));
+        }
+      }
+      if (pidReusable) {
+        logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
+      } else {
+        logger.warn(`PID file references process ${runningPid} but PostgreSQL is not accepting connections; starting fresh instance`);
+        try { process.kill(runningPid, "SIGTERM"); } catch { /* ignore */ }
+        if (existsSync(postmasterPidFile)) rmSync(postmasterPidFile, { force: true });
+      }
+    }
+    if (pidReusable) {
+      // PID verified, skip startup
     } else {
       const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
       try {
@@ -378,7 +400,20 @@ export async function startServer(): Promise<StartedServer> {
     }
   
     const embeddedAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
-    const dbStatus = await ensurePostgresDatabase(embeddedAdminConnectionString, "paperclip");
+    // Retry ensurePostgresDatabase to handle PostgreSQL still finishing crash-recovery
+    let dbStatus: "created" | "exists" | undefined;
+    for (let attempt = 1; attempt <= 30; attempt++) {
+      try {
+        dbStatus = await ensurePostgresDatabase(embeddedAdminConnectionString, "paperclip");
+        break;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const isTransient = msg.includes("starting up") || msg.includes("57P03") || msg.includes("ECONNREFUSED");
+        if (!isTransient || attempt === 30) throw err;
+        if (attempt === 1) logger.info("Waiting for embedded PostgreSQL to finish recovery...");
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
     if (dbStatus === "created") {
       logger.info("Created embedded PostgreSQL database: paperclip");
     }


### PR DESCRIPTION
## Summary
- Verify PID is actually accepting connections before reusing an existing PostgreSQL process (prevents ECONNREFUSED after crash/force-kill)
- Add retry loop around `ensurePostgresDatabase` to handle crash-recovery (error 57P03) and transient ECONNREFUSED

## Problem
After a PostgreSQL crash or force-kill, the `postmaster.pid` file can reference a PID that is still running (or reused by another process) but is not actually PostgreSQL listening on the expected port. The server would skip starting a new instance and immediately fail.

Additionally, when PostgreSQL is performing crash-recovery after an unclean shutdown, the server would fail immediately with `the database system is starting up` instead of waiting for recovery to complete.

## Changes
**Patch 1 – PID verification** (`server/src/index.ts`)
When a `postmaster.pid` exists and the referenced process is running, the server now attempts to connect (up to 10 retries) before trusting the PID. If the process is not accepting connections, it kills the stale process, removes the PID file, and starts a fresh instance.

**Patch 2 – Retry on transient errors** (`server/src/index.ts`)
Wraps `ensurePostgresDatabase` in a retry loop (up to 30 attempts, 1s apart) that catches transient errors: `57P03` ("the database system is starting up"), and `ECONNREFUSED`. Non-transient errors are re-thrown immediately.

## Test plan
- Force-kill postgres.exe, leave stale postmaster.pid, start server → should detect stale PID and start fresh
- Start server while PostgreSQL is performing crash-recovery → should retry and succeed once recovery completes

Generated with [Claude Code](https://claude.com/claude-code)