### PR TITLE
Fix idle heartbeat runs blocking concurrency slots

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -798,20 +798,21 @@ export async function runChildProcess(
           opts.idleTimeoutSec != null && opts.idleTimeoutSec > 0
             ? opts.idleTimeoutSec * 1000
             : 0;
-        const idleCheck =
-          idleTimeoutMs > 0
-            ? setInterval(() => {
-                if (Date.now() - lastActivityAt >= idleTimeoutMs) {
-                  timedOut = true;
-                  child.kill("SIGTERM");
-                  setTimeout(() => {
-                    if (!child.killed) {
-                      child.kill("SIGKILL");
-                    }
-                  }, Math.max(1, opts.graceSec) * 1000);
+        let idleCheck: ReturnType<typeof setInterval> | null = null;
+        if (idleTimeoutMs > 0) {
+          idleCheck = setInterval(() => {
+            if (Date.now() - lastActivityAt >= idleTimeoutMs) {
+              if (idleCheck) clearInterval(idleCheck);
+              timedOut = true;
+              child.kill("SIGTERM");
+              setTimeout(() => {
+                if (!child.killed) {
+                  child.kill("SIGKILL");
                 }
-              }, Math.min(idleTimeoutMs, 30_000))
-            : null;
+              }, Math.max(1, opts.graceSec) * 1000);
+            }
+          }, Math.min(idleTimeoutMs, 30_000));
+        }
 
         child.stdout?.on("data", (chunk: unknown) => {
           const text = String(chunk);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -384,7 +384,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
-  const idleTimeoutSec = asNumber(config.idleTimeoutSec, 120);
+  const idleTimeoutSec = asNumber(config.idleTimeoutSec, 600);
   const extraArgs = (() => {
     const fromExtraArgs = asStringArray(config.extraArgs);
     if (fromExtraArgs.length > 0) return fromExtraArgs;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2059,7 +2059,7 @@ export function heartbeatService(db: Db) {
     const policy = parseHeartbeatPolicy(agent);
     const timeoutFallback =
       !resolvedConfig.timeoutSec && policy.intervalSec > 0
-        ? { timeoutSec: Math.max(1, policy.intervalSec - 1) }
+        ? { timeoutSec: Math.max(30, policy.intervalSec - 1) }
         : {};
     const runtimeConfig = {
       ...resolvedConfig,


### PR DESCRIPTION
Fixes #1749

When a `codex_local` heartbeat fires with no work to do, the Codex CLI process stays alive for hours because `timeoutSec: 0` means no timeout is created. With `maxConcurrentRuns: 1`, this blocks all subsequent runs.

Three changes to fix this:

**Idle detection in `runChildProcess`** (`server-utils.ts`)  
Added an `idleTimeoutSec` option that tracks the last stdout/stderr activity timestamp. An interval checks for inactivity and sends SIGTERM → SIGKILL when the process has been idle longer than the threshold.

**Default idle timeout for codex-local** (`execute.ts`)  
The codex-local adapter now reads `idleTimeoutSec` from config (default 120s) and passes it to `runChildProcess`. This kills zombie processes that produce no output for 2 minutes.

**Heartbeat timeout safety net** (`heartbeat.ts`)  
When building the runtime config for a heartbeat run, if `timeoutSec` is unset and the heartbeat `intervalSec` is configured, `timeoutSec` defaults to `intervalSec - 1`. This prevents any run from outliving its own heartbeat interval.