### PR TITLE
chore(release): publish @paperclipai/ui from release automation

### DIFF
--- a/doc/PUBLISHING.md
+++ b/doc/PUBLISHING.md
@@ -51,9 +51,8 @@ Public packages are discovered from:
 
 - `packages/`
 - `server/`
+- `ui/`
 - `cli/`
-
-`ui/` is ignored because it is private.
 
 The version rewrite step now uses [`scripts/release-package-map.mjs`](../scripts/release-package-map.mjs), which:
 
@@ -64,6 +63,18 @@ The version rewrite step now uses [`scripts/release-package-map.mjs`](../scripts
 - updates the CLI's displayed version string
 
 Those rewrites are temporary. The working tree is restored after publish or dry-run.
+
+## `@paperclipai/ui` packaging
+
+The UI package publishes prebuilt static assets, not the source workspace.
+
+The `ui` package uses [`scripts/generate-ui-package-json.mjs`](../scripts/generate-ui-package-json.mjs) during `prepack` to swap in a lean publish manifest that:
+
+- keeps the release-managed `name` and `version`
+- publishes only `dist/`
+- omits the source-only dependency graph from downstream installs
+
+After packing or publishing, `postpack` restores the development manifest automatically.
 
 ## Version formats
 
@@ -135,6 +146,7 @@ This is the fastest way to restore the default install path if a stable release 
 
 - [`scripts/build-npm.sh`](../scripts/build-npm.sh)
 - [`scripts/generate-npm-package-json.mjs`](../scripts/generate-npm-package-json.mjs)
+- [`scripts/generate-ui-package-json.mjs`](../scripts/generate-ui-package-json.mjs)
 - [`scripts/release-package-map.mjs`](../scripts/release-package-map.mjs)
 - [`cli/esbuild.config.mjs`](../cli/esbuild.config.mjs)
 - [`doc/RELEASING.md`](RELEASING.md)

--- a/doc/RELEASE-AUTOMATION-SETUP.md
+++ b/doc/RELEASE-AUTOMATION-SETUP.md
@@ -35,6 +35,7 @@ At minimum that includes:
 
 - `paperclipai`
 - `@paperclipai/server`
+- `@paperclipai/ui`
 - public packages under `packages/`
 
 ### 2.1. In npm, open each package settings page

--- a/scripts/generate-ui-package-json.mjs
+++ b/scripts/generate-ui-package-json.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const uiDir = join(repoRoot, "ui");
+const packageJsonPath = join(uiDir, "package.json");
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+
+const publishPackageJson = {
+  name: packageJson.name,
+  version: packageJson.version,
+  description: packageJson.description,
+  license: packageJson.license,
+  homepage: packageJson.homepage,
+  bugs: packageJson.bugs,
+  repository: packageJson.repository,
+  type: packageJson.type,
+  files: ["dist"],
+  publishConfig: {
+    access: "public",
+  },
+};
+
+writeFileSync(packageJsonPath, `${JSON.stringify(publishPackageJson, null, 2)}\n`);
+
+console.log("  ✓ Generated publishable UI package.json");

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,11 @@
+# @paperclipai/ui
+
+Published static assets for the Paperclip board UI.
+
+## What gets published
+
+The npm package contains the production build under `dist/`. It does not ship the UI source tree or workspace-only dependencies.
+
+## Typical use
+
+Install the package, then serve or copy the built files from `node_modules/@paperclipai/ui/dist`.

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,13 +1,29 @@
 {
   "name": "@paperclipai/ui",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.3.1",
+  "description": "Prebuilt Paperclip board UI assets.",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "ui"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../scripts/generate-ui-package-json.mjs",
+    "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
### Thinking Path

- Paperclip now has enough surface area that the published UI package needs to be handled explicitly in release automation.
- Local master had one unpublished release-automation follow-up for that, while the separate changelog commits were already present upstream under different hashes.
- This PR carries only the remaining unpublished automation change so we do not duplicate already-merged release notes.

## What changed

- Added the generated UI package metadata script used during packaging.
- Updated release/publishing docs and `ui/package.json`/`ui/README.md` so `@paperclipai/ui` is published correctly from automation.

## Why it matters

- Keeps published UI package metadata consistent and automatable.
- Avoids leaving local-master release automation work behind while keeping the PR small.

## Verification

- `pnpm -r typecheck`
- `pnpm build`

## Risks

- Low-to-moderate packaging risk: touches release automation/docs rather than runtime behavior.
