### PR TITLE
feat(skills): Add Olostep web scraping & research skill

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -55,6 +56,35 @@ import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
+ * the repo's `skills/` directory, so `--add-dir` makes Claude Code discover
+ * them as proper registered skills.
+ */
+async function buildSkillsDir(config: Record<string, unknown>): Promise<string> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-skills-"));
+  const target = path.join(tmp, ".claude", "skills");
+  await fs.mkdir(target, { recursive: true });
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredNames = new Set(
+    resolveClaudeDesiredSkillNames(
+      config,
+      availableEntries,
+    ),
+  );
+  for (const entry of availableEntries) {
+    if (!desiredNames.has(entry.key)) continue;
+    // On Windows, regular symlinks require elevated privileges (EPERM).
+    // Use junctions instead — they work for directories without admin rights.
+    await fs.symlink(
+      entry.source,
+      path.join(target, entry.runtimeName),
+      os.platform() === "win32" ? "junction" : undefined,
+    );
+  }
+  return tmp;
+}
 
 interface ClaudeExecutionInput {
   runId: string;

--- a/skills/olostep/SKILL.md
+++ b/skills/olostep/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: olostep
+description: >
+  Scrape webpages, search the web, crawl sites, batch-scrape URLs, map site
+  structure, and extract structured data using the Olostep API. Use when your
+  task requires fetching live web content — research, competitor analysis,
+  documentation scraping, error debugging, data extraction, or any work that
+  needs real-time information from the internet. Do NOT use for Paperclip
+  coordination (use the paperclip skill for that).
+---
+
+# Olostep Web Skill
+
+You can fetch live web content during your heartbeat using the Olostep API. This skill covers scraping, searching, crawling, batch processing, site mapping, and structured data extraction.
+
+## Authentication
+
+Every request requires your API key via the `Authorization` header:
+
+```
+Authorization: Bearer $OLOSTEP_API_KEY
+```
+
+The base URL for all endpoints is `https://api.olostep.com/v1`.
+
+If `OLOSTEP_API_KEY` is not set in your environment, stop and report this to your manager — the board needs to configure it in your adapter environment.
+
+---
+
+## 1. Scrape a Single Page
+
+Extract content from any URL as markdown, HTML, JSON, or text. Handles JavaScript rendering and anti-bot protections automatically.
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/scrape" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/page",
+    "output_format": "markdown"
+  }'
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `url` | Yes | — | URL to scrape |
+| `output_format` | No | `markdown` | `markdown`, `html`, `json`, or `text` |
+| `country` | No | — | Country code for geo-targeted scraping (e.g., `US`, `GB`) |
+| `wait_before_scraping` | No | `0` | Milliseconds to wait for JS rendering (0–10000) |
+| `parser` | No | — | Specialized parser ID (e.g., `@olostep/amazon-product`) |
+
+**When to use:** Single page content extraction — docs pages, articles, product pages, profiles.
+
+**Tips:**
+- Use `markdown` format for cleanest LLM-ready output
+- For JavaScript-heavy SPAs, set `wait_before_scraping: 2000`
+- Use specialized parsers for Amazon, LinkedIn, etc.
+
+---
+
+## 2. Search the Web
+
+Search the web and get structured results with content.
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/search" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "best AI orchestration frameworks 2026",
+    "country": "US"
+  }'
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `query` | Yes | — | Search query |
+| `country` | No | `US` | Country code for localized results |
+
+**When to use:** Research questions, finding docs, competitive analysis, debugging errors.
+
+**Tips:**
+- Use specific, descriptive queries for best results
+- Combine with scrape to get full content from interesting results
+- For error debugging, search the exact error message in quotes
+
+---
+
+## 3. Crawl a Website
+
+Autonomously discover and scrape pages by following links from a starting URL.
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/crawl" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_url": "https://docs.example.com",
+    "max_pages": 10,
+    "output_format": "markdown"
+  }'
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `start_url` | Yes | — | Starting URL |
+| `max_pages` | No | `10` | Maximum pages to crawl |
+| `follow_links` | No | `true` | Whether to follow discovered links |
+| `output_format` | No | `markdown` | `markdown`, `html`, `json`, or `text` |
+| `country` | No | — | Country code for geo-targeted crawling |
+
+**When to use:** Ingesting documentation sites, blog archives, product catalogs.
+
+**Tips:**
+- Start with `max_pages: 10` to test, then increase
+- Use `map` first to understand site structure before crawling
+- Set `follow_links: false` to scrape only the starting page
+
+---
+
+## 4. Batch Scrape URLs
+
+Scrape up to 10,000 URLs in a single parallel operation.
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/batch-scrape" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "urls_to_scrape": [
+      {"url": "https://example.com/page1", "custom_id": "page1"},
+      {"url": "https://example.com/page2", "custom_id": "page2"}
+    ],
+    "output_format": "markdown"
+  }'
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `urls_to_scrape` | Yes | — | Array of `{url, custom_id?}` objects (1–10,000) |
+| `output_format` | No | `markdown` | `markdown`, `html`, `json`, or `text` |
+| `country` | No | — | Country code |
+| `wait_before_scraping` | No | `0` | Milliseconds to wait per URL |
+
+**When to use:** Large-scale extraction — scraping many product pages, directory listings, documentation sets.
+
+**Tips:**
+- Use `custom_id` to label URLs for easier result tracking
+- Combine with `map` to discover URLs first, then batch scrape them
+- All URLs are processed in parallel for speed
+
+---
+
+## 5. Map a Website
+
+Discover all URLs on a website without scraping their content. Useful for planning what to scrape or crawl.
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/map" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "website_url": "https://example.com",
+    "search_query": "blog"
+  }'
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `website_url` | Yes | — | Website to map |
+| `search_query` | No | — | Filter URLs by keyword |
+| `top_n` | No | — | Limit number of URLs returned |
+| `include_url_patterns` | No | — | Glob patterns to include (e.g., `/blog/**`) |
+| `exclude_url_patterns` | No | — | Glob patterns to exclude (e.g., `/admin/**`) |
+
+**When to use:** Site analysis, content auditing, planning before a crawl or batch scrape.
+
+---
+
+## 6. AI-Powered Answers
+
+Get web-sourced answers with citations. Optionally provide a JSON schema for structured output.
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/answers" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "What are the top 5 AI agent orchestration platforms in 2026?"
+  }'
+```
+
+With structured output:
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/answers" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Find the founders and funding of Paperclip AI",
+    "json": {"company": "", "founders": [], "total_funding": "", "last_round": ""}
+  }'
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `task` | Yes | — | Question or research task |
+| `json` | No | — | JSON schema for structured output |
+
+**When to use:** Research, fact-checking, competitive analysis, gathering structured web intelligence.
+
+---
+
+## 7. Extract Structured Data
+
+Scrape a page and parse it into a specific schema. Combine scrape + parsing for typed output.
+
+**Workflow:**
+1. Scrape the target URL with `output_format: markdown`
+2. Parse the markdown against the desired schema
+3. Output clean JSON
+
+```sh
+# Step 1: Scrape the page
+CONTENT=$(curl -sS -X POST "https://api.olostep.com/v1/scrape" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com/product", "output_format": "markdown"}')
+
+# Step 2: Parse the content against your schema
+# (Use your own LLM reasoning to extract fields from the markdown)
+```
+
+Alternatively, use the **answers** endpoint with a JSON schema for one-step extraction:
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/answers" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Extract product details from https://example.com/product",
+    "json": {"name": "", "price": "", "rating": 0, "features": []}
+  }'
+```
+
+**When to use:** Database seeding, building directories, extracting product data, parsing profiles.
+
+**Tips:**
+- Markdown format strips HTML noise — best for extraction accuracy
+- Use `null` for missing fields — never hallucinate data
+- For many URLs, batch scrape first, then parse each result
+- Use `wait_before_scraping: 3000` for sites with client-side rendering
+
+---
+
+## Common Workflows
+
+### Research a topic for your task
+1. **Search** for the topic to find relevant sources
+2. **Scrape** the most relevant results for full content
+3. Synthesize findings into your task deliverable
+
+### Ingest documentation for code work
+1. **Map** the docs site to discover all pages
+2. **Crawl** or **batch scrape** the relevant sections
+3. Use the content to write code, integrations, or summaries
+
+### Debug an error
+1. **Search** the exact error message
+2. **Scrape** GitHub issues, Stack Overflow answers, or official docs
+3. Apply the fix to your codebase
+
+### Competitive analysis
+1. **Answers** with a structured schema for quick comparison
+2. **Scrape** competitor landing pages for deeper analysis
+3. Compile into a comparison report
+
+---
+
+## Critical Rules
+
+- Always check that `$OLOSTEP_API_KEY` is available before making requests.
+- Use `markdown` output format by default — it's the most token-efficient for LLM processing.
+- Do not scrape pages unnecessarily. Only fetch what your current task actually needs.
+- Report any API errors (rate limits, auth failures) in your task comment so your manager can investigate.
+- This skill is for fetching web data. Use the **paperclip** skill for task coordination, and do your actual domain work (coding, writing, analysis) separately.
+
+## Full Reference
+
+For complete API documentation and additional parameters, see:
+`skills/olostep/references/api-reference.md`

--- a/skills/olostep/SKILL.md
+++ b/skills/olostep/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: olostep
 description: >
-  Scrape webpages, search the web, crawl sites, batch-scrape URLs, map site
-  structure, and extract structured data using the Olostep API. Use when your
+  Scrape webpages, search Google, crawl sites, batch-scrape URLs, map site
+  structure, and get AI-powered answers using the Olostep API. Use when your
   task requires fetching live web content — research, competitor analysis,
   documentation scraping, error debugging, data extraction, or any work that
   needs real-time information from the internet. Do NOT use for Paperclip
@@ -11,7 +11,7 @@ description: >
 
 # Olostep Web Skill
 
-You can fetch live web content during your heartbeat using the Olostep API. This skill covers scraping, searching, crawling, batch processing, site mapping, and structured data extraction.
+You can fetch live web content during your heartbeat using the Olostep API. This skill covers scraping, searching, crawling, batch processing, site mapping, AI-powered answers, and structured data extraction.
 
 ## Authentication
 
@@ -32,52 +32,95 @@ If `OLOSTEP_API_KEY` is not set in your environment, stop and report this to you
 Extract content from any URL as markdown, HTML, JSON, or text. Handles JavaScript rendering and anti-bot protections automatically.
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/scrape" \
+curl -sS -X POST "https://api.olostep.com/v1/scrapes" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://example.com/page",
-    "output_format": "markdown"
+    "url_to_scrape": "https://example.com/page",
+    "formats": ["markdown"]
   }'
 ```
+
+**Response** (key fields):
+```json
+{
+  "id": "scrape_abc123",
+  "object": "scrape",
+  "result": {
+    "markdown_content": "# Page Title\n\nExtracted content...",
+    "html_content": null,
+    "text_content": null,
+    "json_content": null,
+    "markdown_hosted_url": "https://olostep-storage.s3.amazonaws.com/...",
+    "links_on_page": [],
+    "page_metadata": { "status_code": 200, "title": "Page Title" }
+  }
+}
+```
+
+The content is inside `result.markdown_content` (or `result.html_content`, `result.text_content`, etc. depending on which formats you requested).
 
 **Parameters:**
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `url` | Yes | — | URL to scrape |
-| `output_format` | No | `markdown` | `markdown`, `html`, `json`, or `text` |
-| `country` | No | — | Country code for geo-targeted scraping (e.g., `US`, `GB`) |
+| `url_to_scrape` | Yes | — | URL to scrape |
+| `formats` | Yes | — | Array of: `markdown`, `html`, `text`, `json`, `raw_pdf`, `screenshot` |
+| `country` | No | — | Country code for geo-targeted scraping (e.g., `US`, `GB`, `IN`) |
 | `wait_before_scraping` | No | `0` | Milliseconds to wait for JS rendering (0–10000) |
-| `parser` | No | — | Specialized parser ID (e.g., `@olostep/amazon-product`) |
+| `parser` | No | — | Parser object `{"id": "@olostep/google-search"}` for structured JSON |
+| `llm_extract` | No | — | Object with `schema` and/or `prompt` for LLM-based extraction |
+| `remove_css_selectors` | No | `default` | `default`, `none`, or stringified array of selectors to remove |
+| `actions` | No | — | Array of page actions: `wait`, `click`, `fill_input`, `scroll` |
 
 **When to use:** Single page content extraction — docs pages, articles, product pages, profiles.
 
 **Tips:**
-- Use `markdown` format for cleanest LLM-ready output
+- Use `formats: ["markdown"]` for cleanest LLM-ready output (content in `result.markdown_content`)
 - For JavaScript-heavy SPAs, set `wait_before_scraping: 2000`
-- Use specialized parsers for Amazon, LinkedIn, etc.
+- Use specialized parsers for structured JSON (see Section 2)
+- Request multiple formats at once: `formats: ["markdown", "html"]`
 
 ---
 
-## 2. Search the Web
+## 2. Search Google
 
-Search the web and get structured results with content.
+Search Google by scraping a Google search URL with the `@olostep/google-search` parser. There is no separate search endpoint — search is done through the scrapes endpoint.
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/search" \
+curl -sS -X POST "https://api.olostep.com/v1/scrapes" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "best AI orchestration frameworks 2026",
-    "country": "US"
+    "url_to_scrape": "https://www.google.com/search?q=best+AI+orchestration+frameworks+2026&gl=us&hl=en",
+    "formats": ["json"],
+    "parser": {"id": "@olostep/google-search"}
   }'
 ```
 
