### PR TITLE
feat: add cancel all active heartbeats for company

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2055,6 +2055,23 @@ export function agentRoutes(db: Db) {
     res.json(result);
   });
 
+  router.post("/companies/:companyId/heartbeat-runs/cancel-all", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const count = await heartbeat.cancelAllActiveForCompany(companyId);
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "heartbeat.all_cancelled",
+      entityType: "company",
+      entityId: companyId,
+      details: { count },
+    });
+    res.json({ count });
+  });
+
   router.get("/companies/:companyId/heartbeat-runs", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3842,6 +3842,38 @@ export function heartbeatService(db: Db) {
 
     cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
 
+    cancelAllActiveForCompany: async (companyId: string, reason = "Cancelled by user") => {
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.status, ["queued", "running"]),
+          ),
+        );
+
+      for (const run of runs) {
+        await setRunStatus(run.id, "cancelled", {
+          finishedAt: new Date(),
+          error: reason,
+          errorCode: "cancelled",
+        });
+        await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+          finishedAt: new Date(),
+          error: reason,
+        });
+        const running = runningProcesses.get(run.id);
+        if (running) {
+          running.child.kill("SIGTERM");
+          runningProcesses.delete(run.id);
+        }
+        await releaseIssueExecutionAndPromote(run);
+      }
+
+      return runs.length;
+    },
+
     cancelBudgetScopeWork,
 
     getActiveRunForAgent: async (agentId: string) => {

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -50,6 +50,7 @@ export const heartbeatsApi = {
       `/workspace-operations/${operationId}/log?offset=${encodeURIComponent(String(offset))}&limitBytes=${encodeURIComponent(String(limitBytes))}`,
     ),
   cancel: (runId: string) => api.post<void>(`/heartbeat-runs/${runId}/cancel`, {}),
+  cancelAll: (companyId: string) => api.post<{ count: number }>(`/companies/${companyId}/heartbeat-runs/cancel-all`, {}),
   liveRunsForIssue: (issueId: string) =>
     api.get<LiveRunForIssue[]>(`/issues/${issueId}/live-runs`),
   activeRunForIssue: (issueId: string) =>

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -1,14 +1,15 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Issue } from "@paperclipai/shared";
 import { heartbeatsApi, type LiveRunForIssue } from "../api/heartbeats";
 import { issuesApi } from "../api/issues";
 import type { TranscriptEntry } from "../adapters";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, relativeTime } from "../lib/utils";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Square } from "lucide-react";
 import { Identity } from "./Identity";
+import { useToast } from "../context/ToastContext";
 import { RunTranscriptView } from "./transcript/RunTranscriptView";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 
@@ -23,6 +24,10 @@ interface ActiveAgentsPanelProps {
 }
 
 export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const [cancellingAll, setCancellingAll] = useState(false);
+
   const { data: liveRuns } = useQuery({
     queryKey: [...queryKeys.liveRuns(companyId), "dashboard"],
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, MIN_DASHBOARD_RUNS),
@@ -49,11 +54,45 @@ export function ActiveAgentsPanel({ companyId }: ActiveAgentsPanelProps) {
     maxChunksPerRun: 120,
   });
 
