### PR TITLE
fix(ui): require confirmation before deleting triggers, revoking keys, removing attachments

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -4016,10 +4016,10 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                   variant="ghost"
                   size="sm"
                   className="text-destructive hover:text-destructive text-xs"
-                  onClick={() => { if (window.confirm("Revoke this API key? Applications using it will stop working immediately.")) revokeKey.mutate(key.id); }}
-                  disabled={revokeKey.isPending}
+                  onClick={() => { if (confirm("Revoke this API key? Applications using it will stop working immediately.")) revokeKey.mutate(key.id); }}
+                  disabled={revokeKey.isPending && revokeKey.variables === key.id}
                 >
-                  {revokeKey.isPending ? "Revoking..." : "Revoke"}
+                  {revokeKey.isPending && revokeKey.variables === key.id ? "Revoking..." : "Revoke"}
                 </Button>
               </div>
             ))}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -4016,10 +4016,10 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                   variant="ghost"
                   size="sm"
                   className="text-destructive hover:text-destructive text-xs"
-                  onClick={() => revokeKey.mutate(key.id)}
+                  onClick={() => { if (window.confirm("Revoke this API key? Applications using it will stop working immediately.")) revokeKey.mutate(key.id); }}
                   disabled={revokeKey.isPending}
                 >
-                  Revoke
+                  {revokeKey.isPending ? "Revoking..." : "Revoke"}
                 </Button>
               </div>
             ))}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -965,9 +965,9 @@ export function IssueDetail() {
                 <button
                   type="button"
                   className="text-muted-foreground hover:text-destructive"
-                  onClick={() => deleteAttachment.mutate(attachment.id)}
+                  onClick={() => { if (window.confirm(`Delete "${attachment.originalFilename ?? "this attachment"}"?`)) deleteAttachment.mutate(attachment.id); }}
                   disabled={deleteAttachment.isPending}
-                  title="Delete attachment"
+                  title={deleteAttachment.isPending ? "Deleting..." : "Delete attachment"}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </button>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -965,9 +965,9 @@ export function IssueDetail() {
                 <button
                   type="button"
                   className="text-muted-foreground hover:text-destructive"
-                  onClick={() => { if (window.confirm(`Delete "${attachment.originalFilename ?? "this attachment"}"?`)) deleteAttachment.mutate(attachment.id); }}
-                  disabled={deleteAttachment.isPending}
-                  title={deleteAttachment.isPending ? "Deleting..." : "Delete attachment"}
+                  onClick={() => { if (confirm(`Delete "${attachment.originalFilename ?? "this attachment"}"?`)) deleteAttachment.mutate(attachment.id); }}
+                  disabled={deleteAttachment.isPending && deleteAttachment.variables === attachment.id}
+                  title={deleteAttachment.isPending && deleteAttachment.variables === attachment.id ? "Deleting..." : "Delete attachment"}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </button>

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -222,7 +222,7 @@ function TriggerEditor({
             variant="ghost"
             size="sm"
             className="text-muted-foreground hover:text-destructive"
-            onClick={() => onDelete(trigger.id)}
+            onClick={() => { if (window.confirm("Delete this trigger? This cannot be undone.")) onDelete(trigger.id); }}
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -222,7 +222,7 @@ function TriggerEditor({
             variant="ghost"
             size="sm"
             className="text-muted-foreground hover:text-destructive"
-            onClick={() => { if (window.confirm("Delete this trigger? This cannot be undone.")) onDelete(trigger.id); }}
+            onClick={() => { if (confirm("Delete this trigger? This cannot be undone.")) onDelete(trigger.id); }}
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrate ai-agents for zero-human companies
> - But humans need to oversee the agents, manage triggers, keys, and issues
> - Some UI actions are destructive - delete trigger, revoke key, remove attachment
> - These action had no confirmation dialog, one misclick and it is gone
> - So this PR add a confirm() dialog before each destructive action
> - Also it show loading feedback ("Revoking...", "Deleting...") while mutation runs
> - And each button now track its own item ID so only the clicked button show loading, not all sibling buttons

## Problem

Three destructive actions in the app execute immediately with single click and no way to undo:

### 1. Delete routine trigger (RoutineDetail)
The small trash icon next to each trigger fire `onDelete(trigger.id)` immediately. If you have a production webhook or schedule trigger, one accidental click delete it. There is no undo, you have to recreate from scratch.

### 2. Revoke API key (AgentDetail)  
The "Revoke" button on agent API keys call `revokeKey.mutate(key.id)` with one click. This immediately invalidate the key and any service or integration using that key stop working. Very dangerous for production environment.

### 3. Delete file attachment (IssueDetail)
The trash icon on issue attachments delete the file immediately. If you accidentally click it on the wrong attachment, the file is gone.

## What I changed

Added `confirm()` dialog before each destructive action:

- **Trigger delete**: "Delete this trigger? This cannot be undone."
- **Key revoke**: "Revoke this API key? Applications using it will stop working immediately."
- **Attachment delete**: "Delete \<filename\>?" (show actual filename in the dialog)

Also added loading text feedback with per-item tracking:
- Revoke button now show "Revoking..." only for the specific key being revoked (using `revokeKey.variables === key.id`)
- Attachment delete button title change to "Deleting..." only for the specific attachment being deleted (using `deleteAttachment.variables === attachment.id`)

I know `confirm()` is not the prettiest dialog, but the codebase already use it in other place (like AgentDetail file deletion at line 2231) so it's consistent. And it work everywhere including mobile.

## How to test

1. Go to Routines > open routine > Triggers tab > click trash icon on a trigger > should see confirm dialog
2. Go to Agent detail > Keys tab > click "Revoke" on a key > should see confirm dialog, only that key button show "Revoking..."
3. Open any issue with attachment > click trash icon > should see confirm with filename, only that attachment button show "Deleting..."

3 files changed, net 0 lines (just replaced inline). No new import needed.