### PR TITLE
fix(openclaw_gateway): scope generated session keys by agent

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -43,7 +43,7 @@ The adapter supports the same session routing model as HTTP OpenClaw mode:
 
 Resolved session key is sent as `agent.sessionKey`.
 
-When a non-main `agentId` is present, generated `issue` / `run` session keys are automatically agent-scoped (for example `agent:eng:paperclip:issue:<issueId>`) so multi-agent OpenClaw routing preserves issue/run continuity per agent. Existing explicitly scoped fixed keys are preserved as-is.
+When a non-main `agentId` is present, generated `issue` / `run` session keys are automatically agent-scoped (for example `agent:eng:paperclip:issue:<issueId>`) so multi-agent OpenClaw routing preserves issue/run continuity per agent. Unscoped `fixed` session keys are also auto-prefixed for non-main agents (for example `workspace` → `agent:eng:workspace`), so operators should expect a session-key continuity break for those keys on first deploy and may want to drain in-flight sessions first. Existing explicitly scoped fixed keys are preserved as-is.
 
 ## Payload Mapping
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -71,6 +71,17 @@ describe("resolveSessionKey", () => {
     expect(key).toBe("paperclip:run:run-456");
   });
 
+  it("returns legacy run key when agentId is 'main'", () => {
+    const key = resolveSessionKey({
+      strategy: "run",
+      configuredSessionKey: null,
+      runId,
+      issueId: null,
+      agentId: "main",
+    });
+    expect(key).toBe("paperclip:run:run-456");
+  });
+
   it("returns agent-scoped fallback when strategy is fixed with unscoped key", () => {
     const key = resolveSessionKey({
       strategy: "fixed",

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -127,7 +127,7 @@ function normalizeSessionKeyStrategy(value: unknown): SessionKeyStrategy {
 }
 
 function hasAgentScope(sessionKey: string): boolean {
-  return /^agent:[a-z0-9_-]+:.+/i.test(sessionKey.trim());
+  return /^agent:[a-z0-9_-]+:.+/.test(sessionKey.trim());
 }
 
 export function resolveSessionKey(input: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - One way Paperclip does that is by invoking external runtimes through adapters, including the `openclaw_gateway` adapter.
> - In multi-agent OpenClaw setups, routing is determined by both `agentId` and agent-scoped session keys.
> - The adapter already forwards `agentId`, but generated `issue` / `run` session keys were still emitted as legacy unscoped keys like `paperclip:issue:<id>`.
> - OpenClaw correctly treats those unscoped keys as belonging to `main`, which causes a mismatch error when the payload also targets a non-main agent such as `eng` or `coo`.
> - This pull request scopes generated `issue` / `run` session keys by agent when a non-main agent is targeted, while preserving explicitly scoped fixed keys as-is.
> - The benefit is that multi-agent OpenClaw routing keeps true per-issue / per-run continuity without forcing users onto the `fixed` workaround that can blur issue context.

## What Changed

- updated `resolveSessionKey()` in the `openclaw_gateway` adapter to accept `agentId`
- generate agent-scoped `issue` / `run` session keys for non-main agents (for example `agent:eng:paperclip:issue:<issueId>`)
- preserve already-scoped fixed session keys so existing workarounds do not get double-prefixed
- keep `main` / legacy behavior unchanged
- added focused regression tests for `eng`, `coo`, `main`, unscoped fixed keys, and already-scoped fixed keys
- clarified the session-routing behavior in the adapter README, including the continuity impact for unscoped `fixed` keys

Fixes #1205.

## Verification

- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway build`
- `./node_modules/.bin/vitest run --config .vitest-openclaw-gateway-temp.config.ts`
  - targeted `packages/adapters/openclaw-gateway/src/server/execute.test.ts`
  - **11 tests passing locally**
- validated the same fix on a live local Paperclip instance (`/Users/larry/projects/paperclip`) wired to a live OpenClaw gateway:
  - Engineering issue wake accepted with `agent:eng:paperclip:issue:<issueId>`
  - COO issue wake accepted with `agent:coo:paperclip:issue:<issueId>`
  - the prior `invalid agent params: agent "eng/coo" does not match session key agent "main"` repro no longer occurred

## Risks

- Low risk: behavior changes only when a non-main agent is targeted and the generated session key is not already agent-scoped.
- Existing explicit agent-scoped `fixed` workarounds are preserved unchanged to avoid double-prefixing.
- Main / legacy single-agent behavior remains unchanged.
- Deploy note: unscoped `fixed` keys for non-main agents will begin resolving to agent-scoped keys after this change, so operators may want to drain any in-flight sessions first.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I have addressed current Greptile/reviewer comments and re-ran targeted validation
