### PR TITLE
fix(ui): enforce min/max on number inputs in JsonSchemaForm

### DIFF
--- a/ui/src/components/JsonSchemaForm.tsx
+++ b/ui/src/components/JsonSchemaForm.tsx
@@ -547,6 +547,8 @@ const NumberField = React.memo(({
   error,
   defaultValue,
   type,
+  minimum,
+  maximum,
 }: {
   value: unknown;
   onChange: (val: unknown) => void;
@@ -557,6 +559,8 @@ const NumberField = React.memo(({
   error?: string;
   defaultValue?: unknown;
   type: "number" | "integer";
+  minimum?: number;
+  maximum?: number;
 }) => (
   <FieldWrapper
     label={label}
@@ -568,6 +572,8 @@ const NumberField = React.memo(({
     <Input
       type="number"
       step={type === "integer" ? "1" : "any"}
+      min={minimum}
+      max={maximum}
       value={value !== undefined ? String(value) : ""}
       onChange={(e) => {
         const val = e.target.value;
@@ -901,6 +907,8 @@ const FormField = React.memo(({
           error={error}
           defaultValue={propSchema.default}
           type={type as "number" | "integer"}
+          minimum={propSchema.minimum ?? propSchema.exclusiveMinimum}
+          maximum={propSchema.maximum ?? propSchema.exclusiveMaximum}
         />
       );
 


### PR DESCRIPTION
## Problem

In `JsonSchemaForm`, the `NumberField` component render `<input type="number">` but was not passing `min` and `max` HTML attributes even though the JSON schema can specify `minimum`, `maximum`, `exclusiveMinimum` and `exclusiveMaximum` constraints.

What happen is user can type any number they want (including negative or very big numbers) and only see validation error after the form try to validate. The browser native number input spinner also has no bounds - you can click the up/down arrows forever.

## What I changed

- Added `minimum` and `maximum` optional props to `NumberField` component
- Pass them as `min` and `max` attributes on the `<Input>` element
- At the call site in `FormField`, forward `propSchema.minimum` (falling back to `propSchema.exclusiveMinimum`) and same for maximum

## How it works now

If JSON schema say `"minimum": 0, "maximum": 100`:
- Browser native spinner stop at 0 and 100
- If user type -5 manually, browser show validation tooltip
- The existing JS validation (lines 197-207) still work as before as second layer

## How to test

1. Go to any agent config form that use JsonSchemaForm with number fields
2. Check if the field has min/max in schema definition
3. Try to use spinner arrows - should stop at the limits
4. Try to type value outside range - browser should show validation message

1 file changed, 8 lines added.