### PR TITLE
fix(ui): show parent issue link in Sub-issues tab

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1039,35 +1039,57 @@ export function IssueDetail() {
         </TabsContent>
 
         <TabsContent value="subissues">
-          {childIssues.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No sub-issues.</p>
-          ) : (
-            <div className="border border-border rounded-lg divide-y divide-border">
-              {childIssues.map((child) => (
-                <Link
-                  key={child.id}
-                  to={`/issues/${child.identifier ?? child.id}`}
-                  state={location.state}
-                  className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <StatusIcon status={child.status} />
-                    <PriorityIcon priority={child.priority} />
-                    <span className="font-mono text-muted-foreground shrink-0">
-                      {child.identifier ?? child.id.slice(0, 8)}
-                    </span>
-                    <span className="truncate">{child.title}</span>
-                  </div>
-                  {child.assigneeAgentId && (() => {
-                    const name = agentMap.get(child.assigneeAgentId)?.name;
-                    return name
-                      ? <Identity name={name} size="sm" />
-                      : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
-                  })()}
-                </Link>
-              ))}
+          {ancestors.length > 0 && (
+            <div className="mb-3">
+              <p className="text-xs font-medium text-muted-foreground mb-1.5">Parent issue</p>
+              <Link
+                to={`/issues/${ancestors[0].identifier ?? ancestors[0].id}`}
+                state={location.state}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-lg hover:bg-accent/20 transition-colors"
+              >
+                <StatusIcon status={ancestors[0].status} />
+                <PriorityIcon priority={ancestors[0].priority} />
+                <span className="font-mono text-muted-foreground shrink-0">
+                  {ancestors[0].identifier ?? ancestors[0].id.slice(0, 8)}
+                </span>
+                <span className="truncate">{ancestors[0].title}</span>
+              </Link>
             </div>
           )}
+          {childIssues.length === 0 && ancestors.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No sub-issues.</p>
+          ) : childIssues.length > 0 ? (
+            <>
+              {ancestors.length > 0 && (
+                <p className="text-xs font-medium text-muted-foreground mb-1.5">Sub-issues</p>
+              )}
+              <div className="border border-border rounded-lg divide-y divide-border">
+                {childIssues.map((child) => (
+                  <Link
+                    key={child.id}
+                    to={`/issues/${child.identifier ?? child.id}`}
+                    state={location.state}
+                    className="flex items-center justify-between px-3 py-2 text-sm hover:bg-accent/20 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <StatusIcon status={child.status} />
+                      <PriorityIcon priority={child.priority} />
+                      <span className="font-mono text-muted-foreground shrink-0">
+                        {child.identifier ?? child.id.slice(0, 8)}
+                      </span>
+                      <span className="truncate">{child.title}</span>
+                    </div>
+                    {child.assigneeAgentId && (() => {
+                      const name = agentMap.get(child.assigneeAgentId)?.name;
+                      return name
+                        ? <Identity name={name} size="sm" />
+                        : <span className="text-muted-foreground font-mono">{child.assigneeAgentId.slice(0, 8)}</span>;
+                    })()}
+                  </Link>
+                ))}
+              </div>
+            </>
+          ) : null}
         </TabsContent>
 
         <TabsContent value="activity">


### PR DESCRIPTION
## Summary

- The Sub-issues tab on the issue detail page only showed child issues, making navigation one-directional -- you could drill down into sub-issues but had no quick way to navigate back up to the parent issue from within the same tab.
- This adds a "Parent issue" link at the top of the Sub-issues tab when the current issue has a parent (`ancestors[0]`), displaying the parent's status icon, priority icon, identifier, and title in a consistent row style.
- When both a parent and children exist, a "Sub-issues" label is shown above the children list for clarity.
- The "No sub-issues" empty-state message now only appears when there are neither ancestors nor children.

## Test plan

- [ ] Open an issue that has a parent issue -- verify the "Parent issue" section appears at the top of the Sub-issues tab with correct status/priority/identifier/title
- [ ] Click the parent link and confirm it navigates to the parent issue
- [ ] Open an issue with both a parent and child issues -- verify both "Parent issue" and "Sub-issues" labels appear
- [ ] Open an issue with child issues but no parent -- verify only the children list renders (no "Parent issue" or "Sub-issues" labels)
- [ ] Open an issue with no parent and no children -- verify "No sub-issues." text appears
- [ ] Run `pnpm --filter @paperclipai/ui typecheck` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)