### PR TITLE
Fix: Removed Haiku4.6 as it's not supported yet by Anthropic.

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -4,7 +4,7 @@ export const label = "Claude Code (local)";
 export const models = [
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-  { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },
+  // { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" }, // this model is still not supported by Anthropic hence causing failure when selected. Re-enable once supported.
   { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 ];


### PR DESCRIPTION
## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - Dealing with LLM adapters that are currently supported. 
> - Pointing to Haiku4.6 which hasn't been published yet by Anthropic. 
> - Eventually, the agent fails because of this. 
> - This PR comments out Haiku 4.6. It should be brought back once it's supported. 
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

- Commented out Haiku 4.6 from the supported LLMs.

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

- Open the agent configuration >> adapter >> model (dropdown) and verify that Haiku4.6 doesn't exist. 

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

- It's already not working so if anyone has selected it, nothing will work for them at this time. 

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
