### PR TITLE
fix(inbox): show failed-run dismiss button on mobile

### DIFF
--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -148,7 +148,7 @@ function FailedRunCard({
       <button
         type="button"
         onClick={onDismiss}
-        className="absolute right-2 top-2 z-10 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100"
+        className="absolute right-2 top-2 z-10 rounded-md p-1 text-muted-foreground opacity-100 transition-opacity hover:bg-accent hover:text-foreground sm:opacity-0 sm:group-hover:opacity-100"
         aria-label="Dismiss"
       >
         <X className="h-4 w-4" />


### PR DESCRIPTION
## Problem

Failed run cards in Inbox only reveal the dismiss action on hover.
On touch devices there is no reliable hover state, so failed-run items become effectively non-dismissible on mobile.

## Fix

Keep the dismiss button always visible on small screens while preserving the existing hover-only behavior on desktop.

## Why

Failed runs do not support mark-as-read or delete in the Inbox UI, so dismiss is the only available cleanup action. That action needs to stay reachable on touch devices.
