### PR TITLE
fix: enable Express trust proxy for reverse-proxy deployments

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -72,11 +72,16 @@ export async function createApp(
     instanceId?: string;
     hostVersion?: string;
     localPluginDir?: string;
+    trustProxy?: boolean | string;
     betterAuthHandler?: express.RequestHandler;
     resolveSession?: (req: ExpressRequest) => Promise<BetterAuthSessionResult | null>;
   },
 ) {
   const app = express();
+
+  if (opts.trustProxy !== undefined && opts.trustProxy !== false) {
+    app.set("trust proxy", opts.trustProxy);
+  }
 
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -73,6 +73,7 @@ export interface Config {
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
+  trustProxy: boolean | string;
 }
 
 export function loadConfig(): Config {
@@ -255,5 +256,26 @@ export function loadConfig(): Config {
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
+    trustProxy: resolveTrustProxy(process.env.PAPERCLIP_TRUST_PROXY, deploymentMode),
   };
+}
+
+/**
+ * Resolve the Express "trust proxy" setting.
+ *
+ * - Explicit env var wins (`true`, `false`, or a string like `loopback` / `1`).
+ * - When omitted, auto-enable for non-local deployments (authenticated mode
+ *   typically runs behind a reverse proxy).
+ */
+function resolveTrustProxy(
+  envValue: string | undefined,
+  deploymentMode: DeploymentMode,
+): boolean | string {
+  if (envValue !== undefined) {
+    if (envValue === "true") return true;
+    if (envValue === "false") return false;
+    return envValue; // e.g. "loopback", "linklocal", "uniquelocal", or a hop count
+  }
+  // Auto-enable when deployed behind a proxy (i.e. not local_trusted)
+  return deploymentMode !== "local_trusted";
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -526,6 +526,7 @@ export async function startServer(): Promise<StartedServer> {
     bindHost: config.host,
     authReady,
     companyDeletionEnabled: config.companyDeletionEnabled,
+    trustProxy: config.trustProxy,
     betterAuthHandler,
     resolveSession,
   });


### PR DESCRIPTION
## Summary

- Adds `app.set("trust proxy", ...)` to Express server startup, fixing login 500 errors behind reverse proxies (Fly.io, nginx, etc.)
- Auto-enables when `deploymentMode !== "local_trusted"` — no action needed for existing proxy deployments
- Configurable via `PAPERCLIP_TRUST_PROXY` env var for explicit control

## Root cause

Without `trust proxy`, Express sees HTTPS-terminated requests as HTTP, causing better-auth to fail when setting `__Secure-` cookies (which require a secure context).

Fixes #1690

## Test plan

- [ ] Deploy behind nginx/Fly.io and verify login works without 500
- [ ] Verify `local_trusted` mode does NOT enable trust proxy by default
- [ ] Verify `PAPERCLIP_TRUST_PROXY=false` disables even in authenticated mode
- [ ] Verify `PAPERCLIP_TRUST_PROXY=loopback` passes string value through