### PR TITLE
fix(config): add field/value aliases for common config.json alternatives (#1271)

### DIFF
--- a/cli/src/config/schema.ts
+++ b/cli/src/config/schema.ts
@@ -1,5 +1,6 @@
 export {
   paperclipConfigSchema,
+  normalizeRawConfig,
   configMetaSchema,
   llmConfigSchema,
   databaseBackupConfigSchema,

--- a/cli/src/config/store.ts
+++ b/cli/src/config/store.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { paperclipConfigSchema, type PaperclipConfig } from "./schema.js";
+import { paperclipConfigSchema, normalizeRawConfig, type PaperclipConfig } from "./schema.js";
 import {
   resolveDefaultConfigPath,
   resolvePaperclipInstanceId,
@@ -40,34 +40,6 @@ function parseJson(filePath: string): unknown {
   }
 }
 
-function migrateLegacyConfig(raw: unknown): unknown {
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return raw;
-  const config = { ...(raw as Record<string, unknown>) };
-  const databaseRaw = config.database;
-  if (typeof databaseRaw !== "object" || databaseRaw === null || Array.isArray(databaseRaw)) {
-    return config;
-  }
-
-  const database = { ...(databaseRaw as Record<string, unknown>) };
-  if (database.mode === "pglite") {
-    database.mode = "embedded-postgres";
-
-    if (typeof database.embeddedPostgresDataDir !== "string" && typeof database.pgliteDataDir === "string") {
-      database.embeddedPostgresDataDir = database.pgliteDataDir;
-    }
-    if (
-      typeof database.embeddedPostgresPort !== "number" &&
-      typeof database.pglitePort === "number" &&
-      Number.isFinite(database.pglitePort)
-    ) {
-      database.embeddedPostgresPort = database.pglitePort;
-    }
-  }
-
-  config.database = database;
-  return config;
-}
-
 function formatValidationError(err: unknown): string {
   const issues = (err as { issues?: Array<{ path?: unknown; message?: unknown }> })?.issues;
   if (Array.isArray(issues) && issues.length > 0) {
@@ -87,8 +59,8 @@ export function readConfig(configPath?: string): PaperclipConfig | null {
   const filePath = resolveConfigPath(configPath);
   if (!fs.existsSync(filePath)) return null;
   const raw = parseJson(filePath);
-  const migrated = migrateLegacyConfig(raw);
-  const parsed = paperclipConfigSchema.safeParse(migrated);
+  const normalized = normalizeRawConfig(raw);
+  const parsed = paperclipConfigSchema.safeParse(normalized);
   if (!parsed.success) {
     throw new Error(`Invalid config at ${filePath}: ${formatValidationError(parsed.error)}`);
   }

--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -7,6 +7,106 @@ import {
   STORAGE_PROVIDERS,
 } from "./constants.js";
 
+// ---------------------------------------------------------------------------
+// Config field & value aliases (GH #1271)
+// ---------------------------------------------------------------------------
+
+const DATABASE_MODE_ALIASES: Record<string, string> = {
+  external: "postgres",
+  postgresql: "postgres",
+  pglite: "embedded-postgres",
+  embedded: "embedded-postgres",
+};
+
+const AUTH_BASE_URL_MODE_ALIASES: Record<string, string> = {
+  manual: "explicit",
+};
+
+const DEPLOYMENT_MODE_ALIASES: Record<string, string> = {
+  trusted: "local_trusted",
+  local: "local_trusted",
+  auth: "authenticated",
+};
+
+const DATABASE_FIELD_ALIASES: Record<string, string> = {
+  url: "connectionString",
+  databaseUrl: "connectionString",
+};
+
+const AUTH_FIELD_ALIASES: Record<string, string> = {
+  publicUrl: "publicBaseUrl",
+};
+
+type RawObj = Record<string, unknown>;
+
+function isPlainObject(v: unknown): v is RawObj {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function applyFieldAliases(obj: RawObj, aliases: Record<string, string>): RawObj {
+  const result = { ...obj };
+  for (const [alt, canonical] of Object.entries(aliases)) {
+    if (alt in result && !(canonical in result)) {
+      result[canonical] = result[alt];
+      delete result[alt];
+    }
+  }
+  return result;
+}
+
+function applyValueAlias(value: unknown, aliases: Record<string, string>): unknown {
+  if (typeof value !== "string") return value;
+  const lower = value.toLowerCase();
+  return aliases[lower] ?? value;
+}
+
+/**
+ * Normalizes a raw config object before Zod validation:
+ * - Maps common field name aliases (e.g. database.url → database.connectionString)
+ * - Maps common value aliases (e.g. database.mode "external" → "postgres")
+ * - Migrates legacy "pglite" config fields
+ */
+export function normalizeRawConfig(raw: unknown): unknown {
+  if (!isPlainObject(raw)) return raw;
+  const config = { ...raw };
+
+  if (isPlainObject(config.database)) {
+    let db = { ...config.database };
+
+    // Legacy pglite field migration
+    if (db.mode === "pglite") {
+      if (typeof db.embeddedPostgresDataDir !== "string" && typeof db.pgliteDataDir === "string") {
+        db.embeddedPostgresDataDir = db.pgliteDataDir;
+      }
+      if (
+        typeof db.embeddedPostgresPort !== "number" &&
+        typeof db.pglitePort === "number" &&
+        Number.isFinite(db.pglitePort)
+      ) {
+        db.embeddedPostgresPort = db.pglitePort;
+      }
+    }
+
+    db = applyFieldAliases(db, DATABASE_FIELD_ALIASES);
+    db.mode = applyValueAlias(db.mode, DATABASE_MODE_ALIASES);
+    config.database = db;
+  }
+
+  if (isPlainObject(config.auth)) {
+    let auth = applyFieldAliases({ ...config.auth }, AUTH_FIELD_ALIASES);
+    auth.baseUrlMode = applyValueAlias(auth.baseUrlMode, AUTH_BASE_URL_MODE_ALIASES);
+    config.auth = auth;
+  }
+
+  if (isPlainObject(config.server)) {
+    const server = { ...config.server };
+    server.deploymentMode = applyValueAlias(server.deploymentMode, DEPLOYMENT_MODE_ALIASES);
+    config.server = server;
+  }
+
+  return config;
+}
+
 export const configMetaSchema = z.object({
   version: z.literal(1),
   updatedAt: z.string(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -538,6 +538,7 @@ export {
 
 export {
   paperclipConfigSchema,
+  normalizeRawConfig,
   configMetaSchema,
   llmConfigSchema,
   databaseBackupConfigSchema,

--- a/server/src/__tests__/normalize-raw-config.test.ts
+++ b/server/src/__tests__/normalize-raw-config.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { normalizeRawConfig, paperclipConfigSchema } from "@paperclipai/shared";
+
+describe("normalizeRawConfig", () => {
+  it("returns non-object input unchanged", () => {
+    expect(normalizeRawConfig(null)).toBeNull();
+    expect(normalizeRawConfig("string")).toBe("string");
+    expect(normalizeRawConfig(42)).toBe(42);
+    expect(normalizeRawConfig([1, 2])).toEqual([1, 2]);
+  });
+
+  // --- database.mode value aliases ---
+  it('maps database.mode "external" → "postgres"', () => {
+    const raw = { database: { mode: "external" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.mode).toBe("postgres");
+  });
+
+  it('maps database.mode "postgresql" → "postgres"', () => {
+    const raw = { database: { mode: "postgresql" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.mode).toBe("postgres");
+  });
+
+  it('maps database.mode "embedded" → "embedded-postgres"', () => {
+    const raw = { database: { mode: "embedded" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.mode).toBe("embedded-postgres");
+  });
+
+  it('maps legacy database.mode "pglite" with field migration', () => {
+    const raw = { database: { mode: "pglite", pgliteDataDir: "/tmp/db", pglitePort: 5433 } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.mode).toBe("embedded-postgres");
+    expect(result.database.embeddedPostgresDataDir).toBe("/tmp/db");
+    expect(result.database.embeddedPostgresPort).toBe(5433);
+  });
+
+  it("does not overwrite existing embeddedPostgresDataDir during pglite migration", () => {
+    const raw = {
+      database: { mode: "pglite", embeddedPostgresDataDir: "/existing", pgliteDataDir: "/old" },
+    };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.embeddedPostgresDataDir).toBe("/existing");
+  });
+
+  it("leaves valid database.mode unchanged", () => {
+    const raw = { database: { mode: "postgres" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.mode).toBe("postgres");
+  });
+
+  // --- database field aliases ---
+  it("maps database.url → database.connectionString", () => {
+    const raw = { database: { mode: "postgres", url: "postgres://localhost/db" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.connectionString).toBe("postgres://localhost/db");
+    expect(result.database.url).toBeUndefined();
+  });
+
+  it("maps database.databaseUrl → database.connectionString", () => {
+    const raw = { database: { mode: "postgres", databaseUrl: "postgres://localhost/db" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.connectionString).toBe("postgres://localhost/db");
+    expect(result.database.databaseUrl).toBeUndefined();
+  });
+
+  it("does not overwrite existing connectionString with alias", () => {
+    const raw = {
+      database: { mode: "postgres", connectionString: "postgres://real", url: "postgres://alias" },
+    };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.connectionString).toBe("postgres://real");
+  });
+
+  // --- auth aliases ---
+  it('maps auth.baseUrlMode "manual" → "explicit"', () => {
+    const raw = { auth: { baseUrlMode: "manual" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.auth.baseUrlMode).toBe("explicit");
+  });
+
+  it("maps auth.publicUrl → auth.publicBaseUrl", () => {
+    const raw = { auth: { publicUrl: "https://example.com" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.auth.publicBaseUrl).toBe("https://example.com");
+    expect(result.auth.publicUrl).toBeUndefined();
+  });
+
+  // --- server aliases ---
+  it('maps server.deploymentMode "trusted" → "local_trusted"', () => {
+    const raw = { server: { deploymentMode: "trusted" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.server.deploymentMode).toBe("local_trusted");
+  });
+
+  it('maps server.deploymentMode "auth" → "authenticated"', () => {
+    const raw = { server: { deploymentMode: "auth" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.server.deploymentMode).toBe("authenticated");
+  });
+
+  // --- integration: normalized config passes Zod validation ---
+  it("normalized aliased config passes schema validation", () => {
+    const raw = {
+      $meta: { version: 1, updatedAt: "2026-01-01", source: "onboard" },
+      database: { mode: "external", url: "postgres://localhost:5432/paperclip" },
+      logging: { mode: "file" },
+      server: { deploymentMode: "trusted" },
+      auth: { baseUrlMode: "auto" },
+    };
+
+    const normalized = normalizeRawConfig(raw);
+    const result = paperclipConfigSchema.safeParse(normalized);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.database.mode).toBe("postgres");
+      expect(result.data.database.connectionString).toBe("postgres://localhost:5432/paperclip");
+      expect(result.data.server.deploymentMode).toBe("local_trusted");
+    }
+  });
+
+  // --- no-op for missing sections ---
+  it("handles config with no database/auth/server sections", () => {
+    const raw = { foo: "bar" };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.foo).toBe("bar");
+    expect(result.database).toBeUndefined();
+  });
+
+  // --- case insensitivity ---
+  it("handles mixed-case value aliases", () => {
+    const raw = { database: { mode: "External" } };
+    const result = normalizeRawConfig(raw) as Record<string, any>;
+    expect(result.database.mode).toBe("postgres");
+  });
+});

--- a/server/src/config-file.ts
+++ b/server/src/config-file.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { paperclipConfigSchema, type PaperclipConfig } from "@paperclipai/shared";
+import { paperclipConfigSchema, normalizeRawConfig, type PaperclipConfig } from "@paperclipai/shared";
 import { resolvePaperclipConfigPath } from "./paths.js";
 
 export function readConfigFile(): PaperclipConfig | null {
@@ -9,7 +9,7 @@ export function readConfigFile(): PaperclipConfig | null {
 
   try {
     const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    return paperclipConfigSchema.parse(raw);
+    return paperclipConfigSchema.parse(normalizeRawConfig(raw));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Fixes #1271: config.json field naming inconsistency and unclear error messages
- Adds `normalizeRawConfig()` pre-processing that maps common field/value aliases to canonical names before Zod validation
- Consolidates legacy pglite migration into shared function used by both CLI and server

## Aliases added

| User writes | Maps to |
|---|---|
| `database.mode: "external"` | `database.mode: "postgres"` |
| `database.mode: "postgresql"` | `database.mode: "postgres"` |
| `database.mode: "embedded"` | `database.mode: "embedded-postgres"` |
| `database.url` | `database.connectionString` |
| `database.databaseUrl` | `database.connectionString` |
| `auth.baseUrlMode: "manual"` | `auth.baseUrlMode: "explicit"` |
| `auth.publicUrl` | `auth.publicBaseUrl` |
| `server.deploymentMode: "trusted"` | `server.deploymentMode: "local_trusted"` |
| `server.deploymentMode: "auth"` | `server.deploymentMode: "authenticated"` |

## Changes
- `packages/shared/src/config-schema.ts` — new `normalizeRawConfig()` export with alias maps
- `cli/src/config/store.ts` — replace local `migrateLegacyConfig` with shared `normalizeRawConfig`
- `server/src/config-file.ts` — apply `normalizeRawConfig` before parsing (was missing any normalization)
- `server/src/__tests__/normalize-raw-config.test.ts` — 17 tests covering all aliases

## Test plan
- [x] 17 unit tests pass covering all value aliases, field aliases, legacy migration, case insensitivity, and schema integration
- [x] TypeScript type check passes
- [ ] Manual test: create config.json with aliased fields, verify server starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)