### PR TITLE
feat(docker): production hardening and comprehensive deployment guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-trixie-slim AS base
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl git \
+  && apt-get install -y --no-install-recommends ca-certificates curl git openssh-client \
   && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
 
@@ -54,6 +54,10 @@ ENV NODE_ENV=production \
 
 VOLUME ["/paperclip"]
 EXPOSE 3100
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD curl -fsS http://localhost:3100/api/health > /dev/null || exit 1
 
 USER node
+RUN git config --global credential.helper \
+  '!f() { echo "username=x-access-token"; echo "password=${GITHUB_TOKEN}"; }; f'
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -73,23 +73,13 @@ pnpm paperclipai run
 
 Build and run Paperclip in Docker:
 
-```sh
-docker build -t paperclip-local .
-docker run --name paperclip \
-  -p 3100:3100 \
-  -e HOST=0.0.0.0 \
-  -e PAPERCLIP_HOME=/paperclip \
-  -v "$(pwd)/data/docker-paperclip:/paperclip" \
-  paperclip-local
-```
+For Docker Compose deployment (recommended for production), see [doc/DOCKER.md](DOCKER.md).
 
-Or use Compose:
+Quick standalone Docker for dev:
 
 ```sh
 docker compose -f docker-compose.quickstart.yml up --build
 ```
-
-See `doc/DOCKER.md` for API key wiring (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) and persistence details.
 
 ## Docker For Untrusted PR Review
 

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -1,31 +1,109 @@
-# Docker Quickstart
+# Docker Deployment
 
-Run Paperclip in Docker without installing Node or pnpm locally.
+Run Paperclip in Docker with persistent data, automatic restarts, and agent support.
 
-## One-liner (build + run)
+## Prerequisites
 
-```sh
+- Docker and Docker Compose
+- Node.js 20+ and pnpm 9.15+ (for the CLI bootstrap command only)
+
+## Quick Start
+
+### 1. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and fill in secrets:
+
+```bash
+cat > .env <<EOF
+BETTER_AUTH_SECRET=$(openssl rand -hex 32)
+PAPERCLIP_AGENT_JWT_SECRET=$(openssl rand -hex 32)
+PAPERCLIP_PUBLIC_URL=http://localhost:3100
+EOF
+```
+
+| Variable | Required | Description |
+|---|---|---|
+| `BETTER_AUTH_SECRET` | Yes | Session encryption secret |
+| `PAPERCLIP_AGENT_JWT_SECRET` | Yes | JWT secret for agent authentication |
+| `PAPERCLIP_PUBLIC_URL` | Yes | Public URL for auth callbacks and invite links |
+
+> **Do NOT put `DATABASE_URL`, `PORT`, or `SERVE_UI` in `.env`** — the compose file sets these internally. Adding them to `.env` will override the container values and break things.
+
+### 2. Build and start
+
+```bash
+docker compose up -d --build
+```
+
+This starts:
+- **Postgres** on port 5432 (with health checks)
+- **Paperclip server + UI** on port 3100
+
+Both services have `restart: always` and will survive reboots.
+
+### 3. Create your admin account
+
+The CLI connects directly to the Postgres container (exposed on `localhost:5432`):
+
+```bash
+DATABASE_URL=postgres://paperclip:paperclip@localhost:5432/paperclip \
+pnpm paperclipai auth bootstrap-ceo
+```
+
+This prints an invite URL. Open it in your browser to create your account.
+
+> **Note:** If you previously ran `pnpm paperclipai onboard` locally, your config at `~/.paperclip/instances/default/config.json` may be set to `local_trusted` mode. The CLI will refuse to bootstrap in that mode. Fix it:
+> ```bash
+> sed -i 's/local_trusted/authenticated/' ~/.paperclip/instances/default/config.json
+> ```
+
+### 4. Log into Claude inside the container
+
+Claude Code needs to be authenticated inside the container. The host login doesn't carry over.
+
+```bash
+docker compose exec -it server claude login
+```
+
+Complete the OAuth flow. The session persists in the `paperclip-data` volume across restarts.
+
+> **Important:** The server runs as a non-root `node` user (home dir `/paperclip`). Credentials are stored in `/paperclip/.claude/`. If you exec into the container as root and run `claude login`, the credentials land in `/root/.claude/` and agents will fail with "Not logged in". Always use `docker compose exec` (without `-u root`) so the login runs as the correct user.
+
+### 5. Set up SSH keys for Git access
+
+Agents need SSH keys to clone and push to private repos:
+
+```bash
+sudo ./scripts/docker-ssh-setup.sh
+```
+
+This generates an ed25519 key locally, copies it into the container, and prints the public key. Add it to GitHub at https://github.com/settings/ssh/new.
+
+Keys are:
+- Stored in the `paperclip-data` volume at `/paperclip/.ssh/` (persists across restarts)
+- Backed up locally at `docker/.ssh/` (gitignored)
+
+## Standalone Docker (without Compose)
+
+```bash
 docker build -t paperclip-local . && \
 docker run --name paperclip \
   -p 3100:3100 \
   -e HOST=0.0.0.0 \
   -e PAPERCLIP_HOME=/paperclip \