+  const hasActiveRuns = runs.some(isRunActive);
+
+  const handleStopAll = async () => {
+    if (!window.confirm("Stop all active agent runs? This cannot be undone.")) {
+      return;
+    }
+
+    setCancellingAll(true);
+    try {
+      await heartbeatsApi.cancelAll(companyId);
+      queryClient.invalidateQueries({ queryKey: queryKeys.liveRuns(companyId) });
+    } catch (error) {
+      pushToast({
+        title: "Failed to stop all agent runs. Please try again.",
+        tone: "error",
+      });
+      console.error("Error cancelling all runs:", error);
+    } finally {
+      setCancellingAll(false);
+    }
+  };
+
   return (
     <div>
-      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-        Agents
-      </h3>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Agents
+        </h3>
+        {hasActiveRuns && (
+          <button
+            onClick={handleStopAll}
+            disabled={cancellingAll}
+            className="inline-flex items-center gap-1 rounded-full border border-red-500/20 bg-red-500/[0.06] px-2.5 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-500/[0.12] dark:text-red-300 disabled:opacity-50"
+          >
+            <Square className="h-2.5 w-2.5" fill="currentColor" />
+            {cancellingAll ? "Stopping…" : "Stop all"}
+          </button>
+        )}
+      </div>
       {runs.length === 0 ? (
         <div className="rounded-xl border border-border p-4">
           <p className="text-sm text-muted-foreground">No recent agent runs.</p>


### PR DESCRIPTION
## Summary
- Add ability to cancel all active heartbeats for a company at once
- Adds bulk cancel functionality with UI button

## Changes
- **server/src/services/heartbeat.ts**: Add `cancelAllActiveForCompany` method
- **server/src/routes/agents.ts**: Add `POST /companies/:companyId/heartbeat-runs/cancel-all` route with board auth and activity logging
- **ui/src/api/heartbeats.ts**: Add `cancelAll` API method
- **ui/src/components/ActiveAgentsPanel.tsx**: Add "Stop all" button that appears when there are active runs

## UI
The button only shows when there are active agent runs and includes:
- Red stop icon (filled square)
- Loading state while cancelling ("Stopping…")
- Disabled state during operation
- Confirmation dialog before executing the destructive action
- Error toast feedback if the API call fails
- Auto-refreshes the runs list after cancellation

## Thinking Path

### Problem Statement
Users needed a way to quickly cancel all active agent runs for a company without having to manually stop each one individually. This is particularly useful when:
- Multiple agents are stuck or running longer than expected
- A company-wide pause is needed (e.g., maintenance window)
- Accidental batch triggers need to be stopped

### Implementation Approach

**Backend:**
- Added `cancelAllActiveForCompany` method to the heartbeat service
- Uses direct database writes (similar to `cancelActiveForAgentInternal`) instead of `cancelRunInternal` to avoid race conditions
- This prevents queued runs from being promoted to "running" state between cancellations
- Cancels both "queued" and "running" status runs
- Properly kills running processes via `runningProcesses` map
- Calls `releaseIssueExecutionAndPromote` for each run to allow next queued runs to start

**Frontend:**
- Added "Stop all" button in `ActiveAgentsPanel` that conditionally renders when active runs exist
- Handler named `handleStopAll` for consistency with stop/cancel semantics
- Includes confirmation dialog to prevent accidental clicks
- Shows error toast if API call fails
- Auto-invalidates the live runs query to refresh the UI

**API Route:**
- New `POST /companies/:companyId/heartbeat-runs/cancel-all` endpoint
- Uses same auth pattern as single-run cancel (`assertBoard` + `assertCompanyAccess`)
- Logs activity for audit trail

### Design Decisions
1. **Why direct DB writes over `cancelRunInternal`?** The existing `cancelRunInternal` triggers `startNextQueuedRunForAgent` after each cancellation, which creates a race condition where queued runs can be promoted and briefly execute before being cancelled. Direct DB writes avoid this.

2. **Why confirmation dialog?** Stopping all runs is a destructive, irreversible action. A confirmation prevents accidental clicks while scrolling.

3. **Button visibility:** Only shown when `hasActiveRuns` is true, reducing UI clutter.

### How to Verify
1. Start multiple agent runs (mix of queued and running)
2. Observe "Stop all" button appears in Agents panel
3. Click "Stop all" - should see confirmation dialog
4. Confirm - all runs should be cancelled
5. Verify no runs transition to "running" after cancellation
6. Check that `runningProcesses` is properly cleaned up
7. Test error case: mock API failure - should see error toast

### Risks & Mitigations
- **Risk:** Killing processes via `SIGTERM` may not terminate immediately. **Mitigation:** The status is already set to "cancelled" in DB, so even if process lingers, it won't be considered active.
- **Risk:** Large number of concurrent runs could slow down the sequential loop. **Mitigation:** For typical company usage, run counts are manageable. Can parallelize in future if needed.
- **Risk:** Race condition between reading active runs and cancellation. **Mitigation:** We iterate over fetched runs and handle both queued and running states; any runs promoted mid-operation would also be cancelled.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>