### PR TITLE
fix(ui): show loading spinner on approve/reject buttons

### DIFF
--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, XCircle, Clock } from "lucide-react";
+import { CheckCircle2, XCircle, Clock, Loader2 } from "lucide-react";
 import { Link } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { Identity } from "./Identity";
@@ -78,6 +78,7 @@ export function ApprovalCard({
             onClick={onApprove}
             disabled={isPending}
           >
+            {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
             Approve
           </Button>
           <Button
@@ -86,6 +87,7 @@ export function ApprovalCard({
             onClick={onReject}
             disabled={isPending}
           >
+            {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
             Reject
           </Button>
         </div>

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -37,6 +37,7 @@ import {
   X,
   RotateCcw,
   UserPlus,
+  Loader2,
 } from "lucide-react";
 import { PageTabBar } from "../components/PageTabBar";
 import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
@@ -242,6 +243,7 @@ function ApprovalInboxRow({
               onClick={onApprove}
               disabled={isPending}
             >
+              {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
               Approve
             </Button>
             <Button
@@ -251,6 +253,7 @@ function ApprovalInboxRow({
               onClick={onReject}
               disabled={isPending}
             >
+              {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
               Reject
             </Button>
           </div>
@@ -264,6 +267,7 @@ function ApprovalInboxRow({
             onClick={onApprove}
             disabled={isPending}
           >
+            {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
             Approve
           </Button>
           <Button
@@ -273,6 +277,7 @@ function ApprovalInboxRow({
             onClick={onReject}
             disabled={isPending}
           >
+            {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
             Reject
           </Button>
         </div>
@@ -323,6 +328,7 @@ function JoinRequestInboxRow({
             onClick={onApprove}
             disabled={isPending}
           >
+            {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
             Approve
           </Button>
           <Button
@@ -332,6 +338,7 @@ function JoinRequestInboxRow({
             onClick={onReject}
             disabled={isPending}
           >
+            {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
             Reject
           </Button>
         </div>
@@ -343,6 +350,7 @@ function JoinRequestInboxRow({
           onClick={onApprove}
           disabled={isPending}
         >
+          {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
           Approve
         </Button>
         <Button
@@ -352,6 +360,7 @@ function JoinRequestInboxRow({
           onClick={onReject}
           disabled={isPending}
         >
+          {isPending && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
           Reject
         </Button>
       </div>


### PR DESCRIPTION
## What this does

When user click approve or reject button (in Inbox page or ApprovalCard component), the buttons was just getting disabled but there was no visual feedback that something is happening. Now a small spinning loader icon appear next to the button text while the action is processing.

## Changes

- Added `Loader2` spinner icon from lucide-react to approve/reject buttons in `ApprovalCard.tsx`
- Same treatment for approval rows and join request rows in `Inbox.tsx` (both desktop and mobile responsive views)
- Spinner only show when `isPending` is true, so it disappear automatically when action complete

## How to test

1. Go to Inbox page or any page with approval cards
2. Click Approve or Reject on a pending item
3. You should see a small spinning icon appear next to button text while request is processing
4. Button should return to normal state after action complete

Small change, 12 lines added across 2 files. No logic change, just visual feedback improvement.