### PR TITLE
feat(ui): add copy button for stdout output in run transcript

### DIFF
--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { TranscriptEntry } from "../../adapters";
 import { MarkdownBody } from "../MarkdownBody";
 import { cn, formatTokens } from "../../lib/utils";
@@ -895,6 +895,11 @@ function TranscriptStdoutRow({
 }) {
   const [open, setOpen] = useState(!collapseByDefault);
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
 
   return (
     <div>
@@ -914,10 +919,15 @@ function TranscriptStdoutRow({
           <button
             type="button"
             className="inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
-            onClick={() => {
-              navigator.clipboard.writeText(block.text);
-              setCopied(true);
-              setTimeout(() => setCopied(false), 2000);
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(block.text);
+                clearTimeout(timerRef.current);
+                setCopied(true);
+                timerRef.current = setTimeout(() => setCopied(false), 2000);
+              } catch {
+                /* clipboard not available or permission denied */
+              }
             }}
             aria-label="Copy stdout"
           >

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   CircleAlert,
+  Copy,
   TerminalSquare,
   User,
   Wrench,
@@ -893,6 +894,7 @@ function TranscriptStdoutRow({
   collapseByDefault: boolean;
 }) {
   const [open, setOpen] = useState(!collapseByDefault);
+  const [copied, setCopied] = useState(false);
 
   return (
     <div>
@@ -908,6 +910,20 @@ function TranscriptStdoutRow({
         >
           {open ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
         </button>
+        {open && (
+          <button
+            type="button"
+            className="inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => {
+              navigator.clipboard.writeText(block.text);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
+            }}
+            aria-label="Copy stdout"
+          >
+            {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+          </button>
+        )}
       </div>
       {open && (
         <pre className={cn(


### PR DESCRIPTION
## Problem

When reviewing agent run transcripts, the stdout output blocks can be very long and contain important information (error messages, build output, test results, etc). But there was no way to copy this text with one click. You had to manually select all the text in the pre block, which is very tedious specially when the output is hundreds of lines.

## What I did

Added a small copy icon button (from lucide-react) in the stdout block header, next to the existing collapse/expand chevron button. The button:
- Only appear when the stdout block is expanded (no point showing copy when content is hidden)
- Copy the full `block.text` to clipboard using `navigator.clipboard.writeText()`
- Show green checkmark icon for 2 seconds after successful copy, then go back to copy icon
- Match the same visual style as the collapse button (same size, same hover transition)

## How to test

1. Go to any agent detail page > Runs tab
2. Click on a run that has stdout output
3. Expand the stdout block if it's collapsed
4. Should see copy icon button next to the chevron
5. Click it - text get copied and icon change to green checkmark for 2 seconds
6. Paste somewhere to verify the full text was copied

1 file, 16 lines added. No dependency change.