### PR TITLE
fix(ui): style markdown GFM tables with borders and padding

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -692,11 +692,25 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
 
 .paperclip-markdown table {
   width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--border);
+  font-size: 0.8125rem;
+}
+
+.paperclip-markdown th,
+.paperclip-markdown td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.65rem;
+  text-align: left;
 }
 
 .paperclip-markdown th {
   font-weight: 600;
-  text-align: left;
+  background-color: color-mix(in oklab, var(--accent) 50%, transparent);
+}
+
+.paperclip-markdown tr:nth-child(even) td {
+  background-color: color-mix(in oklab, var(--accent) 20%, transparent);
 }
 
 .paperclip-mermaid {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents, issues, comments, and goals all use markdown for their text content
> - Markdown is rendered through a shared CSS class `.paperclip-markdown`
> - GFM (GitHub Flavored Markdown) supports tables, and users write tables for parameter lists, configuration options, comparison data etc.
> - But the table CSS only had `width: 100%` and bold headers - no borders, no padding, no visual separation between cells
> - With 3+ columns the text all flows together and you cannot tell which cell is which
> - This PR adds proper table styling: collapsed borders, cell padding, header background color, alternating row stripes
> - All colors use CSS custom properties (`--border`, `--accent`) so they work automatically in both light and dark mode
> - The benefit is markdown tables are now actually readable instead of being a wall of unstructured text

## Problem

When markdown content contain GFM tables (like in agent instructions, issue descriptions, or documentation), the table was basically unstyled. The CSS only had `width: 100%` on the table and `font-weight: 600` on th elements. That was it.

No borders between cells. No padding inside cells. No header background. No row striping. The result is that all the text in the table just flow together and it's really hard to tell which cell is which, specially when table have 3+ columns.

I noticed this because some agents have markdown instructions with tables describing parameters or configuration options, and the data was completely unreadable.

## What I changed

Added proper table styling to the `.paperclip-markdown` CSS:

- `border-collapse: collapse` and `border: 1px solid var(--border)` on table, th, and td - give clear grid lines
- `padding: 0.4rem 0.65rem` on th and td - give cells breathing room
- Header row (`th`) get subtle background with `color-mix(in oklab, var(--accent) 50%, transparent)`
- Even rows get lighter stripe with `color-mix(in oklab, var(--accent) 20%, transparent)` for better readability
- Slightly smaller font-size (0.8125rem) so tables with many columns fit better

All colors use CSS custom properties (`--border`, `--accent`) so they automatically work in both light and dark mode.

## How to test

Create or view an issue/agent with markdown table like:

| Parameter | Type | Default |
|-----------|------|------------|
| timeout | number | 30 |
| retries | number | 3 |
| verbose | boolean | false |

Should now show a proper bordered table with header background and alternating row colors.

1 file, 15 CSS lines added.