### PR TITLE
fix(server): return descriptive message for agent urlKey conflict (#1848)

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1781,7 +1781,7 @@ export function agentRoutes(db: Db) {
         },
       });
     } catch (err: any) {
-      if (err.status === 409 || err?.code === "23505") {
+      if (err?.code === "23505") {
         res.status(409).json({ error: "Agent name conflicts with an existing agent URL key. Please choose a different name." });
         return;
       }


### PR DESCRIPTION
# Description

## What was done
Added targeted error handling in `server/src/routes/agents.ts` for the `PATCH /agents/:id` endpoint, specifically catching the Postgres raw unique constraint violation error (`code === "23505"`) emitted during `svc.update`. Instead of allowing the generic db exception to fall through, it explicitly returns a 409 status code with a user-friendly error payload indicating the URL key conflict.

## Why it matters
Fixes issue #1848. When an agent is renamed and the resulting `urlKey` conflicts with another agent's `urlKey`, the backend could emit a raw Postgres unique constraint violation (`23505`), which the frontend intercepted and inexplicably mapped to a generic "Agent Not Found" error toast. This masks the actual reason the agent couldn't be saved and causes user confusion. By returning a well-formed 409 with an actionable error string, the user gets clear feedback on the rename dialog.

## How to verify
1. Create two identical agents, 'Test Agent 1' and 'Test Agent 2'.
2. Open the edit dialog for 'Test Agent 2' and try to rename it exactly to 'Test Agent 1'.
3. Click Save. 
4. The backend should return a 409 and the UI should display a "Save failed" toast with the message: "Agent name conflicts with an existing agent URL key. Please choose a different name."

## Risks
None expected. This check explicitly isolates raw Postgres `23505` unique constraint violations rather than blanket-catching all 409s, preventing it from obscuring other legitimate conflict states (e.g., trying to activate a pending or terminated agent).
