### PR TITLE
fix(server): enforce opencode_local validation across agent creation paths

### DIFF
--- a/server/src/__tests__/access-join-approval-opencode.test.ts
+++ b/server/src/__tests__/access-join-approval-opencode.test.ts
@@ -1,0 +1,145 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { unprocessable } from "../errors.js";
+import { accessRoutes } from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockAccessService = vi.hoisted(() => ({
+  hasPermission: vi.fn(),
+  canUser: vi.fn(),
+  isInstanceAdmin: vi.fn(),
+  ensureMembership: vi.fn(),
+  setPrincipalGrants: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  list: vi.fn(),
+  create: vi.fn(),
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockBoardAuthService = vi.hoisted(() => ({
+  createCliAuthChallenge: vi.fn(),
+  describeCliAuthChallenge: vi.fn(),
+  approveCliAuthChallenge: vi.fn(),
+  cancelCliAuthChallenge: vi.fn(),
+  resolveBoardAccess: vi.fn(),
+  assertCurrentBoardKey: vi.fn(),
+  revokeBoardApiKey: vi.fn(),
+}));
+
+const mockPrepareAdapterConfigForPersistence = vi.hoisted(() => vi.fn());
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockNotifyHireApproved = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  boardAuthService: () => mockBoardAuthService,
+  deduplicateAgentName: vi.fn((name: string) => name),
+  logActivity: mockLogActivity,
+  notifyHireApproved: mockNotifyHireApproved,
+  prepareAdapterConfigForPersistence: mockPrepareAdapterConfigForPersistence,
+  secretService: vi.fn(() => ({
+    normalizeAdapterConfigForPersistence: vi.fn(),
+    resolveAdapterConfigForRuntime: vi.fn(),
+  })),
+}));
+
+function createDbStub() {
+  const joinRequest = {
+    id: "request-1",
+    companyId: "company-1",
+    inviteId: "invite-1",
+    requestType: "agent",
+    status: "pending_approval",
+    agentName: "OpenCode Agent",
+    adapterType: "opencode_local",
+    capabilities: null,
+    agentDefaultsPayload: {},
+    createdAgentId: null,
+  };
+  const invite = {
+    id: "invite-1",
+    companyId: "company-1",
+    defaultsPayload: null,
+  };
+  const approved = {
+    ...joinRequest,
+    status: "approved",
+    createdAgentId: "agent-created",
+  };
+
+  const selectWhere = vi
+    .fn()
+    .mockResolvedValueOnce([joinRequest])
+    .mockResolvedValueOnce([invite]);
+  const from = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from }));
+
+  const returning = vi.fn().mockResolvedValue([approved]);
+  const updateWhere = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set }));
+
+  return { select, update };
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes(createDbStub() as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("join approval opencode_local validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalGrants.mockResolvedValue(undefined);
+    mockAgentService.list.mockResolvedValue([
+      { id: "ceo-1", role: "ceo", reportsTo: null, name: "CEO", status: "idle" },
+    ]);
+    mockAgentService.create.mockResolvedValue({ id: "agent-created" });
+    mockPrepareAdapterConfigForPersistence.mockImplementation(async ({ adapterConfig }: { adapterConfig: Record<string, unknown> }) => adapterConfig);
+  });
+
+  it("rejects join approval when opencode_local model is missing", async () => {
+    mockPrepareAdapterConfigForPersistence.mockRejectedValueOnce(
+      unprocessable("OpenCode requires an explicit model in provider/model format."),
+    );
+
+    const res = await request(createApp()).post(
+      "/api/companies/company-1/join-requests/request-1/approve",
+    );
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain(
+      "OpenCode requires an explicit model in provider/model format.",
+    );
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/agent-adapter-config.test.ts
+++ b/server/src/__tests__/agent-adapter-config.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEnsureOpenCodeModelConfiguredAndAvailable = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/adapter-opencode-local/server", () => ({
+  ensureOpenCodeModelConfiguredAndAvailable: mockEnsureOpenCodeModelConfiguredAndAvailable,
+}));
+
+const { prepareAdapterConfigForPersistence } = await import("../services/agent-adapter-config.js");
+
+describe("agent adapter config validation", () => {
+  const secretsSvc = {
+    normalizeAdapterConfigForPersistence: vi.fn(),
+    resolveAdapterConfigForRuntime: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects opencode_local configs without an explicit provider/model", async () => {
+    secretsSvc.normalizeAdapterConfigForPersistence.mockResolvedValue({});
+    secretsSvc.resolveAdapterConfigForRuntime.mockResolvedValue({ config: {} });
+
+    await expect(
+      prepareAdapterConfigForPersistence({
+        companyId: "company-1",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+        strictMode: false,
+        secretsSvc,
+      }),
+    ).rejects.toThrow("OpenCode requires an explicit model in provider/model format.");
+
+    expect(mockEnsureOpenCodeModelConfiguredAndAvailable).not.toHaveBeenCalled();
+  });
+
+  it("passes through normalized opencode_local config when the model is available", async () => {
+    secretsSvc.normalizeAdapterConfigForPersistence.mockResolvedValue({
+      model: "openai/gpt-5-codex",
+    });
+    secretsSvc.resolveAdapterConfigForRuntime.mockResolvedValue({
+      config: {
+        model: "openai/gpt-5-codex",
+        command: "opencode",
+        cwd: "/tmp/workspace",
+        env: {},
+      },
+    });
+    mockEnsureOpenCodeModelConfiguredAndAvailable.mockResolvedValue([]);
+
+    const result = await prepareAdapterConfigForPersistence({
+      companyId: "company-1",
+      adapterType: "opencode_local",
+      adapterConfig: {},
+      strictMode: false,
+      secretsSvc,
+    });
+
+    expect(result).toEqual({ model: "openai/gpt-5-codex" });
+    expect(mockEnsureOpenCodeModelConfiguredAndAvailable).toHaveBeenCalledWith({
+      model: "openai/gpt-5-codex",
+      command: "opencode",
+      cwd: "/tmp/workspace",
+      env: {},
+    });
+  });
+});

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -8,6 +8,7 @@ const mockAgentService = vi.hoisted(() => ({
 }));
 
 const mockNotifyHireApproved = vi.hoisted(() => vi.fn());
