### PR TITLE
feat(ui): add View all links to dashboard activity and tasks sections

### DIFF
--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -309,9 +309,12 @@ export function Dashboard() {
             {/* Recent Activity */}
             {recentActivity.length > 0 && (
               <div className="min-w-0">
-                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                  Recent Activity
-                </h3>
+                <div className="flex items-center justify-between gap-2 mb-3">
+                  <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                    Recent Activity
+                  </h3>
+                  <Link to="/activity" className="text-xs text-muted-foreground hover:text-foreground transition-colors">View all</Link>
+                </div>
                 <div className="border border-border divide-y divide-border overflow-hidden">
                   {recentActivity.map((event) => (
                     <ActivityRow
@@ -329,9 +332,12 @@ export function Dashboard() {
 
             {/* Recent Tasks */}
             <div className="min-w-0">
-              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                Recent Tasks
-              </h3>
+              <div className="flex items-center justify-between gap-2 mb-3">
+                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                  Recent Tasks
+                </h3>
+                <Link to="/issues" className="text-xs text-muted-foreground hover:text-foreground transition-colors">View all</Link>
+              </div>
               {recentIssues.length === 0 ? (
                 <div className="border border-border p-4">
                   <p className="text-sm text-muted-foreground">No tasks yet.</p>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - The Dashboard page is the first thing human users see when they open the app
> - Dashboard show summary sections like "Recent Activity" and "Recent Tasks" with only few latest items
> - But there was no way to navigate from these summaries to the full list, user must know to click sidebar links
> - Almost every dashboard in every app have "View all" links next to summary sections - this is very standard pattern
> - So this PR add "View all" links to both section headers on the Dashboard
> - The benefit is users can now discover and navigate to full Activity and Issues pages naturally from the Dashboard without needing to already know the sidebar navigation

## Problem

The Dashboard page show two summary sections: "Recent Activity" and "Recent Tasks". Both display only the latest few items but there was no link to navigate to the full list. If I want to see all activity or all issues, I have to know that I need to click on "Activity" or "Issues" in the sidebar navigation.

This is a very standard UX pattern that almost every dashboard in every app have - a "View all" or "See more" link next to each summary section header. But it was missing here.

## What I changed

Added "View all" links to both section headers:

- **Recent Activity** header now have "View all" link that go to `/activity`
- **Recent Tasks** header now have "View all" link that go to `/issues`

The links use `text-muted-foreground` color with hover transition to `text-foreground`, so they don't distract from the dashboard content but are clearly visible when you look for them. Positioned on the right side of the header with `justify-between`.

## How to test

1. Go to Dashboard page
2. Look at the "Recent Activity" section header - should see "View all" link on the right
3. Click it - should navigate to the full Activity page
4. Same for "Recent Tasks" - "View all" should go to Issues page

1 file, 12 lines added / 6 removed.