### PR TITLE
fix: infer content type from file extension for attachments

### DIFF
--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -131,4 +131,10 @@ describe("inferContentType", () => {
     expect(inferContentType(undefined, "application/octet-stream")).toBe("application/octet-stream");
     expect(inferContentType("", "application/octet-stream")).toBe("application/octet-stream");
   });
+
+  it("returns original mime type for filenames with no extension", () => {
+    expect(inferContentType("nodotfile", "application/octet-stream")).toBe("application/octet-stream");
+    expect(inferContentType("Makefile", "application/octet-stream")).toBe("application/octet-stream");
+    expect(inferContentType("README", "application/octet-stream")).toBe("application/octet-stream");
+  });
 });

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseAllowedTypes,
   matchesContentType,
+  inferContentType,
   DEFAULT_ALLOWED_TYPES,
 } from "../attachment-types.js";
 
@@ -93,5 +94,41 @@ describe("matchesContentType", () => {
     expect(matchesContentType("application/pdf", patterns)).toBe(true);
     expect(matchesContentType("text/plain", patterns)).toBe(true);
     expect(matchesContentType("application/zip", patterns)).toBe(true);
+  });
+});
+
+describe("inferContentType", () => {
+  it("returns original mime type when not application/octet-stream", () => {
+    expect(inferContentType("test.md", "text/markdown")).toBe("text/markdown");
+    expect(inferContentType("test.png", "image/png")).toBe("image/png");
+  });
+
+  it("infers text/markdown from .md extension", () => {
+    expect(inferContentType("readme.md", "application/octet-stream")).toBe("text/markdown");
+    expect(inferContentType("README.MD", "application/octet-stream")).toBe("text/markdown");
+    expect(inferContentType("docs/guide.md", "application/octet-stream")).toBe("text/markdown");
+  });
+
+  it("infers text/markdown from .markdown extension", () => {
+    expect(inferContentType("readme.markdown", "application/octet-stream")).toBe("text/markdown");
+  });
+
+  it("infers text/plain from .txt extension", () => {
+    expect(inferContentType("notes.txt", "application/octet-stream")).toBe("text/plain");
+  });
+
+  it("infers application/json from .json extension", () => {
+    expect(inferContentType("data.json", "application/octet-stream")).toBe("application/json");
+  });
+
+  it("returns original mime type for unknown extensions", () => {
+    expect(inferContentType("file.xyz", "application/octet-stream")).toBe("application/octet-stream");
+    expect(inferContentType("file.unknown", "application/octet-stream")).toBe("application/octet-stream");
+  });
+
+  it("returns original mime type when filename is null or undefined", () => {
+    expect(inferContentType(null, "application/octet-stream")).toBe("application/octet-stream");
+    expect(inferContentType(undefined, "application/octet-stream")).toBe("application/octet-stream");
+    expect(inferContentType("", "application/octet-stream")).toBe("application/octet-stream");
   });
 });

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -15,6 +15,8 @@
  *   - Wildcards:     "image/*"  or  "application/vnd.openxmlformats-officedocument.*"
  */
 
