### PR TITLE
feat(server): auto-retry runs on transient upstream API failures (#1389)

### DIFF
--- a/packages/db/src/migrations/0044_add_transient_retry_count.sql
+++ b/packages/db/src/migrations/0044_add_transient_retry_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "heartbeat_runs" ADD COLUMN "transient_retry_count" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1774008910991,
       "tag": "0043_reflective_captain_universe",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1774128000000,
+      "tag": "0044_add_transient_retry_count",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -37,6 +37,7 @@ export const heartbeatRuns = pgTable(
       onDelete: "set null",
     }),
     processLossRetryCount: integer("process_loss_retry_count").notNull().default(0),
+    transientRetryCount: integer("transient_retry_count").notNull().default(0),
     contextSnapshot: jsonb("context_snapshot").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/server/src/__tests__/transient-error-detection.test.ts
+++ b/server/src/__tests__/transient-error-detection.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { isTransientApiError } from "../services/transient-error-detection.ts";
+
+describe("isTransientApiError", () => {
+  describe("detects transient errors", () => {
+    it("detects HTTP 500 with api_error type", () => {
+      expect(
+        isTransientApiError(
+          'API Error: 500 {"type":"api_error","message":"Internal server error"}',
+          null,
+        ),
+      ).toBe(true);
+    });
+
+    it("detects HTTP 529 overloaded error", () => {
+      expect(
+        isTransientApiError(
+          'API Error: 529 {"type":"overloaded_error","message":"Overloaded"}',
+          null,
+        ),
+      ).toBe(true);
+    });
+
+    it("detects HTTP 503 service unavailable", () => {
+      expect(
+        isTransientApiError(
+          "API Error: 503 Service Unavailable",
+          null,
+        ),
+      ).toBe(true);
+    });
+
+    it("detects overloaded_error in error message", () => {
+      expect(
+        isTransientApiError("overloaded_error", null),
+      ).toBe(true);
+    });
+
+    it("detects structured overloaded_error JSON", () => {
+      expect(
+        isTransientApiError(
+          null,
+          '{"type": "overloaded_error", "message": "Overloaded"}',
+        ),
+      ).toBe(true);
+    });
+
+    it("detects transient error from stderr excerpt", () => {
+      expect(
+        isTransientApiError(
+          null,
+          'Error: API Error: 529 {"type":"overloaded_error","message":"Overloaded"}',
+        ),
+      ).toBe(true);
+    });
+
+    it("detects 500 internal server error with api_error type in JSON", () => {
+      expect(
+        isTransientApiError(
+          '{"type":"api_error","message":"Internal server error"} 500',
+          null,
+        ),
+      ).toBe(true);
+    });
+
+    it("detects 503 temporarily unavailable", () => {
+      expect(
+        isTransientApiError(
+          "503 temporarily unavailable",
+          null,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("does NOT detect non-transient errors", () => {
+    it("returns false for null inputs", () => {
+      expect(isTransientApiError(null, null)).toBe(false);
+    });
+
+    it("returns false for empty strings", () => {
+      expect(isTransientApiError("", "")).toBe(false);
+    });
+
+    it("returns false for authentication errors", () => {
+      expect(
+        isTransientApiError("API Error: 401 Unauthorized", null),
+      ).toBe(false);
+    });
+
+    it("returns false for rate limit errors (429)", () => {
+      expect(
+        isTransientApiError("API Error: 429 Too Many Requests", null),
+      ).toBe(false);
+    });
+
+    it("returns false for generic adapter failures", () => {
+      expect(
+        isTransientApiError("Adapter failed: process exited with code 1", null),
+      ).toBe(false);
+    });
+
+    it("returns false for timeout errors", () => {
+      expect(
+        isTransientApiError("Timed out after 300 seconds", null),
+      ).toBe(false);
+    });
+
+    it("returns false for permission errors", () => {
+      expect(
+        isTransientApiError("API Error: 403 Forbidden", null),
+      ).toBe(false);
+    });
+
+    it("returns false for invalid request errors", () => {
+      expect(
+        isTransientApiError(
+          '{"type":"invalid_request_error","message":"max_tokens must be positive"}',
+          null,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -24,6 +24,7 @@ import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import { isTransientApiError } from "./transient-error-detection.js";
 import { costService } from "./costs.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
@@ -1511,17 +1512,150 @@ export function heartbeatService(db: Db) {
     return queued;
   }
 
+  async function enqueueTransientRetry(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    delayMs: number,
+  ): Promise<typeof heartbeatRuns.$inferSelect> {
+    const now = new Date();
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const taskKey = deriveTaskKey(contextSnapshot, null);
+    const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const retryCount = (run.transientRetryCount ?? 0) + 1;
+    const retryContextSnapshot = {
+      ...contextSnapshot,
+      retryOfRunId: run.id,
+      wakeReason: "transient_api_retry",
+      retryReason: "transient_api_error",
+      retryAttempt: retryCount,
+    };
+
+    const queued = await db.transaction(async (tx) => {
+      const wakeupRequest = await tx
+        .insert(agentWakeupRequests)
+        .values({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          source: "automation",
+          triggerDetail: "system",
+          reason: "transient_api_retry",
+          payload: {
+            ...(issueId ? { issueId } : {}),
+            retryOfRunId: run.id,
+            retryAttempt: retryCount,
+            delayMs,
+          },
+          status: "queued",
+          requestedByActorType: "system",
+          requestedByActorId: null,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const retryRun = await tx
+        .insert(heartbeatRuns)
+        .values({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          invocationSource: "automation",
+          triggerDetail: "system",
+          status: "queued",
+          wakeupRequestId: wakeupRequest.id,
+          contextSnapshot: retryContextSnapshot,
+          sessionIdBefore: sessionBefore,
+          retryOfRunId: run.id,
+          transientRetryCount: retryCount,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          runId: retryRun.id,
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+      if (issueId) {
+        await tx
+          .update(issues)
+          .set({
+            executionRunId: retryRun.id,
+            executionAgentNameKey: normalizeAgentNameKey(agent.name),
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              eq(issues.executionRunId, run.id),
+            ),
+          );
+      }
+
+      return retryRun;
+    });
+
+    publishLiveEvent({
+      companyId: queued.companyId,
+      type: "heartbeat.run.queued",
+      payload: {
+        runId: queued.id,
+        agentId: queued.agentId,
+        invocationSource: queued.invocationSource,
+        triggerDetail: queued.triggerDetail,
+        wakeupRequestId: queued.wakeupRequestId,
+      },
+    });
+
+    await appendRunEvent(queued, 1, {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message: `Queued automatic retry (attempt ${retryCount}) after transient API error — delay ${Math.round(delayMs / 1000)}s`,
+      payload: {
+        retryOfRunId: run.id,
+        retryAttempt: retryCount,
+        delayMs,
+      },
+    });
+
+    // Schedule delayed execution
+    if (delayMs > 0) {
+      setTimeout(() => {
+        void startNextQueuedRunForAgent(agent.id).catch((err) => {
+          logger.error({ err, agentId: agent.id }, "failed to start queued transient retry run");
+        });
+      }, delayMs);
+    }
+
+    return queued;
+  }
+
   function parseHeartbeatPolicy(agent: typeof agents.$inferSelect) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
+    const transientRetry = parseObject(heartbeat.transientRetry);
 
     return {
       enabled: asBoolean(heartbeat.enabled, true),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      transientRetry: {
+        maxRetries: Math.max(0, Math.min(5, asNumber(transientRetry.maxRetries, 3))),
+        initialDelayMs: Math.max(1000, asNumber(transientRetry.initialDelayMs, 30_000)),
+        backoffMultiplier: Math.max(1, asNumber(transientRetry.backoffMultiplier, 2)),
+      },
     };
   }
+
+  // isTransientApiError is imported from ./transient-error-detection.js
 
   async function countRunningRunsForAgent(agentId: string) {
     const [{ count }] = await db
@@ -2490,6 +2624,14 @@ export function heartbeatService(db: Db) {
               ? "timed_out"
               : "failed";
 
+      // Check for transient API errors eligible for retry
+      const policy = parseHeartbeatPolicy(agent);
+      const currentRetryCount = run.transientRetryCount ?? 0;
+      const shouldRetryTransient =
+        outcome === "failed" &&
+        currentRetryCount < policy.transientRetry.maxRetries &&
+        isTransientApiError(adapterResult.errorMessage, stderrExcerpt);
+
       const usageJson =
         normalizedUsage || adapterResult.costUsd != null
           ? ({
@@ -2516,22 +2658,27 @@ export function heartbeatService(db: Db) {
             } as Record<string, unknown>)
           : null;
 
+      const errorForStatus = outcome === "succeeded"
+        ? null
+        : redactCurrentUserText(
+            adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+            currentUserRedactionOptions,
+          );
+
       await setRunStatus(run.id, status, {
         finishedAt: new Date(),
-        error:
-          outcome === "succeeded"
-            ? null
-            : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
-                currentUserRedactionOptions,
-              ),
+        error: shouldRetryTransient
+          ? `${errorForStatus}; queuing transient retry ${currentRetryCount + 1}/${policy.transientRetry.maxRetries}`
+          : errorForStatus,
         errorCode:
           outcome === "timed_out"
             ? "timeout"
             : outcome === "cancelled"
               ? "cancelled"
               : outcome === "failed"
-                ? (adapterResult.errorCode ?? "adapter_failed")
+                ? shouldRetryTransient
+                  ? "transient_api_error"
+                  : (adapterResult.errorCode ?? "adapter_failed")
                 : null,
         exitCode: adapterResult.exitCode,
         signal: adapterResult.signal,
@@ -2556,13 +2703,28 @@ export function heartbeatService(db: Db) {
           eventType: "lifecycle",
           stream: "system",
           level: outcome === "succeeded" ? "info" : "error",
-          message: `run ${outcome}`,
+          message: shouldRetryTransient
+            ? `run failed (transient API error) — queuing retry ${currentRetryCount + 1}/${policy.transientRetry.maxRetries}`
+            : `run ${outcome}`,
           payload: {
             status,
             exitCode: adapterResult.exitCode,
+            ...(shouldRetryTransient ? { transientRetry: true, retryAttempt: currentRetryCount + 1 } : {}),
           },
         });
-        await releaseIssueExecutionAndPromote(finalizedRun);
+
+        if (shouldRetryTransient) {
+          // Enqueue retry with exponential backoff instead of releasing the issue
+          const delayMs = policy.transientRetry.initialDelayMs *
+            Math.pow(policy.transientRetry.backoffMultiplier, currentRetryCount);
+          const retryRun = await enqueueTransientRetry(finalizedRun, agent, delayMs);
+          logger.info(
+            { runId: run.id, retryRunId: retryRun.id, retryAttempt: currentRetryCount + 1, delayMs },
+            "queued transient API failure retry",
+          );
+        } else {
+          await releaseIssueExecutionAndPromote(finalizedRun);
+        }
       }
 
       if (finalizedRun) {
@@ -2597,6 +2759,13 @@ export function heartbeatService(db: Db) {
       );
       logger.error({ err, runId }, "heartbeat execution failed");
 
+      // Check for transient API errors in the exception path
+      const catchRetryPolicy = parseHeartbeatPolicy(agent);
+      const catchRetryCount = run.transientRetryCount ?? 0;
+      const catchShouldRetry =
+        catchRetryCount < catchRetryPolicy.transientRetry.maxRetries &&
+        isTransientApiError(message, stderrExcerpt);
+
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
         try {
@@ -2607,8 +2776,10 @@ export function heartbeatService(db: Db) {
       }
 
       const failedRun = await setRunStatus(run.id, "failed", {
-        error: message,
-        errorCode: "adapter_failed",
+        error: catchShouldRetry
+          ? `${message}; queuing transient retry ${catchRetryCount + 1}/${catchRetryPolicy.transientRetry.maxRetries}`
+          : message,
+        errorCode: catchShouldRetry ? "transient_api_error" : "adapter_failed",
         finishedAt: new Date(),
         stdoutExcerpt,
         stderrExcerpt,
@@ -2626,9 +2797,22 @@ export function heartbeatService(db: Db) {
           eventType: "error",
           stream: "system",
           level: "error",
-          message,
+          message: catchShouldRetry
+            ? `${message} — queuing transient retry ${catchRetryCount + 1}/${catchRetryPolicy.transientRetry.maxRetries}`
+            : message,
         });
-        await releaseIssueExecutionAndPromote(failedRun);
+
+        if (catchShouldRetry) {
+          const delayMs = catchRetryPolicy.transientRetry.initialDelayMs *
+            Math.pow(catchRetryPolicy.transientRetry.backoffMultiplier, catchRetryCount);
+          const retryRun = await enqueueTransientRetry(failedRun, agent, delayMs);
+          logger.info(
+            { runId: run.id, retryRunId: retryRun.id, retryAttempt: catchRetryCount + 1, delayMs },
+            "queued transient API failure retry (from catch block)",
+          );
+        } else {
+          await releaseIssueExecutionAndPromote(failedRun);
+        }
 
         await updateRuntimeState(agent, failedRun, {
           exitCode: null,

--- a/server/src/services/transient-error-detection.ts
+++ b/server/src/services/transient-error-detection.ts
@@ -1,0 +1,29 @@
+/**
+ * Detects transient upstream API errors that are eligible for automatic retry.
+ *
+ * These patterns match known transient failure responses from providers like
+ * Anthropic (Claude), OpenAI, and other upstream APIs:
+ * - HTTP 500 Internal Server Error
+ * - HTTP 503 Service Unavailable
+ * - HTTP 529 Overloaded (Anthropic-specific)
+ * - Structured error types: overloaded_error, api_error
+ */
+
+export const TRANSIENT_ERROR_PATTERNS: ReadonlyArray<RegExp> = [
+  /\b500\b.*(?:internal\s*server\s*error|api_error)/i,
+  /\b529\b.*overloaded/i,
+  /\b503\b.*(?:service\s*unavailable|temporarily\s*unavailable)/i,
+  /overloaded_error/i,
+  /"type"\s*:\s*"overloaded_error"/,
+  /"type"\s*:\s*"api_error".*\b500\b/,
+  /API\s*Error:\s*(?:500|529|503)\b/i,
+];
+
+export function isTransientApiError(
+  errorMessage: string | null | undefined,
+  stderrExcerpt: string | null | undefined,
+): boolean {
+  const combined = [errorMessage ?? "", stderrExcerpt ?? ""].join("\n");
+  if (!combined.trim()) return false;
+  return TRANSIENT_ERROR_PATTERNS.some((pattern) => pattern.test(combined));
+}


### PR DESCRIPTION
## Summary

- Detect transient upstream API errors (HTTP 500, 529, 503, `overloaded_error`) and automatically retry failed runs with exponential backoff
- Add `enqueueTransientRetry()` with configurable backoff (default: 30s → 60s → 120s, max 3 retries)
- Add `transient_retry_count` column to `heartbeat_runs` schema
- Retry config is per-agent via `runtimeConfig.heartbeat.transientRetry` (maxRetries, initialDelayMs, backoffMultiplier)
- 16 unit tests for transient error detection patterns

## Test plan

- [x] 16 unit tests pass for `isTransientApiError()` — covers 500/529/503/overloaded_error detection and non-transient rejection
- [x] TypeScript compilation passes (server package)
- [x] Existing heartbeat tests still pass
- [ ] Manual: trigger a 529 error and verify retry is queued with correct delay
- [ ] Manual: verify retry count stops at maxRetries and marks run as permanently failed

## Risk notes

- `setTimeout` for delayed retry execution — if server restarts during the delay window, the queued run will be picked up by `resumeQueuedRuns()` on next startup (no retry lost)
- Budget guard: retries create new runs that count against agent budget, preventing infinite retry loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)