### PR TITLE
fix: resolve plugin launcher navigate targets as absolute paths

### DIFF
--- a/ui/src/plugins/launchers.tsx
+++ b/ui/src/plugins/launchers.tsx
@@ -651,16 +651,22 @@ export function PluginLauncherProvider({ children }: { children: ReactNode }) {
       sourceEl?: HTMLElement | null,
     ) => {
       switch (launcher.action.type) {
-        case "navigate":
-          navigate(launcher.action.target);
+        case "navigate": {
+          const target = launcher.action.target;
+          // Ensure plugin navigate targets resolve as absolute paths so they
+          // aren't resolved relative to the current browser URL.
+          navigate(target.startsWith("/") ? target : `/${target}`);
           return;
-        case "deepLink":
-          if (/^https?:\/\//.test(launcher.action.target)) {
-            window.open(launcher.action.target, "_blank", "noopener,noreferrer");
+        }
+        case "deepLink": {
+          const dlTarget = launcher.action.target;
+          if (/^https?:\/\//.test(dlTarget)) {
+            window.open(dlTarget, "_blank", "noopener,noreferrer");
           } else {
-            navigate(launcher.action.target);
+            navigate(dlTarget.startsWith("/") ? dlTarget : `/${dlTarget}`);
           }
           return;
+        }
         case "performAction":
           await pluginsApi.bridgePerformAction(
             launcher.pluginId,


### PR DESCRIPTION
## Thinking Path

- Paperclip hosts third-party plugins via a plugin launcher system
- Plugin launchers can declare `action: { type: "navigate", target: "chat" }` to route the user to a page
- `activateLauncher` passes the target string directly to the custom `useNavigate` wrapper
- The wrapper calls `applyCompanyPrefix`, which only prefixes paths starting with `/` (see `company-routes.ts:65`)
- Bare targets like `"chat"` are returned as-is and React Router resolves them relative to the current URL
- This causes navigation to the wrong path depending on where the user is (e.g. `/ACME/issues/chat` instead of `/ACME/chat`)
- This PR normalizes bare targets to absolute paths before passing them to `navigate()`

## Summary

- Plugin launchers with `action: { type: "navigate", target: "chat" }` resolve the target **relative to the current browser URL**, causing navigation to break depending on which page the user is on
- Normalizes bare targets (e.g. `"chat"` → `"/chat"`) to absolute paths so `applyCompanyPrefix` correctly prepends the company prefix regardless of current location
- Applies the same fix to the `deepLink` action's local-path fallback

## Risks

- **Plugins relying on intentional relative navigation:** No plugin manifest examples in the repo use relative navigate targets that depend on the current URL context. The manifest schema describes `target` as a route name, not a relative path — so this aligns with intended usage.
- **Targets already containing the company prefix:** If a target is already absolute (e.g. `"/ACME/chat"`), `applyCompanyPrefix` detects the existing prefix via `extractCompanyPrefixFromPath` and returns it unchanged — no double-prefixing.
- **External URLs in `deepLink`:** The HTTP regex check runs before the path normalization, so external URLs still open in a new tab as before.

## Test plan

- [ ] Install a plugin with a sidebar launcher using `action: { type: "navigate", target: "chat" }`
- [ ] Click the launcher from various pages (dashboard, issues, agents, another plugin page)
- [ ] Verify it always navigates to `/:companyPrefix/chat`
- [ ] Verify plugins using absolute targets (e.g. `target: "/dashboard"`) still work
- [ ] Verify `deepLink` actions with external URLs still open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)