### PR TITLE
Extract mention-aware link node helper and add tests

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -26,52 +26,12 @@ import {
   thematicBreakPlugin,
   type RealmPlugin,
 } from "@mdxeditor/editor";
-import { LinkNode, type LinkAttributes } from "@lexical/link";
 import { buildAgentMentionHref, buildProjectMentionHref } from "@paperclipai/shared";
 import { AgentIcon } from "./AgentIconPicker";
 import { applyMentionChipDecoration, clearMentionChipDecoration, parseMentionChipHref } from "../lib/mention-chips";
+import { MentionAwareLinkNode, mentionAwareLinkNodeReplacement } from "../lib/mention-aware-link-node";
 import { mentionDeletionPlugin } from "../lib/mention-deletion";
 import { cn } from "../lib/utils";
-
-const CUSTOM_MENTION_URL_RE = /^(agent|project):\/\//;
-
-class MentionAwareLinkNode extends LinkNode {
-  static clone(node: MentionAwareLinkNode): MentionAwareLinkNode {
-    return new MentionAwareLinkNode(
-      node.getURL(),
-      {
-        rel: node.getRel(),
-        target: node.getTarget(),
-        title: node.getTitle(),
-      },
-      node.getKey(),
-    );
-  }
-
-  constructor(url?: string, attributes?: LinkAttributes, key?: string) {
-    super(url, attributes, key);
-  }
-
-  sanitizeUrl(url: string): string {
-    if (CUSTOM_MENTION_URL_RE.test(url)) return url;
-    return super.sanitizeUrl(url);
-  }
-}
-
-const mentionAwareLinkNodeReplacement = {
-  replace: LinkNode,
-  with: (node: LinkNode) =>
-    new MentionAwareLinkNode(
-      node.getURL(),
-      {
-        rel: node.getRel(),
-        target: node.getTarget(),
-        title: node.getTitle(),
-      },
-      node.getKey(),
-    ),
-  withKlass: MentionAwareLinkNode,
-} as const;
 
 /* ---- Mention types ---- */
 
@@ -590,7 +550,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           "paperclip-mdxeditor-content focus:outline-none [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:list-item",
           contentClassName,
         )}
-        additionalLexicalNodes={[mentionAwareLinkNodeReplacement]}
+        additionalLexicalNodes={[MentionAwareLinkNode, mentionAwareLinkNodeReplacement]}
         plugins={plugins}
       />
 

--- a/ui/src/lib/mention-aware-link-node.test.ts
+++ b/ui/src/lib/mention-aware-link-node.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { $createLinkNode } from "@lexical/link";
+import { createEditor } from "lexical";
+import {
+  MentionAwareLinkNode,
+  getMentionAwareLinkNodeInit,
+  mentionAwareLinkNodeReplacement,
+} from "./mention-aware-link-node";
+
+function createTestEditor() {
+  return createEditor({
+    namespace: "mention-aware-link-node-test",
+    nodes: [MentionAwareLinkNode, mentionAwareLinkNodeReplacement],
+    onError(error: Error) {
+      throw error;
+    },
+  });
+}
+
+describe("getMentionAwareLinkNodeInit", () => {
+  it("copies link attributes without carrying over a node key", () => {
+    const init = getMentionAwareLinkNodeInit({
+      getURL: () => "agent://agent-123",
+      getRel: () => "noreferrer",
+      getTarget: () => "_blank",
+      getTitle: () => "Agent mention",
+    });
+
+    expect(Object.keys(init)).toEqual(["url", "attributes"]);
+    expect(init).toEqual({
+      url: "agent://agent-123",
+      attributes: {
+        rel: "noreferrer",
+        target: "_blank",
+        title: "Agent mention",
+      },
+    });
+  });
+
+  it("replaces LinkNode creation with MentionAwareLinkNode without throwing", () => {
+    const editor = createTestEditor();
+    let created: unknown;
+
+    editor.update(() => {
+      created = $createLinkNode("agent://agent-123");
+    });
+
+    expect(created).toBeInstanceOf(MentionAwareLinkNode);
+  });
+});

--- a/ui/src/lib/mention-aware-link-node.ts
+++ b/ui/src/lib/mention-aware-link-node.ts
@@ -1,0 +1,67 @@
+import {
+  LinkNode,
+  type LinkAttributes,
+  type SerializedLinkNode,
+} from "@lexical/link";
+
+const CUSTOM_MENTION_URL_RE = /^(agent|project):\/\//;
+
+export class MentionAwareLinkNode extends LinkNode {
+  static getType(): string {
+    return "mention-aware-link";
+  }
+
+  static clone(node: MentionAwareLinkNode): MentionAwareLinkNode {
+    return new MentionAwareLinkNode(
+      node.getURL(),
+      {
+        rel: node.getRel(),
+        target: node.getTarget(),
+        title: node.getTitle(),
+      },
+      node.getKey(),
+    );
+  }
+
+  static importJSON(serializedNode: SerializedLinkNode): MentionAwareLinkNode {
+    return new MentionAwareLinkNode(
+      serializedNode.url ?? "",
+      {
+        rel: serializedNode.rel ?? null,
+        target: serializedNode.target ?? null,
+        title: serializedNode.title ?? null,
+      },
+    );
+  }
+
+  constructor(url?: string, attributes?: LinkAttributes, key?: string) {
+    super(url, attributes, key);
+  }
+
+  sanitizeUrl(url: string): string {
+    if (CUSTOM_MENTION_URL_RE.test(url)) return url;
+    return super.sanitizeUrl(url);
+  }
+}
+
+type MentionAwareLinkSource = Pick<LinkNode, "getURL" | "getRel" | "getTarget" | "getTitle">;
+
+export function getMentionAwareLinkNodeInit(node: MentionAwareLinkSource) {
+  return {
+    url: node.getURL(),
+    attributes: {
+      rel: node.getRel(),
+      target: node.getTarget(),
+      title: node.getTitle(),
+    },
+  };
+}
+
+export const mentionAwareLinkNodeReplacement = {
+  replace: LinkNode,
+  with: (node: LinkNode) => {
+    const { url, attributes } = getMentionAwareLinkNodeInit(node);
+    return new MentionAwareLinkNode(url, attributes);
+  },
+  withKlass: MentionAwareLinkNode,
+} as const;


### PR DESCRIPTION
## Thinking Path

- Paperclip comments and documents use markdown editors that support agent and project mentions.
- Those mentions rely on custom `agent://` and `project://` link URLs inside Lexical.
- The editor already needed a custom link node to allow those URLs through sanitization.
- But that custom node lived inline inside `MarkdownEditor`, which made it harder to register explicitly and harder to test.
- That left the mention-link node behavior under-covered even though it is foundational to mention editing.
- This PR extracts the custom link node into a dedicated helper module, registers the class explicitly, and adds focused tests.
- The result is a safer path for custom mention links with direct regression coverage.

## What Changed

- move the custom mention-aware `LinkNode` implementation into `ui/src/lib/mention-aware-link-node.ts`
- export a small initializer helper so replacement logic can copy link attributes cleanly without carrying over node keys
- register both the node class and replacement in `MarkdownEditor`
- add focused Vitest coverage for the helper output and custom link-node creation path

## Why It Matters

Mention links are a core part of how work objects stay connected in Paperclip. Giving their custom Lexical node a dedicated module plus tests makes that editor behavior easier to reason about and safer to evolve.

## Verification

- `pnpm test:run ui/src/lib/mention-aware-link-node.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`

## Risks

- Low risk; this is a localized editor refactor with focused regression coverage around the custom mention link node.
