### PR TITLE
feat(claude-local): add Paperclip runtime note to agent prompts

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -117,6 +117,7 @@ function renderPaperclipRuntimeNote(env: Record<string, string>): string {
       "",
       "Paperclip API authentication:",
       "Always include -H \"Authorization: Bearer $PAPERCLIP_API_KEY\" on every Paperclip API call (curl to $PAPERCLIP_API_URL).",
+      "For POST/PATCH requests, also include -H \"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\" so the server can attribute the action to this run.",
     );
   }
   lines.push("", "");

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -102,6 +102,27 @@ function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscri
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }
 
+function renderPaperclipRuntimeNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  const lines = [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+  ];
+  if (hasNonEmptyEnvValue(env, "PAPERCLIP_API_URL") && hasNonEmptyEnvValue(env, "PAPERCLIP_API_KEY")) {
+    lines.push(
+      "",
+      "Paperclip API authentication:",
+      "Always include -H \"Authorization: Bearer $PAPERCLIP_API_KEY\" on every Paperclip API call (curl to $PAPERCLIP_API_URL).",
+    );
+  }
+  lines.push("", "");
+  return lines.join("\n");
+}
+
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
   const { runId, agent, config, context, authToken } = input;
 
@@ -391,9 +412,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const runtimeNote = renderPaperclipRuntimeNote(env);
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
     sessionHandoffNote,
+    runtimeNote,
     renderedPrompt,
   ]);
   const promptMetrics = {


### PR DESCRIPTION
## Summary

- Add `renderPaperclipRuntimeNote()` to the claude-local adapter, matching the existing pattern in gemini-local
- Injects available `PAPERCLIP_*` environment variables and API authentication instructions into agent prompts
- Fixes agents not including `Authorization: Bearer $PAPERCLIP_API_KEY` header, which caused `createdByAgentId` to be null

## Context

The gemini-local adapter already has `renderPaperclipEnvNote()` and `renderApiAccessNote()` that tell agents how to authenticate API calls. The claude-local adapter was missing this, so agents running through it never sent auth headers on Paperclip API calls.

## Test plan

- [ ] Verify agent heartbeat run includes runtime note in prompt
- [ ] Verify agent API calls include Authorization header
- [ ] Verify `createdByAgentId` is populated on issues created by agents

Generated with [Claude Code](https://claude.com/claude-code)