### PR TITLE
Add local-model support via Ollama and manual OpenCode model fallback

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -83,6 +83,7 @@ export interface AdapterExecutionResult {
   resultJson?: Record<string, unknown> | null;
   runtimeServices?: AdapterRuntimeServiceReport[];
   summary?: string | null;
+  issueComment?: string | null;
   clearSession?: boolean;
   question?: {
     prompt: string;
@@ -326,6 +327,7 @@ export interface CreateConfigValues {
   instructionsFilePath?: string;
   promptTemplate: string;
   model: string;
+  allowUndiscoveredModel: boolean;
   thinkingEffort: string;
   chrome: boolean;
   dangerouslySkipPermissions: boolean;

--- a/packages/adapters/ollama-local/package.json
+++ b/packages/adapters/ollama-local/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@paperclipai/adapter-ollama-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/ollama-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/ollama-local/src/index.ts
+++ b/packages/adapters/ollama-local/src/index.ts
@@ -1,0 +1,31 @@
+export const type = "ollama_local";
+export const label = "Ollama (local)";
+export const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434";
+
+export const models: Array<{ id: string; label: string }> = [];
+
+export const agentConfigurationDoc = `# ollama_local agent configuration
+
+Adapter: ollama_local
+
+Use when:
+- You want Paperclip to call a local Ollama server directly
+- You need local models such as qwen2.5, llama, mistral, or gemma
+- You want a local-model worker that can draft Issue replies inside Paperclip
+
+Don't use when:
+- You need a full coding-agent CLI with tool execution and native session resume
+- You want a remote webhook or gateway adapter (use http or openclaw_gateway)
+
+Core fields:
+- baseUrl (string, optional): Ollama server base URL. Defaults to ${DEFAULT_OLLAMA_BASE_URL}
+- model (string, required): Ollama model name, for example qwen2.5:7b
+- allowUndiscoveredModel (boolean, optional): allow a manual model even if /api/tags does not list it
+- instructionsFilePath (string, optional): optional markdown instructions file appended to the system prompt
+- promptTemplate (string, optional): system prompt template used for each run
+
+Notes:
+- This adapter talks to Ollama's native HTTP API (/api/tags and /api/chat).
+- It is intentionally lightweight: it posts text back to Paperclip Issues, but it is not a tool-using coding CLI.
+- If you paste an OpenAI-compatible Ollama URL ending in /v1, Paperclip normalizes it back to the native Ollama base URL.
+`;

--- a/packages/adapters/ollama-local/src/server/execute.ts
+++ b/packages/adapters/ollama-local/src/server/execute.ts
@@ -1,0 +1,258 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  joinPromptSections,
+  parseObject,
+  renderTemplate,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  chatWithOllama,
+  ensureOllamaModelConfiguredAndAvailable,
+  normalizeOllamaBaseUrl,
+} from "./models.js";
+
+function firstNonEmptyLine(text: string) {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function stringifyContext(value: unknown) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+async function readInstructionsFile(candidate: string, cwd: string | null) {
+  const trimmed = candidate.trim();
+  if (!trimmed) return "";
+  const resolvedPath = path.isAbsolute(trimmed)
+    ? trimmed
+    : cwd
+      ? path.resolve(cwd, trimmed)
+      : trimmed;
+  return (await fs.readFile(resolvedPath, "utf8")).trim();
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta } = ctx;
+
+  const parsedConfig = parseObject(config);
+  const model = asString(parsedConfig.model, "").trim();
+  const allowUndiscoveredModel = parsedConfig.allowUndiscoveredModel === true;
+  const timeoutSec = Math.max(30, asNumber(parsedConfig.timeoutSec, 180));
+  const promptTemplate = asString(
+    parsedConfig.promptTemplate,
+    [
+      "You are Paperclip agent {{agent.name}} ({{agent.id}}).",
+      "You are running through the experimental Ollama local adapter.",
+      "You cannot execute tools or edit files in this adapter.",
+      "Write a concise markdown Issue comment for the current task.",
+      "If required information is missing, ask one focused clarifying question instead of guessing.",
+    ].join("\n"),
+  );
+  const runtimeSessionId = runtime.sessionDisplayId ?? runtime.sessionId ?? "";
+  const issue = parseObject(context.paperclipIssue);
+  const workingContext = parseObject(context.paperclipWorkspace);
+  const workingDirectory = asString(
+    parsedConfig.cwd,
+    asString(workingContext.cwd, ""),
+  ).trim();
+  let baseUrl = "";
+
+  try {
+    baseUrl = normalizeOllamaBaseUrl(parsedConfig.baseUrl ?? parsedConfig.url);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Invalid Ollama base URL.";
+    await onLog("stderr", `[paperclip] ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "ollama_base_url_invalid",
+      errorMessage: message,
+      provider: "ollama",
+      biller: "local",
+      model,
+      billingType: "fixed",
+      costUsd: 0,
+    };
+  }
+
+  try {
+    await ensureOllamaModelConfiguredAndAvailable({
+      model,
+      baseUrl,
+      allowUndiscoveredModel,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Configured Ollama model is unavailable.";
+    await onLog("stderr", `[paperclip] ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "ollama_model_invalid",
+      errorMessage: message,
+      provider: "ollama",
+      biller: "local",
+      model,
+      billingType: "fixed",
+      costUsd: 0,
+    };
+  }
+
+  let instructionsText = "";
+  const instructionsFilePath = asString(parsedConfig.instructionsFilePath, "").trim();
+  if (instructionsFilePath) {
+    try {
+      instructionsText = await readInstructionsFile(instructionsFilePath, workingDirectory || null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to read instructions file.";
+      await onLog("stderr", `[paperclip] ${message}\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorCode: "ollama_instructions_read_failed",
+        errorMessage: message,
+        provider: "ollama",
+        biller: "local",
+        model,
+        billingType: "fixed",
+        costUsd: 0,
+      };
+    }
+  }
+
+  const templateData = {
+    agent,
+    run: { id: runId },
+    runtime: {
+      sessionId: runtimeSessionId,
+      taskKey: runtime.taskKey,
+    },
+    issue,
+    context,
+  };
+
+  const systemPrompt = joinPromptSections([
+    renderTemplate(promptTemplate, templateData).trim(),
+    instructionsText ? `Additional instructions:\n${instructionsText}` : null,
+  ]);
+
+  const userPrompt = joinPromptSections([
+    issue.id
+      ? [
+          "Current Paperclip issue:",
+          `- Identifier: ${asString(
+            issue.identifier,
+            typeof issue.id === "string" ? issue.id : "(unknown issue)",
+          )}`,
+          `- Title: ${asString(issue.title, "(untitled issue)")}`,
+          issue.description ? `- Description:\n${asString(issue.description, "").trim()}` : "- Description: (none)",
+        ].join("\n")
+      : "This run is not attached to a Paperclip issue.",
+    runtime.taskKey ? `Task key: ${runtime.taskKey}` : null,
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? `Wake reason: ${context.wakeReason.trim()}`
+      : null,
+    workingDirectory ? `Working directory: ${workingDirectory}` : null,
+    [
+      "Relevant runtime context:",
+      stringifyContext({
+        issueId: context.issueId ?? null,
+        commentId: context.commentId ?? null,
+        approvalId: context.approvalId ?? null,
+        linkedIssueIds: Array.isArray(context.issueIds) ? context.issueIds : [],
+        workspace: context.paperclipWorkspace ?? null,
+      }),
+    ].join("\n"),
+    [
+      "Write the exact markdown comment body to post back to Paperclip.",
+      "Constraints:",
+      "- Be concise and specific.",
+      "- Do not claim you edited files, ran tests, or inspected code unless the provided context explicitly says so.",
+      "- Do not wrap the whole response in code fences.",
+    ].join("\n"),
+  ]);
+
+  await onMeta?.({
+    adapterType: "ollama_local",
+    command: "POST /api/chat",
+    prompt: userPrompt,
+    context: {
+      baseUrl,
+      model,
+      issueId: context.issueId ?? null,
+    },
+  });
+  await onLog("stdout", `${JSON.stringify({ type: "system", text: `Calling Ollama model ${model} at ${baseUrl}` })}\n`);
+
+  try {
+    const response = await chatWithOllama({
+      baseUrl,
+      model,
+      timeoutMs: timeoutSec * 1000,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+    });
+    const reply = response.message?.content?.trim() ?? "";
+    if (!reply) {
+      throw new Error("Ollama returned an empty response.");
+    }
+
+    await onLog("stdout", `${JSON.stringify({ type: "assistant", text: reply })}\n`);
+
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      usage: {
+        inputTokens: asNumber(response.prompt_eval_count, 0),
+        outputTokens: asNumber(response.eval_count, 0),
+      },
+      provider: "ollama",
+      biller: "local",
+      model: asString(response.model, model),
+      billingType: "fixed",
+      costUsd: 0,
+      resultJson: {
+        reply,
+        done: response.done ?? null,
+        doneReason: response.done_reason ?? null,
+        totalDuration: response.total_duration ?? null,
+        loadDuration: response.load_duration ?? null,
+        promptEvalDuration: response.prompt_eval_duration ?? null,
+        evalDuration: response.eval_duration ?? null,
+      },
+      summary: firstNonEmptyLine(reply),
+      issueComment: reply,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Ollama request failed.";
+    await onLog("stderr", `[paperclip] ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: /timed out/i.test(message),
+      errorCode: /timed out/i.test(message) ? "ollama_timeout" : "ollama_request_failed",
+      errorMessage: message,
+      provider: "ollama",
+      biller: "local",
+      model,
+      billingType: "fixed",
+      costUsd: 0,
+    };
+  }
+}

--- a/packages/adapters/ollama-local/src/server/index.ts
+++ b/packages/adapters/ollama-local/src/server/index.ts
@@ -1,0 +1,9 @@
+export { execute } from "./execute.js";
+export {
+  DEFAULT_OLLAMA_BASE_URL,
+  discoverOllamaModels,
+  ensureOllamaModelConfiguredAndAvailable,
+  listOllamaModels,
+  normalizeOllamaBaseUrl,
+} from "./models.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/ollama-local/src/server/models.ts
+++ b/packages/adapters/ollama-local/src/server/models.ts
@@ -1,0 +1,244 @@
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import { asString } from "@paperclipai/adapter-utils/server-utils";
+
+export const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434";
+
+type OllamaTag = {
+  name?: unknown;
+  model?: unknown;
+};
+
+type OllamaTagsResponse = {
+  models?: OllamaTag[];
+};
+
+type OllamaChatMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+type OllamaChatResponse = {
+  model?: string;
+  message?: {
+    role?: string;
+    content?: string;
+  };
+  done?: boolean;
+  done_reason?: string;
+  prompt_eval_count?: number;
+  eval_count?: number;
+  total_duration?: number;
+  load_duration?: number;
+  prompt_eval_duration?: number;
+  eval_duration?: number;
+};
+
+const MODELS_CACHE_TTL_MS = 30_000;
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 15_000;
+const DEFAULT_CHAT_TIMEOUT_MS = 120_000;
+const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+
+function dedupeModels(models: AdapterModel[]) {
+  const seen = new Set<string>();
+  const deduped: AdapterModel[] = [];
+  for (const entry of models) {
+    const id = entry.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    deduped.push({ id, label: entry.label.trim() || id });
+  }
+  return deduped;
+}
+
+function sortModels(models: AdapterModel[]) {
+  return [...models].sort((left, right) =>
+    left.id.localeCompare(right.id, "en", { numeric: true, sensitivity: "base" }),
+  );
+}
+
+function firstNonEmptyLine(text: string) {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function pruneExpiredDiscoveryCache(now: number) {
+  for (const [key, entry] of discoveryCache.entries()) {
+    if (entry.expiresAt <= now) discoveryCache.delete(key);
+  }
+}
+
+function parseModelId(tag: OllamaTag): string {
+  const candidates = [tag.name, tag.model];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return "";
+}
+
+async function fetchJson<T>(
+  url: string,
+  init: RequestInit & { timeoutMs?: number } = {},
+): Promise<T> {
+  const controller = new AbortController();
+  const timeoutMs = init.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        "content-type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      const detail = firstNonEmptyLine(text);
+      throw new Error(detail ? `${response.status} ${response.statusText}: ${detail}` : `${response.status} ${response.statusText}`);
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error("Ollama returned invalid JSON.");
+    }
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`Request timed out after ${timeoutMs / 1000}s.`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function normalizeBasePath(pathname: string) {
+  const trimmed = pathname.replace(/\/+$/, "");
+  return /\/v1$/i.test(trimmed) ? trimmed.slice(0, -3) : trimmed;
+}
+
+export function normalizeOllamaBaseUrl(input: unknown): string {
+  const raw = asString(
+    input,
+    typeof process.env.OLLAMA_HOST === "string" && process.env.OLLAMA_HOST.trim().length > 0
+      ? process.env.OLLAMA_HOST
+      : DEFAULT_OLLAMA_BASE_URL,
+  ).trim();
+  const parsed = new URL(raw || DEFAULT_OLLAMA_BASE_URL);
+  const normalizedPath = normalizeBasePath(parsed.pathname || "");
+  return `${parsed.origin}${normalizedPath}`;
+}
+
+function buildApiUrl(baseUrl: string, pathname: string) {
+  return `${normalizeOllamaBaseUrl(baseUrl)}${pathname}`;
+}
+
+export async function discoverOllamaModels(input: {
+  baseUrl?: unknown;
+  timeoutMs?: number;
+} = {}): Promise<AdapterModel[]> {
+  const baseUrl = normalizeOllamaBaseUrl(input.baseUrl);
+  const data = await fetchJson<OllamaTagsResponse>(buildApiUrl(baseUrl, "/api/tags"), {
+    method: "GET",
+    timeoutMs: input.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS,
+  });
+  const parsed = Array.isArray(data.models)
+    ? data.models
+        .map((entry) => parseModelId(entry))
+        .filter(Boolean)
+        .map((id) => ({ id, label: id }))
+    : [];
+  return sortModels(dedupeModels(parsed));
+}
+
+export async function discoverOllamaModelsCached(input: {
+  baseUrl?: unknown;
+  timeoutMs?: number;
+} = {}): Promise<AdapterModel[]> {
+  const baseUrl = normalizeOllamaBaseUrl(input.baseUrl);
+  const now = Date.now();
+  pruneExpiredDiscoveryCache(now);
+  const cached = discoveryCache.get(baseUrl);
+  if (cached && cached.expiresAt > now) return cached.models;
+  const models = await discoverOllamaModels({
+    baseUrl,
+    timeoutMs: input.timeoutMs,
+  });
+  discoveryCache.set(baseUrl, {
+    expiresAt: now + MODELS_CACHE_TTL_MS,
+    models,
+  });
+  return models;
+}
+
+export async function ensureOllamaModelConfiguredAndAvailable(input: {
+  model?: unknown;
+  baseUrl?: unknown;
+  allowUndiscoveredModel?: unknown;
+}): Promise<AdapterModel[]> {
+  const model = asString(input.model, "").trim();
+  if (!model) {
+    throw new Error("Ollama requires `adapterConfig.model`.");
+  }
+
+  const allowUndiscoveredModel = input.allowUndiscoveredModel === true;
+  let models: AdapterModel[] = [];
+  try {
+    models = await discoverOllamaModelsCached({
+      baseUrl: input.baseUrl,
+    });
+  } catch (err) {
+    if (allowUndiscoveredModel) return [];
+    throw err;
+  }
+
+  if (models.length === 0) {
+    if (allowUndiscoveredModel) return [];
+    throw new Error("Ollama returned no local models from /api/tags.");
+  }
+
+  if (!models.some((entry) => entry.id === model)) {
+    if (allowUndiscoveredModel) return models;
+    const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
+    throw new Error(
+      `Configured Ollama model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
+    );
+  }
+
+  return models;
+}
+
+export async function listOllamaModels(): Promise<AdapterModel[]> {
+  try {
+    return await discoverOllamaModelsCached();
+  } catch {
+    return [];
+  }
+}
+
+export async function chatWithOllama(input: {
+  baseUrl?: unknown;
+  model: string;
+  messages: OllamaChatMessage[];
+  timeoutMs?: number;
+}): Promise<OllamaChatResponse> {
+  const baseUrl = normalizeOllamaBaseUrl(input.baseUrl);
+  return fetchJson<OllamaChatResponse>(buildApiUrl(baseUrl, "/api/chat"), {
+    method: "POST",
+    timeoutMs: input.timeoutMs ?? DEFAULT_CHAT_TIMEOUT_MS,
+    body: JSON.stringify({
+      model: input.model,
+      messages: input.messages,
+      stream: false,
+    }),
+  });
+}
+
+export function resetOllamaModelsCacheForTests() {
+  discoveryCache.clear();
+}

--- a/packages/adapters/ollama-local/src/server/test.ts
+++ b/packages/adapters/ollama-local/src/server/test.ts
@@ -1,0 +1,145 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import {
+  chatWithOllama,
+  discoverOllamaModels,
+  ensureOllamaModelConfiguredAndAvailable,
+  normalizeOllamaBaseUrl,
+} from "./models.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function firstNonEmptyLine(text: string) {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const configuredModel = asString(config.model, "").trim();
+  const allowUndiscoveredModel = config.allowUndiscoveredModel === true;
+
+  let baseUrl = "";
+  try {
+    baseUrl = normalizeOllamaBaseUrl(config.baseUrl ?? config.url);
+    checks.push({
+      code: "ollama_base_url_valid",
+      level: "info",
+      message: `Ollama base URL: ${baseUrl}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "ollama_base_url_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid Ollama base URL",
+    });
+  }
+
+  if (!configuredModel) {
+    checks.push({
+      code: "ollama_model_required",
+      level: "error",
+      message: "Ollama requires a configured model.",
+      hint: "Set adapterConfig.model to a local model such as qwen2.5:7b.",
+    });
+  }
+
+  const canProbe = checks.every((check) => check.level !== "error");
+
+  if (canProbe) {
+    try {
+      const discovered = await discoverOllamaModels({ baseUrl });
+      checks.push({
+        code: "ollama_models_discovered",
+        level: discovered.length > 0 ? "info" : "warn",
+        message:
+          discovered.length > 0
+            ? `Discovered ${discovered.length} local model(s) from Ollama.`
+            : "Ollama returned no local models from /api/tags.",
+      });
+    } catch (err) {
+      checks.push({
+        code: "ollama_models_discovery_failed",
+        level: allowUndiscoveredModel ? "warn" : "error",
+        message: err instanceof Error ? err.message : "Failed to query Ollama /api/tags.",
+        hint: "Check that Ollama is running and reachable from this machine.",
+      });
+    }
+  }
+
+  if (canProbe && configuredModel) {
+    try {
+      await ensureOllamaModelConfiguredAndAvailable({
+        model: configuredModel,
+        baseUrl,
+        allowUndiscoveredModel,
+      });
+      checks.push({
+        code: "ollama_model_configured",
+        level: "info",
+        message: `Configured model: ${configuredModel}`,
+      });
+    } catch (err) {
+      checks.push({
+        code: "ollama_model_invalid",
+        level: allowUndiscoveredModel ? "warn" : "error",
+        message: err instanceof Error ? err.message : "Configured Ollama model is unavailable.",
+        hint: allowUndiscoveredModel
+          ? "Model discovery was relaxed. If runs still fail, verify the model name in `ollama list`."
+          : "Run `ollama list` and choose a local model name returned by Ollama.",
+      });
+    }
+  }
+
+  if (canProbe && configuredModel) {
+    try {
+      const response = await chatWithOllama({
+        baseUrl,
+        model: configuredModel,
+        timeoutMs: 60_000,
+        messages: [
+          { role: "user", content: "Respond with hello." },
+        ],
+      });
+      const reply = response.message?.content?.trim() ?? "";
+      const hasHello = /\bhello\b/i.test(reply);
+      checks.push({
+        code: hasHello ? "ollama_hello_probe_passed" : "ollama_hello_probe_unexpected_output",
+        level: hasHello ? "info" : "warn",
+        message: hasHello
+          ? "Ollama hello probe succeeded."
+          : "Ollama replied, but the response did not include `hello`.",
+        ...(reply ? { detail: firstNonEmptyLine(reply).slice(0, 240) } : {}),
+      });
+    } catch (err) {
+      checks.push({
+        code: "ollama_hello_probe_failed",
+        level: "error",
+        message: err instanceof Error ? err.message : "Ollama hello probe failed.",
+        hint: "Verify that the selected model is pulled locally and Ollama is serving requests.",
+      });
+    }
+  }
+
+  return {
+    adapterType: "ollama_local",
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/ollama-local/src/ui/build-config.ts
+++ b/packages/adapters/ollama-local/src/ui/build-config.ts
@@ -1,0 +1,11 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+export function buildOllamaLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+  if (v.instructionsFilePath) config.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) config.promptTemplate = v.promptTemplate;
+  if (v.url) config.baseUrl = v.url;
+  if (v.model) config.model = v.model;
+  if (v.allowUndiscoveredModel) config.allowUndiscoveredModel = true;
+  return config;
+}

--- a/packages/adapters/ollama-local/src/ui/index.ts
+++ b/packages/adapters/ollama-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { buildOllamaLocalConfig } from "./build-config.js";
+export { parseOllamaStdoutLine } from "./parse-stdout.js";

--- a/packages/adapters/ollama-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/ollama-local/src/ui/parse-stdout.ts
@@ -1,0 +1,36 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown) {
+  return typeof value === "string" ? value : "";
+}
+
+export function parseOllamaStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type);
+  const text = asString(parsed.text);
+
+  if (type === "assistant" && text) {
+    return [{ kind: "assistant", ts, text }];
+  }
+  if (type === "system" && text) {
+    return [{ kind: "system", ts, text }];
+  }
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/ollama-local/tsconfig.json
+++ b/packages/adapters/ollama-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -21,6 +21,7 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
+- allowUndiscoveredModel (boolean, optional): allow a configured model that is not returned by \`opencode models\` (useful for local OpenAI-compatible endpoints)
 - variant (string, optional): provider-specific model variant (for example minimal|low|medium|high|max)
 - promptTemplate (string, optional): run prompt template
 - command (string, optional): defaults to "opencode"

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -6,6 +6,7 @@ import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type Adapter
 import {
   asString,
   asNumber,
+  asBoolean,
   asStringArray,
   parseObject,
   buildPaperclipEnv,
@@ -97,6 +98,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
+  const allowUndiscoveredModel = asBoolean(config.allowUndiscoveredModel, false);
   const variant = asString(config.variant, "").trim();
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
@@ -184,6 +186,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     command,
     cwd,
     env: runtimeEnv,
+    allowUndiscoveredModel,
   });
 
   const timeoutSec = asNumber(config.timeoutSec, 0);

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -170,23 +170,33 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  allowUndiscoveredModel?: unknown;
 }): Promise<AdapterModel[]> {
   const model = asString(input.model, "").trim();
   if (!model) {
     throw new Error("OpenCode requires `adapterConfig.model` in provider/model format.");
   }
 
-  const models = await discoverOpenCodeModelsCached({
-    command: input.command,
-    cwd: input.cwd,
-    env: input.env,
-  });
+  const allowUndiscoveredModel = input.allowUndiscoveredModel === true;
+  let models: AdapterModel[] = [];
+  try {
+    models = await discoverOpenCodeModelsCached({
+      command: input.command,
+      cwd: input.cwd,
+      env: input.env,
+    });
+  } catch (err) {
+    if (allowUndiscoveredModel) return [];
+    throw err;
+  }
 
   if (models.length === 0) {
+    if (allowUndiscoveredModel) return models;
     throw new Error("OpenCode returned no models. Run `opencode models` and verify provider auth.");
   }
 
   if (!models.some((entry) => entry.id === model)) {
+    if (allowUndiscoveredModel) return models;
     const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
     throw new Error(
       `Configured OpenCode model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -5,6 +5,7 @@ import type {
 } from "@paperclipai/adapter-utils";
 import {
   asString,
+  asBoolean,
   asStringArray,
   parseObject,
   ensureAbsoluteDirectory,
@@ -123,6 +124,7 @@ export async function testEnvironment(
 
   let modelValidationPassed = false;
   const configuredModel = asString(config.model, "").trim();
+  const allowUndiscoveredModel = asBoolean(config.allowUndiscoveredModel, false);
 
   if (canRunProbe && configuredModel) {
     try {
@@ -136,9 +138,13 @@ export async function testEnvironment(
       } else {
         checks.push({
           code: "opencode_models_empty",
-          level: "error",
-          message: "OpenCode returned no models.",
-          hint: "Run `opencode models` and verify provider authentication.",
+          level: allowUndiscoveredModel ? "warn" : "error",
+          message: allowUndiscoveredModel
+            ? "OpenCode returned no models. Continuing because allowUndiscoveredModel is enabled."
+            : "OpenCode returned no models.",
+          hint: allowUndiscoveredModel
+            ? "Run `opencode models` when possible to verify provider discovery."
+            : "Run `opencode models` and verify provider authentication.",
         });
       }
     } catch (err) {
@@ -154,9 +160,15 @@ export async function testEnvironment(
       } else {
         checks.push({
           code: "opencode_models_discovery_failed",
-          level: "error",
-          message: errMsg || "OpenCode model discovery failed.",
-          hint: "Run `opencode models` manually to verify provider auth and config.",
+          level: allowUndiscoveredModel ? "warn" : "error",
+          message:
+            errMsg ||
+            (allowUndiscoveredModel
+              ? "OpenCode model discovery failed (continuing because allowUndiscoveredModel is enabled)."
+              : "OpenCode model discovery failed."),
+          hint: allowUndiscoveredModel
+            ? "Run `opencode models` manually when available to validate provider config."
+            : "Run `opencode models` manually to verify provider auth and config.",
         });
       }
     }
@@ -201,6 +213,7 @@ export async function testEnvironment(
         command,
         cwd,
         env: runtimeEnv,
+        allowUndiscoveredModel,
       });
       checks.push({
         code: "opencode_model_configured",
@@ -211,9 +224,11 @@ export async function testEnvironment(
     } catch (err) {
       checks.push({
         code: "opencode_model_invalid",
-        level: "error",
+        level: allowUndiscoveredModel ? "warn" : "error",
         message: err instanceof Error ? err.message : "Configured model is unavailable.",
-        hint: "Run `opencode models` and choose a currently available provider/model ID.",
+        hint: allowUndiscoveredModel
+          ? "Model verification was relaxed. If runs still fail, verify provider/model manually with `opencode run`."
+          : "Run `opencode models` and choose a currently available provider/model ID.",
       });
     }
   }

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -57,6 +57,7 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
   if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
   if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
   if (v.model) ac.model = v.model;
+  if (v.allowUndiscoveredModel) ac.allowUndiscoveredModel = true;
   if (v.thinkingEffort) ac.variant = v.thinkingEffort;
   // OpenCode sessions can run until the CLI exits naturally; keep timeout disabled (0)
   // and rely on graceSec for termination handling when a timeout is configured elsewhere.

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -26,6 +26,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "ollama_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,19 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/ollama-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -447,6 +460,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -598,6 +614,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -35,6 +35,14 @@ import {
 } from "@paperclipai/adapter-gemini-local/server";
 import { agentConfigurationDoc as geminiAgentConfigurationDoc, models as geminiModels } from "@paperclipai/adapter-gemini-local";
 import {
+  execute as ollamaExecute,
+  testEnvironment as ollamaTestEnvironment,
+  listOllamaModels,
+} from "@paperclipai/adapter-ollama-local/server";
+import {
+  agentConfigurationDoc as ollamaAgentConfigurationDoc,
+} from "@paperclipai/adapter-ollama-local";
+import {
   execute as openCodeExecute,
   listOpenCodeSkills,
   syncOpenCodeSkills,
@@ -134,6 +142,16 @@ const geminiLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: geminiAgentConfigurationDoc,
 };
 
+const ollamaLocalAdapter: ServerAdapterModule = {
+  type: "ollama_local",
+  execute: ollamaExecute,
+  testEnvironment: ollamaTestEnvironment,
+  models: [],
+  listModels: listOllamaModels,
+  supportsLocalAgentJwt: false,
+  agentConfigurationDoc: ollamaAgentConfigurationDoc,
+};
+
 const openclawGatewayAdapter: ServerAdapterModule = {
   type: "openclaw_gateway",
   execute: openclawGatewayExecute,
@@ -189,6 +207,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     piLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    ollamaLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
     processAdapter,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -56,6 +56,7 @@ import {
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { ensureOllamaModelConfiguredAndAvailable } from "@paperclipai/adapter-ollama-local/server";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
 import {
   loadDefaultAgentInstructionsBundle,
@@ -67,6 +68,7 @@ export function agentRoutes(db: Db) {
     claude_local: "instructionsFilePath",
     codex_local: "instructionsFilePath",
     gemini_local: "instructionsFilePath",
+    ollama_local: "instructionsFilePath",
     opencode_local: "instructionsFilePath",
     cursor: "instructionsFilePath",
     pi_local: "instructionsFilePath",
@@ -385,19 +387,37 @@ export function agentRoutes(db: Db) {
     adapterType: string | null | undefined,
     adapterConfig: Record<string, unknown>,
   ) {
-    if (adapterType !== "opencode_local") return;
+    if (adapterType !== "opencode_local" && adapterType !== "ollama_local") return;
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(companyId, adapterConfig);
-    const runtimeEnv = asRecord(runtimeConfig.env) ?? {};
-    try {
-      await ensureOpenCodeModelConfiguredAndAvailable({
-        model: runtimeConfig.model,
-        command: runtimeConfig.command,
-        cwd: runtimeConfig.cwd,
-        env: runtimeEnv,
-      });
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+    if (adapterType === "opencode_local") {
+      const runtimeEnv = asRecord(runtimeConfig.env) ?? {};
+      const allowUndiscoveredModel = parseBooleanLike(runtimeConfig.allowUndiscoveredModel) === true;
+      try {
+        await ensureOpenCodeModelConfiguredAndAvailable({
+          model: runtimeConfig.model,
+          command: runtimeConfig.command,
+          cwd: runtimeConfig.cwd,
+          env: runtimeEnv,
+          allowUndiscoveredModel,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+      }
+      return;
+    }
+    if (adapterType === "ollama_local") {
+      const allowUndiscoveredModel = parseBooleanLike(runtimeConfig.allowUndiscoveredModel) === true;
+      try {
+        await ensureOllamaModelConfiguredAndAvailable({
+          model: runtimeConfig.model,
+          baseUrl: runtimeConfig.baseUrl ?? runtimeConfig.url,
+          allowUndiscoveredModel,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw unprocessable(`Invalid ollama_local adapterConfig: ${reason}`);
+      }
     }
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1879,6 +1879,7 @@ export function heartbeatService(db: Db) {
             id: issues.id,
             identifier: issues.identifier,
             title: issues.title,
+            description: issues.description,
             projectId: issues.projectId,
             projectWorkspaceId: issues.projectWorkspaceId,
             executionWorkspaceId: issues.executionWorkspaceId,
@@ -1959,12 +1960,28 @@ export function heartbeatService(db: Db) {
           id: issueContext.id,
           identifier: issueContext.identifier,
           title: issueContext.title,
+          description: issueContext.description,
           projectId: issueContext.projectId,
           projectWorkspaceId: issueContext.projectWorkspaceId,
           executionWorkspaceId: issueContext.executionWorkspaceId,
           executionWorkspacePreference: issueContext.executionWorkspacePreference,
         }
       : null;
+    const adapterContext = issueRef
+      ? {
+          ...context,
+          paperclipIssue: {
+            id: issueRef.id,
+            identifier: issueRef.identifier,
+            title: issueRef.title,
+            description: issueRef.description ?? null,
+            projectId: issueRef.projectId,
+            projectWorkspaceId: issueRef.projectWorkspaceId,
+            executionWorkspaceId: issueRef.executionWorkspaceId,
+            executionWorkspacePreference: issueRef.executionWorkspacePreference,
+          },
+        }
+      : context;
     const existingExecutionWorkspace =
       issueRef?.executionWorkspaceId ? await executionWorkspacesSvc.getById(issueRef.executionWorkspaceId) : null;
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
@@ -2392,7 +2409,7 @@ export function heartbeatService(db: Db) {
         agent,
         runtime: runtimeForAdapter,
         config: runtimeConfig,
-        context,
+        context: adapterContext,
         onLog,
         onMeta: onAdapterMeta,
         onSpawn: async (meta) => {
@@ -2474,6 +2491,18 @@ export function heartbeatService(db: Db) {
         outcome = "succeeded";
       } else {
         outcome = "failed";
+      }
+
+      const issueComment = readNonEmptyString(adapterResult.issueComment);
+      if (outcome === "succeeded" && issueId && issueComment) {
+        try {
+          await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id });
+        } catch (err) {
+          await onLog(
+            "stderr",
+            `[paperclip] Failed to post adapter issue comment: ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
       }
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "./packages/adapters/claude-local" },
     { "path": "./packages/adapters/codex-local" },
     { "path": "./packages/adapters/cursor-local" },
+    { "path": "./packages/adapters/ollama-local" },
     { "path": "./packages/adapters/openclaw-gateway" },
     { "path": "./packages/adapters/opencode-local" },
     { "path": "./packages/adapters/pi-local" },

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/ui/src/adapters/ollama-local/config-fields.tsx
+++ b/ui/src/adapters/ollama-local/config-fields.tsx
@@ -1,0 +1,108 @@
+import { DEFAULT_OLLAMA_BASE_URL } from "@paperclipai/adapter-ollama-local";
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  Field,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (for example AGENTS.md) appended to the Ollama system prompt.";
+
+export function OllamaLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  const baseUrlValue = isCreate
+    ? values!.url
+    : eff("adapterConfig", "baseUrl", String(config.baseUrl ?? config.url ?? ""));
+  const modelValue = isCreate
+    ? values!.model
+    : eff("adapterConfig", "model", String(config.model ?? ""));
+  const allowUndiscoveredModel = isCreate
+    ? values!.allowUndiscoveredModel
+    : eff("adapterConfig", "allowUndiscoveredModel", config.allowUndiscoveredModel === true);
+
+  return (
+    <>
+      <Field label="Ollama base URL">
+        <DraftInput
+          value={baseUrlValue}
+          onCommit={(value) =>
+            isCreate
+              ? set!({ url: value })
+              : mark("adapterConfig", "baseUrl", value || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder={DEFAULT_OLLAMA_BASE_URL}
+        />
+      </Field>
+
+      <Field label="Model">
+        <DraftInput
+          value={modelValue}
+          onCommit={(value) =>
+            isCreate
+              ? set!({ model: value })
+              : mark("adapterConfig", "model", value || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="qwen2.5:7b"
+        />
+      </Field>
+
+      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={allowUndiscoveredModel}
+          onChange={(event) =>
+            isCreate
+              ? set!({ allowUndiscoveredModel: event.target.checked })
+              : mark("adapterConfig", "allowUndiscoveredModel", event.target.checked)
+          }
+        />
+        Allow manual model even if <span className="font-mono">/api/tags</span> does not list it
+      </label>
+
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? values!.instructionsFilePath ?? ""
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(value) =>
+                isCreate
+                  ? set!({ instructionsFilePath: value })
+                  : mark("adapterConfig", "instructionsFilePath", value || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+
+      <p className="text-[11px] text-muted-foreground">
+        This adapter talks to Ollama directly and posts the model response back to the Issue. It does not provide a full tool-using coding CLI.
+      </p>
+    </>
+  );
+}

--- a/ui/src/adapters/ollama-local/index.ts
+++ b/ui/src/adapters/ollama-local/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { buildOllamaLocalConfig, parseOllamaStdoutLine } from "@paperclipai/adapter-ollama-local/ui";
+import { OllamaLocalConfigFields } from "./config-fields";
+
+export const ollamaLocalUIAdapter: UIAdapterModule = {
+  type: "ollama_local",
+  label: "Ollama (local)",
+  parseStdoutLine: parseOllamaStdoutLine,
+  ConfigFields: OllamaLocalConfigFields,
+  buildAdapterConfig: buildOllamaLocalConfig,
+};

--- a/ui/src/adapters/opencode-local/config-fields.tsx
+++ b/ui/src/adapters/opencode-local/config-fields.tsx
@@ -1,7 +1,9 @@
 import type { AdapterConfigFieldsProps } from "../types";
 import {
   Field,
+  ToggleField,
   DraftInput,
+  help,
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
 
@@ -19,31 +21,68 @@ export function OpenCodeLocalConfigFields({
   mark,
   hideInstructionsFile,
 }: AdapterConfigFieldsProps) {
-  if (hideInstructionsFile) return null;
+  const allowUndiscoveredModel = isCreate
+    ? values!.allowUndiscoveredModel
+    : eff(
+        "adapterConfig",
+        "allowUndiscoveredModel",
+        Boolean(config.allowUndiscoveredModel ?? false),
+      );
   return (
-    <Field label="Agent instructions file" hint={instructionsFileHint}>
-      <div className="flex items-center gap-2">
+    <>
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? values!.instructionsFilePath ?? ""
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(v) =>
+                isCreate
+                  ? set!({ instructionsFilePath: v })
+                  : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+      <ToggleField
+        label="Allow Undiscovered Model"
+        hint={
+          "Skip strict `opencode models` availability checks. Useful for local OpenAI-compatible endpoints where model discovery may be incomplete."
+        }
+        checked={allowUndiscoveredModel}
+        onChange={(next) =>
+          isCreate
+            ? set!({ allowUndiscoveredModel: next })
+            : mark("adapterConfig", "allowUndiscoveredModel", next ? true : undefined)
+        }
+      />
+      <Field label="Model (Manual)" hint={help.model}>
         <DraftInput
           value={
             isCreate
-              ? values!.instructionsFilePath ?? ""
-              : eff(
-                  "adapterConfig",
-                  "instructionsFilePath",
-                  String(config.instructionsFilePath ?? ""),
-                )
+              ? values!.model ?? ""
+              : eff("adapterConfig", "model", String(config.model ?? ""))
           }
           onCommit={(v) =>
-            isCreate
-              ? set!({ instructionsFilePath: v })
-              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            isCreate ? set!({ model: v }) : mark("adapterConfig", "model", v || undefined)
           }
           immediate
           className={inputClass}
-          placeholder="/absolute/path/to/AGENTS.md"
+          placeholder="provider/model (e.g. openai/qwen2.5:7b)"
         />
-        <ChoosePathButton />
-      </div>
-    </Field>
+      </Field>
+    </>
   );
 }

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { ollamaLocalUIAdapter } from "./ollama-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -13,6 +14,7 @@ const uiAdapters: UIAdapterModule[] = [
   claudeLocalUIAdapter,
   codexLocalUIAdapter,
   geminiLocalUIAdapter,
+  ollamaLocalUIAdapter,
   openCodeLocalUIAdapter,
   piLocalUIAdapter,
   cursorLocalUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -562,6 +562,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                             : t === "cursor"
                               ? DEFAULT_CURSOR_LOCAL_MODEL
                             : "",
+                        allowUndiscoveredModel: false,
                         effort: "",
                         modelReasoningEffort: "",
                         variant: "",

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -18,6 +18,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
+  ollama_local: "Ollama (local)",
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -26,6 +26,7 @@ type AdvancedAdapterType =
   | "claude_local"
   | "codex_local"
   | "gemini_local"
+  | "ollama_local"
   | "opencode_local"
   | "pi_local"
   | "cursor"
@@ -57,6 +58,12 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     label: "Gemini CLI",
     icon: Gem,
     desc: "Local Gemini agent",
+  },
+  {
+    value: "ollama_local",
+    label: "Ollama",
+    icon: Bot,
+    desc: "Direct local Ollama adapter",
   },
   {
     value: "opencode_local",

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_OLLAMA_BASE_URL } from "@paperclipai/adapter-ollama-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
@@ -56,6 +57,7 @@ type AdapterType =
   | "claude_local"
   | "codex_local"
   | "gemini_local"
+  | "ollama_local"
   | "opencode_local"
   | "pi_local"
   | "cursor"
@@ -108,6 +110,7 @@ export function OnboardingWizard() {
   const [agentName, setAgentName] = useState("CEO");
   const [adapterType, setAdapterType] = useState<AdapterType>("claude_local");
   const [model, setModel] = useState("");
+  const [allowUndiscoveredModel, setAllowUndiscoveredModel] = useState(false);
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [url, setUrl] = useState("");
@@ -196,12 +199,16 @@ export function OnboardingWizard() {
     adapterType === "gemini_local" ||
     adapterType === "opencode_local" ||
     adapterType === "cursor";
+  const showAdapterEnvironmentCheck =
+    isLocalAdapter || adapterType === "ollama_local";
   const effectiveAdapterCommand =
     command.trim() ||
     (adapterType === "codex_local"
       ? "codex"
       : adapterType === "gemini_local"
         ? "gemini"
+      : adapterType === "ollama_local"
+      ? "ollama"
       : adapterType === "cursor"
       ? "agent"
       : adapterType === "opencode_local"
@@ -212,7 +219,7 @@ export function OnboardingWizard() {
     if (step !== 2) return;
     setAdapterEnvResult(null);
     setAdapterEnvError(null);
-  }, [step, adapterType, model, command, args, url]);
+  }, [step, adapterType, model, command, args, url, allowUndiscoveredModel]);
 
   const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
   const hasAnthropicApiKeyOverrideCheck =
@@ -269,6 +276,7 @@ export function OnboardingWizard() {
     setAgentName("CEO");
     setAdapterType("claude_local");
     setModel("");
+    setAllowUndiscoveredModel(false);
     setCommand("");
     setArgs("");
     setUrl("");
@@ -295,6 +303,7 @@ export function OnboardingWizard() {
     const config = adapter.buildAdapterConfig({
       ...defaultCreateValues,
       adapterType,
+      allowUndiscoveredModel,
       model:
         adapterType === "codex_local"
           ? model || DEFAULT_CODEX_LOCAL_MODEL
@@ -396,13 +405,14 @@ export function OnboardingWizard() {
     try {
       if (adapterType === "opencode_local") {
         const selectedModelId = model.trim();
+        const bypassDiscovery = allowUndiscoveredModel;
         if (!selectedModelId) {
           setError(
             "OpenCode requires an explicit model in provider/model format."
           );
           return;
         }
-        if (adapterModelsError) {
+        if (adapterModelsError && !bypassDiscovery) {
           setError(
             adapterModelsError instanceof Error
               ? adapterModelsError.message
@@ -410,14 +420,17 @@ export function OnboardingWizard() {
           );
           return;
         }
-        if (adapterModelsLoading || adapterModelsFetching) {
+        if ((adapterModelsLoading || adapterModelsFetching) && !bypassDiscovery) {
           setError(
             "OpenCode models are still loading. Please wait and try again."
           );
           return;
         }
         const discoveredModels = adapterModels ?? [];
-        if (!discoveredModels.some((entry) => entry.id === selectedModelId)) {
+        if (
+          !bypassDiscovery &&
+          !discoveredModels.some((entry) => entry.id === selectedModelId)
+        ) {
           setError(
             discoveredModels.length === 0
               ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
@@ -427,7 +440,12 @@ export function OnboardingWizard() {
         }
       }
 
-      if (isLocalAdapter) {
+      if (adapterType === "ollama_local" && !model.trim()) {
+        setError("Ollama requires an explicit local model name.");
+        return;
+      }
+
+      if (showAdapterEnvironmentCheck) {
         const result = adapterEnvResult ?? (await runAdapterEnvironmentTest());
         if (!result) return;
       }
@@ -787,6 +805,12 @@ export function OnboardingWizard() {
                             desc: "Local multi-provider agent"
                           },
                           {
+                            value: "ollama_local" as const,
+                            label: "Ollama",
+                            icon: Bot,
+                            desc: "Direct local Ollama adapter"
+                          },
+                          {
                             value: "pi_local" as const,
                             label: "Pi",
                             icon: Terminal,
@@ -822,6 +846,12 @@ export function OnboardingWizard() {
                               if (opt.comingSoon) return;
                               const nextType = opt.value as AdapterType;
                               setAdapterType(nextType);
+                              if (
+                                nextType !== "opencode_local" &&
+                                nextType !== "ollama_local"
+                              ) {
+                                setAllowUndiscoveredModel(false);
+                              }
                               if (nextType === "gemini_local" && !model) {
                                 setModel(DEFAULT_GEMINI_LOCAL_MODEL);
                                 return;
@@ -834,6 +864,10 @@ export function OnboardingWizard() {
                                 if (!model.includes("/")) {
                                   setModel("");
                                 }
+                                return;
+                              }
+                              if (nextType === "ollama_local") {
+                                setModel("");
                                 return;
                               }
                               setModel("");
@@ -857,111 +891,180 @@ export function OnboardingWizard() {
                   {(adapterType === "claude_local" ||
                     adapterType === "codex_local" ||
                     adapterType === "gemini_local" ||
+                    adapterType === "ollama_local" ||
                     adapterType === "opencode_local" ||
                     adapterType === "pi_local" ||
                     adapterType === "cursor") && (
                     <div className="space-y-3">
-                      <div>
-                        <label className="text-xs text-muted-foreground mb-1 block">
-                          Model
-                        </label>
-                        <Popover
-                          open={modelOpen}
-                          onOpenChange={(next) => {
-                            setModelOpen(next);
-                            if (!next) setModelSearch("");
-                          }}
-                        >
-                          <PopoverTrigger asChild>
-                            <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
-                              <span
-                                className={cn(
-                                  !model && "text-muted-foreground"
-                                )}
-                              >
-                                {selectedModel
-                                  ? selectedModel.label
-                                  : model ||
-                                    (adapterType === "opencode_local"
-                                      ? "Select model (required)"
-                                      : "Default")}
-                              </span>
-                              <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent
-                            className="w-[var(--radix-popover-trigger-width)] p-1"
-                            align="start"
+                      {adapterType !== "ollama_local" ? (
+                        <div>
+                          <label className="text-xs text-muted-foreground mb-1 block">
+                            Model
+                          </label>
+                          <Popover
+                            open={modelOpen}
+                            onOpenChange={(next) => {
+                              setModelOpen(next);
+                              if (!next) setModelSearch("");
+                            }}
                           >
-                            <input
-                              className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-                              placeholder="Search models..."
-                              value={modelSearch}
-                              onChange={(e) => setModelSearch(e.target.value)}
-                              autoFocus
-                            />
-                            {adapterType !== "opencode_local" && (
-                              <button
-                                className={cn(
-                                  "flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
-                                  !model && "bg-accent"
-                                )}
-                                onClick={() => {
-                                  setModel("");
-                                  setModelOpen(false);
-                                }}
-                              >
-                                Default
-                              </button>
-                            )}
-                            <div className="max-h-[240px] overflow-y-auto">
-                              {groupedModels.map((group) => (
-                                <div
-                                  key={group.provider}
-                                  className="mb-1 last:mb-0"
-                                >
-                                  {adapterType === "opencode_local" && (
-                                    <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-                                      {group.provider} ({group.entries.length})
-                                    </div>
+                            <PopoverTrigger asChild>
+                              <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
+                                <span
+                                  className={cn(
+                                    !model && "text-muted-foreground"
                                   )}
-                                  {group.entries.map((m) => (
-                                    <button
-                                      key={m.id}
-                                      className={cn(
-                                        "flex items-center w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
-                                        m.id === model && "bg-accent"
-                                      )}
-                                      onClick={() => {
-                                        setModel(m.id);
-                                        setModelOpen(false);
-                                      }}
-                                    >
-                                      <span
-                                        className="block w-full text-left truncate"
-                                        title={m.id}
+                                >
+                                  {selectedModel
+                                    ? selectedModel.label
+                                    : model ||
+                                      (adapterType === "opencode_local"
+                                        ? "Select model (required)"
+                                        : "Default")}
+                                </span>
+                                <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                              className="w-[var(--radix-popover-trigger-width)] p-1"
+                              align="start"
+                            >
+                              <input
+                                className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
+                                placeholder="Search models..."
+                                value={modelSearch}
+                                onChange={(e) => setModelSearch(e.target.value)}
+                                autoFocus
+                              />
+                              {adapterType !== "opencode_local" && (
+                                <button
+                                  className={cn(
+                                    "flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
+                                    !model && "bg-accent"
+                                  )}
+                                  onClick={() => {
+                                    setModel("");
+                                    setModelOpen(false);
+                                  }}
+                                >
+                                  Default
+                                </button>
+                              )}
+                              <div className="max-h-[240px] overflow-y-auto">
+                                {groupedModels.map((group) => (
+                                  <div
+                                    key={group.provider}
+                                    className="mb-1 last:mb-0"
+                                  >
+                                    {adapterType === "opencode_local" && (
+                                      <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                                        {group.provider} ({group.entries.length})
+                                      </div>
+                                    )}
+                                    {group.entries.map((m) => (
+                                      <button
+                                        key={m.id}
+                                        className={cn(
+                                          "flex items-center w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
+                                          m.id === model && "bg-accent"
+                                        )}
+                                        onClick={() => {
+                                          setModel(m.id);
+                                          setModelOpen(false);
+                                        }}
                                       >
-                                        {adapterType === "opencode_local"
-                                          ? extractModelName(m.id)
-                                          : m.label}
-                                      </span>
-                                    </button>
-                                  ))}
-                                </div>
-                              ))}
-                            </div>
-                            {filteredModels.length === 0 && (
-                              <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                                No models discovered.
-                              </p>
-                            )}
-                          </PopoverContent>
-                        </Popover>
-                      </div>
+                                        <span
+                                          className="block w-full text-left truncate"
+                                          title={m.id}
+                                        >
+                                          {adapterType === "opencode_local"
+                                            ? extractModelName(m.id)
+                                            : m.label}
+                                        </span>
+                                      </button>
+                                    ))}
+                                  </div>
+                                ))}
+                              </div>
+                              {filteredModels.length === 0 && (
+                                <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                                  No models discovered.
+                                </p>
+                              )}
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      ) : (
+                        <div className="space-y-2">
+                          <div>
+                            <label className="text-xs text-muted-foreground mb-1 block">
+                              Ollama base URL
+                            </label>
+                            <input
+                              className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                              placeholder={DEFAULT_OLLAMA_BASE_URL}
+                              value={url}
+                              onChange={(e) => setUrl(e.target.value)}
+                            />
+                          </div>
+                          <div>
+                            <label className="text-xs text-muted-foreground mb-1 block">
+                              Model
+                            </label>
+                            <input
+                              className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                              placeholder="qwen2.5:7b"
+                              value={model}
+                              onChange={(e) => setModel(e.target.value)}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {(adapterType === "opencode_local" ||
+                        adapterType === "ollama_local") && (
+                        <div className="space-y-2">
+                          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <input
+                              type="checkbox"
+                              checked={allowUndiscoveredModel}
+                              onChange={(e) =>
+                                setAllowUndiscoveredModel(e.target.checked)
+                              }
+                            />
+                            Allow undiscovered model
+                          </label>
+                          <input
+                            className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                            placeholder={
+                              adapterType === "opencode_local"
+                                ? "provider/model (e.g. openai/qwen2.5:7b)"
+                                : "local model name (e.g. qwen2.5:7b)"
+                            }
+                            value={model}
+                            onChange={(e) => setModel(e.target.value)}
+                          />
+                          <p className="text-[11px] text-muted-foreground">
+                            {adapterType === "opencode_local"
+                              ? (
+                                <>
+                                  Use this for local OpenAI-compatible endpoints where{" "}
+                                  <span className="font-mono">opencode models</span>{" "}
+                                  does not list your target model.
+                                </>
+                              )
+                              : (
+                                <>
+                                  Use this if <span className="font-mono">/api/tags</span>{" "}
+                                  cannot discover your target Ollama model yet.
+                                </>
+                              )}
+                          </p>
+                        </div>
+                      )}
                     </div>
                   )}
 
-                  {isLocalAdapter && (
+                  {showAdapterEnvironmentCheck && (
                     <div className="space-y-2 rounded-md border border-border p-3">
                       <div className="flex items-center justify-between gap-2">
                         <div>
@@ -969,8 +1072,9 @@ export function OnboardingWizard() {
                             Adapter environment check
                           </p>
                           <p className="text-[11px] text-muted-foreground">
-                            Runs a live probe that asks the adapter CLI to
-                            respond with hello.
+                            {adapterType === "ollama_local"
+                              ? "Calls the local Ollama HTTP API and asks the model to respond with hello."
+                              : "Runs a live probe that asks the adapter CLI to respond with hello."}
                           </p>
                         </div>
                         <Button
@@ -1028,7 +1132,9 @@ export function OnboardingWizard() {
                         <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px] space-y-1.5">
                           <p className="font-medium">Manual debug</p>
                           <p className="text-muted-foreground font-mono break-all">
-                            {adapterType === "cursor"
+                            {adapterType === "ollama_local"
+                              ? `curl ${url || DEFAULT_OLLAMA_BASE_URL}/api/tags`
+                              : adapterType === "cursor"
                               ? `${effectiveAdapterCommand} -p --mode ask --output-format json \"Respond with hello.\"`
                               : adapterType === "codex_local"
                               ? `${effectiveAdapterCommand} exec --json -`
@@ -1042,10 +1148,16 @@ export function OnboardingWizard() {
                             Prompt:{" "}
                             <span className="font-mono">Respond with hello.</span>
                           </p>
-                          {adapterType === "cursor" ||
-                          adapterType === "codex_local" ||
-                          adapterType === "gemini_local" ||
-                          adapterType === "opencode_local" ? (
+                          {adapterType === "ollama_local" ? (
+                            <p className="text-muted-foreground">
+                              Also verify{" "}
+                              <span className="font-mono">ollama list</span> shows{" "}
+                              <span className="font-mono">{model || "your-model"}</span>.
+                            </p>
+                          ) : adapterType === "cursor" ||
+                            adapterType === "codex_local" ||
+                            adapterType === "gemini_local" ||
+                            adapterType === "opencode_local" ? (
                             <p className="text-muted-foreground">
                               If auth fails, set{" "}
                               <span className="font-mono">

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -6,6 +6,7 @@ export const defaultCreateValues: CreateConfigValues = {
   instructionsFilePath: "",
   promptTemplate: "",
   model: "",
+  allowUndiscoveredModel: false,
   thinkingEffort: "",
   chrome: false,
   dangerouslySkipPermissions: true,

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -61,6 +61,7 @@ export const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
+  ollama_local: "Ollama (local)",
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -24,6 +24,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude",
   codex_local: "Codex",
   gemini_local: "Gemini",
+  ollama_local: "Ollama",
   opencode_local: "OpenCode",
   cursor: "Cursor",
   openclaw_gateway: "OpenClaw Gateway",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -16,6 +16,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
+  ollama_local: "Ollama (local)",
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -32,6 +32,7 @@ const SUPPORTED_ADVANCED_ADAPTER_TYPES = new Set<CreateConfigValues["adapterType
   "claude_local",
   "codex_local",
   "gemini_local",
+  "ollama_local",
   "opencode_local",
   "pi_local",
   "cursor",
@@ -51,6 +52,8 @@ function createValuesForAdapterType(
     nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
   } else if (adapterType === "cursor") {
     nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
+  } else if (adapterType === "ollama_local") {
+    nextValues.model = "";
   } else if (adapterType === "opencode_local") {
     nextValues.model = "";
   }
@@ -152,11 +155,12 @@ export function NewAgent() {
     setFormError(null);
     if (configValues.adapterType === "opencode_local") {
       const selectedModel = configValues.model.trim();
+      const allowUndiscoveredModel = configValues.allowUndiscoveredModel === true;
       if (!selectedModel) {
         setFormError("OpenCode requires an explicit model in provider/model format.");
         return;
       }
-      if (adapterModelsError) {
+      if (adapterModelsError && !allowUndiscoveredModel) {
         setFormError(
           adapterModelsError instanceof Error
             ? adapterModelsError.message
@@ -164,12 +168,12 @@ export function NewAgent() {
         );
         return;
       }
-      if (adapterModelsLoading || adapterModelsFetching) {
+      if ((adapterModelsLoading || adapterModelsFetching) && !allowUndiscoveredModel) {
         setFormError("OpenCode models are still loading. Please wait and try again.");
         return;
       }
       const discovered = adapterModels ?? [];
-      if (!discovered.some((entry) => entry.id === selectedModel)) {
+      if (!allowUndiscoveredModel && !discovered.some((entry) => entry.id === selectedModel)) {
         setFormError(
           discovered.length === 0
             ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
@@ -177,6 +181,10 @@ export function NewAgent() {
         );
         return;
       }
+    }
+    if (configValues.adapterType === "ollama_local" && !configValues.model.trim()) {
+      setFormError("Ollama requires an explicit local model name.");
+      return;
     }
     createAgent.mutate({
       name: name.trim(),

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -120,6 +120,7 @@ const adapterLabels: Record<string, string> = {
   claude_local: "Claude",
   codex_local: "Codex",
   gemini_local: "Gemini",
+  ollama_local: "Ollama",
   opencode_local: "OpenCode",
   cursor: "Cursor",
   openclaw_gateway: "OpenClaw Gateway",


### PR DESCRIPTION
﻿## Summary
- add an experimental `ollama_local` adapter that talks directly to Ollama's native HTTP API for local model support
- add UI wiring so Ollama appears in advanced agent setup, onboarding, and adapter labels
- improve local-model workflows by allowing explicit undiscovered OpenCode models and by auto-posting lightweight adapter replies back to Paperclip Issues

## What changed
- added a new workspace package: `@paperclipai/adapter-ollama-local`
- implemented model discovery via `/api/tags`, environment testing, and execution via `/api/chat`
- added a minimal issue-comment loop so non-CLI adapters can return `issueComment` and Paperclip will post it to the linked Issue on success
- registered `ollama_local` in shared adapter types, server adapter registry, and UI adapter registry
- added create-flow and onboarding UI for configuring Ollama base URL and local model names
- relaxed OpenCode model validation to support manually entered provider/model IDs when discovery is intentionally bypassed

## Validation
- `corepack pnpm --filter @paperclipai/adapter-ollama-local typecheck`
- `corepack pnpm --filter @paperclipai/server typecheck`
- `corepack pnpm --filter @paperclipai/ui typecheck`
- direct local probe against `http://127.0.0.1:11434` with `qwen2.5:7b` passed for both `testEnvironment()` and `execute()`

## Why
OpenCode alone is not a reliable path for local Ollama models in environments where the runtime does not expose a true local Ollama provider. This PR adds a direct local-model path and keeps the UX inside Paperclip.
