### PR TITLE
feat(ui): show item count next to issue group headers

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -685,7 +685,7 @@ export function IssuesList({
                   <span className="text-sm font-semibold uppercase tracking-wide">
                     {group.label}
                   </span>
-                  <span className="text-xs text-muted-foreground tabular-nums ml-1.5">
+                  <span className="text-xs text-muted-foreground tabular-nums">
                     {group.items.length}
                   </span>
                 </CollapsibleTrigger>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -685,6 +685,9 @@ export function IssuesList({
                   <span className="text-sm font-semibold uppercase tracking-wide">
                     {group.label}
                   </span>
+                  <span className="text-xs text-muted-foreground tabular-nums ml-1.5">
+                    {group.items.length}
+                  </span>
                 </CollapsibleTrigger>
                 <Button
                   variant="ghost"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - So there is a UI where humans can see and manage issues
> - Issues can be grouped by status or priority using group headers
> - But the group headers only show the label, not how many issues are in each group
> - When groups are collapsed you cannot tell how many items are hidden inside
> - This PR add a small count number next to each group header label
> - The benefit is users can quickly see the size of each group without counting manually or expanding collapsed groups

## Problem

When you group issues by status or priority in the issues list, each group header show the category name like "IN PROGRESS" or "HIGH" but no count. If I want to know how many issues are in each status group, I have to count them visually which is impossible when groups are collapsed.

This is a very standard pattern - every project management tool show counts on their group headers (Jira, Linear, GitHub Projects, etc).

## What I changed

Added a small count number right next to the group label text. For example now it show "IN PROGRESS 5" instead of just "IN PROGRESS".

The count use:
- `text-xs text-muted-foreground` so it don't compete visually with the bold label
- `tabular-nums` for consistent width when numbers change
- Spacing between label and count is handled by the parent `gap-1.5` (no extra margin needed)

The count come from `group.items.length` which is already computed in the groupedContent memo - no new computation needed.

## How to test

1. Go to Issues page
2. Click "Group" button and select "Status" or "Priority"
3. Each group header should now show a count number next to the label
4. Collapse a group and the count should still be visible so you know how many items are hidden

1 file, 3 lines added.