### PR TITLE
fix(ui): better image alt text and copy-to-clipboard user feedback

### DIFF
--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -132,7 +132,8 @@ export function MarkdownBody({ children, className, resolveImageSrc }: MarkdownB
   if (resolveImageSrc) {
     components.img = ({ node: _node, src, alt, ...imgProps }) => {
       const resolved = src ? resolveImageSrc(src) : null;
-      return <img {...imgProps} src={resolved ?? src} alt={alt ?? ""} />;
+      const fallbackAlt = src ? decodeURIComponent(src.split("/").pop()?.replace(/\.[^.]+$/, "") ?? "Image") : "Image";
+      return <img {...imgProps} src={resolved ?? src} alt={alt || fallbackAlt} />;
     };
   }
 

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -526,6 +526,7 @@ export function AgentDetail() {
   const { closePanel } = usePanel();
   const { openNewIssue } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { pushToast } = useToast();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [actionError, setActionError] = useState<string | null>(null);
@@ -870,6 +871,7 @@ export function AgentDetail() {
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
                 onClick={() => {
                   navigator.clipboard.writeText(agent.id);
+                  pushToast({ title: "Agent ID copied", tone: "success" });
                   setMoreOpen(false);
                 }}
               >

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -450,7 +450,7 @@ export function CompanySettings() {
                         setSnippetCopyDelightId((prev) => prev + 1);
                         setTimeout(() => setSnippetCopied(false), 2000);
                       } catch {
-                        /* clipboard may not be available */
+                        pushToast({ title: "Could not copy to clipboard", tone: "error" });
                       }
                     }}
                   >


### PR DESCRIPTION
## What was wrong

Three small things that was bothering me:

### 1. Markdown images with empty alt text
In `MarkdownBody.tsx`, when image has no alt text in markdown syntax, we was using `alt=""` which is bad for accessibility. Screen readers just skip the image completely. Now we extract the filename from the image URL and use it as fallback alt text. For example image at `/uploads/dashboard-screenshot.png` will get alt text "dashboard-screenshot" instead of nothing.

### 2. No feedback when copying Agent ID
In agent detail page, there is a "Copy Agent ID" menu item. When you click it, the ID get copied to clipboard but there is no visual confirmation. You just have to trust that it worked. Now it show a small toast saying "Agent ID copied" - same pattern like other copy buttons in the app (IssueDetail, RoutineDetail, CompanySkills all do this already).

### 3. Silent failure when clipboard not available
In CompanySettings, the "Copy snippet" button for invite code was catching clipboard errors and doing nothing (`catch { /* clipboard may not be available */ }`). If clipboard access is blocked (some browsers do this), user think the copy worked but it didn't. Now it show error toast so user know they need to copy manually.

## How to test

1. Create markdown content with image that has no alt text like `![](image.png)` - inspect the rendered img element, should have alt="image"
2. Go to agent detail > click more menu > "Copy Agent ID" - should see success toast
3. For clipboard error case, you can test by revoking clipboard permission in browser settings

3 files changed, net +3 lines.