### PR TITLE
fix: correct delete order and add missing tables in company removal

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -3,15 +3,24 @@ import type { Db } from "@paperclipai/db";
 import {
   companies,
   companyLogos,
+  companySkills,
   assets,
   agents,
   agentApiKeys,
+  agentConfigRevisions,
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
   issues,
+  issueApprovals,
+  issueAttachments,
   issueComments,
+  issueDocuments,
+  issueReadStates,
+  issueWorkProducts,
   projects,
+  projectGoals,
+  projectWorkspaces,
   goals,
   heartbeatRuns,
   heartbeatRunEvents,
@@ -20,11 +29,19 @@ import {
   approvalComments,
   approvals,
   activityLog,
+  budgetIncidents,
+  budgetPolicies,
   companySecrets,
+  documents,
+  documentRevisions,
+  executionWorkspaces,
   joinRequests,
   invites,
   principalPermissionGrants,
   companyMemberships,
+  routines,
+  workspaceOperations,
+  workspaceRuntimeServices,
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 
@@ -263,30 +280,30 @@ export function companyService(db: Db) {
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         // --- Tables referencing issues (must go before issues) ---
-        await tx.execute(sql`DELETE FROM issue_read_states WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM issue_approvals WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM issue_work_products WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM issue_documents WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM issue_attachments WHERE company_id = ${id}`);
+        await tx.delete(issueReadStates).where(eq(issueReadStates.companyId, id));
+        await tx.delete(issueApprovals).where(eq(issueApprovals.companyId, id));
+        await tx.delete(issueWorkProducts).where(eq(issueWorkProducts.companyId, id));
+        await tx.delete(issueDocuments).where(eq(issueDocuments.companyId, id));
+        await tx.delete(issueAttachments).where(eq(issueAttachments.companyId, id));
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
         // --- Tables referencing approvals (must go before approvals) ---
-        await tx.execute(sql`DELETE FROM budget_incidents WHERE company_id = ${id}`);
+        await tx.delete(budgetIncidents).where(eq(budgetIncidents.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         // --- Clear self-referencing FKs, then delete ---
-        await tx.execute(sql`UPDATE issues SET parent_id = NULL WHERE company_id = ${id}`);
+        await tx.update(issues).set({ parentId: null }).where(eq(issues.companyId, id));
         await tx.delete(issues).where(eq(issues.companyId, id));
-        await tx.execute(sql`DELETE FROM execution_workspaces WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM project_workspaces WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM project_goals WHERE company_id = ${id}`);
+        await tx.delete(executionWorkspaces).where(eq(executionWorkspaces.companyId, id));
+        await tx.delete(projectWorkspaces).where(eq(projectWorkspaces.companyId, id));
+        await tx.delete(projectGoals).where(eq(projectGoals.companyId, id));
         await tx.delete(projects).where(eq(projects.companyId, id));
-        await tx.execute(sql`UPDATE goals SET parent_id = NULL WHERE company_id = ${id}`);
+        await tx.update(goals).set({ parentId: null }).where(eq(goals.companyId, id));
         await tx.delete(goals).where(eq(goals.companyId, id));
         // --- Remaining tables ---
-        await tx.execute(sql`DELETE FROM budget_policies WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM document_revisions WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM documents WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM agent_config_revisions WHERE company_id = ${id}`);
+        await tx.delete(budgetPolicies).where(eq(budgetPolicies.companyId, id));
+        await tx.delete(documentRevisions).where(eq(documentRevisions.companyId, id));
+        await tx.delete(documents).where(eq(documents.companyId, id));
+        await tx.delete(agentConfigRevisions).where(eq(agentConfigRevisions.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
         await tx.delete(joinRequests).where(eq(joinRequests.companyId, id));
         await tx.delete(invites).where(eq(invites.companyId, id));
@@ -296,13 +313,13 @@ export function companyService(db: Db) {
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
-        await tx.execute(sql`DELETE FROM routines WHERE company_id = ${id}`);
-        await tx.execute(sql`UPDATE agents SET reports_to = NULL WHERE company_id = ${id}`);
+        await tx.delete(routines).where(eq(routines.companyId, id));
+        await tx.update(agents).set({ reportsTo: null }).where(eq(agents.companyId, id));
         await tx.delete(agents).where(eq(agents.companyId, id));
         // --- Tables only referencing companies (safe to delete in any order) ---
-        await tx.execute(sql`DELETE FROM workspace_operations WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM workspace_runtime_services WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM company_skills WHERE company_id = ${id}`);
+        await tx.delete(workspaceOperations).where(eq(workspaceOperations.companyId, id));
+        await tx.delete(workspaceRuntimeServices).where(eq(workspaceRuntimeServices.companyId, id));
+        await tx.delete(companySkills).where(eq(companySkills.companyId, id));
         const rows = await tx
           .delete(companies)
           .where(eq(companies.id, id))

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -254,14 +254,12 @@ export function companyService(db: Db) {
     remove: (id: string) =>
       db.transaction(async (tx) => {
         // Delete from child tables in dependency order
-        // --- Tables referencing heartbeat_runs (must go before heartbeatRuns) ---
+        // --- Tables with NO ACTION FKs to heartbeat_runs (must go before heartbeatRuns) ---
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
         await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(costEvents).where(eq(costEvents.companyId, id));
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
-        await tx.execute(sql`DELETE FROM workspace_operations WHERE company_id = ${id}`);
-        await tx.execute(sql`DELETE FROM workspace_runtime_services WHERE company_id = ${id}`);
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         // --- Tables referencing issues (must go before issues) ---
@@ -298,8 +296,13 @@ export function companyService(db: Db) {
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
+        await tx.execute(sql`DELETE FROM routines WHERE company_id = ${id}`);
         await tx.execute(sql`UPDATE agents SET reports_to = NULL WHERE company_id = ${id}`);
         await tx.delete(agents).where(eq(agents.companyId, id));
+        // --- Tables only referencing companies (safe to delete in any order) ---
+        await tx.execute(sql`DELETE FROM workspace_operations WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM workspace_runtime_services WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM company_skills WHERE company_id = ${id}`);
         const rows = await tx
           .delete(companies)
           .where(eq(companies.id, id))

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -254,29 +254,52 @@ export function companyService(db: Db) {
     remove: (id: string) =>
       db.transaction(async (tx) => {
         // Delete from child tables in dependency order
+        // --- Tables referencing heartbeat_runs (must go before heartbeatRuns) ---
+        await tx.delete(activityLog).where(eq(activityLog.companyId, id));
+        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
+        await tx.execute(sql`DELETE FROM workspace_operations WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM workspace_runtime_services WHERE company_id = ${id}`);
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
-        await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
-        await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
+        // --- Tables referencing issues (must go before issues) ---
+        await tx.execute(sql`DELETE FROM issue_read_states WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM issue_approvals WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM issue_work_products WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM issue_documents WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM issue_attachments WHERE company_id = ${id}`);
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
-        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
-        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        // --- Tables referencing approvals (must go before approvals) ---
+        await tx.execute(sql`DELETE FROM budget_incidents WHERE company_id = ${id}`);
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
+        // --- Clear self-referencing FKs, then delete ---
+        await tx.execute(sql`UPDATE issues SET parent_id = NULL WHERE company_id = ${id}`);
+        await tx.delete(issues).where(eq(issues.companyId, id));
+        await tx.execute(sql`DELETE FROM execution_workspaces WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM project_workspaces WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM project_goals WHERE company_id = ${id}`);
+        await tx.delete(projects).where(eq(projects.companyId, id));
+        await tx.execute(sql`UPDATE goals SET parent_id = NULL WHERE company_id = ${id}`);
+        await tx.delete(goals).where(eq(goals.companyId, id));
+        // --- Remaining tables ---
+        await tx.execute(sql`DELETE FROM budget_policies WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM document_revisions WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM documents WHERE company_id = ${id}`);
+        await tx.execute(sql`DELETE FROM agent_config_revisions WHERE company_id = ${id}`);
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
         await tx.delete(joinRequests).where(eq(joinRequests.companyId, id));
         await tx.delete(invites).where(eq(invites.companyId, id));
         await tx.delete(principalPermissionGrants).where(eq(principalPermissionGrants.companyId, id));
         await tx.delete(companyMemberships).where(eq(companyMemberships.companyId, id));
-        await tx.delete(issues).where(eq(issues.companyId, id));
+        await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
+        await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
-        await tx.delete(goals).where(eq(goals.companyId, id));
-        await tx.delete(projects).where(eq(projects.companyId, id));
+        await tx.execute(sql`UPDATE agents SET reports_to = NULL WHERE company_id = ${id}`);
         await tx.delete(agents).where(eq(agents.companyId, id));
-        await tx.delete(activityLog).where(eq(activityLog.companyId, id));
         const rows = await tx
           .delete(companies)
           .where(eq(companies.id, id))


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Companies accumulate data across many tables: agents, issues, heartbeat runs, activity logs, cost events, etc.
> - When a company is deleted, all related data must be removed in the correct order to respect foreign key constraints
> - But the `remove` method in `companyService` was deleting tables in an order that violated FK constraints and was missing 18 tables entirely
> - This PR fixes the deletion order and adds all missing table deletes, so company deletion works reliably regardless of what data exists
> - The benefit is that operators can cleanly remove companies without hitting 500 errors or leaving orphaned data

## What changed

Fixed FK constraint violations when deleting a company by correcting the table deletion order and adding all missing tables.

### Ordering fixes
- Move `activityLog`, `costEvents`, `financeEvents` deletes before `heartbeatRuns` (all reference `heartbeat_runs.id` with `ON DELETE NO ACTION`)

### Missing table deletes added (18 tables)
- `issue_read_states`, `issue_approvals`, `issue_work_products`, `issue_documents`, `issue_attachments` (before `issues`)
- `budget_incidents` (before `approvals`)
- `execution_workspaces`, `project_workspaces`, `project_goals` (before `projects`/`goals`)
- `budget_policies`, `document_revisions`, `documents`, `agent_config_revisions`
- `routines` (before `agents` — `routines.assigneeAgentId` references `agents.id` with NO ACTION)
- `workspace_operations`, `workspace_runtime_services`, `company_skills` (before `companies`)

### Self-referencing FKs nullified before bulk delete
- `issues.parent_id`, `goals.parent_id`, `agents.reports_to`

## Why it matters

Without this fix, `DELETE /api/companies/:id` returns a 500 error whenever the company has activity logs, issue read states, routines, or any data in the 18 previously unhandled tables.

## Risks

- Raw SQL (`tx.execute`) is used for tables not exported from `@paperclipai/db`. If those table names change in a migration, the raw SQL won't get a compile-time error. Ideally these tables would be exported from the db package and use the type-safe drizzle API.

## Test plan

- [ ] Create a company with agents, issues, heartbeat runs, activity log entries, routines, and company skills
- [ ] Run `npx paperclipai company delete <id> --yes --confirm <id>`
- [ ] Verify the company and all related data are deleted without FK constraint errors
- [ ] Verify other companies are unaffected

Closes #1659