### PR TITLE
fix: register gemini_local in AGENT_ADAPTER_TYPES and add Gemini 3.x models

### DIFF
--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,6 +4,11 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (Preview)" },
+  {
+    id: "gemini-3.1-pro-preview-customtools",
+    label: "Gemini 3.1 Pro Custom Tools",
+  },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -27,6 +27,7 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "opencode_local",
+  "gemini_local",
   "pi_local",
   "cursor",
   "openclaw_gateway",


### PR DESCRIPTION
## Summary

- **Register `gemini_local` in `AGENT_ADAPTER_TYPES`** (`packages/shared/src/constants.ts`) so Zod validation accepts it when creating agents. Without this, the onboarding flow passes the env probe but fails with a `Validation error` on agent creation.
- **Add Gemini 3.x models** to the `gemini-local` adapter model list: `gemini-3.1-pro-preview` and `gemini-3.1-pro-preview-customtools`.

## Issues fixed

- Closes #1195 — gemini_local not registered in AGENT_ADAPTER_TYPES
- Closes #1629 — gemini_local missing breaks onboarding
- Closes #1506 — model list missing Gemini 3.x

## Changes

| File | Change |
|---|---|
| `packages/shared/src/constants.ts` | Add `"gemini_local"` to `AGENT_ADAPTER_TYPES` array |
| `packages/adapters/gemini-local/src/index.ts` | Add `gemini-3.1-pro-preview` and `gemini-3.1-pro-preview-customtools` models |

## Test plan

- [ ] Create a new agent with `adapterType: "gemini_local"` via API — should no longer return `Validation error`
- [ ] Open the new agent modal in the UI — Gemini CLI (local) should appear in the adapter dropdown
- [ ] Gemini 3.1 Pro (Preview) and Gemini 3.1 Pro Custom Tools should appear in the model dropdown for gemini_local agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)