### PR TITLE
fix(routines): add missing feedback after trigger create/save

### DIFF
--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -476,7 +476,10 @@ export function RoutineDetail() {
           webhookUrl: result.secretMaterial.webhookUrl,
           webhookSecret: result.secretMaterial.webhookSecret,
         });
+      } else {
+        pushToast({ title: "Trigger added", tone: "success" });
       }
+      setNewTrigger({ kind: "schedule", cronExpression: "0 10 * * *", signingMode: "bearer", replayWindowSec: "300" });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.routines.detail(routineId!) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),
@@ -495,6 +498,7 @@ export function RoutineDetail() {
   const updateTrigger = useMutation({
     mutationFn: ({ id, patch }: { id: string; patch: Record<string, unknown> }) => routinesApi.updateTrigger(id, patch),
     onSuccess: async () => {
+      pushToast({ title: "Trigger saved", tone: "success" });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.routines.detail(routineId!) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) }),


### PR DESCRIPTION
## Problem

Two silent-failure UX bugs in `RoutineDetail.tsx` on the `paperclip-routines` branch:

1. **Save trigger** — clicking Save on an existing trigger updates the backend correctly but shows no confirmation toast. Users have no feedback that the save worked.

2. **Add trigger** — after clicking "Add trigger", the form stays populated (appears like nothing happened) and no toast is shown for schedule triggers. Webhook triggers correctly show the secret banner, but schedule triggers get nothing.

## Fix

- `updateTrigger.onSuccess`: add `pushToast({ title: "Trigger saved", tone: "success" })`
- `createTrigger.onSuccess`: add success toast for non-webhook triggers + reset `newTrigger` state back to defaults so the form visually clears

## Testing

1. Open a routine with no triggers
2. Add a schedule trigger → should see "Trigger added" toast and form resets
3. Edit the trigger label → click Save → should see "Trigger saved" toast