### PR TITLE
fix(ui): show error toast when creating issue/goal/project fails

### DIFF
--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { GOAL_STATUSES, GOAL_LEVELS } from "@paperclipai/shared";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { useToast } from "../context/ToastContext";
 import { goalsApi } from "../api/goals";
 import { assetsApi } from "../api/assets";
 import { queryKeys } from "../lib/queryKeys";
@@ -36,6 +37,7 @@ const levelLabels: Record<string, string> = {
 export function NewGoalDialog() {
   const { newGoalOpen, newGoalDefaults, closeNewGoal } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
+  const { pushToast } = useToast();
   const queryClient = useQueryClient();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -65,6 +67,9 @@ export function NewGoalDialog() {
       queryClient.invalidateQueries({ queryKey: queryKeys.goals.list(selectedCompanyId!) });
       reset();
       closeNewGoal();
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to create goal", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -444,6 +444,9 @@ export function NewIssueDialog() {
       reset();
       closeNewIssue();
     },
+    onError: (err) => {
+      pushToast({ title: "Failed to create issue", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+    },
   });
 
   const uploadDescriptionImage = useMutation({

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { useToast } from "../context/ToastContext";
 import { projectsApi } from "../api/projects";
 import { goalsApi } from "../api/goals";
 import { assetsApi } from "../api/assets";
@@ -47,6 +48,7 @@ const projectStatuses = [
 export function NewProjectDialog() {
   const { newProjectOpen, closeNewProject } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
+  const { pushToast } = useToast();
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -71,6 +73,9 @@ export function NewProjectDialog() {
   const createProject = useMutation({
     mutationFn: (data: Record<string, unknown>) =>
       projectsApi.create(selectedCompanyId!, data),
+    onError: (err) => {
+      pushToast({ title: "Failed to create project", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+    },
   });
 
   const uploadDescriptionImage = useMutation({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans still need to watch what the agents are doing and step in when something go wrong
> - The human UI has many creation dialogs - for issues, goals, projects - where the user set up new work items for agents
> - These dialogs call backend API to actually create the resource
> - But if the API call fail (server down, network problem, bad data), the user need to know about it
> - Three creation dialogs was missing proper error feedback - NewIssueDialog had small inline text only, NewProjectDialog same, NewGoalDialog had nothing at all
> - So user click "Create", spinner stop, and nothing happen. Very confusing, they don't know if it work or not
> - This PR add onError toast notification to all three mutation hooks so user always see a clear red error message when creation fail
> - The dialog stay open so user can fix the problem and try again instead of losing their input

## Problem

The three main creation dialogs (New Issue, New Goal, New Project) was not showing toast notification when the API call fail.

- **NewIssueDialog**: Had inline error text display but no toast. User might not notice the small red text specially if the dialog is scrolled.
- **NewProjectDialog**: Same - had inline error text but no toast notification.
- **NewGoalDialog**: Had nothing at all. Complete silence when creation fail. User click "Create" button, it stop spinning, and nothing happen. No message, no error, nothing.

This is related to the earlier PR that added onError to mutations in AgentDetail and Routines pages, but these three creation dialogs was missed because they are in separate component files.

## What I changed

- **NewIssueDialog.tsx**: Added `onError` handler that show error toast with the server error message
- **NewGoalDialog.tsx**: Added `useToast` import + `onError` handler with error toast
- **NewProjectDialog.tsx**: Added `useToast` import + `onError` handler with error toast

All three use same pattern: `pushToast({ title: "Failed to create X", body: err.message, tone: "error" })`

## How to test

1. Try to create an issue/goal/project when server is down or network disconnected
2. Should see red error toast with the error message
3. The dialog stay open so user can try again

3 files, 13 lines added. No logic change, just adding error notifications.