### PR TITLE
Add OpenCode execute regression test

### DIFF
--- a/server/src/__tests__/opencode-local-execute.test.ts
+++ b/server/src/__tests__/opencode-local-execute.test.ts
@@ -168,7 +168,8 @@ describe("opencode execute", () => {
         ]),
       );
       expect(capture.xdgConfigHome).not.toBe(sourceConfigHome);
-      await expect(fs.access(capture.xdgConfigHome ?? "")).rejects.toThrow();
+      expect(capture.xdgConfigHome).not.toBeNull();
+      await expect(fs.access(capture.xdgConfigHome!)).rejects.toThrow();
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME;


### PR DESCRIPTION
## Summary
- add a regression test for the OpenCode execute path when `AGENT_HOME` lives outside the project `cwd`
- verify `execute()` passes a temporary runtime config with `permission.external_directory=allow` into the spawned OpenCode process
- assert existing OpenCode config is preserved and the temporary config home is cleaned up after the run

## Problem observed
In a real Paperclip heartbeat run, an `opencode_local` agent failed with repeated auto-rejections for `external_directory` reads against `AGENT_HOME` files like `HEARTBEAT.md`, `SOUL.md`, and `TOOLS.md`.

The failing shape was:
- working directory under `/paperclip/.../projects/.../_default`
- `AGENT_HOME` under `/paperclip/.../workspaces/<agent-id>`
- headless OpenCode execution with `Skip permissions` enabled

That produced logs like:
- `permission requested: external_directory (...); auto-rejecting`

## Why this PR
The current `master` branch already contains the runtime-config behavior for `opencode_local`, but there was no execute-path regression test covering the exact failure mode above. This test locks in that behavior so the headless permission plumbing does not regress silently.

## Verification
- `pnpm test:run server/src/__tests__/opencode-local-execute.test.ts`
- `pnpm -r typecheck` *(fails on pre-existing unrelated UI Lexical issues on current upstream master)*
- `pnpm test:run` *(fails on the same pre-existing UI Lexical module issues on current upstream master)*
- `pnpm build` *(fails on the same pre-existing UI Lexical module issues on current upstream master)*