### PR TITLE
fix(ui): show validation error for invalid cron in schedule editor

### DIFF
--- a/ui/src/components/ScheduleEditor.tsx
+++ b/ui/src/components/ScheduleEditor.tsx
@@ -151,6 +151,7 @@ function CustomCronInput({ value, onChange }: { value: string; onChange: (v: str
   const trimmed = value.trim();
   const fieldCount = trimmed.length > 0 ? trimmed.split(/\s+/).length : 0;
   const isInvalid = trimmed.length > 0 && fieldCount !== 5;
+  const errorId = "custom-cron-error";
   return (
     <div className="space-y-1.5">
       <Input
@@ -159,9 +160,10 @@ function CustomCronInput({ value, onChange }: { value: string; onChange: (v: str
         placeholder="0 10 * * *"
         className={cn("font-mono text-sm", isInvalid && "border-destructive")}
         aria-invalid={isInvalid}
+        aria-describedby={isInvalid ? errorId : undefined}
       />
       {isInvalid ? (
-        <p className="text-xs text-destructive">Expected 5 fields but got {fieldCount}. Format: minute hour day-of-month month day-of-week</p>
+        <p id={errorId} className="text-xs text-destructive">Expected 5 fields but got {fieldCount}. Format: minute hour day-of-month month day-of-week</p>
       ) : (
         <p className="text-xs text-muted-foreground">Five fields: minute hour day-of-month month day-of-week</p>
       )}
@@ -231,7 +233,7 @@ export function ScheduleEditor({
       </Select>
 
       {preset === "custom" ? (
-        <CustomCronInput value={customCron} onChange={(v) => { setCustomCron(v); emitChange("custom", hour, minute, dayOfWeek, dayOfMonth, v); }} />
+        <CustomCronInput value={customCron} onChange={(v) => { setCustomCron(v); const f = v.trim(); if (f.length === 0 || f.split(/\s+/).length === 5) { emitChange("custom", hour, minute, dayOfWeek, dayOfMonth, v); } }} />
       ) : (
         <div className="flex flex-wrap items-center gap-2">
           {preset !== "every_minute" && preset !== "every_hour" && (

--- a/ui/src/components/ScheduleEditor.tsx
+++ b/ui/src/components/ScheduleEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
 type SchedulePreset = "every_minute" | "every_hour" | "every_day" | "weekdays" | "weekly" | "monthly" | "custom";
@@ -146,6 +147,28 @@ function ordinalSuffix(n: number): string {
 
 export { describeSchedule };
 
+function CustomCronInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const trimmed = value.trim();
+  const fieldCount = trimmed.length > 0 ? trimmed.split(/\s+/).length : 0;
+  const isInvalid = trimmed.length > 0 && fieldCount !== 5;
+  return (
+    <div className="space-y-1.5">
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="0 10 * * *"
+        className={cn("font-mono text-sm", isInvalid && "border-destructive")}
+        aria-invalid={isInvalid}
+      />
+      {isInvalid ? (
+        <p className="text-xs text-destructive">Expected 5 fields but got {fieldCount}. Format: minute hour day-of-month month day-of-week</p>
+      ) : (
+        <p className="text-xs text-muted-foreground">Five fields: minute hour day-of-month month day-of-week</p>
+      )}
+    </div>
+  );
+}
+
 export function ScheduleEditor({
   value,
   onChange,
@@ -208,20 +231,7 @@ export function ScheduleEditor({
       </Select>
 
       {preset === "custom" ? (
-        <div className="space-y-1.5">
-          <Input
-            value={customCron}
-            onChange={(e) => {
-              setCustomCron(e.target.value);
-              emitChange("custom", hour, minute, dayOfWeek, dayOfMonth, e.target.value);
-            }}
-            placeholder="0 10 * * *"
-            className="font-mono text-sm"
-          />
-          <p className="text-xs text-muted-foreground">
-            Five fields: minute hour day-of-month month day-of-week
-          </p>
-        </div>
+        <CustomCronInput value={customCron} onChange={(v) => { setCustomCron(v); emitChange("custom", hour, minute, dayOfWeek, dayOfMonth, v); }} />
       ) : (
         <div className="flex flex-wrap items-center gap-2">
           {preset !== "every_minute" && preset !== "every_hour" && (


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents run on schedule using cron-based triggers
> - Users configure these triggers through the ScheduleEditor UI component
> - When user pick "Custom (cron)" preset, they type a raw cron expression
> - But the input had no validation at all - user could type anything and only get error later from the API
> - This PR add real-time field count validation so user get immediate feedback when they type wrong number of fields
> - The benefit is user see the problem right away instead of waiting for a confusing API error

## Problem

In the ScheduleEditor component, when user choose "Custom (cron)" preset, they type a raw cron expression. But the input had absolutely no validation. User can type:
- `0 10 * *` (only 4 fields instead of 5) 
- `hello world` (not even numbers)
- `0 10 * * * *` (6 fields instead of 5)

And the input just accept it with no error. The help text say "Five fields: minute hour day-of-month month day-of-week" but if user type wrong number of fields, nothing happen until they try to save the trigger and the API reject it with generic error.

## What I changed

Added real-time field count validation to the custom cron input:

1. **Red border** on input when field count is not 5 (using `border-destructive` class + `aria-invalid`)
2. **Error message** replacing the help text: "Expected 5 fields but got X. Format: minute hour day-of-month month day-of-week"
3. **Normal help text** when input is empty or valid (5 fields)
4. **aria-describedby** linking error message to input for screen reader accessibility
5. **Invalid cron not propagated** to parent - only valid (5 fields) or empty values get emitted, so bad data cannot reach the API

Extracted the custom input into a small `CustomCronInput` component to keep the validation logic separate from the main ScheduleEditor which was already getting long.

This is basic field count validation only - it don't check if individual values are valid ranges (like minute 0-59). But it catch the most common mistake which is missing or extra fields.

## How to test

1. Go to Routines > open any routine > Triggers tab
2. Add or edit trigger > select "Custom (cron)" preset
3. Type "0 10 * *" (4 fields) - should see red border and error message
4. Type "0 10 * * 1" (5 fields) - should see normal help text, no red
5. Type "0 10 * * 1 extra" (6 fields) - should see red border and error

1 file, ~30 lines added / 14 removed.