### PR TITLE
fix: sanitize non-UUID runId in logActivity to prevent FK violation

### DIFF
--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -34,6 +34,8 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function logActivity(db: Db, input: LogActivityInput) {
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
@@ -42,6 +44,19 @@ export async function logActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = sanitizedDetails
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;
+
+  // activity_log.run_id is a uuid FK referencing heartbeat_runs.id.
+  // If the caller provides a non-UUID string (or a UUID that doesn't exist in
+  // heartbeat_runs), the INSERT will fail with a FK violation and surface as an
+  // unhandled 500 on the parent request. Sanitize to null when invalid.
+  const runId = input.runId && UUID_RE.test(input.runId) ? input.runId : null;
+  if (input.runId && !runId) {
+    logger.warn(
+      { runId: input.runId, action: input.action, entityId: input.entityId },
+      "logActivity: dropping non-UUID runId to avoid FK violation on activity_log",
+    );
+  }
+
   await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -50,7 +65,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId,
     details: redactedDetails,
   });
 
@@ -64,7 +79,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
+      runId,
       details: redactedDetails,
     },
   });
@@ -82,7 +97,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       payload: {
         ...redactedDetails,
         agentId: input.agentId ?? null,
-        runId: input.runId ?? null,
+        runId,
       },
     };
     void _pluginEventBus.emit(event).then(({ errors }) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents communicate with the Paperclip server using bearer API keys and optional request headers
> - One such header is `X-Paperclip-Run-Id`, which agents include to associate activity with a specific heartbeat run
> - Every mutating action is recorded via `logActivity`, which inserts a row into the `activity_log` table
> - `activity_log.run_id` is a UUID foreign key referencing `heartbeat_runs.id`
> - When an agent (or misconfigured caller) sends a non-UUID string in `X-Paperclip-Run-Id`, the INSERT fails with a FK constraint violation
> - That error propagates as an unhandled 500 on the parent request (e.g. issue creation succeeds in the DB but the response is a 500)
> - This PR validates the runId format before insertion and falls back to null when invalid, preserving the original value in a warning log for debugging

## Problem

When `X-Paperclip-Run-Id` header contains a non-UUID string, the `activity_log` INSERT fails with a foreign key violation against `heartbeat_runs.id`. This surfaces as an unhandled 500 on the parent request.

**Reproduction:**
```bash
curl -X POST 'http://localhost:3100/api/companies/{id}/issues' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer $API_KEY' \
  -H 'X-Paperclip-Run-Id: not-a-uuid' \
  -d '{"title": "test"}'
# Returns: {"error": "Internal server error"} (500)
```

The same request without the header succeeds (201).

## What Changed

- Added a module-level `UUID_RE` regex (compiled once, efficient) to `activity-log.ts`
- Before inserting, validate `input.runId` against the regex; coerce to `null` if invalid
- Emit a structured `logger.warn` with the original value, action, and entityId when dropping an invalid runId
- All three downstream uses of `runId` (DB insert, live event payload, plugin event payload) are updated consistently

## Why It Matters

Agents in the field may send arbitrary strings as run IDs — either due to misconfiguration or a bug in their SDK. Without this fix, any such request that triggers activity logging results in a silent 500 that the agent cannot distinguish from a real server error, making debugging very difficult.

## Verification

1. Start the dev server (`pnpm dev`)
2. Send a request with `X-Paperclip-Run-Id: not-a-uuid` — the request should now succeed (e.g. 201 for issue creation) and a `WARN` log entry should appear with the invalid value
3. Sending a valid UUID run ID continues to work as before
4. `pnpm -r typecheck` passes

## Risks

- A valid-format UUID that does not exist in `heartbeat_runs` would still cause a FK violation. This is a pre-existing edge case (valid UUIDs from terminated/unknown runs) and is deferred as a follow-up; the format check covers the reported failure case.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)