### PR TITLE
fix(ui): show Clear Filters action in issues empty state

### DIFF
--- a/ui/src/components/EmptyState.tsx
+++ b/ui/src/components/EmptyState.tsx
@@ -7,21 +7,30 @@ interface EmptyStateProps {
   message: string;
   action?: string;
   onAction?: () => void;
+  secondaryAction?: string;
+  onSecondaryAction?: () => void;
 }
 
-export function EmptyState({ icon: Icon, message, action, onAction }: EmptyStateProps) {
+export function EmptyState({ icon: Icon, message, action, onAction, secondaryAction, onSecondaryAction }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
       <div className="bg-muted/50 p-4 mb-4">
         <Icon className="h-10 w-10 text-muted-foreground/50" />
       </div>
       <p className="text-sm text-muted-foreground mb-4">{message}</p>
-      {action && onAction && (
-        <Button onClick={onAction}>
-          <Plus className="h-4 w-4 mr-1.5" />
-          {action}
-        </Button>
-      )}
+      <div className="flex items-center gap-2">
+        {action && onAction && (
+          <Button onClick={onAction}>
+            <Plus className="h-4 w-4 mr-1.5" />
+            {action}
+          </Button>
+        )}
+        {secondaryAction && onSecondaryAction && (
+          <Button variant="outline" onClick={onSecondaryAction}>
+            {secondaryAction}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -622,9 +622,15 @@ export function IssuesList({
       {!isLoading && filtered.length === 0 && viewState.viewMode === "list" && (
         <EmptyState
           icon={CircleDot}
-          message="No issues match the current filters or search."
+          message={
+            activeFilterCount > 0 || normalizedIssueSearch.length > 0
+              ? "No issues match the current filters or search."
+              : "No issues yet."
+          }
           action="Create Issue"
           onAction={() => openNewIssue(newIssueDefaults())}
+          secondaryAction={activeFilterCount > 0 ? "Clear Filters" : undefined}
+          onSecondaryAction={activeFilterCount > 0 ? () => updateView({ statuses: [], priorities: [], assignees: [], labels: [] }) : undefined}
         />
       )}
 


### PR DESCRIPTION
## Problem

When you apply filters in the issues list and no issues match, the empty state only show "Create Issue" button. This is bad because maybe there ARE issues in the project, just the current filter combination is hiding all of them. User has to manually go back to filter panel and clear everything, which is annoying.

Also the message was always saying "No issues match the current filters or search." even when there are no filters active and simply no issues exist yet. This is confusing for new users.

## What I changed

**IssuesList.tsx:**
- When filters are active and result is empty, now show "Clear Filters" button next to "Create Issue"
- Clear Filters reset all filter fields (same logic as the "Clear" link in filter popover)
- Message is now contextual: "No issues match the current filters or search." when filters/search active, "No issues yet." when nothing is filtered

**EmptyState.tsx:**
- Added `secondaryAction` and `onSecondaryAction` optional props
- Renders outline-style button next to primary action
- Wrapped both buttons in flex container
- This is backward compatible, existing usage with just `action` still work the same

## How to test

1. Go to issues list in any project that has issues
2. Apply filter that match nothing (e.g. filter by status "done" when no issues are done)
3. Should see empty state with two buttons: "Create Issue" and "Clear Filters"
4. Click "Clear Filters" - filters should reset and issues should appear again
5. Go to project with zero issues and no filters - should just say "No issues yet." with only "Create Issue" button

2 files changed. EmptyState component is now more reusable for other list pages too.