### PR TITLE
fix(server): enable trust proxy for reverse proxy deployments

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -80,7 +80,7 @@ export async function createApp(
 
   // Trust X-Forwarded-* headers from reverse proxies (Fly.io, nginx, etc.) so that
   // better-auth can set __Secure- cookies correctly when HTTPS is terminated upstream.
-  app.set("trust proxy", true);
+  app.set("trust proxy", 1);
 
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -78,6 +78,10 @@ export async function createApp(
 ) {
   const app = express();
 
+  // Trust X-Forwarded-* headers from reverse proxies (Fly.io, nginx, etc.) so that
+  // better-auth can set __Secure- cookies correctly when HTTPS is terminated upstream.
+  app.set("trust proxy", true);
+
   app.use(express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",


### PR DESCRIPTION
## Thinking Path

- Paperclip is a self-hosted platform that users deploy on cloud infrastructure
- Users often deploy behind reverse proxies (Fly.io, nginx, Caddy) that terminate HTTPS at the edge
- Paperclip uses better-auth for authentication, which sets `__Secure-` prefixed session cookies
- `__Secure-` cookies require the request to be over a secure (HTTPS) context
- When behind a reverse proxy, Express sees the request as HTTP (the proxy already stripped TLS), so better-auth's cookie setter fails with a 500
- Express has a built-in `trust proxy` setting that makes it read `X-Forwarded-Proto` to determine the real protocol
- This PR enables `trust proxy` so deployments behind HTTPS-terminating proxies can sign in successfully

## Problem

`POST /api/auth/sign-in/email` returns `500 Internal Server Error` when Paperclip is deployed behind a reverse proxy (Fly.io, nginx, etc.) that terminates HTTPS. The same request to `localhost:3100` works fine.

## Root Cause

Express does not trust `X-Forwarded-*` headers by default. When a reverse proxy terminates HTTPS and forwards the request over HTTP, Express sees the connection as insecure. better-auth then fails to set `__Secure-` prefixed cookies because the request doesn't appear to be in a secure context.

## Fix

Add `app.set("trust proxy", true)` in `server/src/app.ts` immediately after the Express app is created. This tells Express to read `X-Forwarded-Proto` from the proxy and treat the request as HTTPS when appropriate.

This is safe unconditionally — when there is no proxy, `X-Forwarded-*` headers are absent and behaviour is unchanged.

## How to Verify

1. Deploy Paperclip on Fly.io (or behind nginx with HTTPS termination)
2. Set `auth.publicBaseUrl` to your `https://` URL
3. `POST /api/auth/sign-in/email` — should now return `200` with a session cookie instead of `500`

## Risks

Low. `trust proxy: true` only changes how Express reads the protocol/IP from forwarded headers. Without a proxy in front, no `X-Forwarded-*` headers are present so there is no behavioural change for local or direct deployments.

Fixes #1690