### PR TITLE
fix(ui): show success toast when saving agent configuration

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1447,6 +1447,7 @@ function ConfigurationTab({
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.configRevisions(agent.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(agent.companyId) });
+      pushToast({ title: "Agent saved", tone: "success" });
     },
     onError: (err) => {
       setAwaitingRefreshAfterSave(false);


### PR DESCRIPTION
## Problem

When you edit agent configuration (name, instructions, adapter settings, etc) and click Save, the form just quietly go back to normal state. There is no toast, no message, no visual confirmation that the save was successful.

But when the save FAIL, you get a red "Save failed" toast with the error message (line 1459). So the feedback is asymmetrical - you only hear from the system when something go wrong, never when it go right.

This made me click Save multiple times sometimes because I was not sure if it actually work. The button text change from "Saving..." back to "Save" but that transition is easy to miss if you look away for a moment.

## What I changed

Added one line in the `updateAgent` mutation `onSuccess` callback:

```tsx
pushToast({ title: "Agent saved", tone: "success" });
```

Now user see a brief green toast confirming the save. Same pattern used in Routines page when creating a routine (line 132-136) and in many other mutation success handlers across the app.

## How to test

1. Go to any agent detail > Config tab
2. Change any setting (name, instructions, etc)
3. Click Save
4. Should see green "Agent saved" toast appear briefly

1 file, 1 line added.