### PR TITLE
ci: validate Dockerfile deps stage in PR policy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,14 +63,14 @@ jobs:
           # Check all workspace package.json files are copied in the deps stage
           for pkg in $(find $search_roots -maxdepth 2 -name package.json -not -path '*/examples/*' -not -path '*/create-paperclip-plugin/*' -not -path '*/node_modules/*' 2>/dev/null | sort -u); do
             dir="$(dirname "$pkg")"
-            if ! echo "$deps_stage" | grep -q "COPY ${dir}/package.json"; then
+            if ! echo "$deps_stage" | grep -q "^COPY ${dir}/package.json"; then
               echo "::error::Dockerfile deps stage missing: COPY ${pkg} ${dir}/"
               missing=1
             fi
           done
 
           # Check patches directory is copied if it exists
-          if [ -d patches ] && ! echo "$deps_stage" | grep -q 'COPY patches/'; then
+          if [ -d patches ] && ! echo "$deps_stage" | grep -q '^COPY patches/'; then
             echo "::error::Dockerfile deps stage missing: COPY patches/ patches/"
             missing=1
           fi


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The project publishes a Docker image via a GitHub Actions workflow
> - The Dockerfile has a deps stage that copies workspace package.json files and patches for pnpm install
> - Twice now, new packages or patches were added without updating the Dockerfile, breaking the Docker build
> - These breaks went unnoticed because the Docker workflow only runs on master pushes, not on PRs
> - This PR adds a validation step to the PR policy job that checks the Dockerfile deps stage is complete
> - The benefit is catching Dockerfile drift before it reaches master, preventing broken Docker builds

## What Changed

- Added a "Validate Dockerfile deps stage" step to the `policy` job in `.github/workflows/pr.yml`
- The step checks that:
  - Every workspace `package.json` (excluding dev-only examples and create-paperclip-plugin) has a corresponding `COPY` line in the Dockerfile
  - The `patches/` directory is copied if it exists
- Fails with specific error messages pointing to the missing `COPY` lines

## Verification

- [ ] PR policy job runs and passes on this PR
- [ ] Manually verified locally: all current workspace packages are detected and matched
- [ ] Verified failure case: removing a COPY line from the Dockerfile triggers the expected error

## Risks

- Low risk. Only adds a read-only validation step — no changes to build or runtime behavior.
- Dev-only packages (`examples/*`, `create-paperclip-plugin`) are intentionally excluded since they aren't needed in the Docker image.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge