### PR TITLE
fix(ui): code blocks in markdown now scrollable on narrow screens

### DIFF
--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -139,7 +139,7 @@ export function MarkdownBody({ children, className, resolveImageSrc }: MarkdownB
   return (
     <div
       className={cn(
-        "paperclip-markdown prose prose-sm max-w-none break-words overflow-hidden",
+        "paperclip-markdown prose prose-sm max-w-none break-words overflow-x-auto overflow-y-hidden",
         theme === "dark" && "prose-invert",
         className,
       )}


### PR DESCRIPTION
## Problem

Code blocks inside markdown content (agent instructions, issue descriptions, comments) was getting cut off on narrow screens. The text just disappear at the edge and user cannot scroll to see the rest of the line.

The CSS for `<pre>` elements already have `overflow-x: auto` (in index.css line 551) which should make code blocks horizontally scrollable. But the parent `MarkdownBody` container had `overflow-hidden` on the div wrapper which clip everything including the scrollbar.

So the code block try to be scrollable but the parent say "no, hide everything outside my bounds". The scrollbar never appear and long code lines are just invisible.

## What I changed

Changed the container from `overflow-hidden` to `overflow-x-auto overflow-y-hidden`.

- `overflow-x-auto`: allow horizontal scrolling when content is wider than container (this is what enable the code block scrollbar to actually work)
- `overflow-y-hidden`: keep the vertical overflow clipped so tall content doesn't break layout (same behavior as before for vertical direction)

## How to test

1. Go to any issue or agent that has markdown with a long code block
2. On mobile or narrow browser window, the code block should now be horizontally scrollable
3. On desktop with wide screen, no visual change (content fit without scrolling)

Example markdown to test with:
```
const veryLongVariableName = someObject.someProperty.someNestedProperty.someDeeplyNestedFunction(argument1, argument2, argument3, argument4);
```

1 file, 1 line changed.