### PR TITLE
fix(ui): approvals empty state guidance and bolder active nav item

### DIFF
--- a/ui/src/components/SidebarNavItem.tsx
+++ b/ui/src/components/SidebarNavItem.tsx
@@ -41,7 +41,7 @@ export function SidebarNavItem({
         cn(
           "flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors",
           isActive
-            ? "bg-accent text-foreground"
+            ? "bg-accent text-foreground font-semibold"
             : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
           className,
         )

--- a/ui/src/pages/Approvals.tsx
+++ b/ui/src/pages/Approvals.tsx
@@ -109,6 +109,7 @@ export function Approvals() {
           <p className="text-sm text-muted-foreground">
             {statusFilter === "pending" ? "No pending approvals." : "No approvals yet."}
           </p>
+          <p className="text-xs text-muted-foreground/60 mt-2">Agents request approvals when they need permission for critical actions</p>
         </div>
       )}
 


### PR DESCRIPTION
## Problem 1: Approvals page shows no context when empty

When you go to Approvals page and there is nothing to review, you see either "No pending approvals." or "No approvals yet." with a shield icon. But there is zero explanation about what approvals are or how they get created.

I was confused the first time I see this page because I didn't know if I need to configure something to start getting approvals or if they just appear automatically. Added a small subtitle explaining that agents request approvals for critical actions. This way new user understand the feature without needing to read docs.

## Problem 2: Active sidebar nav item not bold enough

The active page in sidebar navigation has `bg-accent` background but uses same `font-medium` weight as all other items. In some color themes (specially light mode), the background difference is very subtle and you have to look carefully to tell which page is selected.

Added `font-semibold` to the active state. This is a simple change but make a big difference because now the text weight difference is visible regardless of the theme colors. Combined with the background it give much stronger visual hierarchy.

## How to test

1. **Approvals:** Go to Approvals page when there are no approvals. Should see "Agents request approvals when they need permission for critical actions" below the main message.
2. **Nav active:** Look at the sidebar navigation. The current page label should be noticeably bolder than the other items.

2 files, net +1 line.