### PR TITLE
feat(ui): show item counts on inbox filter tabs

### DIFF
--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -960,13 +960,13 @@ export function Inbox() {
               items={[
                 {
                   value: "mine",
-                  label: "Mine",
+                  label: `Mine (${mineIssues.length})`,
                 },
                 {
                   value: "recent",
-                  label: "Recent",
+                  label: `Recent (${touchedIssues.length})`,
                 },
-                { value: "unread", label: "Unread" },
+                { value: "unread", label: `Unread (${unreadTouchedIssues.length})` },
                 { value: "all", label: "All" },
               ]}
             />

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -960,13 +960,17 @@ export function Inbox() {
               items={[
                 {
                   value: "mine",
-                  label: `Mine (${mineIssues.length})`,
+                  label: `Mine${isMineIssuesLoading ? "" : ` (${mineIssues.length})`}`,
                 },
                 {
                   value: "recent",
-                  label: `Recent (${touchedIssues.length})`,
+                  label: `Recent${isTouchedIssuesLoading ? "" : ` (${touchedIssues.length})`}`,
                 },
-                { value: "unread", label: `Unread (${unreadTouchedIssues.length})` },
+                {
+                  value: "unread",
+                  // unread is derived from touchedIssues, so we use the same loading flag
+                  label: `Unread${isTouchedIssuesLoading ? "" : ` (${unreadTouchedIssues.length})`}`,
+                },
                 { value: "all", label: "All" },
               ]}
             />


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Human users oversee agents through a web UI, and the Inbox is the main page they land on
> - The Inbox has filter tabs (Mine, Recent, Unread, All) but they did not show how many items each filter has
> - Other pages like Approvals and Agents already show counts on their tabs
> - Without counts, users must click each tab to know how much work is waiting
> - This PR adds issue counts to the three main tabs so users can see at a glance how busy each category is
> - The counts intentionally reflect issues only (not approvals/failed runs/join requests), because issues are the primary work unit that users track and triage in the Inbox

## Problem

The Inbox page have four filter tabs at the top: "Mine", "Recent", "Unread", "All". But none of them show how many items are in each category. When I open the inbox, I don't know if I have 3 unread items or 30 without clicking the "Unread" tab first.

The Approvals page already show count on the "Pending" tab (line 90-96 in Approvals.tsx), and we just added counts to the Agents page tabs too. But Inbox was missing this even though it is probably the most important page to have quick count visibility.

## What I changed

Added item counts to the three main tabs:
- **Mine (5)** - shows mineIssues.length (issues assigned to current user)
- **Recent (12)** - shows touchedIssues.length (recently touched issues)
- **Unread (3)** - shows unreadTouchedIssues.length (issues with unread activity)
- **All** - no count (this tab show mixed content types so a single number would be confusing)

All three arrays are already computed and memoized in the component, so this add zero extra API calls or computation.

### Why counts show issues only, not total rendered items

Each tab also render approvals, failed runs, and join requests alongside issues. The counts here intentionally reflect **issues only** because:
1. Issues are the primary work unit users care about in the Inbox
2. Approvals and failed runs are supplementary items that appear on multiple tabs with the same values, so counting them would inflate numbers without giving useful signal
3. This is consistent with how users think about their inbox - "I have 5 issues to look at" is more useful than "I have 5 issues + 3 approvals that also show on every other tab"

### Loading state

Counts are hidden while the queries are still in-flight, so users will not see misleading (0) values. Once data arrive, the count appears next to each tab label.

## How to test

1. Go to Inbox page
2. While data loads, tabs should show just "Mine", "Recent", "Unread" without any number
3. After loading, tabs should show counts like "Mine (5)", "Recent (12)", "Unread (3)"
4. The numbers should match the actual issue items when you click each tab
5. Non-issue items (approvals, failed runs) are visible in the list but not included in the tab count - this is intentional

1 file, ~7 lines changed.