### PR TITLE
feat(ui): show relative time for routine next scheduled run

### DIFF
--- a/ui/src/lib/timeAgo.ts
+++ b/ui/src/lib/timeAgo.ts
@@ -29,3 +29,16 @@ export function timeAgo(date: Date | string): string {
   const mo = Math.floor(seconds / MONTH);
   return `${mo}mo ago`;
 }
+
+export function timeUntil(date: Date | string): string {
+  const now = Date.now();
+  const then = new Date(date).getTime();
+  const seconds = Math.round((then - now) / 1000);
+
+  if (seconds < 0) return "now";
+  if (seconds < MINUTE) return "in <1m";
+  if (seconds < HOUR) return `in ${Math.floor(seconds / MINUTE)}m`;
+  if (seconds < DAY) return `in ${Math.floor(seconds / HOUR)}h`;
+  if (seconds < WEEK) return `in ${Math.floor(seconds / DAY)}d`;
+  return `in ${Math.floor(seconds / WEEK)}w`;
+}

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -25,7 +25,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useToast } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 import { buildRoutineTriggerPatch } from "../lib/routine-trigger-patch";
-import { timeAgo } from "../lib/timeAgo";
+import { timeAgo, timeUntil } from "../lib/timeAgo";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
@@ -146,9 +146,9 @@ function TriggerEditor({
           {trigger.kind === "schedule" ? <Clock3 className="h-3.5 w-3.5" /> : trigger.kind === "webhook" ? <Webhook className="h-3.5 w-3.5" /> : <Zap className="h-3.5 w-3.5" />}
           {trigger.label ?? trigger.kind}
         </div>
-        <span className="text-xs text-muted-foreground">
+        <span className="text-xs text-muted-foreground" title={trigger.kind === "schedule" && trigger.nextRunAt ? new Date(trigger.nextRunAt).toLocaleString() : undefined}>
           {trigger.kind === "schedule" && trigger.nextRunAt
-            ? `Next: ${new Date(trigger.nextRunAt).toLocaleString()}`
+            ? `Next: ${timeUntil(trigger.nextRunAt)}`
             : trigger.kind === "webhook"
               ? "Webhook"
               : "API"}


### PR DESCRIPTION
## Problem

When looking at a routine trigger's next run time, it was displayed as a full absolute timestamp like "Next: 3/28/2026, 2:30:45 PM". This require me to look at the clock, figure out today's date, and mentally calculate the difference to know when the next run happen.

The rest of the app use relative time everywhere (activity feed show "2h ago", run list show "5m ago", etc) but this one spot was using absolute format. Very inconsistent and hard to scan when you have multiple routines.

## What I changed

**timeAgo.ts:**
Added a new \`timeUntil()\` utility function - the future-facing companion to the existing \`timeAgo()\`. Returns strings like "in 2h", "in 1d", "in 3w". Uses same time thresholds as timeAgo for consistency.

**RoutineDetail.tsx:**
Changed the next run display from \`new Date(trigger.nextRunAt).toLocaleString()\` to \`timeUntil(trigger.nextRunAt)\`. The full absolute date is still available as a hover tooltip so user can see exact time when they need it.

**Before:** "Next: 3/28/2026, 2:30:45 PM"
**After:** "Next: in 2h" (hover to see "3/28/2026, 2:30:45 PM")

## How to test

1. Go to Routines > open any routine with a schedule trigger
2. The trigger header should show "Next: in Xh" or "in Xd" instead of full date
3. Hover over it to see the full absolute timestamp

2 files, 16 lines added.