### PR TITLE
docs: replace broken README Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://github.com/paperclipai/paperclip/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>
   <a href="https://github.com/paperclipai/paperclip/stargazers"><img src="https://img.shields.io/github/stars/paperclipai/paperclip?style=flat" alt="Stars" /></a>
   <a href="https://www.star-history.com/paperclipai/paperclip"><img src="https://api.star-history.com/badge?repo=paperclipai/paperclip" alt="Star History Rank" /></a>
-  <a href="https://discord.gg/m4HZY7xNG3"><img src="https://img.shields.io/discord/000000000?label=discord" alt="Discord" /></a>
+  <a href="https://discord.gg/m4HZY7xNG3"><img src="https://img.shields.io/badge/discord-join-7289da" alt="Discord" /></a>
 </p>
 
 <br/>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - New users meet the project first through the repository README
> - The README header shows a row of shields.io badges
> - The Discord badge points at the placeholder guild id `000000000`
> - shields.io cannot resolve that id, so it returns an error image
> - A broken badge in the first screen makes the project look unmaintained
> - This pull request replaces the badge with a static badge that always renders
> - The benefit is a clean README header and a reliable Discord link

## Linked Issues or Issue Description

No existing issue covers this. The problem is described below.

**Issue type**
Incorrect information

**Where is the issue?**
`README.md`, the badge row below the project banner.

**What's wrong?**
The Discord badge uses `https://img.shields.io/discord/000000000?label=discord`.
The guild id `000000000` is a placeholder. shields.io cannot resolve it. The
README header shows an error badge instead of a Discord badge.

**Suggested fix**
Use the static badge `https://img.shields.io/badge/discord-join-7289da`.
Keep the existing invite link.

## What Changed

- Replace the broken `shields.io/discord/000000000` badge with the static
  `shields.io/badge/discord-join-7289da` badge in `README.md`.
- Keep the `https://discord.gg/m4HZY7xNG3` invite target unchanged.

This branch is rebased onto current `master`. The original version of this pull
request also corrected a "solo-entreprenuer" typo. `master` corrected that typo
in the meantime, so the rebase drops that change.

## Verification

- Open the rendered README on this branch. The badge shows "discord | join".
- Compare with `master`. The same position shows a shields.io error badge.
- Open the two badge URLs directly to see the difference:
  - broken: https://img.shields.io/discord/000000000?label=discord
  - fixed: https://img.shields.io/badge/discord-join-7289da
- Click the badge. It opens https://discord.gg/m4HZY7xNG3.

## Risks

Low risk. The change touches one line of `README.md`. It changes no code, build
step, or test. The new badge does not show the live member count. The Discord
server has its widget disabled, so a dynamic badge cannot show a count today. If
the widget is enabled later, a dynamic badge with the real guild id can replace
this one.

## Model Used

Claude Opus 5 (Anthropic, model id `claude-opus-5`), extended thinking with
repository tool use. The maintainer used the model to rebase this branch onto
current `master` and to write this description. The original one-line change is
the contributor's own work.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (no other open pull request changes this badge)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass (not applicable — README-only change)
- [x] I have added or updated tests where applicable (not applicable — README-only change)
- [x] I have updated relevant documentation to reflect my changes (this change is the documentation change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending re-run after the rebase)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending re-review after the rebase)
- [x] I will address all Greptile and reviewer comments before requesting merge
