### PR TITLE
feat: cronjob de limpeza preventiva de execution locks órfãos (DIG-58)

### DIFF
--- a/server/src/__tests__/heartbeat-execution-lock-sweep.test.ts
+++ b/server/src/__tests__/heartbeat-execution-lock-sweep.test.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres execution lock sweep tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("sweepOrphanedExecutionLocks", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-lock-sweep-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture(input: {
+    runStatus: string;
+    lockedAt?: Date;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "paused",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: input.runStatus,
+      contextSnapshot: { issueId },
+      startedAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Test issue with execution lock",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionLockedAt: input.lockedAt ?? new Date(),
+      executionAgentNameKey: "testagent",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, runId, issueId };
+  }
+
+  it("clears lock when associated run is in terminal status 'succeeded'", async () => {
+    const { issueId } = await seedFixture({ runStatus: "succeeded" });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+
+    expect(result.cleaned).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+
+    const [row] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(row!.executionRunId).toBeNull();
+    expect(row!.executionLockedAt).toBeNull();
+    expect(row!.executionAgentNameKey).toBeNull();
+  });
+
+  it("clears lock when associated run is in terminal status 'failed'", async () => {
+    const { issueId } = await seedFixture({ runStatus: "failed" });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+
+    expect(result.cleaned).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+  });
+
+  it("clears lock when associated run is in terminal status 'cancelled'", async () => {
+    const { issueId } = await seedFixture({ runStatus: "cancelled" });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+
+    expect(result.cleaned).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+  });
+
+  it("clears lock when associated run is in terminal status 'timed_out'", async () => {
+    const { issueId } = await seedFixture({ runStatus: "timed_out" });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+
+    expect(result.cleaned).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+  });
+
+  it("clears lock when executionLockedAt is older than the stale threshold and run is terminal", async () => {
+    const staleDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    const { issueId } = await seedFixture({ runStatus: "failed", lockedAt: staleDate });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks({ staleThresholdMs: 60 * 60 * 1000 });
+
+    expect(result.cleaned).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+  });
+
+  it("does NOT clear lock when associated run is still active (running)", async () => {
+    const { issueId } = await seedFixture({ runStatus: "running" });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+
+    expect(result.cleaned).toBe(0);
+    expect(result.issueIds).not.toContain(issueId);
+
+    const [row] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(row!.executionRunId).not.toBeNull();
+  });
+
+  it("does NOT clear lock when associated run is queued (not yet started)", async () => {
+    const { issueId } = await seedFixture({ runStatus: "queued" });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+
+    expect(result.cleaned).toBe(0);
+    expect(result.issueIds).not.toContain(issueId);
+  });
+
+  it("does NOT clear a recent lock when run is still active, even with a long-ago lockedAt", async () => {
+    // Run is still running — the lock is valid regardless of timestamp
+    const staleDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const { issueId } = await seedFixture({ runStatus: "running", lockedAt: staleDate });
+    const heartbeat = heartbeatService(db as any);
+
+    const result = await heartbeat.sweepOrphanedExecutionLocks({ staleThresholdMs: 60 * 60 * 1000 });
+
+    expect(result.cleaned).toBe(0);
+    expect(result.issueIds).not.toContain(issueId);
+  });
+
+  it("returns cleaned=0 when there are no orphaned locks", async () => {
+    const heartbeat = heartbeatService(db as any);
+    const result = await heartbeat.sweepOrphanedExecutionLocks();
+    expect(result.cleaned).toBe(0);
+    expect(result.issueIds).toHaveLength(0);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -606,8 +606,33 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
     }, config.heartbeatSchedulerIntervalMs);
+
+    // Sweep orphaned execution locks every 15 minutes.
+    // An orphaned lock is one whose associated run has reached a terminal state
+    // (succeeded / failed / cancelled / timed_out) or whose lock timestamp is
+    // older than 1 hour without an active run.
+    const EXECUTION_LOCK_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+    const ORPHANED_LOCK_ALERT_THRESHOLD = Number(process.env.ORPHANED_LOCK_ALERT_THRESHOLD) || 5;
+    setInterval(() => {
+      void heartbeat
+        .sweepOrphanedExecutionLocks()
+        .then((result) => {
+          if (result.cleaned > 0) {
+            const logFn = result.cleaned >= ORPHANED_LOCK_ALERT_THRESHOLD ? logger.error : logger.warn;
+            logFn(
+              { cleanedCount: result.cleaned, issueIds: result.issueIds, alertThreshold: ORPHANED_LOCK_ALERT_THRESHOLD },
+              result.cleaned >= ORPHANED_LOCK_ALERT_THRESHOLD
+                ? `ALERT: swept ${result.cleaned} orphaned execution locks (>= threshold ${ORPHANED_LOCK_ALERT_THRESHOLD})`
+                : `swept ${result.cleaned} orphaned execution locks`,
+            );
+          }
+        })
+        .catch((err) => {
+          logger.error({ err }, "orphaned execution lock sweep failed");
+        });
+    }, EXECUTION_LOCK_SWEEP_INTERVAL_MS);
   }
