### PR TITLE
Fix agent mention pill vertical misalignment with project mention pill

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -355,7 +355,7 @@
   font-size: 0.75rem;
   line-height: 1.3;
   text-decoration: none;
-  vertical-align: baseline;
+  vertical-align: middle;
   white-space: nowrap;
   user-select: none;
 }
@@ -746,7 +746,7 @@ a.paperclip-project-mention-chip {
   font-size: 0.75rem;
   line-height: 1.3;
   text-decoration: none;
-  vertical-align: baseline;
+  vertical-align: middle;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Thinking Path

- Paperclip uses mention chips inside editor and rendered markdown surfaces.
- Agent and project mentions should read as one visual system.
- Their different pseudo-element sizes currently synthesize different baselines, which makes the pills sit at slightly different heights.
- So this PR normalizes the chip `vertical-align` behavior.
- That removes a small but visible polish issue in mixed mention text.

## What Changed

- Changed mention-chip `vertical-align` from `baseline` to `middle` in both editor and rendered markdown styles.

## Verification

- `cd ui && pnpm exec vite build`
