### PR TITLE
fix: replace placeholder Codex icon with official Codex CLI logo

### DIFF
--- a/doc/assets/logos/codex.svg
+++ b/doc/assets/logos/codex.svg
@@ -1,4 +1,3 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="16" cy="16" r="15" fill="#000"/>
-  <path d="M16 6L16 26M11 11L16 6L21 11M11 21L16 26L21 21" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path stroke="#000" stroke-linecap="round" stroke-width="2.484" d="M22.356 19.797H17.17M9.662 12.29l1.979 3.576a.511.511 0 0 1-.005.504l-1.974 3.409M30.758 16c0 8.15-6.607 14.758-14.758 14.758-8.15 0-14.758-6.607-14.758-14.758C1.242 7.85 7.85 1.242 16 1.242c8.15 0 14.758 6.608 14.758 14.758Z"/>
 </svg>


### PR DESCRIPTION
Replace the placeholder Codex icon (a generic up/down arrow symbol) with the official Codex CLI logo — the `>_` terminal prompt inside a circle, sourced directly from the [openai/codex](https://github.com/openai/codex) repository.

<img width="626" height="361" alt="CleanShot 2026-03-27 at 16 55 37" src="https://github.com/user-attachments/assets/fba6b4f6-db21-4c64-8b73-09c1390b396e" />
