### PR TITLE
Keep active heartbeat runs alive across recovery

### DIFF
--- a/server/src/__tests__/heartbeat-reaper.test.ts
+++ b/server/src/__tests__/heartbeat-reaper.test.ts
@@ -1,0 +1,258 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  agents,
+  agentWakeupRequests,
+  applyPendingMigrations,
+  companies,
+  createDb,
+  ensurePostgresDatabase,
+  heartbeatRuns,
+  type Db,
+} from "@paperclipai/db";
+import {
+  DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS,
+  heartbeatService,
+} from "../services/heartbeat.js";
+
+type EmbeddedPostgresInstance = {
+  initialise(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+};
+
+type EmbeddedPostgresCtor = new (opts: {
+  databaseDir: string;
+  user: string;
+  password: string;
+  port: number;
+  persistent: boolean;
+  initdbFlags?: string[];
+  onLog?: (message: unknown) => void;
+  onError?: (message: unknown) => void;
+}) => EmbeddedPostgresInstance;
+
+const tempPaths: string[] = [];
+const runningInstances: EmbeddedPostgresInstance[] = [];
+async function getEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
+  const mod = await import("embedded-postgres");
+  return mod.default as EmbeddedPostgresCtor;
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate test port")));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+async function createTempDatabase(): Promise<string> {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-heartbeat-reaper-"));
+  tempPaths.push(dataDir);
+  const port = await getAvailablePort();
+  const EmbeddedPostgres = await getEmbeddedPostgresCtor();
+  const instance = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    user: "paperclip",
+    password: "paperclip",
+    port,
+    persistent: true,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+  await instance.initialise();
+  await instance.start();
+  runningInstances.push(instance);
+
+  const adminUrl = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+  await ensurePostgresDatabase(adminUrl, "paperclip");
+  return `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
+}
+
+async function createTestDb(): Promise<Db> {
+  const connectionString = await createTempDatabase();
+  await applyPendingMigrations(connectionString);
+  return createDb(connectionString);
+}
+
+function buildIssuePrefix() {
+  return `T${randomUUID().replace(/-/g, "").slice(0, 7).toUpperCase()}`;
+}
+
+async function seedHeartbeatRun(
+  db: Db,
+  input: {
+    runStatus: "queued" | "running";
+    wakeupStatus: "queued" | "claimed";
+    agentStatus: "idle" | "running";
+    updatedAt: Date;
+  },
+) {
+  const companyId = randomUUID();
+  const agentId = randomUUID();
+  const wakeupId = randomUUID();
+  const runId = randomUUID();
+  const now = new Date();
+
+  await db.insert(companies).values({
+    id: companyId,
+    name: "Heartbeat Test Co",
+    issuePrefix: buildIssuePrefix(),
+  });
+  await db.insert(agents).values({
+    id: agentId,
+    companyId,
+    name: "Worker",
+    role: "engineer",
+    status: input.agentStatus,
+    adapterType: "process",
+    adapterConfig: {},
+    runtimeConfig: {},
+  });
+  await db.insert(agentWakeupRequests).values({
+    id: wakeupId,
+    companyId,
+    agentId,
+    source: "on_demand",
+    status: input.wakeupStatus,
+    requestedAt: now,
+    claimedAt: input.wakeupStatus === "claimed" ? now : null,
+  });
+  await db.insert(heartbeatRuns).values({
+    id: runId,
+    companyId,
+    agentId,
+    invocationSource: "on_demand",
+    status: input.runStatus,
+    wakeupRequestId: wakeupId,
+    startedAt: now,
+    updatedAt: input.updatedAt,
+  });
+
+  return { agentId, wakeupId, runId };
+}
+
+afterEach(async () => {
+  while (runningInstances.length > 0) {
+    const instance = runningInstances.pop();
+    if (!instance) continue;
+    await instance.stop();
+  }
+  while (tempPaths.length > 0) {
+    const tempPath = tempPaths.pop();
+    if (!tempPath) continue;
+    fs.rmSync(tempPath, { recursive: true, force: true });
+  }
+});
+
+describe("heartbeatService.reapOrphanedRuns", () => {
+  it(
+    "does not fail a recently updated running run when startup recovery uses the default threshold",
+    async () => {
+      const db = await createTestDb();
+      const { runId } = await seedHeartbeatRun(db, {
+        runStatus: "running",
+        wakeupStatus: "claimed",
+        agentStatus: "running",
+        updatedAt: new Date(),
+      });
+
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.reapOrphanedRuns();
+
+      expect(result).toEqual({ reaped: 0, runIds: [] });
+
+      const [run] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      expect(run?.status).toBe("running");
+    },
+    20_000,
+  );
+
+  it(
+    "reaps a stale running run once it is past the default threshold",
+    async () => {
+      const db = await createTestDb();
+      const staleUpdatedAt = new Date(Date.now() - DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS - 1_000);
+      const { agentId, wakeupId, runId } = await seedHeartbeatRun(db, {
+        runStatus: "running",
+        wakeupStatus: "claimed",
+        agentStatus: "running",
+        updatedAt: staleUpdatedAt,
+      });
+
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.reapOrphanedRuns();
+
+      expect(result.reaped).toBe(1);
+      expect(result.runIds).toEqual([runId]);
+
+      const [run] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      expect(run?.status).toBe("failed");
+      expect(run?.errorCode).toBe("process_lost");
+
+      const [wakeup] = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupId));
+      expect(wakeup?.status).toBe("failed");
+
+      const [agent] = await db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, agentId));
+      expect(agent?.status).toBe("error");
+    },
+    20_000,
+  );
+
+  it(
+    "leaves queued runs alone so startup recovery can resume them separately",
+    async () => {
+      const db = await createTestDb();
+      const oldUpdatedAt = new Date(Date.now() - DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS - 1_000);
+      const { runId } = await seedHeartbeatRun(db, {
+        runStatus: "queued",
+        wakeupStatus: "queued",
+        agentStatus: "idle",
+        updatedAt: oldUpdatedAt,
+      });
+
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 0 });
+
+      expect(result).toEqual({ reaped: 0, runIds: [] });
+
+      const [run] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      expect(run?.status).toBe("queued");
+    },
+    20_000,
+  );
+});

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { agents } from "@paperclipai/db";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  createRunLivenessRefresher,
+  DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS,
   formatRuntimeWorkspaceWarningLog,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  RUN_LIVENESS_TOUCH_INTERVAL_MS,
   resolveRuntimeSessionParamsForWorkspace,
   shouldResetTaskSessionForWake,
+  shouldReapOrphanedRun,
   type ResolvedWorkspaceForRun,
 } from "../services/heartbeat.ts";
 
@@ -49,6 +53,11 @@ function buildAgent(adapterType: string, runtimeConfig: Record<string, unknown> 
     updatedAt: new Date(),
   } as unknown as typeof agents.$inferSelect;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe("resolveRuntimeSessionParamsForWorkspace", () => {
   it("migrates fallback workspace sessions to project workspace when project cwd becomes available", () => {
@@ -188,6 +197,63 @@ describe("formatRuntimeWorkspaceWarningLog", () => {
       stream: "stdout",
       chunk: "[paperclip] Using fallback workspace\n",
     });
+  });
+});
+
+describe("shouldReapOrphanedRun", () => {
+  it("does not reap runs that are still within the stale threshold", () => {
+    const now = new Date("2026-03-21T03:14:19.000Z");
+    const updatedAt = new Date(now.getTime() - DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS + 1);
+
+    expect(
+      shouldReapOrphanedRun({
+        now,
+        updatedAt,
+        staleThresholdMs: DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it("reaps runs once they are past the stale threshold", () => {
+    const now = new Date("2026-03-21T03:14:19.000Z");
+    const updatedAt = new Date(now.getTime() - DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS - 1);
+
+    expect(
+      shouldReapOrphanedRun({
+        now,
+        updatedAt,
+        staleThresholdMs: DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it("reaps immediately when no stale threshold is configured", () => {
+    expect(
+      shouldReapOrphanedRun({
+        now: new Date("2026-03-21T03:14:19.000Z"),
+        updatedAt: new Date("2026-03-21T03:14:18.999Z"),
+        staleThresholdMs: 0,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("createRunLivenessRefresher", () => {
+  it("touches running work on an interval and stops cleanly", async () => {
+    vi.useFakeTimers();
+    const touch = vi.fn().mockResolvedValue(undefined);
+
+    const refresher = createRunLivenessRefresher(touch);
+
+    await vi.advanceTimersByTimeAsync(RUN_LIVENESS_TOUCH_INTERVAL_MS - 1);
+    expect(touch).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(touch).toHaveBeenCalledTimes(1);
+
+    refresher.stop();
+    await vi.advanceTimersByTimeAsync(RUN_LIVENESS_TOUCH_INTERVAL_MS);
+    expect(touch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,7 +26,11 @@ import { createApp } from "./app.js";
 import { loadConfig } from "./config.js";
 import { logger } from "./middleware/logger.js";
 import { setupLiveEventsWebSocketServer } from "./realtime/live-events-ws.js";
-import { heartbeatService, reconcilePersistedRuntimeServicesOnStartup } from "./services/index.js";
+import {
+  DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS,
+  heartbeatService,
+  reconcilePersistedRuntimeServicesOnStartup,
+} from "./services/index.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -527,10 +531,10 @@ export async function startServer(): Promise<StartedServer> {
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any);
   
-    // Reap orphaned running runs at startup while in-memory execution state is empty,
-    // then resume any persisted queued runs that were waiting on the previous process.
+    // Only reap runs after a staleness window. This avoids a second server process
+    // instantly killing healthy runs that are being tracked by another process.
     void heartbeat
-      .reapOrphanedRuns()
+      .reapOrphanedRuns({ staleThresholdMs: DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS })
       .then(() => heartbeat.resumeQueuedRuns())
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");
@@ -547,10 +551,10 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "heartbeat timer tick failed");
         });
   
-      // Periodically reap orphaned runs (5-min staleness threshold) and make sure
+      // Periodically reap runs whose liveness has gone stale and make sure
       // persisted queued work is still being driven forward.
       void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .reapOrphanedRuns({ staleThresholdMs: DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS })
         .then(() => heartbeat.resumeQueuedRuns())
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -63,6 +63,8 @@ const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+export const RUN_LIVENESS_TOUCH_INTERVAL_MS = 30 * 1000;
+export const DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS = 2 * 60 * 1000;
 const execFile = promisify(execFileCallback);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
@@ -501,6 +503,44 @@ export function formatRuntimeWorkspaceWarningLog(warning: string) {
   return {
     stream: "stdout" as const,
     chunk: `[paperclip] ${warning}\n`,
+  };
+}
+
+export function shouldReapOrphanedRun(input: {
+  now: Date;
+  updatedAt: Date | null | undefined;
+  staleThresholdMs: number;
+}) {
+  if (input.staleThresholdMs <= 0) return true;
+  const refTime = input.updatedAt ? new Date(input.updatedAt).getTime() : 0;
+  if (!Number.isFinite(refTime) || refTime <= 0) return true;
+  return input.now.getTime() - refTime >= input.staleThresholdMs;
+}
+
+export function createRunLivenessRefresher(
+  touch: () => Promise<void>,
+  opts?: {
+    intervalMs?: number;
+    onError?: (err: unknown) => void;
+  },
+) {
+  const intervalMs = Math.max(1, opts?.intervalMs ?? RUN_LIVENESS_TOUCH_INTERVAL_MS);
+  let inFlight = false;
+  const timer = setInterval(() => {
+    if (inFlight) return;
+    inFlight = true;
+    void touch()
+      .catch((err) => opts?.onError?.(err))
+      .finally(() => {
+        inFlight = false;
+      });
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    stop() {
+      clearInterval(timer);
+    },
   };
 }
 
@@ -1448,7 +1488,7 @@ export function heartbeatService(db: Db) {
   }
 
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
-    const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const staleThresholdMs = opts?.staleThresholdMs ?? DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS;
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -1461,12 +1501,7 @@ export function heartbeatService(db: Db) {
 
     for (const run of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
-
-      // Apply staleness threshold to avoid false positives
-      if (staleThresholdMs > 0) {
-        const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
-        if (now.getTime() - refTime < staleThresholdMs) continue;
-      }
+      if (!shouldReapOrphanedRun({ now, updatedAt: run.updatedAt, staleThresholdMs })) continue;
 
       await setRunStatus(run.id, "failed", {
         error: "Process lost -- server may have restarted",
@@ -1617,6 +1652,19 @@ export function heartbeatService(db: Db) {
     }
 
     activeRunExecutions.add(run.id);
+    const runLiveness = createRunLivenessRefresher(
+      async () => {
+        await db
+          .update(heartbeatRuns)
+          .set({ updatedAt: new Date() })
+          .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "running")));
+      },
+      {
+        onError: (err) => {
+          logger.warn({ err, runId }, "failed to refresh heartbeat run liveness");
+        },
+      },
+    );
 
     try {
     const agent = await getAgent(run.agentId);
@@ -2435,6 +2483,7 @@ export function heartbeatService(db: Db) {
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
           await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
         } finally {
+          runLiveness.stop();
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
           activeRunExecutions.delete(run.id);
           await startNextQueuedRunForAgent(run.agentId);

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -12,7 +12,7 @@ export { budgetService } from "./budgets.js";
 export { secretService } from "./secrets.js";
 export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
-export { heartbeatService } from "./heartbeat.js";
+export { heartbeatService, DEFAULT_ORPHANED_RUN_STALE_THRESHOLD_MS } from "./heartbeat.js";
 export { dashboardService } from "./dashboard.js";
 export { sidebarBadgeService } from "./sidebar-badges.js";
 export { accessService } from "./access.js";


### PR DESCRIPTION
## Summary
- refresh `heartbeat_runs.updated_at` while a run is actively executing so healthy runs stay alive
- apply the shared stale threshold during startup and periodic orphan reaping
- add a regression suite covering startup recovery and stale-run handling

## Verification
- pnpm -C /Users/benedict/clawd/projects/paperclip-eval exec vitest run server/src/__tests__/heartbeat-reaper.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts server/src/__tests__/heartbeat-run-summary.test.ts