### PR TITLE
fix(ui): consistent date display in issue properties sidebar

### DIFF
--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -605,14 +605,14 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
         )}
         {issue.completedAt && (
           <PropertyRow label="Completed">
-            <span className="text-sm">{formatDate(issue.completedAt)}</span>
+            <span className="text-sm" title={new Date(issue.completedAt).toLocaleString()}>{formatDate(issue.completedAt)}</span>
           </PropertyRow>
         )}
         <PropertyRow label="Created">
-          <span className="text-sm">{formatDate(issue.createdAt)}</span>
+          <span className="text-sm" title={new Date(issue.createdAt).toLocaleString()}>{timeAgo(issue.createdAt)}</span>
         </PropertyRow>
         <PropertyRow label="Updated">
-          <span className="text-sm">{timeAgo(issue.updatedAt)}</span>
+          <span className="text-sm" title={new Date(issue.updatedAt).toLocaleString()}>{timeAgo(issue.updatedAt)}</span>
         </PropertyRow>
       </div>
     </div>


### PR DESCRIPTION
## Problem

The three date fields in the issue properties sidebar was using different formats which is confusing:

- **Created**: showed absolute date like "Mar 25, 2026" (using formatDate). No relative time, no tooltip.
- **Updated**: showed relative time like "2h ago" (using timeAgo). No tooltip with exact date.
- **Completed**: showed absolute date like "Mar 25, 2026". No relative time, no tooltip.

So if I want to know "how old is this issue?" from the Created field, I have to read the date and calculate mentally. But the Updated field right below it show "2h ago" which is immediately scannable. Very inconsistent UX.

Also none of the three fields had a hover tooltip showing the full timestamp with time included (hour, minute, second). The formatDate only show month, day, year.

## What I changed

Made all three fields consistent:

- **Created**: changed from `formatDate(issue.createdAt)` to `timeAgo(issue.createdAt)`. Now show "3d ago" instead of "Mar 25, 2026". Added `title` tooltip with full `toLocaleString()` for exact timestamp.
- **Updated**: kept `timeAgo(issue.updatedAt)` as before. Added `title` tooltip with full timestamp.
- **Completed**: kept `formatDate(issue.completedAt)` since completed dates are usually referenced as specific dates. Added `title` tooltip with full timestamp including time.

## How to test

1. Open any issue > look at the properties sidebar on the right
2. "Created" should now show relative time like "3d ago" (hover for exact date+time)
3. "Updated" should show relative time with hover tooltip (same as before but now with tooltip)
4. If issue is completed, "Completed" show date with hover tooltip including time

1 file, 3 lines changed.