### PR TITLE
fix(ui): show loading text on approval detail action buttons

### DIFF
--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -269,7 +269,7 @@ export function ApprovalDetail() {
                 onClick={() => approveMutation.mutate()}
                 disabled={approveMutation.isPending}
               >
-                {approveMutation.isPending ? "Approving..." : "Approve"}
+                {approveMutation.isPending ? "Approving\u2026" : "Approve"}
               </Button>
               <Button
                 variant="destructive"
@@ -277,7 +277,7 @@ export function ApprovalDetail() {
                 onClick={() => rejectMutation.mutate()}
                 disabled={rejectMutation.isPending}
               >
-                {rejectMutation.isPending ? "Rejecting..." : "Reject"}
+                {rejectMutation.isPending ? "Rejecting\u2026" : "Reject"}
               </Button>
             </>
           )}
@@ -293,7 +293,7 @@ export function ApprovalDetail() {
               onClick={() => revisionMutation.mutate()}
               disabled={revisionMutation.isPending}
             >
-              {revisionMutation.isPending ? "Requesting..." : "Request revision"}
+              {revisionMutation.isPending ? "Requesting\u2026" : "Request revision"}
             </Button>
           )}
           {approval.status === "revision_requested" && (
@@ -303,7 +303,7 @@ export function ApprovalDetail() {
               onClick={() => resubmitMutation.mutate()}
               disabled={resubmitMutation.isPending}
             >
-              {resubmitMutation.isPending ? "Submitting..." : "Mark resubmitted"}
+              {resubmitMutation.isPending ? "Submitting\u2026" : "Mark resubmitted"}
             </Button>
           )}
           {approval.status === "rejected" && approval.type === "hire_agent" && linkedAgentId && (

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -269,7 +269,7 @@ export function ApprovalDetail() {
                 onClick={() => approveMutation.mutate()}
                 disabled={approveMutation.isPending}
               >
-                Approve
+                {approveMutation.isPending ? "Approving..." : "Approve"}
               </Button>
               <Button
                 variant="destructive"
@@ -277,7 +277,7 @@ export function ApprovalDetail() {
                 onClick={() => rejectMutation.mutate()}
                 disabled={rejectMutation.isPending}
               >
-                Reject
+                {rejectMutation.isPending ? "Rejecting..." : "Reject"}
               </Button>
             </>
           )}
@@ -293,7 +293,7 @@ export function ApprovalDetail() {
               onClick={() => revisionMutation.mutate()}
               disabled={revisionMutation.isPending}
             >
-              Request revision
+              {revisionMutation.isPending ? "Requesting..." : "Request revision"}
             </Button>
           )}
           {approval.status === "revision_requested" && (
@@ -303,7 +303,7 @@ export function ApprovalDetail() {
               onClick={() => resubmitMutation.mutate()}
               disabled={resubmitMutation.isPending}
             >
-              Mark resubmitted
+              {resubmitMutation.isPending ? "Submitting..." : "Mark resubmitted"}
             </Button>
           )}
           {approval.status === "rejected" && approval.type === "hire_agent" && linkedAgentId && (


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrate ai-agents for zero-human companies
> - Humans who oversee agent work need approval workflow to approve, reject, or request revision on agent actions
> - The approval detail page have four action buttons - Approve, Reject, Request revision, Mark resubmitted
> - When user click one of these buttons, a mutation fire and button get disabled while processing
> - But the button text was not changing - user see grey "Approve" button and don't know if action is happening or stuck
> - Funny thing is the "Post comment" button on same page already show "Posting…" text while pending
> - Also we already fix this same issue in ApprovalCard and Inbox approval buttons in earlier PR, but this detail page was missed
> - So this PR add loading text feedback to all four action buttons on the approval detail page
> - The benefit is consistent UX across the whole approval system - user always know when action is in progress

## Problem

On the approval detail page, the four action buttons (Approve, Reject, Request revision, Mark resubmitted) was getting disabled while the mutation is processing but the button text stay the same. User click "Approve" and the button just become grey with "Approve" text still showing. They don't know if the action is happening or if something is stuck.

Funny thing is the "Post comment" button on the same page (line 362) already show "Posting…" text while pending. And we already fix this same issue for ApprovalCard and Inbox approval buttons in earlier PR. But this detail page was missed because it's a different component.

## What I changed

- "Approve" -> "Approving…" while pending
- "Reject" -> "Rejecting…" while pending  
- "Request revision" -> "Requesting…" while pending
- "Mark resubmitted" -> "Submitting…" while pending

Simple conditional text render: `{mutation.isPending ? "Loading…" : "Normal text"}`

Uses typographic ellipsis character (U+2026) to match existing "Posting…" pattern on same page.

## How to test

1. Go to any pending approval detail page
2. Click Approve (or any action button)
3. Button text should change to "Approving…" while the request is processing
4. After completion, page will update with new status

1 file, 4 lines changed (text replacements only).