### PR TITLE
UI: Improve design of cancelled task status icon

### DIFF
--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -37,7 +37,7 @@ export function StatusIcon({ status, onChange, className, showLabel }: StatusIco
       )}
       {isCancelled && (
         <svg
-          className="absolute inset-0 m-auto !w-2.5 text-card"
+          className="absolute inset-0 m-auto size-2.5! text-card"
           viewBox="0 0 12 12"
           fill="none"
           stroke="currentColor"

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -21,6 +21,7 @@ export function StatusIcon({ status, onChange, className, showLabel }: StatusIco
   const [open, setOpen] = useState(false);
   const colorClass = issueStatusIcon[status] ?? issueStatusIconDefault;
   const isDone = status === "done";
+  const isCancelled = status === "cancelled";
 
   const circle = (
     <span
@@ -33,6 +34,19 @@ export function StatusIcon({ status, onChange, className, showLabel }: StatusIco
     >
       {isDone && (
         <span className="absolute inset-0 m-auto h-2 w-2 rounded-full bg-current" />
+      )}
+      {isCancelled && (
+        <svg
+          className="absolute inset-0 m-auto !w-2.5 text-card"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        >
+          <line x1="3" y1="3" x2="9" y2="9" />
+          <line x1="9" y1="3" x2="3" y2="9" />
+        </svg>
       )}
     </span>
   );

--- a/ui/src/lib/status-colors.ts
+++ b/ui/src/lib/status-colors.ts
@@ -16,7 +16,7 @@ export const issueStatusIcon: Record<string, string> = {
   in_progress: "text-yellow-600 border-yellow-600 dark:text-yellow-400 dark:border-yellow-400",
   in_review: "text-violet-600 border-violet-600 dark:text-violet-400 dark:border-violet-400",
   done: "text-green-600 border-green-600 dark:text-green-400 dark:border-green-400",
-  cancelled: "text-neutral-500 border-neutral-500 bg-neutral-500",
+  cancelled: "text-neutral-500 border-neutral-500 bg-neutral-500 dark:bg-neutral-500",
   blocked: "text-red-600 border-red-600 dark:text-red-400 dark:border-red-400",
 };
 

--- a/ui/src/lib/status-colors.ts
+++ b/ui/src/lib/status-colors.ts
@@ -16,7 +16,7 @@ export const issueStatusIcon: Record<string, string> = {
   in_progress: "text-yellow-600 border-yellow-600 dark:text-yellow-400 dark:border-yellow-400",
   in_review: "text-violet-600 border-violet-600 dark:text-violet-400 dark:border-violet-400",
   done: "text-green-600 border-green-600 dark:text-green-400 dark:border-green-400",
-  cancelled: "text-neutral-500 border-neutral-500",
+  cancelled: "text-neutral-500 border-neutral-500 bg-neutral-500",
   blocked: "text-red-600 border-red-600 dark:text-red-400 dark:border-red-400",
 };
 


### PR DESCRIPTION
## Thinking Path

> - Notice its hard to differenciate todo and cancelled (even more when they are not near each other)
> - Share suggestion and prototype on Discord, request approval to contribute
> - Build AI-assisted implementation
> - Human-made QA + bug fixing (utilizing wrong color, setting wrong size, using CSS instead of tailwind, not respecting existing heleprs for color classes, ..)

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

- Added icon and background fill to cancelled status icon

Before

<img width="1312" height="572" alt="image" src="https://github.com/user-attachments/assets/49310744-3d9f-470e-9f0b-c7d1dd24797b" />

After

<img width="1062" height="946" alt="CleanShot 2026-03-25 at 17 01 51@2x" src="https://github.com/user-attachments/assets/44e589b1-724d-4534-a1ad-e8bd6384c0a4" />

<img width="1098" height="944" alt="CleanShot 2026-03-25 at 17 01 45@2x" src="https://github.com/user-attachments/assets/4be04337-c90e-4374-b253-2bc7ed6614ea" />

## Verification

Manual QA, as shown in screenshot above. Tests wouldn't benefit UI change too much

## Risks

- Pixel-perfect alignment issue issue
- SVG icon quality

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
