### PR TITLE
feat: add Copilot CLI adapter

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-copilot-cli": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { printCopilotStreamEvent } from "@paperclipai/adapter-copilot-cli/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -44,6 +45,11 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const copilotCliCLIAdapter: CLIAdapterModule = {
+  type: "copilot_cli",
+  formatStdoutEvent: printCopilotStreamEvent,
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
@@ -53,6 +59,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,
     openclawGatewayCLIAdapter,
+    copilotCliCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,
   ].map((a) => [a.type, a]),

--- a/packages/adapter-utils/src/build-paperclip-env.test.ts
+++ b/packages/adapter-utils/src/build-paperclip-env.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import { buildPaperclipEnv } from "./server-utils.js";
+
+const agent = { id: "agent-1", companyId: "company-1" };
+
+describe("buildPaperclipEnv", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("defaults to localhost when no HOST is set", () => {
+    delete process.env.HOST;
+    delete process.env.PAPERCLIP_LISTEN_HOST;
+    delete process.env.PAPERCLIP_API_URL;
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3100");
+  });
+
+  it("uses os.hostname() when HOST is 0.0.0.0 (wildcard bind)", () => {
+    delete process.env.PAPERCLIP_LISTEN_HOST;
+    delete process.env.PAPERCLIP_API_URL;
+    process.env.HOST = "0.0.0.0";
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe(`http://${os.hostname()}:3100`);
+    expect(env.PAPERCLIP_API_URL).not.toContain("localhost");
+  });
+
+  it("uses os.hostname() when HOST is :: (IPv6 wildcard)", () => {
+    delete process.env.PAPERCLIP_LISTEN_HOST;
+    delete process.env.PAPERCLIP_API_URL;
+    process.env.HOST = "::";
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe(`http://${os.hostname()}:3100`);
+  });
+
+  it("respects explicit PAPERCLIP_API_URL over HOST", () => {
+    process.env.HOST = "0.0.0.0";
+    process.env.PAPERCLIP_API_URL = "http://100.64.1.2:3100";
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe("http://100.64.1.2:3100");
+  });
+
+  it("respects PAPERCLIP_LISTEN_HOST over HOST", () => {
+    delete process.env.PAPERCLIP_API_URL;
+    process.env.HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_HOST = "192.168.1.50";
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe("http://192.168.1.50:3100");
+  });
+
+  it("uses custom port from PAPERCLIP_LISTEN_PORT", () => {
+    delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_LISTEN_HOST;
+    process.env.HOST = "my-machine";
+    process.env.PAPERCLIP_LISTEN_PORT = "4200";
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe("http://my-machine:4200");
+  });
+
+  it("wraps bare IPv6 addresses in brackets", () => {
+    delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_LISTEN_HOST;
+    process.env.HOST = "fd12:3456:789a::1";
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_API_URL).toBe("http://[fd12:3456:789a::1]:3100");
+  });
+
+  it("always sets PAPERCLIP_AGENT_ID and PAPERCLIP_COMPANY_ID", () => {
+    const env = buildPaperclipEnv(agent);
+    expect(env.PAPERCLIP_AGENT_ID).toBe("agent-1");
+    expect(env.PAPERCLIP_COMPANY_ID).toBe("company-1");
+  });
+});

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type {
   AdapterSkillEntry,
@@ -204,7 +205,13 @@ export function redactEnvForLogs(env: Record<string, string>): Record<string, st
 export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
-    if (!host || host === "0.0.0.0" || host === "::") return "localhost";
+    // Only fall back to localhost when no host is configured at all.
+    // When HOST is explicitly set to a wildcard like 0.0.0.0 or ::, use the
+    // machine hostname so that remote agents (Tailscale, VPN, LAN) can reach
+    // the server.  Callers who truly want localhost should set HOST=localhost
+    // or PAPERCLIP_API_URL explicitly.
+    if (!host) return "localhost";
+    if (host === "0.0.0.0" || host === "::") return os.hostname();
     if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) return `[${host}]`;
     return host;
   };

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -43,6 +43,7 @@ export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
   "gemini_local",
   "opencode_local",
   "pi_local",
+  "copilot_cli",
 ]);
 
 export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement> = {
@@ -72,6 +73,11 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
     defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
   },
   pi_local: {
+    supportsSessionResume: true,
+    nativeContextManagement: "unknown",
+    defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
+  },
+  copilot_cli: {
     supportsSessionResume: true,
     nativeContextManagement: "unknown",
     defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -344,6 +344,8 @@ export interface CreateConfigValues {
   workspaceBranchTemplate?: string;
   worktreeParentDir?: string;
   runtimeServicesJson?: string;
+  allowTool?: string;
+  denyTool?: string;
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;
   intervalSec: number;

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/copilot-cli/package.json
+++ b/packages/adapters/copilot-cli/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-copilot-cli",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/copilot-cli"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/copilot-cli/src/cli/format-event.ts
+++ b/packages/adapters/copilot-cli/src/cli/format-event.ts
@@ -1,0 +1,90 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Pretty-print a single JSONL event from Copilot CLI output for terminal display.
+ */
+export function printCopilotStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    console.log(line);
+    return;
+  }
+
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+  const data = asRecord(parsed.data) ?? {};
+
+  if (type === "session.tools_updated") {
+    const model = typeof data.model === "string" ? data.model : "unknown";
+    console.log(pc.blue(`Copilot initialized (model: ${model})`));
+    return;
+  }
+
+  if (type === "assistant.message_delta") {
+    const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+    if (deltaContent) process.stdout.write(pc.green(deltaContent));
+    return;
+  }
+
+  if (type === "assistant.message") {
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content) console.log(pc.green(`assistant: ${content}`));
+
+    const toolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : [];
+    for (const reqRaw of toolRequests) {
+      const req = asRecord(reqRaw);
+      if (!req) continue;
+      const name = typeof req.name === "string" ? req.name : "unknown";
+      console.log(pc.yellow(`tool_call: ${name}`));
+      if (req.arguments !== undefined) {
+        console.log(pc.gray(JSON.stringify(req.arguments, null, 2)));
+      }
+    }
+    return;
+  }
+
+  if (type === "tool.execution_complete") {
+    const result = asRecord(data.result) ?? {};
+    const content = typeof result.content === "string" ? result.content : "";
+    const success = data.success !== false;
+    const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";
+    if (!success) {
+      console.log(pc.red(`tool_error [${toolCallId}]: ${content}`));
+    } else if (debug) {
+      console.log(pc.gray(`tool_result [${toolCallId}]: ${content.slice(0, 200)}`));
+    }
+    return;
+  }
+
+  if (type === "result") {
+    const usage = asRecord(parsed.usage) ?? {};
+    const premiumRequests = Number(usage.premiumRequests ?? 0);
+    const totalApiDurationMs = Number(usage.totalApiDurationMs ?? 0);
+    const sessionDurationMs = Number(usage.sessionDurationMs ?? 0);
+    const exitCode = Number(parsed.exitCode ?? 0);
+    const sessionId = typeof parsed.sessionId === "string" ? parsed.sessionId : "";
+
+    if (exitCode !== 0) {
+      console.log(pc.red(`copilot_result: exit_code=${exitCode}`));
+    }
+    console.log(
+      pc.blue(
+        `requests=${premiumRequests} api_time=${totalApiDurationMs}ms session_time=${sessionDurationMs}ms${sessionId ? ` session=${sessionId}` : ""}`,
+      ),
+    );
+    return;
+  }
+
+  if (debug) {
+    console.log(pc.gray(line));
+  }
+}

--- a/packages/adapters/copilot-cli/src/cli/index.ts
+++ b/packages/adapters/copilot-cli/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printCopilotStreamEvent } from "./format-event.js";

