### PR TITLE
fix(ui): remember sidebar Agents/Projects collapse state across page refresh

### DIFF
--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -20,7 +20,9 @@ import {
 } from "@/components/ui/collapsible";
 import type { Agent } from "@paperclipai/shared";
 export function SidebarAgents() {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(() => {
+    try { return localStorage.getItem("paperclip:sidebar-agents-open") !== "false"; } catch { return true; }
+  });
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialog();
   const { isMobile, setSidebarOpen } = useSidebar();
@@ -70,7 +72,7 @@ export function SidebarAgents() {
 
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
+    <Collapsible open={open} onOpenChange={(v) => { setOpen(v); try { localStorage.setItem("paperclip:sidebar-agents-open", String(v)); } catch {} }}>
       <div className="group">
         <div className="flex items-center px-3 py-1.5">
           <CollapsibleTrigger className="flex items-center gap-1 flex-1 min-w-0">

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -116,7 +116,9 @@ function SortableProjectItem({
 }
 
 export function SidebarProjects() {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(() => {
+    try { return localStorage.getItem("paperclip:sidebar-projects-open") !== "false"; } catch { return true; }
+  });
   const { selectedCompany, selectedCompanyId } = useCompany();
   const { openNewProject } = useDialog();
   const { isMobile, setSidebarOpen } = useSidebar();
@@ -174,7 +176,7 @@ export function SidebarProjects() {
   );
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
+    <Collapsible open={open} onOpenChange={(v) => { setOpen(v); try { localStorage.setItem("paperclip:sidebar-projects-open", String(v)); } catch {} }}>
       <div className="group">
         <div className="flex items-center px-3 py-1.5">
           <CollapsibleTrigger className="flex items-center gap-1 flex-1 min-w-0">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans need to watch these agents and manage them through the web UI
> - The sidebar is the main navigation, it has collapsible sections for Agents and Projects
> - When you have many agents or projects, you want to keep some sections collapsed so navigation is cleaner
> - But the collapse state was stored only in React state with `useState(true)`, so every page refresh resets everything to expanded
> - This is very frustrating if you are working all day and have to re-collapse sections after every reload
> - So this PR persists the sidebar collapse state to localStorage, using the same pattern already used in ProjectDetail.tsx for tab persistence
> - The benefit is the sidebar now remembers your preference across refreshes, and it degrades gracefully in private browsing or when storage is full

## Problem

The Agents and Projects collapsible sections in the sidebar was using `useState(true)` for their open/close state. This mean every time you refresh the page, both sections go back to expanded state.

If you have 20+ agents and you prefer to keep that section collapsed to see the navigation links better, you had to click the collapse button every single time you reload or navigate. Very annoying for daily usage.

## What I changed

For both `SidebarAgents.tsx` and `SidebarProjects.tsx`:

1. Changed `useState(true)` initial value to read from localStorage:
   - Key: `paperclip:sidebar-agents-open` / `paperclip:sidebar-projects-open`
   - If not stored yet, default is `true` (expanded, same as before)
   - Uses lazy initializer `useState(() => ...)` so localStorage is only read once on mount

2. Changed `onOpenChange={setOpen}` to also write to localStorage on every toggle

Both localStorage reads and writes are wrapped in `try/catch` so it work fine in private browsing mode or when storage quota is full - just fall back to in-memory state like before.

## How to test

1. Open the app, collapse the Agents section in sidebar
2. Refresh the page
3. Agents section should still be collapsed
4. Same test for Projects section
5. Open in private browsing - should work normally, just won't persist (falls back to expanded default)

Follow the same pattern already used in ProjectDetail.tsx (lines 462, 486) for persisting tab state.

2 files, 8 lines added / 4 removed.