### PR TITLE
fix(ui): add error toast to goal, issue comment, and issues list mutations

### DIFF
--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -6,6 +6,7 @@ import { projectsApi } from "../api/projects";
 import { assetsApi } from "../api/assets";
 import { usePanel } from "../context/PanelContext";
 import { useCompany } from "../context/CompanyContext";
+import { useToast } from "../context/ToastContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
@@ -28,6 +29,7 @@ export function GoalDetail() {
   const { openPanel, closePanel } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
 
   const {
     data: goal,
@@ -69,7 +71,10 @@ export function GoalDetail() {
           queryKey: queryKeys.goals.list(resolvedCompanyId)
         });
       }
-    }
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to update goal", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+    },
   });
 
   const uploadImage = useMutation({
@@ -80,7 +85,10 @@ export function GoalDetail() {
         file,
         `goals/${goalId ?? "draft"}`
       );
-    }
+    },
+    onError: (err) => {
+      pushToast({ title: "Image upload failed", body: err instanceof Error ? err.message : "Could not upload image.", tone: "error" });
+    },
   });
 
   const childGoals = (allGoals ?? []).filter((g) => g.parentId === goalId);

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -518,7 +518,7 @@ export function IssueDetail() {
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
     },
     onError: (err) => {
-      pushToast({ title: "Failed to post comment", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+      pushToast({ title: "Failed to post comment and reassign", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -492,6 +492,9 @@ export function IssueDetail() {
       invalidateIssue();
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
     },
+    onError: (err) => {
+      pushToast({ title: "Failed to post comment", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+    },
   });
 
   const addCommentAndReassign = useMutation({
@@ -513,6 +516,9 @@ export function IssueDetail() {
     onSuccess: () => {
       invalidateIssue();
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.comments(issueId!) });
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to post comment", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -6,6 +6,7 @@ import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
 import { heartbeatsApi } from "../api/heartbeats";
 import { useCompany } from "../context/CompanyContext";
+import { useToast } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
@@ -19,6 +20,7 @@ export function Issues() {
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
 
   const initialSearch = searchParams.get("q") ?? "";
   const participantAgentId = searchParams.get("participantAgentId") ?? undefined;
@@ -97,6 +99,9 @@ export function Issues() {
       issuesApi.update(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(selectedCompanyId!) });
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to update issue", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans need to oversee what agents are doing, so there is a UI dashboard
> - In that dashboard users can edit goals, post comments on issues, reassign issues, etc.
> - When these actions fail (like network error or server down), user should get feedback
> - But several mutations across GoalDetail, IssueDetail, and Issues pages was missing error handling
> - The mutations just fail silently and user don't know something went wrong
> - This PR adds error toast notifications to 5 mutations that was failing without any feedback
> - That way users always know when their action did not succeed and can try again

## Problem

Found 5 more mutations across 3 pages that was failing silently without any user feedback. This is the same pattern we been fixing in previous PRs but these pages was not covered yet.

### GoalDetail.tsx
- **updateGoal**: when user edit goal title or description and save fail, nothing happen. The text just revert back and user don't know why.
- **uploadImage**: when user try to upload image in the goal description markdown editor and it fail, zero feedback. The image just don't appear.

### IssueDetail.tsx
- **addComment**: this is probably the worst one. User type a comment, click submit, the comment mutation fail, but user think it was posted because the editor clear. They leave the page thinking comment was saved.
- **addCommentAndReassign**: same issue but even worse because it also try to reassign the issue. Both the comment and reassignment fail silently.

### Issues.tsx
- **updateIssue**: when user change issue status or priority from the main issues list view (not inside issue detail), failures are silent.

## What I changed

Added `onError` callback with `pushToast` to all 5 mutations. Same pattern used everywhere else in the app. For GoalDetail and Issues I also needed to add the `useToast` import and `pushToast` hook since those files didn't have it. IssueDetail already had it from the copy-to-clipboard feature.

Also fixed toast title for `addCommentAndReassign` - was saying "Failed to post comment" but this mutation do both comment and reassign, so now it say "Failed to post comment and reassign" to be more accurate.

## How to test

1. Try to post a comment on an issue when server is down - should see "Failed to post comment" error toast
2. Try to comment-and-reassign when API fail - should see "Failed to post comment and reassign" toast
3. Try to edit goal title when network disconnected - should see "Failed to update goal" toast
4. Try to change issue status from issues list when API fail - should see error toast

3 files, 21 lines added, 1 line changed.