### PR TITLE
feat: enable OpenClaw Gateway adapter in UI

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -976,7 +976,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "openclaw_gateway"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [


### PR DESCRIPTION
## Summary

The OpenClaw Gateway adapter was fully implemented server-side and UI-side but `openclaw_gateway` was missing from the `ENABLED_ADAPTER_TYPES` set in `AgentConfigForm.tsx`.

This caused the adapter to render as "Coming soon" and disabled in the adapter type dropdown — even though clicking it from the NewAgentDialog navigated to the correct config page.

## Changes

1. **`ui/src/components/AgentConfigForm.tsx`** — Added `"openclaw_gateway"` to `ENABLED_ADAPTER_TYPES` set so the adapter is selectable in the dropdown.

2. **`server/scripts/dev-watch.ts`** — Fixed `tsx` compatibility: changed `require.resolve("tsx/dist/cli.mjs")` to `require.resolve("tsx/cli")`. The subpath `tsx/dist/cli.mjs` is not exported in tsx ≥ 4.19, causing `ERR_PACKAGE_PATH_NOT_EXPORTED` on `pnpm dev` with current dependencies.

## Testing

- The adapter's UI config fields (Gateway URL, auth token, session strategy, role, scopes, wait timeout) were verified in `ui/src/adapters/openclaw-gateway/config-fields.tsx`
- `buildOpenClawGatewayConfig` sets sensible defaults (timeout 120s, waitTimeoutMs 120000, sessionKeyStrategy: issue, role: operator, scopes: [operator.admin])
- The server adapter is already registered in `server/src/adapters/registry.ts`
