### PR TITLE
feat: MCP server URLs per agent

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -334,6 +334,7 @@ export interface CreateConfigValues {
   command: string;
   args: string;
   extraArgs: string;
+  mcpUrls: Record<string, string>; // name → MCP server URL
   envVars: string;
   envBindings: Record<string, unknown>;
   url: string;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -341,6 +341,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const skillsDir = await buildSkillsDir(config);
 
+  // MCP server configuration — write temp file if mcpUrls are set
+  const mcpUrls = (config.mcpUrls ?? {}) as Record<string, string>;
+  let mcpConfigPath: string | undefined;
+  if (Object.keys(mcpUrls).length > 0) {
+    const mcpServers: Record<string, { url: string }> = {};
+    for (const [name, url] of Object.entries(mcpUrls)) {
+      if (url) mcpServers[name] = { url };
+    }
+    if (Object.keys(mcpServers).length > 0) {
+      mcpConfigPath = path.join(skillsDir, "mcp-config.json");
+      await fs.writeFile(mcpConfigPath, JSON.stringify({ mcpServers }, null, 2), "utf-8");
+    }
+  }
+
   // When instructionsFilePath is configured, create a combined temp file that
   // includes both the file content and the path directive, so we only need
   // --append-system-prompt-file (Claude CLI forbids using both flags together).
@@ -415,6 +429,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", effectiveInstructionsFilePath);
     }
     args.push("--add-dir", skillsDir);
+    if (mcpConfigPath) args.push("--mcp-config", mcpConfigPath);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -773,6 +773,21 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 <ClaudeLocalAdvancedFields {...adapterFieldProps} />
               )}
 