--- a/packages/adapters/copilot-cli/src/index.ts
+++ b/packages/adapters/copilot-cli/src/index.ts
@@ -1,0 +1,73 @@
+export const type = "copilot_cli";
+export const label = "GitHub Copilot CLI";
+
+export const models = [
+  { id: "gpt-5.4", label: "GPT 5.4" },
+  { id: "gpt-5.3-codex", label: "GPT 5.3 Codex" },
+  { id: "gpt-5.2-codex", label: "GPT 5.2 Codex" },
+  { id: "gpt-5.2", label: "GPT 5.2" },
+  { id: "gpt-5.1-codex-max", label: "GPT 5.1 Codex Max" },
+  { id: "gpt-5.1-codex", label: "GPT 5.1 Codex" },
+  { id: "gpt-5.1", label: "GPT 5.1" },
+  { id: "gpt-5.4-mini", label: "GPT 5.4 Mini" },
+  { id: "gpt-5.1-codex-mini", label: "GPT 5.1 Codex Mini" },
+  { id: "gpt-5-mini", label: "GPT 5 Mini" },
+  { id: "gpt-4.1", label: "GPT 4.1" },
+  { id: "claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+  { id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+  { id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
+  { id: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  { id: "claude-opus-4.5", label: "Claude Opus 4.5" },
+  { id: "claude-sonnet-4", label: "Claude Sonnet 4" },
+  { id: "gemini-3-pro-preview", label: "Gemini 3 Pro" },
+];
+
+export const agentConfigurationDoc = `# copilot_cli agent configuration
+
+Adapter: copilot_cli
+
+Use when:
+- The agent needs to run GitHub Copilot CLI locally on the host machine
+- You need session persistence across runs (Copilot supports --resume for thread resumption)
+- The task benefits from Copilot's built-in GitHub MCP server integration (issues, PRs, code search)
+- You want multi-model flexibility (GPT, Claude, Gemini models available through one adapter)
+- The agent needs autonomous multi-turn execution via --autopilot mode
+
+Don't use when:
+- You need a simple one-shot script execution (use the "process" adapter instead)
+- The agent doesn't need conversational context between runs (process adapter is simpler)
+- Copilot CLI is not installed on the host (install via: gh extension install github/gh-copilot)
+- You need direct Anthropic API access with Claude-specific features like artifacts (use claude_local instead)
+
+Core fields:
+- cwd (string, optional): default absolute working directory for the agent process (created if missing)
+- model (string, optional): model id (e.g. claude-sonnet-4.6, gpt-5.4)
+- reasoningEffort (string, optional): reasoning effort level (low|medium|high); also accepts "effort" as a legacy alias
+- promptTemplate (string, optional): run prompt template
+- bootstrapPromptTemplate (string, optional): one-time prompt prepended on fresh sessions (when no session to resume); supports the same template variables as promptTemplate
+- maxAutopilotContinues (number, optional): max autonomous turns via --max-autopilot-continues
+- allowAll (boolean, optional): pass --yolo/--allow-all to bypass all permissions (default: true for autonomous execution)
+- noCustomInstructions (boolean, optional): pass --no-custom-instructions to skip workspace instructions
+- skillsEnabled (boolean, optional): inject Paperclip skill instructions via COPILOT_CUSTOM_INSTRUCTIONS_DIRS (default: true); set false to disable
+- command (string, optional): defaults to "copilot"
+- instructionsFilePath (string, optional): absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior; injected into the system prompt at runtime
+- extraArgs (string[], optional): additional CLI args
+- allowTool (string[], optional): tool names to allow without prompting (--allow-tool); comma-separated in the UI
+- denyTool (string[], optional): tool names to always deny (--deny-tool); comma-separated in the UI
+- env (object, optional): KEY=VALUE environment variables
+- mcpConfig (string, optional): JSON string for --additional-mcp-config
+- agent (string, optional): agent name for --agent flag
+- workspaceStrategy (object, optional): execution workspace strategy; supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
+- workspaceRuntime (object, optional): workspace runtime service intents
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Copilot CLI uses --output-format json for JSONL streaming output
+- Prompt is delivered via -p <text> argument
+- Session resume: when a saved session ID is not found, the adapter automatically retries without a session
+- Auth via COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN environment variables
+- When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars
+`;

--- a/packages/adapters/copilot-cli/src/server/execute.ts
+++ b/packages/adapters/copilot-cli/src/server/execute.ts
@@ -1,0 +1,500 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import {
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+  readPaperclipSkillMarkdown,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  parseCopilotJsonl,
+  describeCopilotFailure,
+  detectCopilotLoginRequired,
+  isCopilotMaxTurnsResult,
+  isCopilotUnknownSessionError,
+  stripSkillFrontmatter,
+} from "./parse.js";
+import { createJsonlLogInterceptor } from "./jsonl-interceptor.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolve the Paperclip "paperclip" skill, strip its YAML frontmatter, write
+ * the result to a fresh tmpdir as AGENTS.md, and return the tmpdir path.
+ * Returns null if the skill is not found or is empty after stripping.
+ */
+async function buildCopilotInstructionsTmpDir(): Promise<string | null> {
+  const raw = await readPaperclipSkillMarkdown(__moduleDir, "paperclip");
+  if (!raw) return null;
+  const stripped = stripSkillFrontmatter(raw);
+  if (!stripped) return null;
+  const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-copilot-instructions-"));
+  await fs.writeFile(path.join(tmpdir, "AGENTS.md"), stripped, "utf-8");
+  return tmpdir;
+}
+
+interface CopilotExecutionInput {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  context: Record<string, unknown>;
+  authToken?: string;
+}
+
+interface CopilotRuntimeConfig {
+  command: string;
+  cwd: string;
+  workspaceId: string | null;
+  workspaceRepoUrl: string | null;
+  workspaceRepoRef: string | null;
+  env: Record<string, string>;
+  timeoutSec: number;
+  graceSec: number;
+  extraArgs: string[];
+}
+
+async function buildCopilotRuntimeConfig(input: CopilotExecutionInput): Promise<CopilotRuntimeConfig> {
+  const { runId, agent, config, context, authToken } = input;
+
+  const command = asString(config.command, "copilot");
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "") || null;
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "") || null;
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "") || null;
+  const workspaceBranch = asString(workspaceContext.branchName, "") || null;
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
+  const agentHome = asString(workspaceContext.agentHome, "") || null;
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
+  if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
+  if (agentHome) env.AGENT_HOME = agentHome;
+  if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  if (runtimeServiceIntents.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  }
+  if (runtimeServices.length > 0) {
+    env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  }
+  if (runtimePrimaryUrl) env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  if (authToken && !env.COPILOT_GITHUB_TOKEN && !env.GH_TOKEN && !env.GITHUB_TOKEN) {
+    env.COPILOT_GITHUB_TOKEN = authToken;
+  }
+
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  return {
+    command,
+    cwd,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    env,
+    timeoutSec,
+    graceSec,
+    extraArgs,
+  };
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const model = asString(config.model, "");
+  const reasoningEffort = asString(config.reasoningEffort, asString(config.effort, ""));
+  const allowAll = asBoolean(config.allowAll, true);
+  const maxAutopilotContinues = asNumber(config.maxAutopilotContinues, 0);
+  const noCustomInstructions = asBoolean(config.noCustomInstructions, false);
+  const mcpConfig = asString(config.mcpConfig, "").trim();
+  const agentName = asString(config.agent, "").trim();
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const allowTool = asStringArray(config.allowTool);
+  const denyTool = asStringArray(config.denyTool);
+
+  const skillsEnabled = asBoolean(config.skillsEnabled, true);
+
+  const runtimeConfig = await buildCopilotRuntimeConfig({ runId, agent, config, context, authToken });
+  const {
+    command,
+    cwd,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    env,
+    timeoutSec,
+    graceSec,
+    extraArgs,
+  } = runtimeConfig;
+
+  const instructionsTmpDir = skillsEnabled ? await buildCopilotInstructionsTmpDir() : null;
+  if (instructionsTmpDir) {
+    const existing = env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS ?? "";
+    env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = existing
+      ? `${existing}:${instructionsTmpDir}`
+      : instructionsTmpDir;
+    await onLog("stdout", `[paperclip] Injected Paperclip skill instructions from ${instructionsTmpDir}/AGENTS.md\n`);
+  } else if (skillsEnabled) {
+    await onLog("stdout", `[paperclip] Warning: Could not resolve Paperclip skill instructions (moduleDir: ${__moduleDir})\n`);
+  }
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Copilot session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  // Read agent instructions file if configured
+  let instructionsContent = "";
+  if (instructionsFilePath) {
+    try {
+      instructionsContent = await fs.readFile(instructionsFilePath, "utf-8");
+      const instructionsFileDir = `${path.dirname(instructionsFilePath)}/`;
+      instructionsContent += `\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsFileDir}.`;
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: Could not read instructions file ${instructionsFilePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  // Build Paperclip context block from available runtime data
+  const wakeReason = asString(context.wakeReason, "");
+  const ctxTaskId = asString(context.taskId, "") || asString(context.issueId, "");
+  const ctxTaskKey = asString(context.taskKey, "");
+  const ctxCommentId = asString(context.wakeCommentId, "") || asString(context.commentId, "");
+  const ctxWakeSource = asString(context.wakeSource, "");
+
+  const contextLines: string[] = [
+    `[Paperclip Agent Context]`,
+    `Agent: ${agent.name} (ID: ${agent.id})`,
+    `Company: ${agent.companyId}`,
+    `Run: ${runId}`,
+    `Working directory: ${cwd}`,
+  ];
+  if (wakeReason) contextLines.push(`Wake reason: ${wakeReason}`);
+  if (ctxTaskId) contextLines.push(`Assigned task: ${ctxTaskId}${ctxTaskKey ? ` (${ctxTaskKey})` : ""}`);
+  if (ctxCommentId) contextLines.push(`Triggered by comment: ${ctxCommentId}`);
+  if (ctxWakeSource) contextLines.push(`Wake source: ${ctxWakeSource}`);
+  contextLines.push(
+    ``,
+    `Environment variables injected: PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_AGENT_ID, PAPERCLIP_COMPANY_ID, PAPERCLIP_RUN_ID${ctxTaskId ? ", PAPERCLIP_TASK_ID" : ""}`,
+    ``,
+    `[Paperclip API Usage]`,
+    `You are running natively inside the Paperclip runtime. Use the Paperclip REST API via curl with the injected environment variables. Do NOT use pcli — that is an emulation tool for local development only.`,
+    ``,
+    `API pattern:`,
+    `  curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" "$PAPERCLIP_API_URL/<endpoint>"`,
+    ``,
+    `Common endpoints:`,
+    `  GET  /api/agents/me                                          — your identity`,
+    `  GET  /api/agents/me/inbox-lite                               — @mentions directed at you`,
+    `  GET  /api/companies/{companyId}/dashboard                    — company health overview`,
+    `  GET  /api/companies/{companyId}/issues?status=<s>&limit=50   — list issues`,
+    `  GET  /api/issues/{id}                                        — issue detail`,
+    `  GET  /api/issues/{id}/comments?order=asc                     — issue comments`,
+    `  POST /api/issues/{id}/comments  {"body":"..."}               — post comment`,
+    `  POST /api/issues/{id}/checkout                               — claim a task`,
+    `  PATCH /api/issues/{id}  {"status":"...","comment":"..."}     — update issue`,
+    `  POST /api/companies/{companyId}/issues  {...}                — create issue`,
+    ``,
+    `Use $PAPERCLIP_COMPANY_ID for {companyId}. Always include X-Paperclip-Run-Id on mutating calls.`,
+  );
+  const paperclipContextBlock = contextLines.join("\n");
+
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+
+  // Assemble final prompt: instructions (optional) + bootstrap (fresh sessions only) + Paperclip context + user prompt
+  const promptParts: string[] = [];
+  if (instructionsContent) promptParts.push(instructionsContent);
+  if (renderedBootstrapPrompt) promptParts.push(renderedBootstrapPrompt);
+  promptParts.push(paperclipContextBlock);
+  promptParts.push(renderedPrompt);
+  const prompt = promptParts.join("\n\n---\n\n");
+
+  const buildCopilotArgs = (resumeSessionId: string | null) => {
+    const args = ["-p", prompt, "--output-format", "json", "--silent", "--no-ask-user", "--no-auto-update"];
+    if (resumeSessionId) args.push(`--resume=${resumeSessionId}`);
+    if (allowAll) args.push("--yolo");
+    if (model) args.push("--model", model);
+    if (reasoningEffort) args.push("--reasoning-effort", reasoningEffort);
+    if (maxAutopilotContinues > 0) {
+      args.push("--autopilot", "--max-autopilot-continues", String(maxAutopilotContinues));
+    }
+    if (noCustomInstructions) args.push("--no-custom-instructions");
+    if (mcpConfig) args.push("--additional-mcp-config", mcpConfig);
+    if (agentName) args.push("--agent", agentName);
+    if (allowTool.length > 0) args.push(`--allow-tool=${allowTool.join(",")}`);
+    if (denyTool.length > 0) args.push(`--deny-tool=${denyTool.join(",")}`);
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    return args;
+  };
+
+  const parseFallbackErrorMessage = (proc: RunProcessResult) => {
+    const stderrLine =
+      proc.stderr
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? "";
+
+    if ((proc.exitCode ?? 0) === 0) {
+      return "Failed to parse Copilot JSONL output";
+    }
+
+    return stderrLine
+      ? `Copilot exited with code ${proc.exitCode ?? -1}: ${stderrLine}`
+      : `Copilot exited with code ${proc.exitCode ?? -1}`;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildCopilotArgs(resumeSessionId);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "copilot_cli",
+        command,
+        cwd,
+        commandArgs: args,
+        env: redactEnvForLogs(env),
+        prompt,
+        context,
+      });
+    }
+
+    const interceptor = createJsonlLogInterceptor(onLog);
+
+    const proc = await runChildProcess(runId, command, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onLog: interceptor.onChunk,
+    });
+
+    await interceptor.flush();
+
+    const parsedStream = parseCopilotJsonl(proc.stdout);
+    return { proc, parsedStream };
+  };
+
+  const toAdapterResult = (
+    attempt: {
+      proc: RunProcessResult;
+      parsedStream: ReturnType<typeof parseCopilotJsonl>;
+    },
+    opts: { fallbackSessionId: string | null },
+  ): AdapterExecutionResult => {
+    const { proc, parsedStream } = attempt;
+    const loginMeta = detectCopilotLoginRequired({
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+    });
+
+    if (proc.timedOut) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: "timeout",
+      };
+    }
+
+    if (!parsedStream.resultJson) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: false,
+        errorMessage: parseFallbackErrorMessage(proc),
+        errorCode: loginMeta.requiresLogin ? "copilot_auth_required" : null,
+        resultJson: {
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+        },
+      };
+    }
+
+    const resolvedSessionId =
+      parsedStream.sessionId ?? opts.fallbackSessionId;
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+          sessionId: resolvedSessionId,
+          cwd,
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+          ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        } as Record<string, unknown>)
+      : null;
+    const clearSessionForMaxTurns = isCopilotMaxTurnsResult(parsedStream.resultJson);
+
+    const normalExit = (proc.exitCode ?? 0) === 0 && !loginMeta.requiresLogin;
+
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: false,
+      errorMessage: normalExit
+        ? null
+        : describeCopilotFailure(parsedStream.resultJson) ??
+            `Copilot exited with code ${proc.exitCode ?? -1}`,
+      errorCode: loginMeta.requiresLogin ? "copilot_auth_required" : null,
+      usage: parsedStream.usage ?? undefined,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "github",
+      biller: "github",
+      model: parsedStream.model || model,
+      billingType: "subscription",
+      costUsd: parsedStream.costUsd ?? 0,
+      resultJson: parsedStream.resultJson,
+      summary: parsedStream.summary,
+      clearSession: clearSessionForMaxTurns,
+    };
+  };
+
+  try {
+    const initial = await runAttempt(sessionId ?? null);
+    if (
+      initial.parsedStream.resultJson &&
+      isCopilotUnknownSessionError(initial.parsedStream.resultJson)
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Copilot session "${runtimeSessionId}" not found, retrying without session.\n`,
+      );
+      const retry = await runAttempt(null);
+      const retryResult = toAdapterResult(retry, { fallbackSessionId: null });
+      retryResult.clearSession = true;
+      return retryResult;
+    }
+    return toAdapterResult(initial, {
+      fallbackSessionId: runtimeSessionId || runtime.sessionId,
+    });
+  } finally {
+    if (instructionsTmpDir) {
+      fs.rm(instructionsTmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}

--- a/packages/adapters/copilot-cli/src/server/index.ts
+++ b/packages/adapters/copilot-cli/src/server/index.ts
@@ -1,0 +1,60 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseCopilotJsonl,
+  describeCopilotFailure,
+  detectCopilotLoginRequired,
+  isCopilotMaxTurnsResult,
+  isCopilotUnknownSessionError,
+} from "./parse.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};

--- a/packages/adapters/copilot-cli/src/server/jsonl-interceptor.test.ts
+++ b/packages/adapters/copilot-cli/src/server/jsonl-interceptor.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+import { createJsonlLogInterceptor } from "./jsonl-interceptor.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type LogCall = [stream: "stdout" | "stderr", text: string];
+
+function makeInterceptor() {
+  const calls: LogCall[] = [];
+  const onLog = vi.fn(async (stream: "stdout" | "stderr", text: string) => {
+    calls.push([stream, text]);
+  });
+  const interceptor = createJsonlLogInterceptor(onLog);
+  return { interceptor, calls, onLog };
+}
+
+const jsonlLine = (obj: unknown) => JSON.stringify(obj);
+
+const assistantMsg = (content: string) =>
+  jsonlLine({ type: "assistant.message", data: { content } });
+
+const toolStart = (toolName: string) =>
+  jsonlLine({ type: "tool.execution_start", data: { toolName, toolCallId: "tc1" } });
+
+const resultEvent = () =>
+  jsonlLine({ type: "result", sessionId: "s1", exitCode: 0, usage: {} });
+
+// ─── stderr / non-stdout passthrough ─────────────────────────────────────────
+
+describe("createJsonlLogInterceptor – stream passthrough", () => {
+  it("passes stderr chunks through directly without buffering", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.onChunk("stderr", "Error: something went wrong\n");
+    expect(calls).toEqual([["stderr", "Error: something went wrong\n"]]);
+  });
+
+  it("passes stderr even when interleaved with stdout", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.onChunk("stdout", assistantMsg("hi") + "\n");
+    await interceptor.onChunk("stderr", "stderr chunk\n");
+    await interceptor.flush();
+    expect(calls.some(([s, t]) => s === "stderr" && t === "stderr chunk\n")).toBe(true);
+    // stdout is now the raw JSONL line
+    expect(calls.some(([s]) => s === "stdout")).toBe(true);
+  });
+});
+
+// ─── Raw JSONL passthrough ────────────────────────────────────────────────────
+
+describe("createJsonlLogInterceptor – raw JSONL passthrough", () => {
+  it("passes assistant.message line through as-is with trailing newline", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = assistantMsg("Hello world");
+    await interceptor.onChunk("stdout", line + "\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("passes tool.execution_start line through as-is", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = toolStart("bash");
+    await interceptor.onChunk("stdout", line + "\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("passes result event line through as-is", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = resultEvent();
+    await interceptor.onChunk("stdout", line + "\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("passes session.tools_updated line through as-is", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = jsonlLine({ type: "session.tools_updated", data: { model: "gpt-5" } });
+    await interceptor.onChunk("stdout", line + "\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("passes non-JSON lines through as-is", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.onChunk("stdout", "plain text line\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", "plain text line\n"]]);
+  });
+
+  it("suppresses empty lines within a chunk", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.onChunk("stdout", "\n\n\n");
+    await interceptor.flush();
+    expect(calls).toEqual([]);
+  });
+});
+
+// ─── Multiple lines per chunk ─────────────────────────────────────────────────
+
+describe("createJsonlLogInterceptor – multiple lines in one chunk", () => {
+  it("forwards all complete lines in a single multi-line chunk", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line1 = assistantMsg("First");
+    const line2 = toolStart("edit_file");
+    const line3 = assistantMsg("Second");
+    const chunk = line1 + "\n" + line2 + "\n" + line3 + "\n";
+    await interceptor.onChunk("stdout", chunk);
+    await interceptor.flush();
+    expect(calls).toEqual([
+      ["stdout", line1 + "\n"],
+      ["stdout", line2 + "\n"],
+      ["stdout", line3 + "\n"],
+    ]);
+  });
+
+  it("forwards all event types including suppressed ones", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line1 = assistantMsg("Before tool");
+    const line2 = jsonlLine({ type: "session.tools_updated", data: { model: "gpt-5" } });
+    const line3 = toolStart("bash");
+    const line4 = jsonlLine({ type: "tool.execution_complete", data: { success: true } });
+    const line5 = assistantMsg("After tool");
+    const chunk = [line1, line2, line3, line4, line5].join("\n") + "\n";
+    await interceptor.onChunk("stdout", chunk);
+    await interceptor.flush();
+    expect(calls).toEqual([
+      ["stdout", line1 + "\n"],
+      ["stdout", line2 + "\n"],
+      ["stdout", line3 + "\n"],
+      ["stdout", line4 + "\n"],
+      ["stdout", line5 + "\n"],
+    ]);
+  });
+});
+
+// ─── Chunk boundary / buffering ──────────────────────────────────────────────
+
+describe("createJsonlLogInterceptor – chunk splitting", () => {
+  it("buffers a chunk with no newline and emits nothing until flush", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.onChunk("stdout", assistantMsg("Streaming..."));
+    expect(calls).toEqual([]);
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", assistantMsg("Streaming...") + "\n"]]);
+  });
+
+  it("completes a split JSON when second chunk supplies the newline", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const full = assistantMsg("Split across chunks");
+    const mid = Math.floor(full.length / 2);
+    await interceptor.onChunk("stdout", full.slice(0, mid));
+    expect(calls).toEqual([]);
+    await interceptor.onChunk("stdout", full.slice(mid) + "\n");
+    expect(calls).toEqual([["stdout", full + "\n"]]);
+  });
+
+  it("handles chunk ending exactly on \\n (buffer cleared)", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = assistantMsg("Exact");
+    await interceptor.onChunk("stdout", line + "\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("handles CRLF line endings", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = assistantMsg("CRLF test");
+    await interceptor.onChunk("stdout", line + "\r\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("handles a chunk that completes one line and starts another (no trailing newline)", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const complete = assistantMsg("Complete");
+    const partial = assistantMsg("Partial");
+    const mid = Math.floor(partial.length / 2);
+    await interceptor.onChunk("stdout", complete + "\n" + partial.slice(0, mid));
+    expect(calls).toEqual([["stdout", complete + "\n"]]);
+    await interceptor.onChunk("stdout", partial.slice(mid) + "\n");
+    expect(calls).toEqual([["stdout", complete + "\n"], ["stdout", partial + "\n"]]);
+  });
+
+  it("handles three chunks: split across all three", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const full = assistantMsg("Three parts");
+    const a = full.slice(0, 5);
+    const b = full.slice(5, 15);
+    const c = full.slice(15) + "\n";
+    await interceptor.onChunk("stdout", a);
+    await interceptor.onChunk("stdout", b);
+    await interceptor.onChunk("stdout", c);
+    expect(calls).toEqual([["stdout", full + "\n"]]);
+  });
+
+  it("processes multiple buffered lines that arrive in a single catch-up chunk", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const first = assistantMsg("First");
+    const second = assistantMsg("Second");
+    await interceptor.onChunk("stdout", first);
+    await interceptor.onChunk("stdout", "\n" + second + "\n");
+    expect(calls).toEqual([["stdout", first + "\n"], ["stdout", second + "\n"]]);
+  });
+});
+
+// ─── flush edge cases ─────────────────────────────────────────────────────────
+
+describe("createJsonlLogInterceptor – flush", () => {
+  it("flush with empty buffer is a no-op", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.flush();
+    expect(calls).toEqual([]);
+  });
+
+  it("flush of whitespace-only buffer is a no-op", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    await interceptor.onChunk("stdout", "  ");
+    await interceptor.flush();
+    expect(calls).toEqual([]);
+  });
+
+  it("flush clears the buffer (second flush is a no-op)", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = assistantMsg("Once");
+    await interceptor.onChunk("stdout", line);
+    await interceptor.flush();
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+
+  it("flush after newline-terminated chunk does not re-emit", async () => {
+    const { interceptor, calls } = makeInterceptor();
+    const line = assistantMsg("Already done");
+    await interceptor.onChunk("stdout", line + "\n");
+    await interceptor.flush();
+    expect(calls).toEqual([["stdout", line + "\n"]]);
+  });
+});

--- a/packages/adapters/copilot-cli/src/server/jsonl-interceptor.ts
+++ b/packages/adapters/copilot-cli/src/server/jsonl-interceptor.ts
@@ -1,0 +1,55 @@
+export type LogFn = (stream: "stdout" | "stderr", text: string) => Promise<void>;
+
+export interface JsonlLogInterceptor {
+  /** Feed a raw output chunk from runChildProcess onLog into the interceptor. */
+  onChunk: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  /**
+   * Flush any buffered content that did not end with a newline.
+   * Call once after runChildProcess resolves.
+   */
+  flush: () => Promise<void>;
+}
+
+/**
+ * Create a line-buffered JSONL log interceptor.
+ *
+ * The interceptor wraps an outer `onLog` function so that:
+ * - stderr (and any non-stdout stream) is passed through unchanged.
+ * - stdout chunks are line-buffered; each complete line is forwarded as-is
+ *   to `onLog`, preserving the raw JSONL for client-side parsing by
+ *   parse-stdout.ts (which produces the structured "Nice" transcript view).
+ * - Empty lines are suppressed.
+ *
+ * After runChildProcess resolves, call `flush()` to emit any trailing content
+ * that was not terminated by a newline.
+ */
+export function createJsonlLogInterceptor(onLog: LogFn): JsonlLogInterceptor {
+  let buffer = "";
+
+  return {
+    async onChunk(stream, chunk) {
+      if (stream !== "stdout") {
+        await onLog(stream, chunk);
+        return;
+      }
+      const combined = buffer + chunk;
+      const lines = combined.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line) {
+          await onLog("stdout", line + "\n");
+        }
+      }
+    },
+
+    async flush() {
+      if (buffer) {
+        const trimmed = buffer.trim();
+        if (trimmed) {
+          await onLog("stdout", buffer + "\n");
+        }
+        buffer = "";
+      }
+    },
+  };
+}

--- a/packages/adapters/copilot-cli/src/server/parse.test.ts
+++ b/packages/adapters/copilot-cli/src/server/parse.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCopilotJsonl,
+  describeCopilotFailure,
+  detectCopilotLoginRequired,
+  isCopilotMaxTurnsResult,
+  mapCopilotJsonlLineToLog,
+  stripSkillFrontmatter,
+} from "./parse.js";
+
+const SIMPLE_JSONL = [
+  '{"type":"session.mcp_servers_loaded","data":{"servers":[{"name":"github-mcp-server","status":"connected","source":"builtin"}]},"id":"aaa","timestamp":"2026-03-20T13:38:31.064Z","parentId":"bbb","ephemeral":true}',
+  '{"type":"session.tools_updated","data":{"model":"claude-sonnet-4.6"},"id":"ccc","timestamp":"2026-03-20T13:38:34.968Z","parentId":"ddd","ephemeral":true}',
+  '{"type":"user.message","data":{"content":"hello","transformedContent":"hello","attachments":[],"interactionId":"eee"},"id":"fff","timestamp":"2026-03-20T13:38:34.969Z","parentId":"ggg"}',
+  '{"type":"assistant.turn_start","data":{"turnId":"0","interactionId":"eee"},"id":"hhh","timestamp":"2026-03-20T13:38:34.974Z","parentId":"iii"}',
+  '{"type":"assistant.message_delta","data":{"messageId":"jjj","deltaContent":"hello"},"id":"kkk","timestamp":"2026-03-20T13:38:38.505Z","parentId":"lll","ephemeral":true}',
+  '{"type":"assistant.message_delta","data":{"messageId":"jjj","deltaContent":" world"},"id":"mmm","timestamp":"2026-03-20T13:38:38.505Z","parentId":"nnn","ephemeral":true}',
+  '{"type":"assistant.message","data":{"messageId":"jjj","content":"hello world","toolRequests":[],"interactionId":"eee","outputTokens":5},"id":"ooo","timestamp":"2026-03-20T13:38:38.637Z","parentId":"ppp"}',
+  '{"type":"assistant.turn_end","data":{"turnId":"0"},"id":"qqq","timestamp":"2026-03-20T13:38:38.638Z","parentId":"rrr"}',
+  '{"type":"result","timestamp":"2026-03-20T13:38:38.640Z","sessionId":"7899ee8f-3271-4de8-9c07-5b40d35a2e7a","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":2762,"sessionDurationMs":10959,"codeChanges":{"linesAdded":0,"linesRemoved":0,"filesModified":[]}}}',
+].join("\n");
+
+const TOOL_USE_JSONL = [
+  '{"type":"session.tools_updated","data":{"model":"claude-sonnet-4.6"},"id":"a1","timestamp":"2026-03-20T13:41:00.000Z","parentId":"b1","ephemeral":true}',
+  '{"type":"assistant.message","data":{"messageId":"m1","content":"","toolRequests":[{"toolCallId":"tc1","name":"bash","arguments":{"command":"echo test"},"type":"function"}],"interactionId":"i1","outputTokens":20},"id":"c1","timestamp":"2026-03-20T13:41:11.104Z","parentId":"d1"}',
+  '{"type":"tool.execution_start","data":{"toolCallId":"tc1","toolName":"bash","arguments":{"command":"echo test"}},"id":"e1","timestamp":"2026-03-20T13:41:11.105Z","parentId":"f1"}',
+  '{"type":"tool.execution_complete","data":{"toolCallId":"tc1","model":"claude-sonnet-4.6","interactionId":"i1","success":true,"result":{"content":"test\\n<exited with exit code 0>","detailedContent":"test\\n<exited with exit code 0>"},"toolTelemetry":{}},"id":"g1","timestamp":"2026-03-20T13:41:13.902Z","parentId":"h1"}',
+  '{"type":"assistant.message","data":{"messageId":"m2","content":"Done.","toolRequests":[],"interactionId":"i1","outputTokens":3},"id":"j1","timestamp":"2026-03-20T13:41:17.000Z","parentId":"k1"}',
+  '{"type":"result","timestamp":"2026-03-20T13:41:17.278Z","sessionId":"session-456","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":8558,"sessionDurationMs":22087,"codeChanges":{"linesAdded":0,"linesRemoved":0,"filesModified":[]}}}',
+].join("\n");
+
+describe("parseCopilotJsonl", () => {
+  it("extracts sessionId from result event", () => {
+    const result = parseCopilotJsonl(SIMPLE_JSONL);
+    expect(result.sessionId).toBe("7899ee8f-3271-4de8-9c07-5b40d35a2e7a");
+  });
+
+  it("extracts model from session.tools_updated", () => {
+    const result = parseCopilotJsonl(SIMPLE_JSONL);
+    expect(result.model).toBe("claude-sonnet-4.6");
+  });
+
+  it("collects assistant text content", () => {
+    const result = parseCopilotJsonl(SIMPLE_JSONL);
+    expect(result.summary).toBe("hello world");
+  });
+
+  it("aggregates output tokens across assistant messages", () => {
+    const result = parseCopilotJsonl(SIMPLE_JSONL);
+    expect(result.usage!.outputTokens).toBe(5);
+  });
+
+  it("returns resultJson for result event", () => {
+    const result = parseCopilotJsonl(SIMPLE_JSONL);
+    expect(result.resultJson).not.toBeNull();
+    expect(result.resultJson!.exitCode).toBe(0);
+  });
+
+  it("handles tool-use output with multiple assistant messages", () => {
+    const result = parseCopilotJsonl(TOOL_USE_JSONL);
+    expect(result.sessionId).toBe("session-456");
+    expect(result.summary).toBe("Done.");
+    expect(result.usage!.outputTokens).toBe(23);
+  });
+
+  it("returns null resultJson for empty input", () => {
+    const result = parseCopilotJsonl("");
+    expect(result.sessionId).toBeNull();
+    expect(result.resultJson).toBeNull();
+    expect(result.summary).toBe("");
+  });
+
+  it("returns premiumRequests count", () => {
+    const result = parseCopilotJsonl(SIMPLE_JSONL);
+    expect(result.premiumRequests).toBe(1);
+  });
+});
+
+describe("describeCopilotFailure", () => {
+  it("returns null for exit code 0", () => {
+    expect(describeCopilotFailure({ exitCode: 0 })).toBeNull();
+  });
+
+  it("describes failure for non-zero exit code", () => {
+    expect(describeCopilotFailure({ exitCode: 1 })).toBe("Copilot CLI exited with code 1");
+  });
+});
+
+describe("detectCopilotLoginRequired", () => {
+  it("detects login required message", () => {
+    expect(
+      detectCopilotLoginRequired({
+        stdout: "",
+        stderr: "Error: not logged in. Please run copilot login.",
+      }).requiresLogin,
+    ).toBe(true);
+  });
+
+  it("returns false for normal output", () => {
+    expect(
+      detectCopilotLoginRequired({
+        stdout: "hello world",
+        stderr: "",
+      }).requiresLogin,
+    ).toBe(false);
+  });
+});
+
+describe("isCopilotMaxTurnsResult", () => {
+  it("returns false for normal results", () => {
+    expect(isCopilotMaxTurnsResult({ exitCode: 0 })).toBe(false);
+  });
+});
+
+// ─── mapCopilotJsonlLineToLog ─────────────────────────────────────────────────
+
+const line = (obj: unknown) => JSON.stringify(obj);
+
+describe("mapCopilotJsonlLineToLog", () => {
+  // Empty / whitespace
+  it("returns [] for empty string", () => {
+    expect(mapCopilotJsonlLineToLog("")).toEqual([]);
+  });
+
+  it("returns [] for whitespace-only string", () => {
+    expect(mapCopilotJsonlLineToLog("   \t  ")).toEqual([]);
+  });
+
+  // Non-JSON / malformed
+  it("returns [] for plaintext (malformed JSON)", () => {
+    expect(mapCopilotJsonlLineToLog("plain text line")).toEqual([]);
+  });
+
+  it("returns [] for truncated JSON", () => {
+    expect(mapCopilotJsonlLineToLog('{"type":"assistant.message"')).toEqual([]);
+  });
+
+  // Non-object JSON root values
+  it("returns [] for JSON null", () => {
+    expect(mapCopilotJsonlLineToLog("null")).toEqual([]);
+  });
+
+  it("returns [] for JSON array", () => {
+    expect(mapCopilotJsonlLineToLog('["a","b"]')).toEqual([]);
+  });
+
+  it("returns [] for JSON number", () => {
+    expect(mapCopilotJsonlLineToLog("42")).toEqual([]);
+  });
+
+  it("returns [] for JSON string", () => {
+    expect(mapCopilotJsonlLineToLog('"hello"')).toEqual([]);
+  });
+
+  // assistant.message – happy path
+  it("emits content for assistant.message with trailing newline", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message", data: { content: "Hello, world!" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "Hello, world!\n" }]);
+  });
+
+  // assistant.message – edge cases on content field
+  it("returns [] for assistant.message with empty content", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "assistant.message", data: { content: "" } })),
+    ).toEqual([]);
+  });
+
+  it("returns [] for assistant.message with null content", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "assistant.message", data: { content: null } })),
+    ).toEqual([]);
+  });
+
+  it("returns [] for assistant.message with numeric content", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "assistant.message", data: { content: 42 } })),
+    ).toEqual([]);
+  });
+
+  it("returns [] for assistant.message with missing content field", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "assistant.message", data: { outputTokens: 5 } })),
+    ).toEqual([]);
+  });
+
+  it("returns [] for assistant.message with data as array", () => {
+    // data is not an object → falls back to {} → content is "" → suppressed
+    expect(
+      mapCopilotJsonlLineToLog(
+        line({ type: "assistant.message", data: ["should", "be", "ignored"] }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] for assistant.message with data: null", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "assistant.message", data: null })),
+    ).toEqual([]);
+  });
+
+  it("emits content with trailing newline when other fields also present", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({
+        type: "assistant.message",
+        data: { messageId: "m1", content: "Done.", toolRequests: [], outputTokens: 3 },
+      }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "Done.\n" }]);
+  });
+
+  // tool.execution_start
+  it("emits [toolName]\\n for tool.execution_start using toolName field", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "tool.execution_start", data: { toolName: "bash", toolCallId: "tc1" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "[bash]\n" }]);
+  });
+
+  it("falls back to data.tool when toolName is absent", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "tool.execution_start", data: { tool: "read_file", toolCallId: "tc2" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "[read_file]\n" }]);
+  });
+
+  it("falls back to 'tool' when neither toolName nor tool present", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "tool.execution_start", data: { toolCallId: "tc3" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "[tool]\n" }]);
+  });
+
+  it("falls back to 'tool' when data is null for tool.execution_start", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "tool.execution_start", data: null }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "[tool]\n" }]);
+  });
+
+  // Suppressed event types
+  it("returns [] for session.tools_updated", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "session.tools_updated", data: { model: "gpt-5" } })),
+    ).toEqual([]);
+  });
+
+  it("returns [] for tool.execution_complete", () => {
+    expect(
+      mapCopilotJsonlLineToLog(
+        line({ type: "tool.execution_complete", data: { success: true, result: {} } }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] for result event", () => {
+    expect(
+      mapCopilotJsonlLineToLog(
+        line({ type: "result", sessionId: "s1", exitCode: 0, usage: {} }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] for unknown event type", () => {
+    expect(
+      mapCopilotJsonlLineToLog(line({ type: "client.unknown", data: {} })),
+    ).toEqual([]);
+  });
+
+  it("returns [] for event with no type field", () => {
+    expect(mapCopilotJsonlLineToLog(line({ data: { content: "surprise" } }))).toEqual([]);
+  });
+
+  it("returns [] for event with numeric type", () => {
+    expect(mapCopilotJsonlLineToLog(line({ type: 42, data: {} }))).toEqual([]);
+  });
+
+  // Whitespace around valid JSON
+  it("handles leading/trailing whitespace around valid JSON", () => {
+    const result = mapCopilotJsonlLineToLog(
+      `  ${line({ type: "assistant.message", data: { content: "hi" } })}  `,
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "hi\n" }]);
+  });
+});
+
+// ─── mapCopilotJsonlLineToLog – assistant.message_delta ───────────────────────
+
+describe("mapCopilotJsonlLineToLog – assistant.message_delta", () => {
+  it("emits deltaContent for streaming delta event", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: "hello" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "hello" }]);
+  });
+
+  it("emits deltaContent without trailing newline (raw streaming)", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: " world" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: " world" }]);
+  });
+
+  it("returns [] for delta with empty deltaContent", () => {
+    expect(
+      mapCopilotJsonlLineToLog(
+        line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: "" } }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] for delta with null deltaContent", () => {
+    expect(
+      mapCopilotJsonlLineToLog(
+        line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: null } }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] for delta with missing deltaContent", () => {
+    expect(
+      mapCopilotJsonlLineToLog(
+        line({ type: "assistant.message_delta", data: { messageId: "m1" } }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("tracks messageId in seenDeltaMessageIds set when provided", () => {
+    const seen = new Set<string>();
+    mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: "hi" } }),
+      seen,
+    );
+    expect(seen.has("m1")).toBe(true);
+  });
+
+  it("does not track when seenDeltaMessageIds is not provided", () => {
+    // Just verifies no error and still emits content
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: "hi" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "hi" }]);
+  });
+
+  it("does not track empty messageId", () => {
+    const seen = new Set<string>();
+    mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "", deltaContent: "hi" } }),
+      seen,
+    );
+    expect(seen.size).toBe(0);
+  });
+
+  it("does not track missing messageId", () => {
+    const seen = new Set<string>();
+    mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { deltaContent: "hi" } }),
+      seen,
+    );
+    expect(seen.size).toBe(0);
+  });
+});
+
+// ─── mapCopilotJsonlLineToLog – deduplication ─────────────────────────────────
+
+describe("mapCopilotJsonlLineToLog – deduplication", () => {
+  it("suppresses assistant.message content when deltas were already seen for that messageId", () => {
+    const seen = new Set<string>(["m1"]);
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message", data: { messageId: "m1", content: "hello world" } }),
+      seen,
+    );
+    // Should emit only a newline (terminates the streamed block)
+    expect(result).toEqual([{ stream: "stdout", text: "\n" }]);
+  });
+
+  it("emits full content when messageId was NOT seen in deltas", () => {
+    const seen = new Set<string>(["m-other"]);
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message", data: { messageId: "m1", content: "fresh content" } }),
+      seen,
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "fresh content\n" }]);
+  });
+
+  it("emits full content when seenDeltaMessageIds is not provided", () => {
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message", data: { messageId: "m1", content: "no dedup" } }),
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "no dedup\n" }]);
+  });
+
+  it("emits full content when message has no messageId", () => {
+    const seen = new Set<string>(["m1"]);
+    const result = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message", data: { content: "no id" } }),
+      seen,
+    );
+    expect(result).toEqual([{ stream: "stdout", text: "no id\n" }]);
+  });
+
+  it("end-to-end: delta → delta → full message deduplication", () => {
+    const seen = new Set<string>();
+    // Stream two deltas
+    const d1 = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: "Hello" } }),
+      seen,
+    );
+    const d2 = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: " world" } }),
+      seen,
+    );
+    // Full message arrives — should be deduplicated
+    const full = mapCopilotJsonlLineToLog(
+      line({ type: "assistant.message", data: { messageId: "m1", content: "Hello world" } }),
+      seen,
+    );
+    expect(d1).toEqual([{ stream: "stdout", text: "Hello" }]);
+    expect(d2).toEqual([{ stream: "stdout", text: " world" }]);
+    expect(full).toEqual([{ stream: "stdout", text: "\n" }]);
+  });
+});
+
+// ─── stripSkillFrontmatter ────────────────────────────────────────────────────
+
+describe("stripSkillFrontmatter", () => {
+  it("strips a standard YAML frontmatter block", () => {
+    const input = "---\nname: paperclip\ndescription: test\n---\n# Body Content\n\nSome text.";
+    expect(stripSkillFrontmatter(input)).toBe("# Body Content\n\nSome text.");
+  });
+
+  it("strips frontmatter when there is no trailing newline after closing ---", () => {
+    const input = "---\nname: test\n---\nBody only.";
+    expect(stripSkillFrontmatter(input)).toBe("Body only.");
+  });
+
+  it("returns the whole string when no frontmatter present", () => {
+    const input = "# Just a heading\n\nSome content here.";
+    expect(stripSkillFrontmatter(input)).toBe("# Just a heading\n\nSome content here.");
+  });
+
+  it("returns empty string for input containing only frontmatter", () => {
+    const input = "---\nname: only-meta\n---\n";
+    expect(stripSkillFrontmatter(input)).toBe("");
+  });
+
+  it("returns empty string for input containing only frontmatter with no trailing newline", () => {
+    const input = "---\nname: only-meta\n---";
+    expect(stripSkillFrontmatter(input)).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripSkillFrontmatter("")).toBe("");
+  });
+
+  it("strips multi-line description-style frontmatter", () => {
+    const input =
+      "---\nname: paperclip\ndescription: >\n  Multi-line\n  description here.\n---\n\n# Heading\n";
+    expect(stripSkillFrontmatter(input)).toBe("# Heading");
+  });
+
+  it("strips frontmatter containing backticks in values", () => {
+    const input = "---\nexample: `code`\n---\nContent after.";
+    expect(stripSkillFrontmatter(input)).toBe("Content after.");
+  });
+
+  it("trims leading whitespace from body", () => {
+    const input = "---\nkey: val\n---\n\n\n  Body with leading blank lines.";
+    expect(stripSkillFrontmatter(input)).toBe("Body with leading blank lines.");
+  });
+
+  it("does not strip a lone --- appearing mid-document", () => {
+    // A string starting with `---` but not having a closing `---` is not treated as frontmatter
+    // because the regex is non-greedy and requires a second `---`
+    const input = "---\nOnly one delimiter";
+    // Regex does NOT match (no closing ---) → content is returned as-is but trimmed
+    expect(stripSkillFrontmatter(input)).toBe("---\nOnly one delimiter");
+  });
+});

--- a/packages/adapters/copilot-cli/src/server/parse.ts
+++ b/packages/adapters/copilot-cli/src/server/parse.ts
@@ -1,0 +1,208 @@
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+import { asString, asNumber, parseJson } from "@paperclipai/adapter-utils/server-utils";
+
+/**
+ * Parse Copilot CLI JSONL output (--output-format json).
+ *
+ * Each line is a standalone JSON object with a `type` field.
+ * Key event types:
+ *   session.tools_updated  → model info
+ *   assistant.message      → text content, tool requests, output tokens
+ *   tool.execution_start   → tool invocation
+ *   tool.execution_complete→ tool result
+ *   result                 → terminal event with sessionId, exitCode, usage
+ */
+export function parseCopilotJsonl(stdout: string) {
+  let sessionId: string | null = null;
+  let model = "";
+  let finalResult: Record<string, unknown> | null = null;
+  const assistantTexts: string[] = [];
+  let totalOutputTokens = 0;
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) continue;
+
+    const type = asString(event.type, "");
+    const data =
+      typeof event.data === "object" && event.data !== null && !Array.isArray(event.data)
+        ? (event.data as Record<string, unknown>)
+        : {};
+
+    if (type === "session.tools_updated") {
+      model = asString(data.model, model);
+      continue;
+    }
+
+    if (type === "assistant.message") {
+      const content = asString(data.content, "");
+      if (content) assistantTexts.push(content);
+      totalOutputTokens += asNumber(data.outputTokens, 0);
+      continue;
+    }
+
+    if (type === "result") {
+      finalResult = event;
+      sessionId = asString(event.sessionId, sessionId ?? "") || sessionId;
+    }
+  }
+
+  if (!finalResult) {
+    return {
+      sessionId,
+      model,
+      costUsd: null as number | null,
+      usage: null as UsageSummary | null,
+      summary: assistantTexts.join("\n\n").trim(),
+      resultJson: null as Record<string, unknown> | null,
+    };
+  }
+
+  const usageObj =
+    typeof finalResult.usage === "object" &&
+    finalResult.usage !== null &&
+    !Array.isArray(finalResult.usage)
+      ? (finalResult.usage as Record<string, unknown>)
+      : {};
+
+  // Copilot CLI reports premiumRequests and timing but not standard token counts.
+  // We aggregate outputTokens from assistant.message events.
+  const usage: UsageSummary = {
+    inputTokens: 0,
+    outputTokens: totalOutputTokens,
+    cachedInputTokens: 0,
+  };
+
+  const summary = assistantTexts.join("\n\n").trim();
+  const premiumRequests = asNumber(usageObj.premiumRequests, 0);
+
+  return {
+    sessionId,
+    model,
+    costUsd: null as number | null,
+    usage,
+    summary,
+    resultJson: finalResult,
+    premiumRequests,
+  };
+}
+
+/**
+ * Describe a Copilot CLI failure from the result event.
+ */
+export function describeCopilotFailure(result: Record<string, unknown>): string | null {
+  const exitCode = asNumber(result.exitCode, -1);
+  if (exitCode === 0) return null;
+  return `Copilot CLI exited with code ${exitCode}`;
+}
+
+const AUTH_REQUIRED_RE =
+  /(?:not\s+logged\s+in|please\s+log\s+in|login\s+required|requires\s+login|unauthorized|authentication\s+required|copilot\s+login)/i;
+
+/**
+ * Detect whether the Copilot CLI output indicates an authentication problem.
+ */
+export function detectCopilotLoginRequired(input: {
+  stdout: string;
+  stderr: string;
+}): { requiresLogin: boolean } {
+  const combined = [input.stdout, input.stderr].join("\n");
+  return { requiresLogin: AUTH_REQUIRED_RE.test(combined) };
+}
+
+/**
+ * Check if the failure is due to a max autopilot continues limit.
+ */
+export function isCopilotMaxTurnsResult(result: Record<string, unknown>): boolean {
+  // Copilot CLI doesn't have a specific max-turns error subtype yet.
+  // We inspect the result for relevant patterns.
+  const resultStr = JSON.stringify(result).toLowerCase();
+  return /max.*auto.*pilot|auto.*pilot.*limit/i.test(resultStr);
+}
+
+/**
+ * Check if the failure is due to an unknown or expired session ID.
+ * When --resume is passed with a session that no longer exists, Copilot CLI
+ * emits an error containing session-not-found language.
+ */
+export function isCopilotUnknownSessionError(result: Record<string, unknown>): boolean {
+  const resultStr = JSON.stringify(result).toLowerCase();
+  return /unknown.*session|session.*not found|session.*expired|invalid.*session|session.*invalid/i.test(resultStr);
+}
+
+/**
+ * A loggable entry produced by interpreting a Copilot CLI JSONL line.
+ */
+export interface JsonlLogEntry {
+  stream: "stdout";
+  text: string;
+}
+
+/**
+ * Map a single raw JSONL line from Copilot CLI (--output-format json) to zero
+ * or more log entries that should be forwarded to the Paperclip run log.
+ *
+ * Emits:
+ *   assistant.message_delta → data.deltaContent text (streaming, real-time)
+ *   assistant.message       → data.content text (only when no deltas were seen for this message)
+ *   tool.execution_start    → "[toolName]\n" using data.toolName (or data.tool as fallback)
+ *
+ * All other event types, empty lines, non-JSON input, and non-object JSON
+ * (nulls, arrays, primitives) are silently suppressed → returns [].
+ */
+export function mapCopilotJsonlLineToLog(line: string, seenDeltaMessageIds?: Set<string>): JsonlLogEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return [];
+    const event = parsed as Record<string, unknown>;
+    const type = typeof event.type === "string" ? event.type : "";
+    const data =
+      typeof event.data === "object" && event.data !== null && !Array.isArray(event.data)
+        ? (event.data as Record<string, unknown>)
+        : {};
+
+    if (type === "assistant.message_delta") {
+      const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+      if (!deltaContent) return [];
+      const messageId = typeof data.messageId === "string" ? data.messageId : "";
+      if (messageId && seenDeltaMessageIds) seenDeltaMessageIds.add(messageId);
+      return [{ stream: "stdout", text: deltaContent }];
+    }
+
+    if (type === "assistant.message") {
+      const messageId = typeof data.messageId === "string" ? data.messageId : "";
+      // If we already streamed deltas for this messageId, suppress the full content
+      // to avoid duplication. Emit a newline to terminate the streamed block.
+      if (messageId && seenDeltaMessageIds?.has(messageId)) {
+        return [{ stream: "stdout", text: "\n" }];
+      }
+      const content = typeof data.content === "string" ? data.content : "";
+      return content ? [{ stream: "stdout", text: content + "\n" }] : [];
+    }
+
+    if (type === "tool.execution_start") {
+      const toolName =
+        typeof data.toolName === "string" ? data.toolName :
+        typeof data.tool === "string" ? data.tool :
+        "tool";
+      return [{ stream: "stdout", text: `[${toolName}]\n` }];
+    }
+
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Strip YAML frontmatter (the leading `--- ... ---` block) from a skill
+ * markdown file, returning the trimmed body text.  Returns an empty string
+ * if the body is empty or the input is empty.
+ */
+export function stripSkillFrontmatter(raw: string): string {
+  return raw.replace(/^---[\s\S]*?---\n?/, "").trim();
+}

--- a/packages/adapters/copilot-cli/src/server/session-codec.test.ts
+++ b/packages/adapters/copilot-cli/src/server/session-codec.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { sessionCodec } from "./index.js";
+import { isCopilotUnknownSessionError } from "./parse.js";
+
+// ─── sessionCodec.deserialize ─────────────────────────────────────────────────
+
+describe("sessionCodec.deserialize", () => {
+  it("returns null for null input", () => {
+    expect(sessionCodec.deserialize(null)).toBeNull();
+  });
+
+  it("returns null for non-object input", () => {
+    expect(sessionCodec.deserialize("string")).toBeNull();
+    expect(sessionCodec.deserialize(42)).toBeNull();
+    expect(sessionCodec.deserialize(true)).toBeNull();
+  });
+
+  it("returns null for array input", () => {
+    expect(sessionCodec.deserialize(["a", "b"])).toBeNull();
+  });
+
+  it("returns null when sessionId is missing", () => {
+    expect(sessionCodec.deserialize({ cwd: "/tmp" })).toBeNull();
+  });
+
+  it("returns null when sessionId is empty string", () => {
+    expect(sessionCodec.deserialize({ sessionId: "" })).toBeNull();
+  });
+
+  it("returns null when sessionId is whitespace-only", () => {
+    expect(sessionCodec.deserialize({ sessionId: "   " })).toBeNull();
+  });
+
+  it("extracts sessionId from sessionId field", () => {
+    const result = sessionCodec.deserialize({ sessionId: "abc-123" });
+    expect(result).toEqual({ sessionId: "abc-123" });
+  });
+
+  it("extracts sessionId from session_id field (snake_case fallback)", () => {
+    const result = sessionCodec.deserialize({ session_id: "def-456" });
+    expect(result).toEqual({ sessionId: "def-456" });
+  });
+
+  it("prefers sessionId over session_id", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "camel",
+      session_id: "snake",
+    });
+    expect(result).toEqual({ sessionId: "camel" });
+  });
+
+  it("includes cwd when present", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "s1",
+      cwd: "/home/user/project",
+    });
+    expect(result).toEqual({ sessionId: "s1", cwd: "/home/user/project" });
+  });
+
+  it("falls back to workdir for cwd", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "s1",
+      workdir: "/tmp/work",
+    });
+    expect(result).toEqual({ sessionId: "s1", cwd: "/tmp/work" });
+  });
+
+  it("falls back to folder for cwd", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "s1",
+      folder: "/opt/project",
+    });
+    expect(result).toEqual({ sessionId: "s1", cwd: "/opt/project" });
+  });
+
+  it("includes optional workspace fields", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "s1",
+      cwd: "/tmp",
+      workspaceId: "ws-1",
+      repoUrl: "https://github.com/org/repo",
+      repoRef: "main",
+    });
+    expect(result).toEqual({
+      sessionId: "s1",
+      cwd: "/tmp",
+      workspaceId: "ws-1",
+      repoUrl: "https://github.com/org/repo",
+      repoRef: "main",
+    });
+  });
+
+  it("reads snake_case workspace fields", () => {
+    const result = sessionCodec.deserialize({
+      session_id: "s1",
+      workspace_id: "ws-2",
+      repo_url: "https://github.com/org/repo2",
+      repo_ref: "develop",
+    });
+    expect(result).toEqual({
+      sessionId: "s1",
+      workspaceId: "ws-2",
+      repoUrl: "https://github.com/org/repo2",
+      repoRef: "develop",
+    });
+  });
+
+  it("trims whitespace from values", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "  s1  ",
+      cwd: "  /tmp  ",
+    });
+    expect(result).toEqual({ sessionId: "s1", cwd: "/tmp" });
+  });
+});
+
+// ─── sessionCodec.serialize ───────────────────────────────────────────────────
+
+describe("sessionCodec.serialize", () => {
+  it("returns null for null input", () => {
+    expect(sessionCodec.serialize(null)).toBeNull();
+  });
+
+  it("returns null when sessionId is missing", () => {
+    expect(sessionCodec.serialize({ cwd: "/tmp" })).toBeNull();
+  });
+
+  it("returns null when sessionId is empty", () => {
+    expect(sessionCodec.serialize({ sessionId: "" })).toBeNull();
+  });
+
+  it("serializes sessionId only", () => {
+    expect(sessionCodec.serialize({ sessionId: "s1" })).toEqual({
+      sessionId: "s1",
+    });
+  });
+
+  it("serializes all fields", () => {
+    const input = {
+      sessionId: "s1",
+      cwd: "/tmp",
+      workspaceId: "ws-1",
+      repoUrl: "https://github.com/org/repo",
+      repoRef: "main",
+    };
+    expect(sessionCodec.serialize(input)).toEqual(input);
+  });
+});
+
+// ─── sessionCodec round-trip ──────────────────────────────────────────────────
+
+describe("sessionCodec round-trip", () => {
+  it("round-trips full params through serialize → deserialize", () => {
+    const original = {
+      sessionId: "abc-123",
+      cwd: "/home/user/project",
+      workspaceId: "ws-42",
+      repoUrl: "https://github.com/org/repo",
+      repoRef: "feature-branch",
+    };
+    const serialized = sessionCodec.serialize(original);
+    const deserialized = sessionCodec.deserialize(serialized);
+    expect(deserialized).toEqual(original);
+  });
+
+  it("round-trips minimal params (sessionId only)", () => {
+    const original = { sessionId: "minimal-session" };
+    const serialized = sessionCodec.serialize(original);
+    const deserialized = sessionCodec.deserialize(serialized);
+    expect(deserialized).toEqual(original);
+  });
+});
+
+// ─── sessionCodec.getDisplayId ────────────────────────────────────────────────
+
+describe("sessionCodec.getDisplayId", () => {
+  it("returns null for null input", () => {
+    expect(sessionCodec.getDisplayId!(null)).toBeNull();
+  });
+
+  it("returns sessionId", () => {
+    expect(sessionCodec.getDisplayId!({ sessionId: "display-id" })).toBe("display-id");
+  });
+
+  it("returns session_id as fallback", () => {
+    expect(sessionCodec.getDisplayId!({ session_id: "snake-id" })).toBe("snake-id");
+  });
+
+  it("returns null when no session id field", () => {
+    expect(sessionCodec.getDisplayId!({ cwd: "/tmp" })).toBeNull();
+  });
+});
+
+// ─── isCopilotUnknownSessionError ─────────────────────────────────────────────
+
+describe("isCopilotUnknownSessionError", () => {
+  it("returns false for normal success result", () => {
+    expect(isCopilotUnknownSessionError({ exitCode: 0 })).toBe(false);
+  });
+
+  it("detects 'unknown session' error", () => {
+    expect(
+      isCopilotUnknownSessionError({ error: "unknown session abc-123" }),
+    ).toBe(true);
+  });
+
+  it("detects 'session not found' error", () => {
+    expect(
+      isCopilotUnknownSessionError({ error: "session not found" }),
+    ).toBe(true);
+  });
+
+  it("detects 'session expired' error", () => {
+    expect(
+      isCopilotUnknownSessionError({ error: "session expired" }),
+    ).toBe(true);
+  });
+
+  it("detects 'invalid session' error", () => {
+    expect(
+      isCopilotUnknownSessionError({ error: "invalid session id" }),
+    ).toBe(true);
+  });
+
+  it("detects 'session invalid' error", () => {
+    expect(
+      isCopilotUnknownSessionError({ error: "the session invalid for this request" }),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(
+      isCopilotUnknownSessionError({ error: "network timeout" }),
+    ).toBe(false);
+  });
+
+  it("detects errors in nested result objects", () => {
+    expect(
+      isCopilotUnknownSessionError({
+        exitCode: 1,
+        data: { message: "Session not found for ID abc" },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/adapters/copilot-cli/src/server/test.ts
+++ b/packages/adapters/copilot-cli/src/server/test.ts
@@ -1,0 +1,234 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asBoolean,
+  asNumber,
+  asStringArray,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import path from "node:path";
+import { parseCopilotJsonl, detectCopilotLoginRequired } from "./parse.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "copilot");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({
+      code: "copilot_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "copilot_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "copilot_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "copilot_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  // Check for GitHub token in environment
+  const hasEnvToken =
+    (typeof env.COPILOT_GITHUB_TOKEN === "string" && env.COPILOT_GITHUB_TOKEN.trim().length > 0) ||
+    (typeof env.GH_TOKEN === "string" && env.GH_TOKEN.trim().length > 0) ||
+    (typeof env.GITHUB_TOKEN === "string" && env.GITHUB_TOKEN.trim().length > 0) ||
+    (typeof process.env.COPILOT_GITHUB_TOKEN === "string" && process.env.COPILOT_GITHUB_TOKEN.trim().length > 0) ||
+    (typeof process.env.GH_TOKEN === "string" && process.env.GH_TOKEN.trim().length > 0) ||
+    (typeof process.env.GITHUB_TOKEN === "string" && process.env.GITHUB_TOKEN.trim().length > 0);
+
+  // Token check is deferred until after the hello probe — if the probe succeeds,
+  // Copilot is authenticated via its own stored OAuth session and no env token is needed.
+
+  const canRunProbe = checks.every(
+    (check) => check.code !== "copilot_cwd_invalid" && check.code !== "copilot_command_unresolvable",
+  );
+
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "copilot")) {
+      checks.push({
+        code: "copilot_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `copilot`.",
+        detail: command,
+      });
+    } else {
+      const model = asString(config.model, "").trim();
+      const reasoningEffort = asString(config.reasoningEffort, "").trim();
+      const allowAll = asBoolean(config.allowAll, false);
+      const extraArgs = (() => {
+        const fromExtraArgs = asStringArray(config.extraArgs);
+        if (fromExtraArgs.length > 0) return fromExtraArgs;
+        return asStringArray(config.args);
+      })();
+
+      const args = ["-p", "Respond with exactly: hello", "--output-format", "json", "--silent", "--no-ask-user", "--no-auto-update"];
+      if (allowAll) args.push("--yolo");
+      if (model) args.push("--model", model);
+      if (reasoningEffort) args.push("--reasoning-effort", reasoningEffort);
+      if (extraArgs.length > 0) args.push(...extraArgs);
+
+      const probe = await runChildProcess(
+        `copilot-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        args,
+        {
+          cwd,
+          env,
+          timeoutSec: 60,
+          graceSec: 5,
+          onLog: async () => {},
+        },
+      );
+
+      const parsedStream = parseCopilotJsonl(probe.stdout);
+      const loginMeta = detectCopilotLoginRequired({
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+      });
+      const detail = summarizeProbeDetail(probe.stdout, probe.stderr);
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "copilot_hello_probe_timed_out",
+          level: "warn",
+          message: "Copilot hello probe timed out.",
+          hint: "Retry the probe. If this persists, verify Copilot can run from this directory manually.",
+        });
+      } else if (loginMeta.requiresLogin) {
+        checks.push({
+          code: "copilot_hello_probe_auth_required",
+          level: "warn",
+          message: "Copilot CLI is installed, but login is required.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `copilot login` in this environment, then retry the probe.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        const summary = parsedStream.summary.trim();
+        const hasHello = /\bhello\b/i.test(summary);
+        checks.push({
+          code: hasHello ? "copilot_hello_probe_passed" : "copilot_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "Copilot hello probe succeeded."
+            : "Copilot probe ran but did not return `hello` as expected.",
+          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+          ...(hasHello ? {} : { hint: "Verify Copilot works manually with: copilot -p 'Respond with: hello'" }),
+        });
+      } else {
+        checks.push({
+          code: "copilot_hello_probe_failed",
+          level: "warn",
+          message: `Copilot hello probe exited with code ${probe.exitCode ?? -1}.`,
+          ...(detail ? { detail } : {}),
+          hint: "Verify the Copilot CLI is correctly installed and authenticated.",
+        });
+      }
+    }
+  }
+
+  // Emit token/auth check AFTER the probe so we can distinguish
+  // "no env token but stored OAuth works" from "no auth at all".
+  const probeSucceeded = checks.some((c) => c.code === "copilot_hello_probe_passed");
+  const probeNeedsLogin = checks.some((c) => c.code === "copilot_hello_probe_auth_required");
+
+  if (hasEnvToken) {
+    checks.push({
+      code: "copilot_github_token_found",
+      level: "info",
+      message: "GitHub token detected in environment.",
+    });
+  } else if (probeSucceeded) {
+    checks.push({
+      code: "copilot_auth_stored_session",
+      level: "info",
+      message: "Authenticated via Copilot stored session (`copilot login`).",
+    });
+  } else if (probeNeedsLogin) {
+    checks.push({
+      code: "copilot_github_token_missing",
+      level: "warn",
+      message: "No GitHub token or stored session found.",
+      hint: "Run `copilot login`, or set COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN.",
+    });
+  } else if (!canRunProbe) {
+    // Probe didn't run — we can't confirm auth, so warn
+    checks.push({
+      code: "copilot_github_token_missing",
+      level: "warn",
+      message: "No GitHub token found in environment.",
+      hint: "Set COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN, or run `copilot login`.",
+    });
+  }
+
+  return {
+    adapterType: "copilot_cli",
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/copilot-cli/src/ui/build-config.test.ts
+++ b/packages/adapters/copilot-cli/src/ui/build-config.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { buildCopilotCliConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function baseValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "copilot_cli",
+    cwd: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    maxTurnsPerRun: 100,
+    heartbeatEnabled: false,
+    intervalSec: 0,
+    ...overrides,
+  };
+}
+
+describe("buildCopilotCliConfig", () => {
+  it("returns default timeoutSec and graceSec for empty values", () => {
+    const ac = buildCopilotCliConfig(baseValues());
+    expect(ac.timeoutSec).toBe(0);
+    expect(ac.graceSec).toBe(15);
+  });
+
+  it("includes cwd when set", () => {
+    const ac = buildCopilotCliConfig(baseValues({ cwd: "/home/user/project" }));
+    expect(ac.cwd).toBe("/home/user/project");
+  });
+
+  it("omits cwd when empty", () => {
+    const ac = buildCopilotCliConfig(baseValues({ cwd: "" }));
+    expect(ac.cwd).toBeUndefined();
+  });
+
+  it("includes model when set", () => {
+    const ac = buildCopilotCliConfig(baseValues({ model: "gpt-5.4" }));
+    expect(ac.model).toBe("gpt-5.4");
+  });
+
+  it("maps thinkingEffort to reasoningEffort", () => {
+    const ac = buildCopilotCliConfig(baseValues({ thinkingEffort: "high" }));
+    expect(ac.reasoningEffort).toBe("high");
+  });
+
+  it("maps promptTemplate", () => {
+    const ac = buildCopilotCliConfig(baseValues({ promptTemplate: "Do the work." }));
+    expect(ac.promptTemplate).toBe("Do the work.");
+  });
+
+  it("maps bootstrapPrompt to bootstrapPromptTemplate", () => {
+    const ac = buildCopilotCliConfig(baseValues({ bootstrapPrompt: "Initialize." }));
+    expect(ac.bootstrapPromptTemplate).toBe("Initialize.");
+  });
+
+  it("maps dangerouslySkipPermissions to allowAll", () => {
+    const ac = buildCopilotCliConfig(baseValues({ dangerouslySkipPermissions: true }));
+    expect(ac.allowAll).toBe(true);
+  });
+
+  it("maps maxTurnsPerRun to maxAutopilotContinues", () => {
+    const ac = buildCopilotCliConfig(baseValues({ maxTurnsPerRun: 50 }));
+    expect(ac.maxAutopilotContinues).toBe(50);
+  });
+
+  it("includes command when set", () => {
+    const ac = buildCopilotCliConfig(baseValues({ command: "/usr/local/bin/copilot" }));
+    expect(ac.command).toBe("/usr/local/bin/copilot");
+  });
+
+  it("parses comma-separated extraArgs", () => {
+    const ac = buildCopilotCliConfig(baseValues({ extraArgs: "--verbose, --no-banner" }));
+    expect(ac.extraArgs).toEqual(["--verbose", "--no-banner"]);
+  });
+
+  it("omits extraArgs when empty", () => {
+    const ac = buildCopilotCliConfig(baseValues({ extraArgs: "" }));
+    expect(ac.extraArgs).toBeUndefined();
+  });
+
+  it("parses legacy envVars text", () => {
+    const ac = buildCopilotCliConfig(baseValues({ envVars: "FOO=bar\nBAZ=qux" }));
+    expect(ac.env).toEqual({
+      FOO: { type: "plain", value: "bar" },
+      BAZ: { type: "plain", value: "qux" },
+    });
+  });
+
+  it("parses envBindings with plain values", () => {
+    const ac = buildCopilotCliConfig(
+      baseValues({
+        envBindings: { MY_KEY: { type: "plain", value: "my-value" } },
+      }),
+    );
+    expect(ac.env).toEqual({
+      MY_KEY: { type: "plain", value: "my-value" },
+    });
+  });
+
+  it("parses envBindings with secret_ref values", () => {
+    const ac = buildCopilotCliConfig(
+      baseValues({
+        envBindings: { SECRET: { type: "secret_ref", secretId: "sec-1" } },
+      }),
+    );
+    expect(ac.env).toEqual({
+      SECRET: { type: "secret_ref", secretId: "sec-1" },
+    });
+  });
+
+  it("envBindings take precedence over legacy envVars", () => {
+    const ac = buildCopilotCliConfig(
+      baseValues({
+        envVars: "MY_KEY=legacy",
+        envBindings: { MY_KEY: { type: "plain", value: "binding" } },
+      }),
+    );
+    expect(ac.env).toEqual({
+      MY_KEY: { type: "plain", value: "binding" },
+    });
+  });
+
+  it("omits env when no env vars configured", () => {
+    const ac = buildCopilotCliConfig(baseValues());
+    expect(ac.env).toBeUndefined();
+  });
+
+  it("builds git_worktree workspace strategy", () => {
+    const ac = buildCopilotCliConfig(
+      baseValues({
+        workspaceStrategyType: "git_worktree",
+        workspaceBaseRef: "main",
+        workspaceBranchTemplate: "agent/{{agent.id}}/{{issue.key}}",
+        worktreeParentDir: "/tmp/worktrees",
+      }),
+    );
+    expect(ac.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      baseRef: "main",
+      branchTemplate: "agent/{{agent.id}}/{{issue.key}}",
+      worktreeParentDir: "/tmp/worktrees",
+    });
+  });
+
+  it("omits workspace strategy when type is not git_worktree", () => {
+    const ac = buildCopilotCliConfig(baseValues());
+    expect(ac.workspaceStrategy).toBeUndefined();
+  });
+
+  it("includes workspace runtime when valid JSON with services array", () => {
+    const json = JSON.stringify({ services: [{ type: "postgres" }] });
+    const ac = buildCopilotCliConfig(baseValues({ runtimeServicesJson: json }));
+    expect(ac.workspaceRuntime).toEqual({ services: [{ type: "postgres" }] });
+  });
+
+  it("omits workspace runtime for invalid JSON", () => {
+    const ac = buildCopilotCliConfig(baseValues({ runtimeServicesJson: "not json" }));
+    expect(ac.workspaceRuntime).toBeUndefined();
+  });
+
+  it("parses comma-separated allowTool", () => {
+    const ac = buildCopilotCliConfig(baseValues({ allowTool: "bash, gh, write_file" }));
+    expect(ac.allowTool).toEqual(["bash", "gh", "write_file"]);
+  });
+
+  it("omits allowTool when empty", () => {
+    const ac = buildCopilotCliConfig(baseValues({ allowTool: "" }));
+    expect(ac.allowTool).toBeUndefined();
+  });
+
+  it("omits allowTool when undefined", () => {
+    const ac = buildCopilotCliConfig(baseValues());
+    expect(ac.allowTool).toBeUndefined();
+  });
+
+  it("parses comma-separated denyTool", () => {
+    const ac = buildCopilotCliConfig(baseValues({ denyTool: "rm, curl" }));
+    expect(ac.denyTool).toEqual(["rm", "curl"]);
+  });
+
+  it("omits denyTool when empty", () => {
+    const ac = buildCopilotCliConfig(baseValues({ denyTool: "" }));
+    expect(ac.denyTool).toBeUndefined();
+  });
+
+  it("omits denyTool when undefined", () => {
+    const ac = buildCopilotCliConfig(baseValues());
+    expect(ac.denyTool).toBeUndefined();
+  });
+});

