### PR TITLE
docs: add inline comments to docker-compose quickstart

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -1,3 +1,11 @@
+# Quickstart: single-container Paperclip with embedded database.
+# Copy this file and set the required env vars before running.
+#
+#   cp docker-compose.quickstart.yml docker-compose.yml
+#   export BETTER_AUTH_SECRET="$(openssl rand -hex 32)"
+#   export ANTHROPIC_API_KEY="sk-ant-..."
+#   docker compose up --build
+#
 services:
   paperclip:
     build:
@@ -8,11 +16,21 @@ services:
     environment:
       HOST: "0.0.0.0"
       PAPERCLIP_HOME: "/paperclip"
+
+      # ── LLM provider keys (at least one is needed for agents to work) ──
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+
+      # ── Deployment settings ──
+      # "authenticated" requires login, "local_trusted" skips auth
       PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
+      # "private" = LAN only, "public" = internet-facing (use with TLS)
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
+      # Base URL users will access the UI at
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
+
+      # ── Required secret for session signing (generate with: openssl rand -hex 32) ──
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
     volumes:
+      # Persistent data directory (database, agent workspaces, uploads)
       - "${PAPERCLIP_DATA_DIR:-./data/docker-paperclip}:/paperclip"


### PR DESCRIPTION
## Problem

The `docker-compose.quickstart.yml` file had absolutely zero comments. Just raw YAML with environment variables that new user has to figure out on their own.

When someone want to self-host Paperclip, this is literally the first file they look at. And they see things like:
- `BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"` - what is this? How do I generate it?
- `PAPERCLIP_DEPLOYMENT_MODE: "authenticated"` - what other modes exist?
- `PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"` - what does private mean vs public?
- `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` - are both required? Or just one?

I had to read through separate documentation files to understand each variable. This should be explained right in the file where people actually look.

## What I added

1. **Header block** with step-by-step quickstart commands (copy, export, docker compose up)
2. **Section headers** grouping LLM keys, deployment settings, and secrets
3. **Inline comments** on each non-obvious variable explaining:
   - What values are valid (e.g. "authenticated" vs "local_trusted")
   - What "private" vs "public" exposure mean
   - How to generate BETTER_AUTH_SECRET with openssl command
   - What data the volume persists
4. **Note about LLM keys** clarifying at least one is needed

No functional change at all - only YAML comments added. The file parse exactly the same.

## How to verify

```bash
python3 -c "import yaml; yaml.safe_load(open('docker-compose.quickstart.yml')); print('valid')"
```

1 file, 18 comment lines added.