+  -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
+  -e PAPERCLIP_AGENT_JWT_SECRET=$(openssl rand -hex 32) \
   -v "$(pwd)/data/docker-paperclip:/paperclip" \
   paperclip-local
 ```
 
-Open: `http://localhost:3100`
+This uses the embedded PGlite database (no external Postgres needed).
 
-Data persistence:
-
-- Embedded PostgreSQL data
-- uploaded assets
-- local secrets key
-- local agent workspace data
-
-All persisted under your bind mount (`./data/docker-paperclip` in the example above).
-
-## Compose Quickstart
+## Compose Quickstart (PGlite)
 
 ```sh
 docker compose -f docker-compose.quickstart.yml up --build
@@ -54,7 +132,7 @@ services:
     environment:
       PAPERCLIP_DEPLOYMENT_MODE: authenticated
       PAPERCLIP_DEPLOYMENT_EXPOSURE: private
-      PAPERCLIP_PUBLIC_URL: https://desk.koker.net
+      PAPERCLIP_PUBLIC_URL: https://desk.example.com
 ```
 
 `PAPERCLIP_PUBLIC_URL` is used as the primary source for:
@@ -67,6 +145,16 @@ services:
 Granular overrides remain available if needed (`PAPERCLIP_AUTH_PUBLIC_BASE_URL`, `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, `PAPERCLIP_ALLOWED_HOSTNAMES`).
 
 Set `PAPERCLIP_ALLOWED_HOSTNAMES` explicitly only when you need additional hostnames beyond the public URL host (for example Tailscale/LAN aliases or multiple private hostnames).
+
+## Tailscale (Remote Access)
+
+Set `PAPERCLIP_PUBLIC_URL` in your `.env` to your Tailscale hostname:
+
+```
+PAPERCLIP_PUBLIC_URL=http://your-tailscale-hostname:3100
+```
+
+Then access `http://your-tailscale-hostname:3100` from any device on your Tailnet.
 
 ## Claude + Codex Local Adapters in Docker
 
@@ -92,6 +180,74 @@ Notes:
 
 - Without API keys, the app still runs normally.
 - Adapter environment checks in Paperclip will surface missing auth/CLI prerequisites.
+
+If using Claude Code with subscription auth (not API keys):
+1. Run `claude login` inside the container (step 4 above)
+2. Do **not** set `ANTHROPIC_API_KEY` — Claude will use the subscription session
+
+## Data Persistence
+
+Docker Compose uses two named volumes:
+
+| Volume | Mount | Contents |
+|---|---|---|
+| `pgdata` | `/var/lib/postgresql/data` | Postgres database |
+| `paperclip-data` | `/paperclip` | Config, secrets, agent sessions, SSH keys, backups |
+
+Data persists across `docker compose down` and `docker compose up`.
+
+**To destroy all data:** `docker compose down -v` (the `-v` flag deletes volumes).
+
+## Agent Working Directory
+
+The container's working directory is `/app`. When configuring agents in the dashboard, set their `cwd` to `/app` or a subdirectory. Do **not** use host paths like `/home/user/...` — they don't exist inside the container.
+
+For agents working on code:
+- Agents clone repos from GitHub inside the container, do work, and push commits
+- SSH keys (from step 5) enable access to private repos
+
+## Troubleshooting
+
+**`BETTER_AUTH_SECRET must be set`**
+Your `.env` file is missing or not in the same directory as `docker-compose.yml`.
+
+**`permission denied` on `/paperclip`**
+The volume was created by an older image that ran as root. Fix ownership:
+```bash
+docker compose exec -u root server chown -R node:node /paperclip
+```
+
+**Claude CLI silently exits / produces no output**
+Claude isn't logged in inside the container. Run `docker compose exec -it server claude login`.
+
+**Agents fail with "Not logged in / Please run /login"**
+The server process reads credentials from `/paperclip/.claude/`. If you previously ran `claude login` as root, the credentials are in `/root/.claude/` and inaccessible to the server. Fix: run `claude login` without the `-u root` flag:
+```bash
+docker compose exec -it server claude login
+```
+
+**Agent can't clone repos**
+SSH keys aren't set up. Run `sudo ./scripts/docker-ssh-setup.sh` and add the public key to GitHub.
+
+**`connect ECONNREFUSED 127.0.0.1:54329`**
+The CLI is connecting to the embedded database instead of the Docker Postgres. Pass `DATABASE_URL` explicitly:
+```bash
+DATABASE_URL=postgres://paperclip:paperclip@localhost:5432/paperclip pnpm paperclipai auth bootstrap-ceo
+```
+
+**Adapter environment test says `cwd` permission denied**
+The agent's `cwd` is set to a host path. Change it to `/app` in the dashboard.
+
+## Useful Commands
+
+```bash
+docker compose logs -f          # Watch logs
+docker compose logs -f server   # Server logs only
+docker compose down             # Stop services
+docker compose up -d --build    # Rebuild and restart
+docker compose exec -it server /bin/bash  # Shell into container
+docker compose exec -it server claude login  # Auth Claude
+```
 
 ## Untrusted PR Review Container
 

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    restart: always
     ports:
       - "${PAPERCLIP_PORT:-3100}:3100"
     environment:
@@ -14,5 +15,6 @@ services:
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      PAPERCLIP_AGENT_JWT_SECRET: "${PAPERCLIP_AGENT_JWT_SECRET:-}"
     volumes:
       - "${PAPERCLIP_DATA_DIR:-./data/docker-paperclip}:/paperclip"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   db:
+    restart: always
     image: postgres:17-alpine
     environment:
       POSTGRES_USER: paperclip
@@ -16,9 +17,16 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   server:
+    restart: always
     build: .
     ports:
       - "3100:3100"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3100/api/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
     environment:
       DATABASE_URL: postgres://paperclip:paperclip@db:5432/paperclip
       PORT: "3100"
@@ -27,6 +35,7 @@ services:
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      PAPERCLIP_AGENT_JWT_SECRET: "${PAPERCLIP_AGENT_JWT_SECRET:?PAPERCLIP_AGENT_JWT_SECRET must be set}"
     volumes:
       - paperclip-data:/paperclip
     depends_on:


### PR DESCRIPTION
Add openssh-client for agent Git access, Dockerfile HEALTHCHECK, git credential helper for GITHUB_TOKEN, restart policies and health checks on all compose services, PAPERCLIP_AGENT_JWT_SECRET env var, and a full production deployment guide in doc/DOCKER.md covering Postgres compose setup, Claude auth, SSH key setup, Tailscale, data persistence, troubleshooting, and useful commands.

  Thinking Path

  ▎ - Paperclip orchestrates AI agents for zero-human companies
  ▎ - Agents run inside Docker containers and need to interact with external services (GitHub,
  Claude, etc.)
  ▎ - The existing Docker setup lacks production hardening: no health checks, no restart
  policies, no SSH/git auth, and the deployment guide is a bare-bones quickstart
  ▎ - Self-hosters hitting real issues (Claude auth confusion, permission errors, missing SSH
  keys) have no troubleshooting reference
  ▎ - This pull request adds Dockerfile and compose hardening (healthchecks, restart policies,
  openssh-client, git credential helper, JWT secret) and rewrites doc/DOCKER.md into a
  comprehensive production deployment guide
  ▎ - The benefit is that self-hosted Paperclip deployments are more resilient out of the box,
  and operators have a single reference for setup, auth, networking, and troubleshooting

  What Changed

  - Dockerfile: install openssh-client for agent Git access, add HEALTHCHECK directive, add git
   credential helper for GITHUB_TOKEN auth
  - docker-compose.yml: add restart: always on db and server, healthcheck on server service,
  PAPERCLIP_AGENT_JWT_SECRET required env var
  - docker-compose.quickstart.yml: add restart: always, PAPERCLIP_AGENT_JWT_SECRET optional env
   var
  - doc/DOCKER.md: rewrite from quickstart-only into full production guide covering: Postgres
  compose setup, admin bootstrap, Claude auth inside container, SSH key setup for agents,
  Tailscale remote access, data persistence, agent working directory config, subscription vs
  API key auth, 7 common troubleshooting scenarios, and useful commands reference
  - doc/DEVELOPING.md: simplify Docker section to point to doc/DOCKER.md instead of duplicating
   instructions

  Verification

  - docker compose up -d --build starts Postgres + server with health checks and restart
  policies
  - docker compose -f docker-compose.quickstart.yml up --build still works for quickstart flow
  - docker inspect <server-container> | jq '.[0].State.Health' shows HEALTHCHECK passing after
  startup
  - Missing PAPERCLIP_AGENT_JWT_SECRET in production compose causes a clear error on docker
  compose up
  - docker compose exec -it server ssh -T git@github.com works after SSH key setup

  Risks

  - PAPERCLIP_AGENT_JWT_SECRET is now required in docker-compose.yml (uses ? syntax) — existing
   deployments without it in .env will fail to start. This is intentional since the secret is
  needed for agent auth, but is a breaking change for anyone upgrading without reading the
  guide.
  - The git credential helper bakes GITHUB_TOKEN support into the image — low risk since it
  only activates when the env var is set.

  Checklist

  - I have included a thinking path that traces from project context to this change
  - I have run tests locally and they pass
  - I have added or updated tests where applicable
  - If this change affects the UI, I have included before/after screenshots
  - I have updated relevant documentation to reflect my changes
  - I have considered and documented any risks above
  - I will address all Greptile and reviewer comments before requesting merge