### PR TITLE
fix(issues): clear stale executionRunId lock on same-assignee checkout

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -11,6 +11,7 @@ import {
   companies,
   createDb,
   ensurePostgresDatabase,
+  heartbeatRuns,
   issueComments,
   issues,
 } from "@paperclipai/db";
@@ -100,6 +101,7 @@ describe("issueService.list participantAgentId", () => {
     await db.delete(issueComments);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -280,5 +282,66 @@ describe("issueService.list participantAgentId", () => {
     });
 
     expect(result.map((issue) => issue.id)).toEqual([matchedIssueId]);
+  });
+
+  it("adopts stale execution locks when same-assignee checkout lock is missing", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleRunId = randomUUID();
+    const actorRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReleaseLead",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "scheduler",
+        status: "failed",
+      },
+      {
+        id: actorRunId,
+        companyId,
+        agentId,
+        invocationSource: "scheduler",
+        status: "running",
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Adopt stale execution lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: staleRunId,
+    });
+
+    const updated = await svc.checkout(issueId, agentId, ["todo", "backlog", "blocked"], actorRunId);
+    expect(updated?.id).toBe(issueId);
+    expect(updated?.status).toBe("in_progress");
+    expect(updated?.checkoutRunId).toBe(actorRunId);
+    expect(updated?.executionRunId).toBe(actorRunId);
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1077,14 +1077,33 @@ export function issueService(db: Db) {
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
         current.checkoutRunId == null &&
-        (current.executionRunId == null || current.executionRunId === checkoutRunId) &&
         checkoutRunId
       ) {
+        const staleExecutionLock =
+          current.executionRunId !== null &&
+          current.executionRunId !== checkoutRunId &&
+          (await isTerminalOrMissingHeartbeatRun(current.executionRunId));
+        const executionCondition =
+          current.executionRunId == null || current.executionRunId === checkoutRunId
+            ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
+            : staleExecutionLock
+              ? eq(issues.executionRunId, current.executionRunId)
+              : null;
+        if (!executionCondition) {
+          throw conflict("Issue checkout conflict", {
+            issueId: current.id,
+            status: current.status,
+            assigneeAgentId: current.assigneeAgentId,
+            checkoutRunId: current.checkoutRunId,
+            executionRunId: current.executionRunId,
+          });
+        }
         const adopted = await db
           .update(issues)
           .set({
             checkoutRunId,
             executionRunId: checkoutRunId,
+            executionLockedAt: new Date(),
             updatedAt: new Date(),
           })
           .where(
@@ -1093,7 +1112,7 @@ export function issueService(db: Db) {
               eq(issues.status, "in_progress"),
               eq(issues.assigneeAgentId, agentId),
               isNull(issues.checkoutRunId),
-              or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId)),
+              executionCondition,
             ),
           )
           .returning()


### PR DESCRIPTION
## Summary
- fix issue checkout recovery when an in-progress issue is already assigned to the same agent, has `checkoutRunId = null`, and still carries a stale `executionRunId`
- allow checkout to adopt the caller run lock when the existing execution run is terminal or missing, instead of returning a conflict
- add regression coverage in `issues-service` for the stale execution-lock adoption path

## Trading-program impact
This removes a control-plane friction point where release-lead remediation tasks could remain blocked by stale run locks even though ownership was unchanged, improving overnight handoff reliability.

## Validation
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`
