### PR TITLE
feat(ui): click to copy issue identifier in detail page

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -725,11 +725,15 @@ export function IssueDetail() {
           />
           <button
             type="button"
-            className="text-sm font-mono text-muted-foreground shrink-0 hover:text-foreground transition-colors cursor-pointer"
+            className="bg-transparent border-0 p-0 text-sm font-mono text-muted-foreground shrink-0 hover:text-foreground transition-colors cursor-pointer"
             title="Click to copy identifier"
-            onClick={() => {
-              navigator.clipboard.writeText(issue.identifier ?? issue.id.slice(0, 8));
-              pushToast({ title: "Identifier copied", tone: "success" });
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(issue.identifier ?? issue.id.slice(0, 8));
+                pushToast({ title: "Identifier copied", tone: "success" });
+              } catch {
+                pushToast({ title: "Failed to copy", tone: "error" });
+              }
             }}
           >
             {issue.identifier ?? issue.id.slice(0, 8)}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -723,7 +723,17 @@ export function IssueDetail() {
             priority={issue.priority}
             onChange={(priority) => updateIssue.mutate({ priority })}
           />
-          <span className="text-sm font-mono text-muted-foreground shrink-0">{issue.identifier ?? issue.id.slice(0, 8)}</span>
+          <button
+            type="button"
+            className="text-sm font-mono text-muted-foreground shrink-0 hover:text-foreground transition-colors cursor-pointer"
+            title="Click to copy identifier"
+            onClick={() => {
+              navigator.clipboard.writeText(issue.identifier ?? issue.id.slice(0, 8));
+              pushToast({ title: "Identifier copied", tone: "success" });
+            }}
+          >
+            {issue.identifier ?? issue.id.slice(0, 8)}
+          </button>
 
           {hasLiveRuns && (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400 shrink-0">


### PR DESCRIPTION
## Problem

When you open an issue detail page, the identifier like "PAP-123" is showing in the header but it's just a plain text span. If you want to share this identifier with someone in Slack or email, you have to manually select the text with mouse and copy it. This is specially annoying because the identifier is small text between other interactive elements (status icon, priority icon) and it's easy to accidentally click something else while trying to select.

## What I changed

Changed the identifier from `<span>` to `<button>` element that copy the identifier to clipboard when clicked. Added:
- `hover:text-foreground` so user can see it's clickable when they hover
- `cursor-pointer` for visual hint
- `title="Click to copy identifier"` tooltip for discoverability
- Toast notification "Identifier copied" on click using the existing `pushToast` already available in the component
- `bg-transparent border-0 p-0` reset classes so button does not inherit default browser styling
- `async/await` with `try/catch` around clipboard write so error is handled properly and toast only show on actual success

The button keep the same `font-mono text-muted-foreground` styling so it look the same as before until you hover.

## How to test

1. Go to any issue detail page
2. Hover over the identifier (e.g. PAP-123) next to the status/priority icons
3. Should see cursor change and text get slightly darker
4. Click it - should see "Identifier copied" toast
5. Paste somewhere to verify
6. (Optional) To test error handling: in browser devtools run `navigator.clipboard.writeText = () => Promise.reject()` and click again - should see "Failed to copy" toast

## Thinking path

I noticed while using the app that sharing issue identifiers is a very frequent action - paste in Slack, in commit message, in another tool. But the identifier was just static text and selecting small text between clickable icons was frustrating. The simplest improvement is to make it a button that copies on click.

I chose `<button>` instead of adding an `onClick` to `<span>` because:
- Buttons are keyboard accessible by default (Enter/Space to activate)
- Screen readers announce them as interactive
- No need for `role="button"` or `tabIndex` workarounds

For the clipboard API I followed the same pattern used in the existing `CopyText.tsx` component in this codebase - `async/await` with `try/catch` so the success toast only appears when copy actually succeeds.

1 file, ~15 lines changed. Uses existing pushToast and Copy icon infrastructure already in the file.