### PR TITLE
fix(docker): build plugin-sdk before server in Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/plugins/sdk/package.json packages/plugins/sdk/
 
 RUN pnpm install --frozen-lockfile
 
@@ -27,6 +28,7 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)


### PR DESCRIPTION
## Thinking path

Paperclip's goal is to let anyone self-host an autonomous AI company with zero friction. The Docker build is the primary path to self-hosted deployment. The plugin system (@paperclipai/plugin-sdk) was recently added to enable extensibility — a core part of that roadmap. However, the Dockerfile was not updated alongside the plugin system addition, making it impossible to build the image from source.

## Problem

Building the Docker image fails with `TS2307: Cannot find module '@paperclipai/plugin-sdk'` errors during the server build step:

```
src/app.ts(48,42): error TS2307: Cannot find module '@paperclipai/plugin-sdk'
src/routes/plugins.ts(48,37): error TS2307: Cannot find module '@paperclipai/plugin-sdk'
...
```

`@paperclipai/plugin-sdk` is a `workspace:*` dependency of the server, but the Docker build stage only runs `pnpm --filter @paperclipai/ui build` and `pnpm --filter @paperclipai/server build`. The `plugin-sdk` package is never compiled, so TypeScript can't find its type declarations when building the server.

Additionally, `packages/plugins/sdk/package.json` was missing from the `deps` stage `COPY` list, which prevents pnpm from correctly resolving the workspace package during `pnpm install --frozen-lockfile`.

## Fix

1. Add `COPY packages/plugins/sdk/package.json packages/plugins/sdk/` to the `deps` stage
2. Add `RUN pnpm --filter @paperclipai/plugin-sdk build` before the UI and server builds

## Validated

Tested locally — `docker build --platform linux/amd64 .` completes successfully with this fix.