### PR TITLE
fix(ui): show error feedback when mutations fail silently

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -710,6 +710,9 @@ export function AgentDetail() {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(resolvedCompanyId) });
     },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to update budget");
+    },
   });
 
   const updateIcon = useMutation({
@@ -720,6 +723,9 @@ export function AgentDetail() {
       if (resolvedCompanyId) {
         queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
       }
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to update icon");
     },
   });
 
@@ -2865,6 +2871,7 @@ function RunsTab({
 function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: HeartbeatRun; agentRouteId: string; adapterType: string }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { pushToast } = useToast();
   const { data: hydratedRun } = useQuery({
     queryKey: queryKeys.runDetail(initialRun.id),
     queryFn: () => heartbeatsApi.get(initialRun.id),
@@ -2883,6 +2890,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
     mutationFn: () => heartbeatsApi.cancel(run.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
+    },
+    onError: (err) => {
+      pushToast({ title: "Cancel failed", body: err instanceof Error ? err.message : "Could not cancel this run.", tone: "error" });
     },
   });
   const canResumeLostRun = run.errorCode === "process_lost" && run.status === "failed";
@@ -2919,6 +2929,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
       navigate(`/agents/${agentRouteId}/runs/${resumedRun.id}`);
     },
+    onError: (err) => {
+      pushToast({ title: "Resume failed", body: err instanceof Error ? err.message : "Could not resume this run.", tone: "error" });
+    },
   });
 
   const canRetryRun = run.status === "failed" || run.status === "timed_out";
@@ -2951,6 +2964,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
       navigate(`/agents/${agentRouteId}/runs/${newRun.id}`);
     },
+    onError: (err) => {
+      pushToast({ title: "Retry failed", body: err instanceof Error ? err.message : "Could not retry this run.", tone: "error" });
+    },
   });
 
   const { data: touchedIssues } = useQuery({
@@ -2973,12 +2989,18 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.taskSessions(run.agentId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.runIssues(run.id) });
     },
+    onError: (err) => {
+      pushToast({ title: "Clear sessions failed", body: err instanceof Error ? err.message : "Could not clear sessions.", tone: "error" });
+    },
   });
 
   const runClaudeLogin = useMutation({
     mutationFn: () => agentsApi.loginWithClaude(run.agentId, run.companyId),
     onSuccess: (data) => {
       setClaudeLoginResult(data);
+    },
+    onError: (err) => {
+      pushToast({ title: "Login failed", body: err instanceof Error ? err.message : "Could not start Claude login.", tone: "error" });
     },
   });
 
@@ -3883,6 +3905,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
 function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }) {
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
   const [newKeyName, setNewKeyName] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
   const [tokenVisible, setTokenVisible] = useState(false);
@@ -3901,12 +3924,18 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       setNewKeyName("");
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.keys(agentId) });
     },
+    onError: (err) => {
+      pushToast({ title: "Key creation failed", body: err instanceof Error ? err.message : "Could not create API key.", tone: "error" });
+    },
   });
 
   const revokeKey = useMutation({
     mutationFn: (keyId: string) => agentsApi.revokeKey(agentId, keyId, companyId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.keys(agentId) });
+    },
+    onError: (err) => {
+      pushToast({ title: "Revoke failed", body: err instanceof Error ? err.message : "Could not revoke API key.", tone: "error" });
     },
   });
 

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -136,6 +136,13 @@ export function Routines() {
       });
       navigate(`/routines/${routine.id}?tab=triggers`);
     },
+    onError: (err) => {
+      pushToast({
+        title: "Creation failed",
+        body: err instanceof Error ? err.message : "Could not create routine.",
+        tone: "error",
+      });
+    },
   });
 
   const updateRoutineStatus = useMutation({


### PR DESCRIPTION
## Problem

Many mutation hooks in AgentDetail page and Routines page was not having `onError` callback. When user perform action like updating budget, changing icon, cancelling a run or creating API key - if it fail, nothing happen. No error message, no toast, nothing. User just sit there thinking maybe it worked or maybe it didn't.

## What I changed

Added `onError` handlers to all mutations that was missing them:

**AgentDetail.tsx:**
- `budgetMutation` - now show inline error when budget update fail
- `updateIcon` - now show inline error when icon change fail
- `cancelRun` - toast notification on failure
- `resumeRun` - toast notification on failure
- `retryRun` - toast notification on failure
- `clearSessionsForTouchedIssues` - toast notification on failure
- `runClaudeLogin` - toast notification on failure
- `createKey` - toast notification on failure
- `revokeKey` - toast notification on failure

**Routines.tsx:**
- `createRoutine` - toast notification on failure

## How it works

For the main agent detail section, I use `setActionError` which is the existing pattern already used by `agentAction`, `resetTaskSession` and `updatePermissions` mutations in same component.

For the RunDetail and KeysTab sub-components, I added `useToast()` hook and show toast errors - this match what Routines page already doing for `updateRoutineStatus` and `runRoutine`.

## How to test

1. Go to any agent detail page
2. Try to trigger a mutation when server is down or with network disconnected
3. Should see error toast or inline error message instead of silent failure
4. Same for Routines page - try create routine when network is off

No logic change, only adding error notification. 36 lines added across 2 files.