### PR TITLE
fix: surface full initdb stderr on embedded PostgreSQL failure

### DIFF
--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -750,6 +750,16 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
   }
 
   const port = await findAvailablePort(preferredPort);
+  const logBuffer: string[] = [];
+  const appendLog = (message: unknown) => {
+    const text = typeof message === "string" ? message : message instanceof Error ? message.message : String(message ?? "");
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed) logBuffer.push(trimmed);
+    }
+    if (logBuffer.length > 120) logBuffer.splice(0, logBuffer.length - 120);
+  };
+
   const instance = new EmbeddedPostgres({
     databaseDir: dataDir,
     user: "paperclip",
@@ -757,17 +767,33 @@ async function ensureEmbeddedPostgres(dataDir: string, preferredPort: number): P
     port,
     persistent: true,
     initdbFlags: ["--encoding=UTF8", "--locale=C"],
-    onLog: () => {},
-    onError: () => {},
+    onLog: appendLog,
+    onError: appendLog,
   });
 
   if (!existsSync(path.resolve(dataDir, "PG_VERSION"))) {
-    await instance.initialise();
+    try {
+      await instance.initialise();
+    } catch (err) {
+      const logs = logBuffer.length > 0 ? `\nPostgres logs:\n${logBuffer.join("\n")}` : "";
+      throw new Error(
+        `Failed to initialise embedded PostgreSQL cluster in ${dataDir} on port ${port}${logs}`,
+        { cause: err },
+      );
+    }
   }
   if (existsSync(postmasterPidFile)) {
     rmSync(postmasterPidFile, { force: true });
   }
-  await instance.start();
+  try {
+    await instance.start();
+  } catch (err) {
+    const logs = logBuffer.length > 0 ? `\nPostgres logs:\n${logBuffer.join("\n")}` : "";
+    throw new Error(
+      `Failed to start embedded PostgreSQL on port ${port}${logs}`,
+      { cause: err },
+    );
+  }
 
   return {
     port,

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -144,6 +144,16 @@ async function ensureEmbeddedPostgresConnection(
     };
   }
 
