### PR TITLE
fix(ui): use amber styling for Stop Run button instead of red

### DIFF
--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -125,10 +125,10 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
                     <button
                       onClick={() => handleCancelRun(run.id)}
                       disabled={cancellingRunIds.has(run.id)}
-                      className="inline-flex items-center gap-1 rounded-full border border-red-500/20 bg-red-500/[0.06] px-2.5 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-500/[0.12] dark:text-red-300 disabled:opacity-50"
+                      className="inline-flex items-center gap-1 rounded-full border border-amber-500/25 bg-amber-500/[0.06] px-2.5 py-1 text-[11px] font-medium text-amber-700 transition-colors hover:bg-amber-500/[0.12] dark:text-amber-300 disabled:opacity-50"
                     >
                       <Square className="h-2.5 w-2.5" fill="currentColor" />
-                      {cancellingRunIds.has(run.id) ? "Stopping…" : "Stop"}
+                      {cancellingRunIds.has(run.id) ? "Stopping…" : "Stop Run"}
                     </button>
                   )}
                   <Link


### PR DESCRIPTION
## Summary

- Changed the "Stop" button in Live Runs from red/destructive to amber/warning styling — cancelling a run is routine, not destructive
- Renamed button label from "Stop" to "Stop Run" so it reads as an action verb, not a past state
- Reserves red for truly destructive actions (delete, remove)

Closes #1587

## Test plan

- [ ] Open an issue detail page with an active live run
- [ ] Verify the "Stop Run" button renders with amber styling (border, text, hover)
- [ ] Verify dark mode renders correctly with `dark:text-amber-300`
- [ ] Click "Stop Run" and verify "Stopping…" state still works
- [ ] Confirm visual distinction from the grey "Cancelled" status badge