-**Parameters:**
-| Parameter | Required | Default | Description |
-|-----------|----------|---------|-------------|
-| `query` | Yes | — | Search query |
-| `country` | No | `US` | Country code for localized results |
+**Response** (key fields):
+```json
+{
+  "id": "scrape_xyz789",
+  "object": "scrape",
+  "result": {
+    "json_content": "{\"searchParameters\":{...},\"organic\":[{\"title\":\"...\",\"link\":\"...\",\"snippet\":\"...\"},...],\"peopleAlsoAsk\":[...],\"relatedSearches\":[...]}",
+    "json_hosted_url": "https://olostep-storage.s3.amazonaws.com/..."
+  }
+}
+```
+
+The `result.json_content` is a **stringified JSON string** — parse it to get:
+- `searchParameters`: query info
+- `knowledgeGraph`: entity info (when available)
+- `organic`: array of `{title, link, position, snippet}` results
+- `peopleAlsoAsk`: related questions
+- `relatedSearches`: suggested follow-up queries
+
+**How to construct the Google URL:**
+- Base: `https://www.google.com/search?q=YOUR+QUERY`
+- Add `&gl=us` for country (use ISO codes: `us`, `gb`, `de`, `in`, etc.)
+- Add `&hl=en` for language
+- URL-encode the query (replace spaces with `+`)
 
 **When to use:** Research questions, finding docs, competitive analysis, debugging errors.
 
@@ -85,98 +128,170 @@ curl -sS -X POST "https://api.olostep.com/v1/search" \
 - Use specific, descriptive queries for best results
 - Combine with scrape to get full content from interesting results
 - For error debugging, search the exact error message in quotes
+- The `organic` array gives you titles, URLs, and snippets of top results
 
 ---
 
 ## 3. Crawl a Website
 
