### PR TITLE
fix(ui): preserve cwd and promptTemplate when switching adapter type

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -548,9 +548,15 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 value={adapterType}
                 onChange={(t) => {
                   if (isCreate) {
-                    // Reset all adapter-specific fields to defaults when switching adapter type
+                    // Reset adapter-specific fields to defaults when switching adapter type,
+                    // but preserve shared fields (cwd, promptTemplate) that are not adapter-specific.
                     const { adapterType: _at, ...defaults } = defaultCreateValues;
-                    const nextValues: CreateConfigValues = { ...defaults, adapterType: t };
+                    const nextValues: CreateConfigValues = {
+                      ...defaults,
+                      adapterType: t,
+                      cwd: val!.cwd,
+                      promptTemplate: val!.promptTemplate,
+                    };
                     if (t === "codex_local") {
                       nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
                       nextValues.dangerouslyBypassSandbox =
@@ -564,8 +570,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     }
                     set!(nextValues);
                   } else {
-                    // Clear all adapter config and explicitly blank out model + effort/mode keys
-                    // so the old adapter's values don't bleed through via eff()
+                    // Clear adapter-specific config and explicitly blank out model + effort/mode keys
+                    // so the old adapter's values don't bleed through via eff().
+                    // Preserve shared fields (cwd, promptTemplate) that are not adapter-specific.
                     setOverlay((prev) => ({
                       ...prev,
                       adapterType: t,
@@ -588,6 +595,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                                 DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
                             }
                           : {}),
+                        cwd: eff("adapterConfig", "cwd", String(config.cwd ?? "")),
+                        promptTemplate: eff("adapterConfig", "promptTemplate", String(config.promptTemplate ?? "")),
                       },
                     }));
                   }


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Agents are configured with an adapter type (claude_local, codex_local, gemini_local, etc.) that determines how they connect to an LLM
- Agents also have shared configuration fields — working directory (cwd) and prompt template — that apply regardless of which adapter is used
- When a user switches the adapter type in the agent config form, the handler resets adapterConfig to clear stale adapter-specific values (model, effort, mode, etc.)
- But cwd and promptTemplate were being wiped as a side effect of that reset, even though they are not adapter-specific
- This PR preserves cwd and promptTemplate across adapter switches so users don't lose their configuration

## Problem

When changing the adapter type in the agent configuration form, the `working directory` and `prompt template` fields are cleared — even though these fields are shared across all adapter types and should not be affected by an adapter switch.

## Root Cause

The adapter change handler in `AgentConfigForm.tsx` resets `adapterConfig` to a blank slate (model, effort, mode, etc.) when the adapter type changes. This is correct for adapter-specific fields, but `cwd` and `promptTemplate` are shared fields that apply regardless of which adapter is selected — they were being wiped as a side effect.

This affects both create mode (via `defaultCreateValues` spread) and edit mode (via `setOverlay` with a fresh `adapterConfig` object).

## Fix

Carry `cwd` and `promptTemplate` forward into the new `adapterConfig` on adapter switch in both create and edit modes. All other adapter-specific fields (model, effort, variant, mode, etc.) are still reset as before.

## How to Verify

1. Open an existing agent in edit mode
2. Set a working directory and/or prompt template
3. Switch the adapter type to a different adapter
4. Confirm that working directory and prompt template retain their values

Same steps apply in create mode (new agent form).

## Risks

Low. The change only affects two fields (`cwd`, `promptTemplate`) that are explicitly shared across adapters. All adapter-specific reset behaviour is unchanged.

Fixes #1700