### PR TITLE
feat: add run history and stats endpoints to dashboard

### DIFF
--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -14,5 +14,19 @@ export function dashboardRoutes(db: Db) {
     res.json(summary);
   });
 
+  router.get("/companies/:companyId/dashboard/runs", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const runs = await svc.runs(companyId);
+    res.json(runs);
+  });
+
+  router.get("/companies/:companyId/dashboard/run-stats", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const stats = await svc.runStats(companyId);
+    res.json(stats);
+  });
+
   return router;
 }

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,6 +1,6 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, companies, costEvents, issues } from "@paperclipai/db";
+import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
 import { budgetService } from "./budgets.js";
 
@@ -32,6 +32,19 @@ export function dashboardService(db: Db) {
         .select({ count: sql<number>`count(*)` })
         .from(approvals)
         .where(and(eq(approvals.companyId, companyId), eq(approvals.status, "pending")))
+        .then((rows) => Number(rows[0]?.count ?? 0));
+
+      const staleCutoff = new Date(Date.now() - 60 * 60 * 1000);
+      const staleTasks = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.status, "in_progress"),
+            sql`${issues.startedAt} < ${staleCutoff.toISOString()}`,
+          ),
+        )
         .then((rows) => Number(rows[0]?.count ?? 0));
 
       const agentCounts: Record<string, number> = {
@@ -97,12 +110,112 @@ export function dashboardService(db: Db) {
           monthUtilizationPercent: Number(utilization.toFixed(2)),
         },
         pendingApprovals,
+        staleTasks,
         budgets: {
           activeIncidents: budgetOverview.activeIncidents.length,
           pendingApprovals: budgetOverview.pendingApprovalCount,
           pausedAgents: budgetOverview.pausedAgentCount,
           pausedProjects: budgetOverview.pausedProjectCount,
         },
+      };
+    },
+
+    runs: async (companyId: string) => {
+      const rows = await db
+        .select({
+          id: heartbeatRuns.id,
+          agentId: heartbeatRuns.agentId,
+          agentName: agents.name,
+          issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
+          status: heartbeatRuns.status,
+          invocationSource: heartbeatRuns.invocationSource,
+          startedAt: heartbeatRuns.startedAt,
+          finishedAt: heartbeatRuns.finishedAt,
+          errorCode: heartbeatRuns.errorCode,
+          usageJson: heartbeatRuns.usageJson,
+          createdAt: heartbeatRuns.createdAt,
+        })
+        .from(heartbeatRuns)
+        .leftJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+        .where(and(
+          eq(heartbeatRuns.companyId, companyId),
+          ne(heartbeatRuns.invocationSource, "checkout_upsert"),
+        ))
+        .orderBy(desc(heartbeatRuns.startedAt))
+        .limit(50);
+
+      const issueIds = [...new Set(rows.map((r) => r.issueId).filter(Boolean))] as string[];
+      const issueMap = new Map<string, { title: string; identifier: string | null }>();
+      if (issueIds.length > 0) {
+        const issueRows = await db
+          .select({ id: issues.id, title: issues.title, identifier: issues.identifier })
+          .from(issues)
+          .where(inArray(issues.id, issueIds));
+        for (const row of issueRows) {
+          issueMap.set(row.id, { title: row.title, identifier: row.identifier });
+        }
+      }
+
+      return rows.map((r) => {
+        const usage = r.usageJson as Record<string, unknown> | null;
+        const inputTokens = Number(usage?.inputTokens ?? usage?.input_tokens ?? 0) || null;
+        const outputTokens = Number(usage?.outputTokens ?? usage?.output_tokens ?? 0) || null;
+        const durationMs =
+          r.startedAt && r.finishedAt
+            ? new Date(r.finishedAt).getTime() - new Date(r.startedAt).getTime()
+            : null;
+        const issue = r.issueId ? issueMap.get(r.issueId) : null;
+
+        return {
+          id: r.id,
+          agentId: r.agentId,
+          agentName: r.agentName ?? "Unknown",
+          issueId: r.issueId,
+          issueTitle: issue?.title ?? null,
+          issueIdentifier: issue?.identifier ?? null,
+          status: r.status,
+          invocationSource: r.invocationSource,
+          startedAt: r.startedAt,
+          finishedAt: r.finishedAt,
+          durationMs,
+          inputTokens,
+          outputTokens,
+          errorCode: r.errorCode,
+          createdAt: r.createdAt,
+        };
+      });
+    },
+
+    runStats: async (companyId: string) => {
+      const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+
+      const [stats] = await db
+        .select({
+          totalRuns: sql<number>`count(*)::int`,
+          succeededRuns: sql<number>`count(*) filter (where ${heartbeatRuns.status} = 'succeeded')::int`,
+          failedRuns: sql<number>`count(*) filter (where ${heartbeatRuns.status} = 'failed')::int`,
+          avgDurationMs: sql<number | null>`avg(extract(epoch from (${heartbeatRuns.finishedAt} - ${heartbeatRuns.startedAt})) * 1000)::int`,
+          avgInputTokens: sql<number | null>`avg(coalesce((${heartbeatRuns.usageJson} ->> 'inputTokens')::int, (${heartbeatRuns.usageJson} ->> 'input_tokens')::int))::int`,
+          avgOutputTokens: sql<number | null>`avg(coalesce((${heartbeatRuns.usageJson} ->> 'outputTokens')::int, (${heartbeatRuns.usageJson} ->> 'output_tokens')::int))::int`,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            ne(heartbeatRuns.invocationSource, "checkout_upsert"),
+            gte(heartbeatRuns.startedAt, fourteenDaysAgo),
+          ),
+        );
+
+      const totalRuns = Number(stats.totalRuns);
+      return {
+        totalRuns,
+        succeededRuns: Number(stats.succeededRuns),
+        failedRuns: Number(stats.failedRuns),
+        successRate: totalRuns > 0 ? Number(((Number(stats.succeededRuns) / totalRuns) * 100).toFixed(1)) : 0,
+        avgDurationMs: stats.avgDurationMs ? Number(stats.avgDurationMs) : null,
+        avgInputTokens: stats.avgInputTokens ? Number(stats.avgInputTokens) : null,
+        avgOutputTokens: stats.avgOutputTokens ? Number(stats.avgOutputTokens) : null,
       };
     },
   };

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -42,7 +42,8 @@ export function dashboardService(db: Db) {
           and(
             eq(issues.companyId, companyId),
             eq(issues.status, "in_progress"),
-            sql`${issues.startedAt} < ${staleCutoff.toISOString()}`,
+            // Include issues with NULL startedAt — those are stuck with no start time.
+            sql`(${issues.startedAt} is null or ${issues.startedAt} < ${staleCutoff.toISOString()})`,
           ),
         )
         .then((rows) => Number(rows[0]?.count ?? 0));
