### PR TITLE
feat(ui): display human-readable schedule preview in ScheduleEditor

### DIFF
--- a/ui/src/components/ScheduleEditor.tsx
+++ b/ui/src/components/ScheduleEditor.tsx
@@ -192,8 +192,15 @@ export function ScheduleEditor({
     }
   };
 
+  const preview = value ? describeSchedule(value) : null;
+
   return (
     <div className="space-y-3">
+      {preview && (
+        <p className="text-xs text-muted-foreground bg-muted/50 rounded px-2.5 py-1.5 font-medium">
+          {preview}
+        </p>
+      )}
       <Select value={preset} onValueChange={(v) => handlePresetChange(v as SchedulePreset)}>
         <SelectTrigger className="w-full">
           <SelectValue placeholder="Choose frequency..." />

--- a/ui/src/components/ScheduleEditor.tsx
+++ b/ui/src/components/ScheduleEditor.tsx
@@ -192,7 +192,7 @@ export function ScheduleEditor({
     }
   };
 
-  const preview = value ? describeSchedule(value) : null;
+  const preview = useMemo(() => (value ? describeSchedule(value) : null), [value]);
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The Routines system allow setting up scheduled triggers with cron expressions
> - But cron syntax like `0 10 * * 1` is not easy to read for most people
> - The ScheduleEditor component already have a `describeSchedule()` function that convert cron to human text like "Every day at 10:00 AM"
> - But this function was only exported for other components - it was never shown inside the editor itself
> - So this PR add a small preview text above the preset selector that show the human-readable description in real time
> - The benefit is user can immediately understand what their schedule will do without parsing cron syntax mentally, specially in Custom mode

## Problem

The ScheduleEditor component already has a `describeSchedule()` function that generate beautiful human-readable text from cron expression. Like "Every day at 10:00 AM" or "Monthly on the 15th at 3:00 PM". But this function was only exported for use by other components - it was never shown inside the editor itself!

So when user is editing a schedule, specially in "Custom (cron)" mode, they have to mentally parse the cron syntax `0 10 * * 1` to understand what it mean. Even with the preset mode, having a clear text confirmation of what the schedule will do is very helpful.

## What I changed

Added a small preview paragraph above the preset selector that show `describeSchedule(value)` in real time. The preview:
- Has subtle styling (`bg-muted/50 rounded`) so it look like a read-only info bar
- Updates immediately as user change any setting (preset, hour, minute, day, etc.)
- Show nothing when value is empty (no schedule set)
- For custom cron, it try to parse and describe, or fall back to showing the raw cron text

## How to test

1. Go to Routines > open a routine > Triggers tab
2. Edit or create a trigger with schedule type
3. Should see a preview line at top of schedule editor like "Every day at 10:00 AM"
4. Change the preset to "Weekly" and select "Tue" - preview update to "Every Tue at 10:00 AM"
5. Switch to "Custom (cron)" and type `30 14 * * 1-5` - preview show "Weekdays at 2:30 PM"

1 file, 7 lines added. No new dependency, just using the existing describeSchedule() function that was already there.