### PR TITLE
fix(ui): confirm before restoring agent config revision

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1379,10 +1379,10 @@ function AgentConfigurePage({
                         size="sm"
                         variant="outline"
                         className="h-7 px-2.5 text-xs"
-                        onClick={() => rollbackConfig.mutate(revision.id)}
+                        onClick={() => { if (window.confirm("Restore this config revision? Current configuration will be overwritten.")) rollbackConfig.mutate(revision.id); }}
                         disabled={rollbackConfig.isPending}
                       >
-                        Restore
+                        {rollbackConfig.isPending ? "Restoring..." : "Restore"}
                       </Button>
                     </div>
                     <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

In the agent detail Config tab, there is a revision history section where you can see previous configurations and restore them. The "Restore" button call \`rollbackConfig.mutate()\` immediately with no confirmation dialog.

This is dangerous because restoring a previous revision overwrite the current agent configuration. If you accidentally click the button (easy to do since the buttons are small and close together), your current config is gone and replaced with the old one. There is no undo.

We already add confirmation dialogs to other destructive actions like trigger deletion, API key revocation, and file deletion. This one was missed.

## What I changed

- Added \`window.confirm()\` dialog before calling rollback: "Restore this config revision? Current configuration will be overwritten."
- Added loading text "Restoring..." while the mutation is pending (button was just showing "Restore" during the operation with no feedback)

Same pattern used for other destructive actions in the app.

## How to test

1. Go to any agent > Config tab > scroll down to revision history
2. Click "Restore" on any previous revision
3. Should see confirmation dialog asking to confirm
4. Click Cancel - nothing happen
5. Click OK - button show "Restoring..." and config get restored

1 file, 2 lines changed.