### PR TITLE
fix(ui): show full date on hover for relative time labels

### DIFF
--- a/ui/src/components/ActivityRow.tsx
+++ b/ui/src/components/ActivityRow.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@/lib/router";
 import { Identity } from "./Identity";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, absoluteDate } from "../lib/timeAgo";
 import { cn } from "../lib/utils";
 import { deriveProjectUrlKey, type ActivityEvent, type Agent } from "@paperclipai/shared";
 
@@ -120,7 +120,7 @@ export function ActivityRow({ event, agentMap, entityNameMap, entityTitleMap, cl
         {name && <span className="font-medium">{name}</span>}
         {entityTitle && <span className="text-muted-foreground ml-1">— {entityTitle}</span>}
       </p>
-      <span className="text-xs text-muted-foreground shrink-0 pt-0.5">{timeAgo(event.createdAt)}</span>
+      <span className="text-xs text-muted-foreground shrink-0 pt-0.5" title={absoluteDate(event.createdAt)}>{timeAgo(event.createdAt)}</span>
     </div>
   );
 

--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { Identity } from "./Identity";
 import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer } from "./ApprovalPayload";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, absoluteDate } from "../lib/timeAgo";
 import type { Approval, Agent } from "@paperclipai/shared";
 
 function statusIcon(status: string) {
@@ -55,7 +55,7 @@ export function ApprovalCard({
         <div className="flex items-center gap-1.5 shrink-0">
           {statusIcon(approval.status)}
           <span className="text-xs text-muted-foreground capitalize">{approval.status}</span>
-          <span className="text-xs text-muted-foreground">· {timeAgo(approval.createdAt)}</span>
+          <span className="text-xs text-muted-foreground" title={absoluteDate(approval.createdAt)}>· {timeAgo(approval.createdAt)}</span>
         </div>
       </div>
 

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -18,7 +18,7 @@ import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
 import { formatDate, cn, projectUrl } from "../lib/utils";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, absoluteDate } from "../lib/timeAgo";
 import { Separator } from "@/components/ui/separator";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { User, Hexagon, ArrowUpRight, Tag, Plus, Trash2, Copy, Check } from "lucide-react";
@@ -813,7 +813,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
           <span className="text-sm">{formatDate(issue.createdAt)}</span>
         </PropertyRow>
         <PropertyRow label="Updated">
-          <span className="text-sm">{timeAgo(issue.updatedAt)}</span>
+          <span className="text-sm" title={absoluteDate(issue.updatedAt)}>{timeAgo(issue.updatedAt)}</span>
         </PropertyRow>
       </div>
     </div>

--- a/ui/src/lib/timeAgo.ts
+++ b/ui/src/lib/timeAgo.ts
@@ -4,6 +4,11 @@ const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const MONTH = 30 * DAY;
 
+/** Return a locale-formatted absolute date string, useful as a title/tooltip. */
+export function absoluteDate(date: Date | string): string {
+  return new Date(date).toLocaleString();
+}
+
 export function timeAgo(date: Date | string): string {
   const now = Date.now();
   const then = new Date(date).getTime();

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -17,7 +17,7 @@ import { StatusIcon } from "../components/StatusIcon";
 
 import { ActivityRow } from "../components/ActivityRow";
 import { Identity } from "../components/Identity";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, absoluteDate } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
 import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
@@ -367,7 +367,7 @@ export function Dashboard() {
                                 : null;
                             })()}
                             <span className="text-xs text-muted-foreground sm:hidden">&middot;</span>
-                            <span className="text-xs text-muted-foreground shrink-0 sm:order-last">
+                            <span className="text-xs text-muted-foreground shrink-0 sm:order-last" title={absoluteDate(issue.updatedAt)}>
                               {timeAgo(issue.updatedAt)}
                             </span>
                           </span>

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -19,7 +19,7 @@ import { IssueRow } from "../components/IssueRow";
 import { StatusIcon } from "../components/StatusIcon";
 import { StatusBadge } from "../components/StatusBadge";
 import { approvalLabel, defaultTypeIcon, typeIcon } from "../components/ApprovalPayload";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, absoluteDate } from "../lib/timeAgo";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Tabs } from "@/components/ui/tabs";
