### PR TITLE
fix(docker): remap container UID/GID at runtime to avoid volume mount permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM node:lts-trixie-slim AS base
+ARG USER_UID=1000
+ARG USER_GID=1000
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl git \
+  && apt-get install -y --no-install-recommends ca-certificates curl git gosu \
   && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable
+
+# Modify the existing node user/group to have the specified UID/GID to match host user
+RUN usermod -u $USER_UID --non-unique node \
+  && groupmod -g $USER_GID --non-unique node \
+  && usermod -g $USER_GID -d /paperclip node
 
 FROM base AS deps
 WORKDIR /app
@@ -35,11 +43,16 @@ RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
 
 FROM base AS production
+ARG USER_UID=1000
+ARG USER_GID=1000
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
   && mkdir -p /paperclip \
   && chown node:node /paperclip
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV NODE_ENV=production \
   HOME=/paperclip \
@@ -48,6 +61,8 @@ ENV NODE_ENV=production \
   SERVE_UI=true \
   PAPERCLIP_HOME=/paperclip \
   PAPERCLIP_INSTANCE_ID=default \
+  USER_UID=${USER_UID} \
+  USER_GID=${USER_GID} \
   PAPERCLIP_CONFIG=/paperclip/instances/default/config.json \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private
@@ -55,5 +70,5 @@ ENV NODE_ENV=production \
 VOLUME ["/paperclip"]
 EXPOSE 3100
 
-USER node
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# Capture runtime UID/GID from environment variables, defaulting to 1000
+PUID=${USER_UID:-1000}
+PGID=${USER_GID:-1000}
+
+# Adjust the node user's UID/GID if they differ from the runtime request
+# and fix volume ownership only when a remap is needed
+changed=0
+
+if [ "$(id -u node)" -ne "$PUID" ]; then
+    echo "Updating node UID to $PUID"
+    usermod -o -u "$PUID" node
+    changed=1
+fi
+
+if [ "$(id -g node)" -ne "$PGID" ]; then
+    echo "Updating node GID to $PGID"
+    groupmod -o -g "$PGID" node
+    usermod -g "$PGID" node
+    changed=1
+fi
+
+if [ "$changed" = "1" ]; then
+    chown -R node:node /paperclip
+fi
+
+exec gosu node "$@"


### PR DESCRIPTION
## Thinking Path

> Paperclip orchestrates AI agents for zero-human companies — it runs persistent processes that read and write agent state to a data directory.
>
> To run Paperclip in a hosted or cloud environment, operators use Docker — mounting a host directory as `/paperclip` so data persists across container restarts.
>
> The container runs as the `node` user (UID 1000). When the host directory is owned by a different UID (any non-root user on many Linux distros), writes to the mounted volume fail with permission errors. This is a very common problem, raised repeatedly in the community — as seen again recently in `#dev`.
>
> The standard Docker solution is to remap the container user's UID/GID at startup to match the host directory owner — well-established practice, typically implemented with `gosu` and a minimal shell entrypoint.
>
> The existing Dockerfile has no mechanism for this: it uses a static `USER node` directive with no entrypoint script, so there is no opportunity to perform the remap.
>
> This PR adds `USER_UID`/`USER_GID` build args for build-time pre-baking, installs `gosu`, and adds a minimal `docker-entrypoint.sh` that re-checks and remaps the UID/GID at container startup before dropping privileges and exec-ing the server.

## What Changed

- **`Dockerfile`**
  - Added `ARG USER_UID=1000` and `ARG USER_GID=1000` build args (defaults to 1000 — no behaviour change for existing deployments)
  - Added `gosu` to the base apt install
  - Added `usermod`/`groupmod` at build time to pre-bake the UID/GID into the image layer
  - Added `USER_UID` and `USER_GID` to the `ENV` block so they are available at runtime
  - Replaced static `USER node` directive with `ENTRYPOINT ["docker-entrypoint.sh"]`
  - Copies `docker-entrypoint.sh` to `/usr/local/bin/` and makes it executable
- **`docker-entrypoint.sh`** (new file)
  - Reads `USER_UID`/`USER_GID` env vars at startup
  - Calls `usermod`/`groupmod` if the running UID/GID differ from the node user (handles runtime override without rebuild)
  - Calls `chown -R node:node /paperclip` to correct volume ownership
  - Drops to `node` user via `exec gosu node "$@"` — no persistent root process

**Note on customisation:** A question that keeps coming up is how to add tools, MCP servers, or extra packages to the image (e.g. for specific agent adapters). The cleanest pattern is to build a downstream image using Paperclip as a base:

```dockerfile
FROM paperclipai/paperclip:latest
# Install your tools on top
RUN apt-get update && apt-get install -y ripgrep && rm -rf /var/lib/apt/lists/*
```

This PR keeps the upstream image minimal and focused. Documenting this pattern properly is a good follow-up.

## Verification

Build and run with a non-default UID:

```bash
# Build with custom UID/GID baked in
docker build --build-arg USER_UID=1001 --build-arg USER_GID=1001 -t paperclip-test .

# Or override at runtime without rebuild
docker run -e USER_UID=1001 -e USER_GID=1001 \
  -v /host/paperclip/data:/paperclip \
  paperclip-test

# Confirm server runs as expected UID
docker exec <container> id
# uid=1001(node) gid=1001(node)

# Confirm volume ownership is corrected
docker exec <container> ls -la /paperclip
# drwxr-xr-x node node ...
```

Default build (no args): identical behaviour to the previous image — server runs as `node` (UID 1000), entrypoint is a no-op remap and proceeds immediately to `exec gosu node`.

## Risks

- **Entrypoint runs briefly as root** before the `gosu` drop — this is intentional and necessary for `usermod`/`chown`. The server process itself never runs as root. This is the standard pattern for this use case (Bitnami images, LinuxServer.io images, official Redis/Postgres images all do the same).
- **`gosu` adds a small dependency** (~1 MB). `gosu` is a well-known, audited privilege-drop tool that avoids the TTY and signal-handling issues of `su`/`sudo` in containers.
- **Existing deployments unaffected** — the entrypoint detects no UID/GID change and immediately exec-s the server with zero overhead.

## Checklist

- [x] Thinking path traces from project context to change
- [x] Tests run locally and pass
- [ ] Tests added or updated where applicable *(no unit tests exist for the Dockerfile; this is a runtime change — verification steps above cover it)*
- [x] Before/after screenshots included *(N/A — no UI change)*
- [x] Risks considered and documented
- [x] Will address all Greptile and reviewer comments before merge