### PR TITLE
fix(ui): better empty state for agent runs tab

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2798,7 +2798,12 @@ function RunsTab({
   const { isMobile } = useSidebar();
 
   if (runs.length === 0) {
-    return <p className="text-sm text-muted-foreground">No runs yet.</p>;
+    return (
+      <div className="rounded-lg border border-dashed border-border p-8 text-center">
+        <p className="text-sm text-muted-foreground">No runs yet</p>
+        <p className="text-xs text-muted-foreground/60 mt-1">Runs will appear here when the agent is invoked via issues, routines, or manual trigger</p>
+      </div>
+    );
   }
 
   // Sort by created descending


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Human users watch agents work and oversee their runs through the UI
> - Each agent has a detail page where you can see list of runs that agent did
> - But when agent is brand new or simply never been triggered, the runs list is empty
> - The old code just showed plain floating text "No runs yet." with no container, no border, no guidance
> - This is inconsistent with other empty states in the app (RoutineDetail, CommentThread, Kanban columns) that use dashed border box pattern
> - This PR replaces the bare paragraph with a proper empty state container - dashed border, centered text, and subtitle explaining how runs get created
> - The benefit is new users who just create their first agent now understand what to do next instead of seeing lonely text on an empty page

## Problem

When you go to an agent that has zero runs and click the Runs tab, you see just "No runs yet." as a bare text paragraph floating in the page. No border, no container, no context about what to do.

We already fix this exact pattern in several other places:
- RoutineDetail runs tab (PR #1835) - now has dashed border box with explanation
- CommentThread empty state (PR #1824) - same pattern
- Kanban board empty columns (PR #1793) - has "No issues" text

But the agent detail runs tab was still the old unstyled version.

## What I changed

Replaced the plain `<p>` with a proper empty state container matching the pattern from other pages:
- Dashed border rounded box
- Centered text
- Added subtitle: "Runs will appear here when the agent is invoked via issues, routines, or manual trigger"

This way new users who just created an agent understand how to get their first run started.

## How to test

1. Create a new agent (or find one with no runs)
2. Go to the Runs tab
3. Should see a bordered empty state box with guidance text instead of floating paragraph

1 file, 6 lines added.