### PR TITLE
fix: add keepStdinOpen option to runChildProcess (#1721)

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -728,6 +728,7 @@ export async function runChildProcess(
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
     stdin?: string;
+    keepStdinOpen?: boolean;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -763,7 +764,9 @@ export async function runChildProcess(
 
         if (opts.stdin != null && child.stdin) {
           child.stdin.write(opts.stdin);
-          child.stdin.end();
+          if (!opts.keepStdinOpen) {
+            child.stdin.end();
+          }
         }
 
         if (typeof child.pid === "number" && child.pid > 0 && opts.onSpawn) {
@@ -823,6 +826,9 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           runningProcesses.delete(runId);
+          if (opts.keepStdinOpen && child.stdin && !child.stdin.destroyed) {
+            child.stdin.end();
+          }
           void logChain.finally(() => {
             resolve({
               exitCode: code,


### PR DESCRIPTION
## Summary

Fixes #1721. Adds a `keepStdinOpen` option to `runChildProcess` in `adapter-utils`.

- When `keepStdinOpen: true`, `stdin.end()` is deferred to the `close` handler instead of being called immediately after writing
- Enables RPC-mode adapters (like Pi) to keep stdin open for the duration of the agent session
- Without this, stdin closes immediately causing the child process to exit before generating a response

Builds on the approach from community PR #1754 but applies cleanly to current master without conflicts.

## Test plan
- [ ] CI verify + e2e checks pass
- [ ] Pi adapter with `keepStdinOpen: true` + stdin prompt produces non-empty output
- [ ] Existing adapters (claude, codex) unaffected (they don't set `keepStdinOpen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)