### PR TITLE
fix: execution lock clearing + stale sweep (builds on #1723)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -530,8 +530,12 @@ export async function startServer(): Promise<StartedServer> {
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
+    // Also sweep any issues whose executionRunId points to a dead run — these can
+    // accumulate when the server is killed mid-run and would otherwise block all future
+    // checkouts on those issues indefinitely.
     void heartbeat
       .reapOrphanedRuns()
+      .then(() => heartbeat.sweepStaleExecutionLocks())
       .then(() => heartbeat.resumeQueuedRuns())
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");
@@ -559,10 +563,12 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "routine scheduler tick failed");
         });
   
-      // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-      // persisted queued work is still being driven forward.
+      // Periodically reap orphaned runs (5-min staleness threshold), sweep any stale
+      // execution lock fields left by dead runs, and make sure persisted queued work is
+      // still being driven forward.
       void heartbeat
         .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .then(() => heartbeat.sweepStaleExecutionLocks())
         .then(() => heartbeat.resumeQueuedRuns())
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3844,6 +3844,54 @@ export function heartbeatService(db: Db) {
 
     cancelBudgetScopeWork,
 
+    /**
+     * Sweep all issues whose executionRunId points to a terminal or missing run and clear
+     * the stale execution lock fields.  Should be called once on server startup and
+     * periodically (e.g. every 5 minutes) via the scheduler so that issues stuck by a
+     * crashed run are automatically unblocked without requiring manual intervention.
+     *
+     * This complements reapOrphanedRuns() (which handles in-memory running processes) by
+     * catching the persistence-level case where the DB row was never cleaned up — e.g.
+     * when the server was killed mid-run, when a run was cancelled while the issue lock
+     * was already set, or when the release() call was skipped due to a code path bug.
+     */
+    sweepStaleExecutionLocks: async () => {
+      const TERMINAL_STATUSES = ["succeeded", "failed", "timed_out", "cancelled", "process_lost"];
+
+      // Find issues with an executionRunId that is either missing or terminal.
+      const staleIssues = await db.execute(sql`
+        SELECT i.id, i.identifier, i.execution_run_id
+        FROM issues i
+        WHERE i.execution_run_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM heartbeat_runs hr
+            WHERE hr.id = i.execution_run_id
+              AND hr.status NOT IN (${sql.join(TERMINAL_STATUSES.map((s) => sql`${s}`), sql`, `)})
+          )
+      `);
+
+      if (staleIssues.rows.length === 0) return { cleared: 0 };
+
+      const staleIds = staleIssues.rows.map((r: Record<string, unknown>) => r.id as string);
+
+      await db
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(inArray(issues.id, staleIds));
+
+      logger.info(
+        { count: staleIds.length, issueIds: staleIds },
+        "swept stale execution locks from issues pointing to terminal/missing runs",
+      );
+
+      return { cleared: staleIds.length };
+    },
+
     getActiveRunForAgent: async (agentId: string) => {
       const [run] = await db
         .select()

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3870,9 +3870,9 @@ export function heartbeatService(db: Db) {
           )
       `);
 
-      if (staleIssues.rows.length === 0) return { cleared: 0 };
+      if (staleIssues.length === 0) return { cleared: 0 };
 
-      const staleIds = staleIssues.rows.map((r: Record<string, unknown>) => r.id as string);
+      const staleIds = staleIssues.map((r: Record<string, unknown>) => r.id as string);
 
       await db
         .update(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -902,12 +902,21 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        // Clear the full execution lock when leaving in_progress — otherwise the issue
+        // gets a permanent 409 on any future checkout attempt even though no run owns it.
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        // Reassigning to a different agent also means the current execution lock is stale.
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {
@@ -1190,8 +1199,12 @@ export function issueService(db: Db) {
         .update(issues)
         .set({
           status: "todo",
-          assigneeAgentId: null,
+          // Preserve assigneeAgentId so the issue stays assigned after a lock-release.
+          // Callers that genuinely want to unassign should PATCH assigneeAgentId separately.
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

This PR builds on community PR #1723 by @heathriel and adds a one-line fix for the CI-blocking TypeScript error.

**Original work (from #1723):**
- Fix 1: Clear execution lock when status leaves `in_progress`
- Fix 2: Clear execution lock on assignee change
- Fix 3: Clear execution lock fields in `release()`
- Fix 4: Preserve `assigneeAgentId` in `release()`
- Fix 5: Add startup + periodic sweep for stale execution locks

**Fix added in this PR:**
- `db.execute()` returns a `RowList` (array-like), not `{ rows: [...] }`. Replaced `staleIssues.rows.length` → `staleIssues.length` and `staleIssues.rows.map(...)` → `staleIssues.map(...)` to fix `TS2339`.

Supersedes #1723. Credit to @heathriel for the thorough analysis and implementation.

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit` passes)
- [ ] CI verify + e2e checks pass
- [ ] Manual test: kill server mid-run → restart → stuck issues unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)