### PR TITLE
fix: correct $AGENT_HOME path for essential files in onboarding templates

### DIFF
--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -19,6 +19,6 @@ Invoke it whenever you need to remember, retrieve, or organize anything.
 
 These files are essential. Read them.
 
-- `$AGENT_HOME/HEARTBEAT.md` -- execution and extraction checklist. Run every heartbeat.
-- `$AGENT_HOME/SOUL.md` -- who you are and how you should act.
-- `$AGENT_HOME/TOOLS.md` -- tools you have access to
+- `$AGENT_HOME/instructions/HEARTBEAT.md` -- execution and extraction checklist. Run every heartbeat.
+- `$AGENT_HOME/instructions/SOUL.md` -- who you are and how you should act.
+- `$AGENT_HOME/instructions/TOOLS.md` -- tools you have access to

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -1,3 +1,20 @@
 You are an agent at Paperclip company.
 
 Keep the work moving until it's done. If you need QA to review it, ask them. If you need your boss to review it, ask them. If someone needs to unblock you, assign them the ticket with a comment asking for what you need. Don't let work just sit here. You must always update your task with a comment.
+
+Your home directory is $AGENT_HOME. Everything personal to you -- life, memory, knowledge -- lives there. Other agents may have their own folders and you may update them when necessary.
+
+Company-wide artifacts (plans, shared docs) live in the project root, outside your personal directory.
+
+## Safety Considerations
+
+- Never exfiltrate secrets or private data.
+- Do not perform any destructive commands unless explicitly requested by your manager or the board.
+
+## References
+
+These files are essential. Read them.
+
+- `$AGENT_HOME/instructions/HEARTBEAT.md` -- execution and extraction checklist. Run every heartbeat.
+- `$AGENT_HOME/instructions/SOUL.md` -- who you are and how you should act.
+- `$AGENT_HOME/instructions/TOOLS.md` -- tools you have access to


### PR DESCRIPTION
## Problem

The AGENTS.md onboarding templates (`server/src/onboarding-assets/default/AGENTS.md` and `server/src/onboarding-assets/ceo/AGENTS.md`) reference essential files at `$AGENT_HOME/HEARTBEAT.md`, `$AGENT_HOME/SOUL.md`, and `$AGENT_HOME/TOOLS.md`.

However, those files are placed in the `$AGENT_HOME/instructions/` subdirectory. Every agent therefore fails at startup with "File does not exist" errors.

## Fix

Correct the References section in both onboarding templates to use `$AGENT_HOME/instructions/HEARTBEAT.md` (and SOUL.md, TOOLS.md).

This fix was also applied retroactively to all 18 existing agent instructions in the running instance.

## Test plan

- [ ] Verify new agents (e.g. a newly hired claude_local agent) can read `$AGENT_HOME/instructions/HEARTBEAT.md` at startup
- [ ] Verify existing agents no longer log "File does not exist" for these files