### PR TITLE
fix(a11y): always show subtle underline on markdown links

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -661,11 +661,14 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
 
 .paperclip-markdown a {
   color: color-mix(in oklab, var(--foreground) 76%, #0969da 24%);
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+  text-underline-offset: 0.15em;
 }
 
 .paperclip-markdown a:hover {
   text-decoration: underline;
+  text-decoration-color: currentColor;
   text-underline-offset: 0.15em;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - Agents have instructions, issues, and other content that is written in markdown
> - The dashboard renders this markdown so humans can read it nicely
> - But links inside rendered markdown had no underline by default - only a very slight color shift from surrounding text
> - The underline only appear when you hover, so without moving your mouse you cannot tell which text is clickable
> - This is a WCAG accessibility problem - links should be distinguishable from regular text without relying only on color
> - This pull request makes markdown links always show a subtle underline at 30% opacity, and on hover underline goes to full opacity
> - The benefit is users with low vision, colorblindness, or bright screen conditions can now identify links without needing to hover over every word

## Problem

Links in rendered markdown content had `text-decoration: none` by default. The underline only appear on hover. This mean if you just look at the page without moving your mouse, you cannot tell which text is a link and which is regular text. The only difference is a slight color shift which is not enough for many users.

This is a WCAG accessibility concern - links should be visually distinguishable from surrounding text without relying only on color. Users with low vision, colorblindness, or just bright screen conditions may not notice the subtle color difference.

I noticed this when reading agent instructions that had several links mixed in with regular text. Had to hover over random words to discover which ones are clickable.

## What I changed

Instead of removing the underline completely, now links have a very subtle underline at all times:

- **At rest:** underline visible at 30% opacity (`color-mix(in oklab, currentColor 30%, transparent)`)
- **On hover:** underline goes to full opacity for stronger visual feedback

The 30% opacity underline is light enough to not make text look cluttered or distracting, but strong enough that you can tell "this text is a link" without hovering. Similar to how GitHub renders links in markdown.

## How to test

1. Go to any issue or agent that has markdown with links
2. Without hovering, links should have a faint underline visible
3. Hover over a link - underline should get more prominent
4. Check in both light and dark mode

1 file, 4 lines changed.