+              <Field label="MCP server URLs" hint={help.mcpUrls}>
+                <McpUrlsEditor
+                  value={
+                    isCreate
+                      ? (val!.mcpUrls ?? {})
+                      : ((eff("adapterConfig", "mcpUrls", (config.mcpUrls ?? {})) ?? {}) as Record<string, string>)
+                  }
+                  onChange={(urls) =>
+                    isCreate
+                      ? set!({ mcpUrls: urls })
+                      : mark("adapterConfig", "mcpUrls", Object.keys(urls).length > 0 ? urls : undefined)
+                  }
+                />
+              </Field>
+
               <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
                 <DraftInput
                   value={
@@ -1463,5 +1478,85 @@ function ThinkingEffortDropdown({
         </PopoverContent>
       </Popover>
     </Field>
+  );
+}
+
+/* ---- MCP URLs Editor ---- */
+
+function McpUrlsEditor({
+  value,
+  onChange,
+}: {
+  value: Record<string, string>;
+  onChange: (urls: Record<string, string>) => void;
+}) {
+  type Row = { name: string; url: string };
+
+  function toRows(rec: Record<string, string>): Row[] {
+    const entries = Object.entries(rec).map(([name, url]) => ({ name, url }));
+    return [...entries, { name: "", url: "" }];
+  }
+
+  const [rows, setRows] = useState<Row[]>(() => toRows(value));
+  const valueRef = useRef(value);
+
+  useEffect(() => {
+    if (value !== valueRef.current) {
+      valueRef.current = value;
+      setRows(toRows(value));
+    }
+  }, [value]);
+
+  function commit(updated: Row[]) {
+    setRows(updated);
+    const rec: Record<string, string> = {};
+    for (const r of updated) {
+      if (r.name.trim() && r.url.trim()) rec[r.name.trim()] = r.url.trim();
+    }
+    valueRef.current = rec;
+    onChange(rec);
+  }
+
+  function updateRow(i: number, field: "name" | "url", v: string) {
+    const next = rows.map((r, j) => (j === i ? { ...r, [field]: v } : r));
+    const last = next[next.length - 1];
+    if (last && (last.name || last.url)) next.push({ name: "", url: "" });
+    commit(next);
+  }
+
+  function removeRow(i: number) {
+    const next = rows.filter((_, j) => j !== i);
+    if (next.length === 0) next.push({ name: "", url: "" });
+    commit(next);
+  }
+
+  return (
+    <div className="space-y-2">
+      {rows.map((row, i) => (
+        <div key={i} className="flex gap-2 items-center">
+          <input
+            className="flex-[1] min-w-0 px-2 py-1.5 text-sm rounded border bg-background"
+            placeholder="Name (e.g. jimbo)"
+            value={row.name}
+            onChange={(e) => updateRow(i, "name", e.target.value)}
+          />
+          <input
+            className="flex-[3] min-w-0 px-2 py-1.5 text-sm rounded border bg-background font-mono"
+            placeholder="https://agent.occ.wtf/mcp/..."
+            value={row.url}
+            onChange={(e) => updateRow(i, "url", e.target.value)}
+          />
+          {(row.name || row.url) && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-destructive text-sm px-1"
+              onClick={() => removeRow(i)}
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
   );
 }

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -773,20 +773,22 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 <ClaudeLocalAdvancedFields {...adapterFieldProps} />
               )}
 
-              <Field label="MCP server URLs" hint={help.mcpUrls}>
-                <McpUrlsEditor
-                  value={
-                    isCreate
-                      ? (val!.mcpUrls ?? {})
-                      : ((eff("adapterConfig", "mcpUrls", (config.mcpUrls ?? {})) ?? {}) as Record<string, string>)
-                  }
-                  onChange={(urls) =>
-                    isCreate
-                      ? set!({ mcpUrls: urls })
-                      : mark("adapterConfig", "mcpUrls", Object.keys(urls).length > 0 ? urls : undefined)
-                  }
-                />
-              </Field>
+              {adapterType === "claude_local" && (
+                <Field label="MCP server URLs" hint={help.mcpUrls}>
+                  <McpUrlsEditor
+                    value={
+                      isCreate
+                        ? (val!.mcpUrls ?? {})
+                        : ((eff("adapterConfig", "mcpUrls", (config.mcpUrls ?? {})) ?? {}) as Record<string, string>)
+                    }
+                    onChange={(urls) =>
+                      isCreate
+                        ? set!({ mcpUrls: urls })
+                        : mark("adapterConfig", "mcpUrls", Object.keys(urls).length > 0 ? urls : undefined)
+                    }
+                  />
+                </Field>
+              )}
 
               <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
                 <DraftInput
@@ -1498,22 +1500,22 @@ function McpUrlsEditor({
   }
 
   const [rows, setRows] = useState<Row[]>(() => toRows(value));
-  const valueRef = useRef(value);
+  const serializedRef = useRef(JSON.stringify(value));
 
   useEffect(() => {
-    if (value !== valueRef.current) {
-      valueRef.current = value;
+    const serialized = JSON.stringify(value);
+    if (serialized !== serializedRef.current) {
+      serializedRef.current = serialized;
       setRows(toRows(value));
     }
   }, [value]);
 
-  function commit(updated: Row[]) {
-    setRows(updated);
+  function flush(updated: Row[]) {
     const rec: Record<string, string> = {};
     for (const r of updated) {
       if (r.name.trim() && r.url.trim()) rec[r.name.trim()] = r.url.trim();
     }
-    valueRef.current = rec;
+    serializedRef.current = JSON.stringify(rec);
     onChange(rec);
   }
 
@@ -1521,13 +1523,27 @@ function McpUrlsEditor({
     const next = rows.map((r, j) => (j === i ? { ...r, [field]: v } : r));
     const last = next[next.length - 1];
     if (last && (last.name || last.url)) next.push({ name: "", url: "" });
-    commit(next);
+    setRows(next);
+  }
+
+  function commitRow() {
+    flush(rows);
   }
 
   function removeRow(i: number) {
     const next = rows.filter((_, j) => j !== i);
     if (next.length === 0) next.push({ name: "", url: "" });
-    commit(next);
+    setRows(next);
+    flush(next);
+  }
+
+  // Check for duplicate names
+  const dupeNames = new Set<string>();
+  const seen = new Set<string>();
+  for (const r of rows) {
+    const trimmed = r.name.trim();
+    if (trimmed && seen.has(trimmed)) dupeNames.add(trimmed);
+    if (trimmed) seen.add(trimmed);
   }
 
   return (
@@ -1535,16 +1551,18 @@ function McpUrlsEditor({
       {rows.map((row, i) => (
         <div key={i} className="flex gap-2 items-center">
           <input
-            className="flex-[1] min-w-0 px-2 py-1.5 text-sm rounded border bg-background"
+            className={`flex-[1] min-w-0 px-2 py-1.5 text-sm rounded border bg-background ${dupeNames.has(row.name.trim()) ? "border-destructive" : ""}`}
             placeholder="Name (e.g. jimbo)"
             value={row.name}
             onChange={(e) => updateRow(i, "name", e.target.value)}
+            onBlur={commitRow}
           />
           <input
             className="flex-[3] min-w-0 px-2 py-1.5 text-sm rounded border bg-background font-mono"
             placeholder="https://agent.occ.wtf/mcp/..."
             value={row.url}
             onChange={(e) => updateRow(i, "url", e.target.value)}
+            onBlur={commitRow}
           />
           {(row.name || row.url) && (
             <button
@@ -1557,6 +1575,9 @@ function McpUrlsEditor({
           )}
         </div>
       ))}
+      {dupeNames.size > 0 && (
+        <p className="text-xs text-destructive">Duplicate name: {[...dupeNames].join(", ")}</p>
+      )}
     </div>
   );
 }

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -14,6 +14,7 @@ export const defaultCreateValues: CreateConfigValues = {
   command: "",
   args: "",
   extraArgs: "",
+  mcpUrls: {},
   envVars: "",
   envBindings: {},
   url: "",

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -43,6 +43,7 @@ export const help: Record<string, string> = {
   localCommand: "Override the path to the CLI command you want the adapter to call (e.g. /usr/local/bin/claude, codex, opencode).",
   args: "Command-line arguments, comma-separated.",
   extraArgs: "Extra CLI arguments for local adapters, comma-separated.",
+  mcpUrls: "MCP server URLs. Each agent run will connect to these servers. Paste your OCC agent MCP link here.",
   envVars: "Environment variables injected into the adapter process. Use plain values or secret references.",
   bootstrapPrompt: "Only sent when Paperclip starts a fresh session. Use this for stable setup guidance that should not be repeated on every heartbeat.",
   payloadTemplateJson: "Optional JSON merged into remote adapter request payloads before Paperclip adds its standard wake and workspace fields.",


### PR DESCRIPTION
## Summary

Adds an optional `mcpUrls` field to agent configuration, allowing each agent to connect to one or more MCP servers during execution.

- When configured, a temporary `mcp-config.json` is written to the skills directory and passed via `--mcp-config` to the Claude CLI
- The temp file is cleaned up automatically after the run (lives in skillsDir which is ephemeral)
- If `mcpUrls` is empty or not set, behavior is unchanged — zero impact on existing agents

## Use case

This enables connecting agents to external MCP-based services without manual JSON editing. For example:
- Per-agent governance proxies (policy enforcement, audit logging)
- Tool isolation — different agents get different tool sets
- Connecting to external MCP servers (databases, APIs, custom tools)

## Changes

| File | Change |
|------|--------|
| `packages/adapter-utils/src/types.ts` | Added `mcpUrls: Record<string, string>` to `CreateConfigValues` |
| `packages/adapters/claude-local/src/server/execute.ts` | Writes temp MCP config JSON, passes `--mcp-config` to Claude CLI |
| `ui/src/components/AgentConfigForm.tsx` | `McpUrlsEditor` component — name/URL pair inputs with add/remove |
| `ui/src/components/agent-config-defaults.ts` | Default `mcpUrls: {}` |
| `ui/src/components/agent-config-primitives.tsx` | Help text for the MCP URLs field |

## Test plan

- [ ] Create an agent with one or more MCP server URLs configured
- [ ] Verify the agent config form renders the MCP URLs editor correctly
- [ ] Run the agent and verify `--mcp-config` is passed to Claude CLI
- [ ] Verify agents without `mcpUrls` configured are unaffected
- [ ] Verify temp `mcp-config.json` is written to skillsDir before run

## Screenshot

The MCP server URLs field appears in the agent configuration form, between "Max turns per run" and "Extra args":

```
MCP server URLs (?)
[Name (e.g. jimbo)] [https://agent.occ.wtf/mcp/...]
```