--- a/packages/adapters/copilot-cli/src/ui/build-config.ts
+++ b/packages/adapters/copilot-cli/src/ui/build-config.ts
@@ -1,0 +1,101 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function buildCopilotCliConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
+  if (v.model) ac.model = v.model;
+  if (v.thinkingEffort) ac.reasoningEffort = v.thinkingEffort;
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  ac.maxAutopilotContinues = v.maxTurnsPerRun;
+  ac.allowAll = v.dangerouslySkipPermissions;
+  if (v.workspaceStrategyType === "git_worktree") {
+    ac.workspaceStrategy = {
+      type: "git_worktree",
+      ...(v.workspaceBaseRef ? { baseRef: v.workspaceBaseRef } : {}),
+      ...(v.workspaceBranchTemplate ? { branchTemplate: v.workspaceBranchTemplate } : {}),
+      ...(v.worktreeParentDir ? { worktreeParentDir: v.worktreeParentDir } : {}),
+    };
+  }
+  const runtimeServices = parseJsonObject(v.runtimeServicesJson ?? "");
+  if (runtimeServices && Array.isArray(runtimeServices.services)) {
+    ac.workspaceRuntime = runtimeServices;
+  }
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  if (v.allowTool) ac.allowTool = parseCommaArgs(v.allowTool);
+  if (v.denyTool) ac.denyTool = parseCommaArgs(v.denyTool);
+  return ac;
+}

