### PR TITLE
fix: copy patches in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN corepack enable
 FROM base AS deps
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY patches/ patches/
 COPY cli/package.json cli/
 COPY server/package.json server/
 COPY ui/package.json ui/


### PR DESCRIPTION
###  Problem

<img width="887" height="365" alt="Screenshot 2026-03-24 at 12 13 04 PM" src="https://github.com/user-attachments/assets/cffc1e03-6729-4977-89a8-aa9d6d1850cf" />


### Thinking Path

- pnpm install --frozen-lockfile applies patched dependencies declared in package.json → pnpm.patchedDependencies
- The embedded-postgres patch file (patches/embedded-postgres@18.1.0-beta.16.patch) was never copied into the Docker build context during the dependency-install stage
- pnpm install fails with ENOENT because it resolves the patch path but the file doesn't exist in the container
- This pull request adds COPY patches/ patches/ to the deps stage of the Dockerfile, before pnpm install
- The benefit is Docker builds succeed again without modifying any lockfile or patch configuration

### What Changed

 - Added COPY patches/ patches/ to the deps stage of the Dockerfile, placed after the lockfile/workspace copies and before the per-package package.json copies, so pnpm can resolve patched dependencies during install

### Verification

 - Build the Docker image and confirm the deps stage completes:
   ```sh
     docker build --target deps -t paperclip-deps-check .
   ```
 - Full image build:
   ```sh
     docker build -t paperclip .
   ```

### Risks

 - Low risk. Adds one COPY instruction to an early stage. No behavioral, schema, or API changes. Worst case is a minor layer-cache invalidation when patch files change, which is the correct behavior.

### Checklist

 - I have included a thinking path that traces from project context to this change
 - I have run tests locally and they pass
 - I have added or updated tests where applicable
 - If this change affects the UI, I have included before/after screenshots
 - I have updated relevant documentation to reflect my changes
 - I have considered and documented any risks above
 - I will address all Greptile and reviewer comments before requesting merge