### PR TITLE
fix(a11y): org chart keyboard nav, entity row focus ring, search shortcut hint

### DIFF
--- a/ui/src/components/EntityRow.tsx
+++ b/ui/src/components/EntityRow.tsx
@@ -55,7 +55,7 @@ export function EntityRow({
 
   if (to) {
     return (
-      <Link to={to} className={cn(classes, "no-underline text-inherit")} onClick={onClick}>
+      <Link to={to} className={cn(classes, "no-underline text-inherit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1")} onClick={onClick}>
         {content}
       </Link>
     );

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -64,6 +64,8 @@ export function Sidebar() {
           size="icon-sm"
           className="text-muted-foreground shrink-0"
           onClick={openSearch}
+          title="Search (⌘K)"
+          aria-label="Search agents, issues, and projects (⌘K)"
         >
           <Search className="h-4 w-4" />
         </Button>

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -395,7 +395,9 @@ export function OrgChart() {
             <div
               key={node.id}
               data-org-card
-              className="absolute bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-foreground/20 transition-[box-shadow,border-color] duration-150 cursor-pointer select-none"
+              role="button"
+              tabIndex={0}
+              className="absolute bg-card border border-border rounded-lg shadow-sm hover:shadow-md hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 transition-[box-shadow,border-color] duration-150 cursor-pointer select-none outline-none"
               style={{
                 left: node.x,
                 top: node.y,
@@ -403,6 +405,7 @@ export function OrgChart() {
                 minHeight: CARD_H,
               }}
               onClick={() => navigate(agent ? agentUrl(agent) : `/agents/${node.id}`)}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); navigate(agent ? agentUrl(agent) : `/agents/${node.id}`); } }}
             >
               <div className="flex items-center px-4 py-3 gap-3">
                 {/* Agent icon + status dot */}


### PR DESCRIPTION
## Problem

Three separate accessibility and discoverability gaps:

### 1. OrgChart cards not keyboard accessible
The agent cards in the org chart page was rendered as `<div>` with only `onClick` handler. Keyboard users cannot tab to them or activate with Enter/Space. This is a WCAG violation - all interactive elements must be operable via keyboard.

### 2. EntityRow links have no visible focus ring
When you tab through list pages (issues list, agents list, activity feed), the currently focused EntityRow link has no visual indicator. You literally cannot see where your keyboard focus is. This make keyboard navigation impossible in practice.

### 3. Search button shows no Cmd+K hint
The search icon button in the sidebar open the CommandPalette but there is zero indication that Cmd+K shortcut exists. Most users probably never discover this feature. I used the app for weeks before I found it by accident.

## What I changed

**OrgChart.tsx:**
- Added `role="button"` and `tabIndex={0}` to card divs
- Added `onKeyDown` handler that navigate on Enter or Space
- Added `focus-visible:ring-2 focus-visible:ring-ring` for visible focus indicator
- Added `outline-none` to prevent double outline

**EntityRow.tsx:**
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1` to the Link className

**Sidebar.tsx:**
- Added `title="Search (⌘K)"` tooltip on the search button
- Added `aria-label="Search agents, issues, and projects (⌘K)"` for screen readers

## How to test

1. **OrgChart:** Go to Org page, press Tab repeatedly - cards should get blue focus ring, press Enter to navigate to agent
2. **EntityRow:** Go to Issues or Agents list page, press Tab - each row should show focus ring as you move through
3. **Search hint:** Hover over the search icon in sidebar header - should see "Search (⌘K)" tooltip

3 files, 7 lines added.