### PR TITLE
Fix OpenClaw gateway default adapter scopes

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -26,7 +26,7 @@ Gateway connect identity fields:
 - clientMode (string, optional): gateway client mode (default backend)
 - clientVersion (string, optional): client version string
 - role (string, optional): gateway role (default operator)
-- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin", "operator.approvals", "operator.pairing", "operator.read", "operator.write"])
+- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin", "operator.pairing", "operator.read", "operator.write"])
 - disableDeviceAuth (boolean, optional): disable signed device payload in connect params (default false)
 
 Request behavior fields:

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -26,7 +26,7 @@ Gateway connect identity fields:
 - clientMode (string, optional): gateway client mode (default backend)
 - clientVersion (string, optional): client version string
 - role (string, optional): gateway role (default operator)
-- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin"])
+- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin", "operator.approvals", "operator.pairing", "operator.read", "operator.write"])
 - disableDeviceAuth (boolean, optional): disable signed device payload in connect params (default false)
 
 Request behavior fields:

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -79,7 +79,7 @@ type GatewayClientRequestOptions = {
 };
 
 const PROTOCOL_VERSION = 3;
-const DEFAULT_SCOPES = ["operator.admin"];
+const DEFAULT_SCOPES = ["operator.admin", "operator.approvals", "operator.pairing", "operator.read", "operator.write"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -79,7 +79,7 @@ type GatewayClientRequestOptions = {
 };
 
 const PROTOCOL_VERSION = 3;
-const DEFAULT_SCOPES = ["operator.admin", "operator.approvals", "operator.pairing", "operator.read", "operator.write"];
+const DEFAULT_SCOPES = ["operator.admin", "operator.pairing", "operator.read", "operator.write"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";


### PR DESCRIPTION
## Summary
- expand the OpenClaw gateway adapter's fallback scopes so agents without explicit `adapterConfig.scopes` still satisfy current gateway requirements
- keep the documented default in sync with the runtime default

## Thinking path
Paperclip delegates work to external adapters; the OpenClaw gateway adapter is the adapter responsible for connecting Paperclip agents to OpenClaw operator/device APIs. When an agent omits explicit `adapterConfig.scopes`, the adapter falls back to its runtime default scopes. That default must cover the gateway operations the adapter performs during first connection and normal run execution, so this PR narrows the fix to the OpenClaw gateway fallback and its matching documentation.

## Root cause
The adapter fell back to `['operator.admin']` when `adapterConfig.scopes` was omitted. Current gateway agent operations require `operator.write`, so agents using the default fallback failed at runtime with `missing scope: operator.write`.

## Scope choice
The fallback now defaults to:
- `operator.admin`
- `operator.pairing`
- `operator.read`
- `operator.write`

`operator.pairing` remains in the default set because this adapter enables `autoPairOnFirstConnect` by default and uses `device.pair.list` / `device.pair.approve` during first-connect recovery. `operator.approvals` was removed because this adapter does not currently require it.

## Regression risk
Low. This only affects the fallback scope list used when `adapterConfig.scopes` is not explicitly set. Configurations that already provide `scopes` are unchanged.

## Verification
- `PATH=/usr/local/bin:$PATH pnpm --filter @paperclipai/adapter-openclaw-gateway build`
