### PR TITLE
feat: add per-agent workspace path (cwd) column (#1425)

### DIFF
--- a/packages/db/src/migrations/0044_add_agent_cwd.sql
+++ b/packages/db/src/migrations/0044_add_agent_cwd.sql
@@ -1,0 +1,9 @@
+-- Add per-agent working directory.
+ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "cwd" text;
+--> statement-breakpoint
+-- Backfill from legacy adapter_config.cwd values.
+UPDATE "agents"
+SET "cwd" = nullif(trim("adapter_config"->>'cwd'), '')
+WHERE "cwd" IS NULL
+  AND "adapter_config"->>'cwd' IS NOT NULL
+  AND trim("adapter_config"->>'cwd') != '';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1774008910991,
       "tag": "0043_reflective_captain_universe",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1774136400000,
+      "tag": "0044_add_agent_cwd",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -24,6 +24,7 @@ export const agents = pgTable(
     capabilities: text("capabilities"),
     adapterType: text("adapter_type").notNull().default("process"),
     adapterConfig: jsonb("adapter_config").$type<Record<string, unknown>>().notNull().default({}),
+    cwd: text("cwd"),
     runtimeConfig: jsonb("runtime_config").$type<Record<string, unknown>>().notNull().default({}),
     budgetMonthlyCents: integer("budget_monthly_cents").notNull().default(0),
     spentMonthlyCents: integer("spent_monthly_cents").notNull().default(0),

--- a/server/src/__tests__/agent-cwd-resolution.test.ts
+++ b/server/src/__tests__/agent-cwd-resolution.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentCwd } from "../services/heartbeat.js";
+
+describe("resolveAgentCwd", () => {
+  it("prefers agent.cwd over adapterConfig.cwd", () => {
+    const agent = { cwd: "/workspace/agent-1", adapterConfig: { cwd: "/old/path" } };
+    expect(resolveAgentCwd(agent)).toBe("/workspace/agent-1");
+  });
+
+  it("falls back to adapterConfig.cwd when agent.cwd is null", () => {
+    const agent = { cwd: null, adapterConfig: { cwd: "/legacy/path" } };
+    expect(resolveAgentCwd(agent)).toBe("/legacy/path");
+  });
+
+  it("returns null when no cwd configured", () => {
+    const agent = { cwd: null, adapterConfig: {} };
+    expect(resolveAgentCwd(agent)).toBeNull();
+  });
+
+  it("trims whitespace from cwd", () => {
+    const agent = { cwd: "  /workspace/agent-1  ", adapterConfig: {} };
+    expect(resolveAgentCwd(agent)).toBe("/workspace/agent-1");
+  });
+
+  it("treats empty string as null and falls back", () => {
+    const agent = { cwd: "   ", adapterConfig: { cwd: "/fallback" } };
+    expect(resolveAgentCwd(agent)).toBe("/fallback");
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -303,6 +303,18 @@ export function agentRoutes(db: Db) {
     return trimmed.length > 0 ? trimmed : null;
   }
 
+  function resolveAgentCwd(agent: {
+    cwd?: unknown;
+    adapterConfig?: Record<string, unknown>;
+  }): string | null {
+    const fromColumn = asNonEmptyString(agent.cwd);
+    if (fromColumn && path.isAbsolute(fromColumn)) return fromColumn;
+
+    const fromLegacy = asNonEmptyString(agent.adapterConfig?.cwd);
+    if (fromLegacy && path.isAbsolute(fromLegacy)) return fromLegacy;
+    return null;
+  }
+
   function parseBooleanLike(value: unknown): boolean | null {
     if (typeof value === "boolean") return value;
     if (typeof value === "number") {
@@ -401,18 +413,18 @@ export function agentRoutes(db: Db) {
     }
   }
 
-  function resolveInstructionsFilePath(candidatePath: string, adapterConfig: Record<string, unknown>) {
+  function resolveInstructionsFilePath(
+    candidatePath: string,
+    agent: { cwd?: unknown; adapterConfig: Record<string, unknown> },
+  ) {
     const trimmed = candidatePath.trim();
     if (path.isAbsolute(trimmed)) return trimmed;
 
-    const cwd = asNonEmptyString(adapterConfig.cwd);
+    const cwd = resolveAgentCwd(agent);
     if (!cwd) {
       throw unprocessable(
-        "Relative instructions path requires adapterConfig.cwd to be set to an absolute path",
+        "Relative instructions path requires agent.cwd or adapterConfig.cwd to be set to an absolute path",
       );
-    }
-    if (!path.isAbsolute(cwd)) {
-      throw unprocessable("adapterConfig.cwd must be an absolute path to resolve relative instructions path");
     }
     return path.resolve(cwd, trimmed);
   }
@@ -1461,7 +1473,10 @@ export function agentRoutes(db: Db) {
     if (req.body.path === null) {
       delete nextAdapterConfig[adapterConfigKey];
     } else {
-      nextAdapterConfig[adapterConfigKey] = resolveInstructionsFilePath(req.body.path, existingAdapterConfig);
+      nextAdapterConfig[adapterConfigKey] = resolveInstructionsFilePath(req.body.path, {
+        cwd: existing.cwd ?? null,
+        adapterConfig: existingAdapterConfig,
+      });
     }
 
     const syncedAdapterConfig = syncInstructionsBundleConfigFromFilePath(existing, nextAdapterConfig);

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -30,6 +30,7 @@ type AgentLike = {
   id: string;
   companyId: string;
   name: string;
+  cwd?: string | null;
   adapterConfig: unknown;
 };
 
@@ -86,6 +87,15 @@ function asString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function resolveAgentCwd(agentCwd: string | null | undefined, config: Record<string, unknown>): string | null {
+  const primary = asString(agentCwd);
+  if (primary && path.isAbsolute(primary)) return primary;
+
+  const legacy = asString(config.cwd);
+  if (legacy && path.isAbsolute(legacy)) return legacy;
+  return null;
+}
+
 function isBundleMode(value: unknown): value is BundleMode {
   return value === "managed" || value === "external";
 }
@@ -140,12 +150,16 @@ function resolveManagedInstructionsRoot(agent: AgentLike): string {
   );
 }
 
-function resolveLegacyInstructionsPath(candidatePath: string, config: Record<string, unknown>): string {
+function resolveLegacyInstructionsPath(
+  candidatePath: string,
+  config: Record<string, unknown>,
+  agentCwd?: string | null,
+): string {
   if (path.isAbsolute(candidatePath)) return candidatePath;
-  const cwd = asString(config.cwd);
-  if (!cwd || !path.isAbsolute(cwd)) {
+  const cwd = resolveAgentCwd(agentCwd, config);
+  if (!cwd) {
     throw unprocessable(
-      "Legacy relative instructionsFilePath requires adapterConfig.cwd to be set to an absolute path",
+      "Legacy relative instructionsFilePath requires agent.cwd or adapterConfig.cwd to be set to an absolute path",
     );
   }
   return path.resolve(cwd, candidatePath);
@@ -212,7 +226,7 @@ async function readLegacyInstructions(agent: AgentLike, config: Record<string, u
   const instructionsFilePath = asString(config[FILE_KEY]);
   if (instructionsFilePath) {
     try {
-      const resolvedPath = resolveLegacyInstructionsPath(instructionsFilePath, config);
+      const resolvedPath = resolveLegacyInstructionsPath(instructionsFilePath, config, agent.cwd ?? null);
       return await fs.readFile(resolvedPath, "utf8");
     } catch {
       // Fall back to promptTemplate below.
@@ -243,7 +257,11 @@ function deriveBundleState(agent: AgentLike): BundleState {
 
   if (!rootPath && legacyInstructionsPath) {
     try {
-      const resolvedLegacyPath = resolveLegacyInstructionsPath(legacyInstructionsPath, config);
+      const resolvedLegacyPath = resolveLegacyInstructionsPath(
+        legacyInstructionsPath,
+        config,
+        agent.cwd ?? null,
+      );
       rootPath = path.dirname(resolvedLegacyPath);
       entryFile = path.basename(resolvedLegacyPath);
       mode = resolvedLegacyPath.startsWith(`${resolveManagedInstructionsRoot(agent)}${path.sep}`)
@@ -354,7 +372,7 @@ export function syncInstructionsBundleConfigFromFilePath(
     delete next[ENTRY_KEY];
     return next;
   }
-  const resolvedPath = resolveLegacyInstructionsPath(instructionsFilePath, adapterConfig);
+  const resolvedPath = resolveLegacyInstructionsPath(instructionsFilePath, adapterConfig, agent.cwd ?? null);
   const rootPath = path.dirname(resolvedPath);
   const entryFile = path.basename(resolvedPath);
   const mode: BundleMode = resolvedPath.startsWith(`${resolveManagedInstructionsRoot(agent)}${path.sep}`)

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -32,6 +32,7 @@ const CONFIG_REVISION_FIELDS = [
   "reportsTo",
   "capabilities",
   "adapterType",
+  "cwd",
   "adapterConfig",
   "runtimeConfig",
   "budgetMonthlyCents",
@@ -92,6 +93,7 @@ function buildConfigSnapshot(
     reportsTo: row.reportsTo,
     capabilities: row.capabilities,
     adapterType: row.adapterType,
+    cwd: row.cwd,
     adapterConfig,
     runtimeConfig,
     budgetMonthlyCents: row.budgetMonthlyCents,
@@ -144,6 +146,7 @@ function configPatchFromSnapshot(snapshot: unknown): Partial<typeof agents.$infe
         ? snapshot.capabilities
         : null,
     adapterType: snapshot.adapterType,
+    cwd: typeof snapshot.cwd === "string" || snapshot.cwd === null ? snapshot.cwd : null,
     adapterConfig: isPlainRecord(snapshot.adapterConfig) ? snapshot.adapterConfig : {},
     runtimeConfig: isPlainRecord(snapshot.runtimeConfig) ? snapshot.runtimeConfig : {},
     budgetMonthlyCents: Math.max(0, Math.floor(snapshot.budgetMonthlyCents)),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -264,6 +264,29 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+/**
+ * Resolve agent working directory.
+ * Priority: agent.cwd > adapterConfig.cwd > null.
+ * Only absolute paths are accepted.
+ */
+export function resolveAgentCwd(agent: {
+  cwd?: unknown;
+  adapterConfig?: unknown;
+}): string | null {
+  const normalizeAbsolute = (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return path.isAbsolute(trimmed) ? trimmed : null;
+  };
+
+  const fromColumn = normalizeAbsolute(agent.cwd);
+  if (fromColumn) return fromColumn;
+
+  const adapterConfig = parseObject(agent.adapterConfig);
+  return normalizeAbsolute(adapterConfig.cwd);
+}
+
 function normalizeLedgerBillingType(value: unknown): BillingType {
   const raw = readNonEmptyString(value);
   switch (raw) {
@@ -1083,7 +1106,7 @@ export function heartbeatService(db: Db) {
         missingProjectCwds.push(projectCwd);
       }
 
-      const fallbackCwd = resolveDefaultAgentWorkspaceDir(agent.id);
+      const fallbackCwd = resolveAgentCwd(agent) ?? resolveDefaultAgentWorkspaceDir(agent.id);
       await fs.mkdir(fallbackCwd, { recursive: true });
       const warnings: string[] = [];
       if (preferredWorkspaceWarning) {
@@ -1152,7 +1175,7 @@ export function heartbeatService(db: Db) {
       }
     }
 
-    const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+    const cwd = resolveAgentCwd(agent) ?? resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
     if (sessionCwd) {
@@ -2147,7 +2170,7 @@ export function heartbeatService(db: Db) {
       branchName: executionWorkspace.branchName,
       worktreePath: executionWorkspace.worktreePath,
       agentHome: await (async () => {
-        const home = resolveDefaultAgentWorkspaceDir(agent.id);
+        const home = resolveAgentCwd(agent) ?? resolveDefaultAgentWorkspaceDir(agent.id);
         await fs.mkdir(home, { recursive: true });
         return home;
       })(),


### PR DESCRIPTION
**Thinking path:**
- By default all agents share the same workspace directory
- Agent A can read files created by Agent B, including .env files and credentials
- Issue #1425 requests per-agent workspace isolation
- The UI already treats adapterConfig.cwd as legacy, suggesting product direction is compatible

**Changes:**
- Added nullable `cwd` column to agents table (packages/db/src/schema/agents.ts)
- Migration 0044: ALTER TABLE + backfill from existing adapterConfig.cwd
- Added `resolveAgentCwd()` helper: agent.cwd > adapterConfig.cwd > null
- Applied dual-read in heartbeat.ts, agent-instructions.ts, routes/agents.ts
- Added cwd to CONFIG_REVISION_FIELDS for change tracking
- Added 5 tests for cwd resolution priority, fallback, trimming, empty handling

**Backward compatibility:**
- Fully backward compatible — existing agents continue to work via adapterConfig.cwd fallback
- New column is nullable, no existing data affected
- Migration backfills from adapterConfig.cwd for existing records

**Testing:**
- 5 unit tests for resolveAgentCwd in server/src/__tests__/agent-cwd-resolution.test.ts

Closes #1425