### PR TITLE
fix(a11y): add title and aria-label to status and priority icons

### DIFF
--- a/ui/src/components/PriorityIcon.tsx
+++ b/ui/src/components/PriorityIcon.tsx
@@ -34,6 +34,9 @@ export function PriorityIcon({ priority, onChange, className, showLabel }: Prior
         onChange && !showLabel && "cursor-pointer",
         className
       )}
+      title={config.label}
+      aria-label={`${config.label} priority`}
+      role="img"
     >
       <Icon className="h-3.5 w-3.5" />
     </span>

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -22,6 +22,7 @@ export function StatusIcon({ status, onChange, className, showLabel }: StatusIco
   const colorClass = issueStatusIcon[status] ?? issueStatusIconDefault;
   const isDone = status === "done";
 
+  const label = statusLabel(status);
   const circle = (
     <span
       className={cn(
@@ -30,6 +31,9 @@ export function StatusIcon({ status, onChange, className, showLabel }: StatusIco
         onChange && !showLabel && "cursor-pointer",
         className
       )}
+      title={label}
+      aria-label={label}
+      role="img"
     >
       {isDone && (
         <span className="absolute inset-0 m-auto h-2 w-2 rounded-full bg-current" />


### PR DESCRIPTION
## Problem

The `StatusIcon` and `PriorityIcon` components are used everywhere in the app - every issue card in lists, every issue detail header, the kanban board, etc. But both render purely visual elements (colored circle, directional arrow) without any accessible attributes.

When `showLabel` is false (which is the default in most list views), there is:
- No `title` attribute - so hovering show nothing
- No `aria-label` - so screen readers announce nothing
- No `role` attribute - so assistive technology don't know it's meaningful content

This mean a screen reader user navigating the issues list literally cannot tell what status or priority any issue has. And even sighted users cannot hover over the small icon to confirm what it mean - they have to memorize the color mapping.

## What I changed

**StatusIcon.tsx:**
- Extracted `statusLabel(status)` call to a variable (was already used elsewhere in the component)
- Added `title={label}` for hover tooltip (e.g. "In Progress", "Done", "Blocked")
- Added `aria-label={label}` for screen readers
- Added `role="img"` so assistive technology treat it as meaningful image

**PriorityIcon.tsx:**
- Added `title={config.label}` for hover tooltip (e.g. "Critical", "High", "Medium", "Low")
- Added `aria-label` with context: "High priority", "Critical priority", etc.
- Added `role="img"` 

## How to test

1. Go to any issues list
2. Hover over the colored circle next to an issue - should see tooltip like "In Progress"
3. Hover over the priority arrow icon - should see tooltip like "High"
4. Use VoiceOver or screen reader - navigate through issue rows, should announce status and priority names

2 files, 7 lines added. These two components are used across the entire app so the fix propagate everywhere automatically.