### PR TITLE
fix: scope PAPERCLIP_API_KEY resolution to prevent cross-agent leakage (#1371)

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -5,6 +5,9 @@ import type {
 } from "@paperclipai/adapter-utils";
 import { asNumber, asString, buildPaperclipEnv, parseObject } from "@paperclipai/adapter-utils/server-utils";
 import crypto, { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { WebSocket } from "ws";
 
 type SessionKeyStrategy = "fixed" | "issue" | "run";
@@ -313,8 +316,65 @@ function resolvePaperclipApiUrlOverride(value: unknown): string | null {
   }
 }
 
+/**
+ * Resolve PAPERCLIP_API_KEY for wake context.
+ * Priority chain:
+ *   1. config.paperclipApiKey (explicit per-agent config)
+ *   2. process.env.PAPERCLIP_API_KEY
+ *   3. Claimed key file (agent-scoped path, then cwd path, then default path)
+ */
+export function resolvePaperclipApiKey(config: Record<string, unknown>, agentId?: string): string | null {
+  const configKey = nonEmpty(config.paperclipApiKey);
+  if (configKey) return configKey;
+
+  const envKey = nonEmpty(process.env.PAPERCLIP_API_KEY);
+  if (envKey) return envKey;
+
+  const homeDir = os.homedir();
+  const candidates: string[] = [];
+
+  if (agentId) {
+    candidates.push(
+      path.join(homeDir, ".openclaw", "workspace", agentId, "paperclip-claimed-api-key.json"),
+    );
+  }
+
+  const cwd = nonEmpty(config.cwd);
+  if (cwd) {
+    candidates.push(path.join(cwd, "paperclip-claimed-api-key.json"));
+  }
+
+  candidates.push(path.join(homeDir, ".openclaw", "workspace", "paperclip-claimed-api-key.json"));
+
+  for (const filePath of candidates) {
+    try {
+      const content = fs.readFileSync(filePath, "utf-8");
+      const parsed = JSON.parse(content) as Record<string, unknown>;
+      const key =
+        nonEmpty(parsed.token) ??
+        nonEmpty(parsed.apiKey) ??
+        nonEmpty(parsed.key) ??
+        nonEmpty(parsed.PAPERCLIP_API_KEY);
+      if (!key) continue;
+      const fingerprint = key.length >= 8 ? `${key.slice(0, 4)}...${key.slice(-4)}` : `${key.slice(0, 1)}...`;
+      console.info(
+        `[openclaw-gateway] Resolved PAPERCLIP_API_KEY from ${filePath} for agent ${agentId ?? "unknown"} (${fingerprint})`,
+      );
+      return key;
+    } catch {
+      // Try next candidate.
+    }
+  }
+
+  console.warn(
+    `[openclaw-gateway] Could not resolve PAPERCLIP_API_KEY for agent ${agentId ?? "unknown"}`,
+  );
+  return null;
+}
+
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
   const paperclipApiUrlOverride = resolvePaperclipApiUrlOverride(ctx.config.paperclipApiUrl);
+  const resolvedApiKey = resolvePaperclipApiKey(parseObject(ctx.config), ctx.agent.id);
   const paperclipEnv: Record<string, string> = {
     ...buildPaperclipEnv(ctx.agent),
     PAPERCLIP_RUN_ID: ctx.runId,
@@ -331,12 +391,14 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   if (wakePayload.issueIds.length > 0) {
     paperclipEnv.PAPERCLIP_LINKED_ISSUE_IDS = wakePayload.issueIds.join(",");
   }
+  if (resolvedApiKey) {
+    paperclipEnv.PAPERCLIP_API_KEY = resolvedApiKey;
+  }
 
   return paperclipEnv;
 }
 
 function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -359,6 +421,7 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
 
   const issueIdHint = payload.taskId ?? payload.issueId ?? "";
   const apiBaseHint = paperclipEnv.PAPERCLIP_API_URL ?? "<set PAPERCLIP_API_URL>";
+  const hasResolvedApiKey = nonEmpty(paperclipEnv.PAPERCLIP_API_KEY) !== null;
 
   const lines = [
     "Paperclip wake event for a cloud adapter.",
@@ -367,9 +430,9 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     "",
     "Set these values in your run context:",
     ...envLines,
-    `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
-    "",
-    `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    hasResolvedApiKey
+      ? "PAPERCLIP_API_KEY is provided via environment variable."
+      : "PAPERCLIP_API_KEY could not be resolved. Stop and request re-claim from your manager.",
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,
@@ -446,6 +509,7 @@ function buildStandardPaperclipPayload(
     approvalId: wakePayload.approvalId,
     approvalStatus: wakePayload.approvalStatus,
     apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
+    env: paperclipEnv,
   };
 
   if (workspace) {

--- a/packages/adapters/openclaw-gateway/src/server/index.ts
+++ b/packages/adapters/openclaw-gateway/src/server/index.ts
@@ -1,2 +1,3 @@
 export { execute } from "./execute.js";
+export { resolvePaperclipApiKey } from "./execute.js";
 export { testEnvironment } from "./test.js";

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
-import { execute, testEnvironment } from "@paperclipai/adapter-openclaw-gateway/server";
+import { execute, resolvePaperclipApiKey, testEnvironment } from "@paperclipai/adapter-openclaw-gateway/server";
 import {
   buildOpenClawGatewayConfig,
   parseOpenClawGatewayStdoutLine,
@@ -551,6 +554,98 @@ describe("openclaw gateway adapter execute", () => {
       expect(gateway.getAgentPayload()).toBeTruthy();
     } finally {
       await gateway.close();
+    }
+  });
+});
+
+describe("resolvePaperclipApiKey", () => {
+  it("resolves from config.paperclipApiKey", () => {
+    const key = resolvePaperclipApiKey({ paperclipApiKey: "test-key-123" });
+    expect(key).toBe("test-key-123");
+  });
+
+  it("resolves from PAPERCLIP_API_KEY env var", () => {
+    const previous = process.env.PAPERCLIP_API_KEY;
+    process.env.PAPERCLIP_API_KEY = "env-key-456";
+    try {
+      const key = resolvePaperclipApiKey({});
+      expect(key).toBe("env-key-456");
+    } finally {
+      if (previous === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previous;
+    }
+  });
+
+  it("prefers config over env", () => {
+    const previous = process.env.PAPERCLIP_API_KEY;
+    process.env.PAPERCLIP_API_KEY = "env-key";
+    try {
+      const key = resolvePaperclipApiKey({ paperclipApiKey: "config-key" });
+      expect(key).toBe("config-key");
+    } finally {
+      if (previous === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previous;
+    }
+  });
+
+  it("returns null when nothing is found", () => {
+    const previous = process.env.PAPERCLIP_API_KEY;
+    const fsSpy = vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("not found");
+    });
+    try {
+      delete process.env.PAPERCLIP_API_KEY;
+      const key = resolvePaperclipApiKey({});
+      expect(key).toBeNull();
+    } finally {
+      fsSpy.mockRestore();
+      if (previous === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previous;
+    }
+  });
+
+  it("resolves from claimed key file", () => {
+    const previous = process.env.PAPERCLIP_API_KEY;
+    const homeSpy = vi.spyOn(os, "homedir").mockReturnValue("/tmp/home");
+    const fsSpy = vi.spyOn(fs, "readFileSync").mockImplementation((targetPath: fs.PathOrFileDescriptor) => {
+      const value = String(targetPath);
+      if (value === path.join("/tmp/home", ".openclaw", "workspace", "agent-42", "paperclip-claimed-api-key.json")) {
+        return JSON.stringify({ token: "file-key-9999" });
+      }
+      throw new Error("missing");
+    });
+    try {
+      delete process.env.PAPERCLIP_API_KEY;
+      const key = resolvePaperclipApiKey({}, "agent-42");
+      expect(key).toBe("file-key-9999");
+    } finally {
+      fsSpy.mockRestore();
+      homeSpy.mockRestore();
+      if (previous === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previous;
+    }
+  });
+
+  it("does not log actual key value", () => {
+    const previous = process.env.PAPERCLIP_API_KEY;
+    const homeSpy = vi.spyOn(os, "homedir").mockReturnValue("/tmp/home");
+    const fsSpy = vi.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({ token: "very-secret-key-12345678" }),
+    );
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      delete process.env.PAPERCLIP_API_KEY;
+      const key = resolvePaperclipApiKey({}, "agent-7");
+      expect(key).toBe("very-secret-key-12345678");
+      const logged = infoSpy.mock.calls.map((call) => call.map(String).join(" ")).join("\n");
+      expect(logged).toContain("very...5678");
+      expect(logged).not.toContain("very-secret-key-12345678");
+    } finally {
+      infoSpy.mockRestore();
+      fsSpy.mockRestore();
+      homeSpy.mockRestore();
+      if (previous === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previous;
     }
   });
 });


### PR DESCRIPTION
**Thinking path:**
- OpenClaw gateway wake prompt tells the agent to read API key from a hardcoded file path
- If multiple agents share a workspace, one agent can pick up another agent's claimed key
- This is because the key is resolved via prompt instruction, not server-side
- Server-side resolution with strict scoping prevents cross-agent credential leakage

**Changes:**
- Added `resolvePaperclipApiKey(config, agentId)` with priority chain:
  1. `config.paperclipApiKey` (explicit per-agent config)
  2. `process.env.PAPERCLIP_API_KEY` (environment)
  3. Agent-scoped claimed key file (by agent ID)
  4. Default claimed key file (last resort)
- Key is now resolved server-side and passed via env, not prompt instruction
- `buildWakeText` updated: shows "provided via env" or "could not be resolved"
- Key values never logged — only fingerprints (first/last 4 chars)
- Added 6 tests: config source, env source, priority, null case, file source, no leakage

**Testing:**
- 6 unit tests for resolvePaperclipApiKey
- Existing adapter behavior unchanged for users with env-based keys

Closes #1371