### PR TITLE
fix: resolve tsx CLI via exported subpath

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 


### PR DESCRIPTION
## Thinking path
- Paperclip runs the server dev loop through `tsx watch` in `server/scripts/dev-watch.ts`
- Newer `tsx` versions do not export direct `./dist/*` internals through the package `exports` field
- Resolving `tsx/dist/cli.mjs` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, which breaks `pnpm dev`
- `tsx` provides a stable public exported subpath at `tsx/cli` for the same CLI entrypoint
- Switching `require.resolve` to `tsx/cli` fixes local dev startup without changing runtime behavior

## Summary
- fix server dev watch startup by resolving the tsx CLI through its exported subpath
- replace `require.resolve("tsx/dist/cli.mjs")` with `require.resolve("tsx/cli")`

## Why
Recent `tsx` versions export `./cli` but do not expose `./dist/cli.mjs` through package exports. The previous path causes `ERR_PACKAGE_PATH_NOT_EXPORTED` during `pnpm dev`, which prevents the Paperclip server from starting in local development.

## Risk
- low risk: this switches from a private internal path to the package's public exported CLI path
- assumes a `tsx` version that exports `./cli`, which is true for the version currently installed in this repo during verification

## Verification
- reproduced the startup failure locally
- applied this patch
- reran `pnpm dev`
- confirmed Paperclip started successfully on `http://127.0.0.1:3100`