### PR TITLE
chore: add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,15 @@
   Required. Trace your reasoning from the top of the project down to this
   specific change. Start with what Paperclip is, then narrow through the
   subsystem, the problem, and why this PR exists. Use blockquote style.
-  See CONTRIBUTING.md for full examples.
+  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
 -->
 
 > - Paperclip orchestrates AI agents for zero-human companies
-> - ...
+> - [Which subsystem or capability is involved]
+> - [What problem or gap exists]
+> - [Why it needs to be addressed]
 > - This pull request ...
+> - The benefit is ...
 
 ## What Changed
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Contributors (both human and AI) submit PRs regularly
> - CONTRIBUTING.md defines a "thinking path" format and PR expectations, but there's no structured template enforcing them
> - Without a template, PRs arrive in inconsistent formats and reviewers have to ask for missing context
> - This PR adds a `.github/PULL_REQUEST_TEMPLATE.md` that pre-populates the expected sections and a checklist
> - The benefit is consistent, reviewable PRs from day one — especially for new contributors and AI agents

## What Changed

- Added `.github/PULL_REQUEST_TEMPLATE.md` with:
  - **Thinking Path** section with placeholder and instructions
  - **What Changed** section for bullet-pointed changes
  - **Verification** section for test commands and manual steps
  - **Risks** section for migration safety, breaking changes, etc.
  - **Checklist** with seven items covering: thinking path, local tests, new/updated tests, screenshots for UI changes, documentation updates, risk assessment, and commitment to address review feedback

## Verification

- Open a new PR on this repo after merge — the template should auto-populate
- Confirm all sections and checklist items render correctly in the GitHub PR form

## Risks

- Low risk. This only adds a new file and doesn't affect any existing workflows or code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)