### PR TITLE
Allow manual OpenCode provider/model entry in the UI

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -25,7 +25,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { FolderOpen, Heart, ChevronDown, X } from "lucide-react";
 import { cn } from "../lib/utils";
-import { extractModelName, extractProviderId } from "../lib/model-utils";
+import {
+  extractModelName,
+  extractProviderId,
+  shouldOfferCustomModelEntry,
+} from "../lib/model-utils";
 import { queryKeys } from "../lib/queryKeys";
 import { useCompany } from "../context/CompanyContext";
 import {
@@ -1305,6 +1309,13 @@ function ModelDropdown({
 }) {
   const [modelSearch, setModelSearch] = useState("");
   const selected = models.find((m) => m.id === value);
+  const customModelCandidate = modelSearch.trim();
+  const showCustomModelEntry = groupByProvider
+    ? shouldOfferCustomModelEntry(
+        customModelCandidate,
+        models.map((model) => model.id),
+      )
+    : false;
   const filteredModels = useMemo(() => {
     return models.filter((m) => {
       if (!modelSearch.trim()) return true;
@@ -1363,9 +1374,15 @@ function ModelDropdown({
         <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-1" align="start">
           <input
             className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-            placeholder="Search models..."
+            placeholder={groupByProvider ? "Search or paste provider/model..." : "Search models..."}
             value={modelSearch}
             onChange={(e) => setModelSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter" || !showCustomModelEntry) return;
+              e.preventDefault();
+              onChange(customModelCandidate);
+              onOpenChange(false);
+            }}
             autoFocus
           />
           <div className="max-h-[240px] overflow-y-auto">
@@ -1381,6 +1398,17 @@ function ModelDropdown({
                 }}
               >
                 Default
+              </button>
+            )}
+            {showCustomModelEntry && (
+              <button
+                className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50 border border-dashed border-border/70 mb-1"
+                onClick={() => {
+                  onChange(customModelCandidate);
+                  onOpenChange(false);
+                }}
+              >
+                {`Use custom model: ${customModelCandidate}`}
               </button>
             )}
             {groupedModels.map((group) => (
@@ -1410,11 +1438,20 @@ function ModelDropdown({
               </div>
             ))}
             {filteredModels.length === 0 && (
-              <p className="px-2 py-1.5 text-xs text-muted-foreground">No models found.</p>
+              <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                {groupByProvider
+                  ? "No discovered models found. Paste provider/model and press Enter."
+                  : "No models found."}
+              </p>
             )}
           </div>
         </PopoverContent>
       </Popover>
+      {groupByProvider && (
+        <p className="text-[11px] text-muted-foreground mt-1">
+          Tip: for OpenCode you can paste a provider/model value even if discovery misses it.
+        </p>
+      )}
     </Field>
   );
 }

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -19,7 +19,9 @@ import { Button } from "@/components/ui/button";
 import { cn } from "../lib/utils";
 import {
   extractModelName,
-  extractProviderIdWithFallback
+  extractProviderIdWithFallback,
+  isProviderModelId,
+  shouldOfferCustomModelEntry,
 } from "../lib/model-utils";
 import { getUIAdapter } from "../adapters";
 import { defaultCreateValues } from "./agent-config-defaults";
@@ -178,12 +180,7 @@ export function OnboardingWizard() {
     if (step === 3) autoResizeTextarea();
   }, [step, taskDescription, autoResizeTextarea]);
 
-  const {
-    data: adapterModels,
-    error: adapterModelsError,
-    isLoading: adapterModelsLoading,
-    isFetching: adapterModelsFetching
-  } = useQuery({
+  const { data: adapterModels } = useQuery({
     queryKey: createdCompanyId
       ? queryKeys.agents.adapterModels(createdCompanyId, adapterType)
       : ["agents", "none", "adapter-models", adapterType],
@@ -218,6 +215,13 @@ export function OnboardingWizard() {
   }, [step, adapterType, model, command, args, url]);
 
   const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
+  const customModelCandidate = model.trim();
+  const showCustomModelEntry =
+    adapterType === "opencode_local" &&
+    shouldOfferCustomModelEntry(
+      customModelCandidate,
+      (adapterModels ?? []).map((entry) => entry.id),
+    );
   const hasAnthropicApiKeyOverrideCheck =
     adapterEnvResult?.checks.some(
       (check) =>
@@ -405,27 +409,8 @@ export function OnboardingWizard() {
           );
           return;
         }
-        if (adapterModelsError) {
-          setError(
-            adapterModelsError instanceof Error
-              ? adapterModelsError.message
-              : "Failed to load OpenCode models."
-          );
-          return;
-        }
-        if (adapterModelsLoading || adapterModelsFetching) {
-          setError(
-            "OpenCode models are still loading. Please wait and try again."
-          );
-          return;
-        }
-        const discoveredModels = adapterModels ?? [];
-        if (!discoveredModels.some((entry) => entry.id === selectedModelId)) {
-          setError(
-            discoveredModels.length === 0
-              ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
-              : `Configured OpenCode model is unavailable: ${selectedModelId}`
-          );
+        if (!isProviderModelId(selectedModelId)) {
+          setError("OpenCode model must use provider/model format.");
           return;
         }
       }
@@ -898,9 +883,19 @@ export function OnboardingWizard() {
                           >
                             <input
                               className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-                              placeholder="Search models..."
+                              placeholder={
+                                adapterType === "opencode_local"
+                                  ? "Search models or paste provider/model..."
+                                  : "Search models..."
+                              }
                               value={modelSearch}
                               onChange={(e) => setModelSearch(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key !== "Enter" || !showCustomModelEntry) return;
+                                e.preventDefault();
+                                setModel(customModelCandidate);
+                                setModelOpen(false);
+                              }}
                               autoFocus
                             />
                             {adapterType !== "opencode_local" && (
@@ -918,6 +913,17 @@ export function OnboardingWizard() {
                               </button>
                             )}
                             <div className="max-h-[240px] overflow-y-auto">
+                              {showCustomModelEntry && (
+                                <button
+                                  className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50 border border-dashed border-border/70 mb-1"
+                                  onClick={() => {
+                                    setModel(customModelCandidate);
+                                    setModelOpen(false);
+                                  }}
+                                >
+                                  {`Use custom model: ${customModelCandidate}`}
+                                </button>
+                              )}
                               {groupedModels.map((group) => (
                                 <div
                                   key={group.provider}
@@ -955,11 +961,18 @@ export function OnboardingWizard() {
                             </div>
                             {filteredModels.length === 0 && (
                               <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                                No models discovered.
+                                {adapterType === "opencode_local"
+                                  ? "No discovered models found. Paste provider/model and press Enter."
+                                  : "No models discovered."}
                               </p>
                             )}
                           </PopoverContent>
                         </Popover>
+                        {adapterType === "opencode_local" && (
+                          <p className="text-[11px] text-muted-foreground mt-1">
+                            Tip: for OpenCode you can paste a provider/model value even if discovery misses it.
+                          </p>
+                        )}
                       </div>
                     </div>
                   )}

--- a/ui/src/lib/model-utils.test.ts
+++ b/ui/src/lib/model-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractModelName,
+  extractProviderId,
+  isProviderModelId,
+  shouldOfferCustomModelEntry,
+} from "./model-utils";
+
+describe("model utils", () => {
+  it("extracts provider and model names from hierarchical ids", () => {
+    expect(extractProviderId("github-models/openai/gpt-4.1")).toBe("github-models");
+    expect(extractModelName("github-models/openai/gpt-4.1")).toBe("openai/gpt-4.1");
+  });
+
+  it("accepts provider/model ids with nested model paths", () => {
+    expect(isProviderModelId("opencode-go/minimax-m2.5")).toBe(true);
+    expect(isProviderModelId("github-models/openai/gpt-4.1")).toBe(true);
+  });
+
+  it("rejects blank or malformed provider/model ids", () => {
+    expect(isProviderModelId("")).toBe(false);
+    expect(isProviderModelId("gpt-5")).toBe(false);
+    expect(isProviderModelId("/gpt-5")).toBe(false);
+    expect(isProviderModelId("openai/")).toBe(false);
+  });
+
+  it("offers custom model entries only for valid unseen ids", () => {
+    const discovered = ["openai/gpt-5.4", "github-models/openai/gpt-4.1"];
+    expect(shouldOfferCustomModelEntry("openai/gpt-5.4", discovered)).toBe(false);
+    expect(shouldOfferCustomModelEntry("openai/gpt-5.5-preview", discovered)).toBe(true);
+    expect(shouldOfferCustomModelEntry("gpt-5.5-preview", discovered)).toBe(false);
+  });
+});

--- a/ui/src/lib/model-utils.ts
+++ b/ui/src/lib/model-utils.ts
@@ -14,3 +14,21 @@ export function extractModelName(modelId: string): string {
   if (!trimmed.includes("/")) return trimmed;
   return trimmed.slice(trimmed.indexOf("/") + 1).trim();
 }
+
+export function isProviderModelId(modelId: string): boolean {
+  const trimmed = modelId.trim();
+  if (!trimmed.includes("/")) return false;
+  const slashIndex = trimmed.indexOf("/");
+  const provider = trimmed.slice(0, slashIndex).trim();
+  const model = trimmed.slice(slashIndex + 1).trim();
+  return provider.length > 0 && model.length > 0;
+}
+
+export function shouldOfferCustomModelEntry(
+  search: string,
+  modelIds: readonly string[],
+): boolean {
+  const trimmed = search.trim();
+  if (!isProviderModelId(trimmed)) return false;
+  return !modelIds.some((modelId) => modelId === trimmed);
+}

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/popover";
 import { Shield } from "lucide-react";
 import { cn, agentUrl } from "../lib/utils";
+import { isProviderModelId } from "../lib/model-utils";
 import { roleLabels } from "../components/agent-config-primitives";
 import { AgentConfigForm, type CreateConfigValues } from "../components/AgentConfigForm";
 import { defaultCreateValues } from "../components/agent-config-defaults";
@@ -80,12 +81,7 @@ export function NewAgent() {
     enabled: !!selectedCompanyId,
   });
 
-  const {
-    data: adapterModels,
-    error: adapterModelsError,
-    isLoading: adapterModelsLoading,
-    isFetching: adapterModelsFetching,
-  } = useQuery({
+  const { data: adapterModels } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.agents.adapterModels(selectedCompanyId, configValues.adapterType)
       : ["agents", "none", "adapter-models", configValues.adapterType],
@@ -155,25 +151,8 @@ export function NewAgent() {
         setFormError("OpenCode requires an explicit model in provider/model format.");
         return;
       }
-      if (adapterModelsError) {
-        setFormError(
-          adapterModelsError instanceof Error
-            ? adapterModelsError.message
-            : "Failed to load OpenCode models.",
-        );
-        return;
-      }
-      if (adapterModelsLoading || adapterModelsFetching) {
-        setFormError("OpenCode models are still loading. Please wait and try again.");
-        return;
-      }
-      const discovered = adapterModels ?? [];
-      if (!discovered.some((entry) => entry.id === selectedModel)) {
-        setFormError(
-          discovered.length === 0
-            ? "No OpenCode models discovered. Run `opencode models` and authenticate providers."
-            : `Configured OpenCode model is unavailable: ${selectedModel}`,
-        );
+      if (!isProviderModelId(selectedModel)) {
+        setFormError("OpenCode model must use provider/model format.");
         return;
       }
     }


### PR DESCRIPTION
## Summary
- allow manual OpenCode `provider/model` entry in the shared agent config model picker
- reuse the same fallback in onboarding and new-agent validation instead of blocking on discovery-only lists
- add shared model-id helpers and regression tests for valid custom entry behavior

## Testing
- pnpm -r typecheck
- pnpm test:run
- pnpm build
