### PR TITLE
Fix imported agent bundle frontmatter leakage

### DIFF
--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -2112,4 +2112,74 @@ describe("company portability", () => {
     expect(materializedFiles["AGENTS.md"]).not.toMatch(/^---\n/);
     expect(materializedFiles["AGENTS.md"]).not.toContain('name: "ClaudeCoder"');
   });
+
+  it("strips root AGENTS frontmatter when importing a nested agent entry path", async () => {
+    const portability = companyPortabilityService({} as any);
+
+    companySvc.create.mockResolvedValue({
+      id: "company-imported",
+      name: "Imported Paperclip",
+    });
+    accessSvc.ensureMembership.mockResolvedValue(undefined);
+    agentSvc.create.mockResolvedValue({
+      id: "agent-created",
+      name: "ClaudeCoder",
+    });
+
+    const exported = await portability.exportBundle("company-1", {
+      include: {
+        company: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+    });
+    const originalAgentsMarkdown = exported.files["agents/claudecoder/AGENTS.md"];
+    expect(typeof originalAgentsMarkdown).toBe("string");
+
+    const files = {
+      ...exported.files,
+      "agents/claudecoder/nested/AGENTS.md": originalAgentsMarkdown!,
+    };
+
+    agentSvc.list.mockResolvedValue([]);
+
+    await portability.importBundle({
+      source: {
+        type: "inline",
+        rootPath: exported.rootPath,
+        files,
+      },
+      include: {
+        company: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+      target: {
+        mode: "new_company",
+        newCompanyName: "Imported Paperclip",
+      },
+      agents: ["claudecoder"],
+      collisionStrategy: "rename",
+      adapterOverrides: {
+        claudecoder: {
+          adapterType: "codex_local",
+          adapterConfig: {
+            dangerouslyBypassApprovalsAndSandbox: true,
+          },
+        },
+      },
+    }, "user-1");
+
+    const nestedMaterializedFiles = agentInstructionsSvc.materializeManagedBundle.mock.calls
+      .map(([, filesArg]) => filesArg as Record<string, string>)
+      .find((filesArg) => typeof filesArg["nested/AGENTS.md"] === "string");
+
+    expect(nestedMaterializedFiles).toBeDefined();
+    expect(nestedMaterializedFiles?.["nested/AGENTS.md"]).toContain("You are ClaudeCoder.");
+    expect(nestedMaterializedFiles?.["AGENTS.md"]).toContain("You are ClaudeCoder.");
+    expect(nestedMaterializedFiles?.["AGENTS.md"]).not.toMatch(/^---\n/);
+    expect(nestedMaterializedFiles?.["AGENTS.md"]).not.toContain('name: "ClaudeCoder"');
+  });
 });

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3870,7 +3870,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
         if (typeof markdownRaw === "string") {
           const importedInstructionsBody = parseFrontmatterMarkdown(markdownRaw).body;
           bundleFiles[entryRelativePath] = importedInstructionsBody;
-          if (entryRelativePath !== "AGENTS.md" && !bundleFiles["AGENTS.md"]) {
+          if (entryRelativePath !== "AGENTS.md") {
             bundleFiles["AGENTS.md"] = importedInstructionsBody;
           }
         }


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies.
- Imported companies need their managed agent instruction bundles to survive export/import intact.
- Those bundles are materialized back into instruction files during import.
- But imported `AGENTS.md` content was still carrying YAML frontmatter from the portable bundle.
- That leaked adapter metadata into the live instruction file instead of just the markdown body.
- This PR strips the imported frontmatter body before materializing the managed bundle files.
- The result is imported agents reopen with clean instruction markdown instead of frontmatter noise.

## What Changed

- parse imported `AGENTS.md` bundle content through the existing frontmatter parser before writing it back into the managed bundle
- keep the entry file and `AGENTS.md` fallback in sync with the stripped markdown body
- add a regression assertion in the company portability test to ensure imported materialized files do not contain frontmatter or leaked agent metadata

## Why It Matters

Imported companies should behave like native ones. Leaving frontmatter in the live instruction file breaks that expectation and makes imported agent prompts look corrupted.

## Verification

- `pnpm test:run server/src/__tests__/company-portability.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server build`

## Risks

- Low risk; this only changes import-time materialization of managed instruction bundles and adds regression coverage around that path.
