### PR TITLE
feat(ui): display company ID with click-to-copy in company settings

### DIFF
--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -241,6 +241,19 @@ export function CompanySettings() {
               onChange={(e) => setCompanyName(e.target.value)}
             />
           </Field>
+          <Field label="Company ID" hint="Use this ID when calling the Paperclip API.">
+            <button
+              type="button"
+              className="w-full rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-sm text-muted-foreground font-mono text-left cursor-copy hover:text-foreground transition-colors"
+              title="Click to copy"
+              onClick={() => {
+                navigator.clipboard.writeText(selectedCompanyId!);
+                pushToast({ title: "Company ID copied", tone: "success" });
+              }}
+            >
+              {selectedCompanyId}
+            </button>
+          </Field>
           <Field
             label="Description"
             hint="Optional description shown in the company profile."


### PR DESCRIPTION
## Problem

The company ID was not shown anywhere in the Company Settings page. When I need the company ID for API calls, writing scripts, or setting up integrations, I had to:
- Open browser developer tools
- Inspect a network request that include the company ID
- Or manually extract it from the URL path

This is very annoying because the company ID is a common thing you need when working with the Paperclip API. Other detail pages (agents, issues, goals) already show their IDs prominently - but the company settings page was hiding it.

## What I changed

Added a "Company ID" field in the General section of Company Settings, right above the Description field. The field:

- Show the full UUID in monospace font for easy reading
- Has muted background (\`bg-muted/30\`) to visually indicate it's not editable
- Click anywhere on it to copy to clipboard (uses \`cursor-copy\` hover style)
- Show "Company ID copied" success toast after copying
- Has hint text: "Use this ID when calling the Paperclip API."

## How to test

1. Go to Company Settings page
2. In the General section, should see "Company ID" field with a UUID
3. Click on the ID - should copy to clipboard with success toast
4. Paste somewhere to verify

1 file, 13 lines added.