### PR TITLE
feat(ui): show agent count numbers on filter tabs

### DIFF
--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -131,6 +131,13 @@ export function Agents() {
 
   const filtered = filterAgents(agents ?? [], tab, showTerminated);
   const filteredOrg = filterOrgTree(orgTree ?? [], tab, showTerminated);
+  const allAgents = agents ?? [];
+  const counts = {
+    all: allAgents.filter((a) => a.status !== "terminated").length,
+    active: allAgents.filter((a) => a.status === "active" || a.status === "running" || a.status === "idle").length,
+    paused: allAgents.filter((a) => a.status === "paused").length,
+    error: allAgents.filter((a) => a.status === "error").length,
+  };
 
   return (
     <div className="space-y-4">
@@ -138,10 +145,10 @@ export function Agents() {
         <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
           <PageTabBar
             items={[
-              { value: "all", label: "All" },
-              { value: "active", label: "Active" },
-              { value: "paused", label: "Paused" },
-              { value: "error", label: "Error" },
+              { value: "all", label: `All (${counts.all})` },
+              { value: "active", label: `Active (${counts.active})` },
+              { value: "paused", label: `Paused (${counts.paused})` },
+              { value: "error", label: `Error (${counts.error})` },
             ]}
             value={tab}
             onValueChange={(v) => navigate(`/agents/${v}`)}

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -131,13 +131,15 @@ export function Agents() {
 
   const filtered = filterAgents(agents ?? [], tab, showTerminated);
   const filteredOrg = filterOrgTree(orgTree ?? [], tab, showTerminated);
-  const allAgents = agents ?? [];
-  const counts = {
-    all: allAgents.filter((a) => a.status !== "terminated").length,
-    active: allAgents.filter((a) => a.status === "active" || a.status === "running" || a.status === "idle").length,
-    paused: allAgents.filter((a) => a.status === "paused").length,
-    error: allAgents.filter((a) => a.status === "error").length,
-  };
+  const counts = useMemo(() => {
+    const all = agents ?? [];
+    return {
+      all: all.filter((a) => matchesFilter(a.status, "all", showTerminated)).length,
+      active: all.filter((a) => matchesFilter(a.status, "active", showTerminated)).length,
+      paused: all.filter((a) => matchesFilter(a.status, "paused", showTerminated)).length,
+      error: all.filter((a) => matchesFilter(a.status, "error", showTerminated)).length,
+    };
+  }, [agents, showTerminated]);
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - The Agents page has filter tabs (All, Active, Paused, Error) so human can quickly see distribution of agent states
> - This PR adds count numbers to those tabs so user can see at glance how many agents in each state
> - But first version had a bug: the counts was computed with manual status checks separate from the `matchesFilter` function
> - The `matchesFilter` function includes terminated agents in every tab when "Show terminated" toggle is on
> - The manual counts did not account for this, so when toggle was enabled, tab numbers showed less than actual list length
> - This fix makes counts go through same `matchesFilter` logic, so numbers always match what user sees
> - Also wrapped counts in `useMemo` for consistency with other memoized derived data in this component

## Problem

On the Agents page, the filter tabs at the top show "All", "Active", "Paused", "Error" but with no numbers. If I have 20 agents and want to know how many are in error state, I have to click the "Error" tab and count manually (or look at the list length). Same for active and paused.

This is a very basic UX pattern that every list page should have - showing the count next to each filter option so user can scan the distribution at a glance.

## What I changed

Computed counts for each status category using the existing `matchesFilter` function (same logic that drives filtered lists):
- All: non-terminated agents (plus terminated when showTerminated is on)
- Active: agents with status active, running, or idle (plus terminated when toggle on)
- Paused: agents with status paused (plus terminated when toggle on)
- Error: agents with status error (plus terminated when toggle on)

Then show them in the tab labels as parenthesized numbers: "Active (5)", "Error (2)", etc.

Counts are wrapped in `useMemo` with `[agents, showTerminated]` deps, consistent with other memoized data in this component (`liveRunByAgent`, `agentMap`).

## How to test

1. Go to Agents page
2. Tab labels should now show counts like "All (12)", "Active (8)", "Paused (2)", "Error (2)"
3. The numbers should match the actual list contents when you click each tab
4. Enable "Show terminated" toggle - counts should increase to include terminated agents
5. Disable toggle again - counts should go back to previous numbers

## Review feedback addressed

- **P1**: Counts now use `matchesFilter` instead of manual status checks, so they respect `showTerminated` state
- **P2**: Counts wrapped in `useMemo` to avoid 4x array iteration on every render

1 file changed, 9 insertions(+), 7 deletions(-) (net +2 lines).