+import path from "node:path";
+
 export const DEFAULT_ALLOWED_TYPES: readonly string[] = [
   "image/png",
   "image/jpeg",
@@ -63,7 +65,7 @@ export function inferContentType(
   if (!filename) {
     return reportedMimeType;
   }
-  const ext = filename.toLowerCase().slice(filename.lastIndexOf("."));
+  const ext = path.extname(filename).toLowerCase();
   const inferred = EXTENSION_TO_MIME_TYPE[ext];
   return inferred || reportedMimeType;
 }

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -30,6 +30,45 @@ export const DEFAULT_ALLOWED_TYPES: readonly string[] = [
 ];
 
 /**
+ * Map of file extensions to their canonical MIME types.
+ * Used when the browser sends a generic type like application/octet-stream.
+ */
+export const EXTENSION_TO_MIME_TYPE: Record<string, string> = {
+  ".md": "text/markdown",
+  ".markdown": "text/markdown",
+  ".txt": "text/plain",
+  ".json": "application/json",
+  ".csv": "text/csv",
+  ".html": "text/html",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+};
+
+/**
+ * Infer the content type from a filename when the browser sends a generic type.
+ * Returns the inferred MIME type if the extension is known, otherwise returns the original.
+ */
+export function inferContentType(
+  filename: string | null | undefined,
+  reportedMimeType: string,
+): string {
+  // Only infer when the browser sends a generic binary type
+  if (reportedMimeType.toLowerCase() !== "application/octet-stream") {
+    return reportedMimeType;
+  }
+  if (!filename) {
+    return reportedMimeType;
+  }
+  const ext = filename.toLowerCase().slice(filename.lastIndexOf("."));
+  const inferred = EXTENSION_TO_MIME_TYPE[ext];
+  return inferred || reportedMimeType;
+}
+
+/**
  * Parse a comma-separated list of MIME type patterns into a normalised array.
  * Returns the default image-only list when the input is empty or undefined.
  */

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -34,7 +34,7 @@ import { logger } from "../middleware/logger.js";
 import { forbidden, HttpError, unauthorized } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
-import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { isAllowedContentType, inferContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
@@ -1464,7 +1464,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: "Missing file field 'file'" });
       return;
     }
-    const contentType = (file.mimetype || "").toLowerCase();
+    // Infer content type from filename when browser sends generic octet-stream
+    const contentType = inferContentType(file.originalname, (file.mimetype || "").toLowerCase());
     if (!isAllowedContentType(contentType)) {
       res.status(422).json({ error: `Unsupported attachment type: ${contentType || "unknown"}` });
       return;


### PR DESCRIPTION
## Thinking Path

**Problem:** Users reported that markdown files (.md) couldn't be uploaded to issues because browsers often send `application/octet-stream` as the MIME type instead of `text/markdown`.

**Root Cause:** The attachment upload validation only checked the MIME type reported by the browser. When the browser doesn't recognize the file type, it sends a generic `application/octet-stream` which gets rejected even though `text/markdown` is in the allowed types list.

**Solution Approach:** Instead of relying solely on the browser-reported MIME type, infer the correct type from the file extension when the browser sends `application/octet-stream`. This is a common pattern used by many file upload systems.

**Why This Works:**
1. The inference only kicks in for `application/octet-stream` - we don't override known MIME types
2. We only map to types already in the allowed list (`text/markdown`, `text/plain`, etc.)
3. Unknown extensions fall back to the original MIME type, preserving existing behavior
4. Using `path.extname()` ensures correct handling of edge cases (no extension, multiple dots)

**Benefits:**
- Fixes #632 - markdown files can now be uploaded
- Also fixes uploads for other common text formats (.txt, .json, .csv, .html)
- No new attack surface - only maps to already-allowed types
- Minimal code change, well-tested

**Risks:**
- Low risk. The change is scoped to the octet-stream case only
- If a user intentionally wants to upload a file with a different extension as octet-stream, they can still do so if the extension is not in our map

**Verification:**
- All 20 tests pass
- TypeScript type-check passes
- Manual test: upload a .md file that browser sends as application/octet-stream

---

## Summary

Fixes #632 - Markdown files (.md, .markdown) can now be uploaded even when the browser sends `application/octet-stream` as the MIME type.

## Changes

- Added `inferContentType()` function in `attachment-types.ts` that detects MIME type from file extension
- Added `EXTENSION_TO_MIME_TYPE` mapping for common file types (.md, .txt, .json, .csv, .html, .pdf, images)
- Updated issues route to use `inferContentType()` before validation
- Added 8 new tests for `inferContentType()` function
- Uses `path.extname()` for robust extension extraction

## Files changed

- `server/src/attachment-types.ts` - Added inferContentType function and extension mapping
- `server/src/routes/issues.ts` - Updated to use inferContentType before validation  
- `server/src/__tests__/attachment-types.test.ts` - Added 8 new tests

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5