### PR TITLE
fix(ui): error feedback for inbox retry/mark-all-read and swipe archive accessibility

### DIFF
--- a/ui/src/components/SwipeToArchive.tsx
+++ b/ui/src/components/SwipeToArchive.tsx
@@ -118,6 +118,7 @@ export function SwipeToArchive({
     <div
       ref={containerRef}
       className={cn("relative overflow-hidden touch-pan-y", className)}
+      aria-label="Swipe left to archive"
       style={{
         height: lockedHeight === null ? undefined : isCollapsing ? 0 : lockedHeight,
         opacity: isCollapsing ? 0 : 1,

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -774,6 +774,9 @@ export function Inbox() {
     onMutate: (run) => {
       setRetryingRunIds((prev) => new Set(prev).add(run.id));
     },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to retry run");
+    },
     onSuccess: ({ newRun, originalRun }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(originalRun.companyId, originalRun.agentId) });
@@ -853,6 +856,9 @@ export function Inbox() {
   const markAllReadMutation = useMutation({
     mutationFn: async (issueIds: string[]) => {
       await Promise.all(issueIds.map((issueId) => issuesApi.markRead(issueId)));
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to mark all as read");
     },
     onMutate: (issueIds) => {
       setFadingOutIssues((prev) => {


### PR DESCRIPTION
## Problem

The latest inbox update added several new mutations but two of them was missing error handlers:

### 1. retryRunMutation (Inbox.tsx line 754)
When user click retry on a failed run from the inbox, if the retry fail (agent not invokable, network error, etc) there was no error message shown. The button just go back to normal state. Other mutations in the same file like approveMutation (line 704) and rejectMutation (line 716) already set actionError properly - this one was missed.

### 2. markAllReadMutation (Inbox.tsx line 853)
The "Mark all as read" batch operation can fail if one of the markRead API calls throw. But there was no onError handler, so user click the button, some items fade out, but then silently fail. Single markRead (line 834) has proper error handling but the batch version don't.

### 3. SwipeToArchive accessibility
The new SwipeToArchive component (beautiful gesture implementation btw) respond only to touch events. The container div had no aria-label, so screen reader users don't know they can swipe to archive. Added aria-label="Swipe left to archive" so at least the intention is announced.

## What I changed

- Added `onError` to `retryRunMutation` that call `setActionError` with the error message
- Added `onError` to `markAllReadMutation` same pattern
- Added `aria-label` to SwipeToArchive container

All three follow existing patterns already in the same files.

## How to test

1. Try to retry a failed run when the agent is paused or network disconnected - should see error message in the inbox
2. Try "Mark all as read" when API is down - should see error instead of silent failure
3. Use screen reader on inbox items - SwipeToArchive container should announce "Swipe left to archive"

2 files, 7 lines added.