### PR TITLE
fix(ui): explain estimated cost badges with hover tooltip

### DIFF
--- a/ui/src/components/FinanceBillerCard.tsx
+++ b/ui/src/components/FinanceBillerCard.tsx
@@ -34,7 +34,7 @@ export function FinanceBillerCard({ row }: FinanceBillerCardProps) {
             <div className="mt-1 font-medium tabular-nums">{formatCents(row.creditCents)}</div>
           </div>
           <div className="border border-border p-3">
-            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">estimated</div>
+            <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground cursor-help" title="Estimated cost based on token usage. Final amount may differ once provider invoice is processed.">estimated</div>
             <div className="mt-1 font-medium tabular-nums">{formatCents(row.estimatedDebitCents)}</div>
           </div>
         </div>

--- a/ui/src/components/FinanceTimelineCard.tsx
+++ b/ui/src/components/FinanceTimelineCard.tsx
@@ -59,7 +59,7 @@ export function FinanceTimelineCard({
                 <div className="text-right tabular-nums">
                   <div className="text-sm font-semibold">{formatCents(row.amountCents)}</div>
                   <div className="text-xs text-muted-foreground">{row.currency}</div>
-                  {row.estimated ? <div className="text-[11px] uppercase tracking-[0.12em] text-amber-600">estimated</div> : null}
+                  {row.estimated ? <div className="text-[11px] uppercase tracking-[0.12em] text-amber-600 cursor-help" title="This cost is estimated based on token usage. Final amount may differ once the provider invoice is processed.">estimated</div> : null}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Problem

In the finance section, some costs show an amber "ESTIMATED" label but there is no explanation what this word mean. I was looking at the cost breakdown page and see some items marked estimated and some not, and I had no idea why. Is it a warning? Is the money already charged? Will the number change later?

The Costs page MetricCard already have a subtitle that say "Estimated debits that are not yet invoice-authoritative" but the individual finance event cards and biller summary card don't explain it at all.

## What I changed

Added `title` tooltip to the "estimated" text in two components:

**FinanceTimelineCard.tsx** (per-event "ESTIMATED" badge):
- Tooltip: "This cost is estimated based on token usage. Final amount may differ once the provider invoice is processed."
- Added `cursor-help` class so mouse cursor hint that tooltip is available

**FinanceBillerCard.tsx** (section header "estimated"):
- Tooltip: "Estimated cost based on token usage. Final amount may differ once provider invoice is processed."
- Added `cursor-help` class

## How to test

1. Go to Costs page > scroll down to Finance timeline or click on a biller card
2. Find any entry or section with amber "estimated" label
3. Hover over the word - should see tooltip explaining what it mean

2 files, 2 lines changed (inline attribute additions).