### PR TITLE
fix: resolve tsx CLI via exported subpath instead of internal path

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 


### PR DESCRIPTION
## Problem

`pnpm dev` fails to start the server with the following error:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/cli.mjs' is not defined
by "exports" in .../server/node_modules/tsx/package.json
```

In `server/scripts/dev-watch.ts`, the tsx CLI was being resolved via its internal file path:

```ts
const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
```

The `tsx` package tightened its `exports` field in a recent update — `./dist/cli.mjs` is no longer listed as an exported subpath. Node.js enforces the `exports` map and rejects direct access to unlisted paths, causing the dev server to crash on startup.

## Fix

Use the officially exported subpath `tsx/cli`, which resolves to the same `dist/cli.mjs` file:

```ts
const tsxCliPath = require.resolve("tsx/cli");
```

## Test plan

- [ ] Run `pnpm dev` — server starts without `ERR_PACKAGE_PATH_NOT_EXPORTED`
- [ ] Verify file watching works (`tsx watch` spawns correctly)