### PR TITLE
fix: release endpoint preserves assigneeAgentId and status

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1310,9 +1310,10 @@ export function issueService(db: Db) {
       const updated = await db
         .update(issues)
         .set({
-          status: "todo",
-          assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
+          executionAgentNameKey: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

- **Bug:** `POST /api/issues/:id/release` was clearing `assigneeAgentId` and resetting `status` to `"todo"`, causing assigned tasks to become orphaned
- **Impact:** 9 issues lost their assignee across 6 agents in 2 companies
- **Fix:** Only clear execution lock fields (`checkoutRunId`, `executionRunId`, `executionLockedAt`, `executionAgentNameKey`). Leave `assigneeAgentId` and `status` untouched.

Rebased cleanly on current master (replaces #1716).

Fixes #1678

## Test plan

- [ ] Call `POST /api/issues/:id/release` on an in-progress issue and verify `assigneeAgentId` is preserved
- [ ] Verify `status` is not reset to `"todo"` after release
- [ ] Verify execution lock fields are all cleared
- [ ] Verify the agent can be re-woken for the same issue after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)