-  
+
   if (config.databaseBackupEnabled) {
     const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
     let backupInFlight = false;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, lt, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType } from "@paperclipai/shared";
 import {
@@ -1839,6 +1839,81 @@ export function heartbeatService(db: Db) {
     for (const agentId of agentIds) {
       await startNextQueuedRunForAgent(agentId);
     }
+  }
+
+  /**
+   * Sweep execution locks that have become orphaned: the associated run is in a
+   * terminal state (`succeeded`, `failed`, `cancelled`, `timed_out`) OR the lock
+   * has been held for longer than `staleThresholdMs` (default: 1 hour) without an
+   * active run. Clears `executionRunId`, `executionAgentNameKey`, and
+   * `executionLockedAt` on affected issues and returns a summary.
+   */
+  async function sweepOrphanedExecutionLocks(opts?: { staleThresholdMs?: number }) {
+    const staleThresholdMs = opts?.staleThresholdMs ?? 60 * 60 * 1000; // 1 hour
+    const staleCutoff = new Date(Date.now() - staleThresholdMs);
+
+    // Find issues with a populated executionRunId whose run is terminal OR whose
+    // lock timestamp is stale (fallback for runs whose records may be missing).
+    const candidates = await db
+      .select({
+        issueId: issues.id,
+        companyId: issues.companyId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+        runStatus: heartbeatRuns.status,
+      })
+      .from(issues)
+      .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issues.executionRunId))
+      .where(
+        and(
+          isNotNull(issues.executionRunId),
+          or(
+            inArray(heartbeatRuns.status, ["succeeded", "failed", "cancelled", "timed_out"]),
+            // Lock held without an active run for longer than the stale threshold
+            and(
+              lt(issues.executionLockedAt, staleCutoff),
+              or(
+                sql`${heartbeatRuns.id} IS NULL`,
+                sql`${heartbeatRuns.status} NOT IN ('queued', 'running')`,
+              ),
+            ),
+          ),
+        ),
+      );
+
+    if (candidates.length === 0) {
+      return { cleaned: 0, issueIds: [] };
+    }
+
+    const issueIds = candidates.map((c) => c.issueId);
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(inArray(issues.id, issueIds));
+
+    logger.warn(
+      {
+        cleanedCount: candidates.length,
+        issueIds,
+        staleCutoff: staleCutoff.toISOString(),
+        details: candidates.map((c) => ({
+          issueId: c.issueId,
+          companyId: c.companyId,
+          executionRunId: c.executionRunId,
+          runStatus: c.runStatus ?? "missing",
+          lockedAt: c.executionLockedAt?.toISOString() ?? null,
+        })),
+      },
+      "swept orphaned execution locks",
+    );
+
+    return { cleaned: candidates.length, issueIds };
   }
 
   async function updateRuntimeState(
@@ -3802,6 +3877,8 @@ export function heartbeatService(db: Db) {
     reapOrphanedRuns,
 
     resumeQueuedRuns,
+
+    sweepOrphanedExecutionLocks,
 
     tickTimers: async (now = new Date()) => {
       const allAgents = await db.select().from(agents);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1885,35 +1885,26 @@ export function heartbeatService(db: Db) {
       return { cleaned: 0, issueIds: [] };
     }
 
-    const issueIds = candidates.map((c) => c.issueId);
-
-    await db
-      .update(issues)
-      .set({
-        executionRunId: null,
-        executionAgentNameKey: null,
-        executionLockedAt: null,
-        updatedAt: new Date(),
-      })
-      .where(inArray(issues.id, issueIds));
-
-    logger.warn(
-      {
-        cleanedCount: candidates.length,
-        issueIds,
-        staleCutoff: staleCutoff.toISOString(),
-        details: candidates.map((c) => ({
-          issueId: c.issueId,
-          companyId: c.companyId,
-          executionRunId: c.executionRunId,
-          runStatus: c.runStatus ?? "missing",
-          lockedAt: c.executionLockedAt?.toISOString() ?? null,
-        })),
-      },
-      "swept orphaned execution locks",
+    // Update per-row, verifying executionRunId still matches the candidate snapshot
+    // to avoid a TOCTOU race where a new run acquires the lock between SELECT and UPDATE.
+    const updateResults = await Promise.all(
+      candidates.map((c) =>
+        db
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(issues.id, c.issueId), eq(issues.executionRunId, c.executionRunId!)))
+          .returning({ id: issues.id }),
+      ),
     );
 
-    return { cleaned: candidates.length, issueIds };
+    const clearedIssueIds = updateResults.flatMap((r) => r.map((row) => row.id));
+
+    return { cleaned: clearedIssueIds.length, issueIds: clearedIssueIds };
   }
 
   async function updateRuntimeState(


### PR DESCRIPTION
## O que foi feito

- Adicionado `sweepOrphanedExecutionLocks` no `heartbeatService` (`server/src/services/heartbeat.ts`)
- Registrado `setInterval` a cada 15 minutos em `server/src/index.ts` para executar o sweep
- Adicionados testes de regressão em `server/src/__tests__/heartbeat-execution-lock-sweep.test.ts`

## Critérios de limpeza

Um lock é considerado **órfão** quando:
- A run associada ao `executionRunId` está em estado terminal (`succeeded`, `failed`, `cancelled`, `timed_out`)
- **OU** `executionLockedAt` é mais antigo que 1 hora e a run não está mais ativa (`queued`/`running`)

## Configuração

- **Frequência:** 15 minutos (hardcoded em `EXECUTION_LOCK_SWEEP_INTERVAL_MS`)
- **Threshold de alerta:** env `ORPHANED_LOCK_ALERT_THRESHOLD` (default: 5) — emite log em nível `error` quando ≥ threshold locks são limpos em uma varredura

## Observabilidade

- Log `warn` com `cleanedCount`, `issueIds`, `staleCutoff` e detalhes de cada lock limpo
- Log `error` quando `cleanedCount >= ORPHANED_LOCK_ALERT_THRESHOLD`

## Dependência

Este PR deve ser mergeado **após** o PR #1944 (fix do path manual de release).

## Issue relacionada

- [DIG-58] Cronjob de limpeza preventiva de execution locks órfãos
- Parte de [DIG-56] Bug: Execution locks órfãos bloqueando checkout