### PR TITLE
fix(ui): kanban empty column placeholder and replay window input validation

### DIFF
--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -84,6 +84,11 @@ function KanbanColumn({
           items={issues.map((i) => i.id)}
           strategy={verticalListSortingStrategy}
         >
+          {issues.length === 0 && (
+            <p className="text-xs text-muted-foreground/40 text-center py-8">
+              No issues
+            </p>
+          )}
           {issues.map((issue) => (
             <KanbanCard
               key={issue.id}

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -195,6 +195,7 @@ function TriggerEditor({
               <Input
                 type="number"
                 min={0}
+                step={1}
                 value={draft.replayWindowSec}
                 onChange={(event) => setDraft((current) => ({ ...current, replayWindowSec: event.target.value }))}
               />
@@ -929,7 +930,7 @@ export function RoutineDetail() {
                   </div>
                   <div className="space-y-1.5">
                     <Label className="text-xs">Replay window (seconds)</Label>
-                    <Input type="number" min={0} value={newTrigger.replayWindowSec} onChange={(event) => setNewTrigger((current) => ({ ...current, replayWindowSec: event.target.value }))} />
+                    <Input type="number" min={0} step={1} value={newTrigger.replayWindowSec} onChange={(event) => setNewTrigger((current) => ({ ...current, replayWindowSec: event.target.value }))} />
                   </div>
                 </>
               )}

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -193,6 +193,8 @@ function TriggerEditor({
             <div className="space-y-1.5">
               <Label className="text-xs">Replay window (seconds)</Label>
               <Input
+                type="number"
+                min={0}
                 value={draft.replayWindowSec}
                 onChange={(event) => setDraft((current) => ({ ...current, replayWindowSec: event.target.value }))}
               />
@@ -927,7 +929,7 @@ export function RoutineDetail() {
                   </div>
                   <div className="space-y-1.5">
                     <Label className="text-xs">Replay window (seconds)</Label>
-                    <Input value={newTrigger.replayWindowSec} onChange={(event) => setNewTrigger((current) => ({ ...current, replayWindowSec: event.target.value }))} />
+                    <Input type="number" min={0} value={newTrigger.replayWindowSec} onChange={(event) => setNewTrigger((current) => ({ ...current, replayWindowSec: event.target.value }))} />
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The platform has many features like issues tracking with kanban board view, and routines with configurable triggers
> - When user look at kanban board, empty columns show just blank gray area - user cannot tell if column is empty or if something broke
> - Also, the routine trigger editor let user type text like "abc" into replay window seconds field, which cause invalid data
> - So this PR fix two small UI problems: add "No issues" placeholder text in empty kanban columns, and change replay window input to number type with min=0 and step=1
> - The benefit is better user experience - empty columns clearly communicate they are empty on purpose, and number input prevent invalid values from being entered

## Problem 1: Empty kanban columns look broken

When using the board view in issues list, columns that have zero issues show just a blank gray rectangle (`bg-muted/20` with `min-h-[120px]`). User cannot tell if the column is empty on purpose or if something fail to load. It look the same as a loading state without skeleton.

Added a subtle "No issues" text centered in the empty drop zone. The text use very light color (`text-muted-foreground/40`) so it don't distract but still communicate that the column is working, just empty. The text disappear automatically when issues get dragged into the column because the `issues.length === 0` check will be false.

## Problem 2: Replay window accepts invalid input

In RoutineDetail page, the "Replay window (seconds)" input field was using default text input type. User could type "abc" or "-50" and try to save. The value would silently get converted to NaN or pass as invalid to the API.

Changed both replay window inputs (trigger editor form and new trigger creation form) to use `type="number"` with `min={0}` and `step={1}`. Now browser enforce that only non-negative whole numbers can be entered and the spinner arrows work properly.

## How to test

1. **Kanban:** Go to Issues > switch to Board view. If any status column has zero issues, should see "No issues" text in the column instead of blank space.
2. **Replay window:** Go to Routines > open any routine > edit a trigger with replay window. The input should now be a number input that reject negative values, fractional values, and text.

## Risks

- Very small change, low risk. The kanban placeholder is inside the SortableContext so drag-and-drop is not affected. The number input already has `Number()` conversion with fallback to "300" in the submit handler, so the existing safety net still works.