### PR TITLE
fix(server): use stable tsx/cli entry point in dev-watch

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 


### PR DESCRIPTION
---

> - Paperclip orchestrates ai-agents for zero-human companies
> - The dev server uses tsx watch to hot-reload during development
> - The dev-watch script resolves the tsx CLI binary path at runtime using require.resolve()
> - But it was using the internal path tsx/dist/cli.mjs, which is an undocumented implementation detail
> - When tsx updated its internal file structure, this path broke and the dev server could not start
> - This PR switches to the stable, officially exported entry point tsx/cli
> - The benefit is that dev-watch is now resilient to tsx internal refactors and will work across versions

## What changed

- server/scripts/dev-watch.ts: Changed require.resolve("tsx/dist/cli.mjs") -> require.resolve("tsx/cli")
## Why

The tsx/dist/cli.mjs path is an internal implementation detail that is not guaranteed by tsx's public API. The tsx/cli export is the official, stable entry point documented in tsx's package exports.

## Verification

- [x] pnpm -r typecheck passes (all packages)
- [ ] - [x] pnpm test:run passes (137 test files, 682 tests passed)
- [ ] - [x] Dev server starts correctly with pnpm dev
---
