### PR TITLE
feat: add agents:runtime-reset permission for session resets

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -343,6 +343,7 @@ export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
   "agents:create",
+  "agents:runtime-reset",
   "users:invite",
   "users:manage_permissions",
   "tasks:assign",

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -272,4 +272,83 @@ describe("agent permission routes", () => {
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
   });
+
+  it("allows board users to reset agent runtime sessions", async () => {
+    mockHeartbeatService.resetRuntimeSession.mockResolvedValue({ ok: true });
+
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/agents/${agentId}/runtime-state/reset-session`)
+      .send({ taskKey: "task-123" });
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.hasPermission).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.resetRuntimeSession).toHaveBeenCalledWith(agentId, { taskKey: "task-123" });
+  });
+
+  it("rejects agent runtime-session resets without an explicit grant", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(false);
+
+    const app = createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-123",
+    });
+
+    const res = await request(app)
+      .post(`/api/agents/${agentId}/runtime-state/reset-session`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Missing permission: agents:runtime-reset");
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "agents:runtime-reset",
+    );
+    expect(mockHeartbeatService.resetRuntimeSession).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("allows granted agents to reset sessions and logs the agent actor metadata", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockHeartbeatService.resetRuntimeSession.mockResolvedValue({ ok: true });
+
+    const app = createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-123",
+    });
+
+    const res = await request(app)
+      .post(`/api/agents/${agentId}/runtime-state/reset-session`)
+      .send({ taskKey: "task-456" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.resetRuntimeSession).toHaveBeenCalledWith(agentId, { taskKey: "task-456" });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId,
+        actorType: "agent",
+        actorId: agentId,
+        agentId,
+        runId: "run-123",
+        action: "agent.runtime_session_reset",
+        entityType: "agent",
+        entityId: agentId,
+        details: { taskKey: "task-456" },
+      }),
+    );
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -245,6 +245,22 @@ export function agentRoutes(db: Db) {
     }
   }
 
+  /**
+   * Allow board users unconditionally, or agents holding the specified
+   * company-scoped permission grant.  Throws 403 otherwise.
+   */
+  async function assertBoardOrGranted(req: Request, companyId: string, permissionKey: "agents:runtime-reset") {
+    assertCompanyAccess(req, companyId);
+    if (req.actor.type === "board") return;
+    if (req.actor.type !== "agent" || !req.actor.agentId) {
+      throw forbidden("Board access or explicit permission grant required");
+    }
+    const granted = await access.hasPermission(companyId, "agent", req.actor.agentId, permissionKey);
+    if (!granted) {
+      throw forbidden(`Missing permission: ${permissionKey}`);
+    }
+  }
+
   async function resolveCompanyIdForAgentReference(req: Request): Promise<string | null> {
     const companyIdQuery = req.query.companyId;
     const requestedCompanyId =
@@ -1111,14 +1127,13 @@ export function agentRoutes(db: Db) {
   });
 
   router.post("/agents/:id/runtime-state/reset-session", validate(resetAgentSessionSchema), async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
     const agent = await svc.getById(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    assertCompanyAccess(req, agent.companyId);
+    await assertBoardOrGranted(req, agent.companyId, "agents:runtime-reset");
 
     const taskKey =
       typeof req.body.taskKey === "string" && req.body.taskKey.trim().length > 0
@@ -1126,10 +1141,13 @@ export function agentRoutes(db: Db) {
         : null;
     const state = await heartbeat.resetRuntimeSession(id, { taskKey });
 
+    const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
       action: "agent.runtime_session_reset",
       entityType: "agent",
       entityId: id,


### PR DESCRIPTION
## Summary

- Adds `agents:runtime-reset` to `PERMISSION_KEYS` in `@paperclipai/shared`
- Replaces hard-coded `assertBoard()` on `POST /api/agents/:id/runtime-state/reset-session` with `assertBoardOrGranted()`, which allows board users unconditionally **or** agents holding the `agents:runtime-reset` company-scoped permission grant
- Fixes the activity log on this route to properly record agent actors (was hardcoding `actorType: "user"`)

## Context

OpenClaw can inspect agents and create/comment on issues, but runtime session resets fail with HTTP 403 because the endpoint required board-level access. This change enables any agent with the explicit `agents:runtime-reset` grant to perform resets — scoped to their own company only.

## Granting the permission

After deploying, grant the permission to OpenClaw via:

```sql
INSERT INTO principal_permission_grants (company_id, principal_type, principal_id, permission_key, granted_by_user_id)
VALUES ('<company-id>', 'agent', '<openclaw-agent-id>', 'agents:runtime-reset', '<board-user-id>');
```

Or via the access management API endpoints.

## Test plan

- [ ] Board users can still reset sessions (unchanged behavior)
- [ ] Agents **without** the grant still receive 403
- [ ] Agents **with** `agents:runtime-reset` grant can call the endpoint successfully
- [ ] Activity log correctly records agent actor type when an agent performs the reset
- [ ] Cross-company agent access is still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)