+const mockPrepareAdapterConfigForPersistence = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/agents.js", () => ({
   agentService: vi.fn(() => mockAgentService),
@@ -15,6 +16,17 @@ vi.mock("../services/agents.js", () => ({
 
 vi.mock("../services/hire-hook.js", () => ({
   notifyHireApproved: mockNotifyHireApproved,
+}));
+
+vi.mock("../services/agent-adapter-config.js", () => ({
+  prepareAdapterConfigForPersistence: mockPrepareAdapterConfigForPersistence,
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: vi.fn(() => ({
+    normalizeAdapterConfigForPersistence: vi.fn(),
+    resolveAdapterConfigForRuntime: vi.fn(),
+  })),
 }));
 
 type ApprovalRecord = {
@@ -58,6 +70,9 @@ function createDbStub(selectResults: ApprovalRecord[][], updateResults: Approval
 describe("approvalService resolution idempotency", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrepareAdapterConfigForPersistence.mockImplementation(
+      async ({ adapterConfig }: { adapterConfig: Record<string, unknown> }) => adapterConfig,
+    );
     mockAgentService.activatePendingApproval.mockResolvedValue(undefined);
     mockAgentService.create.mockResolvedValue({ id: "agent-1" });
     mockAgentService.terminate.mockResolvedValue(undefined);
@@ -95,7 +110,7 @@ describe("approvalService resolution idempotency", () => {
 
   it("still performs side effects when the resolution update is newly applied", async () => {
     const approved = createApproval("approved");
-    const dbStub = createDbStub([[createApproval("pending")]], [approved]);
+    const dbStub = createDbStub([[createApproval("pending")], [createApproval("pending")]], [approved]);
 
     const svc = approvalService(dbStub.db as any);
     const result = await svc.approve("approval-1", "board", "ship it");
@@ -103,5 +118,51 @@ describe("approvalService resolution idempotency", () => {
     expect(result.applied).toBe(true);
     expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1");
     expect(mockNotifyHireApproved).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects approval-created opencode_local agents without model", async () => {
+    const pending = createApproval("pending");
+    pending.payload = {
+      name: "OpenCode Agent",
+      role: "general",
+      adapterType: "opencode_local",
+      adapterConfig: {},
+    };
+    const approved = { ...pending, status: "approved" };
+    const dbStub = createDbStub([[pending]], [approved]);
+    mockPrepareAdapterConfigForPersistence.mockRejectedValueOnce(
+      new Error("OpenCode requires an explicit model in provider/model format."),
+    );
+
+    const svc = approvalService(dbStub.db as any);
+
+    await expect(svc.approve("approval-1", "board", "ship it")).rejects.toThrow(
+      "OpenCode requires an explicit model in provider/model format.",
+    );
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps repeated approve retries as no-ops for already-approved opencode_local hires", async () => {
+    const approved = createApproval("approved");
+    approved.payload = {
+      name: "OpenCode Agent",
+      role: "general",
+      adapterType: "opencode_local",
+      adapterConfig: {},
+    };
+    const dbStub = createDbStub([[approved], [approved]], []);
+    mockPrepareAdapterConfigForPersistence.mockRejectedValueOnce(
+      new Error("OpenCode requires an explicit model in provider/model format."),
+    );
+
+    const svc = approvalService(dbStub.db as any);
+    const result = await svc.approve("approval-1", "board", "ship it");
+
+    expect(result.applied).toBe(false);
+    expect(result.approval.status).toBe("approved");
+    expect(mockPrepareAdapterConfigForPersistence).not.toHaveBeenCalled();
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+    expect(mockAgentService.activatePendingApproval).not.toHaveBeenCalled();
+    expect(mockNotifyHireApproved).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/cli-auth-routes.test.ts
+++ b/server/src/__tests__/cli-auth-routes.test.ts
@@ -25,14 +25,18 @@ const mockBoardAuthService = vi.hoisted(() => ({
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
-vi.mock("../services/index.js", () => ({
-  accessService: () => mockAccessService,
-  agentService: () => mockAgentService,
-  boardAuthService: () => mockBoardAuthService,
-  logActivity: mockLogActivity,
-  notifyHireApproved: vi.fn(),
-  deduplicateAgentName: vi.fn((name: string) => name),
-}));
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    boardAuthService: () => mockBoardAuthService,
+    logActivity: mockLogActivity,
+    notifyHireApproved: vi.fn(),
+    deduplicateAgentName: vi.fn((name: string) => name),
+  };
+});
 
 function createApp(actor: any) {
   const app = express();

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -64,6 +64,8 @@ const agentInstructionsSvc = {
   materializeManagedBundle: vi.fn(),
 };
 
+const mockPrepareAdapterConfigForPersistence = vi.hoisted(() => vi.fn());
+
 vi.mock("../services/companies.js", () => ({
   companyService: () => companySvc,
 }));
@@ -100,6 +102,17 @@ vi.mock("../services/agent-instructions.js", () => ({
   agentInstructionsService: () => agentInstructionsSvc,
 }));
 
+vi.mock("../services/agent-adapter-config.js", () => ({
+  prepareAdapterConfigForPersistence: mockPrepareAdapterConfigForPersistence,
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: vi.fn(() => ({
+    normalizeAdapterConfigForPersistence: vi.fn(),
+    resolveAdapterConfigForRuntime: vi.fn(),
+  })),
+}));
+
 vi.mock("../routes/org-chart-svg.js", () => ({
   renderOrgChartPng: vi.fn(async () => Buffer.from("png")),
 }));
@@ -117,6 +130,9 @@ describe("company portability", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrepareAdapterConfigForPersistence.mockImplementation(
+      async ({ adapterConfig }: { adapterConfig: Record<string, unknown> }) => adapterConfig,
+    );
     companySvc.getById.mockResolvedValue({
       id: "company-1",
       name: "Paperclip",
@@ -2183,5 +2199,77 @@ describe("company portability", () => {
     expect(nestedMaterializedFiles?.["AGENTS.md"]).toContain("You are ClaudeCoder.");
     expect(nestedMaterializedFiles?.["AGENTS.md"]).not.toMatch(/^---\n/);
     expect(nestedMaterializedFiles?.["AGENTS.md"]).not.toContain('name: "ClaudeCoder"');
+  });
+
+  it("warns and skips opencode_local imports without an explicit model", async () => {
+    const portability = companyPortabilityService({} as any);
+
+    companySvc.create.mockResolvedValue({
+      id: "company-imported",
+      name: "Imported Paperclip",
+    });
+    agentSvc.list.mockResolvedValue([]);
+    mockPrepareAdapterConfigForPersistence.mockRejectedValueOnce(
+      new Error("OpenCode requires an explicit model in provider/model format."),
+    );
+
+    const result = await portability.importBundle({
+      source: {
+        type: "inline",
+        rootPath: "paperclip-demo",
+        files: {
+          "COMPANY.md": [
+            "---",
+            'schema: "agentcompanies/v1"',
+            'name: "Imported Paperclip"',
+            "---",
+            "",
+          ].join("\n"),
+          "agents/opencode-agent/AGENTS.md": [
+            "---",
+            'name: "OpenCode Agent"',
+            "---",
+            "",
+            "Run OpenCode locally.",
+            "",
+          ].join("\n"),
+        },
+      },
+      include: {
+        company: true,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+      target: {
+        mode: "new_company",
+        newCompanyName: "Imported Paperclip",
+      },
+      agents: "all",
+      collisionStrategy: "rename",
+      adapterOverrides: {
+        "opencode-agent": {
+          adapterType: "opencode_local",
+          adapterConfig: {},
+        },
+      },
+    }, "user-1");
+
+    expect(result.company).toEqual({
+      id: "company-imported",
+      name: "Imported Paperclip",
+      action: "created",
+    });
+    expect(result.warnings).toContain(
+      "Skipped agent opencode-agent: invalid adapter config (OpenCode requires an explicit model in provider/model format.)",
+    );
+    expect(result.agents).toContainEqual({
+      slug: "opencode-agent",
+      id: null,
+      action: "skipped",
+      name: "OpenCode Agent",
+      reason: "Invalid adapter config.",
+    });
+    expect(agentSvc.create).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/openclaw-invite-prompt-route.test.ts
+++ b/server/src/__tests__/openclaw-invite-prompt-route.test.ts
@@ -36,14 +36,18 @@ const mockBoardAuthService = vi.hoisted(() => ({
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
-vi.mock("../services/index.js", () => ({
-  accessService: () => mockAccessService,
-  agentService: () => mockAgentService,
-  boardAuthService: () => mockBoardAuthService,
-  deduplicateAgentName: vi.fn(),
-  logActivity: mockLogActivity,
-  notifyHireApproved: vi.fn(),
-}));
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    boardAuthService: () => mockBoardAuthService,
+    deduplicateAgentName: vi.fn(),
+    logActivity: mockLogActivity,
+    notifyHireApproved: vi.fn(),
+  };
+});
 
 function createDbStub() {
   const createdInvite = {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -46,6 +46,8 @@ import {
   boardAuthService,
   deduplicateAgentName,
   logActivity,
+  prepareAdapterConfigForPersistence,
+  secretService,
   notifyHireApproved
 } from "../services/index.js";
 import { assertCompanyAccess } from "./authz.js";
@@ -1579,6 +1581,8 @@ export function accessRoutes(
   const access = accessService(db);
   const boardAuth = boardAuthService(db);
   const agents = agentService(db);
+  const secrets = secretService(db);
+  const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
   async function assertInstanceAdmin(req: Request) {
     if (req.actor.type !== "board") throw unauthorized();
@@ -2661,6 +2665,18 @@ export function accessRoutes(
             status: a.status
           }))
         );
+        const adapterType = existing.adapterType ?? "process";
+        const normalizedAdapterConfig = await prepareAdapterConfigForPersistence({
+          companyId,
+          adapterType,
+          adapterConfig:
+            existing.agentDefaultsPayload &&
+            typeof existing.agentDefaultsPayload === "object"
+              ? (existing.agentDefaultsPayload as Record<string, unknown>)
+              : {},
+          strictMode: strictSecretsMode,
+          secretsSvc: secrets,
+        });
 
         const created = await agents.create(companyId, {
           name: agentName,
@@ -2669,12 +2685,8 @@ export function accessRoutes(
           status: "idle",
           reportsTo: managerId,
           capabilities: existing.capabilities ?? null,
-          adapterType: existing.adapterType ?? "process",
-          adapterConfig:
-            existing.agentDefaultsPayload &&
-            typeof existing.agentDefaultsPayload === "object"
-              ? (existing.agentDefaultsPayload as Record<string, unknown>)
-              : {},
+          adapterType,
+          adapterConfig: normalizedAdapterConfig,
           runtimeConfig: {},
           budgetMonthlyCents: 0,
           spentMonthlyCents: 0,

--- a/server/src/services/agent-adapter-config.ts
+++ b/server/src/services/agent-adapter-config.ts
@@ -1,0 +1,137 @@
+import { generateKeyPairSync } from "node:crypto";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { ensureOpenCodeModelConfiguredAndAvailable } from "@paperclipai/adapter-opencode-local/server";
+import { unprocessable } from "../errors.js";
+
+export type AdapterConfigSecretsService = {
+  normalizeAdapterConfigForPersistence(
+    companyId: string,
+    adapterConfig: Record<string, unknown>,
+    options: { strictMode: boolean },
+  ): Promise<Record<string, unknown>>;
+  resolveAdapterConfigForRuntime(
+    companyId: string,
+    adapterConfig: Record<string, unknown>,
+  ): Promise<{ config: Record<string, unknown> }>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseBooleanLike(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return null;
+  }
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  if (["false", "0", "no", "off"].includes(normalized)) return false;
+  return null;
+}
+
+function generateEd25519PrivateKeyPem(): string {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+}
+
+function ensureGatewayDeviceKey(
+  adapterType: string | null | undefined,
+  adapterConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  if (adapterType !== "openclaw_gateway") return adapterConfig;
+  const disableDeviceAuth = parseBooleanLike(adapterConfig.disableDeviceAuth) === true;
+  if (disableDeviceAuth) return adapterConfig;
+  if (asNonEmptyString(adapterConfig.devicePrivateKeyPem)) return adapterConfig;
+  return { ...adapterConfig, devicePrivateKeyPem: generateEd25519PrivateKeyPem() };
+}
+
+export function applyCreateDefaultsByAdapterType(
+  adapterType: string | null | undefined,
+  adapterConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = { ...adapterConfig };
+  if (adapterType === "codex_local") {
+    if (!asNonEmptyString(next.model)) {
+      next.model = DEFAULT_CODEX_LOCAL_MODEL;
+    }
+    const hasBypassFlag =
+      typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean"
+      || typeof next.dangerouslyBypassSandbox === "boolean";
+    if (!hasBypassFlag) {
+      next.dangerouslyBypassApprovalsAndSandbox = DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+    }
+    return ensureGatewayDeviceKey(adapterType, next);
+  }
+  if (adapterType === "gemini_local" && !asNonEmptyString(next.model)) {
+    next.model = DEFAULT_GEMINI_LOCAL_MODEL;
+    return ensureGatewayDeviceKey(adapterType, next);
+  }
+  if (adapterType === "cursor" && !asNonEmptyString(next.model)) {
+    next.model = DEFAULT_CURSOR_LOCAL_MODEL;
+  }
+  return ensureGatewayDeviceKey(adapterType, next);
+}
+
+export async function assertAdapterConfigConstraints(
+  companyId: string,
+  adapterType: string | null | undefined,
+  adapterConfig: Record<string, unknown>,
+  secretsSvc: AdapterConfigSecretsService,
+) {
+  if (adapterType !== "opencode_local") return;
+  const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(companyId, adapterConfig);
+  const runtimeEnv = asRecord(runtimeConfig.env) ?? {};
+  const configuredModel = asNonEmptyString(runtimeConfig.model);
+  if (!configuredModel || !configuredModel.includes("/")) {
+    throw unprocessable("OpenCode requires an explicit model in provider/model format.");
+  }
+  try {
+    await ensureOpenCodeModelConfiguredAndAvailable({
+      model: configuredModel,
+      command: runtimeConfig.command,
+      cwd: runtimeConfig.cwd,
+      env: runtimeEnv,
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+  }
+}
+
+export async function prepareAdapterConfigForPersistence(input: {
+  companyId: string;
+  adapterType: string | null | undefined;
+  adapterConfig: Record<string, unknown>;
+  strictMode: boolean;
+  secretsSvc: AdapterConfigSecretsService;
+}): Promise<Record<string, unknown>> {
+  const withDefaults = applyCreateDefaultsByAdapterType(input.adapterType, input.adapterConfig);
+  const normalized = await input.secretsSvc.normalizeAdapterConfigForPersistence(
+    input.companyId,
+    withDefaults,
+    { strictMode: input.strictMode },
+  );
+  await assertAdapterConfigConstraints(
+    input.companyId,
+    input.adapterType,
+    normalized,
+    input.secretsSvc,
+  );
+  return normalized;
+}

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -3,15 +3,19 @@ import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { redactCurrentUserText } from "../log-redaction.js";
+import { prepareAdapterConfigForPersistence } from "./agent-adapter-config.js";
 import { agentService } from "./agents.js";
 import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
+import { secretService } from "./secrets.js";
 
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
   const budgets = budgetService(db);
   const instanceSettings = instanceSettingsService(db);
+  const secrets = secretService(db);
+  const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
   const canResolveStatuses = new Set(["pending", "revision_requested"]);
   const resolvableStatuses = Array.from(canResolveStatuses);
   type ApprovalRecord = typeof approvals.$inferSelect;
@@ -100,6 +104,26 @@ export function approvalService(db: Db) {
         .then((rows) => rows[0]),
 
     approve: async (id: string, decidedByUserId: string, decisionNote?: string | null) => {
+      const existing = await getExistingApproval(id);
+      let prevalidatedAdapterConfig: Record<string, unknown> | null = null;
+      if (canResolveStatuses.has(existing.status) && existing.type === "hire_agent") {
+        const payload = existing.payload as Record<string, unknown>;
+        const payloadAgentId = typeof payload.agentId === "string" ? payload.agentId : null;
+        if (!payloadAgentId) {
+          const adapterType = String(payload.adapterType ?? "process");
+          prevalidatedAdapterConfig = await prepareAdapterConfigForPersistence({
+            companyId: existing.companyId,
+            adapterType,
+            adapterConfig:
+              typeof payload.adapterConfig === "object" && payload.adapterConfig !== null
+                ? (payload.adapterConfig as Record<string, unknown>)
+                : {},
+            strictMode: strictSecretsMode,
+            secretsSvc: secrets,
+          });
+        }
+      }
+
       const { approval: updated, applied } = await resolveApproval(
         id,
         "approved",
@@ -116,17 +140,26 @@ export function approvalService(db: Db) {
           await agentsSvc.activatePendingApproval(payloadAgentId);
           hireApprovedAgentId = payloadAgentId;
         } else {
+          const adapterType = String(payload.adapterType ?? "process");
+          const normalizedAdapterConfig = prevalidatedAdapterConfig
+            ?? await prepareAdapterConfigForPersistence({
+              companyId: updated.companyId,
+              adapterType,
+              adapterConfig:
+                typeof payload.adapterConfig === "object" && payload.adapterConfig !== null
+                  ? (payload.adapterConfig as Record<string, unknown>)
+                  : {},
+              strictMode: strictSecretsMode,
+              secretsSvc: secrets,
+            });
           const created = await agentsSvc.create(updated.companyId, {
             name: String(payload.name ?? "New Agent"),
             role: String(payload.role ?? "general"),
             title: typeof payload.title === "string" ? payload.title : null,
             reportsTo: typeof payload.reportsTo === "string" ? payload.reportsTo : null,
             capabilities: typeof payload.capabilities === "string" ? payload.capabilities : null,
-            adapterType: String(payload.adapterType ?? "process"),
-            adapterConfig:
-              typeof payload.adapterConfig === "object" && payload.adapterConfig !== null
-                ? (payload.adapterConfig as Record<string, unknown>)
-                : {},
+            adapterType,
+            adapterConfig: normalizedAdapterConfig,
             budgetMonthlyCents:
               typeof payload.budgetMonthlyCents === "number" ? payload.budgetMonthlyCents : 0,
             metadata:

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -48,6 +48,7 @@ import {
 import { notFound, unprocessable } from "../errors.js";
 import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
+import { prepareAdapterConfigForPersistence } from "./agent-adapter-config.js";
 import { accessService } from "./access.js";
 import { agentService } from "./agents.js";
 import { agentInstructionsService } from "./agent-instructions.js";
@@ -60,6 +61,7 @@ import { validateCron } from "./cron.js";
 import { issueService } from "./issues.js";
 import { projectService } from "./projects.js";
 import { routineService } from "./routines.js";
+import { secretService } from "./secrets.js";
 
 /** Build OrgNode tree from manifest agent list (slug + reportsToSlug). */
 function buildOrgTreeFromManifest(agents: CompanyPortabilityManifest["agents"]): OrgNode[] {
@@ -2667,9 +2669,11 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
   const assetRecords = assetService(db);
   const instructions = agentInstructionsService();
   const access = accessService(db);
+  const secrets = secretService(db);
   const projects = projectService(db);
   const issues = issueService(db);
   const companySkills = companySkillService(db);
+  const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
   async function resolveSource(source: CompanyPortabilityPreview["source"]): Promise<ResolvedSource> {
     if (source.type === "inline") {
@@ -3970,6 +3974,27 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
         delete adapterConfigWithSkills.instructionsBundleMode;
         delete adapterConfigWithSkills.instructionsRootPath;
         delete adapterConfigWithSkills.instructionsEntryFile;
+        let normalizedAdapterConfig: Record<string, unknown>;
+        try {
+          normalizedAdapterConfig = await prepareAdapterConfigForPersistence({
+            companyId: targetCompany.id,
+            adapterType: effectiveAdapterType,
+            adapterConfig: adapterConfigWithSkills,
+            strictMode: strictSecretsMode,
+            secretsSvc: secrets,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          warnings.push(`Skipped agent ${manifestAgent.slug}: invalid adapter config (${reason})`);
+          resultAgents.push({
+            slug: planAgent.slug,
+            id: null,
+            action: "skipped",
+            name: planAgent.plannedName,
+            reason: "Invalid adapter config.",
+          });
+          continue;
+        }
         const patch = {
           name: planAgent.plannedName,
           role: manifestAgent.role,
@@ -3978,7 +4003,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           capabilities: manifestAgent.capabilities,
           reportsTo: null,
           adapterType: effectiveAdapterType,
-          adapterConfig: adapterConfigWithSkills,
+          adapterConfig: normalizedAdapterConfig,
           runtimeConfig: disableImportedTimerHeartbeat(manifestAgent.runtimeConfig),
           budgetMonthlyCents: manifestAgent.budgetMonthlyCents,
           permissions: manifestAgent.permissions,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -11,6 +11,11 @@ export { issueApprovalService } from "./issue-approvals.js";
 export { goalService } from "./goals.js";
 export { activityService, type ActivityFilters } from "./activity.js";
 export { approvalService } from "./approvals.js";
+export {
+  applyCreateDefaultsByAdapterType,
+  assertAdapterConfigConstraints,
+  prepareAdapterConfigForPersistence,
+} from "./agent-adapter-config.js";
 export { budgetService } from "./budgets.js";
 export { secretService } from "./secrets.js";
 export { routineService } from "./routines.js";


### PR DESCRIPTION
## What Changed

- Added `server/src/services/agent-adapter-config.ts` to centralize adapter create/update defaults, secrets normalization, and explicit `opencode_local` validation.
- Reused the shared helper in `routes/agents.ts`, `routes/access.ts`, `services/company-portability.ts`, and `services/approvals.ts` so join approvals, imports, and approval-created hires no longer bypass the stronger validation.
- Made manual `hire_agent` approval resolution pre-validate adapter config before writing `approved`, so invalid OpenCode payloads do not leave approvals in a half-complete state.
- Added direct helper coverage plus regression tests for join approval, import, approval-created hires, and the unchanged environment-test behavior when model discovery succeeds without an explicit model.
- Updated the board-operator guide to note that the explicit `opencode_local` model requirement now applies across direct creation, governed hires, imports, and approved joins.

## Verification

- `pnpm -r typecheck` ✅
- `pnpm build` ✅
- `pnpm exec vitest run server/src/__tests__/agent-adapter-config.test.ts server/src/__tests__/approvals-service.test.ts server/src/__tests__/company-portability.test.ts server/src/__tests__/access-join-approval-opencode.test.ts server/src/__tests__/opencode-local-adapter-environment.test.ts server/src/__tests__/openclaw-invite-prompt-route.test.ts server/src/__tests__/cli-auth-routes.test.ts server/src/__tests__/agent-skills-routes.test.ts server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/agent-instructions-routes.test.ts` ✅ (10 files / 66 tests)
- `pnpm test:run` ❌ hits pre-existing unrelated failures in plugin-sdk-backed suites and `packages/db/src/client.test.ts` migration timeouts; these failures were reproduced after the fix but are outside this change scope.

## Risks

- Low risk for the targeted bug: this change narrows previously inconsistent agent materialization paths onto the same validation helper already implied by the direct agent routes.
- Approval creation/resubmission still accepts generic payloads and relies on approve-time validation; this PR intentionally fixes the persistence/materialization inconsistency without redesigning the broader approval workflow.
- Full `pnpm test:run` still has unrelated repo baseline failures, which should be considered separately from this PR.

## Checklist

- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
