### PR TITLE
feat: add SAM.gov API integration for federal bids

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 DATABASE_URL=postgres://paperclip:paperclip@localhost:5432/paperclip
 PORT=3100
 SERVE_UI=false
+
+# SAM.gov API key for federal contract opportunity search
+# Register at https://sam.gov to get a public API key
+SAM_API_KEY=

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,7 @@ import { instanceSettingsRoutes } from "./routes/instance-settings.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { samGovRoutes } from "./routes/sam-gov.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -69,6 +70,7 @@ export async function createApp(
     bindHost: string;
     authReady: boolean;
     companyDeletionEnabled: boolean;
+    samApiKey?: string;
     instanceId?: string;
     hostVersion?: string;
     localPluginDir?: string;
@@ -153,6 +155,7 @@ export async function createApp(
   api.use(dashboardRoutes(db));
   api.use(sidebarBadgeRoutes(db));
   api.use(instanceSettingsRoutes(db));
+  api.use("/sam", samGovRoutes(opts.samApiKey));
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = createPluginWorkerManager();
   const pluginRegistry = pluginRegistryService(db);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -70,6 +70,7 @@ export interface Config {
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
+  samApiKey: string | undefined;
 }
 
 export function loadConfig(): Config {
@@ -252,5 +253,6 @@ export function loadConfig(): Config {
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
+    samApiKey: process.env.SAM_API_KEY ?? undefined,
   };
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -488,6 +488,7 @@ export async function startServer(): Promise<StartedServer> {
     bindHost: config.host,
     authReady,
     companyDeletionEnabled: config.companyDeletionEnabled,
+    samApiKey: config.samApiKey,
     betterAuthHandler,
     resolveSession,
   });

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -15,3 +15,4 @@ export { sidebarBadgeRoutes } from "./sidebar-badges.js";
 export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
 export { instanceSettingsRoutes } from "./instance-settings.js";
+export { samGovRoutes } from "./sam-gov.js";

--- a/server/src/routes/sam-gov.ts
+++ b/server/src/routes/sam-gov.ts
@@ -1,0 +1,91 @@
+import { Router } from "express";
+import { samGovService, type SamSearchParams } from "../services/sam-gov.js";
+
+/**
+ * SAM.gov proxy routes.
+ *
+ * GET /sam/opportunities          — search federal contract opportunities
+ * GET /sam/opportunities/:noticeId — get a single opportunity by notice ID
+ */
+export function samGovRoutes(samApiKey: string | undefined) {
+  const router = Router();
+
+  // Guard: all routes require a configured API key
+  router.use((_req, res, next) => {
+    if (!samApiKey) {
+      res.status(503).json({
+        error: "SAM.gov integration is not configured. Set the SAM_API_KEY environment variable.",
+      });
+      return;
+    }
+    next();
+  });
+
+  router.get("/opportunities", async (req, res) => {
+    try {
+      const service = samGovService(samApiKey!);
+
+      // Default date range: last 30 days
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now);
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+      const fmt = (d: Date) =>
+        `${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}/${d.getFullYear()}`;
+
+      const params: SamSearchParams = {
+        postedFrom: (req.query.postedFrom as string) || fmt(thirtyDaysAgo),
+        postedTo: (req.query.postedTo as string) || fmt(now),
+        limit: req.query.limit ? Number(req.query.limit) : 10,
+        offset: req.query.offset ? Number(req.query.offset) : 0,
+      };
+
+      // Pass through optional filters
+      const optionalKeys: (keyof SamSearchParams)[] = [
+        "ptype",
+        "solnum",
+        "noticeid",
+        "title",
+        "state",
+        "zip",
+        "ncode",
+        "ccode",
+        "typeOfSetAside",
+        "organizationName",
+        "rdlfrom",
+        "rdlto",
+      ];
+      for (const key of optionalKeys) {
+        const val = req.query[key];
+        if (typeof val === "string" && val.length > 0) {
+          (params as unknown as Record<string, unknown>)[key] = val;
+        }
+      }
+
+      const result = await service.search(params);
+      res.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      res.status(502).json({ error: message });
+    }
+  });
+
+  router.get("/opportunities/:noticeId", async (req, res) => {
+    try {
+      const service = samGovService(samApiKey!);
+      const opportunity = await service.getOpportunity(req.params.noticeId);
+
+      if (!opportunity) {
+        res.status(404).json({ error: "Opportunity not found" });
+        return;
+      }
+
+      res.json(opportunity);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      res.status(502).json({ error: message });
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/sam-gov.ts
+++ b/server/src/services/sam-gov.ts
@@ -1,0 +1,162 @@
+/**
+ * SAM.gov Opportunities API service.
+ *
+ * Wraps the public Get Opportunities v2 API so Paperclip agents can search
+ * federal contract opportunities (bids) directly.
+ *
+ * API docs: https://open.gsa.gov/api/get-opportunities-public-api/
+ */
+
+const SAM_BASE_URL = "https://api.sam.gov/opportunities/v2/search";
+
+export interface SamSearchParams {
+  /** Posted-date range start (MM/dd/yyyy) */
+  postedFrom: string;
+  /** Posted-date range end   (MM/dd/yyyy) */
+  postedTo: string;
+
+  /* ---- optional filters ---- */
+  /** Procurement type codes: u,p,a,r,s,o,g,k,i */
+  ptype?: string;
+  /** Solicitation number */
+  solnum?: string;
+  /** Notice ID */
+  noticeid?: string;
+  /** Keyword in title */
+  title?: string;
+  /** Place-of-performance state abbreviation */
+  state?: string;
+  /** Place-of-performance zip */
+  zip?: string;
+  /** NAICS code (max 6 digits) */
+  ncode?: string;
+  /** Classification code */
+  ccode?: string;
+  /** Set-aside code (SBA, 8A, HZC, SDVOSBC, WOSB, …) */
+  typeOfSetAside?: string;
+  /** Department / subtier name */
+  organizationName?: string;
+  /** Response-deadline range start (MM/dd/yyyy) */
+  rdlfrom?: string;
+  /** Response-deadline range end   (MM/dd/yyyy) */
+  rdlto?: string;
+  /** Records per page (1-1000, default 10) */
+  limit?: number;
+  /** Page offset (default 0) */
+  offset?: number;
+}
+
+export interface SamOpportunity {
+  noticeId: string;
+  title: string;
+  solicitationNumber: string;
+  department: string | null;
+  subTier: string | null;
+  office: string | null;
+  postedDate: string;
+  type: string;
+  baseType: string;
+  setAsideDescription: string | null;
+  setAsideCode: string | null;
+  responseDeadLine: string | null;
+  naicsCode: string | null;
+  classificationCode: string | null;
+  active: string;
+  award: {
+    date: string | null;
+    number: string | null;
+    amount: string | null;
+    awardee: { name: string | null } | null;
+  } | null;
+  pointOfContact: Array<{
+    type: string;
+    fullName: string | null;
+    email: string | null;
+    phone: string | null;
+  }>;
+  description: string | null;
+  organizationType: string | null;
+  uiLink: string;
+  placeOfPerformance: {
+    streetAddress: string | null;
+    city: { code: string | null; name: string | null };
+    state: { code: string | null; name: string | null };
+    zip: string | null;
+    country: { code: string | null; name: string | null };
+  } | null;
+  // passthrough for any extra fields SAM returns
+  [key: string]: unknown;
+}
+
+export interface SamSearchResult {
+  totalRecords: number;
+  limit: number;
+  offset: number;
+  opportunitiesData: SamOpportunity[];
+}
+
+export function samGovService(apiKey: string) {
+  async function search(params: SamSearchParams): Promise<SamSearchResult> {
+    const url = new URL(SAM_BASE_URL);
+    url.searchParams.set("api_key", apiKey);
+    url.searchParams.set("postedFrom", params.postedFrom);
+    url.searchParams.set("postedTo", params.postedTo);
+    url.searchParams.set("limit", String(params.limit ?? 10));
+    url.searchParams.set("offset", String(params.offset ?? 0));
+
+    const optionalKeys: (keyof SamSearchParams)[] = [
+      "ptype",
+      "solnum",
+      "noticeid",
+      "title",
+      "state",
+      "zip",
+      "ncode",
+      "ccode",
+      "typeOfSetAside",
+      "organizationName",
+      "rdlfrom",
+      "rdlto",
+    ];
+    for (const key of optionalKeys) {
+      const val = params[key];
+      if (val !== undefined && val !== null && val !== "") {
+        url.searchParams.set(key, String(val));
+      }
+    }
+
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `SAM.gov API error ${res.status}: ${body || res.statusText}`,
+      );
+    }
+
+    return (await res.json()) as SamSearchResult;
+  }
+
+  async function getOpportunity(noticeId: string): Promise<SamOpportunity | null> {
+    const now = new Date();
+    const oneYearAgo = new Date(now);
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+    const fmt = (d: Date) =>
+      `${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}/${d.getFullYear()}`;
+
+    const result = await search({
+      postedFrom: fmt(oneYearAgo),
+      postedTo: fmt(now),
+      noticeid: noticeId,
+      limit: 1,
+    });
+
+    return result.opportunitiesData?.[0] ?? null;
+  }
+
+  return { search, getOpportunity };
+}


### PR DESCRIPTION
## Summary
- Adds proxy service and routes to search federal contract opportunities on SAM.gov via the Get Opportunities Public API v2
- New endpoints: `GET /api/sam/opportunities` (search with filters) and `GET /api/sam/opportunities/:noticeId` (single lookup)
- Configurable via `SAM_API_KEY` env var; returns 503 with helpful message if unset

## Test plan
- [x] Server builds cleanly (`pnpm --filter @paperclipai/server build`)
- [x] Routes return 503 when no API key configured
- [x] Routes return live data (21,635 opportunities) with valid API key
- [x] Query params (limit, title, ncode, state, etc.) pass through correctly
- [ ] Verify no regressions on existing routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)