### PR TITLE
fix(ui): add missing DialogTitle and DialogDescription to creation dialogs

### DIFF
--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -8,6 +8,8 @@ import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
   DialogContent,
+  DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -131,6 +133,8 @@ export function NewAgentDialog() {
         showCloseButton={false}
         className="sm:max-w-md p-0 gap-0 overflow-hidden"
       >
+        <DialogTitle className="sr-only">Add Agent</DialogTitle>
+        <DialogDescription className="sr-only">Add a new agent to your company.</DialogDescription>
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
           <span className="text-sm text-muted-foreground">Add a new agent</span>

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -9,6 +9,8 @@ import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
   DialogContent,
+  DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -119,6 +121,8 @@ export function NewGoalDialog() {
         className={cn("p-0 gap-0", expanded ? "sm:max-w-2xl" : "sm:max-w-lg")}
         onKeyDown={handleKeyDown}
       >
+        <DialogTitle className="sr-only">Create Goal</DialogTitle>
+        <DialogDescription className="sr-only">Create a new goal for your company.</DialogDescription>
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -21,6 +21,8 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -869,7 +871,6 @@ export function NewIssueDialog() {
     >
       <DialogContent
         showCloseButton={false}
-        aria-describedby={undefined}
         className={cn(
           "p-0 gap-0 flex flex-col max-h-[calc(100dvh-2rem)]",
           expanded
@@ -899,6 +900,8 @@ export function NewIssueDialog() {
           }
         }}
       >
+        <DialogTitle className="sr-only">Create Issue</DialogTitle>
+        <DialogDescription className="sr-only">Create a new issue and assign it to an agent or user.</DialogDescription>
         {/* Header bar */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border shrink-0">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -9,6 +9,8 @@ import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
   DialogContent,
+  DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -194,6 +196,8 @@ export function NewProjectDialog() {
         className={cn("p-0 gap-0", expanded ? "sm:max-w-2xl" : "sm:max-w-lg")}
         onKeyDown={handleKeyDown}
       >
+        <DialogTitle className="sr-only">Create Project</DialogTitle>
+        <DialogDescription className="sr-only">Create a new project for your company.</DialogDescription>
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- Added visually-hidden `DialogTitle` and `DialogDescription` to `NewIssueDialog`, `NewGoalDialog`, `NewAgentDialog`, and `NewProjectDialog`
- Removes Radix UI console warnings: "DialogContent requires a DialogTitle" and "Missing Description or aria-describedby"
- Removed the `aria-describedby={undefined}` workaround from `NewIssueDialog` since a proper `DialogDescription` is now provided

Closes #1473

## Test plan

- [ ] Open each creation dialog (Issue, Goal, Agent, Project) and verify no Radix warnings in console
- [ ] Verify dialogs render visually identical (sr-only elements are hidden)
- [ ] Test with screen reader to confirm accessible labels are announced
- [ ] Verify dialog open/close behavior is unchanged