-Autonomously discover and scrape pages by following links from a starting URL.
+Start an async crawl that discovers and scrapes pages by following links. Crawls run in the background — poll for results.
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/crawl" \
+# Start the crawl
+curl -sS -X POST "https://api.olostep.com/v1/crawls" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "start_url": "https://docs.example.com",
-    "max_pages": 10,
-    "output_format": "markdown"
+    "max_pages": 10
   }'
 ```
+
+**Response:**
+```json
+{
+  "id": "crawl_abc123",
+  "object": "crawl",
+  "status": "in_progress",
+  "pages_count": 0
+}
+```
+
+**Check status:**
+```sh
+curl -sS "https://api.olostep.com/v1/crawls/CRAWL_ID" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+```
+
+**Get crawled pages** (once `status` is `completed`):
+```sh
+curl -sS "https://api.olostep.com/v1/crawls/CRAWL_ID/pages?limit=10" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+```
+
+Pages response returns `retrieve_id` per page. Use `/v1/retrieve?retrieve_id=RETRIEVE_ID&formats=markdown` to get the actual content.
 
 **Parameters:**
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `start_url` | Yes | — | Starting URL |
-| `max_pages` | No | `10` | Maximum pages to crawl |
-| `follow_links` | No | `true` | Whether to follow discovered links |
-| `output_format` | No | `markdown` | `markdown`, `html`, `json`, or `text` |
-| `country` | No | — | Country code for geo-targeted crawling |
+| `max_pages` | Yes | — | Maximum pages to crawl |
+| `include_urls` | No | `["/**"]` | Glob patterns for URLs to include (e.g., `["/blog/**"]`) |
+| `exclude_urls` | No | — | Glob patterns for URLs to exclude (e.g., `["/admin/**"]`) |
+| `max_depth` | No | — | Maximum link depth from start URL |
+| `include_external` | No | `false` | Whether to crawl first-degree external links |
+| `search_query` | No | — | Sort crawled pages by relevance to this query |
+| `top_n` | No | — | Only follow top N most relevant links per page |
+| `timeout` | No | — | End crawl after N seconds |
 
 **When to use:** Ingesting documentation sites, blog archives, product catalogs.
 
 **Tips:**
+- Crawls are **async** — you must poll `/v1/crawls/{id}` until `status: "completed"`
 - Start with `max_pages: 10` to test, then increase
 - Use `map` first to understand site structure before crawling
-- Set `follow_links: false` to scrape only the starting page
+- Use `include_urls` to limit crawling to relevant sections
 
 ---
 
 ## 4. Batch Scrape URLs
 
-Scrape up to 10,000 URLs in a single parallel operation.
+Scrape up to 10,000 URLs in a single parallel batch. Batches run async — poll for results.
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/batch-scrape" \
+curl -sS -X POST "https://api.olostep.com/v1/batches" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "urls_to_scrape": [
+    "items": [
       {"url": "https://example.com/page1", "custom_id": "page1"},
       {"url": "https://example.com/page2", "custom_id": "page2"}
-    ],
-    "output_format": "markdown"
+    ]
   }'
 ```
+
+**Response:**
+```json
+{
+  "id": "batch_abc123",
+  "object": "batch",
+  "status": "in_progress",
+  "total_urls": 2,
+  "completed_urls": 0
+}
+```
+
+**Check status:**
+```sh
+curl -sS "https://api.olostep.com/v1/batches/BATCH_ID" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+```
+
+**Get results** (once `status` is `completed`):
+```sh
+curl -sS "https://api.olostep.com/v1/batches/BATCH_ID/items?limit=10" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+```
+
+Items response returns `retrieve_id` per item. Use `/v1/retrieve?retrieve_id=RETRIEVE_ID&formats=markdown` to get content.
 
 **Parameters:**
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `urls_to_scrape` | Yes | — | Array of `{url, custom_id?}` objects (1–10,000) |
-| `output_format` | No | `markdown` | `markdown`, `html`, `json`, or `text` |
+| `items` | Yes | — | Array of `{"url": "...", "custom_id": "..."}` objects (1–10,000) |
 | `country` | No | — | Country code |
-| `wait_before_scraping` | No | `0` | Milliseconds to wait per URL |
+| `parser` | No | — | Parser object for structured extraction, e.g. `{"id": "@olostep/google-search"}` |
 
 **When to use:** Large-scale extraction — scraping many product pages, directory listings, documentation sets.
 
 **Tips:**
+- Batches are **async** (usually 5–8 minutes regardless of size)
 - Use `custom_id` to label URLs for easier result tracking
-- Combine with `map` to discover URLs first, then batch scrape them
-- All URLs are processed in parallel for speed
+- Combine with `map` to discover URLs first, then batch them
+- Use parser for structured JSON output at scale
 
 ---
 
 ## 5. Map a Website
 