@@ -158,8 +159,10 @@ export function dashboardService(db: Db) {
 
       return rows.map((r) => {
         const usage = r.usageJson as Record<string, unknown> | null;
-        const inputTokens = Number(usage?.inputTokens ?? usage?.input_tokens ?? 0) || null;
-        const outputTokens = Number(usage?.outputTokens ?? usage?.output_tokens ?? 0) || null;
+        const rawInput = usage?.inputTokens ?? usage?.input_tokens;
+        const rawOutput = usage?.outputTokens ?? usage?.output_tokens;
+        const inputTokens = rawInput != null ? Number(rawInput) : null;
+        const outputTokens = rawOutput != null ? Number(rawOutput) : null;
         const durationMs =
           r.startedAt && r.finishedAt
             ? new Date(r.finishedAt).getTime() - new Date(r.startedAt).getTime()


### PR DESCRIPTION
## Summary

- **`GET /dashboard/runs`**: last 50 runs with agent name, issue title/identifier, duration, token counts, and error codes — gives operators a live feed of what agents are doing
- **`GET /dashboard/run-stats`**: 14-day aggregates (total, succeeded, failed, success rate, avg duration, avg token usage) — enables trend dashboards
- **`staleTasks`** added to dashboard summary: counts `in_progress` issues older than 1 hour to surface stuck agents

## Motivation

Without run history, debugging agent failures requires inspecting raw DB tables or logs. These endpoints expose the data needed for an operational dashboard showing agent activity, failure rates, and cost trends.

## Test plan

- [ ] `GET /api/companies/:id/dashboard/runs` returns last 50 runs with correct fields
- [ ] `GET /api/companies/:id/dashboard/run-stats` returns correct success rate and averages
- [ ] `staleTasks` in summary reflects issues in_progress > 1 hour
- [ ] `checkout_upsert` invocation source filtered from both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)