### PR TITLE
fix(server): check MIGRATION_AUTO_APPLY before MIGRATION_PROMPT

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -94,8 +94,8 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   async function promptApplyMigrations(migrations: string[]): Promise<boolean> {
-    if (process.env.PAPERCLIP_MIGRATION_PROMPT === "never") return false;
     if (process.env.PAPERCLIP_MIGRATION_AUTO_APPLY === "true") return true;
+    if (process.env.PAPERCLIP_MIGRATION_PROMPT === "never") return false;
     if (!stdin.isTTY || !stdout.isTTY) return true;
   
     const prompt = createInterface({ input: stdin, output: stdout });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents run as a local server backed by an embedded PostgreSQL database
> - The database schema evolves over time, so the server checks for and applies pending migrations on startup
> - The `dev:watch` script sets both `PAPERCLIP_MIGRATION_AUTO_APPLY=true` and `PAPERCLIP_MIGRATION_PROMPT=never` via cross-env
> - But `promptApplyMigrations` checked `PROMPT=never` first (returning false) before checking `AUTO_APPLY=true`
> - So on existing databases with pending migrations, `dev:watch` would always error instead of auto-applying
> - This PR swaps the check order so `AUTO_APPLY` takes precedence over `PROMPT`
> - The benefit is that developers can pull latest and `dev:watch` will seamlessly apply migrations without manual intervention

## Summary
- Swap the check order in `promptApplyMigrations` so `PAPERCLIP_MIGRATION_AUTO_APPLY=true` is evaluated before `PAPERCLIP_MIGRATION_PROMPT=never`
- Previously, `dev:watch` (which sets both env vars via `cross-env`) would always refuse to auto-apply migrations on existing databases because `PROMPT=never` returned `false` before `AUTO_APPLY` was checked

## Test plan
- [ ] Run `pnpm --filter @paperclipai/server dev:watch` against an existing embedded-postgres instance with pending migrations — should auto-apply instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)