### PR TITLE
fix: Dockerfile missing plugin-sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
 
 RUN pnpm install --frozen-lockfile
 
@@ -27,6 +28,7 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)


### PR DESCRIPTION
## Summary

Two issues that prevent a clean Docker build after the plugin system was introduced:

1. **@paperclipai/plugin-sdk missing from Dockerfile** — The deps stage doesn't copy packages/plugins/sdk/package.json, and the build stage doesn't build the SDK before the server. This causes the server build to fail with TS2307: Cannot find module '@paperclipai/plugin-sdk' errors.

2. **pnpm-lock.yaml out of sync** — packages/db/package.json gained embedded-postgres as a dependency but the lockfile wasn't updated, causing pnpm install --frozen-lockfile to fail in the Docker build.

## Fix

- Add to the deps stage: 
- Add to the build stage before the UI and server builds: 

Closes #1111