### PR TITLE
feat(openclaw-gateway): fetch token usage via sessions.usage after agent.wait

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1323,6 +1323,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         }
       }
 
+      // Fetch session usage from OpenClaw (token counts, model, cost).
+      // OpenClaw tracks per-session usage internally but does not include it
+      // in the agent.wait response.  The sessions.usage RPC returns totals and
+      // a per-model breakdown for the session identified by `sessionKey`.
+      let sessionUsageResult: Record<string, unknown> | null = null;
+      try {
+        sessionUsageResult = await client.request<Record<string, unknown>>(
+          "sessions.usage",
+          { key: sessionKey },
+          { timeoutMs: 10_000 },
+        );
+      } catch (usageErr) {
+        await ctx.onLog(
+          "stderr",
+          `[openclaw-gateway] sessions.usage failed (non-fatal): ${usageErr instanceof Error ? usageErr.message : String(usageErr)}\n`,
+        );
+      }
+
       const summaryFromEvents = assistantChunks.join("").trim();
       const summaryFromPayload =
         extractResultText(asRecord(acceptedPayload?.result)) ??
@@ -1344,12 +1362,42 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         asRecord(mergedMeta.agentMeta) ??
         asRecord(acceptedMeta?.agentMeta) ??
         asRecord(latestMeta?.agentMeta);
-      const usage = parseUsage(agentMeta?.usage ?? mergedMeta.usage);
-      const runtimeServices = extractRuntimeServicesFromMeta(agentMeta ?? mergedMeta);
-      const provider = nonEmpty(agentMeta?.provider) ?? nonEmpty(mergedMeta.provider) ?? "openclaw";
-      const model = nonEmpty(agentMeta?.model) ?? nonEmpty(mergedMeta.model) ?? null;
-      const costUsd = asNumber(agentMeta?.costUsd ?? mergedMeta.costUsd, 0);
+      // Extract sessions.usage data (token counts, model, cost).
+      const sessionUsage = asRecord(sessionUsageResult);
+      const sessionTotals = asRecord(sessionUsage?.totals);
+      const sessionAggregates = asRecord(sessionUsage?.aggregates);
+      const sessionByModel = Array.isArray(sessionAggregates?.byModel)
+        ? sessionAggregates.byModel
+        : [];
+      // byModel is pre-sorted by cost desc by OpenClaw — first entry is the primary model.
+      const primaryModelEntry =
+        sessionByModel.length > 0 ? asRecord(sessionByModel[0]) : null;
 
+      // Prefer agentMeta (forward-compatible), fall back to sessions.usage.
+      const usage =
+        parseUsage(agentMeta?.usage ?? mergedMeta.usage) ??
+        parseUsage(sessionTotals);
+      const runtimeServices = extractRuntimeServicesFromMeta(agentMeta ?? mergedMeta);
+      const provider =
+        nonEmpty(agentMeta?.provider) ??
+        nonEmpty(mergedMeta.provider) ??
+        nonEmpty(primaryModelEntry?.provider) ??
+        "openclaw";
+      const model =
+        nonEmpty(agentMeta?.model) ??
+        nonEmpty(mergedMeta.model) ??
+        nonEmpty(primaryModelEntry?.model) ??
+        null;
+      const costUsd =
+        asNumber(agentMeta?.costUsd ?? mergedMeta.costUsd, 0) ||
+        asNumber(sessionTotals?.totalCost, 0);
+
+      if (sessionUsageResult) {
+        await ctx.onLog(
+          "stdout",
+          `[openclaw-gateway] sessions.usage: input=${usage?.inputTokens ?? 0} output=${usage?.outputTokens ?? 0} cached=${usage?.cachedInputTokens ?? 0} model=${model ?? "unknown"} cost=$${costUsd.toFixed(4)}\n`,
+        );
+      }
       await ctx.onLog(
         "stdout",
         `[openclaw-gateway] run completed runId=${Array.from(trackedRunIds).join(",")} status=ok\n`,


### PR DESCRIPTION
## Summary

- The `openclaw_gateway` adapter records **zero token usage, model, and cost** because `agent.wait` only returns `{runId, status, startedAt, endedAt}` — no usage metadata
- OpenClaw tracks per-session usage internally via the `sessions.usage` WebSocket RPC
- This PR calls `sessions.usage` after `agent.wait` completes, extracting token counts, model, provider, and cost
- The call is wrapped in try/catch — it never breaks a run if the gateway doesn't support it

## Changes

Single file: `packages/adapters/openclaw-gateway/src/server/execute.ts` (+52 lines, -4 lines)

1. **New `sessions.usage` RPC call** after `agent.wait` succeeds (10s timeout, non-fatal try/catch)
2. **Updated extraction logic** — `agentMeta` remains primary source (forward-compatible), `sessions.usage` is fallback:
   - `parseUsage(sessionTotals)` for token counts (input, output, cached)
   - `primaryModelEntry.model` / `.provider` from `aggregates.byModel[0]` (pre-sorted by cost desc)
   - `sessionTotals.totalCost` for USD cost estimate
3. **Diagnostic log line** showing extracted usage data

## Test plan

- [ ] Build adapter: `pnpm --filter @paperclipai/adapter-openclaw-gateway build` (verified locally)
- [ ] Deploy and trigger an agent run via `openclaw_gateway`
- [ ] Verify run logs show `[openclaw-gateway] sessions.usage:` with non-zero token counts
- [ ] Verify `cost_events` table records tokens, model, and cost for the run
- [ ] Verify adapter falls back gracefully if `sessions.usage` is not supported (older gateway)

Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)