### PR TITLE
fix: inbox badge only counts unread issues

### DIFF
--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -266,7 +266,7 @@ export function computeInboxBadgeData({
   const visibleJoinRequests = joinRequests.filter(
     (jr) => !dismissed.has(`join:${jr.id}`),
   ).length;
-  const visibleMineIssues = mineIssues.length;
+  const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;


### PR DESCRIPTION
### Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans want to watch the agents and oversee their work through the UI
> - The inbox shows issues that need human attention
> - The inbox badge displays a count to help users know how many items need their attention
> - But the badge count wasn't decreasing when users clicked on items
> - The issue was that the badge counted ALL "mine" issues instead of only unread ones
> - This PR fixes the badge calculation to filter by `isUnreadForMe` property
> - Now users see accurate unread counts that decrease as they review items

## What Changed

Fixed the inbox badge calculation in [ui/src/lib/inbox.ts:269](ui/src/lib/inbox.ts#L269) to only count unread issues instead of all "mine" issues.

**Before:**
```typescript
const visibleMineIssues = mineIssues.length;
```

**After:**
```typescript
const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
```

## Why It Matters

The inbox badge is a key indicator for users to know when they have items requiring attention. When the count didn't decrease after clicking items, it created confusion and made the badge unreliable.

## How to Verify

1. Start Paperclip and navigate to the inbox
2. Note the badge count in the sidebar
3. Click on unread items (ones with blue dots)
4. Observe that the badge count decreases as you click items
5. Verify the count reaches 0 when all items are read

## Risks

Low risk - this is a focused UI fix that only changes the badge calculation logic. The underlying read state tracking and API remain unchanged.