### PR TITLE
fix(ui): add detailed breakdown to dashboard chart bar tooltips

### DIFF
--- a/ui/src/components/ActivityCharts.tsx
+++ b/ui/src/components/ActivityCharts.tsx
@@ -85,7 +85,7 @@ export function RunActivityChart({ runs }: { runs: HeartbeatRun[] }) {
           const total = entry.succeeded + entry.failed + entry.other;
           const heightPct = (total / maxValue) * 100;
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} runs`}>
+            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} runs (${entry.succeeded} succeeded, ${entry.failed} failed${entry.other > 0 ? `, ${entry.other} other` : ""})`}>
               {total > 0 ? (
                 <div className="flex flex-col-reverse gap-px overflow-hidden" style={{ height: `${heightPct}%`, minHeight: 2 }}>
                   {entry.succeeded > 0 && <div className="bg-emerald-500" style={{ flex: entry.succeeded }} />}
@@ -137,7 +137,7 @@ export function PriorityChart({ issues }: { issues: { priority: string; createdA
           const total = Object.values(entry).reduce((a, b) => a + b, 0);
           const heightPct = (total / maxValue) * 100;
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} issues`}>
+            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} issues (${priorityOrder.filter(p => entry[p] > 0).map(p => `${entry[p]} ${p}`).join(", ")})`}>
               {total > 0 ? (
                 <div className="flex flex-col-reverse gap-px overflow-hidden" style={{ height: `${heightPct}%`, minHeight: 2 }}>
                   {priorityOrder.map(p => entry[p] > 0 ? (
@@ -204,7 +204,7 @@ export function IssueStatusChart({ issues }: { issues: { status: string; created
           const total = Object.values(entry).reduce((a, b) => a + b, 0);
           const heightPct = (total / maxValue) * 100;
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} issues`}>
+            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} issues (${statusOrder.filter(s => (entry[s] ?? 0) > 0).map(s => `${entry[s]} ${statusLabels[s] ?? s}`).join(", ")})`}>
               {total > 0 ? (
                 <div className="flex flex-col-reverse gap-px overflow-hidden" style={{ height: `${heightPct}%`, minHeight: 2 }}>
                   {statusOrder.map(s => (entry[s] ?? 0) > 0 ? (


### PR DESCRIPTION
## Problem

The three stacked bar charts on the Dashboard page (Run Activity, Priority, Issue Status) show colored segments but when you hover over a bar, the tooltip only show the total number. Like "2026-03-25: 5 runs" or "2026-03-25: 8 issues".

The problem is these charts use stacked colors to show different categories (green for succeeded, red for failed, etc) but you cannot see the actual numbers per category without counting pixels. The SuccessRateChart was already doing it right - showing "85% (6/7)" in the tooltip.

## What I changed

Enhanced the `title` attribute on all three chart bar containers:

**RunActivityChart:**
Before: `"2026-03-25: 5 runs"`
After: `"2026-03-25: 5 runs (3 succeeded, 2 failed)"`

**PriorityChart:**
Before: `"2026-03-25: 8 issues"`
After: `"2026-03-25: 8 issues (2 critical, 3 high, 3 medium)"`

**IssueStatusChart:**
Before: `"2026-03-25: 6 issues"`
After: `"2026-03-25: 6 issues (2 In Progress, 3 Done, 1 Blocked)"`

Only show categories that have count > 0 in the breakdown so the tooltip is not cluttered with zeros.

## How to test

1. Go to Dashboard page
2. Hover over any bar in the Run Activity chart - should see succeeded/failed/other counts
3. Hover over any bar in the Priority chart - should see breakdown by priority level
4. Hover over any bar in the Issue Status chart - should see breakdown by status name
5. SuccessRateChart should be unchanged (already had good tooltips)

1 file, 3 lines changed.