### PR TITLE
feat(gemini-local): add Gemini 3.1 Pro models to gemini-local adapter

### DIFF
--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,6 +4,8 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { id: "gemini-3.1-pro-preview-customtools", label: "Gemini 3.1 Pro Preview (Custom Tools)" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },


### PR DESCRIPTION
**Thinking path**

The gemini_local adapter's model dropdown (packages/adapters/gemini-local/src/index.ts)
still lists only Gemini 2.x. Google has since shipped the Gemini 3.1 Pro family, so users
can't pick the current flagship from the dashboard and instead hit ModelNotFoundError when
they type an ID by hand (#1506). The adapter passes the selected string straight to
`gemini --model`, so the fix is to surface the valid 3.1 Pro IDs in the list.

**What I did**
Added two entries to the `models` array, above the existing 2.x entries:
- `gemini-3.1-pro-preview` — Gemini 3.1 Pro (Preview)
- `gemini-3.1-pro-preview-customtools` — custom-tools variant, tuned for agentic/tool use

**Why it matters**
Users can select the current flagship 3.1 Pro (and its custom-tools endpoint) directly,
instead of guessing IDs and hitting ModelNotFoundError.

**How to verify**
Open the gemini_local model dropdown in the dashboard; both entries appear above the 2.5
entries and run against `gemini --model <id>` without error.

**Risks**
Minimal — additive, single-file change to a static list; nothing removed. Both IDs are
confirmed-valid Google API identifiers.

Fixes #1506.
