### PR TITLE
fix: prevent http.fetch timeout race with RPC bridge

### DIFF
--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -39,8 +39,21 @@ import { logger } from "../middleware/logger.js";
 // SSRF protection for plugin HTTP fetch
 // ---------------------------------------------------------------------------
 
-/** Maximum time (ms) a plugin fetch request may take before being aborted. */
-const PLUGIN_FETCH_TIMEOUT_MS = 30_000;
+/**
+ * Maximum **end-to-end** time (ms) for the entire `http.fetch` handler,
+ * including DNS resolution, SSRF validation, and the HTTP request itself.
+ *
+ * This MUST be strictly less than the worker→host RPC timeout (30 000 ms
+ * in `worker-rpc-host.ts`). If the two values are equal or close, slow
+ * HTTP requests race against the RPC timeout — the worker receives an
+ * opaque "RPC timed out" error instead of a clean fetch-abort error,
+ * and the server-side fetch keeps running after the worker has already
+ * given up.
+ *
+ * 25 s leaves a 5 s margin for DNS resolution overhead (up to
+ * `DNS_LOOKUP_TIMEOUT_MS`) plus RPC serialization round-trip.
+ */
+const PLUGIN_FETCH_TIMEOUT_MS = 25_000;
 
 /** Maximum time (ms) to wait for a DNS lookup before aborting. */
 const DNS_LOOKUP_TIMEOUT_MS = 5_000;
@@ -574,14 +587,22 @@ export function buildHostServices(
 
     http: {
       async fetch(params) {
-        // SSRF protection: validate protocol whitelist + block private IPs.
-        // Resolve once, then connect directly to that IP to prevent DNS rebinding.
-        const target = await validateAndResolveFetchUrl(params.url);
-
+        // End-to-end deadline covering DNS resolution + SSRF validation +
+        // the HTTP request itself.  This fires before the worker-side RPC
+        // timeout (30 s) so the plugin receives a clean abort error rather
+        // than an opaque "RPC timed out".
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), PLUGIN_FETCH_TIMEOUT_MS);
 
         try {
+          // SSRF protection: validate protocol whitelist + block private IPs.
+          // Resolve once, then connect directly to that IP to prevent DNS rebinding.
+          const target = await validateAndResolveFetchUrl(params.url);
+
+          if (controller.signal.aborted) {
+            throw new Error("Plugin fetch aborted — deadline exceeded during DNS resolution");
+          }
+
           const init = params.init as RequestInit | undefined;
           return await executePinnedHttpRequest(target, init, controller.signal);
         } finally {

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -599,10 +599,6 @@ export function buildHostServices(
           // Resolve once, then connect directly to that IP to prevent DNS rebinding.
           const target = await validateAndResolveFetchUrl(params.url);
 
-          if (controller.signal.aborted) {
-            throw new Error("Plugin fetch aborted — deadline exceeded during DNS resolution");
-          }
-
           const init = params.init as RequestInit | undefined;
           return await executePinnedHttpRequest(target, init, controller.signal);
         } finally {


### PR DESCRIPTION
## Summary

The plugin `http.fetch` host handler and the worker-to-host RPC bridge both use a 30,000 ms timeout. When an HTTP request approaches 30 seconds (e.g. Telegram long polling, slow third-party APIs), the two timers race:

- The worker-side RPC timeout (`worker-rpc-host.ts`, `DEFAULT_RPC_TIMEOUT_MS = 30_000`) fires at the same time or before the server-side fetch abort
- The plugin receives an opaque "RPC timed out" error instead of a clean fetch-abort error
- The server-side fetch continues running uselessly after the worker has already given up

### Changes

1. **Lower `PLUGIN_FETCH_TIMEOUT_MS` from 30s to 25s** so the HTTP fetch abort always fires before the 30s RPC bridge timeout, leaving a 5s margin.

2. **Move the `AbortController` to wrap the entire handler** (DNS resolution + SSRF validation + HTTP request), not just the HTTP request. Previously, a slow DNS lookup (up to `DNS_LOOKUP_TIMEOUT_MS = 5_000`) preceded the fetch timer, so the total could reach ~35s and still race with the RPC timeout.

### Files changed

- `server/src/services/plugin-host-services.ts` — timeout constant + handler restructure

## Test plan

- [ ] Verify existing plugin tests pass (the timeout constant is not referenced in tests)
- [ ] Manual test: plugin calling a slow endpoint (>25s) should receive a fetch abort error, not an RPC timeout
- [ ] Manual test: plugin calling a fast endpoint should work unchanged