### PR TITLE
fix(gemini-local): support assistant message events

### DIFF
--- a/packages/adapters/gemini-local/src/cli/format-event.ts
+++ b/packages/adapters/gemini-local/src/cli/format-event.ts
@@ -13,6 +13,10 @@ function asNumber(value: unknown, fallback = 0): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
+function readMessagePayload(value: Record<string, unknown>): unknown {
+  return value.content ?? value.message;
+}
+
 function stringifyUnknown(value: unknown): string {
   if (typeof value === "string") return value;
   if (value === null || value === undefined) return "";
@@ -44,6 +48,11 @@ function printTextMessage(prefix: string, colorize: (text: string) => string, me
   if (typeof messageRaw === "string") {
     const text = messageRaw.trim();
     if (text) console.log(colorize(`${prefix}: ${text}`));
+    return;
+  }
+
+  if (Array.isArray(messageRaw)) {
+    printTextMessage(prefix, colorize, { content: messageRaw });
     return;
   }
 
@@ -147,6 +156,19 @@ export function printGeminiStreamEvent(raw: string, _debug: boolean): void {
   if (type === "assistant") {
     printTextMessage("assistant", pc.green, parsed.message);
     return;
+  }
+
+  if (type === "message") {
+    const role = asString(parsed.role).trim().toLowerCase();
+    const payload = readMessagePayload(parsed);
+    if (role === "assistant") {
+      printTextMessage("assistant", pc.green, payload);
+      return;
+    }
+    if (role === "user") {
+      printTextMessage("user", pc.gray, payload);
+      return;
+    }
   }
 
   if (type === "user") {

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -37,10 +37,11 @@ function collectMessageText(message: unknown): string[] {
 function extractQuestion(message: unknown): { prompt: string; choices: Array<{ key: string; label: string; description?: string }> } | null {
   if (typeof message === "string") return null;
 
+  const record = Array.isArray(message) ? null : parseObject(message);
   const content = Array.isArray(message)
     ? message
-    : Array.isArray(parseObject(message).content)
-      ? (parseObject(message).content as unknown[])
+    : Array.isArray(record?.content)
+      ? (record.content as unknown[])
       : [];
 
   for (const partRaw of content) {

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -1,15 +1,8 @@
 import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
 
-function collectMessageText(message: unknown): string[] {
-  if (typeof message === "string") {
-    const trimmed = message.trim();
-    return trimmed ? [trimmed] : [];
-  }
-
-  const record = parseObject(message);
-  const direct = asString(record.text, "").trim();
-  const lines: string[] = direct ? [direct] : [];
-  const content = Array.isArray(record.content) ? record.content : [];
+function collectContentParts(contentRaw: unknown): string[] {
+  const content = Array.isArray(contentRaw) ? contentRaw : [];
+  const lines: string[] = [];
 
   for (const partRaw of content) {
     const part = parseObject(partRaw);
@@ -21,6 +14,52 @@ function collectMessageText(message: unknown): string[] {
   }
 
   return lines;
+}
+
+function collectMessageText(message: unknown): string[] {
+  if (typeof message === "string") {
+    const trimmed = message.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  if (Array.isArray(message)) {
+    return collectContentParts(message);
+  }
+
+  const record = parseObject(message);
+  const direct = asString(record.text, "").trim();
+  const lines: string[] = direct ? [direct] : [];
+  lines.push(...collectContentParts(record.content));
+
+  return lines;
+}
+
+function extractQuestion(message: unknown): { prompt: string; choices: Array<{ key: string; label: string; description?: string }> } | null {
+  if (typeof message === "string") return null;
+
+  const content = Array.isArray(message)
+    ? message
+    : Array.isArray(parseObject(message).content)
+      ? (parseObject(message).content as unknown[])
+      : [];
+
+  for (const partRaw of content) {
+    const part = parseObject(partRaw);
+    if (asString(part.type, "").trim() !== "question") continue;
+    return {
+      prompt: asString(part.prompt, "").trim(),
+      choices: (Array.isArray(part.choices) ? part.choices : []).map((choiceRaw) => {
+        const choice = parseObject(choiceRaw);
+        return {
+          key: asString(choice.key, "").trim(),
+          label: asString(choice.label, "").trim(),
+          description: asString(choice.description, "").trim() || undefined,
+        };
+      }),
+    };
+  }
+
+  return null;
 }
 
 function readSessionId(event: Record<string, unknown>): string | null {
@@ -97,27 +136,10 @@ export function parseGeminiJsonl(stdout: string) {
 
     const type = asString(event.type, "").trim();
 
-    if (type === "assistant") {
-      messages.push(...collectMessageText(event.message));
-      const messageObj = parseObject(event.message);
-      const content = Array.isArray(messageObj.content) ? messageObj.content : [];
-      for (const partRaw of content) {
-        const part = parseObject(partRaw);
-        if (asString(part.type, "").trim() === "question") {
-          question = {
-            prompt: asString(part.prompt, "").trim(),
-            choices: (Array.isArray(part.choices) ? part.choices : []).map((choiceRaw) => {
-              const choice = parseObject(choiceRaw);
-              return {
-                key: asString(choice.key, "").trim(),
-                label: asString(choice.label, "").trim(),
-                description: asString(choice.description, "").trim() || undefined,
-              };
-            }),
-          };
-          break; // only one question per message
-        }
-      }
+    if (type === "assistant" || (type === "message" && asString(event.role, "").trim().toLowerCase() === "assistant")) {
+      const messagePayload = type === "assistant" ? event.message : (event.content ?? event.message);
+      messages.push(...collectMessageText(messagePayload));
+      question = question ?? extractQuestion(messagePayload);
       continue;
     }
 

--- a/packages/adapters/gemini-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/gemini-local/src/ui/parse-stdout.ts
@@ -21,6 +21,10 @@ function asNumber(value: unknown, fallback = 0): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
+function readMessagePayload(value: Record<string, unknown>): unknown {
+  return value.content ?? value.message;
+}
+
 function stringifyUnknown(value: unknown): string {
   if (typeof value === "string") return value;
   if (value === null || value === undefined) return "";
@@ -54,6 +58,10 @@ function collectTextEntries(messageRaw: unknown, ts: string, kind: "assistant" |
     return text ? [{ kind, ts, text }] : [];
   }
 
+  if (Array.isArray(messageRaw)) {
+    return collectTextEntries({ content: messageRaw }, ts, kind);
+  }
+
   const message = asRecord(messageRaw);
   if (!message) return [];
 
@@ -78,6 +86,10 @@ function parseAssistantMessage(messageRaw: unknown, ts: string): TranscriptEntry
   if (typeof messageRaw === "string") {
     const text = messageRaw.trim();
     return text ? [{ kind: "assistant", ts, text }] : [];
+  }
+
+  if (Array.isArray(messageRaw)) {
+    return parseAssistantMessage({ content: messageRaw }, ts);
   }
 
   const message = asRecord(messageRaw);
@@ -231,6 +243,17 @@ export function parseGeminiStdoutLine(line: string, ts: string): TranscriptEntry
 
   if (type === "assistant") {
     return parseAssistantMessage(parsed.message, ts);
+  }
+
+  if (type === "message") {
+    const role = asString(parsed.role).trim().toLowerCase();
+    const payload = readMessagePayload(parsed);
+    if (role === "assistant") {
+      return parseAssistantMessage(payload, ts);
+    }
+    if (role === "user") {
+      return collectTextEntries(payload, ts, "user");
+    }
   }
 
   if (type === "user") {

--- a/server/src/__tests__/gemini-local-adapter.test.ts
+++ b/server/src/__tests__/gemini-local-adapter.test.ts
@@ -57,6 +57,36 @@ describe("gemini_local parser", () => {
     expect(parsed.summary).toBe("hello");
   });
 
+  it("extracts array content and questions from newer message events", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "message",
+        role: "assistant",
+        content: [
+          { type: "output_text", text: "hello from parts" },
+          {
+            type: "question",
+            prompt: "Which model?",
+            choices: [
+              { key: "pro", label: "Gemini Pro", description: "Better" },
+              { key: "flash", label: "Gemini Flash" },
+            ],
+          },
+        ],
+      }),
+    ].join("\n");
+
+    const parsed = parseGeminiJsonl(stdout);
+    expect(parsed.summary).toBe("hello from parts");
+    expect(parsed.question).toEqual({
+      prompt: "Which model?",
+      choices: [
+        { key: "pro", label: "Gemini Pro", description: "Better" },
+        { key: "flash", label: "Gemini Flash", description: undefined },
+      ],
+    });
+  });
+
   it("extracts structured questions", () => {
     const stdout = [
       JSON.stringify({
@@ -138,6 +168,19 @@ describe("gemini_local ui stdout parser", () => {
     expect(
       parseGeminiStdoutLine(
         JSON.stringify({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello from parts" }],
+        }),
+        ts,
+      ),
+    ).toEqual([
+      { kind: "assistant", ts, text: "hello from parts" },
+    ]);
+
+    expect(
+      parseGeminiStdoutLine(
+        JSON.stringify({
           type: "result",
           subtype: "success",
           result: "Done",
@@ -199,6 +242,14 @@ describe("gemini_local cli formatter", () => {
       );
       printGeminiStreamEvent(
         JSON.stringify({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello from parts" }],
+        }),
+        false,
+      );
+      printGeminiStreamEvent(
+        JSON.stringify({
           type: "result",
           subtype: "success",
           usage: {
@@ -222,6 +273,7 @@ describe("gemini_local cli formatter", () => {
     expect(joined).toContain("Gemini init");
     expect(joined).toContain("assistant: hello");
     expect(joined).toContain("assistant: hello from new format");
+    expect(joined).toContain("assistant: hello from parts");
     expect(joined).toContain("tokens: in=10 out=5 cached=2 cost=$0.000420");
     expect(joined).toContain("error: boom");
   });

--- a/server/src/__tests__/gemini-local-adapter.test.ts
+++ b/server/src/__tests__/gemini-local-adapter.test.ts
@@ -40,6 +40,23 @@ describe("gemini_local parser", () => {
     expect(parsed.errorMessage).toBe("model access denied");
   });
 
+  it("extracts assistant text from newer message events", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "message",
+        role: "assistant",
+        content: "hello",
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+      }),
+    ].join("\n");
+
+    const parsed = parseGeminiJsonl(stdout);
+    expect(parsed.summary).toBe("hello");
+  });
+
   it("extracts structured questions", () => {
     const stdout = [
       JSON.stringify({
@@ -108,6 +125,19 @@ describe("gemini_local ui stdout parser", () => {
     expect(
       parseGeminiStdoutLine(
         JSON.stringify({
+          type: "message",
+          role: "assistant",
+          content: "hello from new format",
+        }),
+        ts,
+      ),
+    ).toEqual([
+      { kind: "assistant", ts, text: "hello from new format" },
+    ]);
+
+    expect(
+      parseGeminiStdoutLine(
+        JSON.stringify({
           type: "result",
           subtype: "success",
           result: "Done",
@@ -161,6 +191,14 @@ describe("gemini_local cli formatter", () => {
       );
       printGeminiStreamEvent(
         JSON.stringify({
+          type: "message",
+          role: "assistant",
+          content: "hello from new format",
+        }),
+        false,
+      );
+      printGeminiStreamEvent(
+        JSON.stringify({
           type: "result",
           subtype: "success",
           usage: {
@@ -183,6 +221,7 @@ describe("gemini_local cli formatter", () => {
 
     expect(joined).toContain("Gemini init");
     expect(joined).toContain("assistant: hello");
+    expect(joined).toContain("assistant: hello from new format");
     expect(joined).toContain("tokens: in=10 out=5 cached=2 cost=$0.000420");
     expect(joined).toContain("error: boom");
   });


### PR DESCRIPTION
Thinking path
- Paperclip uses Gemini stream output in more than one place: the environment probe, the server-side result parser, and the transcript/CLI formatting paths.
- The older Gemini stream shape used `type: "assistant"` with message content nested under `message`.
- But newer Gemini CLI output can emit `type: "message"` with `role: "assistant"` and the text under `content`.
- That means Paperclip can miss valid assistant output even when Gemini actually returned the right answer.
- I focused this PR on that parser mismatch only, without mixing in the timeout or sandbox parts of #1625.

What I changed
- Updated the Gemini server parser to accept assistant text from the newer `type: "message"` / `role: "assistant"` event shape.
- Updated the UI stdout parser and CLI formatter to recognize the same newer message shape too.
- Added regression coverage for the new event format.

Why this matters
- It fixes one concrete root cause behind the misleading Gemini hello-probe failures in #1625.
- It also keeps the UI and CLI views in sync with the server-side parser instead of only fixing one surface.

How I verified it
- `pnpm exec vitest run server/src/__tests__/gemini-local-adapter.test.ts`
- `pnpm --filter @paperclipai/adapter-gemini-local typecheck`
- `pnpm --filter @paperclipai/server typecheck`

Risks
- Low risk. This only broadens Gemini event parsing to support an additional stream shape.
- I did not change the timeout or sandbox behavior in this PR.

Related to #1625