### PR TITLE
fix(ui): better empty states for command palette search and routine run history

### DIFF
--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -111,7 +111,10 @@ export function CommandPalette() {
         onValueChange={setQuery}
       />
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandEmpty>
+          <p className="text-sm">No results found</p>
+          <p className="text-xs text-muted-foreground/60 mt-1">Try searching for issues, agents, or projects by name</p>
+        </CommandEmpty>
 
         <CommandGroup heading="Actions">
           <CommandItem

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -962,7 +962,10 @@ export function RoutineDetail() {
             <LiveRunWidget issueId={activeIssueId} companyId={routine.companyId} />
           )}
           {(routineRuns ?? []).length === 0 ? (
-            <p className="text-xs text-muted-foreground">No runs yet.</p>
+            <div className="rounded-lg border border-dashed border-border p-8 text-center">
+              <p className="text-sm text-muted-foreground">No runs yet</p>
+              <p className="text-xs text-muted-foreground/60 mt-1">Runs will appear here when triggered by a schedule or webhook</p>
+            </div>
           ) : (
             <div className="border border-border rounded-lg divide-y divide-border">
               {(routineRuns ?? []).map((run) => (


### PR DESCRIPTION
## Problem 1: Command palette dead end

When you open the command palette (Cmd+K) and type something that return no results, you see just "No results found." and nothing else. The user is stuck - they don't know if they mistyped something or if they searching for the wrong thing. There is no guidance about what categories you can search (issues, agents, projects).

Added a small hint line below the message: "Try searching for issues, agents, or projects by name". This help specially new users who are still learning what the command palette can do.

## Problem 2: Routine run history empty state inconsistent

The run history tab in routine detail page was showing plain text "No runs yet." as a bare `<p>` tag with no visual container. Compare this to other empty states in the app (like the comment thread empty state we fix before, or the kanban column empty state) which have proper border boxes and centered layout.

Changed to a dashed-border container with centered text and added explanation "Runs will appear here when triggered by a schedule or webhook" so new users understand how runs get created.

## How to test

1. **Command palette:** Press Cmd+K, type something random like "xyzabc" - should see "No results found" with "Try searching for issues, agents, or projects by name" below it
2. **Routine run history:** Open any routine that has no runs yet > go to Runs tab > should see a proper bordered empty state instead of plain text

2 files, 8 lines added.