### PR TITLE
fix(claude-local): log instructions file to stdout instead of stderr

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -352,7 +352,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const combinedPath = path.join(skillsDir, "agent-instructions.md");
       await fs.writeFile(combinedPath, instructionsContent + pathDirective, "utf-8");
       effectiveInstructionsFilePath = combinedPath;
-      await onLog("stderr", `[paperclip] Loaded agent instructions file: ${instructionsFilePath}\n`);
+      await onLog("stdout", `[paperclip] Loaded agent instructions file: ${instructionsFilePath}\n`);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(


### PR DESCRIPTION
## Summary

- The `claude-local` adapter was logging the "Loaded agent instructions file" message to `stderr` instead of `stdout`, causing it to appear as an error in agent run output
- All other adapters (`codex-local`, `gemini-local`, `cursor-local`, `opencode-local`, `pi-local`) correctly use `stdout` for this informational message
- Changed `onLog("stderr", ...)` to `onLog("stdout", ...)` in `claude-local/src/server/execute.ts`

Fixes OCT-311

## Test plan

- [ ] Verify typecheck passes for `@paperclipai/adapter-claude-local`
- [ ] Run a claude-local agent heartbeat and confirm the instructions file message no longer appears as stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)