### PR TITLE
fix: reject in_review without assignee

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -217,3 +217,51 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([matchedIssueId]);
   });
 });
+
+describeEmbeddedPostgres("issueService.update assignee validation", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-update-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("rejects in_review without an assignee", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs review",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.update(issueId, { status: "in_review", assigneeAgentId: null }),
+    ).rejects.toThrow("in_review issues require an assignee");
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -910,6 +910,9 @@ export function issueService(db: Db) {
       if (patch.status === "in_progress" && !nextAssigneeAgentId && !nextAssigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      if (patch.status === "in_review" && !nextAssigneeAgentId && !nextAssigneeUserId) {
+        throw unprocessable("in_review issues require an assignee");
+      }
       if (issueData.assigneeAgentId) {
         await assertAssignableAgent(existing.companyId, issueData.assigneeAgentId);
       }


### PR DESCRIPTION
## Summary

- Fixes #1762 — `in_review` status with no assignee orphans the issue from all inboxes
- Adds validation matching the existing `in_progress` check: transitioning to `in_review` now requires either `assigneeAgentId` or `assigneeUserId`
- Adds an embedded-Postgres test covering the new 422 rejection

## Test plan

- [x] New test `rejects in_review without an assignee` passes
- [x] Full `pnpm test -- run` passes (3 pre-existing infra failures unrelated to this change)

Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)