### PR TITLE
fix(a11y): add ARIA progressbar attributes to ProviderQuotaCard

### DIFF
--- a/ui/src/components/ProviderQuotaCard.tsx
+++ b/ui/src/components/ProviderQuotaCard.tsx
@@ -205,6 +205,11 @@ export function ProviderQuotaCard({
                       </div>
                       <div className="h-2 w-full border border-border overflow-hidden">
                         <div
+                          role="progressbar"
+                          aria-valuenow={Math.round(barPct)}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-label={`${w} window: ${Math.round(barPct)}% of peak`}
                           className="h-full bg-primary/60 transition-[width] duration-150"
                           style={{ width: `${barPct}%` }}
                         />
@@ -242,6 +247,11 @@ export function ProviderQuotaCard({
                 <>
                   <div className="h-1.5 w-full border border-border overflow-hidden">
                     <div
+                      role="progressbar"
+                      aria-valuenow={Math.round(subSharePct)}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-label={`Subscription share: ${Math.round(subSharePct)}%`}
                       className="h-full bg-primary/60 transition-[width] duration-150"
                       style={{ width: `${subSharePct}%` }}
                     />
@@ -284,13 +294,13 @@ export function ProviderQuotaCard({
                       </div>
                     </div>
                     {/* token share bar */}
-                    <div className="relative h-2 w-full border border-border overflow-hidden">
+                    <div className="relative h-2 w-full border border-border overflow-hidden" role="img" aria-label={`${row.model}: ${Math.round(tokenPct)}% of tokens, ${Math.round(costPct)}% of cost`}>
                       <div
                         className="absolute inset-y-0 left-0 bg-primary/60 transition-[width] duration-150"
                         style={{ width: `${tokenPct}%` }}
                         title={`${Math.round(tokenPct)}% of provider tokens`}
                       />
-                      {/* cost share overlay — narrower, opaque, shows relative cost weight */}
+                      {/* cost share overlay - narrower, opaque, shows relative cost weight */}
                       <div
                         className="absolute inset-y-0 left-0 bg-primary/85 transition-[width] duration-150"
                         style={{ width: `${costPct}%` }}
@@ -356,6 +366,11 @@ export function ProviderQuotaCard({
                           {qw.usedPercent != null && fillColor != null && (
                             <div className="h-2 w-full border border-border overflow-hidden">
                               <div
+                                role="progressbar"
+                                aria-valuenow={Math.round(qw.usedPercent)}
+                                aria-valuemin={0}
+                                aria-valuemax={100}
+                                aria-label={`Quota usage: ${qw.usedPercent}% used`}
                                 className={`h-full transition-[width] duration-150 ${fillColor}`}
                                 style={{ width: `${qw.usedPercent}%` }}
                               />


### PR DESCRIPTION
## Problem

The ProviderQuotaCard component show several horizontal progress bars for visualizing token usage, cost percentages, subscription share, and quota consumption. But ALL of them was just plain `<div>` elements with width percentage styling - no semantic HTML and no ARIA attributes at all.

Screen reader users navigating the provider/costs section literally cannot access any of this quantitative data. They see nothing where sighted users see bars at 45%, 67%, etc.

We already fix this same issue in BudgetPolicyCard (PR #1805) where we added role=progressbar. This PR apply the same pattern to ProviderQuotaCard which has 4 different types of progress bars.

## What I changed

Added `role="progressbar"`, `aria-valuenow`, `aria-valuemin={0}`, `aria-valuemax={100}`, and descriptive `aria-label` to all progress bars:

1. **Rolling window bars** - label like "5h window: 45% of peak"
2. **Subscription share bar** - label like "Subscription share: 23%"
3. **Model token/cost overlay bars** - these have two overlapping bars (tokens + cost), so I used `role="img"` on the container with combined label like "gpt-4: 32% of tokens, 45% of cost"
4. **Quota window usage bars** - label like "Quota usage: 67% used"

## How to test

1. Go to Costs page > click on any provider card to expand details
2. Use screen reader (VoiceOver Cmd+F5) to navigate through the bar sections
3. Each bar should announce its percentage and context

1 file, 17 lines added.