### PR TITLE
feat: extend approval types for Human in the Loop

### DIFF
--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -111,7 +111,7 @@ export function registerApprovalCommands(program: Command): void {
       .command("create")
       .description("Create an approval request")
       .requiredOption("-C, --company-id <id>", "Company ID")
-      .requiredOption("--type <type>", "Approval type (hire_agent|approve_ceo_strategy)")
+      .requiredOption("--type <type>", "Approval type (see APPROVAL_TYPES in @paperclipai/shared)")
       .requiredOption("--payload <json>", "Approval payload as JSON object")
       .option("--requested-by-agent-id <id>", "Requesting agent ID")
       .option("--issue-ids <csv>", "Comma-separated linked issue IDs")

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -217,6 +217,10 @@ export const APPROVAL_TYPES = [
   "approve_ceo_strategy",
   "budget_override_required",
   "request_board_approval",
+  "plan_approval",
+  "architecture_decision",
+  "external_action",
+  "policy_change",
 ] as const;
 export type ApprovalType = (typeof APPROVAL_TYPES)[number];
 

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -1,4 +1,4 @@
-import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck } from "lucide-react";
+import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck, ClipboardCheck, Building2, ExternalLink, FileText } from "lucide-react";
 import { formatCents } from "../lib/utils";
 
 export const typeLabel: Record<string, string> = {
@@ -6,6 +6,10 @@ export const typeLabel: Record<string, string> = {
   approve_ceo_strategy: "CEO Strategy",
   budget_override_required: "Budget Override",
   request_board_approval: "Board Approval",
+  plan_approval: "Plan Approval",
+  architecture_decision: "Architecture Decision",
+  external_action: "External Action",
+  policy_change: "Policy Change",
 };
 
 function firstNonEmptyString(...values: unknown[]): string | null {
@@ -41,6 +45,10 @@ export const typeIcon: Record<string, typeof UserPlus> = {
   approve_ceo_strategy: Lightbulb,
   budget_override_required: ShieldAlert,
   request_board_approval: ShieldCheck,
+  plan_approval: ClipboardCheck,
+  architecture_decision: Building2,
+  external_action: ExternalLink,
+  policy_change: FileText,
 };
 
 export const defaultTypeIcon = ShieldCheck;


### PR DESCRIPTION
## Summary

- Adds four new approval type constants to `APPROVAL_TYPES` in `packages/shared/src/constants.ts`: `plan_approval`, `architecture_decision`, `external_action`, `policy_change`
- These new types enable more granular human-in-the-loop control over agent workflows
- All existing types (`hire_agent`, `approve_ceo_strategy`, `budget_override_required`) are preserved

## Details

The DB `type` column is `text` (not a Postgres enum), so no migration is needed. The derived TypeScript type `ApprovalType` uses `(typeof APPROVAL_TYPES)[number]` and the Zod validator in `approval.ts` uses `z.enum(APPROVAL_TYPES)` — both automatically pick up the new constants with no additional changes required.

### New approval types

| Type | Purpose |
|------|---------|
| `plan_approval` | Require human sign-off on agent-generated plans before execution |
| `architecture_decision` | Gate architectural changes behind human review |
| `external_action` | Require approval before agents take actions outside the system (e.g., API calls, emails) |
| `policy_change` | Require approval for changes to organizational policies or configurations |

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit` passes with no errors)
- [ ] Verify downstream consumers handle new types gracefully

Co-Authored-By: Paperclip <noreply@paperclip.ing>