### PR TITLE
fix(adapters): inject wake context into resumed session prompt

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -210,17 +210,25 @@ export function buildWakeContextNote(context: Record<string, unknown>): string {
       lines.push(`A new comment was posted on your task.`);
       if (effectiveIssueId) lines.push(`Issue ID: ${effectiveIssueId}`);
       if (wakeCommentId) lines.push(`Comment ID: ${wakeCommentId}`);
-      lines.push(
-        `Action: Fetch the comment using GET /api/issues/${effectiveIssueId}/comments/${wakeCommentId} and respond appropriately. Post your response as a new comment on the issue.`,
-      );
+      if (effectiveIssueId && wakeCommentId) {
+        lines.push(
+          `Action: Fetch the comment using GET /api/issues/${effectiveIssueId}/comments/${wakeCommentId} and respond appropriately. Post your response as a new comment on the issue.`,
+        );
+      } else {
+        lines.push(`Action: Check the issue and respond to the latest comment.`);
+      }
       break;
 
     case "issue_assigned":
       lines.push(`A task was assigned to you.`);
       if (effectiveIssueId) lines.push(`Issue ID: ${effectiveIssueId}`);
-      lines.push(
-        `Action: Fetch the issue using GET /api/issues/${effectiveIssueId} to understand the task, then begin working on it following the Paperclip heartbeat procedure.`,
-      );
+      if (effectiveIssueId) {
+        lines.push(
+          `Action: Fetch the issue using GET /api/issues/${effectiveIssueId} to understand the task, then begin working on it following the Paperclip heartbeat procedure.`,
+        );
+      } else {
+        lines.push(`Action: Check your assignments and begin working on the assigned task.`);
+      }
       break;
 
     case "approval_resolved":

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -183,6 +183,67 @@ export function renderTemplate(template: string, data: Record<string, unknown>) 
   return template.replace(/{{\s*([a-zA-Z0-9_.-]+)\s*}}/g, (_, path) => resolvePathValue(data, path));
 }
 
+/**
+ * Build a human-readable wake context note from the execution context.
+ * This ensures agents receiving a resumed session know *why* they were
+ * woken and what triggered the run, even when the bootstrap prompt is
+ * skipped on `--resume`.
+ */
+export function buildWakeContextNote(context: Record<string, unknown>): string {
+  const wakeReason = typeof context.wakeReason === "string" ? context.wakeReason.trim() : "";
+  if (!wakeReason) return "";
+
+  const taskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
+  const issueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
+  const wakeCommentId =
+    typeof context.wakeCommentId === "string" ? context.wakeCommentId.trim() : "";
+  const approvalId = typeof context.approvalId === "string" ? context.approvalId.trim() : "";
+  const approvalStatus =
+    typeof context.approvalStatus === "string" ? context.approvalStatus.trim() : "";
+  const effectiveIssueId = taskId || issueId;
+
+  const lines: string[] = ["[Paperclip Wake Context]"];
+
+  switch (wakeReason) {
+    case "issue_commented":
+    case "issue_comment_mentioned":
+      lines.push(`A new comment was posted on your task.`);
+      if (effectiveIssueId) lines.push(`Issue ID: ${effectiveIssueId}`);
+      if (wakeCommentId) lines.push(`Comment ID: ${wakeCommentId}`);
+      lines.push(
+        `Action: Fetch the comment using GET /api/issues/${effectiveIssueId}/comments/${wakeCommentId} and respond appropriately. Post your response as a new comment on the issue.`,
+      );
+      break;
+
+    case "issue_assigned":
+      lines.push(`A task was assigned to you.`);
+      if (effectiveIssueId) lines.push(`Issue ID: ${effectiveIssueId}`);
+      lines.push(
+        `Action: Fetch the issue using GET /api/issues/${effectiveIssueId} to understand the task, then begin working on it following the Paperclip heartbeat procedure.`,
+      );
+      break;
+
+    case "approval_resolved":
+      lines.push(`An approval was resolved.`);
+      if (approvalId) lines.push(`Approval ID: ${approvalId}`);
+      if (approvalStatus) lines.push(`Status: ${approvalStatus}`);
+      if (effectiveIssueId) lines.push(`Related Issue ID: ${effectiveIssueId}`);
+      lines.push(
+        `Action: Review the approval outcome and update any related issues accordingly.`,
+      );
+      break;
+
+    default:
+      lines.push(`Wake reason: ${wakeReason}`);
+      if (effectiveIssueId) lines.push(`Issue ID: ${effectiveIssueId}`);
+      if (wakeCommentId) lines.push(`Comment ID: ${wakeCommentId}`);
+      lines.push(`Action: Check your assignments and continue your Paperclip work.`);
+      break;
+  }
+
+  return lines.join("\n");
+}
+
 export function joinPromptSections(
   sections: Array<string | null | undefined>,
   separator = "\n\n",

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -13,6 +13,7 @@ import {
   parseJson,
   buildPaperclipEnv,
   readPaperclipRuntimeSkillEntries,
+  buildWakeContextNote,
   joinPromptSections,
   redactEnvForLogs,
   ensureAbsoluteDirectory,
@@ -392,9 +393,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeContextNote = buildWakeContextNote(context);
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    wakeContextNote,
     renderedPrompt,
   ]);
   const promptMetrics = {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -17,6 +17,7 @@ import {
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
   renderTemplate,
+  buildWakeContextNote,
   joinPromptSections,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -455,10 +456,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeContextNote = buildWakeContextNote(context);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    wakeContextNote,
     renderedPrompt,
   ]);
   const promptMetrics = {

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -18,6 +18,7 @@ import {
   resolvePaperclipDesiredSkillNames,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
+  buildWakeContextNote,
   joinPromptSections,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -355,11 +356,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeContextNote = buildWakeContextNote(context);
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    wakeContextNote,
     paperclipEnvNote,
     renderedPrompt,
   ]);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -13,6 +13,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
