### PR TITLE
fix: add missing ignore fields to pino file transport to prevent OOM

### DIFF
--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -37,7 +37,7 @@ export const logger = pino({
     },
     {
       target: "pino-pretty",
-      options: { ...sharedOpts, colorize: false, destination: logFile, mkdir: true },
+      options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: false, destination: logFile, mkdir: true },
       level: "debug",
     },
   ],


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The server uses pino with pino-pretty for structured logging to both stdout and a file
> - The stdout transport correctly ignores `req,res,responseTime` fields to avoid serializing large HTTP request/response objects
> - But the file transport was missing the same `ignore` option
> - Every HTTP request serialized full `req` and `res` objects (~1.5KB each) into the file transport's pino-pretty ThreadStream buffer
> - With multiple agents heartbeating and UI polling, the buffer grew without bound
> - The server OOMed every ~60 minutes, causing 32+ restarts per day
> - This one-line fix adds the same `ignore` option to the file transport, matching stdout

## What changed

Added `ignore: "pid,hostname,req,res,responseTime"` to the file transport target options in `server/src/middleware/logger.ts`, matching what the stdout transport already had.

**Before:**
```ts
// stdout — ignores large objects ✅
{ target: "pino-pretty", options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: true, destination: 1 }, level: "info" },
// file — does NOT ignore them ❌
{ target: "pino-pretty", options: { ...sharedOpts, colorize: false, destination: logFile, mkdir: true }, level: "debug" },
```

**After:**
```ts
// stdout — ignores large objects ✅
{ target: "pino-pretty", options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: true, destination: 1 }, level: "info" },
// file — now also ignores them ✅
{ target: "pino-pretty", options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: false, destination: logFile, mkdir: true }, level: "debug" },
```

## Why it matters

Servers were crashing every ~60 minutes due to unbounded memory growth in the pino-pretty ThreadStream buffer. This caused agent disconnections ("process lost — server may have restarted") and required systemd to restart the process 32+ times per day.

## Test plan

- [x] No existing logger tests to regress
- [x] Full test suite passes (same pre-existing UI/e2e infra failures only)
- [x] Config-level fix — the ignore field is a standard pino-pretty option

Fixes #1825