### PR TITLE
Harden live events and share UI sockets

### DIFF
--- a/cli/src/__tests__/onboard.test.ts
+++ b/cli/src/__tests__/onboard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { resolveOpenOnListenValueForOnboardRun } from "../commands/onboard.js";
+
+describe("resolveOpenOnListenValueForOnboardRun", () => {
+  it("defaults to opening the browser when no explicit preference is set", () => {
+    expect(resolveOpenOnListenValueForOnboardRun(undefined)).toBe("true");
+  });
+
+  it("preserves an explicit false preference from the caller environment", () => {
+    expect(resolveOpenOnListenValueForOnboardRun("false")).toBe("false");
+  });
+});

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -233,6 +233,10 @@ function canCreateBootstrapInviteImmediately(config: Pick<PaperclipConfig, "data
   return config.server.deploymentMode === "authenticated" && config.database.mode !== "embedded-postgres";
 }
 
+export function resolveOpenOnListenValueForOnboardRun(existingValue: string | undefined) {
+  return existingValue?.trim().length ? existingValue : "true";
+}
+
 export async function onboard(opts: OnboardOptions): Promise<void> {
   printPaperclipCliBanner();
   p.intro(pc.bgCyan(pc.black(" paperclipai onboard ")));
@@ -471,7 +475,9 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
   }
 
   if (shouldRunNow && !opts.invokedByRun) {
-    process.env.PAPERCLIP_OPEN_ON_LISTEN = "true";
+    process.env.PAPERCLIP_OPEN_ON_LISTEN = resolveOpenOnListenValueForOnboardRun(
+      process.env.PAPERCLIP_OPEN_ON_LISTEN,
+    );
     const { runCommand } = await import("./run.js");
     await runCommand({ config: configPath, repair: true, yes: true });
     return;

--- a/server/src/__tests__/live-events-ws.test.ts
+++ b/server/src/__tests__/live-events-ws.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import { agentApiKeys, agents } from "@paperclipai/db";
+import { authorizeUpgrade } from "../realtime/live-events-ws.js";
+
+function createDbStub(options?: {
+  keyRow?: Record<string, unknown> | null;
+  agentRow?: Record<string, unknown> | null;
+}) {
+  let currentTable: unknown = null;
+  return {
+    select() {
+      return {
+        from(table: unknown) {
+          currentTable = table;
+          return {
+            where() {
+              if (currentTable === agentApiKeys) {
+                return Promise.resolve(options?.keyRow ? [options.keyRow] : []);
+              }
+              if (currentTable === agents) {
+                return Promise.resolve(options?.agentRow ? [options.agentRow] : []);
+              }
+              return Promise.resolve([]);
+            },
+          };
+        },
+      };
+    },
+    update() {
+      return {
+        set() {
+          return {
+            where() {
+              return Promise.resolve();
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("authorizeUpgrade", () => {
+  it("rejects local-trusted board websocket upgrades from untrusted origins", async () => {
+    const req = {
+      headers: {
+        host: "127.0.0.1:3100",
+        origin: "https://evil.example",
+      },
+    } as any;
+
+    const result = await authorizeUpgrade(
+      createDbStub() as never,
+      req,
+      "company-1",
+      new URL("http://127.0.0.1:3100/api/companies/company-1/events/ws"),
+      {
+        deploymentMode: "local_trusted",
+        deploymentExposure: "private",
+        allowedHostnames: [],
+        bindHost: "127.0.0.1",
+      },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("allows local-trusted board websocket upgrades from trusted origins", async () => {
+    const req = {
+      headers: {
+        host: "127.0.0.1:3100",
+        origin: "http://127.0.0.1:3100",
+      },
+    } as any;
+
+    const result = await authorizeUpgrade(
+      createDbStub() as never,
+      req,
+      "company-1",
+      new URL("http://127.0.0.1:3100/api/companies/company-1/events/ws"),
+      {
+        deploymentMode: "local_trusted",
+        deploymentExposure: "private",
+        allowedHostnames: [],
+        bindHost: "127.0.0.1",
+      },
+    );
+
+    expect(result).toEqual({
+      actorId: "board",
+      actorType: "board",
+      companyId: "company-1",
+    });
+  });
+
+  it("rejects agent websocket upgrades when the agent is terminated", async () => {
+    const req = {
+      headers: {
+        host: "127.0.0.1:3100",
+        authorization: "Bearer test-token",
+      },
+    } as any;
+
+    const result = await authorizeUpgrade(
+      createDbStub({
+        keyRow: { id: "key-1", keyHash: "hash", companyId: "company-1", agentId: "agent-1" },
+        agentRow: { id: "agent-1", companyId: "company-1", status: "terminated" },
+      }) as never,
+      req,
+      "company-1",
+      new URL("http://127.0.0.1:3100/api/companies/company-1/events/ws"),
+      {
+        deploymentMode: "authenticated",
+        deploymentExposure: "private",
+        allowedHostnames: [],
+        bindHost: "127.0.0.1",
+      },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects websocket upgrades on private authenticated deployments when the host is not allowed", async () => {
+    const req = {
+      headers: {
+        host: "evil.example:3100",
+        authorization: "Bearer test-token",
+      },
+    } as any;
+
+    const result = await authorizeUpgrade(
+      createDbStub({
+        keyRow: { id: "key-1", keyHash: "hash", companyId: "company-1", agentId: "agent-1" },
+        agentRow: { id: "agent-1", companyId: "company-1", status: "active" },
+      }) as never,
+      req,
+      "company-1",
+      new URL("http://evil.example:3100/api/companies/company-1/events/ws"),
+      {
+        deploymentMode: "authenticated",
+        deploymentExposure: "private",
+        allowedHostnames: [],
+        bindHost: "127.0.0.1",
+      },
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -508,6 +508,9 @@ export async function startServer(): Promise<StartedServer> {
   
   setupLiveEventsWebSocketServer(server, db as any, {
     deploymentMode: config.deploymentMode,
+    deploymentExposure: config.deploymentExposure,
+    allowedHostnames: config.allowedHostnames,
+    bindHost: config.host,
     resolveSessionFromHeaders,
   });
 

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -4,10 +4,11 @@ import { createRequire } from "node:module";
 import type { Duplex } from "node:stream";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agentApiKeys, companyMemberships, instanceUserRoles } from "@paperclipai/db";
-import type { DeploymentMode } from "@paperclipai/shared";
+import { agentApiKeys, agents, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
+import { resolvePrivateHostnameAllowSet } from "../middleware/private-hostname-guard.js";
 import { subscribeCompanyLiveEvents } from "../services/live-events.js";
 
 interface WsSocket {
@@ -92,22 +93,92 @@ function headersFromIncomingMessage(req: IncomingMessage): Headers {
   return headers;
 }
 
-async function authorizeUpgrade(
+function extractUpgradeHost(req: IncomingMessage) {
+  const forwardedHost = req.headers["x-forwarded-host"];
+  const raw = Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost;
+  const host = raw?.split(",")[0]?.trim() || req.headers.host?.trim() || "";
+  return host.length > 0 ? host.toLowerCase() : null;
+}
+
+function extractUpgradeHostname(req: IncomingMessage) {
+  const host = extractUpgradeHost(req);
+  if (!host) return null;
+  try {
+    return new URL(`http://${host}`).hostname.trim().toLowerCase();
+  } catch {
+    return host.trim().toLowerCase();
+  }
+}
+
+function parseOrigin(rawOrigin: string | string[] | undefined) {
+  const origin = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+  if (!origin) return null;
+  try {
+    return new URL(origin);
+  } catch {
+    return null;
+  }
+}
+
+function isUpgradeHostAllowed(
+  req: IncomingMessage,
+  opts: {
+    deploymentMode: DeploymentMode;
+    deploymentExposure: DeploymentExposure;
+    allowedHostnames: string[];
+    bindHost: string;
+  },
+) {
+  if (opts.deploymentMode !== "authenticated" || opts.deploymentExposure !== "private") {
+    return true;
+  }
+
+  const hostname = extractUpgradeHostname(req);
+  if (!hostname) return false;
+
+  const allowSet = resolvePrivateHostnameAllowSet({
+    allowedHostnames: opts.allowedHostnames,
+    bindHost: opts.bindHost,
+  });
+  return allowSet.has(hostname);
+}
+
+function isTrustedBoardUpgradeOrigin(req: IncomingMessage) {
+  const host = extractUpgradeHost(req);
+  const origin = parseOrigin(req.headers.origin);
+  if (!host || !origin) return false;
+
+  const trustedOrigins = new Set([`http://${host}`.toLowerCase(), `https://${host}`.toLowerCase()]);
+  return trustedOrigins.has(origin.origin.toLowerCase());
+}
+
+export async function authorizeUpgrade(
   db: Db,
   req: IncomingMessage,
   companyId: string,
   url: URL,
   opts: {
     deploymentMode: DeploymentMode;
+    deploymentExposure: DeploymentExposure;
+    allowedHostnames: string[];
+    bindHost: string;
     resolveSessionFromHeaders?: (headers: Headers) => Promise<BetterAuthSessionResult | null>;
   },
 ): Promise<UpgradeContext | null> {
+  if (!isUpgradeHostAllowed(req, opts)) {
+    return null;
+  }
+
   const queryToken = url.searchParams.get("token")?.trim() ?? "";
   const authToken = parseBearerToken(req.headers.authorization);
   const token = authToken ?? (queryToken.length > 0 ? queryToken : null);
 
   // Browser board context has no bearer token in local_trusted and authenticated modes.
   if (!token) {
+    if (!isTrustedBoardUpgradeOrigin(req)) {
+      return null;
+    }
+
     if (opts.deploymentMode === "local_trusted") {
       return {
         companyId,
@@ -168,6 +239,21 @@ async function authorizeUpgrade(
     .set({ lastUsedAt: new Date() })
     .where(eq(agentApiKeys.id, key.id));
 
+  const agentRecord = await db
+    .select()
+    .from(agents)
+    .where(eq(agents.id, key.agentId))
+    .then((rows) => rows[0] ?? null);
+
+  if (
+    !agentRecord ||
+    agentRecord.companyId !== companyId ||
+    agentRecord.status === "terminated" ||
+    agentRecord.status === "pending_approval"
+  ) {
+    return null;
+  }
+
   return {
     companyId,
     actorType: "agent",
@@ -180,6 +266,9 @@ export function setupLiveEventsWebSocketServer(
   db: Db,
   opts: {
     deploymentMode: DeploymentMode;
+    deploymentExposure: DeploymentExposure;
+    allowedHostnames: string[];
+    bindHost: string;
     resolveSessionFromHeaders?: (headers: Headers) => Promise<BetterAuthSessionResult | null>;
   },
 ) {
@@ -248,6 +337,9 @@ export function setupLiveEventsWebSocketServer(
 
     void authorizeUpgrade(db, req, companyId, url, {
       deploymentMode: opts.deploymentMode,
+      deploymentExposure: opts.deploymentExposure,
+      allowedHostnames: opts.allowedHostnames,
+      bindHost: opts.bindHost,
       resolveSessionFromHeaders: opts.resolveSessionFromHeaders,
     })
       .then((context) => {

--- a/ui/src/components/transcript/useLiveRunTranscripts.ts
+++ b/ui/src/components/transcript/useLiveRunTranscripts.ts
@@ -4,6 +4,7 @@ import type { LiveEvent } from "@paperclipai/shared";
 import { instanceSettingsApi } from "../../api/instanceSettings";
 import { heartbeatsApi, type LiveRunForIssue } from "../../api/heartbeats";
 import { buildTranscript, getUIAdapter, type RunLogChunk, type TranscriptEntry } from "../../adapters";
+import { subscribeToCompanyLiveEvents } from "../../lib/live-events-socket";
 import { queryKeys } from "../../lib/queryKeys";
 
 const LOG_POLL_INTERVAL_MS = 2000;
@@ -174,32 +175,8 @@ export function useLiveRunTranscripts({
   useEffect(() => {
     if (!companyId || activeRunIds.size === 0) return;
 
-    let closed = false;
-    let reconnectTimer: number | null = null;
-    let socket: WebSocket | null = null;
-
-    const scheduleReconnect = () => {
-      if (closed) return;
-      reconnectTimer = window.setTimeout(connect, 1500);
-    };
-
-    const connect = () => {
-      if (closed) return;
-      const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-      const url = `${protocol}://${window.location.host}/api/companies/${encodeURIComponent(companyId)}/events/ws`;
-      socket = new WebSocket(url);
-
-      socket.onmessage = (message) => {
-        const raw = typeof message.data === "string" ? message.data : "";
-        if (!raw) return;
-
-        let event: LiveEvent;
-        try {
-          event = JSON.parse(raw) as LiveEvent;
-        } catch {
-          return;
-        }
-
+    const unsubscribe = subscribeToCompanyLiveEvents(companyId, {
+      onEvent: (event: LiveEvent) => {
         if (event.companyId !== companyId) return;
         const payload = event.payload ?? {};
         const runId = readString(payload["runId"]);
@@ -247,28 +224,11 @@ export function useLiveRunTranscripts({
             dedupeKey: `socket:status:${runId}:${status}:${readString(payload["finishedAt"]) ?? ""}`,
           }]);
         }
-      };
-
-      socket.onerror = () => {
-        socket?.close();
-      };
-
-      socket.onclose = () => {
-        scheduleReconnect();
-      };
-    };
-
-    connect();
+      },
+    });
 
     return () => {
-      closed = true;
-      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
-      if (socket) {
-        socket.onmessage = null;
-        socket.onerror = null;
-        socket.onclose = null;
-        socket.close(1000, "live_run_transcripts_unmount");
-      }
+      unsubscribe();
     };
   }, [activeRunIds, companyId, runById]);
 

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -4,6 +4,7 @@ import type { Agent, Issue, LiveEvent } from "@paperclipai/shared";
 import type { RunForIssue } from "../api/activity";
 import type { ActiveRunForIssue, LiveRunForIssue } from "../api/heartbeats";
 import { authApi } from "../api/auth";
+import { subscribeToCompanyLiveEvents } from "../lib/live-events-socket";
 import { useCompany } from "./CompanyContext";
 import type { ToastInput } from "./ToastContext";
 import { useToast } from "./ToastContext";
@@ -679,78 +680,22 @@ export function LiveUpdatesProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!selectedCompanyId) return;
 
-    let closed = false;
-    let reconnectAttempt = 0;
-    let reconnectTimer: number | null = null;
-    let socket: WebSocket | null = null;
-
-    const clearReconnect = () => {
-      if (reconnectTimer !== null) {
-        window.clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-    };
-
-    const scheduleReconnect = () => {
-      if (closed) return;
-      reconnectAttempt += 1;
-      const delayMs = Math.min(15000, 1000 * 2 ** Math.min(reconnectAttempt - 1, 4));
-      reconnectTimer = window.setTimeout(() => {
-        reconnectTimer = null;
-        connect();
-      }, delayMs);
-    };
-
-    const connect = () => {
-      if (closed) return;
-      const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-      const url = `${protocol}://${window.location.host}/api/companies/${encodeURIComponent(selectedCompanyId)}/events/ws`;
-      socket = new WebSocket(url);
-
-      socket.onopen = () => {
-        if (reconnectAttempt > 0) {
+    const unsubscribe = subscribeToCompanyLiveEvents(selectedCompanyId, {
+      onOpen: ({ isReconnect }) => {
+        if (isReconnect) {
           gateRef.current.suppressUntil = Date.now() + RECONNECT_SUPPRESS_MS;
         }
-        reconnectAttempt = 0;
-      };
-
-      socket.onmessage = (message) => {
-        const raw = typeof message.data === "string" ? message.data : "";
-        if (!raw) return;
-
-        try {
-          const parsed = JSON.parse(raw) as LiveEvent;
-          handleLiveEvent(queryClient, selectedCompanyId, pathnameRef.current, parsed, pushToast, gateRef.current, {
-            userId: currentUserId,
-            agentId: null,
-          });
-        } catch {
-          // Ignore non-JSON payloads.
-        }
-      };
-
-      socket.onerror = () => {
-        socket?.close();
-      };
-
-      socket.onclose = () => {
-        if (closed) return;
-        scheduleReconnect();
-      };
-    };
-
-    connect();
+      },
+      onEvent: (parsed) => {
+        handleLiveEvent(queryClient, selectedCompanyId, pathnameRef.current, parsed, pushToast, gateRef.current, {
+          userId: currentUserId,
+          agentId: null,
+        });
+      },
+    });
 
     return () => {
-      closed = true;
-      clearReconnect();
-      if (socket) {
-        socket.onopen = null;
-        socket.onmessage = null;
-        socket.onerror = null;
-        socket.onclose = null;
-        socket.close(1000, "provider_unmount");
-      }
+      unsubscribe();
     };
   }, [queryClient, selectedCompanyId, pushToast, currentUserId]);
 

--- a/ui/src/lib/live-events-socket.test.ts
+++ b/ui/src/lib/live-events-socket.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LiveEvent } from "@paperclipai/shared";
+import { createCompanyLiveEventsRegistry } from "./live-events-socket";
+
+interface FakeSocket {
+  close: ReturnType<typeof vi.fn>;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+  onerror: (() => void) | null;
+  onclose: (() => void) | null;
+}
+
+function createFakeSocket(): FakeSocket {
+  return {
+    close: vi.fn(),
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+  };
+}
+
+describe("createCompanyLiveEventsRegistry", () => {
+  it("shares a single websocket per company across multiple subscribers", () => {
+    const sockets: FakeSocket[] = [];
+    const registry = createCompanyLiveEventsRegistry({
+      createSocket: () => {
+        const socket = createFakeSocket();
+        sockets.push(socket);
+        return socket as never;
+      },
+      getLocation: () => ({
+        host: "127.0.0.1:3100",
+        protocol: "http:",
+      }),
+    });
+    const receivedByA: LiveEvent[] = [];
+    const receivedByB: LiveEvent[] = [];
+
+    const unsubscribeA = registry.subscribe("company-1", {
+      onEvent: (event) => {
+        receivedByA.push(event);
+      },
+    });
+    const unsubscribeB = registry.subscribe("company-1", {
+      onEvent: (event) => {
+        receivedByB.push(event);
+      },
+    });
+
+    expect(sockets).toHaveLength(1);
+
+    sockets[0]?.onmessage?.({
+      data: JSON.stringify({
+        id: 1,
+        type: "heartbeat.run.status",
+        companyId: "company-1",
+        createdAt: "2026-03-23T00:00:00.000Z",
+        payload: { runId: "run-1", status: "running" },
+      } satisfies LiveEvent),
+    });
+
+    expect(receivedByA).toHaveLength(1);
+    expect(receivedByB).toHaveLength(1);
+
+    unsubscribeA();
+    expect(sockets[0]?.close).not.toHaveBeenCalled();
+
+    unsubscribeB();
+    expect(sockets[0]?.close).toHaveBeenCalledWith(1000, "last_subscriber");
+  });
+
+  it("notifies late subscribers immediately when the shared socket is already open", () => {
+    const socket = createFakeSocket();
+    const registry = createCompanyLiveEventsRegistry({
+      createSocket: () => socket as never,
+      getLocation: () => ({
+        host: "127.0.0.1:3100",
+        protocol: "http:",
+      }),
+    });
+    const onOpen = vi.fn();
+
+    registry.subscribe("company-1", {});
+    socket.onopen?.();
+
+    const unsubscribe = registry.subscribe("company-1", { onOpen });
+
+    expect(onOpen).toHaveBeenCalledWith({ isReconnect: false });
+
+    unsubscribe();
+  });
+});

--- a/ui/src/lib/live-events-socket.ts
+++ b/ui/src/lib/live-events-socket.ts
@@ -1,0 +1,157 @@
+import type { LiveEvent } from "@paperclipai/shared";
+
+interface WebSocketLike {
+  onopen: ((event?: unknown) => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+  onclose: ((event?: unknown) => void) | null;
+  close(code?: number, reason?: string): void;
+}
+
+interface Subscriber {
+  onEvent?: (event: LiveEvent) => void;
+  onOpen?: (info: { isReconnect: boolean }) => void;
+  onClose?: () => void;
+}
+
+interface RegistryOptions {
+  createSocket?: (url: string) => WebSocketLike;
+  getLocation?: () => { protocol: string; host: string };
+}
+
+interface Entry {
+  reconnectAttempt: number;
+  reconnectTimer: number | null;
+  socket: WebSocketLike | null;
+  socketOpen: boolean;
+  subscribers: Set<Subscriber>;
+}
+
+function buildLiveEventsUrl(companyId: string, location: { protocol: string; host: string }) {
+  const protocol = location.protocol === "https:" ? "wss" : "ws";
+  return `${protocol}://${location.host}/api/companies/${encodeURIComponent(companyId)}/events/ws`;
+}
+
+export function createCompanyLiveEventsRegistry(opts: RegistryOptions = {}) {
+  const entries = new Map<string, Entry>();
+  const createSocket = opts.createSocket ?? ((url: string) => new WebSocket(url) as unknown as WebSocketLike);
+  const getLocation = opts.getLocation ?? (() => window.location);
+
+  const clearReconnect = (entry: Entry) => {
+    if (entry.reconnectTimer !== null) {
+      window.clearTimeout(entry.reconnectTimer);
+      entry.reconnectTimer = null;
+    }
+  };
+
+  const cleanupEntry = (companyId: string, entry: Entry, reason: string) => {
+    clearReconnect(entry);
+    if (entry.socket) {
+      entry.socket.onopen = null;
+      entry.socket.onmessage = null;
+      entry.socket.onerror = null;
+      entry.socket.onclose = null;
+      entry.socket.close(1000, reason);
+      entry.socket = null;
+    }
+    entry.socketOpen = false;
+    entries.delete(companyId);
+  };
+
+  const notifyClose = (entry: Entry) => {
+    for (const subscriber of entry.subscribers) {
+      subscriber.onClose?.();
+    }
+  };
+
+  const notifyOpen = (entry: Entry, isReconnect: boolean) => {
+    for (const subscriber of entry.subscribers) {
+      subscriber.onOpen?.({ isReconnect });
+    }
+  };
+
+  const connect = (companyId: string, entry: Entry) => {
+    const socket = createSocket(buildLiveEventsUrl(companyId, getLocation()));
+    entry.socket = socket;
+    entry.socketOpen = false;
+
+    socket.onopen = () => {
+      const isReconnect = entry.reconnectAttempt > 0;
+      entry.reconnectAttempt = 0;
+      entry.socketOpen = true;
+      notifyOpen(entry, isReconnect);
+    };
+
+    socket.onmessage = (message: { data: unknown }) => {
+      if (typeof message.data !== "string" || message.data.length === 0) return;
+
+      try {
+        const event = JSON.parse(message.data) as LiveEvent;
+        for (const subscriber of entry.subscribers) {
+          subscriber.onEvent?.(event);
+        }
+      } catch {
+        // Ignore malformed payloads from the shared stream.
+      }
+    };
+
+    socket.onerror = () => {
+      entry.socket?.close();
+    };
+
+    socket.onclose = () => {
+      entry.socketOpen = false;
+      entry.socket = null;
+      notifyClose(entry);
+
+      if (entry.subscribers.size === 0) {
+        entries.delete(companyId);
+        return;
+      }
+
+      entry.reconnectAttempt += 1;
+      const delayMs = Math.min(15_000, 1000 * 2 ** Math.min(entry.reconnectAttempt - 1, 4));
+      entry.reconnectTimer = window.setTimeout(() => {
+        entry.reconnectTimer = null;
+        connect(companyId, entry);
+      }, delayMs);
+    };
+  };
+
+  return {
+    subscribe(companyId: string, subscriber: Subscriber) {
+      let entry = entries.get(companyId);
+      if (!entry) {
+        entry = {
+          reconnectAttempt: 0,
+          reconnectTimer: null,
+          socket: null,
+          socketOpen: false,
+          subscribers: new Set(),
+        };
+        entries.set(companyId, entry);
+        connect(companyId, entry);
+      }
+
+      entry.subscribers.add(subscriber);
+      if (entry.socketOpen) {
+        subscriber.onOpen?.({ isReconnect: false });
+      }
+
+      return () => {
+        const currentEntry = entries.get(companyId);
+        if (!currentEntry) return;
+        currentEntry.subscribers.delete(subscriber);
+        if (currentEntry.subscribers.size === 0) {
+          cleanupEntry(companyId, currentEntry, "last_subscriber");
+        }
+      };
+    },
+  };
+}
+
+const defaultRegistry = createCompanyLiveEventsRegistry();
+
+export function subscribeToCompanyLiveEvents(companyId: string, subscriber: Subscriber) {
+  return defaultRegistry.subscribe(companyId, subscriber);
+}

--- a/ui/src/lib/service-worker.test.ts
+++ b/ui/src/lib/service-worker.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { shouldRegisterServiceWorker } from "./service-worker";
+
+describe("shouldRegisterServiceWorker", () => {
+  it("does not register the service worker in development", () => {
+    expect(shouldRegisterServiceWorker({ isProduction: false, hasServiceWorkerApi: true })).toBe(false);
+  });
+
+  it("registers the service worker in production when the browser supports it", () => {
+    expect(shouldRegisterServiceWorker({ isProduction: true, hasServiceWorkerApi: true })).toBe(true);
+  });
+});

--- a/ui/src/lib/service-worker.ts
+++ b/ui/src/lib/service-worker.ts
@@ -1,0 +1,6 @@
+export function shouldRegisterServiceWorker(opts: {
+  isProduction: boolean;
+  hasServiceWorkerApi: boolean;
+}) {
+  return opts.isProduction && opts.hasServiceWorkerApi;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -16,12 +16,13 @@ import { ThemeProvider } from "./context/ThemeContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { initPluginBridge } from "./plugins/bridge-init";
 import { PluginLauncherProvider } from "./plugins/launchers";
+import { shouldRegisterServiceWorker } from "./lib/service-worker";
 import "@mdxeditor/editor/style.css";
 import "./index.css";
 
 initPluginBridge(React, ReactDOM);
 
-if ("serviceWorker" in navigator) {
+if (shouldRegisterServiceWorker({ isProduction: import.meta.env.PROD, hasServiceWorkerApi: "serviceWorker" in navigator })) {
   window.addEventListener("load", () => {
     navigator.serviceWorker.register("/sw.js");
   });

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -41,6 +41,7 @@ import { PackageFileTree, buildFileTree } from "../components/PackageFileTree";
 import { ScrollToBottom } from "../components/ScrollToBottom";
 import { formatCents, formatDate, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { cn } from "../lib/utils";
+import { subscribeToCompanyLiveEvents } from "../lib/live-events-socket";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
@@ -3526,36 +3527,14 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   useEffect(() => {
     if (!isLive) return;
 
-    let closed = false;
-    let reconnectTimer: number | null = null;
-    let socket: WebSocket | null = null;
-
-    const scheduleReconnect = () => {
-      if (closed) return;
-      reconnectTimer = window.setTimeout(connect, 1500);
-    };
-
-    const connect = () => {
-      if (closed) return;
-      const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-      const url = `${protocol}://${window.location.host}/api/companies/${encodeURIComponent(run.companyId)}/events/ws`;
-      socket = new WebSocket(url);
-
-      socket.onopen = () => {
+    const unsubscribe = subscribeToCompanyLiveEvents(run.companyId, {
+      onOpen: () => {
         setIsStreamingConnected(true);
-      };
-
-      socket.onmessage = (message) => {
-        const rawMessage = typeof message.data === "string" ? message.data : "";
-        if (!rawMessage) return;
-
-        let event: LiveEvent;
-        try {
-          event = JSON.parse(rawMessage) as LiveEvent;
-        } catch {
-          return;
-        }
-
+      },
+      onClose: () => {
+        setIsStreamingConnected(false);
+      },
+      onEvent: (event: LiveEvent) => {
         if (event.companyId !== run.companyId) return;
         const payload = asRecord(event.payload);
         const eventRunId = asNonEmptyString(payload?.runId);
@@ -3606,31 +3585,12 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           if (prev.some((existing) => existing.seq === seq)) return prev;
           return [...prev, liveEvent];
         });
-      };
-
-      socket.onerror = () => {
-        socket?.close();
-      };
-
-      socket.onclose = () => {
-        setIsStreamingConnected(false);
-        scheduleReconnect();
-      };
-    };
-
-    connect();
+      },
+    });
 
     return () => {
-      closed = true;
       setIsStreamingConnected(false);
-      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
-      if (socket) {
-        socket.onopen = null;
-        socket.onmessage = null;
-        socket.onerror = null;
-        socket.onclose = null;
-        socket.close(1000, "run_detail_unmount");
-      }
+      unsubscribe();
     };
   }, [isLive, run.companyId, run.id, run.agentId]);
 

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- harden live events websocket authorization to align with private-host and agent-status checks
- respect PAPERCLIP_OPEN_ON_LISTEN during onboard and only register the service worker in production
- share one live-events websocket per company across the main UI consumers

## Verification
- pnpm test:run
- pnpm --filter @paperclipai/ui typecheck
- pnpm build
- manual smoke: PAPERCLIP_OPEN_ON_LISTEN=false pnpm paperclipai onboard --yes