-Discover all URLs on a website without scraping their content. Useful for planning what to scrape or crawl.
+Discover all URLs on a website without scraping their content. Synchronous — returns immediately.
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/map" \
+curl -sS -X POST "https://api.olostep.com/v1/maps" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "website_url": "https://example.com",
-    "search_query": "blog"
+    "url": "https://example.com",
+    "include_urls": ["/blog/**"],
+    "top_n": 50
   }'
 ```
+
+**Response:**
+```json
+{
+  "id": "map_abc123",
+  "urls_count": 50,
+  "urls": [
+    "https://example.com/blog/post-1",
+    "https://example.com/blog/post-2"
+  ],
+  "cursor": null
+}
+```
+
+If `cursor` is not null, pass it in the next request to get more URLs.
 
 **Parameters:**
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `website_url` | Yes | — | Website to map |
-| `search_query` | No | — | Filter URLs by keyword |
+| `url` | Yes | — | Website to map |
+| `search_query` | No | — | Sort URLs by relevance to this query |
 | `top_n` | No | — | Limit number of URLs returned |
-| `include_url_patterns` | No | — | Glob patterns to include (e.g., `/blog/**`) |
-| `exclude_url_patterns` | No | — | Glob patterns to exclude (e.g., `/admin/**`) |
+| `include_urls` | No | — | Glob patterns to include (e.g., `["/blog/**"]`) |
+| `exclude_urls` | No | — | Glob patterns to exclude (e.g., `["/admin/**"]`) |
+| `include_subdomain` | No | `true` | Whether to include subdomains |
+| `cursor` | No | — | Pagination cursor from previous response |
 
 **When to use:** Site analysis, content auditing, planning before a crawl or batch scrape.
 
@@ -184,7 +299,7 @@ curl -sS -X POST "https://api.olostep.com/v1/map" \
 
 ## 6. AI-Powered Answers
 
-Get web-sourced answers with citations. Optionally provide a JSON schema for structured output.
+Get web-sourced answers with citations. Optionally provide a JSON schema for structured output. Synchronous.
 
 ```sh
 curl -sS -X POST "https://api.olostep.com/v1/answers" \
@@ -202,15 +317,30 @@ curl -sS -X POST "https://api.olostep.com/v1/answers" \
   -H "Content-Type: application/json" \
   -d '{
     "task": "Find the founders and funding of Paperclip AI",
-    "json": {"company": "", "founders": [], "total_funding": "", "last_round": ""}
+    "json_format": {"company": "", "founders": [], "total_funding": "", "last_round": ""}
   }'
 ```
+
+**Response:**
+```json
+{
+  "id": "answer_abc123",
+  "object": "answer",
+  "result": {
+    "json_content": "{\"company\": \"Paperclip\", \"founders\": [...], ...}",
+    "json_hosted_url": "https://olostep-storage.s3.amazonaws.com/...",
+    "sources": ["https://example.com/article1", "https://example.com/article2"]
+  }
+}
+```
+
+The `result.json_content` is a stringified JSON string matching your schema. `result.sources` lists the URLs used.
 
 **Parameters:**
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `task` | Yes | — | Question or research task |
-| `json` | No | — | JSON schema for structured output |
+| `json_format` | No | — | JSON schema for structured output (object with empty values as template) |
 
 **When to use:** Research, fact-checking, competitive analysis, gathering structured web intelligence.
 
@@ -218,73 +348,118 @@ curl -sS -X POST "https://api.olostep.com/v1/answers" \
 
 ## 7. Extract Structured Data
 
-Scrape a page and parse it into a specific schema. Combine scrape + parsing for typed output.
+Three approaches, from simplest to most powerful:
 
-**Workflow:**
-1. Scrape the target URL with `output_format: markdown`
-2. Parse the markdown against the desired schema
-3. Output clean JSON
+### Option A: LLM Extraction (simplest)
+
+Use the scrapes endpoint with `llm_extract` to extract structured data in one call:
 
 ```sh
-# Step 1: Scrape the page
-CONTENT=$(curl -sS -X POST "https://api.olostep.com/v1/scrape" \
+curl -sS -X POST "https://api.olostep.com/v1/scrapes" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/product", "output_format": "markdown"}')
-
-# Step 2: Parse the content against your schema
-# (Use your own LLM reasoning to extract fields from the markdown)
+  -d '{
+    "url_to_scrape": "https://example.com/product",
+    "formats": ["json"],
+    "llm_extract": {
+      "schema": {"name": "", "price": "", "rating": 0, "features": []}
+    }
+  }'
 ```
 
-Alternatively, use the **answers** endpoint with a JSON schema for one-step extraction:
+Response: `result.json_content` contains the extracted structured JSON.
+
+### Option B: Answers endpoint (quick research + extraction)
+
 ```sh
 curl -sS -X POST "https://api.olostep.com/v1/answers" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "task": "Extract product details from https://example.com/product",
-    "json": {"name": "", "price": "", "rating": 0, "features": []}
+    "json_format": {"name": "", "price": "", "rating": 0, "features": []}
   }'
+```
+
+### Option C: Scrape + LLM reasoning (most control)
+
+```sh
+# Step 1: Scrape the page
+RESPONSE=$(curl -sS -X POST "https://api.olostep.com/v1/scrapes" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url_to_scrape": "https://example.com/product", "formats": ["markdown"]}')
+
+# Step 2: The response is JSON. Extract the markdown content:
+# MARKDOWN=$(echo "$RESPONSE" | jq -r '.result.markdown_content')
+# Then use your own LLM reasoning to extract fields from the markdown.
 ```
 
 **When to use:** Database seeding, building directories, extracting product data, parsing profiles.
 
 **Tips:**
-- Markdown format strips HTML noise — best for extraction accuracy
+- LLM extraction (`llm_extract`) costs 20 credits vs 1 credit for plain scrape
+- Use parsers (e.g., `@olostep/google-search`, `@olostep/amazon-it-product`) for known site types — faster and cheaper
 - Use `null` for missing fields — never hallucinate data
-- For many URLs, batch scrape first, then parse each result
-- Use `wait_before_scraping: 3000` for sites with client-side rendering
+- For many URLs, batch first, then retrieve each result
+
+---
+
+## Retrieving Content by ID
+
+Crawl and batch results return a `retrieve_id` per page/item. Use this endpoint to get the actual content:
+
+```sh
+curl -sS "https://api.olostep.com/v1/retrieve?retrieve_id=RETRIEVE_ID&formats=markdown" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+```
 
 ---
 
 ## Common Workflows
 
 ### Research a topic for your task
-1. **Search** for the topic to find relevant sources
-2. **Scrape** the most relevant results for full content
+1. **Search Google** via scrapes with `@olostep/google-search` parser to find sources
+2. **Scrape** the most relevant result URLs for full content
 3. Synthesize findings into your task deliverable
 
 ### Ingest documentation for code work
 1. **Map** the docs site to discover all pages
-2. **Crawl** or **batch scrape** the relevant sections
-3. Use the content to write code, integrations, or summaries
+2. **Crawl** or **batch** the relevant sections
+3. Retrieve content via `/v1/retrieve` and use it
 
 ### Debug an error
-1. **Search** the exact error message
+1. **Search Google** for the exact error message
 2. **Scrape** GitHub issues, Stack Overflow answers, or official docs
 3. Apply the fix to your codebase
 
 ### Competitive analysis
-1. **Answers** with a structured schema for quick comparison
+1. **Answers** with a structured `json_format` for quick comparison
 2. **Scrape** competitor landing pages for deeper analysis
 3. Compile into a comparison report
+
+---
+
+## Available Parsers
+
+Use with `"parser": {"id": "PARSER_ID"}` and `"formats": ["json"]` in scrapes or batches:
+
+| Parser ID | Use Case |
+|-----------|----------|
+| `@olostep/google-search` | Google search results (organic, knowledge graph, PAA) |
+| `@olostep/amazon-it-product` | Amazon product pages |
+| `@olostep/extract-emails` | Extract email addresses from pages |
+| `@olostep/extract-calendars` | Extract calendar/event data |
+| `@olostep/extract-socials` | Extract social media links |
 
 ---
 
 ## Critical Rules
 
 - Always check that `$OLOSTEP_API_KEY` is available before making requests.
-- Use `markdown` output format by default — it's the most token-efficient for LLM processing.
+- Use `formats: ["markdown"]` by default — it's the most token-efficient for LLM processing.
+- Response content is inside `result.markdown_content` (or `result.html_content`, etc.) — not a top-level field.
+- Crawls and batches are **async** — poll their status endpoint before fetching results.
 - Do not scrape pages unnecessarily. Only fetch what your current task actually needs.
 - Report any API errors (rate limits, auth failures) in your task comment so your manager can investigate.
 - This skill is for fetching web data. Use the **paperclip** skill for task coordination, and do your actual domain work (coding, writing, analysis) separately.

--- a/skills/olostep/references/api-reference.md
+++ b/skills/olostep/references/api-reference.md
@@ -8,135 +8,161 @@ Complete endpoint reference for the Olostep web scraping API. For the core skill
 
 ---
 
-## Scrape — `POST /v1/scrape`
+## Scrape — `POST /v1/scrapes`
 
-Extract content from a single webpage.
+Extract content from a single webpage. Synchronous — returns content immediately.
 
 ### Request Body
 
 ```json
 {
-  "url": "https://example.com",
-  "output_format": "markdown",
+  "url_to_scrape": "https://example.com",
+  "formats": ["markdown"],
   "country": "US",
   "wait_before_scraping": 2000,
-  "parser": "@olostep/amazon-product"
+  "remove_css_selectors": "default"
 }
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `url` | string | Yes | — | The webpage URL to scrape |
-| `output_format` | string | No | `markdown` | One of: `markdown`, `html`, `json`, `text` |
-| `country` | string | No | — | ISO country code for geo-targeting (e.g., `US`, `GB`, `DE`) |
+| `url_to_scrape` | string | Yes | — | The webpage URL to scrape |
+| `formats` | array | Yes | — | Array of: `markdown`, `html`, `text`, `json`, `raw_pdf`, `screenshot` |
+| `country` | string | No | — | ISO country code for geo-targeting (e.g., `US`, `GB`, `DE`, `IN`) |
 | `wait_before_scraping` | integer | No | `0` | Milliseconds to wait for JS rendering (0–10000) |
-| `parser` | string | No | — | Specialized parser ID for popular platforms |
+| `parser` | object | No | — | Parser for structured JSON: `{"id": "@olostep/google-search"}` |
+| `llm_extract` | object | No | — | LLM extraction: `{"schema": {...}}` and/or `{"prompt": "..."}` |
+| `remove_css_selectors` | string | No | `default` | `default`, `none`, or stringified array of selectors |
+| `remove_images` | boolean | No | `false` | Remove images from content |
+| `transformer` | string | No | — | `postlight` or `none` — HTML transformer |
+| `actions` | array | No | — | Page interactions before scraping (see Actions below) |
+| `links_on_page` | object | No | — | Get links on page: `{"absolute_links": true}` |
+| `screen_size` | object | No | — | `{"screen_type": "desktop"}` or custom width/height |
 
 ### Available Parsers
 
-| Parser ID | Platform |
+| Parser ID | Use Case |
 |-----------|----------|
-| `@olostep/amazon-product` | Amazon product pages |
-| `@olostep/linkedin-profile` | LinkedIn profiles |
-| `@olostep/google-maps` | Google Maps listings |
+| `@olostep/google-search` | Google search results (structured SERP data) |
+| `@olostep/amazon-it-product` | Amazon product pages |
+| `@olostep/extract-emails` | Extract email addresses |
+| `@olostep/extract-calendars` | Extract calendar/event data |
+| `@olostep/extract-socials` | Extract social media links |
+
+### Page Actions
+
+Array of actions to perform before scraping (e.g., clicking "Load More"):
+
+```json
+"actions": [
+  {"type": "wait", "milliseconds": 2000},
+  {"type": "click", "selector": "#load-more"},
+  {"type": "fill_input", "selector": "#search", "value": "query"},
+  {"type": "scroll", "direction": "down", "amount": 500}
+]
+```
 
 ### Response
 
 ```json
 {
+  "id": "scrape_6h89o8u1kt",
+  "object": "scrape",
+  "created": 1745673871,
+  "metadata": {},
+  "retrieve_id": "6h89o8u1kt",
+  "url_to_scrape": "https://example.com",
   "result": {
-    "content": "# Page Title\n\nExtracted content in markdown...",
-    "url": "https://example.com",
-    "status_code": 200
+    "html_content": null,
+    "markdown_content": "# Page Title\n\nExtracted content...",
+    "text_content": null,
+    "json_content": null,
+    "screenshot_hosted_url": null,
+    "html_hosted_url": null,
+    "markdown_hosted_url": "https://olostep-storage.s3.us-east-1.amazonaws.com/markDown_6h89o8u1kt.txt",
+    "json_hosted_url": null,
+    "text_hosted_url": null,
+    "links_on_page": [],
+    "page_metadata": {
+      "status_code": 200,
+      "title": "Page Title"
+    }
   }
 }
 ```
 
+Content is in `result.markdown_content`, `result.html_content`, `result.text_content`, or `result.json_content` depending on which formats you requested. Fields for unrequested formats are `null`. If content is large, use the `*_hosted_url` fields to fetch it.
+
 ### Example
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/scrape" \
+curl -sS -X POST "https://api.olostep.com/v1/scrapes" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://docs.paperclip.ing/guides/getting-started",
-    "output_format": "markdown",
+    "url_to_scrape": "https://docs.paperclip.ing/guides/getting-started",
+    "formats": ["markdown"],
     "wait_before_scraping": 2000
   }'
 ```
 
 ---
 
-## Search — `POST /v1/search`
+## Google Search — via `POST /v1/scrapes`
 
-Search the web and get structured results.
+There is no separate search endpoint. Search Google by scraping a Google URL with the `@olostep/google-search` parser.
 
 ### Request Body
 
 ```json
 {
-  "query": "AI agent orchestration tools 2026",
-  "country": "US"
+  "url_to_scrape": "https://www.google.com/search?q=paperclip+ai+orchestration&gl=us&hl=en",
+  "formats": ["json"],
+  "parser": {"id": "@olostep/google-search"}
 }
 ```
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `query` | string | Yes | — | Search query |
-| `country` | string | No | `US` | ISO country code for localized results |
+**Constructing the Google URL:**
+- Base: `https://www.google.com/search?q=YOUR+QUERY`
+- `&gl=us` — country (ISO code lowercase)
+- `&hl=en` — language
+- URL-encode query (spaces → `+`)
 
 ### Response
 
+The `result.json_content` is a **stringified JSON string**. Parse it to access:
+
 ```json
 {
-  "results": [
-    {
-      "title": "Result Title",
-      "url": "https://example.com/article",
-      "snippet": "Brief description of the result...",
-      "content": "Full scraped content if available..."
-    }
-  ]
+  "searchParameters": {"type": "search", "engine": "google", "q": "..."},
+  "knowledgeGraph": {"title": "...", "type": "...", "description": "...", "attributes": {...}},
+  "organic": [
+    {"title": "...", "link": "https://...", "position": 1, "snippet": "..."},
+    {"title": "...", "link": "https://...", "position": 2, "snippet": "..."}
+  ],
+  "peopleAlsoAsk": [{"question": "..."}],
+  "relatedSearches": [{"query": "..."}]
 }
 ```
 
 ### Example
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/search" \
+curl -sS -X POST "https://api.olostep.com/v1/scrapes" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "how to set up Paperclip agent heartbeats",
-    "country": "US"
+    "url_to_scrape": "https://www.google.com/search?q=how+to+set+up+Paperclip+agent+heartbeats&gl=us&hl=en",
+    "formats": ["json"],
+    "parser": {"id": "@olostep/google-search"}
   }'
 ```
 
 ---
 
-## Google Search — `POST /v1/google-search`
+## Crawl — `POST /v1/crawls`
 
-Get Google-specific SERP data with rich snippets.
-
-### Request Body
-
-```json
-{
-  "query": "paperclip ai orchestration",
-  "country": "US"
-}
-```
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `query` | string | Yes | — | Search query |
-| `country` | string | No | `US` | ISO country code |
-
----
-
-## Crawl — `POST /v1/crawl`
-
-Autonomously crawl a website by following links.
+**Async** — starts a crawl job and returns immediately. Poll for results.
 
 ### Request Body
 
@@ -144,155 +170,222 @@ Autonomously crawl a website by following links.
 {
   "start_url": "https://docs.example.com",
   "max_pages": 10,
-  "follow_links": true,
-  "output_format": "markdown",
-  "country": "US"
+  "include_urls": ["/guides/**"],
+  "exclude_urls": ["/admin/**"]
 }
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `start_url` | string | Yes | — | Starting URL for the crawl |
-| `max_pages` | integer | No | `10` | Maximum pages to crawl |
-| `follow_links` | boolean | No | `true` | Whether to follow discovered links |
-| `output_format` | string | No | `markdown` | One of: `markdown`, `html`, `json`, `text` |
-| `country` | string | No | — | ISO country code |
-| `parser` | string | No | — | Specialized parser ID |
+| `max_pages` | integer | Yes | — | Maximum pages to crawl |
+| `include_urls` | array | No | `["/**"]` | Glob patterns for URLs to include |
+| `exclude_urls` | array | No | — | Glob patterns for URLs to exclude |
+| `max_depth` | integer | No | — | Maximum link depth from start URL |
+| `include_external` | boolean | No | `false` | Crawl first-degree external links |
+| `include_subdomain` | boolean | No | `false` | Include subdomains |
+| `search_query` | string | No | — | Sort results by relevance to this query |
+| `top_n` | integer | No | — | Only follow top N most relevant links per page |
+| `webhook_url` | string | No | — | URL called when crawl completes |
+| `timeout` | integer | No | — | End crawl after N seconds |
 
-### Response
+### Response (create)
 
 ```json
 {
-  "results": [
-    {
-      "url": "https://docs.example.com/page1",
-      "content": "# Page content in markdown...",
-      "status_code": 200
-    }
-  ]
+  "id": "crawl_abc123",
+  "object": "crawl",
+  "status": "in_progress",
+  "created": 1745673871,
+  "start_url": "https://docs.example.com",
+  "max_pages": 10,
+  "pages_count": 0
 }
 ```
+
+### Check Status — `GET /v1/crawls/{crawl_id}`
+
+Poll until `status` is `"completed"`.
+
+### Get Pages — `GET /v1/crawls/{crawl_id}/pages`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | integer | Number of pages per request (default: 10) |
+| `cursor` | string | Pagination cursor from previous response |
+
+```json
+{
+  "pages": [
+    {"url": "https://docs.example.com/page1", "retrieve_id": "abc123"},
+    {"url": "https://docs.example.com/page2", "retrieve_id": "def456"}
+  ],
+  "cursor": "next_page_token"
+}
+```
+
+Use `retrieve_id` with the Retrieve endpoint to get content.
 
 ### Example
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/crawl" \
+# Start crawl
+curl -sS -X POST "https://api.olostep.com/v1/crawls" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "start_url": "https://docs.example.com/guides",
-    "max_pages": 25,
-    "output_format": "markdown"
+    "max_pages": 25
   }'
+
+# Check status
+curl -sS "https://api.olostep.com/v1/crawls/CRAWL_ID" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+
+# Get pages
+curl -sS "https://api.olostep.com/v1/crawls/CRAWL_ID/pages?limit=10" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
 ```
 
 ---
 
-## Batch Scrape — `POST /v1/batch-scrape`
+## Batch — `POST /v1/batches`
 
-Scrape up to 10,000 URLs in parallel.
+**Async** — scrape up to 10,000 URLs in parallel. Usually completes in 5–8 minutes.
 
 ### Request Body
 
 ```json
 {
-  "urls_to_scrape": [
+  "items": [
     {"url": "https://example.com/page1", "custom_id": "p1"},
     {"url": "https://example.com/page2", "custom_id": "p2"},
-    {"url": "https://example.com/page3"}
+    {"url": "https://example.com/page3", "custom_id": "p3"}
   ],
-  "output_format": "markdown",
   "country": "US",
-  "wait_before_scraping": 2000
+  "parser": {"id": "@olostep/google-search"}
 }
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `urls_to_scrape` | array | Yes | — | Array of `{url, custom_id?}` objects (1–10,000 items) |
-| `output_format` | string | No | `markdown` | One of: `markdown`, `html`, `json`, `text` |
+| `items` | array | Yes | — | Array of `{"url": "...", "custom_id": "..."}` objects (1–10,000) |
 | `country` | string | No | — | ISO country code |
-| `wait_before_scraping` | integer | No | `0` | Milliseconds to wait per URL (0–10000) |
-| `parser` | string | No | — | Specialized parser ID |
+| `parser` | object | No | — | Parser for structured extraction: `{"id": "parser_id"}` |
 
-### Response
+### Response (create)
 
 ```json
 {
-  "results": [
-    {
-      "url": "https://example.com/page1",
-      "custom_id": "p1",
-      "content": "# Page 1 content...",
-      "status_code": 200
-    }
-  ]
+  "id": "batch_abc123",
+  "object": "batch",
+  "status": "in_progress",
+  "total_urls": 3,
+  "completed_urls": 0
 }
 ```
+
+### Check Status — `GET /v1/batches/{batch_id}`
+
+Poll until `status` is `"completed"`.
+
+### Get Items — `GET /v1/batches/{batch_id}/items`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | integer | Items per page |
+| `cursor` | string/number | Pagination cursor |
+| `status` | string | Filter by item status |
+
+```json
+{
+  "items": [
+    {"custom_id": "p1", "url": "https://example.com/page1", "retrieve_id": "abc123", "status": "completed"},
+    {"custom_id": "p2", "url": "https://example.com/page2", "retrieve_id": "def456", "status": "completed"}
+  ],
+  "cursor": "next_token"
+}
+```
+
+Use `retrieve_id` with the Retrieve endpoint to get content.
 
 ### Example
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/batch-scrape" \
+# Start batch
+curl -sS -X POST "https://api.olostep.com/v1/batches" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "urls_to_scrape": [
+    "items": [
       {"url": "https://example.com/products/1", "custom_id": "prod-1"},
       {"url": "https://example.com/products/2", "custom_id": "prod-2"},
       {"url": "https://example.com/products/3", "custom_id": "prod-3"}
-    ],
-    "output_format": "markdown"
+    ]
   }'
+
+# Check status
+curl -sS "https://api.olostep.com/v1/batches/BATCH_ID" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+
+# Get items
+curl -sS "https://api.olostep.com/v1/batches/BATCH_ID/items?limit=10" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
 ```
 
 ---
 
-## Map — `POST /v1/map`
+## Map — `POST /v1/maps`
 
-Discover all URLs on a website.
+Discover all URLs on a website. Synchronous — returns immediately (up to 120s for large sites).
 
 ### Request Body
 
 ```json
 {
-  "website_url": "https://example.com",
-  "search_query": "blog",
-  "top_n": 100,
-  "include_url_patterns": ["/blog/**", "/docs/**"],
-  "exclude_url_patterns": ["/admin/**", "/internal/**"]
+  "url": "https://example.com",
+  "include_urls": ["/blog/**", "/docs/**"],
+  "exclude_urls": ["/admin/**"],
+  "top_n": 100
 }
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `website_url` | string | Yes | — | Website to map |
-| `search_query` | string | No | — | Filter URLs by keyword |
+| `url` | string | Yes | — | Website to map |
+| `search_query` | string | No | — | Sort URLs by relevance to this query |
 | `top_n` | integer | No | — | Max URLs to return |
-| `include_url_patterns` | array | No | — | Glob patterns for URLs to include |
-| `exclude_url_patterns` | array | No | — | Glob patterns for URLs to exclude |
+| `include_urls` | array | No | — | Glob patterns for URLs to include |
+| `exclude_urls` | array | No | — | Glob patterns for URLs to exclude |
+| `include_subdomain` | boolean | No | `true` | Include subdomains |
+| `cursor` | string | No | — | Pagination cursor from previous response |
 
 ### Response
 
 ```json
 {
+  "id": "map_abc123",
+  "urls_count": 22,
   "urls": [
     "https://example.com/blog/post-1",
     "https://example.com/blog/post-2",
     "https://example.com/docs/getting-started"
-  ]
+  ],
+  "cursor": null
 }
 ```
+
+If `cursor` is not null, pass it in the next request to get more URLs (10MB response limit).
 
 ### Example
 
 ```sh
-curl -sS -X POST "https://api.olostep.com/v1/map" \
+curl -sS -X POST "https://api.olostep.com/v1/maps" \
   -H "Authorization: Bearer $OLOSTEP_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "website_url": "https://docs.example.com",
-    "include_url_patterns": ["/guides/**"],
+    "url": "https://docs.example.com",
+    "include_urls": ["/guides/**"],
     "top_n": 50
   }'
 ```
@@ -301,14 +394,14 @@ curl -sS -X POST "https://api.olostep.com/v1/map" \
 
 ## Answers — `POST /v1/answers`
 
-Get AI-powered answers with citations from the web.
+Get AI-powered answers with citations from the web. Synchronous (3–30s depending on complexity).
 
 ### Request Body
 
 ```json
 {
   "task": "What are the pricing tiers for Vercel in 2026?",
-  "json": {
+  "json_format": {
     "provider": "",
     "tiers": [{"name": "", "price": "", "features": []}]
   }
@@ -318,34 +411,25 @@ Get AI-powered answers with citations from the web.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `task` | string | Yes | — | Question or research task |
-| `json` | object | No | — | JSON schema for structured output |
+| `json_format` | object | No | — | JSON schema for structured output (object with empty values as template) |
 
-### Response (unstructured)
-
-```json
-{
-  "answer": "Based on current information, Vercel offers three tiers...",
-  "sources": [
-    {"url": "https://vercel.com/pricing", "title": "Vercel Pricing"},
-    {"url": "https://blog.example.com/vercel-review", "title": "Vercel Review 2026"}
-  ]
-}
-```
-
-### Response (with JSON schema)
+### Response
 
 ```json
 {
-  "answer": {
-    "provider": "Vercel",
-    "tiers": [
-      {"name": "Hobby", "price": "Free", "features": ["..."]},
-      {"name": "Pro", "price": "$20/mo", "features": ["..."]}
-    ]
-  },
-  "sources": [...]
+  "id": "answer_9bi0sbj9xa",
+  "object": "answer",
+  "created": 1745673871,
+  "task": "What are the pricing tiers for Vercel in 2026?",
+  "result": {
+    "json_content": "{\"provider\": \"Vercel\", \"tiers\": [{\"name\": \"Hobby\", \"price\": \"Free\", ...}]}",
+    "json_hosted_url": "https://olostep-storage.s3.amazonaws.com/...",
+    "sources": ["https://vercel.com/pricing", "https://blog.example.com/vercel-review"]
+  }
 }
 ```
+
+The `result.json_content` is a stringified JSON string matching your `json_format` schema. `result.sources` is an array of URL strings.
 
 ### Example
 
@@ -355,7 +439,7 @@ curl -sS -X POST "https://api.olostep.com/v1/answers" \
   -H "Content-Type: application/json" \
   -d '{
     "task": "Compare the top 3 headless browser services for web scraping in 2026",
-    "json": {
+    "json_format": {
       "services": [{"name": "", "pricing": "", "features": [], "pros": [], "cons": []}]
     }
   }'
@@ -363,15 +447,34 @@ curl -sS -X POST "https://api.olostep.com/v1/answers" \
 
 ---
 
-## Rate Limits
+## Retrieve — `GET /v1/retrieve`
 
-| Plan | Requests/min | Concurrent | Batch Max |
-|------|-------------|------------|-----------|
-| Free | 10 | 5 | 100 |
-| Pro | 100 | 50 | 10,000 |
-| Enterprise | Custom | Custom | Custom |
+Retrieve content for crawl pages and batch items using their `retrieve_id`.
 
-When rate-limited, the API returns HTTP 429. Back off and retry after the `Retry-After` header value.
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `retrieve_id` | string | Yes | The retrieve ID from a crawl page or batch item |
+| `formats` | string | No | Comma-separated formats: `markdown`, `html`, `text`, `json` |
+
+### Response
+
+```json
+{
+  "html_content": null,
+  "markdown_content": "# Page content...",
+  "text_content": null,
+  "json_content": null
+}
+```
+
+### Example
+
+```sh
+curl -sS "https://api.olostep.com/v1/retrieve?retrieve_id=abc123&formats=markdown" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY"
+```
 
 ---
 
@@ -380,27 +483,17 @@ When rate-limited, the API returns HTTP 429. Back off and retry after the `Retry
 | Status | Meaning |
 |--------|---------|
 | 400 | Bad request — check parameters |
-| 401 | Invalid or missing API key |
-| 429 | Rate limited — wait and retry |
+| 402 | Invalid or missing API key |
 | 500 | Server error — retry once, then report |
-
-All errors return:
-```json
-{
-  "error": {
-    "message": "Description of what went wrong",
-    "code": "ERROR_CODE"
-  }
-}
-```
 
 ---
 
 ## Best Practices
 
-1. **Use markdown format** by default — most token-efficient for LLM processing
+1. **Use `formats: ["markdown"]`** by default — most token-efficient for LLM processing
 2. **Batch when possible** — one batch call is cheaper and faster than N individual scrapes
 3. **Map before crawling** — understand site structure before committing to a large crawl
 4. **Set wait times** for JS-heavy sites (SPAs, e-commerce) — `wait_before_scraping: 2000`
-5. **Use specialized parsers** when available (Amazon, LinkedIn, etc.) for higher accuracy
-6. **Report errors** — if you get auth failures or rate limits, comment on your Paperclip task so your manager can address it
+5. **Use parsers** when available (Google search, Amazon, etc.) for structured JSON at scale
+6. **Poll async endpoints** — crawls and batches return immediately with `status: "in_progress"`
+7. **Report errors** — if you get auth failures or rate limits, comment on your Paperclip task so your manager can address it

--- a/skills/olostep/references/api-reference.md
+++ b/skills/olostep/references/api-reference.md
@@ -1,0 +1,406 @@
+# Olostep API Reference
+
+Complete endpoint reference for the Olostep web scraping API. For the core skill instructions and common workflows, see the main `SKILL.md`.
+
+**Base URL:** `https://api.olostep.com/v1`  
+**Auth:** `Authorization: Bearer $OLOSTEP_API_KEY`  
+**Content-Type:** `application/json`
+
+---
+
+## Scrape — `POST /v1/scrape`
+
+Extract content from a single webpage.
+
+### Request Body
+
+```json
+{
+  "url": "https://example.com",
+  "output_format": "markdown",
+  "country": "US",
+  "wait_before_scraping": 2000,
+  "parser": "@olostep/amazon-product"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | Yes | — | The webpage URL to scrape |
+| `output_format` | string | No | `markdown` | One of: `markdown`, `html`, `json`, `text` |
+| `country` | string | No | — | ISO country code for geo-targeting (e.g., `US`, `GB`, `DE`) |
+| `wait_before_scraping` | integer | No | `0` | Milliseconds to wait for JS rendering (0–10000) |
+| `parser` | string | No | — | Specialized parser ID for popular platforms |
+
+### Available Parsers
+
+| Parser ID | Platform |
+|-----------|----------|
+| `@olostep/amazon-product` | Amazon product pages |
+| `@olostep/linkedin-profile` | LinkedIn profiles |
+| `@olostep/google-maps` | Google Maps listings |
+
+### Response
+
+```json
+{
+  "result": {
+    "content": "# Page Title\n\nExtracted content in markdown...",
+    "url": "https://example.com",
+    "status_code": 200
+  }
+}
+```
+
+### Example
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/scrape" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://docs.paperclip.ing/guides/getting-started",
+    "output_format": "markdown",
+    "wait_before_scraping": 2000
+  }'
+```
+
+---
+
+## Search — `POST /v1/search`
+
+Search the web and get structured results.
+
+### Request Body
+
+```json
+{
+  "query": "AI agent orchestration tools 2026",
+  "country": "US"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | Yes | — | Search query |
+| `country` | string | No | `US` | ISO country code for localized results |
+
+### Response
+
+```json
+{
+  "results": [
+    {
+      "title": "Result Title",
+      "url": "https://example.com/article",
+      "snippet": "Brief description of the result...",
+      "content": "Full scraped content if available..."
+    }
+  ]
+}
+```
+
+### Example
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/search" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "how to set up Paperclip agent heartbeats",
+    "country": "US"
+  }'
+```
+
+---
+
+## Google Search — `POST /v1/google-search`
+
+Get Google-specific SERP data with rich snippets.
+
+### Request Body
+
+```json
+{
+  "query": "paperclip ai orchestration",
+  "country": "US"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | Yes | — | Search query |
+| `country` | string | No | `US` | ISO country code |
+
+---
+
+## Crawl — `POST /v1/crawl`
+
+Autonomously crawl a website by following links.
+
+### Request Body
+
+```json
+{
+  "start_url": "https://docs.example.com",
+  "max_pages": 10,
+  "follow_links": true,
+  "output_format": "markdown",
+  "country": "US"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `start_url` | string | Yes | — | Starting URL for the crawl |
+| `max_pages` | integer | No | `10` | Maximum pages to crawl |
+| `follow_links` | boolean | No | `true` | Whether to follow discovered links |
+| `output_format` | string | No | `markdown` | One of: `markdown`, `html`, `json`, `text` |
+| `country` | string | No | — | ISO country code |
+| `parser` | string | No | — | Specialized parser ID |
+
+### Response
+
+```json
+{
+  "results": [
+    {
+      "url": "https://docs.example.com/page1",
+      "content": "# Page content in markdown...",
+      "status_code": 200
+    }
+  ]
+}
+```
+
+### Example
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/crawl" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start_url": "https://docs.example.com/guides",
+    "max_pages": 25,
+    "output_format": "markdown"
+  }'
+```
+
+---
+
+## Batch Scrape — `POST /v1/batch-scrape`
+
+Scrape up to 10,000 URLs in parallel.
+
+### Request Body
+
+```json
+{
+  "urls_to_scrape": [
+    {"url": "https://example.com/page1", "custom_id": "p1"},
+    {"url": "https://example.com/page2", "custom_id": "p2"},
+    {"url": "https://example.com/page3"}
+  ],
+  "output_format": "markdown",
+  "country": "US",
+  "wait_before_scraping": 2000
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `urls_to_scrape` | array | Yes | — | Array of `{url, custom_id?}` objects (1–10,000 items) |
+| `output_format` | string | No | `markdown` | One of: `markdown`, `html`, `json`, `text` |
+| `country` | string | No | — | ISO country code |
+| `wait_before_scraping` | integer | No | `0` | Milliseconds to wait per URL (0–10000) |
+| `parser` | string | No | — | Specialized parser ID |
+
+### Response
+
+```json
+{
+  "results": [
+    {
+      "url": "https://example.com/page1",
+      "custom_id": "p1",
+      "content": "# Page 1 content...",
+      "status_code": 200
+    }
+  ]
+}
+```
+
+### Example
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/batch-scrape" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "urls_to_scrape": [
+      {"url": "https://example.com/products/1", "custom_id": "prod-1"},
+      {"url": "https://example.com/products/2", "custom_id": "prod-2"},
+      {"url": "https://example.com/products/3", "custom_id": "prod-3"}
+    ],
+    "output_format": "markdown"
+  }'
+```
+
+---
+
+## Map — `POST /v1/map`
+
+Discover all URLs on a website.
+
+### Request Body
+
+```json
+{
+  "website_url": "https://example.com",
+  "search_query": "blog",
+  "top_n": 100,
+  "include_url_patterns": ["/blog/**", "/docs/**"],
+  "exclude_url_patterns": ["/admin/**", "/internal/**"]
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `website_url` | string | Yes | — | Website to map |
+| `search_query` | string | No | — | Filter URLs by keyword |
+| `top_n` | integer | No | — | Max URLs to return |
+| `include_url_patterns` | array | No | — | Glob patterns for URLs to include |
+| `exclude_url_patterns` | array | No | — | Glob patterns for URLs to exclude |
+
+### Response
+
+```json
+{
+  "urls": [
+    "https://example.com/blog/post-1",
+    "https://example.com/blog/post-2",
+    "https://example.com/docs/getting-started"
+  ]
+}
+```
+
+### Example
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/map" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "website_url": "https://docs.example.com",
+    "include_url_patterns": ["/guides/**"],
+    "top_n": 50
+  }'
+```
+
+---
+
+## Answers — `POST /v1/answers`
+
+Get AI-powered answers with citations from the web.
+
+### Request Body
+
+```json
+{
+  "task": "What are the pricing tiers for Vercel in 2026?",
+  "json": {
+    "provider": "",
+    "tiers": [{"name": "", "price": "", "features": []}]
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `task` | string | Yes | — | Question or research task |
+| `json` | object | No | — | JSON schema for structured output |
+
+### Response (unstructured)
+
+```json
+{
+  "answer": "Based on current information, Vercel offers three tiers...",
+  "sources": [
+    {"url": "https://vercel.com/pricing", "title": "Vercel Pricing"},
+    {"url": "https://blog.example.com/vercel-review", "title": "Vercel Review 2026"}
+  ]
+}
+```
+
+### Response (with JSON schema)
+
+```json
+{
+  "answer": {
+    "provider": "Vercel",
+    "tiers": [
+      {"name": "Hobby", "price": "Free", "features": ["..."]},
+      {"name": "Pro", "price": "$20/mo", "features": ["..."]}
+    ]
+  },
+  "sources": [...]
+}
+```
+
+### Example
+
+```sh
+curl -sS -X POST "https://api.olostep.com/v1/answers" \
+  -H "Authorization: Bearer $OLOSTEP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Compare the top 3 headless browser services for web scraping in 2026",
+    "json": {
+      "services": [{"name": "", "pricing": "", "features": [], "pros": [], "cons": []}]
+    }
+  }'
+```
+
+---
+
+## Rate Limits
+
+| Plan | Requests/min | Concurrent | Batch Max |
+|------|-------------|------------|-----------|
+| Free | 10 | 5 | 100 |
+| Pro | 100 | 50 | 10,000 |
+| Enterprise | Custom | Custom | Custom |
+
+When rate-limited, the API returns HTTP 429. Back off and retry after the `Retry-After` header value.
+
+---
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Bad request — check parameters |
+| 401 | Invalid or missing API key |
+| 429 | Rate limited — wait and retry |
+| 500 | Server error — retry once, then report |
+
+All errors return:
+```json
+{
+  "error": {
+    "message": "Description of what went wrong",
+    "code": "ERROR_CODE"
+  }
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use markdown format** by default — most token-efficient for LLM processing
+2. **Batch when possible** — one batch call is cheaper and faster than N individual scrapes
+3. **Map before crawling** — understand site structure before committing to a large crawl
+4. **Set wait times** for JS-heavy sites (SPAs, e-commerce) — `wait_before_scraping: 2000`
+5. **Use specialized parsers** when available (Amazon, LinkedIn, etc.) for higher accuracy
+6. **Report errors** — if you get auth failures or rate limits, comment on your Paperclip task so your manager can address it


### PR DESCRIPTION
## Summary

Adds the **Olostep** community skill — the first third-party skill for Paperclip. This gives any agent the ability to scrape web pages, search the web, crawl sites, and extract structured data using the [Olostep API](https://olostep.com).

Also includes a Windows compatibility fix for the `claude_local` adapter's skill directory symlink creation.

## What's included

### 1. Olostep Skill (`skills/olostep/`)

- **`SKILL.md`** — Full skill with YAML frontmatter for Paperclip routing and 7 capability sections:
  1. Scrape a single page (with JS rendering, anti-bot handling)
  2. Search the web (Google-quality structured results)
  3. Crawl websites (follow links, multi-page)
  4. Batch scrape (up to 10,000 URLs in parallel)
  5. Map website structure (URL discovery without scraping)
  6. AI-powered answers (with citations and structured JSON output)
  7. Extract structured data (scrape + parse into schemas)
- **`references/api-reference.md`** — Detailed API endpoint documentation

Each section includes ready-to-use `curl` examples, parameter tables, tips, and common workflow patterns.

### 2. Windows junction fix (`packages/adapters/claude-local/`)

`buildSkillsDir()` uses `fs.symlink()` to link skills into a temp directory. On Windows, directory symlinks require Administrator privileges (EPERM). This change passes `'junction'` as the symlink type on Windows, which works without elevation, and remains a no-op on other platforms.

## Why this approach

- A Paperclip skill is the lowest-friction way to expose Olostep’s scrape/search/crawl/batch/map/answer workflows to existing agents without adding new runtime integrations.
- Keeping the Olostep addition inside `skills/olostep/` makes the contribution easy to review, easy to remove, and easy to iterate on independently of the core runtime.
- The Windows fix stays narrowly scoped to the symlink behavior in `claude_local`, instead of changing broader workspace or adapter logic.

## Alternatives considered

- **Adding a dedicated adapter/runtime integration for Olostep** — more powerful, but much heavier than needed for an initial community integration.
- **Leaving the Windows path unchanged and documenting admin requirements** — rejected because junctions solve the real Windows problem with a smaller UX cost.
- **Adding a separate Google search endpoint to the skill docs** — rejected after checking the actual Olostep API/docs; search is handled through scrapes with the `@olostep/google-search` parser.

## Risks / tradeoffs

- Third-party skills increase the surface area of what agents may choose to use, so documentation quality matters a lot.
- The Olostep skill depends on a user-supplied `OLOSTEP_API_KEY`, so poor examples or stale endpoint docs would create agent confusion quickly.
- The Windows junction change is intentionally minimal, but filesystem behavior across platforms is always worth watching.

## Testing

Tested end-to-end on Windows with a local Paperclip instance:
- Agent successfully discovers and uses the Olostep skill during heartbeats
- Verified all 7 capabilities (scrape, search, crawl, batch, map, answers, structured extraction)
- Agent completed research tasks using `curl` + `OLOSTEP_API_KEY` env var
- Junction fix resolves EPERM errors on Windows without requiring admin

## Setup for users

1. Copy `skills/olostep/` into your Paperclip `skills/` directory (already included)
2. Create an agent with `claude_local` adapter
3. Add env var `OLOSTEP_API_KEY` with your Olostep API key (get one at https://olostep.com)
4. Assign a web research task and run a heartbeat