+  buildWakeContextNote,
   joinPromptSections,
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
@@ -298,12 +299,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeContextNote = buildWakeContextNote(context);
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const apiAccessNote = renderApiAccessNote(env);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    wakeContextNote,
     paperclipEnvNote,
     apiAccessNote,
     renderedPrompt,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -9,6 +9,7 @@ import {
   asStringArray,
   parseObject,
   buildPaperclipEnv,
+  buildWakeContextNote,
   joinPromptSections,
   redactEnvForLogs,
   ensureAbsoluteDirectory,
@@ -263,10 +264,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeContextNote = buildWakeContextNote(context);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    wakeContextNote,
     renderedPrompt,
   ]);
   const promptMetrics = {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -9,6 +9,7 @@ import {
   asStringArray,
   parseObject,
   buildPaperclipEnv,
+  buildWakeContextNote,
   joinPromptSections,
   redactEnvForLogs,
   ensureAbsoluteDirectory,
@@ -301,9 +302,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeContextNote = buildWakeContextNote(context);
   const userPrompt = joinPromptSections([
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    wakeContextNote,
     renderedHeartbeatPrompt,
   ]);
   const promptMetrics = {


### PR DESCRIPTION
## Problem

When a `claude_local` (or any local adapter) agent resumes an existing session via `--resume`, it receives no information about why it was woken. The bootstrap prompt is intentionally skipped on resume, but the wake context (which comment triggered the run, which issue, etc.) is also lost.

**Result:** Agent gets ~3 tokens of input, says "Standing by for instructions", and the run produces no useful output. This affects all `*_local` adapters.

See #1583 for full details with run transcripts and evidence.

## Fix

Adds a `buildWakeContextNote()` function to `@paperclipai/adapter-utils` that constructs a human-readable wake context section from the execution context. This note is injected into the prompt for **all 5 local adapters**, regardless of whether the session is fresh or resumed.

### What the wake context includes:
- **issue_commented / issue_comment_mentioned**: Tells the agent a new comment was posted, provides issue ID + comment ID, instructs it to fetch and respond
- **issue_assigned**: Tells the agent a task was assigned, provides issue ID, instructs it to fetch and begin work
- **approval_resolved**: Tells the agent an approval was resolved, provides approval ID + status
- **default**: Passes through any other wake reason with available IDs

### Files changed:
- `packages/adapter-utils/src/server-utils.ts` — new `buildWakeContextNote()` function
- `packages/adapters/claude-local/src/server/execute.ts` — inject wake context
- `packages/adapters/codex-local/src/server/execute.ts` — inject wake context
- `packages/adapters/cursor-local/src/server/execute.ts` — inject wake context
- `packages/adapters/opencode-local/src/server/execute.ts` — inject wake context
- `packages/adapters/gemini-local/src/server/execute.ts` — inject wake context

### Example prompt on resume (before vs after):

**Before:** `"You are agent X. Continue your Paperclip work."` (3 tokens, agent says "Standing by")

**After:**
```
[Paperclip Wake Context]
A new comment was posted on your task.
Issue ID: 6d8285b3-1843-4ec3-a43b-d88211bbe223
Comment ID: 9cd41904-c6a7-455c-a195-abf1ad1b999f
Action: Fetch the comment using GET /api/issues/6d8285b3.../comments/9cd41904... and respond appropriately. Post your response as a new comment on the issue.

You are agent X. Continue your Paperclip work.
```

Fixes #1583