### PR TITLE
fix(ui): label costs date inputs and style comment thread empty state

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -132,7 +132,11 @@ const TimelineList = memo(function TimelineList({
   highlightCommentId?: string | null;
 }) {
   if (timeline.length === 0) {
-    return <p className="text-sm text-muted-foreground">No comments or runs yet.</p>;
+    return (
+      <div className="rounded-lg border border-dashed border-border p-6 text-center">
+        <p className="text-sm text-muted-foreground">No comments yet. Use the editor below to start the conversation.</p>
+      </div>
+    );
   }
 
   return (

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -568,6 +568,7 @@ export function Costs() {
                 value={customFrom}
                 onChange={(event) => setCustomFrom(event.target.value)}
                 className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                aria-label="Start date"
               />
               <span className="text-sm text-muted-foreground">to</span>
               <input
@@ -575,6 +576,7 @@ export function Costs() {
                 value={customTo}
                 onChange={(event) => setCustomTo(event.target.value)}
                 className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                aria-label="End date"
               />
             </div>
           ) : null}


### PR DESCRIPTION
## Problem 1: Costs page date inputs have no labels

On the Costs page, when you select "Custom" date range preset, two date picker inputs appear. But they have no `<label>` or `aria-label` at all. The only way to know which is start and which is end is by the small "to" text between them. Screen reader users hear just "date input" twice with no way to tell them apart.

Added `aria-label="Start date"` and `aria-label="End date"` to the two inputs.

## Problem 2: Comment thread empty state looks like orphan text

When opening an issue that has zero comments, the comment area show just a plain text "No comments or runs yet." as a bare `<p>` tag. It has no visual container, no border, no centering - just floating text that look like something went wrong with the layout.

Changed to a proper empty state with:
- Dashed border container (`border-dashed`) matching the visual pattern used elsewhere
- Centered text with padding
- Updated message to "No comments yet. Use the editor below to start the conversation." which actually tell user what to do next

## How to test

1. **Date labels:** Go to Costs page > select "Custom" date preset > use screen reader or inspect the input elements - should have aria-label "Start date" / "End date"
2. **Comment empty state:** Open any issue that has zero comments > the comment area should show a nice dashed-border box with centered guidance text instead of floating paragraph

2 files, 7 lines added.