### PR TITLE
Preserve task assignment grants for joined agents

### DIFF
--- a/server/src/__tests__/invite-join-grants.test.ts
+++ b/server/src/__tests__/invite-join-grants.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { agentJoinGrantsFromDefaults } from "../routes/access.js";
+
+describe("agentJoinGrantsFromDefaults", () => {
+  it("adds tasks:assign when invite defaults do not specify agent grants", () => {
+    expect(agentJoinGrantsFromDefaults(null)).toEqual([
+      {
+        permissionKey: "tasks:assign",
+        scope: null,
+      },
+    ]);
+  });
+
+  it("preserves invite agent grants and appends tasks:assign", () => {
+    expect(
+      agentJoinGrantsFromDefaults({
+        agent: {
+          grants: [
+            {
+              permissionKey: "agents:create",
+              scope: null,
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        permissionKey: "agents:create",
+        scope: null,
+      },
+      {
+        permissionKey: "tasks:assign",
+        scope: null,
+      },
+    ]);
+  });
+
+  it("does not duplicate tasks:assign when invite defaults already include it", () => {
+    expect(
+      agentJoinGrantsFromDefaults({
+        agent: {
+          grants: [
+            {
+              permissionKey: "tasks:assign",
+              scope: { projectId: "project-1" },
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        permissionKey: "tasks:assign",
+        scope: { projectId: "project-1" },
+      },
+    ]);
+  });
+});

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1411,6 +1411,25 @@ function grantsFromDefaults(
   return result;
 }
 
+export function agentJoinGrantsFromDefaults(
+  defaultsPayload: Record<string, unknown> | null | undefined
+): Array<{
+  permissionKey: (typeof PERMISSION_KEYS)[number];
+  scope: Record<string, unknown> | null;
+}> {
+  const grants = grantsFromDefaults(defaultsPayload, "agent");
+  if (grants.some((grant) => grant.permissionKey === "tasks:assign")) {
+    return grants;
+  }
+  return [
+    ...grants,
+    {
+      permissionKey: "tasks:assign",
+      scope: null
+    }
+  ];
+}
+
 type JoinRequestManagerCandidate = {
   id: string;
   role: string;
@@ -2618,17 +2637,8 @@ export function accessRoutes(
           "member",
           "active"
         );
-        await access.setPrincipalPermission(
-          companyId,
-          "agent",
-          created.id,
-          "tasks:assign",
-          true,
-          req.actor.userId ?? null
-        );
-        const grants = grantsFromDefaults(
-          invite.defaultsPayload as Record<string, unknown> | null,
-          "agent"
+        const grants = agentJoinGrantsFromDefaults(
+          invite.defaultsPayload as Record<string, unknown> | null
         );
         await access.setPrincipalGrants(
           companyId,


### PR DESCRIPTION
## Thinking Path

- Joined agents need the same baseline task-assignment ability as directly created agents.
- Invite defaults may include additional grants that should survive the join flow.
- The current join path hardcodes `tasks:assign` separately and can overwrite or bypass invite grant intent.
- So this PR centralizes the agent-join grant calculation and preserves invite defaults while ensuring `tasks:assign` is present.
- That makes join-created agents land with the expected permission set.

## What Changed

- Added `agentJoinGrantsFromDefaults` in `server/src/routes/access.ts`.
- Preserved invite-configured agent grants while appending `tasks:assign` when missing.
- Removed the separate hardcoded permission write in favor of setting the merged grant list once.
- Added targeted tests covering null defaults, appended grants, and non-duplication.

## Verification

- `pnpm exec vitest run server/src/__tests__/invite-join-grants.test.ts`
