### PR TITLE
fix(ui): show error toast for project detail mutations

### DIFF
--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -149,6 +149,7 @@ function ColorPicker({
 
 function ProjectIssuesList({ projectId, companyId }: { projectId: string; companyId: string }) {
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(companyId),
@@ -183,6 +184,9 @@ function ProjectIssuesList({ projectId, companyId }: { projectId: string; compan
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listByProject(companyId, projectId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to update issue", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 
@@ -277,6 +281,9 @@ export function ProjectDetail() {
     mutationFn: (data: Record<string, unknown>) =>
       projectsApi.update(projectLookupRef, data, resolvedCompanyId ?? lookupCompanyId),
     onSuccess: invalidateProject,
+    onError: (err) => {
+      pushToast({ title: "Failed to update project", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+    },
   });
 
   const archiveProject = useMutation({
@@ -448,6 +455,9 @@ export function ProjectDetail() {
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectLookupRef) });
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(resolvedCompanyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(resolvedCompanyId) });
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to update budget", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 


### PR DESCRIPTION
<!-- Written in Simplified Technical English: short sentences, active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Humans watch and manage these agents through a web UI.
> - The UI shows project data in a `ProjectDetail` page.
> - This page runs several mutations that call the API to save changes.
> - Three mutations here had no error handler: the project update, the issue update, and the budget update.
> - When one of these API calls failed, the UI showed no message to the user.
> - This pull request adds an `onError` handler to each of the three mutations.
> - The benefit is that the user now sees a red error toast when a mutation fails.

## Linked Issues or Issue Description

No issue is linked by the author. The change fixes a bug, described below.

**What happened?**
Three mutations on the `ProjectDetail` page did not handle errors. The `updateProject`, `updateIssue`, and `budgetMutation` calls failed silently. The user saw no message when an API call failed.

**Expected behavior**
A failed mutation must show a clear error message. The author notes that the adjacent `archiveProject` mutation already showed an error toast, so the behavior was inconsistent.

**Steps to reproduce**
Open a project detail page. Update a project property, an issue, or the budget while the server is down. Observe that no error feedback appears.

## What Changed

- Added an `onError` handler to the project update mutation in `ui/src/pages/ProjectDetail.tsx`. It calls `pushToast` with the title "Failed to update project" and tone "error".
- Added an `onError` handler to the issue update mutation in the `ProjectIssuesList` component. It shows a toast with the title "Failed to update issue".
- Added an `onError` handler to the budget mutation. It shows a toast with the title "Failed to update budget".
- Each handler shows the error message when the error is an `Error`, or "Something went wrong." otherwise.
- Added the `useToast()` hook to the `ProjectIssuesList` component so it can call `pushToast`.

## Verification

The author describes these manual steps:

1. Go to any project detail page.
2. Try to update project properties when the server is down or the network is disconnected.
3. A red error toast with the error message must appear.
4. Repeat for budget changes and issue updates within the project.

The author does not state that automated tests were run. The reviewer asked for before/after screenshots of the toast; the author has not provided them.

## Risks

Low risk. The change only adds error handlers and does not change the success path or the API calls. It follows the pattern already used by the `archiveProject` mutation.

## Model Used

Not stated by the author.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

## Original description

## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans need to watch and manage these agents through a web UI
> - Inside the UI, users organize work into Projects - each project has settings, issues, and budget
> - On the ProjectDetail page, there are several mutations that talk to the API to save changes
> - But three of these mutations (updateProject, updateIssue, budgetMutation) had no error handling at all
> - So when API call fails, the user see nothing - field just silently revert and user is confused
> - The strange part is that archiveProject mutation, which is right next to updateProject in same file, already had proper onError with toast notification
> - So this PR adds onError handler to the three mutations that was missing it, following the exact same pattern already used by archiveProject
> - Now user gets a clear red toast message when something goes wrong, which is consistent with rest of the application

## Problem

Three mutations in ProjectDetail page was silently failing when API call goes wrong:

1. **updateProject** - when user change project name, color, description, status, or any property through the settings panel. If it fail, nothing happen. The field just revert back with no explanation.
2. **updateIssue** - when user update an issue from within the project issues tab (drag status in kanban, change priority, etc). Silent failure.
3. **budgetMutation** - when user try to set or update project budget amount. Silent failure.

Funny thing is the `archiveProject` mutation (literally 3 lines below updateProject in the file) already had proper `onError` with toast notification. So user get feedback when archive fail but not when a normal update fail. Very inconsistent.

## What I changed

Added `onError` handler to all three mutations following the exact same pattern used by `archiveProject` and the other mutations we fixed in earlier PRs (AgentDetail, Routines, etc).

Also added `useToast()` hook to the `ProjectIssuesList` sub-component because it's a separate function component inside the file that didn't have access to `pushToast` before.

## How to test

1. Go to any project detail page
2. Try to update project properties when server is down or network disconnected
3. Should see red error toast with the error message
4. Same for budget changes and issue updates within the project

1 file, 10 lines added.