### PR TITLE
fix(ui): external links in markdown open in new tab

### DIFF
--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -122,8 +122,9 @@ export function MarkdownBody({ children, className, resolveImageSrc }: MarkdownB
           </a>
         );
       }
+      const isExternal = href && /^https?:\/\//.test(href);
       return (
-        <a href={href} rel="noreferrer">
+        <a href={href} rel="noreferrer" {...(isExternal ? { target: "_blank" } : {})}>
           {linkChildren}
         </a>
       );


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents, issues, comments, goals - all contain markdown content that gets rendered in the browser
> - Markdown often has external links to GitHub repos, documentation, API references, etc.
> - But clicking any external link navigated away from Paperclip in the same tab
> - User lose their current context - the issue they was reading, the agent config they was reviewing - all gone
> - The MarkdownBody component renders all markdown links but did not distinguish between internal and external URLs
> - This PR adds a regex check for http/https URLs and sets `target="_blank"` on external links only
> - Internal links (mentions, relative paths, anchors) still open in same tab which is correct behavior
> - The `rel="noreferrer"` was already present which prevents the opened page from accessing `window.opener`, so adding `target="_blank"` is safe
> - The benefit is users can follow external references without losing their place in Paperclip

**Note:** The current code uses `rel="noreferrer"` which implicitly includes `noopener` behavior in modern browsers. However for maximum compatibility (older browsers, WebView contexts), it would be better to explicitly add `noopener` as well: `rel="noopener noreferrer"`. This is a minor hardening that can be done in follow-up or in this PR if reviewer prefers.

## Problem

When markdown content contain external links (like GitHub URLs, documentation links, API references, etc), clicking them navigate away from Paperclip in the same tab. User lose their current work context - whatever issue they was reading, whatever agent config they was reviewing, all gone. They have to use browser back button to come back.

This affect all markdown rendered in the app: agent instructions, issue descriptions, comments, goal descriptions. Basically anywhere MarkdownBody component is used.

## What I changed

Added a check for external URLs (starts with http:// or https://) and set `target="_blank"` on those links. Internal links (relative paths, anchor links, mention chips) still open in the same tab which is the correct behavior.

The `rel="noreferrer"` attribute was already on all links, so adding `target="_blank"` is safe - noreferrer prevent the opened page from accessing window.opener.

## How to test

1. Open any issue or agent that has markdown with an external link
2. Click the link
3. Should open in new browser tab instead of navigating away
4. Internal links (like mention chips to agents/projects) should still work normally in same tab

1 file, 2 lines added.