### PR TITLE
feat(ui): display run duration in agent runs list

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2770,8 +2770,12 @@ function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelect
           {summary.slice(0, 60)}
         </span>
       )}
-      {(metrics.totalTokens > 0 || metrics.cost > 0) && (
+      {(metrics.totalTokens > 0 || metrics.cost > 0 || (run.startedAt && run.finishedAt)) && (
         <div className="flex items-center gap-2 pl-5.5 text-[11px] text-muted-foreground tabular-nums">
+          {run.startedAt && run.finishedAt && (() => {
+            const sec = Math.round((new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()) / 1000);
+            return <span>{sec >= 60 ? `${Math.floor(sec / 60)}m ${sec % 60}s` : `${sec}s`}</span>;
+          })()}
           {metrics.totalTokens > 0 && <span>{formatTokens(metrics.totalTokens)} tok</span>}
           {metrics.cost > 0 && <span>${metrics.cost.toFixed(3)}</span>}
         </div>


### PR DESCRIPTION
## Problem

When looking at the agent runs list, you can see run ID, status badge, invocation source, creation time, tokens count and cost. But you cannot see how long each run took without clicking into the detail view for every single run.

This is very annoying when trying to debug performance issues or find which run was unusually slow. I have to click into each run one by one just to check the duration. The run detail view already show the duration nicely (line 3080-3083), but the list view had nothing.

## What I changed

Added duration calculation and display to RunListItem component. For finished runs that have both `startedAt` and `finishedAt`, it now show the elapsed time like "45s" or "2m 12s" at the beginning of the metrics line (before tokens and cost).

Uses exactly the same formatting logic as the run detail view:
- Under 60 seconds: show `Xs` (e.g. "45s")
- 60 seconds or more: show `Xm Ys` (e.g. "2m 12s")

Duration only render for completed runs. Running or queued runs that don't have finishedAt yet won't show anything (to avoid confusing partial data).

Also updated the metrics row condition to show when duration is available even if tokens and cost are zero. Before it was `(metrics.totalTokens > 0 || metrics.cost > 0)` which would hide the row for runs that had zero cost but still had a meaningful duration.

## How to test

1. Go to any agent detail > Runs tab
2. Look at the run list items
3. Finished runs should show duration like "45s" or "1m 23s" in the metrics line
4. Running or queued runs should not show duration

1 file, 5 lines added.