### PR TITLE
Fix dev-watch tsx exports resolution

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs a Node.js dev server using `tsx` in watch mode
> - The dev-watch script spawns a child process via `require.resolve` to locate the `tsx` CLI binary
> - `tsx/dist/cli.mjs` is an internal path not exposed in `tsx`'s `exports` map, so `require.resolve` throws on startup
> - Changing to `tsx/cli` uses the officially exported subpath, which resolves to the same binary
> - This fixes `pnpm dev` / `pnpm dev:watch` crashing before the server can listen

## What changed

`require.resolve("tsx/dist/cli.mjs")` → `require.resolve("tsx/cli")` in `server/scripts/dev-watch.ts`.

## Why it matters

`pnpm dev` was completely broken — the server couldn't start.

## How to verify

1. `pnpm dev` starts successfully and server listens on port 3100
2. `curl http://127.0.0.1:3100/api/health` returns `{"status":"ok"}`

## Risks

Minimal — no other code is affected and the `tsx/cli` exported subpath is stable across `tsx` versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)