### PR TITLE
fix: add gemini_local adapter type and fix stream-json parser

### DIFF
--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -7,7 +7,7 @@ function collectMessageText(message: unknown): string[] {
   }
 
   const record = parseObject(message);
-  const direct = asString(record.text, "").trim();
+  const direct = asString(record.text, "").trim() || (typeof record.content === "string" ? record.content.trim() : "");
   const lines: string[] = direct ? [direct] : [];
   const content = Array.isArray(record.content) ? record.content : [];
 
@@ -97,9 +97,12 @@ export function parseGeminiJsonl(stdout: string) {
 
     const type = asString(event.type, "").trim();
 
-    if (type === "assistant") {
-      messages.push(...collectMessageText(event.message));
-      const messageObj = parseObject(event.message);
+    if (type === "assistant" || (type === "message" && asString(event.role, "").trim() === "assistant")) {
+      // Gemini stream-json emits {type:"message", role:"assistant", content:"..."}
+      // while other formats use {type:"assistant", message:{...}}
+      const messageSource = type === "message" ? event : event.message;
+      messages.push(...collectMessageText(messageSource));
+      const messageObj = parseObject(messageSource);
       const content = Array.isArray(messageObj.content) ? messageObj.content : [];
       for (const partRaw of content) {
         const part = parseObject(partRaw);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "gemini_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - There are many types of adapters for each LLM provider
> - Gemini CLI (local) adapter is fully implemented (adapter package, server/CLI/UI registries, config fields)
> - But `gemini_local` was missing from the `AGENT_ADAPTER_TYPES` constant in shared, so it didn't appear as a selectable adapter type in the UI
> - Additionally, the stream-json parser didn't handle Gemini's `{type:"message", role:"assistant", content:"..."}` event format, causing the hello probe to always fail with "did not return hello as expected"
> - This PR adds `gemini_local` to the constant and fixes the parser to correctly extract assistant messages from Gemini's output format

## What changed

### 1. `packages/shared/src/constants.ts`
- Added `"gemini_local"` to the `AGENT_ADAPTER_TYPES` array so it appears in the UI adapter type dropdown

### 2. `packages/adapters/gemini-local/src/server/parse.ts`
- Updated `parseGeminiJsonl` to also match `{type:"message", role:"assistant"}` events (Gemini CLI's stream-json format), not just `{type:"assistant"}`
- Updated `collectMessageText` to handle string `content` fields — Gemini puts the response text directly in `content` as a string, not nested in `text` or an array

## Why it matters

Without these fixes:
- Gemini CLI (local) adapter type is invisible in the agent configuration UI despite being fully implemented
- The "Test environment" hello probe always fails because the parser can't extract the response from Gemini's output format

## How to verify

1. Select "Gemini CLI (local)" as adapter type on any agent
2. Click "Test environment" — the hello probe should pass
3. Run a heartbeat with a Gemini-backed agent — messages should be parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>