### PR TITLE
fix(codex-local): handle missing codex binary gracefully in quota service

### DIFF
--- a/packages/adapters/codex-local/src/server/quota.ts
+++ b/packages/adapters/codex-local/src/server/quota.ts
@@ -407,18 +407,27 @@ type PendingRequest = {
 };
 
 class CodexRpcClient {
-  private proc = spawn(
-    "codex",
-    ["-s", "read-only", "-a", "untrusted", "app-server"],
-    { stdio: ["pipe", "pipe", "pipe"], env: process.env },
-  );
-
+  private proc;
   private nextId = 1;
   private buffer = "";
   private pending = new Map<number, PendingRequest>();
   private stderr = "";
+  private spawnError: Error | null = null;
 
   constructor() {
+    this.proc = spawn(
+      "codex",
+      ["-s", "read-only", "-a", "untrusted", "app-server"],
+      { stdio: ["pipe", "pipe", "pipe"], env: process.env },
+    );
+    this.proc.on("error", (err: Error) => {
+      this.spawnError = err;
+      for (const request of this.pending.values()) {
+        clearTimeout(request.timer);
+        request.reject(new Error(`codex binary not available: ${err.message}`));
+      }
+      this.pending.clear();
+    });
     this.proc.stdout.setEncoding("utf8");
     this.proc.stderr.setEncoding("utf8");
     this.proc.stdout.on("data", (chunk: string) => this.onStdout(chunk));
@@ -459,6 +468,9 @@ class CodexRpcClient {
   }
 
   private request(method: string, params: Record<string, unknown> = {}, timeoutMs = 6_000): Promise<Record<string, unknown>> {
+    if (this.spawnError) {
+      return Promise.reject(new Error(`codex binary not available: ${this.spawnError.message}`));
+    }
     const id = this.nextId++;
     const payload = JSON.stringify({ id, method, params }) + "\n";
     return new Promise<Record<string, unknown>>((resolve, reject) => {
@@ -500,7 +512,9 @@ class CodexRpcClient {
   }
 
   async shutdown() {
-    this.proc.kill("SIGTERM");
+    if (!this.spawnError) {
+      this.proc.kill("SIGTERM");
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Added `error` event handler on the spawned codex process to catch `ENOENT` when the binary is missing
- Added early rejection in `request()` when spawn has already failed, preventing further attempts
- Added guard in `shutdown()` to avoid killing a process that never started
- The existing `getQuotaWindows()` try/catch now properly catches the error and falls back gracefully

**Root cause:** `CodexRpcClient` spawned the codex binary eagerly with no `error` handler. When the binary wasn't installed, Node emitted an unhandled `ENOENT` error that crashed the server — even if no agents used the `codex_local` adapter.

Closes #1557

## Test plan

- [ ] Start the server without `codex` installed — verify no crash
- [ ] Navigate to Costs > Providers — verify page loads (codex quota shows error, not crash)
- [ ] Start the server with `codex` installed — verify quota fetching still works normally
- [ ] Verify other adapters (claude_local, etc.) are unaffected