### PR TITLE
fix: add SIGKILL fallback to cancelActiveForAgent (#1403)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -161,6 +161,7 @@ describe("heartbeat orphaned process recovery", () => {
 
   async function seedRunFixture(input?: {
     adapterType?: string;
+    agentStatus?: "paused" | "running" | "idle";
     runStatus?: "running" | "queued" | "failed";
     processPid?: number | null;
     processLossRetryCount?: number;
@@ -188,7 +189,7 @@ describe("heartbeat orphaned process recovery", () => {
       companyId,
       name: "CodexCoder",
       role: "engineer",
-      status: "paused",
+      status: input?.agentStatus ?? "paused",
       adapterType: input?.adapterType ?? "codex_local",
       adapterConfig: {},
       runtimeConfig: {},
@@ -328,6 +329,103 @@ describe("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("does not start queued runs during agent-wide cancel loop", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const run1Id = randomUUID();
+    const run2Id = randomUUID();
+    const wake1Id = randomUUID();
+    const wake2Id = randomUUID();
+    const now = new Date("2026-03-20T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Runner",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values([
+      {
+        id: wake1Id,
+        companyId,
+        agentId,
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: {},
+        status: "claimed",
+        runId: run1Id,
+        claimedAt: now,
+      },
+      {
+        id: wake2Id,
+        companyId,
+        agentId,
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: {},
+        status: "queued",
+        runId: run2Id,
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: run1Id,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: wake1Id,
+        contextSnapshot: {},
+        startedAt: now,
+        updatedAt: now,
+      },
+      {
+        id: run2Id,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "queued",
+        wakeupRequestId: wake2Id,
+        contextSnapshot: {},
+        startedAt: null,
+        updatedAt: now,
+      },
+    ]);
+
+    const heartbeat = heartbeatService(db);
+    const cancelledCount = await heartbeat.cancelActiveForAgent(agentId);
+    expect(cancelledCount).toBe(2);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    const run1 = runs.find((row) => row.id === run1Id);
+    const run2 = runs.find((row) => row.id === run2Id);
+    expect(run1?.status).toBe("cancelled");
+    expect(run2?.status).toBe("cancelled");
+    expect(run2?.startedAt).toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4,8 +4,9 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { eq } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   applyPendingMigrations,
   createDb,
@@ -90,6 +91,33 @@ function spawnAliveProcess() {
   return spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
     stdio: "ignore",
   });
+}
+
+function createMockCancelableChild(options: { exitOnSigterm: boolean }): ChildProcess {
+  const emitter = new EventEmitter() as EventEmitter & ChildProcess;
+  emitter.exitCode = null;
+  emitter.signalCode = null;
+  emitter.killed = false;
+  emitter.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    if (signal === "SIGTERM") {
+      if (options.exitOnSigterm) {
+        emitter.killed = true;
+        emitter.exitCode = 0;
+        emitter.emit("exit", 0, "SIGTERM");
+        emitter.emit("close", 0, "SIGTERM");
+      }
+      return true;
+    }
+    if (signal === "SIGKILL") {
+      emitter.killed = true;
+      emitter.signalCode = "SIGKILL";
+      emitter.emit("exit", null, "SIGKILL");
+      emitter.emit("close", null, "SIGKILL");
+      return true;
+    }
+    return true;
+  }) as ChildProcess["kill"];
+  return emitter;
 }
 
 describe("heartbeat orphaned process recovery", () => {
@@ -317,5 +345,63 @@ describe("heartbeat orphaned process recovery", () => {
     const run = await heartbeat.getRun(runId);
     expect(run?.errorCode).toBeNull();
     expect(run?.error).toBeNull();
+  });
+
+  it("sends SIGKILL after SIGTERM timeout when cancelling active runs", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agentId, runId } = await seedRunFixture({ includeIssue: false });
+      const heartbeat = heartbeatService(db);
+      const child = createMockCancelableChild({ exitOnSigterm: false });
+      runningProcesses.set(runId, { child, graceSec: 1 });
+
+      const cancellation = heartbeat.cancelActiveForAgent(agentId);
+      await vi.advanceTimersByTimeAsync(1_000);
+      const cancelledCount = await cancellation;
+
+      expect(cancelledCount).toBe(1);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not send SIGKILL when process exits on SIGTERM", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agentId, runId } = await seedRunFixture({ includeIssue: false });
+      const heartbeat = heartbeatService(db);
+      const child = createMockCancelableChild({ exitOnSigterm: true });
+      runningProcesses.set(runId, { child, graceSec: 1 });
+
+      const cancellation = heartbeat.cancelActiveForAgent(agentId);
+      await vi.advanceTimersByTimeAsync(1_000);
+      const cancelledCount = await cancellation;
+
+      expect(cancelledCount).toBe(1);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cleans up runningProcesses tracking after active cancel", async () => {
+    vi.useFakeTimers();
+    try {
+      const { agentId, runId } = await seedRunFixture({ includeIssue: false });
+      const heartbeat = heartbeatService(db);
+      const child = createMockCancelableChild({ exitOnSigterm: false });
+      runningProcesses.set(runId, { child, graceSec: 1 });
+
+      const cancellation = heartbeat.cancelActiveForAgent(agentId);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await cancellation;
+
+      expect(runningProcesses.has(runId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3420,7 +3420,11 @@ export function heartbeatService(db: Db) {
     return wakeupIds.length;
   }
 
-  async function cancelRunInternal(runId: string, reason = "Cancelled by control plane") {
+  async function cancelRunInternal(
+    runId: string,
+    reason = "Cancelled by control plane",
+    options?: { skipStartNext?: boolean },
+  ) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
     if (run.status !== "running" && run.status !== "queued") return run;
@@ -3453,7 +3457,14 @@ export function heartbeatService(db: Db) {
           child.once("exit", onExit);
           child.once("close", onClose);
 
-          const timer = setTimeout(() => finish(false), timeoutMs);
+          const timer = setTimeout(() => {
+            // Re-check: process may have exited in the race window
+            if (child.exitCode !== null || child.signalCode !== null) {
+              finish(true);
+            } else {
+              finish(false);
+            }
+          }, timeoutMs);
         });
 
       try {
@@ -3470,6 +3481,8 @@ export function heartbeatService(db: Db) {
         } catch {
           // Process may have exited between checks.
         }
+        // Wait briefly for kernel to reap the process.
+        await waitForExit(2000);
       }
     }
 
@@ -3496,7 +3509,9 @@ export function heartbeatService(db: Db) {
 
     runningProcesses.delete(run.id);
     await finalizeAgentStatus(run.agentId, "cancelled");
-    await startNextQueuedRunForAgent(run.agentId);
+    if (!options?.skipStartNext) {
+      await startNextQueuedRunForAgent(run.agentId);
+    }
     return cancelled;
   }
 
@@ -3507,8 +3522,9 @@ export function heartbeatService(db: Db) {
       .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, ["queued", "running"])));
 
     for (const run of runs) {
-      await cancelRunInternal(run.id, reason);
+      await cancelRunInternal(run.id, reason, { skipStartNext: true });
     }
+    await startNextQueuedRunForAgent(agentId);
 
     return runs.length;
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3427,13 +3427,50 @@ export function heartbeatService(db: Db) {
 
     const running = runningProcesses.get(run.id);
     if (running) {
-      running.child.kill("SIGTERM");
       const graceMs = Math.max(1, running.graceSec) * 1000;
-      setTimeout(() => {
-        if (!running.child.killed) {
-          running.child.kill("SIGKILL");
+      const child = running.child;
+
+      const waitForExit = (timeoutMs: number): Promise<boolean> =>
+        new Promise((resolve) => {
+          // Child may already be gone by the time cancellation starts.
+          if (child.exitCode !== null || child.signalCode !== null) {
+            resolve(true);
+            return;
+          }
+
+          let done = false;
+          const finish = (exited: boolean) => {
+            if (done) return;
+            done = true;
+            clearTimeout(timer);
+            child.removeListener("exit", onExit);
+            child.removeListener("close", onClose);
+            resolve(exited);
+          };
+          const onExit = () => finish(true);
+          const onClose = () => finish(true);
+
+          child.once("exit", onExit);
+          child.once("close", onClose);
+
+          const timer = setTimeout(() => finish(false), timeoutMs);
+        });
+
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Process may already be gone.
+      }
+
+      const exitedAfterSigterm = await waitForExit(graceMs);
+      if (!exitedAfterSigterm) {
+        try {
+          child.kill("SIGKILL");
+          logger.warn({ runId: run.id, agentId: run.agentId, graceMs }, "run did not exit after SIGTERM; sent SIGKILL");
+        } catch {
+          // Process may have exited between checks.
         }
-      }, graceMs);
+      }
     }
 
     const cancelled = await setRunStatus(run.id, "cancelled", {
@@ -3470,23 +3507,7 @@ export function heartbeatService(db: Db) {
       .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, ["queued", "running"])));
 
     for (const run of runs) {
-      await setRunStatus(run.id, "cancelled", {
-        finishedAt: new Date(),
-        error: reason,
-        errorCode: "cancelled",
-      });
-
-      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
-        finishedAt: new Date(),
-        error: reason,
-      });
-
-      const running = runningProcesses.get(run.id);
-      if (running) {
-        running.child.kill("SIGTERM");
-        runningProcesses.delete(run.id);
-      }
-      await releaseIssueExecutionAndPromote(run);
+      await cancelRunInternal(run.id, reason);
     }
 
     return runs.length;


### PR DESCRIPTION
**Thinking path:**
- When an agent is cancelled, SIGTERM is sent to the child process
- If the process ignores SIGTERM (stuck LLM call, hanging I/O), no escalation happens
- The process becomes orphaned: "cancelled" in Paperclip, but still running and spending API credits
- This is the root cause of #1403 and likely contributes to stale execution locks (#1420)

**Changes:**
- Unified `cancelActiveForAgentInternal` to delegate to `cancelRunInternal` (single cancel path)
- Added SIGKILL escalation in `cancelRunInternal`: SIGTERM → wait grace period → SIGKILL if still alive
- Process tracking cleanup (`runningProcesses.delete`) now happens after kill confirmation, not before
- `finalizeAgentStatus` and `startNextQueuedRunForAgent` now apply consistently for agent-wide cancels
- Added 3 tests: SIGKILL after timeout, no SIGKILL on clean exit, tracking cleanup

**Testing:**
- Added `server/src/__tests__/heartbeat-process-recovery.test.ts` with 3 test cases
- Existing cancel flow unchanged for processes that exit cleanly on SIGTERM

Closes #1403