### PR TITLE
fix(ui): show hover arrow on clickable dashboard metric cards

### DIFF
--- a/ui/src/components/MetricCard.tsx
+++ b/ui/src/components/MetricCard.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "@/lib/router";
+import { ArrowUpRight } from "lucide-react";
 
 interface MetricCardProps {
   icon: LucideIcon;
@@ -15,7 +16,7 @@ export function MetricCard({ icon: Icon, value, label, description, to, onClick 
   const isClickable = !!(to || onClick);
 
   const inner = (
-    <div className={`h-full px-4 py-4 sm:px-5 sm:py-5 rounded-lg transition-colors${isClickable ? " hover:bg-accent/50 cursor-pointer" : ""}`}>
+    <div className={`h-full px-4 py-4 sm:px-5 sm:py-5 rounded-lg transition-colors${isClickable ? " group hover:bg-accent/50 cursor-pointer" : ""}`}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           <p className="text-2xl sm:text-3xl font-semibold tracking-tight tabular-nums">
@@ -28,7 +29,10 @@ export function MetricCard({ icon: Icon, value, label, description, to, onClick 
             <div className="text-xs text-muted-foreground/70 mt-1.5 hidden sm:block">{description}</div>
           )}
         </div>
-        <Icon className="h-4 w-4 text-muted-foreground/50 shrink-0 mt-1.5" />
+        <div className="shrink-0 mt-1.5 flex items-center gap-1">
+          <Icon className="h-4 w-4 text-muted-foreground/50" />
+          {isClickable && <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground/0 group-hover:text-muted-foreground/50 transition-colors" />}
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/MetricCard.tsx
+++ b/ui/src/components/MetricCard.tsx
@@ -1,7 +1,6 @@
-import type { LucideIcon } from "lucide-react";
+import { ArrowUpRight, type LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "@/lib/router";
-import { ArrowUpRight } from "lucide-react";
 
 interface MetricCardProps {
   icon: LucideIcon;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans still need to oversee and monitor agent activity through the Dashboard
> - The Dashboard show four MetricCards (Agents Enabled, Tasks In Progress, Month Spend, Pending Approvals) that link to detail pages
> - But there is no visual indication that these cards are clickable - user must hover by accident to notice the pointer cursor
> - So this PR adds a subtle ArrowUpRight icon that fade in on hover to give affordance that the card is clickable
> - The benefit is that user can now discover the navigation to detail pages more naturally without guessing

## Problem

The four MetricCards on Dashboard page (Agents Enabled, Tasks In Progress, Month Spend, Pending Approvals) all link to their respective detail pages but there was zero visual cue that they are clickable. The only hint was the cursor changing to pointer on hover, but user have to accidentally discover this.

I was using the app for a while before I realize I can click on these cards to go to the detail pages. This is not good because the cards have useful summary info and linking to the full page is very convenient.

## What I changed

Added a subtle `ArrowUpRight` icon from lucide-react that appear on hover. The icon is completely transparent at rest (`text-muted-foreground/0`) and fade in to visible (`group-hover:text-muted-foreground/50`) when user hover the card. This way:

- Cards look clean and unchanged in resting state
- On hover, user see the arrow hint and understand they can click
- The transition is smooth because of `transition-colors`

Used Tailwind's `group` / `group-hover` pattern - the card container div get `group` class and the arrow icon use `group-hover:` modifier.

## Why it matters

Clickable elements should always communicate that they are interactive. This is a basic UX principle. Without any affordance, user may never discover the shortcut navigation and keep using the sidebar or other way to reach the detail pages. A small arrow icon on hover is a standard pattern used across many web applications.

## How to test

1. Go to Dashboard page
2. Hover over any of the four top metric cards
3. Should see a small arrow icon fade in next to the category icon (top right area of card)
4. Click the card - should navigate to the detail page
5. Verify that non-clickable cards (if any) do not show the arrow

## Risks

- Very minimal. 1 file, 6 lines changed
- No visual change at rest, only on hover
- The `group` class is scoped only to clickable cards so non-clickable cards are not affected
- No new dependencies - `lucide-react` is already used in the project