### PR TITLE
Fix Pi adapter RPC stdin closing immediately and model discovery

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -728,6 +728,7 @@ export async function runChildProcess(
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
     stdin?: string;
+    keepStdinOpen?: boolean;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -763,7 +764,9 @@ export async function runChildProcess(
 
         if (opts.stdin != null && child.stdin) {
           child.stdin.write(opts.stdin);
-          child.stdin.end();
+          if (!opts.keepStdinOpen) {
+            child.stdin.end();
+          }
         }
 
         if (typeof child.pid === "number" && child.pid > 0 && opts.onSpawn) {
@@ -823,6 +826,9 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           runningProcesses.delete(runId);
+          if (opts.keepStdinOpen && child.stdin && !child.stdin.destroyed) {
+            child.stdin.end();
+          }
           void logChain.finally(() => {
             resolve({
               exitCode: code,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -403,6 +403,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onSpawn,
       onLog: bufferedOnLog,
       stdin: buildRpcStdin(),
+      keepStdinOpen: true,
     });
     
     // Flush any remaining buffer content

--- a/packages/adapters/pi-local/src/server/models.ts
+++ b/packages/adapters/pi-local/src/server/models.ts
@@ -131,7 +131,7 @@ export async function discoverPiModels(input: {
     throw new Error(detail ? `\`pi --list-models\` failed: ${detail}` : "`pi --list-models` failed.");
   }
 
-  return sortModels(dedupeModels(parseModelsOutput(result.stdout)));
+  return sortModels(dedupeModels(parseModelsOutput(result.stderr)));
 }
 
 function normalizeEnv(input: unknown): Record<string, string> {


### PR DESCRIPTION
Fixes #1721

`runChildProcess` closes stdin immediately after writing, but Pi's RPC mode needs the pipe open until the process finishes. Added `keepStdinOpen` option that defers `stdin.end()` to the close handler.

Also fixed `discoverPiModels` reading stdout instead of stderr for `pi --list-models` output.