### PR TITLE
Fix company export/import/settings routing

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -338,6 +338,9 @@ export function App() {
           <Route path="projects/:projectId/issues/:filter" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/configuration" element={<UnprefixedBoardRedirect />} />
           <Route path="tests/ux/runs" element={<UnprefixedBoardRedirect />} />
+          <Route path="company/settings" element={<UnprefixedBoardRedirect />} />
+          <Route path="company/export/*" element={<UnprefixedBoardRedirect />} />
+          <Route path="company/import" element={<UnprefixedBoardRedirect />} />
           <Route path=":companyPrefix" element={<Layout />}>
             {boardRoutes()}
           </Route>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The web UI uses React Router with a `/:companyPrefix` catch-all route to scope pages to a specific company
> - Unprefixed paths like `/agents` or `/projects` have `UnprefixedBoardRedirect` entries that prepend the selected company prefix before the catch-all matches
> - But `/company/export`, `/company/import`, and `/company/settings` were missing these redirect entries
> - So navigating to `/company/export` hit the catch-all, which treated `"company"` as a company slug and showed "Company not found — No company matches prefix 'COMPANY'"
> - This PR adds the three missing `UnprefixedBoardRedirect` routes so these paths redirect correctly

## What changed

Added three `<Route>` entries with `UnprefixedBoardRedirect` in `ui/src/App.tsx` for:
- `company/settings`
- `company/export/*`
- `company/import`

This follows the exact same pattern used by all other unprefixed routes (agents, projects, issues, etc.).

## Why it matters

The company export and import pages were completely inaccessible via their absolute URLs (used by links in CompanySettings and OrgChart pages).

## How to verify

1. Navigate to `/company/export` — should redirect to `/<PREFIX>/company/export` and show the export page
2. Navigate to `/company/import` — should redirect and show the import page
3. Navigate to `/company/settings` — should redirect and show settings
4. Click the export/import links from Company Settings and Org Chart pages

## Risks

Minimal — this is a purely additive change using the existing `UnprefixedBoardRedirect` pattern. No existing routes are modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)