### PR TITLE
fix(ui): add hover tooltips for truncated text and aria-label for icon button

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -817,8 +817,8 @@ export function AgentDetail() {
             </button>
           </AgentIconPicker>
           <div className="min-w-0">
-            <h2 className="text-2xl font-bold truncate">{agent.name}</h2>
-            <p className="text-sm text-muted-foreground truncate">
+            <h2 className="text-2xl font-bold truncate" title={agent.name}>{agent.name}</h2>
+            <p className="text-sm text-muted-foreground truncate" title={`${roleLabels[agent.role] ?? agent.role}${agent.title ? ` - ${agent.title}` : ""}`}>
               {roleLabels[agent.role] ?? agent.role}
               {agent.title ? ` - ${agent.title}` : ""}
             </p>

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -551,7 +551,7 @@ function SkillPane({
       <div className="border-b border-border px-5 py-4">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
-            <h1 className="flex items-center gap-2 truncate text-2xl font-semibold">
+            <h1 className="flex items-center gap-2 truncate text-2xl font-semibold" title={detail.name}>
               <SourceIcon className="h-5 w-5 shrink-0 text-muted-foreground" />
               {detail.name}
             </h1>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -702,7 +702,7 @@ export function IssueDetail() {
             </span>
           ))}
           <ChevronRight className="h-3 w-3 shrink-0" />
-          <span className="text-foreground/60 truncate max-w-[200px]">{issue.title}</span>
+          <span className="text-foreground/60 truncate max-w-[200px]" title={issue.title}>{issue.title}</span>
         </nav>
       )}
 
@@ -1064,7 +1064,7 @@ export function IssueDetail() {
                     <span className="font-mono text-muted-foreground shrink-0">
                       {child.identifier ?? child.id.slice(0, 8)}
                     </span>
-                    <span className="truncate">{child.title}</span>
+                    <span className="truncate" title={child.title}>{child.title}</span>
                   </div>
                   {child.assigneeAgentId && (() => {
                     const name = agentMap.get(child.assigneeAgentId)?.name;

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -223,6 +223,7 @@ function TriggerEditor({
             size="sm"
             className="text-muted-foreground hover:text-destructive"
             onClick={() => onDelete(trigger.id)}
+            aria-label="Delete trigger"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>
@@ -973,7 +974,7 @@ export function RoutineDetail() {
                       {run.status.replaceAll("_", " ")}
                     </Badge>
                     {run.trigger && (
-                      <span className="text-muted-foreground truncate">{run.trigger.label ?? run.trigger.kind}</span>
+                      <span className="text-muted-foreground truncate" title={run.trigger.label ?? run.trigger.kind}>{run.trigger.label ?? run.trigger.kind}</span>
                     )}
                     {run.linkedIssue && (
                       <Link to={`/issues/${run.linkedIssue.identifier ?? run.linkedIssue.id}`} className="text-muted-foreground hover:underline truncate">

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -548,7 +548,7 @@ export function Routines() {
                               className="shrink-0 h-3 w-3 rounded-sm"
                               style={{ backgroundColor: projectById.get(routine.projectId)?.color ?? "#6366f1" }}
                             />
-                            <span className="truncate">{projectById.get(routine.projectId)?.name ?? "Unknown"}</span>
+                            <span className="truncate" title={projectById.get(routine.projectId)?.name ?? "Unknown"}>{projectById.get(routine.projectId)?.name ?? "Unknown"}</span>
                           </div>
                         ) : (
                           <span className="text-xs text-muted-foreground">—</span>
@@ -560,7 +560,7 @@ export function Routines() {
                           return agent ? (
                             <div className="flex items-center gap-2 text-sm text-muted-foreground">
                               <AgentIcon icon={agent.icon} className="h-4 w-4 shrink-0" />
-                              <span className="truncate">{agent.name}</span>
+                              <span className="truncate" title={agent.name}>{agent.name}</span>
                             </div>
                           ) : (
                             <span className="text-xs text-muted-foreground">Unknown</span>


### PR DESCRIPTION
## Problem

In many places across the UI we use CSS `truncate` class to clip long text with ellipsis, but the `title` attribute was not set. So when user hover over the clipped text, there is no tooltip showing the full content. This is specially annoying for long agent names, issue titles and project names where user need to see the full text.

Also found one icon-only delete button (in RoutineDetail trigger list) that was missing `aria-label`, so screen reader users have no way to know what this button does.

## Changes

**Tooltips on truncated text:**
- `IssueDetail.tsx` - current issue title in breadcrumb + child issue titles in sub-issues list
- `AgentDetail.tsx` - agent name heading + agent role/title subtitle
- `CompanySkills.tsx` - skill name in the detail header
- `RoutineDetail.tsx` - trigger label in run history table
- `Routines.tsx` - project name column + agent name column in routines list

**Accessibility:**
- `RoutineDetail.tsx` - added `aria-label="Delete trigger"` to the trash icon button

## How to test

1. Go to any agent with a long name - hover over the name in detail page header, should see tooltip
2. Go to issue list, open issue with long title - hover over title in breadcrumb, should see tooltip
3. Go to Routines page with long project or agent names - hover over truncated names in the table
4. Use screen reader on RoutineDetail page, focus on delete button - should announce "Delete trigger"

Very small change, just adding `title` and `aria-label` attributes. 5 files touched, net +1 line.