### PR TITLE
fix: remove dangling skill symlinks after adapter updates

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import type { Agent } from "@paperclipai/shared";
 import {
+  removeDanglingSkillSymlinks,
   removeMaintainerOnlySkillSymlinks,
   resolvePaperclipSkillsDir,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -72,11 +73,12 @@ async function installSkillsForTarget(
   };
 
   await fs.mkdir(targetSkillsDir, { recursive: true });
+  const danglingRemoved = await removeDanglingSkillSymlinks(targetSkillsDir);
   const entries = await fs.readdir(sourceSkillsDir, { withFileTypes: true });
-  summary.removed = await removeMaintainerOnlySkillSymlinks(
+  summary.removed = [...danglingRemoved, ...await removeMaintainerOnlySkillSymlinks(
     targetSkillsDir,
     entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
-  );
+  )];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const source = path.join(sourceSkillsDir, entry.name);

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -705,6 +705,36 @@ export async function removeMaintainerOnlySkillSymlinks(
   }
 }
 
+export async function removeDanglingSkillSymlinks(
+  skillsHome: string,
+): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(skillsHome, { withFileTypes: true });
+    const removed: string[] = [];
+    for (const entry of entries) {
+      const target = path.join(skillsHome, entry.name);
+      const existing = await fs.lstat(target).catch(() => null);
+      if (!existing?.isSymbolicLink()) continue;
+
+      const linkedPath = await fs.readlink(target).catch(() => null);
+      if (!linkedPath) continue;
+
+      const resolvedLinkedPath = path.isAbsolute(linkedPath)
+        ? linkedPath
+        : path.resolve(path.dirname(target), linkedPath);
+      const targetExists = await fs.stat(resolvedLinkedPath).then(() => true).catch(() => false);
+      if (targetExists) continue;
+
+      await fs.unlink(target);
+      removed.push(entry.name);
+    }
+
+    return removed;
+  } catch {
+    return [];
+  }
+}
+
 export async function ensureCommandResolvable(command: string, cwd: string, env: NodeJS.ProcessEnv) {
   const resolved = await resolveCommandPath(command, cwd, env);
   if (resolved) return;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  removeDanglingSkillSymlinks,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   joinPromptSections,
@@ -125,6 +126,13 @@ export async function ensureCursorSkillsInjected(
       `[paperclip] Failed to prepare Cursor skills directory ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     return;
+  }
+  const danglingSkills = await removeDanglingSkillSymlinks(skillsHome);
+  for (const skillName of danglingSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed dangling Cursor skill symlink "${skillName}" from ${skillsHome}\n`,
+    );
   }
   const removedSkills = await removeMaintainerOnlySkillSymlinks(
     skillsHome,

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -17,6 +17,7 @@ import {
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  removeDanglingSkillSymlinks,
   removeMaintainerOnlySkillSymlinks,
   parseObject,
   redactEnvForLogs,
@@ -101,6 +102,13 @@ async function ensureGeminiSkillsInjected(
       `[paperclip] Failed to prepare Gemini skills directory ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     return;
+  }
+  const danglingSkills = await removeDanglingSkillSymlinks(skillsHome);
+  for (const skillName of danglingSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed dangling Gemini skill symlink "${skillName}" from ${skillsHome}\n`,
+    );
   }
   const removedSkills = await removeMaintainerOnlySkillSymlinks(
     skillsHome,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -22,7 +22,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
-import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
+import { removeDanglingSkillSymlinks, removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -59,6 +59,13 @@ async function ensureOpenCodeSkillsInjected(
   await fs.mkdir(skillsHome, { recursive: true });
   const desiredSet = new Set(desiredSkillNames ?? skillsEntries.map((entry) => entry.key));
   const selectedEntries = skillsEntries.filter((entry) => desiredSet.has(entry.key));
+  const danglingSkills = await removeDanglingSkillSymlinks(skillsHome);
+  for (const skillName of danglingSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed dangling OpenCode skill symlink "${skillName}" from ${skillsHome}\n`,
+    );
+  }
   const removedSkills = await removeMaintainerOnlySkillSymlinks(
     skillsHome,
     selectedEntries.map((entry) => entry.runtimeName),

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -17,6 +17,7 @@ import {
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  removeDanglingSkillSymlinks,
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   runChildProcess,
@@ -61,6 +62,13 @@ async function ensurePiSkillsInjected(
   const selectedEntries = skillsEntries.filter((entry) => desiredSet.has(entry.key));
   if (selectedEntries.length === 0) return;
   await fs.mkdir(PI_AGENT_SKILLS_DIR, { recursive: true });
+  const danglingSkills = await removeDanglingSkillSymlinks(PI_AGENT_SKILLS_DIR);
+  for (const skillName of danglingSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed dangling Pi skill symlink "${skillName}" from ${PI_AGENT_SKILLS_DIR}\n`,
+    );
+  }
   const removedSkills = await removeMaintainerOnlySkillSymlinks(
     PI_AGENT_SKILLS_DIR,
     selectedEntries.map((entry) => entry.runtimeName),

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   listPaperclipSkillEntries,
+  removeDanglingSkillSymlinks,
   removeMaintainerOnlySkillSymlinks,
 } from "@paperclipai/adapter-utils/server-utils";
 
@@ -58,5 +59,46 @@ describe("paperclip skill utils", () => {
     await expect(fs.lstat(path.join(skillsHome, "release"))).rejects.toThrow();
     expect((await fs.lstat(path.join(skillsHome, "paperclip"))).isSymbolicLink()).toBe(true);
     expect((await fs.lstat(path.join(skillsHome, "release-notes"))).isSymbolicLink()).toBe(true);
+  });
+
+  it("removes dangling symlinks whose targets no longer exist", async () => {
+    const root = await makeTempDir("paperclip-dangling-cleanup-");
+    cleanupDirs.add(root);
+
+    const skillsHome = path.join(root, "skills-home");
+    const validSkill = path.join(root, "skills", "paperclip");
+    const missingSkill = path.join(root, "skills", "deleted-adapter-skill");
+
+    await fs.mkdir(skillsHome, { recursive: true });
+    await fs.mkdir(validSkill, { recursive: true });
+    // Do NOT create missingSkill — it simulates a removed adapter package
+
+    await fs.symlink(validSkill, path.join(skillsHome, "paperclip"));
+    await fs.symlink(missingSkill, path.join(skillsHome, "deleted-adapter-skill"));
+
+    const removed = await removeDanglingSkillSymlinks(skillsHome);
+
+    expect(removed).toEqual(["deleted-adapter-skill"]);
+    await expect(fs.lstat(path.join(skillsHome, "deleted-adapter-skill"))).rejects.toThrow();
+    expect((await fs.lstat(path.join(skillsHome, "paperclip"))).isSymbolicLink()).toBe(true);
+  });
+
+  it("does not remove non-symlink entries or valid symlinks", async () => {
+    const root = await makeTempDir("paperclip-dangling-noop-");
+    cleanupDirs.add(root);
+
+    const skillsHome = path.join(root, "skills-home");
+    const validSkill = path.join(root, "skills", "paperclip");
+
+    await fs.mkdir(skillsHome, { recursive: true });
+    await fs.mkdir(validSkill, { recursive: true });
+    await fs.mkdir(path.join(skillsHome, "regular-dir"), { recursive: true });
+    await fs.symlink(validSkill, path.join(skillsHome, "paperclip"));
+
+    const removed = await removeDanglingSkillSymlinks(skillsHome);
+
+    expect(removed).toEqual([]);
+    expect((await fs.lstat(path.join(skillsHome, "paperclip"))).isSymbolicLink()).toBe(true);
+    expect((await fs.stat(path.join(skillsHome, "regular-dir"))).isDirectory()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `removeDanglingSkillSymlinks()` to `adapter-utils/server-utils` that scans for symlinks whose targets no longer exist and removes them
- Calls it in the skill injection phase of pi-local, gemini-local, cursor-local, opencode-local adapters and the CLI `agent local-cli` skill installer
- Adds two test cases covering dangling removal and no-op behavior

Closes #1618

## Test plan

- [x] Existing tests pass (`pnpm vitest run server/src/__tests__/paperclip-skill-utils.test.ts`)
- [x] Two new tests: removes dangling symlinks, leaves valid symlinks and non-symlinks alone
- [x] TypeScript compiles clean across adapter-utils, all 4 adapters, and CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)