### PR TITLE
fix: add missing ignore fields to pino file transport to prevent OOM

### DIFF
--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -37,7 +37,7 @@ export const logger = pino({
     },
     {
       target: "pino-pretty",
-      options: { ...sharedOpts, colorize: false, destination: logFile, mkdir: true },
+      options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: false, destination: logFile, mkdir: true },
       level: "debug",
     },
   ],


### PR DESCRIPTION
## Summary

- Adds `ignore: "pid,hostname,req,res,responseTime"` to the pino file transport, matching the stdout transport
- Prevents unbounded buffer growth from serializing full req/res objects (~1.5KB each) on every HTTP request
- Fixes server OOM crashes occurring every ~60 minutes

Cherry-pick of community PR #1840.

## Test plan

- [x] Single-line config change using standard pino-pretty option
- [x] Matches existing stdout transport configuration
- [x] No existing logger tests to regress

Fixes #1825

🤖 Generated with [Claude Code](https://claude.com/claude-code)