--- a/packages/adapters/copilot-cli/src/ui/index.ts
+++ b/packages/adapters/copilot-cli/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseCopilotStdoutLine } from "./parse-stdout.js";
+export { buildCopilotCliConfig } from "./build-config.js";

--- a/packages/adapters/copilot-cli/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/copilot-cli/src/ui/parse-stdout.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+import { parseCopilotStdoutLine } from "./parse-stdout.js";
+
+const ts = "2026-03-20T13:38:34.000Z";
+
+describe("parseCopilotStdoutLine", () => {
+  it("returns stdout for non-JSON lines", () => {
+    const entries = parseCopilotStdoutLine("plain text", ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("stdout");
+  });
+
+  it("parses session.tools_updated as init", () => {
+    const line = JSON.stringify({
+      type: "session.tools_updated",
+      data: { model: "gpt-5-4" },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("init");
+    if (entries[0]!.kind === "init") {
+      expect(entries[0]!.model).toBe("gpt-5-4");
+    }
+  });
+
+  it("parses assistant.message_delta as streaming delta", () => {
+    const line = JSON.stringify({
+      type: "assistant.message_delta",
+      data: { messageId: "m1", deltaContent: "hello" },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("assistant");
+    if (entries[0]!.kind === "assistant") {
+      expect(entries[0]!.text).toBe("hello");
+      expect(entries[0]!.delta).toBe(true);
+    }
+  });
+
+  it("parses assistant.message with text content", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: {
+        messageId: "m1",
+        content: "hello world",
+        toolRequests: [],
+        interactionId: "i1",
+        outputTokens: 5,
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries.some((e: TranscriptEntry) => e.kind === "assistant")).toBe(true);
+  });
+
+  it("parses assistant.message with tool requests", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: {
+        messageId: "m1",
+        content: "",
+        toolRequests: [
+          {
+            toolCallId: "tc1",
+            name: "bash",
+            arguments: { command: "ls" },
+            type: "function",
+          },
+        ],
+        interactionId: "i1",
+        outputTokens: 10,
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries.some((e: TranscriptEntry) => e.kind === "tool_call")).toBe(true);
+    const toolCall = entries.find((e: TranscriptEntry) => e.kind === "tool_call");
+    if (toolCall && toolCall.kind === "tool_call") {
+      expect(toolCall.name).toBe("bash");
+      expect(toolCall.toolUseId).toBe("tc1");
+    }
+  });
+
+  it("parses tool.execution_start", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_start",
+      data: {
+        toolCallId: "tc1",
+        toolName: "bash",
+        arguments: { command: "echo hi" },
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("tool_call");
+  });
+
+  it("parses tool.execution_complete", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolCallId: "tc1",
+        model: "claude-sonnet-4.6",
+        interactionId: "i1",
+        success: true,
+        result: { content: "output", detailedContent: "output" },
+        toolTelemetry: {},
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("tool_result");
+    if (entries[0]!.kind === "tool_result") {
+      expect(entries[0]!.content).toBe("output");
+      expect(entries[0]!.isError).toBe(false);
+    }
+  });
+
+  it("parses tool.execution_complete failure", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolCallId: "tc2",
+        success: false,
+        result: { content: "command failed" },
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    if (entries[0]!.kind === "tool_result") {
+      expect(entries[0]!.isError).toBe(true);
+    }
+  });
+
+  it("parses result event", () => {
+    const line = JSON.stringify({
+      type: "result",
+      sessionId: "sess-123",
+      exitCode: 0,
+      usage: { premiumRequests: 1 },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("result");
+    if (entries[0]!.kind === "result") {
+      expect(entries[0]!.isError).toBe(false);
+    }
+  });
+
+  it("parses result event with non-zero exit code as error", () => {
+    const line = JSON.stringify({
+      type: "result",
+      sessionId: "sess-123",
+      exitCode: 1,
+      usage: {},
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    if (entries[0]!.kind === "result") {
+      expect(entries[0]!.isError).toBe(true);
+    }
+  });
+
+  it("returns empty array for ephemeral session events", () => {
+    const line = JSON.stringify({
+      type: "session.mcp_servers_loaded",
+      data: { servers: [] },
+      ephemeral: true,
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("parses reasoning delta", () => {
+    const line = JSON.stringify({
+      type: "assistant.reasoning_delta",
+      data: { reasoningId: "r1", deltaContent: "thinking..." },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("thinking");
+  });
+
+  it("parses user.message", () => {
+    const line = JSON.stringify({
+      type: "user.message",
+      data: { content: "test prompt", transformedContent: "test prompt", attachments: [] },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.kind).toBe("user");
+  });
+});

--- a/packages/adapters/copilot-cli/src/ui/parse-stdout.ts
+++ b/packages/adapters/copilot-cli/src/ui/parse-stdout.ts
@@ -1,0 +1,165 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a single JSONL line from Copilot CLI stdout into TranscriptEntry[].
+ *
+ * Copilot CLI JSONL uses:
+ *   type: "session.tools_updated" → model init
+ *   type: "assistant.message"     → text content, tool requests
+ *   type: "assistant.message_delta" → streaming text delta
+ *   type: "user.message"          → user prompt
+ *   type: "tool.execution_start"  → tool invocation
+ *   type: "tool.execution_complete" → tool result
+ *   type: "result"                → terminal event with session/usage
+ */
+export function parseCopilotStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+  const data = asRecord(parsed.data) ?? {};
+
+  // Model init event
+  if (type === "session.tools_updated") {
+    const model = typeof data.model === "string" ? data.model : "unknown";
+    return [
+      {
+        kind: "init",
+        ts,
+        model,
+        sessionId: "",
+      },
+    ];
+  }
+
+  // Streaming text delta
+  if (type === "assistant.message_delta") {
+    const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+    if (deltaContent) {
+      return [{ kind: "assistant", ts, text: deltaContent, delta: true }];
+    }
+    return [];
+  }
+
+  // Full assistant message (with possible tool requests)
+  if (type === "assistant.message") {
+    const entries: TranscriptEntry[] = [];
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content) {
+      entries.push({ kind: "assistant", ts, text: content });
+    }
+    const toolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : [];
+    for (const reqRaw of toolRequests) {
+      const req = asRecord(reqRaw);
+      if (!req) continue;
+      entries.push({
+        kind: "tool_call",
+        ts,
+        name: typeof req.name === "string" ? req.name : "unknown",
+        toolUseId: typeof req.toolCallId === "string" ? req.toolCallId : undefined,
+        input: req.arguments ?? {},
+      });
+    }
+    // Extended thinking
+    const reasoningText = typeof data.reasoningText === "string" ? data.reasoningText : "";
+    if (reasoningText) {
+      entries.push({ kind: "thinking", ts, text: reasoningText });
+    }
+    return entries.length > 0 ? entries : [{ kind: "stdout", ts, text: line }];
+  }
+
+  // Reasoning delta (extended thinking stream)
+  if (type === "assistant.reasoning_delta") {
+    const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+    if (deltaContent) {
+      return [{ kind: "thinking", ts, text: deltaContent, delta: true }];
+    }
+    return [];
+  }
+
+  // User message
+  if (type === "user.message") {
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content) {
+      return [{ kind: "user", ts, text: content }];
+    }
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  // Tool execution start
+  if (type === "tool.execution_start") {
+    return [
+      {
+        kind: "tool_call",
+        ts,
+        name: typeof data.toolName === "string" ? data.toolName : "unknown",
+        toolUseId: typeof data.toolCallId === "string" ? data.toolCallId : undefined,
+        input: data.arguments ?? {},
+      },
+    ];
+  }
+
+  // Tool execution complete
+  if (type === "tool.execution_complete") {
+    const result = asRecord(data.result) ?? {};
+    const content = typeof result.content === "string" ? result.content : "";
+    return [
+      {
+        kind: "tool_result",
+        ts,
+        toolUseId: typeof data.toolCallId === "string" ? data.toolCallId : "",
+        content,
+        isError: data.success === false,
+      },
+    ];
+  }
+
+  // Terminal result event
+  if (type === "result") {
+    const usage = asRecord(parsed.usage) ?? {};
+    const outputTokens = 0; // Not available in result event
+    const sessionId = typeof parsed.sessionId === "string" ? parsed.sessionId : "";
+    const exitCode = asNumber(parsed.exitCode);
+    const isError = exitCode !== 0;
+    return [
+      {
+        kind: "result",
+        ts,
+        text: sessionId ? `Session: ${sessionId}` : "",
+        inputTokens: 0,
+        outputTokens,
+        cachedTokens: 0,
+        costUsd: 0,
+        subtype: isError ? "error" : "",
+        isError,
+        errors: isError ? [`Exit code: ${exitCode}`] : [],
+      },
+    ];
+  }
+
+  // Ephemeral events we can skip (session.mcp_servers_loaded, session.background_tasks_changed)
+  if (type.startsWith("session.") || type === "assistant.turn_start" || type === "assistant.turn_end" || type === "assistant.reasoning") {
+    return [];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/copilot-cli/tsconfig.json
+++ b/packages/adapters/copilot-cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/copilot-cli/vitest.config.ts
+++ b/packages/adapters/copilot-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "copilot_cli",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-cli':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-cli
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -114,6 +117,22 @@ importers:
         version: 5.9.3
 
   packages/adapters/codex-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/copilot-cli:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -441,6 +460,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-cli':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-cli
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -592,6 +614,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-cli':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-cli
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-copilot-cli": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -75,6 +75,15 @@ import {
   agentConfigurationDoc as hermesAgentConfigurationDoc,
   models as hermesModels,
 } from "hermes-paperclip-adapter";
+import {
+  execute as copilotCliExecute,
+  testEnvironment as copilotCliTestEnvironment,
+  sessionCodec as copilotCliSessionCodec,
+} from "@paperclipai/adapter-copilot-cli/server";
+import {
+  agentConfigurationDoc as copilotCliAgentConfigurationDoc,
+  models as copilotCliModels,
+} from "@paperclipai/adapter-copilot-cli";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
@@ -181,6 +190,17 @@ const hermesLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: hermesAgentConfigurationDoc,
 };
 
+const copilotCliAdapter: ServerAdapterModule = {
+  type: "copilot_cli",
+  execute: copilotCliExecute,
+  testEnvironment: copilotCliTestEnvironment,
+  sessionCodec: copilotCliSessionCodec,
+  sessionManagement: getAdapterSessionManagement("copilot_cli") ?? undefined,
+  models: copilotCliModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: copilotCliAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
@@ -191,6 +211,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
+    copilotCliAdapter,
     processAdapter,
     httpAdapter,
   ].map((a) => [a.type, a]),

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-copilot-cli": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/shared": "workspace:*",

--- a/ui/src/adapters/copilot-cli/config-fields.tsx
+++ b/ui/src/adapters/copilot-cli/config-fields.tsx
@@ -1,0 +1,175 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  ToggleField,
+  DraftInput,
+  DraftNumberInput,
+  help,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime.";
+
+export function CopilotCliConfigFields({
+  mode,
+  isCreate,
+  adapterType,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
+  );
+}
+
+export function CopilotCliAdvancedFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <ToggleField
+        label="Allow all permissions"
+        hint="Pass --yolo to Copilot CLI, bypassing all permission prompts"
+        checked={
+          isCreate
+            ? values!.dangerouslySkipPermissions
+            : eff(
+                "adapterConfig",
+                "allowAll",
+                config.allowAll !== false,
+              )
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ dangerouslySkipPermissions: v })
+            : mark("adapterConfig", "allowAll", v)
+        }
+      />
+      <Field label="Max autopilot continues" hint="Maximum autonomous turns via --max-autopilot-continues">
+        {isCreate ? (
+          <input
+            type="number"
+            className={inputClass}
+            value={values!.maxTurnsPerRun}
+            onChange={(e) => set!({ maxTurnsPerRun: Number(e.target.value) })}
+          />
+        ) : (
+          <DraftNumberInput
+            value={eff(
+              "adapterConfig",
+              "maxAutopilotContinues",
+              Number(config.maxAutopilotContinues ?? 100),
+            )}
+            onCommit={(v) => mark("adapterConfig", "maxAutopilotContinues", v || 100)}
+            immediate
+            className={inputClass}
+          />
+        )}
+      </Field>
+      <Field label="Allowed tools" hint="Comma-separated tool names to allow without prompting (--allow-tool)">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.allowTool ?? ""
+              : eff(
+                  "adapterConfig",
+                  "allowTool",
+                  Array.isArray(config.allowTool) ? config.allowTool.join(", ") : String(config.allowTool ?? ""),
+                )
+          }
+          onCommit={(v) => {
+            if (isCreate) {
+              set!({ allowTool: v });
+            } else {
+              const parsed = v
+                .split(",")
+                .map((s: string) => s.trim())
+                .filter(Boolean);
+              mark("adapterConfig", "allowTool", parsed.length > 0 ? parsed : undefined);
+            }
+          }}
+          immediate
+          className={inputClass}
+          placeholder="e.g. bash, gh, write_file"
+        />
+      </Field>
+      <Field label="Denied tools" hint="Comma-separated tool names to always deny (--deny-tool)">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.denyTool ?? ""
+              : eff(
+                  "adapterConfig",
+                  "denyTool",
+                  Array.isArray(config.denyTool) ? config.denyTool.join(", ") : String(config.denyTool ?? ""),
+                )
+          }
+          onCommit={(v) => {
+            if (isCreate) {
+              set!({ denyTool: v });
+            } else {
+              const parsed = v
+                .split(",")
+                .map((s: string) => s.trim())
+                .filter(Boolean);
+              mark("adapterConfig", "denyTool", parsed.length > 0 ? parsed : undefined);
+            }
+          }}
+          immediate
+          className={inputClass}
+          placeholder="e.g. rm, curl"
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/copilot-cli/index.ts
+++ b/ui/src/adapters/copilot-cli/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseCopilotStdoutLine } from "@paperclipai/adapter-copilot-cli/ui";
+import { CopilotCliConfigFields } from "./config-fields";
+import { buildCopilotCliConfig } from "@paperclipai/adapter-copilot-cli/ui";
+
+export const copilotCliUIAdapter: UIAdapterModule = {
+  type: "copilot_cli",
+  label: "GitHub Copilot CLI",
+  parseStdoutLine: parseCopilotStdoutLine,
+  ConfigFields: CopilotCliConfigFields,
+  buildAdapterConfig: buildCopilotCliConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { geminiLocalUIAdapter } from "./gemini-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
+import { copilotCliUIAdapter } from "./copilot-cli";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 
@@ -17,6 +18,7 @@ const uiAdapters: UIAdapterModule[] = [
   piLocalUIAdapter,
   cursorLocalUIAdapter,
   openClawGatewayUIAdapter,
+  copilotCliUIAdapter,
   processUIAdapter,
   httpUIAdapter,
 ];

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -41,6 +41,7 @@ import {
 import { defaultCreateValues } from "./agent-config-defaults";
 import { getUIAdapter } from "../adapters";
 import { ClaudeLocalAdvancedFields } from "../adapters/claude-local/config-fields";
+import { CopilotCliAdvancedFields } from "../adapters/copilot-cli/config-fields";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
@@ -297,7 +298,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     adapterType === "gemini_local" ||
     adapterType === "opencode_local" ||
     adapterType === "pi_local" ||
-    adapterType === "cursor";
+    adapterType === "cursor" ||
+    adapterType === "copilot_cli";
   const showLegacyWorkingDirectoryField =
     isLocal && shouldShowLegacyWorkingDirectoryField({ isCreate, adapterConfig: config });
   const uiAdapter = useMemo(() => getUIAdapter(adapterType), [adapterType]);
@@ -368,13 +370,15 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const thinkingEffortKey =
     adapterType === "codex_local"
       ? "modelReasoningEffort"
-      : adapterType === "cursor"
-        ? "mode"
-        : adapterType === "opencode_local"
-          ? "variant"
-          : "effort";
+      : adapterType === "copilot_cli"
+        ? "reasoningEffort"
+        : adapterType === "cursor"
+          ? "mode"
+          : adapterType === "opencode_local"
+            ? "variant"
+            : "effort";
   const thinkingEffortOptions =
-    adapterType === "codex_local"
+    adapterType === "codex_local" || adapterType === "copilot_cli"
       ? codexThinkingEffortOptions
       : adapterType === "cursor"
         ? cursorModeOptions
@@ -389,6 +393,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
           "modelReasoningEffort",
           String(config.modelReasoningEffort ?? config.reasoningEffort ?? ""),
         )
+      : adapterType === "copilot_cli"
+        ? eff("adapterConfig", "reasoningEffort", String(config.reasoningEffort ?? ""))
       : adapterType === "cursor"
         ? eff("adapterConfig", "mode", String(config.mode ?? ""))
       : adapterType === "opencode_local"
@@ -756,6 +762,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               {adapterType === "claude_local" && (
                 <ClaudeLocalAdvancedFields {...adapterFieldProps} />
               )}
+              {adapterType === "copilot_cli" && (
+                <CopilotCliAdvancedFields {...adapterFieldProps} />
+              )}
 
               <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
                 <DraftInput
@@ -960,7 +969,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "copilot_cli"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -21,6 +21,7 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",
+  copilot_cli: "Copilot (local)",
   process: "Process",
   http: "HTTP",
 };

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -15,6 +15,7 @@ import {
   Bot,
   Code,
   Gem,
+  Github,
   MousePointer2,
   Sparkles,
   Terminal,
@@ -25,6 +26,7 @@ import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 type AdvancedAdapterType =
   | "claude_local"
   | "codex_local"
+  | "copilot_cli"
   | "gemini_local"
   | "opencode_local"
   | "pi_local"
@@ -51,6 +53,12 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     icon: Code,
     desc: "Local Codex agent",
     recommended: true,
+  },
+  {
+    value: "copilot_cli",
+    label: "Copilot CLI",
+    icon: Github,
+    desc: "Local GitHub Copilot agent",
   },
   {
     value: "gemini_local",

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -48,6 +48,7 @@ import {
   Check,
   Loader2,
   ChevronDown,
+  Github,
   X
 } from "lucide-react";
 
@@ -55,6 +56,7 @@ type Step = 1 | 2 | 3 | 4;
 type AdapterType =
   | "claude_local"
   | "codex_local"
+  | "copilot_cli"
   | "gemini_local"
   | "opencode_local"
   | "pi_local"
@@ -193,6 +195,7 @@ export function OnboardingWizard() {
   const isLocalAdapter =
     adapterType === "claude_local" ||
     adapterType === "codex_local" ||
+    adapterType === "copilot_cli" ||
     adapterType === "gemini_local" ||
     adapterType === "opencode_local" ||
     adapterType === "cursor";
@@ -200,6 +203,8 @@ export function OnboardingWizard() {
     command.trim() ||
     (adapterType === "codex_local"
       ? "codex"
+      : adapterType === "copilot_cli"
+        ? "copilot"
       : adapterType === "gemini_local"
         ? "gemini"
       : adapterType === "cursor"
@@ -779,6 +784,12 @@ export function OnboardingWizard() {
                             label: "Gemini CLI",
                             icon: Gem,
                             desc: "Local Gemini agent"
+                          },
+                          {
+                            value: "copilot_cli" as const,
+                            label: "Copilot CLI",
+                            icon: Github,
+                            desc: "Local GitHub Copilot agent"
                           },
                           {
                             value: "opencode_local" as const,

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -64,6 +64,7 @@ export const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",
+  copilot_cli: "Copilot (local)",
   process: "Process",
   http: "HTTP",
 };

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -26,6 +26,7 @@ const adapterLabels: Record<string, string> = {
   gemini_local: "Gemini",
   opencode_local: "OpenCode",
   cursor: "Cursor",
+  copilot_cli: "Copilot",
   openclaw_gateway: "OpenClaw Gateway",
   process: "Process",
   http: "HTTP",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -19,6 +19,7 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode (local)",
   openclaw_gateway: "OpenClaw Gateway",
   cursor: "Cursor (local)",
+  copilot_cli: "Copilot (local)",
   process: "Process",
   http: "HTTP",
 };

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -122,6 +122,7 @@ const adapterLabels: Record<string, string> = {
   gemini_local: "Gemini",
   opencode_local: "OpenCode",
   cursor: "Cursor",
+  copilot_cli: "Copilot",
   openclaw_gateway: "OpenClaw Gateway",
   process: "Process",
   http: "HTTP",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/db", "packages/adapters/opencode-local", "server", "ui", "cli"],
+    projects: ["packages/db", "packages/adapter-utils", "packages/adapters/opencode-local", "packages/adapters/copilot-cli", "server", "ui", "cli"],
   },
 });


### PR DESCRIPTION
- Full adapter package (packages/adapters/copilot-cli) with server execute, JSONL parse, session codec, UI config fields, CLI format, and tests
- Register copilot_cli in server, UI, and CLI adapter registries
- Add Copilot CLI to NewAgentDialog and OnboardingWizard adapter selection
- Fix exit-code detection: treat exit code 1 as normal for Copilot CLI
- Support 18 models (GPT, Claude, Gemini families)