### PR TITLE
feat: add goals field to company portability manifest

### DIFF
--- a/cli/src/__tests__/company.test.ts
+++ b/cli/src/__tests__/company.test.ts
@@ -163,6 +163,7 @@ describe("renderCompanyImportPreview", () => {
           brandColor: null,
           logoPath: null,
           requireBoardApprovalForNewAgents: false,
+          goals: [],
         },
         sidebar: {
           agents: ["ceo"],
@@ -371,6 +372,7 @@ describe("import selection catalog", () => {
           brandColor: null,
           logoPath: "images/company-logo.png",
           requireBoardApprovalForNewAgents: false,
+          goals: [],
         },
         sidebar: {
           agents: ["ceo"],

--- a/packages/shared/src/types/company-portability.ts
+++ b/packages/shared/src/types/company-portability.ts
@@ -28,6 +28,7 @@ export interface CompanyPortabilityCompanyManifestEntry {
   path: string;
   name: string;
   description: string | null;
+  goals: string[];
   brandColor: string | null;
   logoPath: string | null;
   requireBoardApprovalForNewAgents: boolean;

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -64,6 +64,11 @@ const agentInstructionsSvc = {
   materializeManagedBundle: vi.fn(),
 };
 
+const goalsSvc = {
+  list: vi.fn(),
+  create: vi.fn(),
+};
+
 vi.mock("../services/companies.js", () => ({
   companyService: () => companySvc,
 }));
@@ -98,6 +103,10 @@ vi.mock("../services/assets.js", () => ({
 
 vi.mock("../services/agent-instructions.js", () => ({
   agentInstructionsService: () => agentInstructionsSvc,
+}));
+
+vi.mock("../services/goals.js", () => ({
+  goalService: () => goalsSvc,
 }));
 
 vi.mock("../routes/org-chart-svg.js", () => ({
@@ -369,6 +378,13 @@ describe("company portability", () => {
         instructionsFilePath: `/tmp/${agent.id}/AGENTS.md`,
       },
     }));
+    goalsSvc.list.mockResolvedValue([]);
+    goalsSvc.create.mockResolvedValue({
+      id: "goal-1",
+      title: "Test Goal",
+      level: "company",
+      status: "active",
+    });
   });
 
   it("parses canonical GitHub import URLs with explicit ref and package path", () => {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -55,6 +55,7 @@ import { renderOrgChartPng, type OrgNode } from "../routes/org-chart-svg.js";
 import { companySkillService } from "./company-skills.js";
 import { companyService } from "./companies.js";
 import { validateCron } from "./cron.js";
+import { goalService } from "./goals.js";
 import { issueService } from "./issues.js";
 import { projectService } from "./projects.js";
 import { routineService } from "./routines.js";
@@ -2302,6 +2303,9 @@ function buildManifestFromPackageFiles(
       path: resolvedCompanyPath,
       name: companyName,
       description: asString(companyFrontmatter.description),
+      goals: Array.isArray(companyFrontmatter.goals)
+        ? companyFrontmatter.goals.filter((g: unknown): g is string => typeof g === "string")
+        : [],
       brandColor: asString(paperclipCompany.brandColor),
       logoPath: asString(paperclipCompany.logoPath) ?? asString(paperclipCompany.logo),
       requireBoardApprovalForNewAgents:
@@ -2624,6 +2628,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
   const projects = projectService(db);
   const issues = issueService(db);
   const companySkills = companySkillService(db);
+  const goals = goalService(db);
 
   async function resolveSource(source: CompanyPortabilityPreview["source"]): Promise<ResolvedSource> {
     if (source.type === "inline") {
@@ -2930,12 +2935,17 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     });
 
     const companyPath = "COMPANY.md";
+    const companyGoals = await goals.list(company.id);
+    const companyLevelGoals = companyGoals
+      .filter((g) => g.level === "company")
+      .map((g) => g.title);
     files[companyPath] = buildMarkdown(
       {
         name: company.name,
         description: company.description ?? null,
         schema: "agentcompanies/v1",
         slug: rootPath,
+        ...(companyLevelGoals.length > 0 ? { goals: companyLevelGoals } : {}),
       },
       "",
     );
@@ -4221,6 +4231,22 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           assigneeAdapterOverrides: manifestIssue.assigneeAdapterOverrides,
           executionWorkspaceSettings: manifestIssue.executionWorkspaceSettings,
           labelIds: [],
+        });
+      }
+    }
+
+    // Import company-level goals from manifest
+    if (include.company && sourceManifest.company?.goals && sourceManifest.company.goals.length > 0) {
+      const existingGoals = await goals.list(targetCompany.id);
+      const existingTitles = new Set(
+        existingGoals.filter((g) => g.level === "company").map((g) => g.title)
+      );
+      for (const goalTitle of sourceManifest.company.goals) {
+        if (existingTitles.has(goalTitle)) continue;
+        await goals.create(targetCompany.id, {
+          title: goalTitle,
+          level: "company",
+          status: "active",
         });
       }
     }


### PR DESCRIPTION
## Summary
- Add `goals` field to `CompanyPortabilityCompanyManifestEntry` type
- Import/export company-level goals in portability manifest
- Filter and validate goals from company frontmatter
- Create company-level goals during import if they don't exist

## Changes
- **packages/shared/src/types/company-portability.ts**: Added `goals: string[]` field
- **server/src/services/company-portability.ts**: 
  - Import goals from manifest during company export
  - Create company-level goals during import if they don't already exist