+  const logBuffer: string[] = [];
+  const appendLog = (message: unknown) => {
+    const text = typeof message === "string" ? message : message instanceof Error ? message.message : String(message ?? "");
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed) logBuffer.push(trimmed);
+    }
+    if (logBuffer.length > 120) logBuffer.splice(0, logBuffer.length - 120);
+  };
+
   const instance = new EmbeddedPostgres({
     databaseDir: dataDir,
     user: "paperclip",
@@ -151,17 +161,18 @@ async function ensureEmbeddedPostgresConnection(
     port: selectedPort,
     persistent: true,
     initdbFlags: ["--encoding=UTF8", "--locale=C"],
-    onLog: () => {},
-    onError: () => {},
+    onLog: appendLog,
+    onError: appendLog,
   });
 
   if (!existsSync(path.resolve(dataDir, "PG_VERSION"))) {
     try {
       await instance.initialise();
     } catch (error) {
+      const logs = logBuffer.length > 0 ? `\nPostgres logs:\n${logBuffer.join("\n")}` : "";
       throw toError(
         error,
-        `Failed to initialize embedded PostgreSQL cluster in ${dataDir} on port ${selectedPort}`,
+        `Failed to initialize embedded PostgreSQL cluster in ${dataDir} on port ${selectedPort}${logs}`,
       );
     }
   }
@@ -171,7 +182,8 @@ async function ensureEmbeddedPostgresConnection(
   try {
     await instance.start();
   } catch (error) {
-    throw toError(error, `Failed to start embedded PostgreSQL on port ${selectedPort}`);
+    const logs = logBuffer.length > 0 ? `\nPostgres logs:\n${logBuffer.join("\n")}` : "";
+    throw toError(error, `Failed to start embedded PostgreSQL on port ${selectedPort}${logs}`);
   }
 
   const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${selectedPort}/postgres`;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -276,16 +276,27 @@ export async function startServer(): Promise<StartedServer> {
       }
     };
     const logEmbeddedPostgresFailure = (phase: "initialise" | "start", err: unknown) => {
-      if (embeddedPostgresLogBuffer.length > 0) {
-        logger.error(
-          {
-            phase,
-            recentLogs: embeddedPostgresLogBuffer,
-            err,
-          },
-          "Embedded PostgreSQL failed; showing buffered startup logs",
-        );
-      }
+      logger.error(
+        {
+          phase,
+          recentLogs: embeddedPostgresLogBuffer.length > 0 ? embeddedPostgresLogBuffer : ["(no logs captured)"],
+          err,
+        },
+        "Embedded PostgreSQL failed; showing buffered startup logs",
+      );
+    };
+    const enrichInitError = (phase: "initialise" | "start", err: unknown): Error => {
+      const original = err instanceof Error ? err.message : String(err);
+      const logs = embeddedPostgresLogBuffer.length > 0
+        ? embeddedPostgresLogBuffer.join("\n")
+        : "(no logs captured — stderr may not have been piped)";
+      return new Error(
+        `Embedded PostgreSQL failed to ${phase}.\n` +
+        `Original error: ${original}\n` +
+        `Buffered postgres logs:\n${logs}\n` +
+        `Hint: re-run with PAPERCLIP_EMBEDDED_POSTGRES_VERBOSE=true for real-time logging, ` +
+        `or run 'initdb --encoding=UTF8 --locale=C -D <dataDir>' manually to see full stderr.`,
+      );
     };
   
     if (config.databaseMode === "postgres") {
@@ -357,7 +368,7 @@ export async function startServer(): Promise<StartedServer> {
             await embeddedPostgres.initialise();
           } catch (err) {
             logEmbeddedPostgresFailure("initialise", err);
-            throw err;
+            throw enrichInitError("initialise", err);
           }
         } else {
           logger.info(`Embedded PostgreSQL cluster already exists (${clusterVersionFile}); skipping init`);
@@ -371,7 +382,7 @@ export async function startServer(): Promise<StartedServer> {
           await embeddedPostgres.start();
         } catch (err) {
           logEmbeddedPostgresFailure("start", err);
-          throw err;
+          throw enrichInitError("start", err);
         }
         embeddedPostgresStartedByThisProcess = true;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Paperclip ships an embedded PostgreSQL so users don't need to install Postgres separately
> - But embedded Postgres needs to run `initdb` to initialise a fresh data cluster on first launch
> - On some environments (notably WSL2 / minimal Ubuntu), `initdb` fails due to missing locale data or libc incompatibilities
> - When `initdb` fails, the error output (stderr) is either silently swallowed or only partially captured — users see a cryptic "Postgres init script exited with code 1" with just 2 lines of preamble and no actual root cause
> - This makes it impossible for users to self-diagnose the problem
> - This PR surfaces the full buffered postgres logs in error messages across all 3 callsites, and adds actionable hints so users can debug initdb failures themselves

## What changed

### `server/src/index.ts`
- **Removed the buffer-length guard** on `logEmbeddedPostgresFailure` — errors are now always logged to pino, even if no postgres output was captured (previously silently dropped)
- **Added `enrichInitError()` helper** — wraps the thrown error with: the original error message, all buffered postgres logs, and a hint to use `PAPERCLIP_EMBEDDED_POSTGRES_VERBOSE=true` or run `initdb` manually for full stderr

### `packages/db/src/migration-runtime.ts`
- **Replaced silent `() => {}` log handlers** with actual log capture using the same circular buffer pattern from the server
- **Error messages now include buffered postgres logs** when `initialise()` or `start()` fails

### `cli/src/commands/worktree.ts`
- **Same fix** — replaced silent `() => {}` handlers with log capture
- **Added proper try/catch** around `initialise()` and `start()` (previously unhandled — would throw raw errors with no context)
- Error messages include buffered logs and use `{ cause: err }` for proper error chaining

## Why it matters

Without this fix, any user whose `initdb` fails (WSL2, minimal Linux installs, libc mismatches) gets an error message with zero diagnostic information. They cannot tell whether the problem is a missing locale, a permission issue, or an incompatible binary — and neither can anyone helping them.

With this fix, the full postgres output is included in the error, and users get an actionable hint to re-run with verbose logging or run `initdb` manually.

## How to verify

1. Simulate an `initdb` failure (e.g., corrupt the embedded postgres binary path, or run on a minimal container missing locale data)
2. Run `npx paperclipai run` — the error message should now include the full buffered postgres logs and hint text
3. Existing tests still pass (`vitest run cli/src/__tests__/worktree.test.ts`, `vitest run packages/db/src/runtime-config.test.ts`)

## Risks

- **Low risk** — no behavioral change on the happy path; only error messages are improved on failure
- No new dependencies
- No API/schema changes

Fixes #1032