### PR TITLE
feat(ui): show comment and sub-issue counts on issue detail tabs

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1006,11 +1006,11 @@ export function IssueDetail() {
         <TabsList variant="line" className="w-full justify-start gap-1">
           <TabsTrigger value="comments" className="gap-1.5">
             <MessageSquare className="h-3.5 w-3.5" />
-            Comments
+            Comments{comments && comments.length > 0 ? ` (${comments.length})` : ""}
           </TabsTrigger>
           <TabsTrigger value="subissues" className="gap-1.5">
             <ListTree className="h-3.5 w-3.5" />
-            Sub-issues
+            Sub-issues{childIssues.length > 0 ? ` (${childIssues.length})` : ""}
           </TabsTrigger>
           <TabsTrigger value="activity" className="gap-1.5">
             <ActivityIcon className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - Human users can view issues, which is central screen for understanding what agents are doing
> - Each issue has detail page with tabs: Comments, Sub-issues, Activity
> - But these tabs do not show any count, so user must click each tab to know if there is content inside
> - The "Linked Approvals" tab already shows count in parentheses, so the pattern exist but was not applied to main tabs
> - This PR adds count numbers to Comments and Sub-issues tabs, using data that is already loaded in the component
> - The benefit is that during triage, user can immediately see which issues have discussion or are broken down into sub-tasks, without clicking back and forth

## Problem

When looking at an issue detail page, the tabs at the bottom show "Comments", "Sub-issues", "Activity" - but no counts. I cannot see if there are 0 or 50 comments without clicking the tab. Same for sub-issues.

This is specially annoying when triaging issues because I want to quickly see which issues have discussion (comments) and which are broken down into sub-tasks (sub-issues) without clicking back and forth between tabs.

The "Linked Approvals" tab further down already show a count in parentheses, so the pattern exist in the same page but was not applied to the main tabs.

## What I changed

Added count display to Comments and Sub-issues tabs:
- **Comments (5)** - shows when there are comments
- **Sub-issues (3)** - shows when there are child issues
- Just **Comments** or **Sub-issues** when count is zero (no distracting "(0)")

Both use data already loaded and available in the component (`comments` from useQuery and `childIssues` from useMemo).

## How to test

1. Open any issue that has comments and/or sub-issues
2. The Comments tab should show count like "Comments (5)"
3. The Sub-issues tab should show count like "Sub-issues (2)"
4. Open issue with zero comments - should show just "Comments" with no number

1 file, 2 lines changed.