### PR TITLE
fix(heartbeat): auto-retry process_lost on server restart

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1680,7 +1680,7 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
-      const shouldRetry = tracksLocalChild && !!run.processPid && (run.processLossRetryCount ?? 0) < 1;
+      const shouldRetry = tracksLocalChild && (run.processLossRetryCount ?? 0) < 1;
       const baseMessage = run.processPid
         ? `Process lost -- child pid ${run.processPid} is no longer running`
         : "Process lost -- server may have restarted";
@@ -1721,7 +1721,17 @@ export function heartbeatService(db: Db) {
       });
 
       await finalizeAgentStatus(run.agentId, "failed");
-      await startNextQueuedRunForAgent(run.agentId);
+      if (retriedRun) {
+        // Delay retry by ~10s so the system has time to stabilize after restart
+        const agentId = run.agentId;
+        setTimeout(() => {
+          void startNextQueuedRunForAgent(agentId).catch((err) =>
+            logger.warn({ err, agentId, retryRunId: retriedRun!.id }, "delayed process_lost retry start failed"),
+          );
+        }, 10_000);
+      } else {
+        await startNextQueuedRunForAgent(run.agentId);
+      }
       runningProcesses.delete(run.id);
       reaped.push(run.id);
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `shouldRetry` in `reapOrphanedRuns` required `run.processPid` to be set, but on full server restarts the PID is never recorded — so retries were silently skipped
- Removed `processPid` requirement so all `process_lost` failures on local adapters get one automatic retry
- Added 10-second delay before starting retry run to let the system stabilize

## Test plan

- [ ] Verify CI passes (typecheck, tests, build)
- [ ] Deploy and confirm process_lost failures now auto-retry ~10s after detection
- [ ] Check run `dc310c0c` scenario: server restart → process_lost → auto-retry fires

Closes DLD-819

🤖 Generated with [Claude Code](https://claude.com/claude-code)