@@ -141,7 +141,7 @@ function FailedRunInboxRow({
               <StatusBadge status={run.status} />
               {linkedAgentName && issue ? <span>{linkedAgentName}</span> : null}
               <span className="truncate max-w-[300px]">{displayError}</span>
-              <span>{timeAgo(run.createdAt)}</span>
+              <span title={absoluteDate(run.createdAt)}>{timeAgo(run.createdAt)}</span>
             </span>
           </span>
         </Link>
@@ -230,7 +230,7 @@ function ApprovalInboxRow({
             <span className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
               <span className="capitalize">{approvalStatusLabel(approval.status)}</span>
               {requesterName ? <span>requested by {requesterName}</span> : null}
-              <span>updated {timeAgo(approval.updatedAt)}</span>
+              <span title={absoluteDate(approval.updatedAt)}>updated {timeAgo(approval.updatedAt)}</span>
             </span>
           </span>
         </Link>
@@ -311,7 +311,7 @@ function JoinRequestInboxRow({
               {label}
             </span>
             <span className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-              <span>requested {timeAgo(joinRequest.createdAt)} from IP {joinRequest.requestIp}</span>
+              <span title={absoluteDate(joinRequest.createdAt)}>requested {timeAgo(joinRequest.createdAt)} from IP {joinRequest.requestIp}</span>
               {joinRequest.adapterType && <span>adapter: {joinRequest.adapterType}</span>}
             </span>
           </span>

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -25,7 +25,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { buildRoutineTriggerPatch } from "../lib/routine-trigger-patch";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, absoluteDate } from "../lib/timeAgo";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
@@ -981,7 +981,7 @@ export function RoutineDetail() {
                       </Link>
                     )}
                   </div>
-                  <span className="text-xs text-muted-foreground shrink-0 ml-2">{timeAgo(run.triggeredAt)}</span>
+                  <span className="text-xs text-muted-foreground shrink-0 ml-2" title={absoluteDate(run.triggeredAt)}>{timeAgo(run.triggeredAt)}</span>
                 </div>
               ))}
             </div>
@@ -1009,7 +1009,7 @@ export function RoutineDetail() {
                       </span>
                     )}
                   </div>
-                  <span className="text-muted-foreground/60 shrink-0">{timeAgo(event.createdAt)}</span>
+                  <span className="text-muted-foreground/60 shrink-0" title={absoluteDate(event.createdAt)}>{timeAgo(event.createdAt)}</span>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Problem

Everywhere in the UI we show relative time like "2h ago" or "5d ago" but there was no way to see the actual date and time. If I want to know exactly when something happened, I have to go dig in the database or look at API response. This is very annoying specially when you need to correlate events across different pages or compare timestamps.

## What I did

Added small helper function `absoluteDate()` in `timeAgo.ts` that format a date using `toLocaleString()` (so it respect user's locale and timezone settings). Then added `title` attribute to all the `<span>` elements that render `timeAgo()` output.

Now when you hover over any relative time label, browser show a tooltip with full date like "3/26/2026, 2:45:30 PM" (or whatever format your locale use).

## Where it applied

- **ActivityRow** - event timestamps in activity feed
- **ApprovalCard** - approval creation time
- **IssueProperties** - "Updated" field in issue sidebar
- **Dashboard** - issue update times in dashboard list
- **Inbox** - run times, approval update times, join request times
- **RoutineDetail** - run triggered times and event log times

Note: some places use `timeAgo()` as a string prop (like `mobileMeta`) where we cannot add HTML attributes. Those stay as before - only the JSX rendered timestamps got the tooltip.

## How to test

1. Go to any page that show relative times (Dashboard, Inbox, Activity, etc.)
2. Hover mouse over any "2h ago" or "3d ago" label
3. Should see browser tooltip with full date and time

7 files, net +5 lines.