### PR TITLE
fix(ui): format dollar amounts with commas and add search clear button

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -342,9 +342,19 @@ export function IssuesList({
                 onSearchChange?.(e.target.value);
               }}
               placeholder="Search issues..."
-              className="pl-7 text-xs sm:text-sm"
+              className="pl-7 pr-7 text-xs sm:text-sm"
               aria-label="Search issues"
             />
+            {issueSearch.length > 0 && (
+              <button
+                type="button"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => { setIssueSearch(""); onSearchChange?.(""); }}
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
           </div>
         </div>
 

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -8,7 +8,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
+  return (cents / 100).toLocaleString("en-US", { style: "currency", currency: "USD" });
 }
 
 export function formatDate(date: Date | string): string {


### PR DESCRIPTION
## Problem 1: Dollar amounts hard to read

The `formatCents()` function was doing simple `(cents / 100).toFixed(2)` which give output like `$10000.00` for large numbers. On the Costs page, Dashboard budget cards, and BillerSpendCard where numbers can be in thousands or more, this is really hard to read without comma separator.

**Before:** `$10000.00`
**After:** `$10,000.00`

Changed to use `toLocaleString("en-US", { style: "currency", currency: "USD" })` which handle comma separator, dollar sign, and two decimal place all in one call. This affect 50+ places across the app because they all use the same formatCents function, so one line change fix everything.

## Problem 2: No way to clear search quickly

In the issues list, search input had no clear button. When you type something and want to clear it, you have to select all text and delete manually, or press backspace many times. Every modern search input have a X button for this.

Added small X icon button that appear on right side of search input only when there is text. Click it and search clear immediately. Also added `pr-7` padding to input so text don't go under the X button.

## How to test

1. **Dollar formatting:** Go to Costs page or Dashboard - all dollar amounts should now have comma separators for thousands
2. **Search clear:** Go to Issues list, type in search box, should see X button appear on right side. Click it to clear.

2 files changed, net +10 lines.