### PR TITLE
fix: Docker hostname resolution and session resume behavior

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -550,7 +550,11 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
-  const apiUrl = process.env.PAPERCLIP_API_URL ?? `http://${runtimeHost}:${runtimePort}`;
+  let apiUrl = process.env.PAPERCLIP_API_URL ?? `http://${runtimeHost}:${runtimePort}`;
+  // Child processes (e.g. Claude CLI) run inside the same container as the server.
+  // Docker service hostnames like "server" only resolve via Docker DNS for
+  // inter-container traffic — replace with localhost for child processes.
+  apiUrl = apiUrl.replace(/^(https?:\/\/)server(:\d+)/, "$1localhost$2");
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
 }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -554,7 +554,7 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   // Child processes (e.g. Claude CLI) run inside the same container as the server.
   // Docker service hostnames like "server" only resolve via Docker DNS for
   // inter-container traffic — replace with localhost for child processes.
-  apiUrl = apiUrl.replace(/^(https?:\/\/)server(:\d+)/, "$1localhost$2");
+  apiUrl = apiUrl.replace(/^(https?:\/\/)server(:\d+)?(?=\/|$)/, "$1localhost$2");
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
 }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -375,8 +375,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   // Don't resume sessions on manual invocations (user wants a fresh start) or
   // event-triggered wakes (comment mentions open a new task context).
   const isManualInvoke = asString(context.wakeTriggerDetail, "") === "manual";
+  // Match the wakeCommentId resolution at lines 155-158: check both fields
   const isEventTriggered =
-    typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0;
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0);
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     hasMatchingPromptBundle &&
@@ -394,7 +396,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           : `cwd mismatch ("${runtimeSessionCwd}" vs "${cwd}")`;
     await onLog(
       "stdout",
-      `[paperclip] Skipping saved session resume because this is a ${reason}.\n`,
+      `[paperclip] Skipping saved session resume (session "${runtimeSessionId}"): ${reason}.\n`,
     );
   }
   if (runtimeSessionId && runtimePromptBundleKey.length > 0 && runtimePromptBundleKey !== promptBundle.bundleKey) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -372,19 +372,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const runtimePromptBundleKey = asString(runtimeSessionParams.promptBundleKey, "");
   const hasMatchingPromptBundle =
     runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
+  // Don't resume sessions on manual invocations (user wants a fresh start) or
+  // event-triggered wakes (comment mentions open a new task context).
+  const isManualInvoke = asString(context.wakeTriggerDetail, "") === "manual";
+  const isEventTriggered =
+    typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0;
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     hasMatchingPromptBundle &&
+    !isManualInvoke &&
+    !isEventTriggered &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
   const sessionId = canResumeSession ? runtimeSessionId : null;
-  if (
-    runtimeSessionId &&
-    runtimeSessionCwd.length > 0 &&
-    path.resolve(runtimeSessionCwd) !== path.resolve(cwd)
-  ) {
+  if (runtimeSessionId && !canResumeSession) {
+    const reason = isManualInvoke
+      ? "manual invoke"
+      : isEventTriggered
+        ? "new event trigger (comment mention)"
+        : !hasMatchingPromptBundle
+          ? "prompt bundle changed"
+          : `cwd mismatch ("${runtimeSessionCwd}" vs "${cwd}")`;
     await onLog(
       "stdout",
-      `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+      `[paperclip] Skipping saved session resume because this is a ${reason}.\n`,
     );
   }
   if (runtimeSessionId && runtimePromptBundleKey.length > 0 && runtimePromptBundleKey !== promptBundle.bundleKey) {


### PR DESCRIPTION
## Summary

**Fix 1: Docker hostname in `buildPaperclipEnv()`**

When Paperclip runs inside Docker, `PAPERCLIP_API_URL` may use the container service name (`http://server:3100`). This hostname only resolves via Docker's internal DNS for container-to-container traffic. Child processes like the Claude CLI run inside the same container and need `localhost` instead.

**Fix 2: Claude local adapter — skip session resume on manual invokes and comment events**

Previously, any wakeup would attempt to resume the last Claude session if CWD matched. This caused two bugs:
- Manual invocations should always start fresh — the user explicitly triggered a new run
- Comment-mention wakeups open a new task context; inheriting a previous session's conversation history causes confusion

Both now skip resume with an explanatory log message.

## Test plan

- [ ] Docker: child process `PAPERCLIP_API_URL` is `localhost:3100`, not `server:3100`
- [ ] Manual invoke: Claude starts a fresh session (no resume)
- [ ] Comment mention: Claude starts fresh session (no resume)
- [ ] Timer/automation wake with matching CWD: still resumes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)