### PR TITLE
feat(ui): display copyable goal ID in goal detail page

### DIFF
--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -6,6 +6,7 @@ import { projectsApi } from "../api/projects";
 import { assetsApi } from "../api/assets";
 import { usePanel } from "../context/PanelContext";
 import { useCompany } from "../context/CompanyContext";
+import { useToast } from "../context/ToastContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
@@ -24,6 +25,7 @@ import type { Goal, Project } from "@paperclipai/shared";
 export function GoalDetail() {
   const { goalId } = useParams<{ goalId: string }>();
   const { selectedCompanyId, setSelectedCompanyId } = useCompany();
+  const { pushToast } = useToast();
   const { openNewGoal } = useDialog();
   const { openPanel, closePanel } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -122,6 +124,17 @@ export function GoalDetail() {
             {goal.level}
           </span>
           <StatusBadge status={goal.status} />
+          <button
+            type="button"
+            className="text-xs font-mono text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            title="Click to copy goal ID"
+            onClick={() => {
+              navigator.clipboard.writeText(goal.id);
+              pushToast({ title: "Goal ID copied", tone: "success" });
+            }}
+          >
+            {goal.id.slice(0, 8)}
+          </button>
         </div>
 
         <InlineEditor

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -128,9 +128,13 @@ export function GoalDetail() {
             type="button"
             className="text-xs font-mono text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
             title="Click to copy goal ID"
-            onClick={() => {
-              navigator.clipboard.writeText(goal.id);
-              pushToast({ title: "Goal ID copied", tone: "success" });
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(goal.id);
+                pushToast({ title: "Goal ID copied", tone: "success" });
+              } catch {
+                pushToast({ title: "Failed to copy goal ID", tone: "error" });
+              }
             }}
           >
             {goal.id.slice(0, 8)}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - Human users work with goals to track what the agents are doing
> - When user look at a goal detail page, they sometimes need to reference the goal ID - for sharing with teammate or for API work
> - But the goal ID was not displayed anywhere on the page, user had to dig into URL or dev tools
> - So we added a small copyable goal ID button in the header, same pattern as issue identifier
> - The clipboard write is properly awaited with error handling so user get correct feedback

## Problem

When looking at a goal detail page, the goal ID was not visible anywhere. The header show the level badge (like "TEAM" or "COMPANY") and the status badge, but no ID.

This is inconsistent with the issue detail page where we show the issue identifier (like PAP-123) and user can click it to copy. When working with API or sharing goal reference with teammate, user had to inspect the URL or look in browser dev tools to find the goal ID. Very annoying.

## What I changed

Added the first 8 characters of the goal ID as a small monospaced text button next to the level and status badges. Same visual pattern as the issue identifier we added before:

- Small font-mono text in muted color
- Get darker on hover to show it's interactive
- Click to copy full goal ID to clipboard
- Show "Goal ID copied" success toast
- On clipboard failure, show "Failed to copy goal ID" error toast (properly awaited Promise with try/catch)

Also added useToast import since it wasn't in this file yet.

## How to test

1. Go to any goal detail page
2. Next to the level label and status badge, should see a short ID like "a1b2c3d4"
3. Hover over it - text should darken and cursor change to pointer
4. Click it - full goal ID copied to clipboard, success toast appear
5. (Optional) Test clipboard failure: in browser devtools, override navigator.clipboard.writeText to reject - should see error toast instead of success

1 file, 13 lines added.