### PR TITLE
fix(issues): recover stale execution run lock on checkout

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -162,6 +162,21 @@ Seed modes:
 
 After `worktree init`, both the server and the CLI auto-load the repo-local `.paperclip/.env` when run inside that worktree, so normal commands like `pnpm dev`, `paperclipai doctor`, and `paperclipai db:backup` stay scoped to the worktree instance.
 
+Git remote configuration is different: linked git worktrees share one common git dir, so `remote.*` config is shared across the base checkout and every linked worktree. Keep `origin` pointed at the canonical hosted repo URL. If you need a local-path remote for ad hoc fetches, add it under a different name such as `base-local`; do not repoint `origin` at another local clone path because that changes push/fetch behavior for every sibling worktree that shares the same common git dir.
+
+Audit a workspace tree when needed:
+
+```sh
+./scripts/audit-git-remote-urls.sh /var/lib/paperclip/instances/nl-vps/workspaces
+```
+
+Batch-correct local-path `origin` remotes to the canonical hosted URL when needed:
+
+```sh
+./scripts/fix-git-remote-urls.sh /var/lib/paperclip/instances/nl-vps/workspaces \
+  https://github.com/paperclipai/paperclip.git
+```
+
 That repo-local env also sets:
 
 - `PAPERCLIP_IN_WORKTREE=true`

--- a/report/2026-03-25-issue-route-hardening-and-wakeup-repair.md
+++ b/report/2026-03-25-issue-route-hardening-and-wakeup-repair.md
@@ -1,0 +1,37 @@
+# Issue Route Hardening And Wakeup Repair
+
+This change set closes three Paperclip failure paths that were causing avoidable friction for the overnight Poly Capital org:
+
+- malformed UUID filters/cursors in issue APIs could reach deeper service queries and surface as 500s instead of clean 400s
+- incremental comment polling could break when the anchor timestamp was bound through postgres-js as a raw `Date`
+- queued issue wakeups could be persisted without an attached heartbeat run, leaving assignment/comment work stranded until later recovery
+
+## Behavior changes
+
+- `GET /api/companies/:companyId/issues` now rejects malformed UUID query filters such as `assigneeAgentId`, `participantAgentId`, `projectId`, `parentId`, and `labelId` with `400`.
+- Issue comment routes now reject malformed `afterCommentId` and `commentId` values with `400`.
+- Heartbeat-context, approval unlink, label delete, work product mutation, and attachment content/delete routes now reject malformed UUID path/query params with `400`.
+- Incremental comment fetch now compares against the anchor timestamp using an ISO string cursor, which keeps polling stable.
+- Heartbeat resume now repairs queued issue wakeups that were saved without a corresponding heartbeat run.
+- New wakeup creation now persists the wakeup request and queued heartbeat run in one transaction so Paperclip does not recreate that orphaned state in normal execution.
+
+## Trading-program impact
+
+- Agents and operators should see fewer avoidable 500s while filtering issues or polling comments.
+- Assignment and comment wakes should be less likely to disappear into queued-but-unrunnable state after restarts or partial failures.
+- Overnight remediation work should resume more predictably because Paperclip now repairs the missing-run wakeup state during queued-run recovery.
+
+## QA checks
+
+Run these against a dev instance:
+
+1. Request `GET /api/companies/:companyId/issues?assigneeAgentId=not-a-uuid` and confirm `400` with no server error.
+2. Request `GET /api/issues/:id/comments?afterCommentId=not-a-uuid` and confirm `400`.
+3. Create two comments on an issue, then request `GET /api/issues/:id/comments?afterCommentId=<first-comment-id>&order=asc` and confirm only the later comment returns.
+4. Assign an issue to an agent or add a wake-triggering comment, restart the server mid-flight if needed, and confirm the wakeup still results in a queued/running heartbeat after recovery.
+
+## Verification
+
+- `pnpm -r typecheck`
+- `pnpm test:run`
+- `pnpm build`

--- a/scripts/audit-git-remote-urls.sh
+++ b/scripts/audit-git-remote-urls.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="${1:-$PWD}"
+
+if [[ ! -d "$ROOT_DIR" ]]; then
+  echo "Root directory does not exist: $ROOT_DIR" >&2
+  exit 1
+fi
+
+classify_origin() {
+  local url="$1"
+
+  if [[ -z "$url" ]]; then
+    printf 'missing'
+    return
+  fi
+
+  if [[ "$url" =~ ^https:// ]] || [[ "$url" =~ ^git@ ]] || [[ "$url" =~ ^ssh:// ]]; then
+    printf 'hosted'
+    return
+  fi
+
+  if [[ "$url" =~ ^/ ]] || [[ "$url" =~ ^\.\.?/ ]]; then
+    printf 'local_path'
+    return
+  fi
+
+  printf 'other'
+}
+
+find_git_entries() {
+  find "$ROOT_DIR" \( -type d -name .git -o -type f -name .git \) -print | sort
+}
+
+printf 'repo_path\tgit_common_dir\torigin_url\torigin_kind\n'
+
+while IFS= read -r git_entry; do
+  repo_dir="$(dirname "$git_entry")"
+
+  if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    continue
+  fi
+
+  common_dir="$(git -C "$repo_dir" rev-parse --git-common-dir)"
+  origin_url="$(git -C "$repo_dir" config --get remote.origin.url || true)"
+  origin_kind="$(classify_origin "$origin_url")"
+
+  printf '%s\t%s\t%s\t%s\n' "$repo_dir" "$common_dir" "$origin_url" "$origin_kind"
+done < <(find_git_entries)

--- a/scripts/fix-git-remote-urls.sh
+++ b/scripts/fix-git-remote-urls.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="${1:-$PWD}"
+CANONICAL_URL="${2:-}"
+
+if [[ ! -d "$ROOT_DIR" ]]; then
+  echo "Root directory does not exist: $ROOT_DIR" >&2
+  exit 1
+fi
+
+if [[ -z "$CANONICAL_URL" ]]; then
+  echo "Usage: $0 <root-dir> <canonical-origin-url>" >&2
+  exit 1
+fi
+
+find_git_entries() {
+  find "$ROOT_DIR" \( -type d -name .git -o -type f -name .git \) -print | sort
+}
+
+printf 'repo_path\tgit_common_dir\told_origin_url\tnew_origin_url\taction\n'
+
+while IFS= read -r git_entry; do
+  repo_dir="$(dirname "$git_entry")"
+
+  if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    continue
+  fi
+
+  common_dir="$(git -C "$repo_dir" rev-parse --git-common-dir)"
+  origin_url="$(git -C "$repo_dir" config --get remote.origin.url || true)"
+
+  if [[ -z "$origin_url" ]]; then
+    printf '%s\t%s\t%s\t%s\tskip_missing_origin\n' \
+      "$repo_dir" "$common_dir" "$origin_url" "$CANONICAL_URL"
+    continue
+  fi
+
+  if [[ "$origin_url" == "$CANONICAL_URL" ]]; then
+    printf '%s\t%s\t%s\t%s\tskip_already_canonical\n' \
+      "$repo_dir" "$common_dir" "$origin_url" "$CANONICAL_URL"
+    continue
+  fi
+
+  if [[ "$origin_url" =~ ^https:// ]] || [[ "$origin_url" =~ ^git@ ]] || [[ "$origin_url" =~ ^ssh:// ]]; then
+    printf '%s\t%s\t%s\t%s\tskip_hosted_origin\n' \
+      "$repo_dir" "$common_dir" "$origin_url" "$CANONICAL_URL"
+    continue
+  fi
+
+  git -C "$repo_dir" remote set-url origin "$CANONICAL_URL"
+  printf '%s\t%s\t%s\t%s\tupdated\n' \
+    "$repo_dir" "$common_dir" "$origin_url" "$CANONICAL_URL"
+done < <(find_git_entries)

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -46,6 +46,7 @@ function createApp() {
 describe("activity routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockActivityService.list.mockResolvedValue([]);
   });
 
   it("resolves issue identifiers before loading runs", async () => {
@@ -86,5 +87,27 @@ describe("activity routes", () => {
     expect(mockIssueService.getById).not.toHaveBeenCalled();
     expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
     expect(mockActivityService.forIssue).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid agentId filter on company activity list", async () => {
+    const res = await request(createApp()).get("/api/companies/company-1/activity?agentId=not-a-uuid");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid agentId filter");
+    expect(mockActivityService.list).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed object query values for activity filters instead of forwarding them", async () => {
+    const res = await request(createApp()).get(
+      "/api/companies/company-1/activity?agentId[bad]=1&entityType[bad]=issue&entityId[bad]=abc",
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockActivityService.list).toHaveBeenCalledWith({
+      companyId: "company-1",
+      agentId: undefined,
+      entityType: undefined,
+      entityId: undefined,
+    });
   });
 });

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -89,6 +89,14 @@ describe("activity routes", () => {
     expect(mockActivityService.forIssue).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for malformed run ids on heartbeat run issues route", async () => {
+    const res = await request(createApp()).get("/api/heartbeat-runs/not-a-uuid/issues");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid run id");
+    expect(mockActivityService.issuesForRun).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid agentId filter on company activity list", async () => {
     const res = await request(createApp()).get("/api/companies/company-1/activity?agentId=not-a-uuid");
 

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -67,4 +67,24 @@ describe("activity routes", () => {
     expect(mockActivityService.runsForIssue).toHaveBeenCalledWith("company-1", "issue-uuid-1");
     expect(res.body).toEqual([{ runId: "run-1" }]);
   });
+
+  it("returns 400 for malformed issue ids on runs route", async () => {
+    const res = await request(createApp()).get("/api/issues/not-a-valid-ref/runs");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid issue id");
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+    expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
+    expect(mockActivityService.runsForIssue).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed issue ids on activity route", async () => {
+    const res = await request(createApp()).get("/api/issues/not-a-valid-ref/activity");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid issue id");
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+    expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
+    expect(mockActivityService.forIssue).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -69,6 +69,8 @@ const mockIssueApprovalService = vi.hoisted(() => ({
 
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
 }));
 
 const mockSecretService = vi.hoisted(() => ({
@@ -271,5 +273,39 @@ describe("agent permission routes", () => {
     );
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
+  });
+
+  it("returns 400 for malformed issue ids on issue live-runs route", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get("/api/issues/not-a-valid-ref/live-runs");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid issue id");
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+    expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed issue ids on issue active-run route", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get("/api/issues/not-a-valid-ref/active-run");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid issue id");
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+    expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -58,6 +58,8 @@ function createApp() {
 }
 
 describe("approval routes idempotent retries", () => {
+  const approvalId = "11111111-1111-4111-8111-111111111111";
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockHeartbeatService.wakeup.mockResolvedValue({ id: "wake-1" });
@@ -79,7 +81,7 @@ describe("approval routes idempotent retries", () => {
     });
 
     const res = await request(createApp())
-      .post("/api/approvals/approval-1/approve")
+      .post(`/api/approvals/${approvalId}/approve`)
       .send({});
 
     expect(res.status).toBe(200);
@@ -101,7 +103,7 @@ describe("approval routes idempotent retries", () => {
     });
 
     const res = await request(createApp())
-      .post("/api/approvals/approval-1/reject")
+      .post(`/api/approvals/${approvalId}/reject`)
       .send({});
 
     expect(res.status).toBe(200);
@@ -115,5 +117,13 @@ describe("approval routes idempotent retries", () => {
     expect(res.body.error).toContain("Invalid approval id");
     expect(mockApprovalService.getById).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.listIssuesForApproval).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed approval ids on approve route", async () => {
+    const res = await request(createApp()).post("/api/approvals/not-a-valid-id/approve").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid approval id");
+    expect(mockApprovalService.approve).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -107,4 +107,13 @@ describe("approval routes idempotent retries", () => {
     expect(res.status).toBe(200);
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
+
+  it("returns 400 for malformed approval ids on approval issue-link route", async () => {
+    const res = await request(createApp()).get("/api/approvals/not-a-valid-id/issues");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid approval id");
+    expect(mockApprovalService.getById).not.toHaveBeenCalled();
+    expect(mockIssueApprovalService.listIssuesForApproval).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -119,6 +119,14 @@ describe("approval routes idempotent retries", () => {
     expect(mockIssueApprovalService.listIssuesForApproval).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for invalid approval status filters", async () => {
+    const res = await request(createApp()).get("/api/companies/company-1/approvals?status=not_a_status");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid approval status filter");
+    expect(mockApprovalService.list).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for malformed approval ids on approve route", async () => {
     const res = await request(createApp()).post("/api/approvals/not-a-valid-id/approve").send({});
 

--- a/server/src/__tests__/authz-actor-info.test.ts
+++ b/server/src/__tests__/authz-actor-info.test.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { getActorInfo } from "../routes/authz.js";
+
+describe("getActorInfo runId normalization", () => {
+  it("drops malformed non-uuid runId values for board actors", () => {
+    const req = {
+      actor: {
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: false,
+        runId: { bad: true },
+      },
+    } as any;
+
+    expect(getActorInfo(req)).toMatchObject({
+      actorType: "user",
+      actorId: "board-user",
+      runId: null,
+    });
+  });
+
+  it("preserves valid uuid runId values for agent actors", () => {
+    const runId = randomUUID();
+    const req = {
+      actor: {
+        type: "agent",
+        agentId: randomUUID(),
+        companyId: randomUUID(),
+        runId,
+      },
+    } as any;
+
+    expect(getActorInfo(req)).toMatchObject({
+      actorType: "agent",
+      runId,
+    });
+  });
+});
+

--- a/server/src/__tests__/company-branding-route.test.ts
+++ b/server/src/__tests__/company-branding-route.test.ts
@@ -34,6 +34,7 @@ const mockCompanyPortabilityService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const AGENT_RUN_ID = "22222222-2222-4222-8222-222222222222";
 
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
@@ -94,7 +95,7 @@ describe("PATCH /api/companies/:companyId/branding", () => {
       agentId: "agent-1",
       companyId: "company-1",
       source: "agent_key",
-      runId: "run-1",
+      runId: AGENT_RUN_ID,
     });
 
     const res = await request(app)
@@ -119,7 +120,7 @@ describe("PATCH /api/companies/:companyId/branding", () => {
       agentId: "agent-1",
       companyId: "company-1",
       source: "agent_key",
-      runId: "run-1",
+      runId: AGENT_RUN_ID,
     });
 
     const res = await request(app)
@@ -142,7 +143,7 @@ describe("PATCH /api/companies/:companyId/branding", () => {
         actorType: "agent",
         actorId: "agent-1",
         agentId: "agent-1",
-        runId: "run-1",
+        runId: AGENT_RUN_ID,
         action: "company.branding_updated",
         details: {
           logoAssetId: "11111111-1111-4111-8111-111111111111",

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -1,0 +1,61 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executionWorkspaceRoutes } from "../routes/execution-workspaces.js";
+import { errorHandler } from "../middleware/index.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  executionWorkspaceService: () => mockExecutionWorkspaceService,
+  logActivity: vi.fn(async () => undefined),
+  workspaceOperationService: () => ({
+    create: vi.fn(),
+    complete: vi.fn(),
+    fail: vi.fn(),
+  }),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", executionWorkspaceRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("execution workspace route query parsing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecutionWorkspaceService.list.mockResolvedValue([]);
+  });
+
+  it("normalizes duplicate status query params to a safe first string", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/execution-workspaces?status=active&status=idle`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockExecutionWorkspaceService.list).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({
+        status: "active",
+      }),
+    );
+  });
+});
+

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -302,6 +302,88 @@ describe("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBe(runId);
   });
 
+  it("repairs issue-scoped queued wakeups that were persisted without a heartbeat run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "QueuedWakeAgent",
+      role: "engineer",
+      status: "paused",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Repair orphaned wakeup",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "create" },
+      status: "queued",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+
+    const repairedWakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(repairedWakeup?.runId).toBeTruthy();
+    expect(repairedWakeup?.status).toBe("queued");
+
+    const repairedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, repairedWakeup!.runId!))
+      .then((rows) => rows[0] ?? null);
+    expect(repairedRun?.status).toBe("queued");
+    expect(repairedRun?.wakeupRequestId).toBe(wakeupRequestId);
+    expect(repairedRun?.contextSnapshot).toMatchObject({
+      issueId,
+      taskId: issueId,
+      wakeReason: "issue_assigned",
+      wakeSource: "assignment",
+      wakeTriggerDetail: "system",
+    });
+
+    const repairedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(repairedIssue?.executionRunId).toBe(repairedRun?.id ?? null);
+  });
+
   it("clears the detached warning when the run reports activity again", async () => {
     const { runId } = await seedRunFixture({
       includeIssue: false,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -461,6 +461,14 @@ describe("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
     await heartbeat.resumeQueuedRuns();
 
+    const repairedWakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(repairedWakeup?.status).toBe("failed");
+    expect(repairedWakeup?.runId).toBeNull();
+
     const issue = await db
       .select()
       .from(issues)

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -384,6 +384,92 @@ describe("heartbeat orphaned process recovery", () => {
     expect(repairedIssue?.executionRunId).toBe(repairedRun?.id ?? null);
   });
 
+  it("does not overwrite execution lock when orphaned wakeup issue is reassigned or already locked", async () => {
+    const companyId = randomUUID();
+    const wakeupAgentId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const issueId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const existingExecutionRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: wakeupAgentId,
+        companyId,
+        name: "WakeupAgent",
+        role: "engineer",
+        status: "paused",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "AssigneeAgent",
+        role: "engineer",
+        status: "running",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: existingExecutionRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Do not clobber reassigned lock",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      executionRunId: existingExecutionRunId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId: wakeupAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      status: "queued",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).toBe(assigneeAgentId);
+    expect(issue?.executionRunId).toBe(existingExecutionRunId);
+  });
+
   it("clears the detached warning when the run reports activity again", async () => {
     const { runId } = await seedRunFixture({
       includeIssue: false,

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -246,4 +246,29 @@ describe("queueIssueAssignmentWakeup", () => {
       }),
     );
   });
+
+  it("drops requester ids when requester actor type is missing", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorId: "33333333-3333-4333-8333-333333333333",
+    });
+
+    expect(wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        requestedByActorType: undefined,
+        requestedByActorId: null,
+      }),
+    );
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -161,6 +161,42 @@ describe("queueIssueAssignmentWakeup", () => {
     expect(wakeup).not.toHaveBeenCalled();
   });
 
+  it("skips wakeup when issue id is non-uuid", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "not-a-uuid",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("skips wakeup when assignee id is non-uuid", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "not-a-uuid",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
   it("preserves non-uuid requester ids for user-triggered wakeups", async () => {
     const wakeup = vi.fn(async () => undefined);
 

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+describe("queueIssueAssignmentWakeup", () => {
+  it("enqueues wakeup for assigned non-backlog issues", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "test",
+    });
+
+    expect(wakeup).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips wakeup when the assigned agent triggered the assignment", async () => {
+    const agentId = "22222222-2222-4222-8222-222222222222";
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: agentId,
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -40,4 +40,22 @@ describe("queueIssueAssignmentWakeup", () => {
 
     expect(wakeup).not.toHaveBeenCalled();
   });
+
+  it("skips wakeup for terminal issue statuses", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "done",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -20,6 +20,33 @@ describe("queueIssueAssignmentWakeup", () => {
     expect(wakeup).toHaveBeenCalledTimes(1);
   });
 
+  it("normalizes forwarded issue and requester ids in wakeup payload", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: " 11111111-1111-4111-8111-111111111111 ".toUpperCase(),
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorType: "agent",
+      requestedByActorId: " 33333333-3333-4333-8333-333333333333 ".toUpperCase(),
+    });
+
+    expect(wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        requestedByActorId: "33333333-3333-4333-8333-333333333333",
+        payload: expect.objectContaining({ issueId: "11111111-1111-4111-8111-111111111111" }),
+        contextSnapshot: expect.objectContaining({ issueId: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+  });
+
   it("skips wakeup when the assigned agent triggered the assignment", async () => {
     const agentId = "22222222-2222-4222-8222-222222222222";
     const wakeup = vi.fn(async () => undefined);

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -160,4 +160,29 @@ describe("queueIssueAssignmentWakeup", () => {
 
     expect(wakeup).not.toHaveBeenCalled();
   });
+
+  it("preserves non-uuid requester ids for user-triggered wakeups", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorType: "user",
+      requestedByActorId: "  User-ABC  ",
+    });
+
+    expect(wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        requestedByActorId: "User-ABC",
+      }),
+    );
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -58,4 +58,22 @@ describe("queueIssueAssignmentWakeup", () => {
 
     expect(wakeup).not.toHaveBeenCalled();
   });
+
+  it("skips wakeup for terminal statuses with mixed case/whitespace", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "  DoNe  ",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -41,6 +41,27 @@ describe("queueIssueAssignmentWakeup", () => {
     expect(wakeup).not.toHaveBeenCalled();
   });
 
+  it("skips wakeup when agent ids match with case/whitespace differences", async () => {
+    const agentId = "22222222-2222-4222-8222-222222222222";
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: agentId.toUpperCase(),
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorType: "agent",
+      requestedByActorId: `  ${agentId}  `,
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
   it("skips wakeup for terminal issue statuses", async () => {
     const wakeup = vi.fn(async () => undefined);
 

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -271,4 +271,30 @@ describe("queueIssueAssignmentWakeup", () => {
       }),
     );
   });
+
+  it("drops malformed requester ids for agent actor type", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorType: "agent",
+      requestedByActorId: "not-a-uuid",
+    });
+
+    expect(wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        requestedByActorType: undefined,
+        requestedByActorId: null,
+      }),
+    );
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -97,4 +97,22 @@ describe("queueIssueAssignmentWakeup", () => {
 
     expect(wakeup).not.toHaveBeenCalled();
   });
+
+  it("skips wakeup when assignee id is whitespace-only", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "   ",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -221,4 +221,29 @@ describe("queueIssueAssignmentWakeup", () => {
       }),
     );
   });
+
+  it("normalizes blank requester ids to null", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+      requestedByActorType: "user",
+      requestedByActorId: "   ",
+    });
+
+    expect(wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        requestedByActorId: null,
+      }),
+    );
+  });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -142,4 +142,22 @@ describe("queueIssueAssignmentWakeup", () => {
 
     expect(wakeup).not.toHaveBeenCalled();
   });
+
+  it("skips wakeup when issue id is missing/whitespace", async () => {
+    const wakeup = vi.fn(async () => undefined);
+
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: {
+        id: "   " as any,
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "test",
+    });
+
+    expect(wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -44,7 +44,7 @@ vi.mock("../services/index.js", () => ({
   workProductService: () => ({}),
 }));
 
-function createApp() {
+function createApp(actorOverride?: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -54,6 +54,7 @@ function createApp() {
       companyIds: ["company-1"],
       source: "local_implicit",
       isInstanceAdmin: false,
+      ...actorOverride,
     };
     next();
   });
@@ -142,5 +143,27 @@ describe("issue comment reopen routes", () => {
         }),
       }),
     );
+  });
+
+  it("skips assignee wakeup for agent self-comments when ids differ only by case", async () => {
+    const assigneeId = "22222222-2222-4222-8222-222222222222";
+    mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+    const app = createApp({
+      type: "agent",
+      companyId: "company-1",
+      companyIds: ["company-1"],
+      agentId: ` ${assigneeId.toUpperCase()} `,
+      runId: "44444444-4444-4444-8444-444444444444",
+      source: "agent_api_key",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "self-comment" });
+
+    expect(res.status).toBe(201);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -166,4 +166,31 @@ describe("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
+
+  it("skips mention wakeup for patch comments when mentioned agent matches actor by case-insensitive id", async () => {
+    const actorAgentId = "22222222-2222-4222-8222-222222222222";
+    mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("todo"),
+      ...patch,
+    }));
+    mockIssueService.findMentionedAgents.mockResolvedValueOnce([actorAgentId.toUpperCase()]);
+
+    const app = createApp({
+      type: "agent",
+      companyId: "company-1",
+      companyIds: ["company-1"],
+      agentId: ` ${actorAgentId.toUpperCase()} `,
+      runId: "44444444-4444-4444-8444-444444444444",
+      source: "agent_api_key",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "@self please review" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issues-checkout-wakeup.test.ts
+++ b/server/src/__tests__/issues-checkout-wakeup.test.ts
@@ -45,4 +45,26 @@ describe("shouldWakeAssigneeOnCheckout", () => {
       }),
     ).toBe(true);
   });
+
+  it("skips wakeup when self-checkout ids only differ by case/whitespace", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: "  AGENT-1  ",
+        checkoutAgentId: "agent-1",
+        checkoutRunId: " run-1 ",
+      }),
+    ).toBe(false);
+  });
+
+  it("still wakes when checkout agent id is malformed whitespace", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        checkoutAgentId: "   ",
+        checkoutRunId: "run-1",
+      }),
+    ).toBe(true);
+  });
 });

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -184,4 +184,19 @@ describe("issue goal context routes", () => {
     );
     expect(mockGoalService.getDefaultCompanyGoal).not.toHaveBeenCalled();
   });
+
+  it("returns 404 when wakeCommentId resolves to a comment on another issue", async () => {
+    mockIssueService.getComment.mockResolvedValueOnce({
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      issueId: "99999999-9999-4999-8999-999999999999",
+      body: "foreign comment",
+    });
+
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context?wakeCommentId=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Wake comment not found on issue" });
+  });
 });

--- a/server/src/__tests__/issues-label-route-validation.test.ts
+++ b/server/src/__tests__/issues-label-route-validation.test.ts
@@ -4,9 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { issueRoutes } from "../routes/issues.js";
 import { errorHandler } from "../middleware/index.js";
 
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+
 const mockIssueService = vi.hoisted(() => ({
   getLabelById: vi.fn(),
   deleteLabel: vi.fn(),
+  listLabels: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({
@@ -41,7 +44,7 @@ function createApp() {
     (req as any).actor = {
       type: "board",
       userId: "local-board",
-      companyIds: ["company-1"],
+      companyIds: [COMPANY_ID],
       source: "local_implicit",
       isInstanceAdmin: false,
     };
@@ -57,6 +60,7 @@ describe("issue label route validation", () => {
     vi.clearAllMocks();
     mockIssueService.getLabelById.mockResolvedValue(null);
     mockIssueService.deleteLabel.mockResolvedValue(null);
+    mockIssueService.listLabels.mockResolvedValue([]);
   });
 
   it("returns 400 for malformed label ids instead of querying the DB", async () => {
@@ -66,5 +70,12 @@ describe("issue label route validation", () => {
     expect(res.body.error).toContain("Invalid labelId");
     expect(mockIssueService.getLabelById).not.toHaveBeenCalled();
     expect(mockIssueService.deleteLabel).not.toHaveBeenCalled();
+  });
+
+  it("normalizes companyId path for label listing", async () => {
+    const res = await request(createApp()).get(`/api/companies/%20${COMPANY_ID.toUpperCase()}%20/labels`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.listLabels).toHaveBeenCalledWith(COMPANY_ID);
   });
 });

--- a/server/src/__tests__/issues-label-route-validation.test.ts
+++ b/server/src/__tests__/issues-label-route-validation.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   getLabelById: vi.fn(),
   deleteLabel: vi.fn(),
   listLabels: vi.fn(),
+  createLabel: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({
@@ -61,6 +62,12 @@ describe("issue label route validation", () => {
     mockIssueService.getLabelById.mockResolvedValue(null);
     mockIssueService.deleteLabel.mockResolvedValue(null);
     mockIssueService.listLabels.mockResolvedValue([]);
+    mockIssueService.createLabel.mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      companyId: COMPANY_ID,
+      name: "Ops",
+      color: "#123456",
+    });
   });
 
   it("returns 400 for malformed label ids instead of querying the DB", async () => {
@@ -77,5 +84,17 @@ describe("issue label route validation", () => {
 
     expect(res.status).toBe(200);
     expect(mockIssueService.listLabels).toHaveBeenCalledWith(COMPANY_ID);
+  });
+
+  it("normalizes companyId path for label creation", async () => {
+    const res = await request(createApp())
+      .post(`/api/companies/%20${COMPANY_ID.toUpperCase()}%20/labels`)
+      .send({ name: "Ops", color: "#123456" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.createLabel).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({ name: "Ops", color: "#123456" }),
+    );
   });
 });

--- a/server/src/__tests__/issues-label-route-validation.test.ts
+++ b/server/src/__tests__/issues-label-route-validation.test.ts
@@ -1,0 +1,70 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getLabelById: vi.fn(),
+  deleteLabel: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue label route validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.getLabelById.mockResolvedValue(null);
+    mockIssueService.deleteLabel.mockResolvedValue(null);
+  });
+
+  it("returns 400 for malformed label ids instead of querying the DB", async () => {
+    const res = await request(createApp()).delete("/api/labels/not-a-uuid");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid labelId");
+    expect(mockIssueService.getLabelById).not.toHaveBeenCalled();
+    expect(mockIssueService.deleteLabel).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issues-label-route-validation.test.ts
+++ b/server/src/__tests__/issues-label-route-validation.test.ts
@@ -79,6 +79,14 @@ describe("issue label route validation", () => {
     expect(mockIssueService.deleteLabel).not.toHaveBeenCalled();
   });
 
+  it("normalizes labelId path before lookup", async () => {
+    const labelId = "22222222-2222-4222-8222-222222222222";
+    const res = await request(createApp()).delete(`/api/labels/%20${labelId.toUpperCase()}%20`);
+
+    expect(res.status).toBe(404);
+    expect(mockIssueService.getLabelById).toHaveBeenCalledWith(labelId);
+  });
+
   it("normalizes companyId path for label listing", async () => {
     const res = await request(createApp()).get(`/api/companies/%20${COMPANY_ID.toUpperCase()}%20/labels`);
 

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -112,4 +112,14 @@ describe("issues list query parsing", () => {
     expect(res.body.error).toContain("originId");
     expect(mockIssueService.list).not.toHaveBeenCalled();
   });
+
+  it("returns 400 for invalid includeRoutineExecutions query values", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?includeRoutineExecutions=maybe`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("includeRoutineExecutions");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -72,4 +72,24 @@ describe("issues list query parsing", () => {
       }),
     );
   });
+
+  it("normalizes comma-separated status filters before calling service", async () => {
+    const res = await request(createApp()).get("/api/companies/company-1/issues?status=todo,,in_progress,");
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        status: "todo,in_progress",
+      }),
+    );
+  });
+
+  it("returns 400 for invalid status filters instead of passing bad enum values to service", async () => {
+    const res = await request(createApp()).get("/api/companies/company-1/issues?status=todo,not_a_status");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid status filter");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { issueRoutes } from "../routes/issues.js";
 import { errorHandler } from "../middleware/index.js";
 
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
 }));
@@ -40,7 +42,7 @@ function createApp() {
     (req as any).actor = {
       type: "board",
       userId: "local-board",
-      companyIds: ["company-1"],
+      companyIds: [COMPANY_ID],
       source: "local_implicit",
       isInstanceAdmin: false,
     };
@@ -59,12 +61,12 @@ describe("issues list query parsing", () => {
 
   it("normalizes duplicate query params to safe strings for issue listing", async () => {
     const res = await request(createApp()).get(
-      "/api/companies/company-1/issues?status=todo&status=done&q=alpha&q=beta&includeRoutineExecutions=true&includeRoutineExecutions=false",
+      `/api/companies/${COMPANY_ID}/issues?status=todo&status=done&q=alpha&q=beta&includeRoutineExecutions=true&includeRoutineExecutions=false`,
     );
 
     expect(res.status).toBe(200);
     expect(mockIssueService.list).toHaveBeenCalledWith(
-      "company-1",
+      COMPANY_ID,
       expect.objectContaining({
         status: "todo",
         q: "alpha",
@@ -74,11 +76,11 @@ describe("issues list query parsing", () => {
   });
 
   it("normalizes comma-separated status filters before calling service", async () => {
-    const res = await request(createApp()).get("/api/companies/company-1/issues?status=todo,,in_progress,");
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?status=todo,,in_progress,`);
 
     expect(res.status).toBe(200);
     expect(mockIssueService.list).toHaveBeenCalledWith(
-      "company-1",
+      COMPANY_ID,
       expect.objectContaining({
         status: "todo,in_progress",
       }),
@@ -86,7 +88,7 @@ describe("issues list query parsing", () => {
   });
 
   it("returns 400 for invalid status filters instead of passing bad enum values to service", async () => {
-    const res = await request(createApp()).get("/api/companies/company-1/issues?status=todo,not_a_status");
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?status=todo,not_a_status`);
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Invalid status filter");
@@ -94,7 +96,7 @@ describe("issues list query parsing", () => {
   });
 
   it("returns 400 for invalid originKind filters instead of passing bad enum values to service", async () => {
-    const res = await request(createApp()).get("/api/companies/company-1/issues?originKind=unexpected");
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?originKind=unexpected`);
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Invalid originKind filter");

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -147,6 +147,26 @@ describe("issues list query parsing", () => {
     expect(mockIssueService.list).not.toHaveBeenCalled();
   });
 
+  it("returns 403 for touchedByUserId=me when board user id is malformed", async () => {
+    const res = await request(createApp({ userId: { bad: true } })).get(
+      `/api/companies/${COMPANY_ID}/issues?touchedByUserId=me`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("touchedByUserId=me");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for unreadForUserId=me when board user id is malformed", async () => {
+    const res = await request(createApp({ userId: { bad: true } })).get(
+      `/api/companies/${COMPANY_ID}/issues?unreadForUserId=me`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("unreadForUserId=me");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid status filters instead of passing bad enum values to service", async () => {
     const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?status=todo,not_a_status`);
 

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -89,8 +89,9 @@ describe("issues list query parsing", () => {
 
   it("normalizes status/origin filters for case and surrounding whitespace", async () => {
     const originId = "22222222-2222-4222-8222-222222222222";
+    const uppercaseOriginId = originId.toUpperCase();
     const res = await request(createApp()).get(
-      `/api/companies/${COMPANY_ID}/issues?status=%20TODO,%20IN_PROGRESS%20&originKind=%20ROUTINE_EXECUTION%20&originId=%20${originId}%20`,
+      `/api/companies/${COMPANY_ID}/issues?status=%20TODO,%20IN_PROGRESS%20&originKind=%20ROUTINE_EXECUTION%20&originId=%20${uppercaseOriginId}%20`,
     );
 
     expect(res.status).toBe(200);

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -92,4 +92,12 @@ describe("issues list query parsing", () => {
     expect(res.body.error).toContain("Invalid status filter");
     expect(mockIssueService.list).not.toHaveBeenCalled();
   });
+
+  it("returns 400 for invalid originKind filters instead of passing bad enum values to service", async () => {
+    const res = await request(createApp()).get("/api/companies/company-1/issues?originKind=unexpected");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid originKind filter");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -104,6 +104,22 @@ describe("issues list query parsing", () => {
     );
   });
 
+  it("normalizes me user filters for case and surrounding whitespace", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeUserId=%20ME%20&touchedByUserId=%20Me%20&unreadForUserId=%20mE%20`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({
+        assigneeUserId: "local-board",
+        touchedByUserId: "local-board",
+        unreadForUserId: "local-board",
+      }),
+    );
+  });
+
   it("returns 400 for invalid status filters instead of passing bad enum values to service", async () => {
     const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?status=todo,not_a_status`);
 

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -75,6 +75,21 @@ describe("issues list query parsing", () => {
     );
   });
 
+  it("prefers first non-empty duplicate query values", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?status=&status=done&q=&q=beta`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({
+        status: "done",
+        q: "beta",
+      }),
+    );
+  });
+
   it("normalizes comma-separated status filters before calling service", async () => {
     const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?status=todo,,in_progress,`);
 

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -35,7 +35,7 @@ vi.mock("../services/index.js", () => ({
   workProductService: () => ({}),
 }));
 
-function createApp() {
+function createApp(actorOverride?: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -45,6 +45,7 @@ function createApp() {
       companyIds: [COMPANY_ID],
       source: "local_implicit",
       isInstanceAdmin: false,
+      ...actorOverride,
     };
     next();
   });
@@ -134,6 +135,16 @@ describe("issues list query parsing", () => {
         unreadForUserId: "local-board",
       }),
     );
+  });
+
+  it("returns 403 for me user filters when board user id is malformed", async () => {
+    const res = await request(createApp({ userId: { bad: true } })).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeUserId=me`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("assigneeUserId=me");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid status filters instead of passing bad enum values to service", async () => {

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -1,0 +1,75 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issues list query parsing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.list.mockResolvedValue([]);
+  });
+
+  it("normalizes duplicate query params to safe strings for issue listing", async () => {
+    const res = await request(createApp()).get(
+      "/api/companies/company-1/issues?status=todo&status=done&q=alpha&q=beta&includeRoutineExecutions=true&includeRoutineExecutions=false",
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        status: "todo",
+        q: "alpha",
+        includeRoutineExecutions: true,
+      }),
+    );
+  });
+});

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -102,4 +102,14 @@ describe("issues list query parsing", () => {
     expect(res.body.error).toContain("Invalid originKind filter");
     expect(mockIssueService.list).not.toHaveBeenCalled();
   });
+
+  it("returns 400 for routine_execution origin filters with malformed originId", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?originKind=routine_execution&originId=not-a-uuid`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("originId");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issues-list-query-parsing.test.ts
+++ b/server/src/__tests__/issues-list-query-parsing.test.ts
@@ -87,6 +87,23 @@ describe("issues list query parsing", () => {
     );
   });
 
+  it("normalizes status/origin filters for case and surrounding whitespace", async () => {
+    const originId = "22222222-2222-4222-8222-222222222222";
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?status=%20TODO,%20IN_PROGRESS%20&originKind=%20ROUTINE_EXECUTION%20&originId=%20${originId}%20`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({
+        status: "todo,in_progress",
+        originKind: "routine_execution",
+        originId,
+      }),
+    );
+  });
+
   it("returns 400 for invalid status filters instead of passing bad enum values to service", async () => {
     const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?status=todo,not_a_status`);
 

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -399,6 +399,33 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.checkout).not.toHaveBeenCalled();
   });
 
+  it("trims workProductId path on work product delete route", async () => {
+    const workProductId = "77777777-7777-4777-8777-777777777777";
+    mockWorkProductService.getById.mockResolvedValueOnce(null);
+
+    const res = await request(createApp()).delete(`/api/work-products/%20${workProductId.toUpperCase()}%20`);
+
+    expect(res.status).toBe(404);
+    expect(mockWorkProductService.getById).toHaveBeenCalledWith(workProductId);
+  });
+
+  it("trims approvalId path on issue approval unlink route", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const approvalId = "88888888-8888-4888-8888-888888888888";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+
+    const res = await request(createApp()).delete(
+      `/api/issues/${issueId}/approvals/%20${approvalId.toUpperCase()}%20`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueApprovalService.unlink).toHaveBeenCalledWith(issueId, approvalId);
+  });
+
   it("returns 401 for agent checkout when runId is malformed non-uuid string", async () => {
     const agentId = "33333333-3333-4333-8333-333333333333";
     const app = createApp({

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -124,6 +124,16 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
   });
 
+  it("returns 400 when after and afterCommentId cursors conflict", async () => {
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=22222222-2222-4222-8222-222222222222&afterCommentId=33333333-3333-4333-8333-333333333333",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Conflicting comment cursors");
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid comment order query values", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/comments?order=sideways",

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  getById: vi.fn(),
+  listComments: vi.fn(),
+  getByIdentifier: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issues routes UUID validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.list.mockResolvedValue([]);
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.getById.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "todo",
+    });
+    mockIssueService.listComments.mockResolvedValue([]);
+  });
+
+  it("returns 400 for invalid UUID-based list filters", async () => {
+    const res = await request(createApp()).get("/api/companies/company-1/issues?projectId=not-a-uuid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("projectId");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid issue id path on comments routes", async () => {
+    const res = await request(createApp()).get("/api/issues/not-a-uuid/comments");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid issue id");
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid comment cursor in comment list query", async () => {
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=not-a-uuid",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("after comment cursor");
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -161,6 +161,23 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.checkout).not.toHaveBeenCalled();
   });
 
+  it("returns 401 for agent checkout when runId is malformed non-uuid string", async () => {
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId,
+      runId: "run-1",
+    });
+    const res = await request(app)
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/checkout")
+      .send({ agentId, expectedStatuses: ["todo"] });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("run id");
+    expect(mockIssueService.checkout).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {
     const res = await request(createApp()).get("/api/attachments/not-a-uuid/content");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -355,6 +355,45 @@ describe("issues routes UUID validation", () => {
     );
   });
 
+  it("treats case-only assignee agent id patch as no reassignment change", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      createdByUserId: "creator-user",
+    });
+    mockIssueService.update.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      createdByUserId: "creator-user",
+    });
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId: "44444444-4444-4444-8444-444444444444",
+      runId: "55555555-5555-4555-8555-555555555555",
+    });
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: agentId.toUpperCase() });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        assigneeAgentId: agentId,
+      }),
+    );
+  });
+
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {
     const res = await request(createApp()).get("/api/attachments/not-a-uuid/content");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -125,6 +125,27 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.getById).not.toHaveBeenCalled();
   });
 
+  it("trims identifier-style issue path params before lookup", async () => {
+    const identifier = "PAP-123";
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    mockIssueService.getByIdentifier.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+
+    const res = await request(createApp()).get(`/api/issues/%20${identifier}%20/comments`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getByIdentifier).toHaveBeenCalledWith(identifier);
+    expect(mockIssueService.getById).toHaveBeenCalledWith(issueId);
+  });
+
   it("normalizes UUID issue id path params to lowercase before service calls", async () => {
     const issueIdLower = "11111111-1111-4111-8111-111111111111";
     const issueIdUpper = issueIdLower.toUpperCase();

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -19,6 +19,11 @@ const mockIssueApprovalService = vi.hoisted(() => ({
   unlink: vi.fn(),
 }));
 
+const mockHeartbeat = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+}));
+
 const mockWorkProductService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
@@ -34,10 +39,7 @@ vi.mock("../services/index.js", () => ({
   documentService: () => ({}),
   executionWorkspaceService: () => ({}),
   goalService: () => ({}),
-  heartbeatService: () => ({
-    wakeup: vi.fn(async () => undefined),
-    reportRunActivity: vi.fn(async () => undefined),
-  }),
+  heartbeatService: () => mockHeartbeat,
   issueApprovalService: () => mockIssueApprovalService,
   issueService: () => mockIssueService,
   logActivity: vi.fn(async () => undefined),
@@ -82,6 +84,8 @@ describe("issues routes UUID validation", () => {
     mockIssueService.getAttachmentById.mockResolvedValue(null);
     mockWorkProductService.getById.mockResolvedValue(null);
     mockIssueApprovalService.unlink.mockResolvedValue(undefined);
+    mockHeartbeat.wakeup.mockResolvedValue(undefined);
+    mockHeartbeat.reportRunActivity.mockResolvedValue(undefined);
   });
 
   it("returns 400 for invalid UUID-based list filters", async () => {
@@ -186,6 +190,33 @@ describe("issues routes UUID validation", () => {
     expect(res.status).toBe(401);
     expect(res.body.error).toContain("run id");
     expect(mockIssueService.checkout).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue assignee wakeup for checkout no-op when issue already owned in-progress", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+    });
+    mockIssueService.checkout.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+    });
+
+    const res = await request(createApp())
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeat.wakeup).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -235,6 +235,76 @@ describe("issues routes UUID validation", () => {
     expect(mockHeartbeat.wakeup).not.toHaveBeenCalled();
   });
 
+  it("treats equivalent assignee ids as checkout no-op even when request id casing differs", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const assigneeLower = "33333333-3333-4333-8333-333333333333";
+    const assigneeUpper = assigneeLower.toUpperCase();
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: assigneeLower,
+      checkoutRunId: null,
+    });
+    mockIssueService.checkout.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: assigneeLower,
+      checkoutRunId: null,
+    });
+
+    const res = await request(createApp())
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: assigneeUpper, expectedStatuses: ["in_progress"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      assigneeLower,
+      ["in_progress"],
+      null,
+    );
+    expect(mockHeartbeat.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("allows agent checkout as self when ids differ only by case/whitespace", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+    });
+    mockIssueService.checkout.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: "44444444-4444-4444-8444-444444444444",
+    });
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId: ` ${agentId.toUpperCase()} `,
+      runId: "44444444-4444-4444-8444-444444444444",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      agentId,
+      ["todo"],
+      "44444444-4444-4444-8444-444444444444",
+    );
+  });
+
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {
     const res = await request(createApp()).get("/api/attachments/not-a-uuid/content");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -29,6 +29,8 @@ const mockHeartbeat = vi.hoisted(() => ({
 
 const mockWorkProductService = vi.hoisted(() => ({
   getById: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({
@@ -110,6 +112,8 @@ describe("issues routes UUID validation", () => {
     mockIssueApprovalService.unlink.mockResolvedValue(undefined);
     mockHeartbeat.wakeup.mockResolvedValue(undefined);
     mockHeartbeat.reportRunActivity.mockResolvedValue(undefined);
+    mockWorkProductService.update.mockResolvedValue(null);
+    mockWorkProductService.remove.mockResolvedValue(null);
   });
 
   it("returns 400 for invalid UUID-based list filters", async () => {
@@ -407,6 +411,30 @@ describe("issues routes UUID validation", () => {
 
     expect(res.status).toBe(404);
     expect(mockWorkProductService.getById).toHaveBeenCalledWith(workProductId);
+  });
+
+  it("trims workProductId path on work product patch route", async () => {
+    const workProductId = "77777777-7777-4777-8777-777777777777";
+    mockWorkProductService.getById.mockResolvedValueOnce({
+      id: workProductId,
+      companyId: COMPANY_ID,
+      issueId: "11111111-1111-4111-8111-111111111111",
+      type: "artifact",
+    });
+    mockWorkProductService.update.mockResolvedValueOnce({
+      id: workProductId,
+      companyId: COMPANY_ID,
+      issueId: "11111111-1111-4111-8111-111111111111",
+      type: "artifact",
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/work-products/%20${workProductId.toUpperCase()}%20`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockWorkProductService.getById).toHaveBeenCalledWith(workProductId);
+    expect(mockWorkProductService.update).toHaveBeenCalledWith(workProductId, {});
   });
 
   it("trims approvalId path on issue approval unlink route", async () => {

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -9,6 +9,11 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   listComments: vi.fn(),
   getByIdentifier: vi.fn(),
+  getAttachmentById: vi.fn(),
+}));
+
+const mockWorkProductService = vi.hoisted(() => ({
+  getById: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({
@@ -33,7 +38,7 @@ vi.mock("../services/index.js", () => ({
   routineService: () => ({
     syncRunStatusForIssue: vi.fn(async () => undefined),
   }),
-  workProductService: () => ({}),
+  workProductService: () => mockWorkProductService,
 }));
 
 function createApp() {
@@ -65,6 +70,8 @@ describe("issues routes UUID validation", () => {
       status: "todo",
     });
     mockIssueService.listComments.mockResolvedValue([]);
+    mockIssueService.getAttachmentById.mockResolvedValue(null);
+    mockWorkProductService.getById.mockResolvedValue(null);
   });
 
   it("returns 400 for invalid UUID-based list filters", async () => {
@@ -88,5 +95,21 @@ describe("issues routes UUID validation", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("after comment cursor");
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid attachment ids before attachment lookup", async () => {
+    const res = await request(createApp()).get("/api/attachments/not-a-uuid/content");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("attachmentId");
+    expect(mockIssueService.getAttachmentById).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid work-product ids before work-product lookup", async () => {
+    const res = await request(createApp())
+      .patch("/api/work-products/not-a-uuid")
+      .send({ title: "noop" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("work product id");
+    expect(mockWorkProductService.getById).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -256,6 +256,32 @@ describe("issues routes UUID validation", () => {
     );
   });
 
+  it("enforces run-id checkout ownership on patch when assignee/actor ids differ only by case", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: "44444444-4444-4444-8444-444444444444",
+    });
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId: ` ${agentId.toUpperCase()} `,
+      runId: { bad: true },
+    });
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ priority: "high" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("run id");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("does not enqueue assignee wakeup for checkout no-op when issue already owned in-progress", async () => {
     const issueId = "11111111-1111-4111-8111-111111111111";
     const agentId = "33333333-3333-4333-8333-333333333333";

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -97,6 +97,16 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
   });
 
+  it("returns 400 when duplicate after cursors resolve to an invalid first value", async () => {
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=not-a-uuid&after=22222222-2222-4222-8222-222222222222",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("after comment cursor");
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {
     const res = await request(createApp()).get("/api/attachments/not-a-uuid/content");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { issueRoutes } from "../routes/issues.js";
 import { errorHandler } from "../middleware/index.js";
 
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
@@ -52,7 +54,7 @@ function createApp() {
     (req as any).actor = {
       type: "board",
       userId: "local-board",
-      companyIds: ["company-1"],
+      companyIds: [COMPANY_ID],
       source: "local_implicit",
       isInstanceAdmin: false,
     };
@@ -69,8 +71,8 @@ describe("issues routes UUID validation", () => {
     mockIssueService.list.mockResolvedValue([]);
     mockIssueService.getByIdentifier.mockResolvedValue(null);
     mockIssueService.getById.mockResolvedValue({
-      id: "11111111-1111-4111-8111-111111111111",
-      companyId: "company-1",
+      id: "22222222-2222-4222-8222-222222222222",
+      companyId: COMPANY_ID,
       status: "todo",
     });
     mockIssueService.listComments.mockResolvedValue([]);
@@ -80,9 +82,16 @@ describe("issues routes UUID validation", () => {
   });
 
   it("returns 400 for invalid UUID-based list filters", async () => {
-    const res = await request(createApp()).get("/api/companies/company-1/issues?projectId=not-a-uuid");
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?projectId=not-a-uuid`);
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("projectId");
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid companyId path on company-scoped issue routes", async () => {
+    const res = await request(createApp()).get("/api/companies/not-a-uuid/issues");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("companyId");
     expect(mockIssueService.list).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -125,6 +125,21 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.getById).not.toHaveBeenCalled();
   });
 
+  it("normalizes UUID issue id path params to lowercase before service calls", async () => {
+    const issueIdLower = "11111111-1111-4111-8111-111111111111";
+    const issueIdUpper = issueIdLower.toUpperCase();
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueIdLower,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+
+    const res = await request(createApp()).get(`/api/issues/${issueIdUpper}/comments`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getById).toHaveBeenCalledWith(issueIdLower);
+  });
+
   it("returns 400 for invalid comment cursor in comment list query", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=not-a-uuid",

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -209,6 +209,7 @@ describe("issues routes UUID validation", () => {
     const issueIdLower = "22222222-2222-4222-8222-222222222222";
     const issueIdUpper = issueIdLower.toUpperCase();
     const commentId = "33333333-3333-4333-8333-333333333333";
+    const commentIdUpper = commentId.toUpperCase();
     mockIssueService.getById.mockResolvedValueOnce({
       id: issueIdLower,
       companyId: COMPANY_ID,
@@ -221,7 +222,7 @@ describe("issues routes UUID validation", () => {
       body: "ok",
     });
 
-    const res = await request(createApp()).get(`/api/issues/${issueIdUpper}/comments/${commentId}`);
+    const res = await request(createApp()).get(`/api/issues/${issueIdUpper}/comments/${commentIdUpper}`);
 
     expect(res.status).toBe(200);
     expect(mockIssueService.getComment).toHaveBeenCalledWith(commentId);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -138,6 +138,22 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
   });
 
+  it("accepts equivalent after cursors that differ only by UUID case", async () => {
+    const cursorUpper = "22222222-2222-4222-8222-2222222222AB";
+    const cursorLower = cursorUpper.toLowerCase();
+    const res = await request(createApp()).get(
+      `/api/issues/11111111-1111-4111-8111-111111111111/comments?after=${cursorUpper}&afterCommentId=${cursorLower}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        afterCommentId: cursorLower,
+      }),
+    );
+  });
+
   it("returns 400 for invalid comment order query values", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/comments?order=sideways",

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -175,6 +175,26 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.getById).toHaveBeenCalledWith(issueIdLower);
   });
 
+  it("trims identifier path params before issue lookup", async () => {
+    const issueIdLower = "11111111-1111-4111-8111-111111111111";
+    mockIssueService.getByIdentifier.mockResolvedValueOnce({
+      id: issueIdLower,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueIdLower,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+
+    const res = await request(createApp()).get("/api/issues/%20pap-123%20/comments");
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getByIdentifier).toHaveBeenCalledWith("pap-123");
+    expect(mockIssueService.getById).toHaveBeenCalledWith(issueIdLower);
+  });
+
   it("returns 400 for invalid comment cursor in comment list query", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=not-a-uuid",

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -140,6 +140,20 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.getById).toHaveBeenCalledWith(issueIdLower);
   });
 
+  it("trims UUID issue id path params before service calls", async () => {
+    const issueIdLower = "11111111-1111-4111-8111-111111111111";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueIdLower,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+
+    const res = await request(createApp()).get(`/api/issues/%20${issueIdLower.toUpperCase()}%20/comments`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getById).toHaveBeenCalledWith(issueIdLower);
+  });
+
   it("returns 400 for invalid comment cursor in comment list query", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=not-a-uuid",

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
   checkout: vi.fn(),
+  update: vi.fn(),
   listComments: vi.fn(),
   getByIdentifier: vi.fn(),
   getAttachmentById: vi.fn(),
@@ -80,6 +81,14 @@ describe("issues routes UUID validation", () => {
       status: "todo",
     });
     mockIssueService.checkout.mockResolvedValue(null);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      id: "22222222-2222-4222-8222-222222222222",
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: patch.assigneeAgentId ?? null,
+      assigneeUserId: patch.assigneeUserId ?? null,
+      createdByUserId: "creator-user",
+    }));
     mockIssueService.listComments.mockResolvedValue([]);
     mockIssueService.getAttachmentById.mockResolvedValue(null);
     mockWorkProductService.getById.mockResolvedValue(null);
@@ -302,6 +311,47 @@ describe("issues routes UUID validation", () => {
       agentId,
       ["todo"],
       "44444444-4444-4444-8444-444444444444",
+    );
+  });
+
+  it("allows agent returning issue to creator when assignee/actor ids differ only by case", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    const creatorUserId = "creator-user";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      createdByUserId: creatorUserId,
+    });
+    mockIssueService.update.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: creatorUserId,
+      createdByUserId: creatorUserId,
+    });
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId: ` ${agentId.toUpperCase()} `,
+      runId: "44444444-4444-4444-8444-444444444444",
+    });
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: null, assigneeUserId: creatorUserId });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        assigneeAgentId: null,
+        assigneeUserId: creatorUserId,
+      }),
     );
   });
 

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -9,6 +9,7 @@ const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
+  checkout: vi.fn(),
   listComments: vi.fn(),
   getByIdentifier: vi.fn(),
   getAttachmentById: vi.fn(),
@@ -47,7 +48,7 @@ vi.mock("../services/index.js", () => ({
   workProductService: () => mockWorkProductService,
 }));
 
-function createApp() {
+function createApp(actorOverride?: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -57,6 +58,7 @@ function createApp() {
       companyIds: [COMPANY_ID],
       source: "local_implicit",
       isInstanceAdmin: false,
+      ...actorOverride,
     };
     next();
   });
@@ -75,6 +77,7 @@ describe("issues routes UUID validation", () => {
       companyId: COMPANY_ID,
       status: "todo",
     });
+    mockIssueService.checkout.mockResolvedValue(null);
     mockIssueService.listComments.mockResolvedValue([]);
     mockIssueService.getAttachmentById.mockResolvedValue(null);
     mockWorkProductService.getById.mockResolvedValue(null);
@@ -139,6 +142,23 @@ describe("issues routes UUID validation", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Invalid comment limit");
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for agent checkout when runId is malformed non-string", async () => {
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId,
+      runId: { bad: true },
+    });
+    const res = await request(app)
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/checkout")
+      .send({ agentId, expectedStatuses: ["todo"] });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("run id");
+    expect(mockIssueService.checkout).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -118,6 +118,16 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.list).not.toHaveBeenCalled();
   });
 
+  it("trims and normalizes companyId path on company-scoped issue routes", async () => {
+    const res = await request(createApp()).get(`/api/companies/%20${COMPANY_ID.toUpperCase()}%20/issues`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.any(Object),
+    );
+  });
+
   it("returns 400 for invalid issue id path on comments routes", async () => {
     const res = await request(createApp()).get("/api/issues/not-a-uuid/comments");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -12,6 +12,10 @@ const mockIssueService = vi.hoisted(() => ({
   getAttachmentById: vi.fn(),
 }));
 
+const mockIssueApprovalService = vi.hoisted(() => ({
+  unlink: vi.fn(),
+}));
+
 const mockWorkProductService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
@@ -31,7 +35,7 @@ vi.mock("../services/index.js", () => ({
     wakeup: vi.fn(async () => undefined),
     reportRunActivity: vi.fn(async () => undefined),
   }),
-  issueApprovalService: () => ({}),
+  issueApprovalService: () => mockIssueApprovalService,
   issueService: () => mockIssueService,
   logActivity: vi.fn(async () => undefined),
   projectService: () => ({}),
@@ -72,6 +76,7 @@ describe("issues routes UUID validation", () => {
     mockIssueService.listComments.mockResolvedValue([]);
     mockIssueService.getAttachmentById.mockResolvedValue(null);
     mockWorkProductService.getById.mockResolvedValue(null);
+    mockIssueApprovalService.unlink.mockResolvedValue(undefined);
   });
 
   it("returns 400 for invalid UUID-based list filters", async () => {
@@ -121,5 +126,15 @@ describe("issues routes UUID validation", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("work product id");
     expect(mockWorkProductService.getById).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid approval ids before unlinking issue approvals", async () => {
+    const res = await request(createApp()).delete(
+      "/api/issues/11111111-1111-4111-8111-111111111111/approvals/not-a-uuid",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("approvalId");
+    expect(mockIssueApprovalService.unlink).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -112,6 +112,26 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for invalid comment order query values", async () => {
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/comments?order=sideways",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid comment order");
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid comment limit query values", async () => {
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/comments?limit=0",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid comment limit");
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid attachment ids before attachment lookup", async () => {
     const res = await request(createApp()).get("/api/attachments/not-a-uuid/content");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -159,6 +159,21 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
   });
 
+  it("uses the first non-empty duplicate after cursor value", async () => {
+    const cursor = "22222222-2222-4222-8222-222222222222";
+    const res = await request(createApp()).get(
+      `/api/issues/11111111-1111-4111-8111-111111111111/comments?after=&after=${cursor}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        afterCommentId: cursor,
+      }),
+    );
+  });
+
   it("returns 400 when after and afterCommentId cursors conflict", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/comments?after=22222222-2222-4222-8222-222222222222&afterCommentId=33333333-3333-4333-8333-333333333333",

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -320,6 +320,22 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
   });
 
+  it("trims attachmentId path on attachment content route", async () => {
+    const attachmentId = "33333333-3333-4333-8333-333333333333";
+    const res = await request(createApp()).get(`/api/attachments/%20${attachmentId.toUpperCase()}%20/content`);
+
+    expect(res.status).toBe(404);
+    expect(mockIssueService.getAttachmentById).toHaveBeenCalledWith(attachmentId);
+  });
+
+  it("trims attachmentId path on attachment delete route", async () => {
+    const attachmentId = "33333333-3333-4333-8333-333333333333";
+    const res = await request(createApp()).delete(`/api/attachments/%20${attachmentId.toUpperCase()}%20`);
+
+    expect(res.status).toBe(404);
+    expect(mockIssueService.getAttachmentById).toHaveBeenCalledWith(attachmentId);
+  });
+
   it("returns a comment when the issue id path casing differs from stored canonical id", async () => {
     const issueIdLower = "22222222-2222-4222-8222-222222222222";
     const issueIdUpper = issueIdLower.toUpperCase();

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -243,6 +243,29 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.getComment).toHaveBeenCalledWith(commentId);
   });
 
+  it("trims commentId path values before UUID validation", async () => {
+    const issueIdLower = "22222222-2222-4222-8222-222222222222";
+    const commentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueIdLower,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+    mockIssueService.getComment.mockResolvedValueOnce({
+      id: commentId,
+      issueId: issueIdLower,
+      companyId: COMPANY_ID,
+      body: "ok",
+    });
+
+    const res = await request(createApp()).get(
+      `/api/issues/${issueIdLower}/comments/%20${commentId.toUpperCase()}%20`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getComment).toHaveBeenCalledWith(commentId);
+  });
+
   it("returns 401 for agent checkout when runId is malformed non-string", async () => {
     const agentId = "33333333-3333-4333-8333-333333333333";
     const app = createApp({

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -9,6 +9,7 @@ const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
+  getComment: vi.fn(),
   checkout: vi.fn(),
   update: vi.fn(),
   listComments: vi.fn(),
@@ -89,6 +90,12 @@ describe("issues routes UUID validation", () => {
       assigneeUserId: patch.assigneeUserId ?? null,
       createdByUserId: "creator-user",
     }));
+    mockIssueService.getComment.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      issueId: "22222222-2222-4222-8222-222222222222",
+      companyId: COMPANY_ID,
+      body: "ok",
+    });
     mockIssueService.listComments.mockResolvedValue([]);
     mockIssueService.getAttachmentById.mockResolvedValue(null);
     mockWorkProductService.getById.mockResolvedValue(null);
@@ -181,6 +188,28 @@ describe("issues routes UUID validation", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Invalid comment limit");
     expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+
+  it("returns a comment when the issue id path casing differs from stored canonical id", async () => {
+    const issueIdLower = "22222222-2222-4222-8222-222222222222";
+    const issueIdUpper = issueIdLower.toUpperCase();
+    const commentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueIdLower,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+    mockIssueService.getComment.mockResolvedValueOnce({
+      id: commentId,
+      issueId: issueIdLower,
+      companyId: COMPANY_ID,
+      body: "ok",
+    });
+
+    const res = await request(createApp()).get(`/api/issues/${issueIdUpper}/comments/${commentId}`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getComment).toHaveBeenCalledWith(commentId);
   });
 
   it("returns 401 for agent checkout when runId is malformed non-string", async () => {

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -148,6 +148,21 @@ describe("issues routes UUID validation", () => {
     );
   });
 
+  it("trims and normalizes companyId path on company-scoped attachment upload route", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+    });
+
+    const res = await request(createApp())
+      .post(`/api/companies/%20${COMPANY_ID.toUpperCase()}%20/issues/${issueId}/attachments`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Missing file");
+  });
+
   it("returns 400 for invalid issue id path on comments routes", async () => {
     const res = await request(createApp()).get("/api/issues/not-a-uuid/comments");
     expect(res.status).toBe(400);

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -8,6 +8,7 @@ const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
 
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
+  create: vi.fn(),
   getById: vi.fn(),
   getComment: vi.fn(),
   checkout: vi.fn(),
@@ -75,6 +76,13 @@ describe("issues routes UUID validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIssueService.list.mockResolvedValue([]);
+    mockIssueService.create.mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      companyId: COMPANY_ID,
+      status: "backlog",
+      title: "Test issue",
+      identifier: "PAP-1",
+    });
     mockIssueService.getByIdentifier.mockResolvedValue(null);
     mockIssueService.getById.mockResolvedValue({
       id: "22222222-2222-4222-8222-222222222222",
@@ -125,6 +133,18 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.list).toHaveBeenCalledWith(
       COMPANY_ID,
       expect.any(Object),
+    );
+  });
+
+  it("trims and normalizes companyId path on issue creation route", async () => {
+    const res = await request(createApp())
+      .post(`/api/companies/%20${COMPANY_ID.toUpperCase()}%20/issues`)
+      .send({ title: "Test issue" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expect.objectContaining({ title: "Test issue" }),
     );
   });
 

--- a/server/src/__tests__/issues-route-uuid-validation.test.ts
+++ b/server/src/__tests__/issues-route-uuid-validation.test.ts
@@ -217,6 +217,45 @@ describe("issues routes UUID validation", () => {
     expect(mockIssueService.checkout).not.toHaveBeenCalled();
   });
 
+  it("normalizes agent checkout runId casing before service checkout call", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const agentId = "33333333-3333-4333-8333-333333333333";
+    const runIdLower = "44444444-4444-4444-8444-444444444444";
+    const runIdUpper = runIdLower.toUpperCase();
+    mockIssueService.getById.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+    });
+    mockIssueService.checkout.mockResolvedValueOnce({
+      id: issueId,
+      companyId: COMPANY_ID,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: runIdLower,
+    });
+    const app = createApp({
+      type: "agent",
+      companyId: COMPANY_ID,
+      agentId,
+      runId: runIdUpper,
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      agentId,
+      ["todo"],
+      runIdLower,
+    );
+  });
+
   it("does not enqueue assignee wakeup for checkout no-op when issue already owned in-progress", async () => {
     const issueId = "11111111-1111-4111-8111-111111111111";
     const agentId = "33333333-3333-4333-8333-333333333333";

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -641,6 +641,43 @@ describe("issueService.list participantAgentId", () => {
     expect(comments).toEqual([]);
   });
 
+  it("caps malformed explicit comment limits for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Malformed comment limit safety",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values(
+      Array.from({ length: 505 }, (_, index) => ({
+        issueId,
+        companyId,
+        body: `comment-${index}`,
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, 0, index)),
+      })),
+    );
+
+    const comments = await svc.listComments(issueId, {
+      order: "asc",
+      limit: "not-a-number" as any,
+    });
+    expect(comments).toHaveLength(500);
+    expect(comments[0]?.body).toBe("comment-0");
+    expect(comments[499]?.body).toBe("comment-499");
+  });
+
   it("returns an empty comment page when issueId is malformed", async () => {
     const comments = await svc.listComments("not-a-uuid", {
       order: "asc",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1783,6 +1783,30 @@ describe("issueService.list participantAgentId", () => {
     ).resolves.toBeNull();
   });
 
+  it("normalizes update issue uuid casing/whitespace for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "before update",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const updated = await svc.update(` ${issueId.toUpperCase()} `, { title: "after update" });
+    expect(updated?.id).toBe(issueId);
+    expect(updated?.title).toBe("after update");
+  });
+
   it("returns not found for malformed issue ids on assertCheckoutOwner", async () => {
     await expect(
       svc.assertCheckoutOwner("not-a-uuid", randomUUID(), null),
@@ -1846,6 +1870,29 @@ describe("issueService.list participantAgentId", () => {
 
   it("returns null for malformed issue ids on remove", async () => {
     await expect(svc.remove("not-a-uuid")).resolves.toBeNull();
+  });
+
+  it("normalizes remove issue uuid casing/whitespace for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "remove normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const removed = await svc.remove(` ${issueId.toUpperCase()} `);
+    expect(removed?.id).toBe(issueId);
   });
 
   it("returns null for malformed label ids on getLabelById", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -642,4 +642,22 @@ describe("issueService.list participantAgentId", () => {
   it("returns null for malformed attachment ids on removeAttachment", async () => {
     await expect(svc.removeAttachment("not-a-uuid")).resolves.toBeNull();
   });
+
+  it("returns not found for malformed issue ids on addComment", async () => {
+    await expect(
+      svc.addComment("not-a-uuid", "hello", {}),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
+
+  it("returns not found for malformed issue ids on markRead", async () => {
+    await expect(
+      svc.markRead(randomUUID(), "not-a-uuid", "user-1", new Date()),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -65,7 +65,8 @@ async function getAvailablePort(): Promise<number> {
 }
 
 async function startTempDatabase() {
-  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-issues-service-"));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-issues-service-"));
+  const dataDir = path.join(tempDir, "pgdata");
   const port = await getAvailablePort();
   const EmbeddedPostgres = await getEmbeddedPostgresCtor();
   const instance = new EmbeddedPostgres({
@@ -85,7 +86,7 @@ async function startTempDatabase() {
   await ensurePostgresDatabase(adminConnectionString, "paperclip");
   const connectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
   await applyPendingMigrations(connectionString);
-  return { connectionString, dataDir, instance };
+  return { connectionString, dataDir: tempDir, instance };
 }
 
 describe("issueService.list participantAgentId", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -759,6 +759,15 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed readAt values on markRead", async () => {
+    await expect(
+      svc.markRead(randomUUID(), randomUUID(), "user-1", "not-a-date" as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid readAt",
+    });
+  });
+
   it("returns null for malformed issue ids on getById", async () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -754,6 +754,35 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.findMentionedProjectIds("not-a-uuid")).resolves.toEqual([]);
   });
 
+  it("ignores malformed project mention ids instead of throwing", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Mention parser safety [bad](project://not-a-uuid)",
+      description: "Also malformed [project](project://still-not-a-uuid)",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "comment malformed mention [oops](project://definitely-not-a-uuid)",
+    });
+
+    await expect(svc.findMentionedProjectIds(issueId)).resolves.toEqual([]);
+  });
+
   it("returns an empty list for malformed issue ids on getAncestors", async () => {
     await expect(svc.getAncestors("not-a-uuid")).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -386,6 +386,44 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("normalizes checkout expected statuses for non-route callers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "NormalizeCheckoutStatuses",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Checkout expected status normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const updated = await svc.checkout(issueId, agentId, [" TODO "], null);
+    expect(updated?.id).toBe(issueId);
+    expect(updated?.status).toBe("in_progress");
+    expect(updated?.assigneeAgentId).toBe(agentId);
+  });
+
   it("returns not found for malformed issue ids on checkout", async () => {
     await expect(
       svc.checkout("not-a-uuid", randomUUID(), ["todo"], null),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -665,6 +665,59 @@ describe("issueService.list participantAgentId", () => {
     expect(comments.map((comment) => comment.body)).toEqual(["second"]);
   });
 
+  it("normalizes issue/comment ids for non-route comment fetch callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Comment id normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "normalized comment",
+    });
+
+    const insertedCommentId = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .then((rows) => rows[0]?.id ?? null);
+    expect(insertedCommentId).toBeTruthy();
+
+    const paddedIssueId = ` ${issueId.toUpperCase()} `;
+    const paddedCommentId = ` ${insertedCommentId!.toUpperCase()} `;
+
+    const comments = await svc.listComments(paddedIssueId, { order: "asc" });
+    expect(comments).toHaveLength(1);
+
+    await expect(svc.getCommentCursor(paddedIssueId)).resolves.toEqual(
+      expect.objectContaining({
+        totalComments: 1,
+        latestCommentId: insertedCommentId,
+      }),
+    );
+
+    await expect(svc.getComment(paddedCommentId)).resolves.toEqual(
+      expect.objectContaining({
+        id: insertedCommentId,
+        issueId,
+      }),
+    );
+  });
+
   it("ignores malformed non-string comment cursors instead of throwing", async () => {
     const comments = await svc.listComments(randomUUID(), {
       afterCommentId: { bad: true } as any,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -815,4 +815,75 @@ describe("issueService.list participantAgentId", () => {
       message: "One or more labels must be valid UUIDs",
     });
   });
+
+  it("returns unprocessable for malformed project/parent/goal ids on create", async () => {
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Invalid project id guard",
+        projectId: "not-a-uuid",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid projectId",
+    });
+
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Invalid parent id guard",
+        parentId: "not-a-uuid",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid parentId",
+    });
+
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Invalid goal id guard",
+        goalId: "not-a-uuid",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid goalId",
+    });
+  });
+
+  it("returns unprocessable for malformed project/parent/goal ids on update", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Update malformed ids guard",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.update(issueId, { projectId: "not-a-uuid" } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid projectId",
+    });
+
+    await expect(
+      svc.update(issueId, { parentId: "not-a-uuid" } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid parentId",
+    });
+
+    await expect(
+      svc.update(issueId, { goalId: "not-a-uuid" } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid goalId",
+    });
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -660,4 +660,17 @@ describe("issueService.list participantAgentId", () => {
       message: "Issue not found",
     });
   });
+
+  it("returns not found for malformed issue ids on assertCheckoutOwner", async () => {
+    await expect(
+      svc.assertCheckoutOwner("not-a-uuid", randomUUID(), null),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
+
+  it("returns null for malformed issue ids on release", async () => {
+    await expect(svc.release("not-a-uuid")).resolves.toBeNull();
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1209,6 +1209,41 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed createdByUserId on createAttachment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Attachment createdByUserId validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.createAttachment({
+        issueId,
+        provider: "local",
+        objectKey: `issues/${issueId}/file.txt`,
+        contentType: "text/plain",
+        byteSize: 10,
+        sha256: "abc123",
+        createdByUserId: { bad: true } as any,
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid createdByUserId",
+    });
+  });
+
   it("normalizes attachment issue/attachment uuid inputs for non-route callers", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2105,6 +2105,18 @@ describe("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
+    await db.insert(agents).values({
+      id: explicitValidMentionId,
+      companyId,
+      name: "ExplicitAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
     const result = await svc.findMentionedAgents(
       companyId,
       [
@@ -2145,12 +2157,81 @@ describe("issueService.list participantAgentId", () => {
       permissions: {},
     });
 
+    await db.insert(agents).values({
+      id: explicitValidMentionId,
+      companyId,
+      name: "ExplicitAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
     const result = await svc.findMentionedAgents(
       ` ${companyId.toUpperCase()} `,
       `[good](agent://${explicitValidMentionId.toUpperCase()}) @WakeAgent`,
     );
 
     expect(result.sort()).toEqual([explicitValidMentionId, mentionedByNameId].sort());
+  });
+
+  it("ignores explicit agent mention ids that do not belong to the company", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const companyMentionId = randomUUID();
+    const otherCompanyMentionId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Other",
+        issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    await db.insert(agents).values([
+      {
+        id: companyMentionId,
+        companyId,
+        name: "WakeAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherCompanyMentionId,
+        companyId: otherCompanyId,
+        name: "OtherAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const result = await svc.findMentionedAgents(
+      companyId,
+      [
+        `[good](agent://${companyMentionId})`,
+        `[foreign](agent://${otherCompanyMentionId})`,
+      ].join(" "),
+    );
+
+    expect(result).toEqual([companyMentionId]);
   });
 
   it("returns an empty list for malformed issue ids on getAncestors", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { asc, eq } from "drizzle-orm";
 import {
   activityLog,
   agents,
@@ -574,6 +575,54 @@ describe("issueService.list participantAgentId", () => {
     });
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toBe("older");
+  });
+
+  it("normalizes comment cursor case for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cursor case normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        issueId,
+        companyId,
+        body: "first",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        issueId,
+        companyId,
+        body: "second",
+        createdAt: new Date("2026-01-01T00:00:01.000Z"),
+      },
+    ]);
+    const firstCommentId = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id))
+      .then((rows) => rows[0]?.id ?? null);
+    expect(firstCommentId).toBeTruthy();
+
+    const comments = await svc.listComments(issueId, {
+      order: "asc",
+      afterCommentId: firstCommentId!.toUpperCase(),
+    });
+    expect(comments.map((comment) => comment.body)).toEqual(["second"]);
   });
 
   it("ignores malformed non-string comment cursors instead of throwing", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -465,4 +465,42 @@ describe("issueService.list participantAgentId", () => {
 
     expect(result.map((issue) => issue.id)).toContain(issueId);
   });
+
+  it("ignores malformed non-string unread status filters instead of throwing", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Unread malformed status filter safety",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: userId,
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "new external comment",
+      authorAgentId: null,
+      authorUserId: null,
+    });
+
+    const unreadCount = await svc.countUnreadTouchedByUser(
+      companyId,
+      userId,
+      { bad: true } as unknown as string,
+    );
+
+    expect(unreadCount).toBe(1);
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -578,6 +578,10 @@ describe("issueService.list participantAgentId", () => {
     }
   });
 
+  it("returns an empty list when companyId is malformed for list", async () => {
+    await expect(svc.list("not-a-uuid", {})).resolves.toEqual([]);
+  });
+
   it("ignores malformed non-string unread status filters instead of throwing", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();
@@ -614,6 +618,11 @@ describe("issueService.list participantAgentId", () => {
     );
 
     expect(unreadCount).toBe(1);
+  });
+
+  it("returns zero unread count when companyId is malformed", async () => {
+    const unreadCount = await svc.countUnreadTouchedByUser("not-a-uuid", randomUUID(), "todo");
+    expect(unreadCount).toBe(0);
   });
 
   it("returns not found for malformed non-uuid issue ids on createAttachment", async () => {
@@ -726,6 +735,19 @@ describe("issueService.list participantAgentId", () => {
 
   it("returns null for malformed label ids on deleteLabel", async () => {
     await expect(svc.deleteLabel("not-a-uuid")).resolves.toBeNull();
+  });
+
+  it("returns an empty label list when companyId is malformed", async () => {
+    await expect(svc.listLabels("not-a-uuid")).resolves.toEqual([]);
+  });
+
+  it("returns unprocessable for malformed company ids on createLabel", async () => {
+    await expect(
+      svc.createLabel("not-a-uuid", { name: "Bug", color: "#FF0000" }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid companyId",
+    });
   });
 
   it("returns an empty list for malformed issue ids on findMentionedProjectIds", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -705,6 +705,15 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed non-string comment bodies on addComment", async () => {
+    await expect(
+      svc.addComment(randomUUID(), { bad: true } as any, {}),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid comment body",
+    });
+  });
+
   it("returns not found for malformed issue ids on markRead", async () => {
     await expect(
       svc.markRead(randomUUID(), "not-a-uuid", "user-1", new Date()),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -377,4 +377,32 @@ describe("issueService.list participantAgentId", () => {
 
     expect(comments).toEqual([]);
   });
+
+  it("ignores malformed non-string list filters instead of throwing", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Malformed filter safety",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const result = await svc.list(companyId, {
+      status: { bad: true } as unknown as string,
+      q: ["broken"] as unknown as string,
+      assigneeAgentId: 123 as unknown as string,
+    });
+
+    expect(result.map((issue) => issue.id)).toContain(issueId);
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -741,6 +741,24 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed company ids on markRead", async () => {
+    await expect(
+      svc.markRead("not-a-uuid", randomUUID(), "user-1", new Date()),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid companyId",
+    });
+  });
+
+  it("returns unprocessable for malformed user ids on markRead", async () => {
+    await expect(
+      svc.markRead(randomUUID(), randomUUID(), { bad: true } as any, new Date()),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid userId",
+    });
+  });
+
   it("returns null for malformed issue ids on getById", async () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -728,6 +728,14 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.deleteLabel("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("returns an empty list for malformed issue ids on findMentionedProjectIds", async () => {
+    await expect(svc.findMentionedProjectIds("not-a-uuid")).resolves.toEqual([]);
+  });
+
+  it("returns an empty list for malformed issue ids on getAncestors", async () => {
+    await expect(svc.getAncestors("not-a-uuid")).resolves.toEqual([]);
+  });
+
   it("returns null for malformed issue ids on release", async () => {
     await expect(svc.release("not-a-uuid")).resolves.toBeNull();
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -763,6 +763,10 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("returns null for malformed non-string issue identifiers on getByIdentifier", async () => {
+    await expect(svc.getByIdentifier({ bad: true } as any)).resolves.toBeNull();
+  });
+
   it("returns null for malformed issue ids on update", async () => {
     await expect(
       svc.update("not-a-uuid", { title: "ignored" }),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -494,6 +494,46 @@ describe("issueService.list participantAgentId", () => {
     expect(comments).toEqual([]);
   });
 
+  it("normalizes comment order filters for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Order normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        issueId,
+        companyId,
+        body: "older",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        issueId,
+        companyId,
+        body: "newer",
+        createdAt: new Date("2026-01-01T00:00:01.000Z"),
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      order: "ASC" as any,
+    });
+    expect(comments.map((comment) => comment.body)).toEqual(["older", "newer"]);
+  });
+
   it("ignores malformed non-string comment cursors instead of throwing", async () => {
     const comments = await svc.listComments(randomUUID(), {
       afterCommentId: { bad: true } as any,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2089,6 +2089,38 @@ describe("issueService.list participantAgentId", () => {
     expect(result.sort()).toEqual([explicitValidMentionId, mentionedByNameId].sort());
   });
 
+  it("normalizes findMentionedAgents company and explicit mention uuids for non-route callers", async () => {
+    const companyId = randomUUID();
+    const mentionedByNameId = randomUUID();
+    const explicitValidMentionId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: mentionedByNameId,
+      companyId,
+      name: "WakeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const result = await svc.findMentionedAgents(
+      ` ${companyId.toUpperCase()} `,
+      `[good](agent://${explicitValidMentionId.toUpperCase()}) @WakeAgent`,
+    );
+
+    expect(result.sort()).toEqual([explicitValidMentionId, mentionedByNameId].sort());
+  });
+
   it("returns an empty list for malformed issue ids on getAncestors", async () => {
     await expect(svc.getAncestors("not-a-uuid")).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -385,6 +385,82 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns not found for malformed issue ids on checkout", async () => {
+    await expect(
+      svc.checkout("not-a-uuid", randomUUID(), ["todo"], null),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
+
+  it("returns unprocessable for malformed agent ids on checkout", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Malformed agent id checkout",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.checkout(issueId, "not-a-uuid", ["todo"], null),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid agentId",
+    });
+  });
+
+  it("returns unprocessable for malformed checkout run ids", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CheckoutAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Malformed run id checkout",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.checkout(issueId, agentId, ["todo"], "not-a-uuid"),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid checkoutRunId",
+    });
+  });
+
   it("returns an empty page for malformed non-uuid comment cursors", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1407,6 +1407,33 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for unknown author agent ids on addComment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "addComment author agent existence validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.addComment(issueId, "hello", { agentId: randomUUID() }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid authorAgentId",
+    });
+  });
+
   it("returns unprocessable for malformed author user ids on addComment", async () => {
     await expect(
       svc.addComment(randomUUID(), "hello", { userId: { bad: true } as any }),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1808,6 +1808,54 @@ describe("issueService.list participantAgentId", () => {
     expect(updated?.title).toBe("after update");
   });
 
+  it("normalizes assignee and label uuids during update for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const labelId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "UpdateNormalizeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "update-ops",
+      color: "#00AAFF",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "before update normalize",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const updated = await svc.update(issueId, {
+      assigneeAgentId: ` ${agentId.toUpperCase()} `,
+      labelIds: [` ${labelId.toUpperCase()} `],
+    } as any);
+    expect(updated?.assigneeAgentId).toBe(agentId);
+    expect(updated?.labelIds).toContain(labelId);
+  });
+
   it("returns not found for malformed issue ids on assertCheckoutOwner", async () => {
     await expect(
       svc.assertCheckoutOwner("not-a-uuid", randomUUID(), null),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -345,6 +345,46 @@ describe("issueService.list participantAgentId", () => {
     expect(updated?.executionRunId).toBe(actorRunId);
   });
 
+  it("rejects checkout calls with no valid expected statuses", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReleaseLead",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Status validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.checkout(issueId, agentId, [] as string[], null),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "expectedStatuses must include at least one valid issue status",
+    });
+  });
+
   it("returns an empty page for malformed non-uuid comment cursors", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -426,6 +426,61 @@ describe("issueService.list participantAgentId", () => {
     expect(updated?.assigneeAgentId).toBe(agentId);
   });
 
+  it("normalizes checkout UUID inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "NormalizeCheckoutUuids",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Checkout uuid normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "scheduler",
+      status: "running",
+    });
+
+    const updated = await svc.checkout(
+      ` ${issueId.toUpperCase()} `,
+      ` ${agentId.toUpperCase()} `,
+      ["todo"],
+      ` ${checkoutRunId.toUpperCase()} `,
+    );
+
+    expect(updated?.id).toBe(issueId);
+    expect(updated?.status).toBe("in_progress");
+    expect(updated?.assigneeAgentId).toBe(agentId);
+    expect(updated?.checkoutRunId).toBe(checkoutRunId);
+    expect(updated?.executionRunId).toBe(checkoutRunId);
+  });
+
   it("returns not found for malformed issue ids on checkout", async () => {
     await expect(
       svc.checkout("not-a-uuid", randomUUID(), ["todo"], null),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -418,6 +418,18 @@ describe("issueService.list participantAgentId", () => {
     expect(comments).toEqual([]);
   });
 
+  it("returns an empty comment page when issueId is malformed", async () => {
+    const comments = await svc.listComments("not-a-uuid", {
+      order: "asc",
+      limit: 10,
+    });
+    expect(comments).toEqual([]);
+  });
+
+  it("returns null for malformed non-uuid comment ids", async () => {
+    await expect(svc.getComment("not-a-uuid")).resolves.toBeNull();
+  });
+
   it("ignores malformed non-string list filters instead of throwing", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -534,6 +534,48 @@ describe("issueService.list participantAgentId", () => {
     expect(comments.map((comment) => comment.body)).toEqual(["older", "newer"]);
   });
 
+  it("accepts numeric-string comment limits for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "String limit normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        issueId,
+        companyId,
+        body: "older",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        issueId,
+        companyId,
+        body: "newer",
+        createdAt: new Date("2026-01-01T00:00:01.000Z"),
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      order: "asc",
+      limit: "1" as any,
+    });
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toBe("older");
+  });
+
   it("ignores malformed non-string comment cursors instead of throwing", async () => {
     const comments = await svc.listComments(randomUUID(), {
       afterCommentId: { bad: true } as any,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -430,6 +430,14 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.getComment("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("returns an empty cursor payload for malformed non-uuid issue ids", async () => {
+    await expect(svc.getCommentCursor("not-a-uuid")).resolves.toEqual({
+      totalComments: 0,
+      latestCommentId: null,
+      latestCommentAt: null,
+    });
+  });
+
   it("ignores malformed non-string list filters instead of throwing", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -11,6 +11,7 @@ import {
   companies,
   createDb,
   ensurePostgresDatabase,
+  heartbeatRuns,
   issueComments,
   issues,
 } from "@paperclipai/db";
@@ -100,6 +101,7 @@ describe("issueService.list participantAgentId", () => {
     await db.delete(issueComments);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -280,5 +282,66 @@ describe("issueService.list participantAgentId", () => {
     });
 
     expect(result.map((issue) => issue.id)).toEqual([matchedIssueId]);
+  });
+
+  it("adopts stale execution locks when same-assignee checkout lock is missing", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleRunId = randomUUID();
+    const actorRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReleaseLead",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "scheduler",
+        status: "failed",
+      },
+      {
+        id: actorRunId,
+        companyId,
+        agentId,
+        invocationSource: "scheduler",
+        status: "running",
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Adopt stale execution lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: staleRunId,
+    });
+
+    const updated = await svc.checkout(issueId, agentId, ["todo", "backlog", "blocked"], actorRunId);
+    expect(updated?.id).toBe(issueId);
+    expect(updated?.status).toBe("in_progress");
+    expect(updated?.checkoutRunId).toBe(actorRunId);
+    expect(updated?.executionRunId).toBe(actorRunId);
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1989,6 +1989,24 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed label names on createLabel", async () => {
+    await expect(
+      svc.createLabel(randomUUID(), { name: 123 as any, color: "#FF0000" } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid label name",
+    });
+  });
+
+  it("returns unprocessable for malformed label colors on createLabel", async () => {
+    await expect(
+      svc.createLabel(randomUUID(), { name: "Bug", color: null as any } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid label color",
+    });
+  });
+
   it("returns an empty list for malformed issue ids on findMentionedProjectIds", async () => {
     await expect(svc.findMentionedProjectIds("not-a-uuid")).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1792,6 +1792,58 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("normalizes assertCheckoutOwner uuid inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CheckoutOwnerAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "scheduler",
+      status: "running",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "assertCheckoutOwner normalization",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    });
+
+    const owner = await svc.assertCheckoutOwner(
+      ` ${issueId.toUpperCase()} `,
+      ` ${agentId.toUpperCase()} `,
+      ` ${checkoutRunId.toUpperCase()} `,
+    );
+    expect(owner).toEqual(expect.objectContaining({ id: issueId, assigneeAgentId: agentId, adoptedFromRunId: null }));
+  });
+
   it("returns null for malformed issue ids on remove", async () => {
     await expect(svc.remove("not-a-uuid")).resolves.toBeNull();
   });
@@ -1939,6 +1991,61 @@ describe("issueService.list participantAgentId", () => {
     });
 
     const released = await svc.release(issueId, agentId, checkoutRunId.toUpperCase());
+    expect(released?.id).toBe(issueId);
+    expect(released?.status).toBe("todo");
+    expect(released?.assigneeAgentId).toBeNull();
+    expect(released?.checkoutRunId).toBeNull();
+  });
+
+  it("normalizes release issue and assignee uuid inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReleaseNormalizeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "scheduler",
+      status: "running",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Release issue/assignee normalization",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    });
+
+    const released = await svc.release(
+      ` ${issueId.toUpperCase()} `,
+      ` ${agentId.toUpperCase()} `,
+      ` ${checkoutRunId.toUpperCase()} `,
+    );
     expect(released?.id).toBe(issueId);
     expect(released?.status).toBe("todo");
     expect(released?.assigneeAgentId).toBeNull();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1231,6 +1231,57 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.release("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("accepts uppercase checkout run ids when releasing as assignee", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReleaseAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "scheduler",
+      status: "running",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Release run id normalization",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    });
+
+    const released = await svc.release(issueId, agentId, checkoutRunId.toUpperCase());
+    expect(released?.id).toBe(issueId);
+    expect(released?.status).toBe("todo");
+    expect(released?.assigneeAgentId).toBeNull();
+    expect(released?.checkoutRunId).toBeNull();
+  });
+
   it("returns unprocessable for malformed assigneeAgentId on create", async () => {
     await expect(
       svc.create(randomUUID(), {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1488,6 +1488,59 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns not found for unknown issue ids on markRead", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await expect(
+      svc.markRead(companyId, randomUUID(), "user-1", new Date()),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
+
+  it("returns not found when markRead company/issue do not match", async () => {
+    const issueCompanyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: issueCompanyId,
+        name: "Paperclip Issue Company",
+        issuePrefix: `T${issueCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Paperclip Other Company",
+        issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: issueCompanyId,
+      title: "markRead company mismatch",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.markRead(otherCompanyId, issueId, "user-1", new Date()),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
+
   it("returns unprocessable for malformed user ids on markRead", async () => {
     await expect(
       svc.markRead(randomUUID(), randomUUID(), { bad: true } as any, new Date()),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -961,6 +961,39 @@ describe("issueService.list participantAgentId", () => {
     expect(unreadCount).toBe(1);
   });
 
+  it("trims unread user ids for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Unread userId trim normalization",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: userId,
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "new external comment",
+      authorAgentId: null,
+      authorUserId: null,
+    });
+
+    const unreadCount = await svc.countUnreadTouchedByUser(companyId, ` ${userId} `, "todo");
+    expect(unreadCount).toBe(1);
+  });
+
   it("returns zero unread count when companyId is malformed", async () => {
     const unreadCount = await svc.countUnreadTouchedByUser("not-a-uuid", randomUUID(), "todo");
     expect(unreadCount).toBe(0);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -853,6 +853,39 @@ describe("issueService.list participantAgentId", () => {
     expect(unreadCount).toBe(1);
   });
 
+  it("normalizes unread status filters for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Unread status normalization",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: userId,
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "new external comment",
+      authorAgentId: null,
+      authorUserId: null,
+    });
+
+    const unreadCount = await svc.countUnreadTouchedByUser(companyId, userId, " TODO ");
+    expect(unreadCount).toBe(1);
+  });
+
   it("returns zero unread count when companyId is malformed", async () => {
     const unreadCount = await svc.countUnreadTouchedByUser("not-a-uuid", randomUUID(), "todo");
     expect(unreadCount).toBe(0);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -899,6 +899,30 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.list("not-a-uuid", {})).resolves.toEqual([]);
   });
 
+  it("normalizes companyId casing/whitespace for non-route list callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Company id normalization",
+      status: "todo",
+      priority: "medium",
+      originKind: "manual",
+    });
+
+    const normalized = await svc.list(` ${companyId.toUpperCase()} `, {});
+    expect(normalized.map((issue) => issue.id)).toContain(issueId);
+  });
+
   it("ignores malformed non-string unread status filters instead of throwing", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -761,4 +761,58 @@ describe("issueService.list participantAgentId", () => {
   it("returns null for malformed issue ids on release", async () => {
     await expect(svc.release("not-a-uuid")).resolves.toBeNull();
   });
+
+  it("returns unprocessable for malformed assigneeAgentId on create", async () => {
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Invalid assignee guard",
+        assigneeAgentId: "not-a-uuid",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid assigneeAgentId",
+    });
+  });
+
+  it("returns unprocessable for malformed workspace ids on create", async () => {
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Invalid workspace guard",
+        projectWorkspaceId: "not-a-uuid",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid projectWorkspaceId",
+    });
+
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Invalid execution workspace guard",
+        executionWorkspaceId: "not-a-uuid",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid executionWorkspaceId",
+    });
+  });
+
+  it("returns unprocessable for malformed label ids on create", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await expect(
+      svc.create(companyId, {
+        title: "Malformed labels guard",
+        labelIds: ["not-a-uuid"],
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "One or more labels must be valid UUIDs",
+    });
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1174,6 +1174,47 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("normalizes attachment issue/attachment uuid inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Attachment uuid normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const created = await svc.createAttachment({
+      issueId: ` ${issueId.toUpperCase()} `,
+      provider: "local",
+      objectKey: `issues/${issueId}/file.txt`,
+      contentType: "text/plain",
+      byteSize: 10,
+      sha256: "abc123",
+    });
+    expect(created.issueId).toBe(issueId);
+
+    const listed = await svc.listAttachments(` ${issueId.toUpperCase()} `);
+    expect(listed.map((attachment) => attachment.id)).toContain(created.id);
+
+    await expect(svc.getAttachmentById(` ${created.id.toUpperCase()} `)).resolves.toEqual(
+      expect.objectContaining({ id: created.id }),
+    );
+
+    await expect(svc.removeAttachment(` ${created.id.toUpperCase()} `)).resolves.toEqual(
+      expect.objectContaining({ id: created.id }),
+    );
+  });
+
   it("returns an empty attachment list for malformed issue ids", async () => {
     await expect(svc.listAttachments("not-a-uuid")).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -697,6 +697,10 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns null for malformed issue ids on getById", async () => {
+    await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
+  });
+
   it("returns not found for malformed issue ids on assertCheckoutOwner", async () => {
     await expect(
       svc.assertCheckoutOwner("not-a-uuid", randomUUID(), null),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -494,6 +494,14 @@ describe("issueService.list participantAgentId", () => {
     expect(comments).toEqual([]);
   });
 
+  it("ignores malformed non-string comment cursors instead of throwing", async () => {
+    const comments = await svc.listComments(randomUUID(), {
+      afterCommentId: { bad: true } as any,
+      order: "asc",
+    });
+    expect(comments).toEqual([]);
+  });
+
   it("returns an empty comment page when issueId is malformed", async () => {
     const comments = await svc.listComments("not-a-uuid", {
       order: "asc",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -720,6 +720,14 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.remove("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("returns null for malformed label ids on getLabelById", async () => {
+    await expect(svc.getLabelById("not-a-uuid")).resolves.toBeNull();
+  });
+
+  it("returns null for malformed label ids on deleteLabel", async () => {
+    await expect(svc.deleteLabel("not-a-uuid")).resolves.toBeNull();
+  });
+
   it("returns null for malformed issue ids on release", async () => {
     await expect(svc.release("not-a-uuid")).resolves.toBeNull();
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -14,6 +14,7 @@ import {
   ensurePostgresDatabase,
   heartbeatRuns,
   issueComments,
+  issueReadStates,
   issues,
 } from "@paperclipai/db";
 import { issueService, type IssueFilters } from "../services/issues.ts";
@@ -100,6 +101,7 @@ describe("issueService.list participantAgentId", () => {
 
   afterEach(async () => {
     await db.delete(issueComments);
+    await db.delete(issueReadStates);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
@@ -1128,6 +1130,32 @@ describe("issueService.list participantAgentId", () => {
       status: 422,
       message: "Invalid userId",
     });
+  });
+
+  it("trims markRead user ids for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "markRead userId trim normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const readAt = new Date("2026-02-01T00:00:00.000Z");
+    const row = await svc.markRead(companyId, issueId, ` ${userId} `, readAt);
+    expect(row.userId).toBe(userId);
+    expect(new Date(row.lastReadAt).toISOString()).toBe(readAt.toISOString());
   });
 
   it("returns unprocessable for malformed readAt values on markRead", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -701,6 +701,12 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("returns null for malformed issue ids on update", async () => {
+    await expect(
+      svc.update("not-a-uuid", { title: "ignored" }),
+    ).resolves.toBeNull();
+  });
+
   it("returns not found for malformed issue ids on assertCheckoutOwner", async () => {
     await expect(
       svc.assertCheckoutOwner("not-a-uuid", randomUUID(), null),
@@ -708,6 +714,10 @@ describe("issueService.list participantAgentId", () => {
       status: 404,
       message: "Issue not found",
     });
+  });
+
+  it("returns null for malformed issue ids on remove", async () => {
+    await expect(svc.remove("not-a-uuid")).resolves.toBeNull();
   });
 
   it("returns null for malformed issue ids on release", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -14,8 +14,10 @@ import {
   ensurePostgresDatabase,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issueReadStates,
   issues,
+  labels,
 } from "@paperclipai/db";
 import { issueService, type IssueFilters } from "../services/issues.ts";
 
@@ -908,6 +910,84 @@ describe("issueService.list participantAgentId", () => {
       const result = await svc.list(companyId, { [key]: "not-a-uuid" } as Pick<IssueFilters, typeof key>);
       expect(result).toEqual([]);
     }
+  });
+
+  it("normalizes uuid list filters for non-route callers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const parentId = randomUUID();
+    const issueId = randomUUID();
+    const otherIssueId = randomUUID();
+    const labelId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "FilterNormalizeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Parent issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: issueId,
+        companyId,
+        title: "Target issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        parentId,
+      },
+      {
+        id: otherIssueId,
+        companyId,
+        title: "Other issue",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "urgent",
+      color: "#FF0000",
+    });
+    await db.insert(issueLabels).values({
+      issueId,
+      labelId,
+      companyId,
+    });
+
+    const assigneeResult = await svc.list(companyId, { assigneeAgentId: ` ${agentId.toUpperCase()} ` });
+    expect(assigneeResult.map((issue) => issue.id)).toContain(issueId);
+
+    const participantResult = await svc.list(companyId, { participantAgentId: ` ${agentId.toUpperCase()} ` });
+    expect(participantResult.map((issue) => issue.id)).toContain(issueId);
+
+    const parentResult = await svc.list(companyId, { parentId: ` ${parentId.toUpperCase()} ` });
+    expect(parentResult.map((issue) => issue.id)).toContain(issueId);
+
+    const labelResult = await svc.list(companyId, { labelId: ` ${labelId.toUpperCase()} ` });
+    expect(labelResult.map((issue) => issue.id)).toContain(issueId);
   });
 
   it("normalizes status and originKind filters for non-route callers", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1856,6 +1856,29 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.deleteLabel("not-a-uuid")).resolves.toBeNull();
   });
 
+  it("normalizes label company and id uuid inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const created = await svc.createLabel(` ${companyId.toUpperCase()} `, { name: "Ops", color: "#00AAFF" });
+    expect(created.companyId).toBe(companyId);
+
+    const listed = await svc.listLabels(` ${companyId.toUpperCase()} `);
+    expect(listed.map((label) => label.id)).toContain(created.id);
+
+    const fetched = await svc.getLabelById(` ${created.id.toUpperCase()} `);
+    expect(fetched?.id).toBe(created.id);
+
+    const removed = await svc.deleteLabel(` ${created.id.toUpperCase()} `);
+    expect(removed?.id).toBe(created.id);
+  });
+
   it("returns an empty label list when companyId is malformed", async () => {
     await expect(svc.listLabels("not-a-uuid")).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1209,6 +1209,41 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for unknown createdByAgentId on createAttachment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Attachment createdByAgentId existence validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.createAttachment({
+        issueId,
+        provider: "local",
+        objectKey: `issues/${issueId}/file.txt`,
+        contentType: "text/plain",
+        byteSize: 10,
+        sha256: "abc123",
+        createdByAgentId: randomUUID(),
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid createdByAgentId",
+    });
+  });
+
   it("returns unprocessable for malformed createdByUserId on createAttachment", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -806,6 +806,7 @@ describe("issueService.list participantAgentId", () => {
     const companyId = randomUUID();
     const routineIssueId = randomUUID();
     const manualIssueId = randomUUID();
+    const routineOriginId = randomUUID();
 
     await db.insert(companies).values({
       id: companyId,
@@ -822,7 +823,7 @@ describe("issueService.list participantAgentId", () => {
         status: "todo",
         priority: "medium",
         originKind: "routine_execution",
-        originId: randomUUID(),
+        originId: routineOriginId,
       },
       {
         id: manualIssueId,
@@ -839,6 +840,12 @@ describe("issueService.list participantAgentId", () => {
 
     const originResult = await svc.list(companyId, { originKind: " ROUTINE_EXECUTION " });
     expect(originResult.map((issue) => issue.id)).toContain(routineIssueId);
+
+    const originByIdResult = await svc.list(companyId, {
+      originKind: "routine_execution",
+      originId: routineOriginId.toUpperCase(),
+    });
+    expect(originByIdResult.map((issue) => issue.id)).toContain(routineIssueId);
   });
 
   it("keeps routine_execution issues excluded by default for malformed non-route origin/include filters", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -783,6 +783,42 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.findMentionedProjectIds(issueId)).resolves.toEqual([]);
   });
 
+  it("ignores malformed agent mention ids while keeping valid mentions", async () => {
+    const companyId = randomUUID();
+    const mentionedByNameId = randomUUID();
+    const explicitValidMentionId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: mentionedByNameId,
+      companyId,
+      name: "WakeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const result = await svc.findMentionedAgents(
+      companyId,
+      [
+        "[bad](agent://not-a-uuid)",
+        `[good](agent://${explicitValidMentionId})`,
+        "@WakeAgent",
+      ].join(" "),
+    );
+
+    expect(result.sort()).toEqual([explicitValidMentionId, mentionedByNameId].sort());
+  });
+
   it("returns an empty list for malformed issue ids on getAncestors", async () => {
     await expect(svc.getAncestors("not-a-uuid")).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -18,6 +18,7 @@ import {
   issueReadStates,
   issues,
   labels,
+  projects,
 } from "@paperclipai/db";
 import { issueService, type IssueFilters } from "../services/issues.ts";
 
@@ -1943,6 +1944,38 @@ describe("issueService.list participantAgentId", () => {
     await expect(svc.findMentionedProjectIds("not-a-uuid")).resolves.toEqual([]);
   });
 
+  it("normalizes findMentionedProjectIds issue and mentioned project uuids for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const projectId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Risk Controls",
+      status: "todo",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: `Investigate [project](project://${projectId.toUpperCase()})`,
+      description: null,
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(svc.findMentionedProjectIds(` ${issueId.toUpperCase()} `)).resolves.toEqual([projectId]);
+    await db.delete(projects).where(eq(projects.id, projectId));
+  });
+
   it("ignores malformed project mention ids instead of throwing", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();
@@ -2010,6 +2043,40 @@ describe("issueService.list participantAgentId", () => {
 
   it("returns an empty list for malformed issue ids on getAncestors", async () => {
     await expect(svc.getAncestors("not-a-uuid")).resolves.toEqual([]);
+  });
+
+  it("normalizes getAncestors issue uuid casing/whitespace for non-route callers", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    const childId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Parent issue",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: childId,
+        companyId,
+        title: "Child issue",
+        status: "todo",
+        priority: "medium",
+        parentId,
+      },
+    ]);
+
+    const ancestors = await svc.getAncestors(` ${childId.toUpperCase()} `);
+    expect(ancestors.map((row) => row.id)).toEqual([parentId]);
   });
 
   it("returns null for malformed issue ids on release", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -839,6 +839,17 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns not found for non-existent company ids on create", async () => {
+    await expect(
+      svc.create(randomUUID(), {
+        title: "Missing company guard",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Company not found",
+    });
+  });
+
   it("returns unprocessable for malformed workspace ids on create", async () => {
     await expect(
       svc.create(randomUUID(), {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1222,6 +1222,33 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("normalizes addComment issue uuid inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "addComment uuid normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const created = await svc.addComment(` ${issueId.toUpperCase()} `, "hello", {
+      userId: "operator-1",
+    });
+
+    expect(created.issueId).toBe(issueId);
+    expect(created.authorUserId).toBe("operator-1");
+  });
+
   it("returns not found for malformed issue ids on markRead", async () => {
     await expect(
       svc.markRead(randomUUID(), "not-a-uuid", "user-1", new Date()),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -594,6 +594,53 @@ describe("issueService.list participantAgentId", () => {
     }
   });
 
+  it("keeps routine_execution issues excluded by default for malformed non-route origin/include filters", async () => {
+    const companyId = randomUUID();
+    const routineIssueId = randomUUID();
+    const manualIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: routineIssueId,
+        companyId,
+        title: "Routine execution issue",
+        status: "todo",
+        priority: "medium",
+        originKind: "routine_execution",
+        originId: randomUUID(),
+      },
+      {
+        id: manualIssueId,
+        companyId,
+        title: "Manual issue",
+        status: "todo",
+        priority: "medium",
+        originKind: "manual",
+      },
+    ]);
+
+    const defaultLikeResult = await svc.list(companyId, {
+      includeRoutineExecutions: "false" as unknown as boolean,
+      originKind: { bad: true } as unknown as string,
+      originId: { bad: true } as unknown as string,
+    });
+    expect(defaultLikeResult.map((issue) => issue.id)).toEqual([manualIssueId]);
+
+    const explicitIncludeResult = await svc.list(companyId, {
+      includeRoutineExecutions: "true" as unknown as boolean,
+    });
+    expect(new Set(explicitIncludeResult.map((issue) => issue.id))).toEqual(
+      new Set([manualIssueId, routineIssueId]),
+    );
+  });
+
   it("returns an empty list when companyId is malformed for list", async () => {
     await expect(svc.list("not-a-uuid", {})).resolves.toEqual([]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1242,6 +1242,31 @@ describe("issueService.list participantAgentId", () => {
     expect(new Date(row.lastReadAt).toISOString()).toBe(readAt.toISOString());
   });
 
+  it("normalizes markRead company/issue uuid inputs for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "markRead uuid normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const row = await svc.markRead(` ${companyId.toUpperCase()} `, ` ${issueId.toUpperCase()} `, userId, new Date());
+    expect(row.companyId).toBe(companyId);
+    expect(row.issueId).toBe(issueId);
+  });
+
   it("returns unprocessable for malformed readAt values on markRead", async () => {
     await expect(
       svc.markRead(randomUUID(), randomUUID(), "user-1", "not-a-date" as any),
@@ -1253,6 +1278,30 @@ describe("issueService.list participantAgentId", () => {
 
   it("returns null for malformed issue ids on getById", async () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
+  });
+
+  it("normalizes getById uuid casing/whitespace for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "getById uuid normalization",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(svc.getById(` ${issueId.toUpperCase()} `)).resolves.toEqual(
+      expect.objectContaining({ id: issueId }),
+    );
   });
 
   it("returns null for malformed non-string issue identifiers on getByIdentifier", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -344,4 +344,37 @@ describe("issueService.list participantAgentId", () => {
     expect(updated?.checkoutRunId).toBe(actorRunId);
     expect(updated?.executionRunId).toBe(actorRunId);
   });
+
+  it("returns an empty page for malformed non-uuid comment cursors", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cursor validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "first comment",
+    });
+
+    const comments = await svc.listComments(issueId, {
+      afterCommentId: "not-a-uuid",
+      order: "asc",
+    });
+
+    expect(comments).toEqual([]);
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -554,4 +554,16 @@ describe("issueService.list participantAgentId", () => {
       message: "Issue comment not found",
     });
   });
+
+  it("returns an empty attachment list for malformed issue ids", async () => {
+    await expect(svc.listAttachments("not-a-uuid")).resolves.toEqual([]);
+  });
+
+  it("returns null for malformed attachment ids on getAttachmentById", async () => {
+    await expect(svc.getAttachmentById("not-a-uuid")).resolves.toBeNull();
+  });
+
+  it("returns null for malformed attachment ids on removeAttachment", async () => {
+    await expect(svc.removeAttachment("not-a-uuid")).resolves.toBeNull();
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -15,7 +15,7 @@ import {
   issueComments,
   issues,
 } from "@paperclipai/db";
-import { issueService } from "../services/issues.ts";
+import { issueService, type IssueFilters } from "../services/issues.ts";
 
 type EmbeddedPostgresInstance = {
   initialise(): Promise<void>;
@@ -540,6 +540,42 @@ describe("issueService.list participantAgentId", () => {
     });
 
     expect(result.map((issue) => issue.id)).toContain(issueId);
+  });
+
+  it("returns an empty list for malformed uuid string list filters", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Malformed uuid filter safety",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const uuidFilterKeys: Array<keyof Pick<
+      IssueFilters,
+      "assigneeAgentId" | "participantAgentId" | "projectId" | "parentId" | "labelId"
+    >> = [
+      "assigneeAgentId",
+      "participantAgentId",
+      "projectId",
+      "parentId",
+      "labelId",
+    ];
+
+    for (const key of uuidFilterKeys) {
+      const result = await svc.list(companyId, { [key]: "not-a-uuid" } as Pick<IssueFilters, typeof key>);
+      expect(result).toEqual([]);
+    }
   });
 
   it("ignores malformed non-string unread status filters instead of throwing", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -891,6 +891,11 @@ describe("issueService.list participantAgentId", () => {
     expect(unreadCount).toBe(0);
   });
 
+  it("returns zero unread count for malformed non-string user ids", async () => {
+    const unreadCount = await svc.countUnreadTouchedByUser(randomUUID(), { bad: true } as any, "todo");
+    expect(unreadCount).toBe(0);
+  });
+
   it("returns not found for malformed non-uuid issue ids on createAttachment", async () => {
     await expect(
       svc.createAttachment({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1080,6 +1080,39 @@ describe("issueService.list participantAgentId", () => {
     expect(unreadCount).toBe(1);
   });
 
+  it("normalizes unread count company ids for non-route callers", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Unread company id normalization",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: userId,
+    });
+
+    await db.insert(issueComments).values({
+      issueId,
+      companyId,
+      body: "new external comment",
+      authorAgentId: null,
+      authorUserId: null,
+    });
+
+    const unreadCount = await svc.countUnreadTouchedByUser(` ${companyId.toUpperCase()} `, userId, "todo");
+    expect(unreadCount).toBe(1);
+  });
+
   it("returns zero unread count when companyId is malformed", async () => {
     const unreadCount = await svc.countUnreadTouchedByUser("not-a-uuid", randomUUID(), "todo");
     expect(unreadCount).toBe(0);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -503,4 +503,55 @@ describe("issueService.list participantAgentId", () => {
 
     expect(unreadCount).toBe(1);
   });
+
+  it("returns not found for malformed non-uuid issue ids on createAttachment", async () => {
+    await expect(
+      svc.createAttachment({
+        issueId: "not-a-uuid",
+        provider: "local",
+        objectKey: "issues/not-a-uuid/file.txt",
+        contentType: "text/plain",
+        byteSize: 10,
+        sha256: "abc123",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue not found",
+    });
+  });
+
+  it("returns not found for malformed non-uuid issueCommentId on createAttachment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Attachment comment id validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.createAttachment({
+        issueId,
+        issueCommentId: "not-a-uuid",
+        provider: "local",
+        objectKey: `issues/${issueId}/file.txt`,
+        contentType: "text/plain",
+        byteSize: 10,
+        sha256: "abc123",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Issue comment not found",
+    });
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1174,6 +1174,41 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed createdByAgentId on createAttachment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Attachment createdByAgentId validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.createAttachment({
+        issueId,
+        provider: "local",
+        objectKey: `issues/${issueId}/file.txt`,
+        contentType: "text/plain",
+        byteSize: 10,
+        sha256: "abc123",
+        createdByAgentId: "not-a-uuid",
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid createdByAgentId",
+    });
+  });
+
   it("normalizes attachment issue/attachment uuid inputs for non-route callers", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2189,6 +2189,47 @@ describe("issueService.list participantAgentId", () => {
     expect(released?.checkoutRunId).toBeNull();
   });
 
+  it("normalizes assignee and label uuids during create for non-route callers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const labelId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CreateNormalizeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "ops",
+      color: "#0099FF",
+    });
+
+    const created = await svc.create(companyId, {
+      title: "Create UUID normalization",
+      assigneeAgentId: ` ${agentId.toUpperCase()} `,
+      labelIds: [` ${labelId.toUpperCase()} `],
+    } as any);
+
+    expect(created.assigneeAgentId).toBe(agentId);
+    expect(created.labelIds).toContain(labelId);
+  });
+
   it("returns unprocessable for malformed assigneeAgentId on create", async () => {
     await expect(
       svc.create(randomUUID(), {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -502,6 +502,14 @@ describe("issueService.list participantAgentId", () => {
     expect(comments).toEqual([]);
   });
 
+  it("ignores malformed non-number comment limits instead of throwing", async () => {
+    const comments = await svc.listComments(randomUUID(), {
+      limit: Symbol("bad") as any,
+      order: "asc",
+    });
+    expect(comments).toEqual([]);
+  });
+
   it("returns an empty comment page when issueId is malformed", async () => {
     const comments = await svc.listComments("not-a-uuid", {
       order: "asc",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -850,6 +850,17 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed company ids on create", async () => {
+    await expect(
+      svc.create("not-a-uuid", {
+        title: "Invalid company guard",
+      } as any),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid companyId",
+    });
+  });
+
   it("returns unprocessable for malformed workspace ids on create", async () => {
     await expect(
       svc.create(randomUUID(), {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1244,6 +1244,54 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed required attachment fields on createAttachment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Attachment required field validation",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.createAttachment({
+        issueId,
+        provider: "local",
+        objectKey: `issues/${issueId}/file.txt`,
+        contentType: "text/plain",
+        byteSize: -1,
+        sha256: "abc123",
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid byteSize",
+    });
+
+    await expect(
+      svc.createAttachment({
+        issueId,
+        provider: " ",
+        objectKey: `issues/${issueId}/file.txt`,
+        contentType: "text/plain",
+        byteSize: 10,
+        sha256: "abc123",
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid provider",
+    });
+  });
+
   it("normalizes attachment issue/attachment uuid inputs for non-route callers", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1989,6 +1989,15 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns not found for non-existent company ids on createLabel", async () => {
+    await expect(
+      svc.createLabel(randomUUID(), { name: "Bug", color: "#FF0000" }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Company not found",
+    });
+  });
+
   it("returns unprocessable for malformed label names on createLabel", async () => {
     await expect(
       svc.createLabel(randomUUID(), { name: 123 as any, color: "#FF0000" } as any),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -594,6 +594,45 @@ describe("issueService.list participantAgentId", () => {
     }
   });
 
+  it("normalizes status and originKind filters for non-route callers", async () => {
+    const companyId = randomUUID();
+    const routineIssueId = randomUUID();
+    const manualIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      {
+        id: routineIssueId,
+        companyId,
+        title: "Routine issue",
+        status: "todo",
+        priority: "medium",
+        originKind: "routine_execution",
+        originId: randomUUID(),
+      },
+      {
+        id: manualIssueId,
+        companyId,
+        title: "Manual issue",
+        status: "todo",
+        priority: "medium",
+        originKind: "manual",
+      },
+    ]);
+
+    const statusResult = await svc.list(companyId, { status: " TODO " });
+    expect(statusResult.map((issue) => issue.id)).toContain(manualIssueId);
+
+    const originResult = await svc.list(companyId, { originKind: " ROUTINE_EXECUTION " });
+    expect(originResult.map((issue) => issue.id)).toContain(routineIssueId);
+  });
+
   it("keeps routine_execution issues excluded by default for malformed non-route origin/include filters", async () => {
     const companyId = randomUUID();
     const routineIssueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -714,6 +714,24 @@ describe("issueService.list participantAgentId", () => {
     });
   });
 
+  it("returns unprocessable for malformed author agent ids on addComment", async () => {
+    await expect(
+      svc.addComment(randomUUID(), "hello", { agentId: "not-a-uuid" }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid authorAgentId",
+    });
+  });
+
+  it("returns unprocessable for malformed author user ids on addComment", async () => {
+    await expect(
+      svc.addComment(randomUUID(), "hello", { userId: { bad: true } as any }),
+    ).rejects.toMatchObject({
+      status: 422,
+      message: "Invalid authorUserId",
+    });
+  });
+
   it("returns not found for malformed issue ids on markRead", async () => {
     await expect(
       svc.markRead(randomUUID(), "not-a-uuid", "user-1", new Date()),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2090,6 +2090,10 @@ describe("issueService.list participantAgentId", () => {
     expect(result.sort()).toEqual([explicitValidMentionId, mentionedByNameId].sort());
   });
 
+  it("returns an empty mention list for malformed non-string bodies", async () => {
+    await expect(svc.findMentionedAgents(randomUUID(), 123 as any)).resolves.toEqual([]);
+  });
+
   it("normalizes findMentionedAgents company and explicit mention uuids for non-route callers", async () => {
     const companyId = randomUUID();
     const mentionedByNameId = randomUUID();

--- a/server/src/__tests__/plugin-host-services-companyid.test.ts
+++ b/server/src/__tests__/plugin-host-services-companyid.test.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { createPluginEventBus } from "../services/plugin-event-bus.js";
+import { buildHostServices } from "../services/plugin-host-services.js";
+
+describe("plugin host services companyId validation", () => {
+  it("rejects malformed companyId for issues.list", async () => {
+    const host = buildHostServices(
+      {} as Db,
+      randomUUID(),
+      "test.plugin",
+      createPluginEventBus(),
+    );
+
+    await expect(
+      host.issues.list({ companyId: "not-a-uuid" } as any),
+    ).rejects.toThrow("Invalid companyId");
+
+    host.dispose();
+  });
+
+  it("rejects malformed companyId for issues.listComments", async () => {
+    const host = buildHostServices(
+      {} as Db,
+      randomUUID(),
+      "test.plugin",
+      createPluginEventBus(),
+    );
+
+    await expect(
+      host.issues.listComments({
+        companyId: "not-a-uuid",
+        issueId: randomUUID(),
+      } as any),
+    ).rejects.toThrow("Invalid companyId");
+
+    host.dispose();
+  });
+});

--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -336,5 +336,5 @@ describe("routine routes end-to-end", () => {
         "routine.run_triggered",
       ]),
     );
-  });
+  }, 15_000);
 });

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -117,6 +117,22 @@ describe("routine routes", () => {
     mockLogActivity.mockResolvedValue(undefined);
   });
 
+  it("returns 400 for malformed routine run limit query values", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get(`/api/routines/${routineId}/runs?limit=not-a-number`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid limit");
+    expect(mockRoutineService.listRuns).not.toHaveBeenCalled();
+  });
+
   it("requires tasks:assign permission for non-admin board routine creation", async () => {
     const app = createApp({
       type: "board",

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -451,6 +451,12 @@ describe("routine service live-execution coalescing", () => {
     expect(routineIssues).toHaveLength(0);
   });
 
+  it("falls back to a safe default when listRuns receives a malformed limit", async () => {
+    const { routine, svc } = await seedFixture();
+
+    await expect(svc.listRuns(routine.id, Number.NaN as any)).resolves.toEqual([]);
+  });
+
   it("accepts standard second-precision webhook timestamps for HMAC triggers", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger, secretMaterial } = await svc.createTrigger(

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -6,6 +6,7 @@ import { validate } from "../middleware/validate.js";
 import { activityService } from "../services/activity.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
 import { issueService } from "../services/index.js";
+import { readQueryString } from "./query-utils.js";
 import { sanitizeRecord } from "../redaction.js";
 
 const createActivitySchema = z.object({
@@ -22,15 +23,6 @@ export function activityRoutes(db: Db) {
   const router = Router();
   const svc = activityService(db);
   const issueSvc = issueService(db);
-
-  function readQueryString(value: unknown): string | undefined {
-    if (typeof value === "string") return value;
-    if (Array.isArray(value)) {
-      const first = value.find((entry): entry is string => typeof entry === "string");
-      return first;
-    }
-    return undefined;
-  }
 
   async function resolveIssueByRef(rawId: string) {
     if (/^[A-Z]+-\d+$/i.test(rawId)) {

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import type { Db } from "@paperclipai/db";
+import { isUuidLike } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { activityService } from "../services/activity.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
@@ -24,9 +25,12 @@ export function activityRoutes(db: Db) {
 
   async function resolveIssueByRef(rawId: string) {
     if (/^[A-Z]+-\d+$/i.test(rawId)) {
-      return issueSvc.getByIdentifier(rawId);
+      return { issue: await issueSvc.getByIdentifier(rawId), invalidRef: false };
     }
-    return issueSvc.getById(rawId);
+    if (isUuidLike(rawId)) {
+      return { issue: await issueSvc.getById(rawId), invalidRef: false };
+    }
+    return { issue: null, invalidRef: true };
   }
 
   router.get("/companies/:companyId/activity", async (req, res) => {
@@ -56,7 +60,11 @@ export function activityRoutes(db: Db) {
 
   router.get("/issues/:id/activity", async (req, res) => {
     const rawId = req.params.id as string;
-    const issue = await resolveIssueByRef(rawId);
+    const { issue, invalidRef } = await resolveIssueByRef(rawId);
+    if (invalidRef) {
+      res.status(400).json({ error: "Invalid issue id. Use UUID or identifier like PAP-123." });
+      return;
+    }
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
@@ -68,7 +76,11 @@ export function activityRoutes(db: Db) {
 
   router.get("/issues/:id/runs", async (req, res) => {
     const rawId = req.params.id as string;
-    const issue = await resolveIssueByRef(rawId);
+    const { issue, invalidRef } = await resolveIssueByRef(rawId);
+    if (invalidRef) {
+      res.status(400).json({ error: "Invalid issue id. Use UUID or identifier like PAP-123." });
+      return;
+    }
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -106,6 +106,10 @@ export function activityRoutes(db: Db) {
 
   router.get("/heartbeat-runs/:runId/issues", async (req, res) => {
     const runId = req.params.runId as string;
+    if (!isUuidLike(runId)) {
+      res.status(400).json({ error: "Invalid run id" });
+      return;
+    }
     const result = await svc.issuesForRun(runId);
     res.json(result);
   });

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -23,6 +23,15 @@ export function activityRoutes(db: Db) {
   const svc = activityService(db);
   const issueSvc = issueService(db);
 
+  function readQueryString(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      const first = value.find((entry): entry is string => typeof entry === "string");
+      return first;
+    }
+    return undefined;
+  }
+
   async function resolveIssueByRef(rawId: string) {
     if (/^[A-Z]+-\d+$/i.test(rawId)) {
       return { issue: await issueSvc.getByIdentifier(rawId), invalidRef: false };
@@ -36,12 +45,17 @@ export function activityRoutes(db: Db) {
   router.get("/companies/:companyId/activity", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    const agentId = readQueryString(req.query.agentId);
+    if (agentId && !isUuidLike(agentId)) {
+      res.status(400).json({ error: "Invalid agentId filter" });
+      return;
+    }
 
     const filters = {
       companyId,
-      agentId: req.query.agentId as string | undefined,
-      entityType: req.query.entityType as string | undefined,
-      entityId: req.query.entityId as string | undefined,
+      agentId,
+      entityType: readQueryString(req.query.entityType),
+      entityId: readQueryString(req.query.entityId),
     };
     const result = await svc.list(filters);
     res.json(result);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2229,6 +2229,10 @@ export function agentRoutes(db: Db) {
 
   router.get("/issues/:issueId/live-runs", async (req, res) => {
     const rawId = req.params.issueId as string;
+    if (!/^[A-Z]+-\d+$/i.test(rawId) && !isUuidLike(rawId)) {
+      res.status(400).json({ error: "Invalid issue id. Use UUID or identifier like PAP-123." });
+      return;
+    }
     const issueSvc = issueService(db);
     const isIdentifier = /^[A-Z]+-\d+$/i.test(rawId);
     const issue = isIdentifier ? await issueSvc.getByIdentifier(rawId) : await issueSvc.getById(rawId);
@@ -2267,6 +2271,10 @@ export function agentRoutes(db: Db) {
 
   router.get("/issues/:issueId/active-run", async (req, res) => {
     const rawId = req.params.issueId as string;
+    if (!/^[A-Z]+-\d+$/i.test(rawId) && !isUuidLike(rawId)) {
+      res.status(400).json({ error: "Invalid issue id. Use UUID or identifier like PAP-123." });
+      return;
+    }
     const issueSvc = issueService(db);
     const isIdentifier = /^[A-Z]+-\d+$/i.test(rawId);
     const issue = isIdentifier ? await issueSvc.getByIdentifier(rawId) : await issueSvc.getById(rawId);

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import {
   addApprovalCommentSchema,
   createApprovalSchema,
+  isUuidLike,
   requestApprovalRevisionSchema,
   resolveApprovalSchema,
   resubmitApprovalSchema,
@@ -108,6 +109,10 @@ export function approvalRoutes(db: Db) {
 
   router.get("/approvals/:id/issues", async (req, res) => {
     const id = req.params.id as string;
+    if (!isUuidLike(id)) {
+      res.status(400).json({ error: "Invalid approval id" });
+      return;
+    }
     const approval = await svc.getById(id);
     if (!approval) {
       res.status(404).json({ error: "Approval not found" });

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -19,6 +19,7 @@ import {
   secretService,
 } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { readQueryString } from "./query-utils.js";
 import { redactEventPayload } from "../redaction.js";
 
 function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(approval: T): T {
@@ -36,15 +37,6 @@ export function approvalRoutes(db: Db) {
   const secretsSvc = secretService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
   const APPROVAL_STATUS_SET = new Set(APPROVAL_STATUSES);
-
-  function readQueryString(value: unknown): string | undefined {
-    if (typeof value === "string") return value;
-    if (Array.isArray(value)) {
-      const first = value.find((entry): entry is string => typeof entry === "string");
-      return first;
-    }
-    return undefined;
-  }
 
   function parseApprovalId(rawId: string, res: Response) {
     if (!isUuidLike(rawId)) {

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -1,6 +1,7 @@
 import { Router, type Response } from "express";
 import type { Db } from "@paperclipai/db";
 import {
+  APPROVAL_STATUSES,
   addApprovalCommentSchema,
   createApprovalSchema,
   isUuidLike,
@@ -34,6 +35,16 @@ export function approvalRoutes(db: Db) {
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
+  const APPROVAL_STATUS_SET = new Set(APPROVAL_STATUSES);
+
+  function readQueryString(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      const first = value.find((entry): entry is string => typeof entry === "string");
+      return first;
+    }
+    return undefined;
+  }
 
   function parseApprovalId(rawId: string, res: Response) {
     if (!isUuidLike(rawId)) {
@@ -46,7 +57,11 @@ export function approvalRoutes(db: Db) {
   router.get("/companies/:companyId/approvals", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const status = req.query.status as string | undefined;
+    const status = readQueryString(req.query.status);
+    if (status && !APPROVAL_STATUS_SET.has(status as typeof APPROVAL_STATUSES[number])) {
+      res.status(400).json({ error: `Invalid approval status filter: ${status}` });
+      return;
+    }
     const result = await svc.list(companyId, status);
     res.json(result.map((approval) => redactApprovalPayload(approval)));
   });

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, type Response } from "express";
 import type { Db } from "@paperclipai/db";
 import {
   addApprovalCommentSchema,
@@ -35,6 +35,14 @@ export function approvalRoutes(db: Db) {
   const secretsSvc = secretService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
 
+  function parseApprovalId(rawId: string, res: Response) {
+    if (!isUuidLike(rawId)) {
+      res.status(400).json({ error: "Invalid approval id" });
+      return null;
+    }
+    return rawId;
+  }
+
   router.get("/companies/:companyId/approvals", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -44,7 +52,8 @@ export function approvalRoutes(db: Db) {
   });
 
   router.get("/approvals/:id", async (req, res) => {
-    const id = req.params.id as string;
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const approval = await svc.getById(id);
     if (!approval) {
       res.status(404).json({ error: "Approval not found" });
@@ -108,11 +117,8 @@ export function approvalRoutes(db: Db) {
   });
 
   router.get("/approvals/:id/issues", async (req, res) => {
-    const id = req.params.id as string;
-    if (!isUuidLike(id)) {
-      res.status(400).json({ error: "Invalid approval id" });
-      return;
-    }
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const approval = await svc.getById(id);
     if (!approval) {
       res.status(404).json({ error: "Approval not found" });
@@ -125,7 +131,8 @@ export function approvalRoutes(db: Db) {
 
   router.post("/approvals/:id/approve", validate(resolveApprovalSchema), async (req, res) => {
     assertBoard(req);
-    const id = req.params.id as string;
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const { approval, applied } = await svc.approve(
       id,
       req.body.decidedByUserId ?? "board",
@@ -220,7 +227,8 @@ export function approvalRoutes(db: Db) {
 
   router.post("/approvals/:id/reject", validate(resolveApprovalSchema), async (req, res) => {
     assertBoard(req);
-    const id = req.params.id as string;
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const { approval, applied } = await svc.reject(
       id,
       req.body.decidedByUserId ?? "board",
@@ -247,7 +255,8 @@ export function approvalRoutes(db: Db) {
     validate(requestApprovalRevisionSchema),
     async (req, res) => {
       assertBoard(req);
-      const id = req.params.id as string;
+      const id = parseApprovalId(req.params.id as string, res);
+      if (!id) return;
       const approval = await svc.requestRevision(
         id,
         req.body.decidedByUserId ?? "board",
@@ -269,7 +278,8 @@ export function approvalRoutes(db: Db) {
   );
 
   router.post("/approvals/:id/resubmit", validate(resubmitApprovalSchema), async (req, res) => {
-    const id = req.params.id as string;
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const existing = await svc.getById(id);
     if (!existing) {
       res.status(404).json({ error: "Approval not found" });
@@ -307,7 +317,8 @@ export function approvalRoutes(db: Db) {
   });
 
   router.get("/approvals/:id/comments", async (req, res) => {
-    const id = req.params.id as string;
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const approval = await svc.getById(id);
     if (!approval) {
       res.status(404).json({ error: "Approval not found" });
@@ -319,7 +330,8 @@ export function approvalRoutes(db: Db) {
   });
 
   router.post("/approvals/:id/comments", validate(addApprovalCommentSchema), async (req, res) => {
-    const id = req.params.id as string;
+    const id = parseApprovalId(req.params.id as string, res);
+    if (!id) return;
     const approval = await svc.getById(id);
     if (!approval) {
       res.status(404).json({ error: "Approval not found" });

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -1,4 +1,5 @@
 import type { Request } from "express";
+import { isUuidLike } from "@paperclipai/shared";
 import { forbidden, unauthorized } from "../errors.js";
 
 export function assertBoard(req: Request) {
@@ -34,12 +35,15 @@ export function getActorInfo(req: Request) {
   if (req.actor.type === "none") {
     throw unauthorized();
   }
+  const runId = typeof req.actor.runId === "string" && isUuidLike(req.actor.runId)
+    ? req.actor.runId
+    : null;
   if (req.actor.type === "agent") {
     return {
       actorType: "agent" as const,
       actorId: req.actor.agentId ?? "unknown-agent",
       agentId: req.actor.agentId ?? null,
-      runId: req.actor.runId ?? null,
+      runId,
     };
   }
 
@@ -47,6 +51,6 @@ export function getActorInfo(req: Request) {
     actorType: "user" as const,
     actorId: req.actor.userId ?? "board",
     agentId: null,
-    runId: req.actor.runId ?? null,
+    runId,
   };
 }

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -11,6 +11,7 @@ import {
   stopRuntimeServicesForExecutionWorkspace,
 } from "../services/workspace-runtime.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { readQueryString } from "./query-utils.js";
 
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 
@@ -18,15 +19,6 @@ export function executionWorkspaceRoutes(db: Db) {
   const router = Router();
   const svc = executionWorkspaceService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
-
-  function readQueryString(value: unknown): string | undefined {
-    if (typeof value === "string") return value;
-    if (Array.isArray(value)) {
-      const first = value.find((entry): entry is string => typeof entry === "string");
-      return first;
-    }
-    return undefined;
-  }
 
   router.get("/companies/:companyId/execution-workspaces", async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -19,15 +19,29 @@ export function executionWorkspaceRoutes(db: Db) {
   const svc = executionWorkspaceService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
 
+  function readQueryString(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      const first = value.find((entry): entry is string => typeof entry === "string");
+      return first;
+    }
+    return undefined;
+  }
+
   router.get("/companies/:companyId/execution-workspaces", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    const projectId = readQueryString(req.query.projectId);
+    const projectWorkspaceId = readQueryString(req.query.projectWorkspaceId);
+    const issueId = readQueryString(req.query.issueId);
+    const status = readQueryString(req.query.status);
+    const reuseEligible = readQueryString(req.query.reuseEligible) === "true";
     const workspaces = await svc.list(companyId, {
-      projectId: req.query.projectId as string | undefined,
-      projectWorkspaceId: req.query.projectWorkspaceId as string | undefined,
-      issueId: req.query.issueId as string | undefined,
-      status: req.query.status as string | undefined,
-      reuseEligible: req.query.reuseEligible === "true",
+      projectId,
+      projectWorkspaceId,
+      issueId,
+      status,
+      reuseEligible,
     });
     res.json(workspaces);
   });

--- a/server/src/routes/issues-checkout-wakeup.ts
+++ b/server/src/routes/issues-checkout-wakeup.ts
@@ -6,9 +6,20 @@ type CheckoutWakeInput = {
 };
 
 export function shouldWakeAssigneeOnCheckout(input: CheckoutWakeInput): boolean {
+  const normalizedActorAgentId = typeof input.actorAgentId === "string"
+    ? input.actorAgentId.trim().toLowerCase()
+    : null;
+  const normalizedCheckoutAgentId = typeof input.checkoutAgentId === "string"
+    ? input.checkoutAgentId.trim().toLowerCase()
+    : "";
+  const normalizedCheckoutRunId = typeof input.checkoutRunId === "string"
+    ? input.checkoutRunId.trim()
+    : null;
+
   if (input.actorType !== "agent") return true;
-  if (!input.actorAgentId) return true;
-  if (input.actorAgentId !== input.checkoutAgentId) return true;
-  if (!input.checkoutRunId) return true;
+  if (!normalizedActorAgentId) return true;
+  if (!normalizedCheckoutAgentId) return true;
+  if (normalizedActorAgentId !== normalizedCheckoutAgentId) return true;
+  if (!normalizedCheckoutRunId) return true;
   return false;
 }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -938,8 +938,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    const normalizedPatchAssigneeAgentId = typeof req.body.assigneeAgentId === "string"
+      ? req.body.assigneeAgentId.trim().toLowerCase()
+      : req.body.assigneeAgentId;
+    const normalizedExistingAssigneeAgentIdForChange = typeof existing.assigneeAgentId === "string"
+      ? existing.assigneeAgentId.trim().toLowerCase()
+      : existing.assigneeAgentId;
     const assigneeWillChange =
-      (req.body.assigneeAgentId !== undefined && req.body.assigneeAgentId !== existing.assigneeAgentId) ||
+      (req.body.assigneeAgentId !== undefined &&
+        normalizedPatchAssigneeAgentId !== normalizedExistingAssigneeAgentIdForChange) ||
       (req.body.assigneeUserId !== undefined && req.body.assigneeUserId !== existing.assigneeUserId);
     const normalizedActorAgentId = typeof req.actor.agentId === "string"
       ? req.actor.agentId.trim().toLowerCase()
@@ -969,6 +976,9 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const { comment: commentBody, reopen: reopenRequested, hiddenAt: hiddenAtRaw, ...updateFields } = req.body;
     if (hiddenAtRaw !== undefined) {
       updateFields.hiddenAt = hiddenAtRaw ? new Date(hiddenAtRaw) : null;
+    }
+    if (typeof updateFields.assigneeAgentId === "string") {
+      updateFields.assigneeAgentId = updateFields.assigneeAgentId.trim().toLowerCase();
     }
     if (commentBody && reopenRequested === true && isClosed && updateFields.status === undefined) {
       updateFields.status = "todo";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1406,11 +1406,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!isUuidLike(commentId)) {
+    const normalizedCommentIdInput = typeof commentId === "string" ? commentId.trim() : "";
+    if (!isUuidLike(normalizedCommentIdInput)) {
       res.status(400).json({ error: "Invalid commentId" });
       return;
     }
-    const normalizedCommentId = commentId.trim().toLowerCase();
+    const normalizedCommentId = normalizedCommentIdInput.toLowerCase();
     const comment = await svc.getComment(normalizedCommentId);
     if (!comment || comment.issueId !== issue.id) {
       res.status(404).json({ error: "Comment not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1197,6 +1197,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
+    const checkoutAlreadyOwnedByRequestedAssignee =
+      issue.assigneeAgentId === req.body.agentId &&
+      issue.status === "in_progress" &&
+      (checkoutRunId ? issue.checkoutRunId === checkoutRunId : issue.checkoutRunId == null);
     const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
     const actor = getActorInfo(req);
 
@@ -1213,6 +1217,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     });
 
     if (
+      !checkoutAlreadyOwnedByRequestedAssignee &&
       shouldWakeAssigneeOnCheckout({
         actorType: req.actor.type,
         actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -830,6 +830,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
   router.delete("/issues/:id/approvals/:approvalId", async (req, res) => {
     const id = req.params.id as string;
     const approvalId = req.params.approvalId as string;
+    if (!isUuidLike(approvalId)) {
+      res.status(400).json({ error: "Invalid approvalId" });
+      return;
+    }
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -251,7 +251,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const companyId = req.params.companyId as string;
     if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
-    const statusFilter = readQueryString(req.query.status);
+    const statusFilter = readQueryString(req.query.status)?.trim();
     const assigneeAgentIdFilter = readQueryString(req.query.assigneeAgentId);
     const participantAgentIdFilter = readQueryString(req.query.participantAgentId);
     const assigneeUserFilterRaw = readQueryString(req.query.assigneeUserId);
@@ -260,12 +260,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const projectIdFilter = readQueryString(req.query.projectId);
     const parentIdFilter = readQueryString(req.query.parentId);
     const labelIdFilter = readQueryString(req.query.labelId);
-    const originKindFilter = readQueryString(req.query.originKind);
-    const originIdFilter = readQueryString(req.query.originId);
+    const originKindFilter = readQueryString(req.query.originKind)?.trim().toLowerCase();
+    const originIdFilterRaw = readQueryString(req.query.originId);
+    const originIdFilter = originIdFilterRaw && originIdFilterRaw.trim().length > 0
+      ? originIdFilterRaw.trim()
+      : undefined;
     const includeRoutineExecutionsFilter = readQueryString(req.query.includeRoutineExecutions);
     const searchFilter = readQueryString(req.query.q);
     const normalizedStatuses =
-      statusFilter?.split(",").map((value) => value.trim()).filter((value) => value.length > 0) ?? [];
+      statusFilter?.split(",").map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0) ?? [];
     const invalidStatus = normalizedStatuses.find((status) => !ISSUE_STATUS_SET.has(status as typeof ISSUE_STATUSES[number]));
     if (invalidStatus) {
       res.status(400).json({ error: `Invalid status filter: ${invalidStatus}` });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -287,6 +287,17 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: "Invalid originId filter for routine_execution originKind" });
       return;
     }
+    const normalizedIncludeRoutineExecutions = includeRoutineExecutionsFilter?.trim().toLowerCase();
+    if (
+      normalizedIncludeRoutineExecutions &&
+      normalizedIncludeRoutineExecutions !== "true" &&
+      normalizedIncludeRoutineExecutions !== "1" &&
+      normalizedIncludeRoutineExecutions !== "false" &&
+      normalizedIncludeRoutineExecutions !== "0"
+    ) {
+      res.status(400).json({ error: "Invalid includeRoutineExecutions filter. Use true/false or 1/0." });
+      return;
+    }
     const statusFilterNormalized = normalizedStatuses.length > 0 ? Array.from(new Set(normalizedStatuses)).join(",") : undefined;
 
     const assigneeUserId =
@@ -348,7 +359,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       originKind: originKindFilter,
       originId: originIdFilter,
       includeRoutineExecutions:
-        includeRoutineExecutionsFilter === "true" || includeRoutineExecutionsFilter === "1",
+        normalizedIncludeRoutineExecutions === "true" || normalizedIncludeRoutineExecutions === "1",
       q: searchFilter,
     });
     res.json(result);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -143,7 +143,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   function requireAgentRunId(req: Request, res: Response) {
     if (req.actor.type !== "agent") return null;
-    const runId = req.actor.runId?.trim();
+    const runId = typeof req.actor.runId === "string" ? req.actor.runId.trim() : "";
     if (runId) return runId;
     res.status(401).json({ error: "Agent run id required" });
     return null;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1407,7 +1407,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: "Invalid commentId" });
       return;
     }
-    const comment = await svc.getComment(commentId);
+    const normalizedCommentId = commentId.trim().toLowerCase();
+    const comment = await svc.getComment(normalizedCommentId);
     if (!comment || comment.issueId !== issue.id) {
       res.status(404).json({ error: "Comment not found" });
       return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -268,6 +268,9 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const assigneeUserIsMe = assigneeUserFilter?.toLowerCase() === "me";
     const touchedByUserIsMe = touchedByUserFilter?.toLowerCase() === "me";
     const unreadForUserIsMe = unreadForUserFilter?.toLowerCase() === "me";
+    const normalizedBoardUserId = req.actor.type === "board" && typeof req.actor.userId === "string"
+      ? req.actor.userId.trim()
+      : "";
     const projectIdFilter = readQueryString(req.query.projectId);
     const parentIdFilter = readQueryString(req.query.parentId);
     const labelIdFilter = readQueryString(req.query.labelId);
@@ -312,15 +315,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
     const assigneeUserId =
       assigneeUserIsMe && req.actor.type === "board"
-        ? req.actor.userId
+        ? normalizedBoardUserId
         : assigneeUserFilter;
     const touchedByUserId =
       touchedByUserIsMe && req.actor.type === "board"
-        ? req.actor.userId
+        ? normalizedBoardUserId
         : touchedByUserFilter;
     const unreadForUserId =
       unreadForUserIsMe && req.actor.type === "board"
-        ? req.actor.userId
+        ? normalizedBoardUserId
         : unreadForUserFilter;
 
     if (assigneeUserIsMe && (!assigneeUserId || req.actor.type !== "board")) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -369,6 +369,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.delete("/labels/:labelId", async (req, res) => {
     const labelId = req.params.labelId as string;
+    if (!isUuidLike(labelId)) {
+      res.status(400).json({ error: "Invalid labelId" });
+      return;
+    }
     const existing = await svc.getLabelById(labelId);
     if (!existing) {
       res.status(404).json({ error: "Label not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -147,12 +147,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
   ) {
     if (req.actor.type !== "agent") return true;
-    const actorAgentId = req.actor.agentId;
+    const actorAgentId = typeof req.actor.agentId === "string" ? req.actor.agentId.trim().toLowerCase() : "";
     if (!actorAgentId) {
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
-    if (issue.status !== "in_progress" || issue.assigneeAgentId !== actorAgentId) {
+    const assigneeAgentId = typeof issue.assigneeAgentId === "string" ? issue.assigneeAgentId.trim().toLowerCase() : "";
+    if (issue.status !== "in_progress" || assigneeAgentId !== actorAgentId) {
       return true;
     }
     const runId = requireAgentRunId(req, res);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1408,7 +1408,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     const comment = await svc.getComment(commentId);
-    if (!comment || comment.issueId !== id) {
+    if (!comment || comment.issueId !== issue.id) {
       res.status(404).json({ error: "Comment not found" });
       return;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1270,16 +1270,26 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     const orderRaw = readQueryString(req.query.order);
-    const order = orderRaw && orderRaw.trim().toLowerCase() === "asc"
-      ? "asc"
-      : "desc";
+    const normalizedOrder = orderRaw?.trim().toLowerCase();
+    if (normalizedOrder && normalizedOrder !== "asc" && normalizedOrder !== "desc") {
+      res.status(400).json({ error: "Invalid comment order. Use 'asc' or 'desc'." });
+      return;
+    }
+    const order = normalizedOrder === "asc" ? "asc" : "desc";
     const limitRawString = readQueryString(req.query.limit);
-    const limitRaw = limitRawString && limitRawString.trim().length > 0
+    const parsedLimit = limitRawString && limitRawString.trim().length > 0
       ? Number(limitRawString)
       : null;
+    if (
+      parsedLimit !== null &&
+      (!Number.isFinite(parsedLimit) || !Number.isInteger(parsedLimit) || parsedLimit <= 0)
+    ) {
+      res.status(400).json({ error: "Invalid comment limit. Use a positive integer." });
+      return;
+    }
     const limit =
-      limitRaw && Number.isFinite(limitRaw) && limitRaw > 0
-        ? Math.min(Math.floor(limitRaw), MAX_ISSUE_COMMENT_LIMIT)
+      parsedLimit !== null && Number.isFinite(parsedLimit) && parsedLimit > 0
+        ? Math.min(Math.floor(parsedLimit), MAX_ISSUE_COMMENT_LIMIT)
         : null;
     const comments = await svc.listComments(id, {
       afterCommentId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8,6 +8,7 @@ import {
   createIssueLabelSchema,
   checkoutIssueSchema,
   createIssueSchema,
+  ISSUE_STATUSES,
   isUuidLike,
   linkIssueApprovalSchema,
   issueDocumentKeySchema,
@@ -39,6 +40,7 @@ import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const ISSUE_STATUS_SET = new Set(ISSUE_STATUSES);
 
 export function issueRoutes(db: Db, storage: StorageService) {
   const router = Router();
@@ -259,6 +261,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const originIdFilter = readQueryString(req.query.originId);
     const includeRoutineExecutionsFilter = readQueryString(req.query.includeRoutineExecutions);
     const searchFilter = readQueryString(req.query.q);
+    const normalizedStatuses =
+      statusFilter?.split(",").map((value) => value.trim()).filter((value) => value.length > 0) ?? [];
+    const invalidStatus = normalizedStatuses.find((status) => !ISSUE_STATUS_SET.has(status as typeof ISSUE_STATUSES[number]));
+    if (invalidStatus) {
+      res.status(400).json({ error: `Invalid status filter: ${invalidStatus}` });
+      return;
+    }
+    const statusFilterNormalized = normalizedStatuses.length > 0 ? Array.from(new Set(normalizedStatuses)).join(",") : undefined;
 
     const assigneeUserId =
       assigneeUserFilterRaw === "me" && req.actor.type === "board"
@@ -307,7 +317,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
 
     const result = await svc.list(companyId, {
-      status: statusFilter,
+      status: statusFilterNormalized,
       assigneeAgentId: assigneeAgentIdFilter,
       participantAgentId: participantAgentIdFilter,
       assigneeUserId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -195,7 +195,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     if (!isUuidLike(rawId)) {
       throw new HttpError(400, "Invalid issue id. Use UUID or identifier like PAP-123.");
     }
-    return rawId;
+    return rawId.trim().toLowerCase();
   }
 
   async function resolveIssueProjectAndGoal(issue: {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8,6 +8,7 @@ import {
   createIssueLabelSchema,
   checkoutIssueSchema,
   createIssueSchema,
+  ISSUE_ORIGIN_KINDS,
   ISSUE_STATUSES,
   isUuidLike,
   linkIssueApprovalSchema,
@@ -41,6 +42,7 @@ import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const ISSUE_STATUS_SET = new Set(ISSUE_STATUSES);
+const ISSUE_ORIGIN_KIND_SET = new Set(ISSUE_ORIGIN_KINDS);
 
 export function issueRoutes(db: Db, storage: StorageService) {
   const router = Router();
@@ -266,6 +268,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const invalidStatus = normalizedStatuses.find((status) => !ISSUE_STATUS_SET.has(status as typeof ISSUE_STATUSES[number]));
     if (invalidStatus) {
       res.status(400).json({ error: `Invalid status filter: ${invalidStatus}` });
+      return;
+    }
+    if (originKindFilter && !ISSUE_ORIGIN_KIND_SET.has(originKindFilter as typeof ISSUE_ORIGIN_KINDS[number])) {
+      res.status(400).json({ error: `Invalid originKind filter: ${originKindFilter}` });
       return;
     }
     const statusFilterNormalized = normalizedStatuses.length > 0 ? Array.from(new Set(normalizedStatuses)).join(",") : undefined;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -136,7 +136,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   function requireAgentRunId(req: Request, res: Response) {
     if (req.actor.type !== "agent") return null;
     const runId = typeof req.actor.runId === "string" ? req.actor.runId.trim() : "";
-    if (isUuidLike(runId)) return runId;
+    if (isUuidLike(runId)) return runId.toLowerCase();
     res.status(401).json({ error: "Agent run id required" });
     return null;
   }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1661,7 +1661,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.post("/companies/:companyId/issues/:issueId/attachments", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = (req.params.companyId as string).trim().toLowerCase();
     if (!assertValidCompanyId(res, companyId)) return;
     const issueId = req.params.issueId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1522,9 +1522,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
     void (async () => {
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
-      const assigneeId = currentIssue.assigneeAgentId;
+      const assigneeId = typeof currentIssue.assigneeAgentId === "string"
+        ? currentIssue.assigneeAgentId.trim().toLowerCase()
+        : null;
       const actorIsAgent = actor.actorType === "agent";
-      const selfComment = actorIsAgent && actor.actorId === assigneeId;
+      const normalizedActorAgentId = actorIsAgent && typeof actor.actorId === "string"
+        ? actor.actorId.trim().toLowerCase()
+        : null;
+      const selfComment = actorIsAgent && normalizedActorAgentId === assigneeId;
       const skipWake = selfComment || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
@@ -1584,9 +1589,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
       }
 
       for (const mentionedId of mentionedIds) {
-        if (wakeups.has(mentionedId)) continue;
-        if (actorIsAgent && actor.actorId === mentionedId) continue;
-        wakeups.set(mentionedId, {
+        const normalizedMentionedId = typeof mentionedId === "string"
+          ? mentionedId.trim().toLowerCase()
+          : "";
+        if (!normalizedMentionedId) continue;
+        if (wakeups.has(normalizedMentionedId)) continue;
+        if (actorIsAgent && normalizedActorAgentId === normalizedMentionedId) continue;
+        wakeups.set(normalizedMentionedId, {
           source: "automation",
           triggerDetail: "system",
           reason: "issue_comment_mentioned",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -941,11 +941,17 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const assigneeWillChange =
       (req.body.assigneeAgentId !== undefined && req.body.assigneeAgentId !== existing.assigneeAgentId) ||
       (req.body.assigneeUserId !== undefined && req.body.assigneeUserId !== existing.assigneeUserId);
+    const normalizedActorAgentId = typeof req.actor.agentId === "string"
+      ? req.actor.agentId.trim().toLowerCase()
+      : "";
+    const normalizedExistingAssigneeAgentId = typeof existing.assigneeAgentId === "string"
+      ? existing.assigneeAgentId.trim().toLowerCase()
+      : "";
 
     const isAgentReturningIssueToCreator =
       req.actor.type === "agent" &&
-      !!req.actor.agentId &&
-      existing.assigneeAgentId === req.actor.agentId &&
+      !!normalizedActorAgentId &&
+      normalizedExistingAssigneeAgentId === normalizedActorAgentId &&
       req.body.assigneeAgentId === null &&
       typeof req.body.assigneeUserId === "string" &&
       !!existing.createdByUserId &&

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -37,6 +37,7 @@ import { logger } from "../middleware/logger.js";
 import { forbidden, HttpError, unauthorized } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { readQueryString } from "./query-utils.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 
@@ -61,15 +62,6 @@ export function issueRoutes(db: Db, storage: StorageService) {
     storage: multer.memoryStorage(),
     limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
   });
-
-  function readQueryString(value: unknown): string | undefined {
-    if (typeof value === "string") return value;
-    if (Array.isArray(value)) {
-      const first = value.find((entry): entry is string => typeof entry === "string");
-      return first;
-    }
-    return undefined;
-  }
 
   function isNonEmptyUuid(value: string | null | undefined): value is string {
     return typeof value === "string" && value.trim().length > 0 && isUuidLike(value.trim());

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1182,6 +1182,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.post("/issues/:id/checkout", validate(checkoutIssueSchema), async (req, res) => {
     const id = req.params.id as string;
+    const requestedAgentId = typeof req.body.agentId === "string" ? req.body.agentId.trim().toLowerCase() : "";
     const issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
@@ -1202,18 +1203,24 @@ export function issueRoutes(db: Db, storage: StorageService) {
       }
     }
 
-    if (req.actor.type === "agent" && req.actor.agentId !== req.body.agentId) {
-      res.status(403).json({ error: "Agent can only checkout as itself" });
-      return;
+    if (req.actor.type === "agent") {
+      const actorAgentId = typeof req.actor.agentId === "string" ? req.actor.agentId.trim().toLowerCase() : "";
+      if (!actorAgentId || actorAgentId !== requestedAgentId) {
+        res.status(403).json({ error: "Agent can only checkout as itself" });
+        return;
+      }
     }
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
+    const currentAssigneeAgentId = typeof issue.assigneeAgentId === "string"
+      ? issue.assigneeAgentId.trim().toLowerCase()
+      : null;
     const checkoutAlreadyOwnedByRequestedAssignee =
-      issue.assigneeAgentId === req.body.agentId &&
+      currentAssigneeAgentId === requestedAgentId &&
       issue.status === "in_progress" &&
       (checkoutRunId ? issue.checkoutRunId === checkoutRunId : issue.checkoutRunId == null);
-    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
+    const updated = await svc.checkout(id, requestedAgentId, req.body.expectedStatuses, checkoutRunId);
     const actor = getActorInfo(req);
 
     await logActivity(db, {
@@ -1225,7 +1232,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       action: "issue.checked_out",
       entityType: "issue",
       entityId: issue.id,
-      details: { agentId: req.body.agentId },
+      details: { agentId: requestedAgentId },
     });
 
     if (
@@ -1233,12 +1240,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
       shouldWakeAssigneeOnCheckout({
         actorType: req.actor.type,
         actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,
-        checkoutAgentId: req.body.agentId,
+        checkoutAgentId: requestedAgentId,
         checkoutRunId,
       })
     ) {
       void heartbeat
-        .wakeup(req.body.agentId, {
+        .wakeup(requestedAgentId, {
           source: "assignment",
           triggerDetail: "system",
           reason: "issue_checked_out",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -257,6 +257,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const assigneeUserFilterRaw = readQueryString(req.query.assigneeUserId);
     const touchedByUserFilterRaw = readQueryString(req.query.touchedByUserId);
     const unreadForUserFilterRaw = readQueryString(req.query.unreadForUserId);
+    const assigneeUserFilter = assigneeUserFilterRaw?.trim();
+    const touchedByUserFilter = touchedByUserFilterRaw?.trim();
+    const unreadForUserFilter = unreadForUserFilterRaw?.trim();
+    const assigneeUserIsMe = assigneeUserFilter?.toLowerCase() === "me";
+    const touchedByUserIsMe = touchedByUserFilter?.toLowerCase() === "me";
+    const unreadForUserIsMe = unreadForUserFilter?.toLowerCase() === "me";
     const projectIdFilter = readQueryString(req.query.projectId);
     const parentIdFilter = readQueryString(req.query.parentId);
     const labelIdFilter = readQueryString(req.query.labelId);
@@ -296,27 +302,27 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const statusFilterNormalized = normalizedStatuses.length > 0 ? Array.from(new Set(normalizedStatuses)).join(",") : undefined;
 
     const assigneeUserId =
-      assigneeUserFilterRaw === "me" && req.actor.type === "board"
+      assigneeUserIsMe && req.actor.type === "board"
         ? req.actor.userId
-        : assigneeUserFilterRaw;
+        : assigneeUserFilter;
     const touchedByUserId =
-      touchedByUserFilterRaw === "me" && req.actor.type === "board"
+      touchedByUserIsMe && req.actor.type === "board"
         ? req.actor.userId
-        : touchedByUserFilterRaw;
+        : touchedByUserFilter;
     const unreadForUserId =
-      unreadForUserFilterRaw === "me" && req.actor.type === "board"
+      unreadForUserIsMe && req.actor.type === "board"
         ? req.actor.userId
-        : unreadForUserFilterRaw;
+        : unreadForUserFilter;
 
-    if (assigneeUserFilterRaw === "me" && (!assigneeUserId || req.actor.type !== "board")) {
+    if (assigneeUserIsMe && (!assigneeUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "assigneeUserId=me requires board authentication" });
       return;
     }
-    if (touchedByUserFilterRaw === "me" && (!touchedByUserId || req.actor.type !== "board")) {
+    if (touchedByUserIsMe && (!touchedByUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "touchedByUserId=me requires board authentication" });
       return;
     }
-    if (unreadForUserFilterRaw === "me" && (!unreadForUserId || req.actor.type !== "board")) {
+    if (unreadForUserIsMe && (!unreadForUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "unreadForUserId=me requires board authentication" });
       return;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -741,17 +741,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.patch("/work-products/:workProductId", validate(updateIssueWorkProductSchema), async (req, res) => {
     const id = req.params.workProductId as string;
-    if (!isUuidLike(id)) {
+    const normalizedWorkProductId = typeof id === "string" ? id.trim().toLowerCase() : "";
+    if (!isUuidLike(normalizedWorkProductId)) {
       res.status(400).json({ error: "Invalid work product id" });
       return;
     }
-    const existing = await workProductsSvc.getById(id);
+    const existing = await workProductsSvc.getById(normalizedWorkProductId);
     if (!existing) {
       res.status(404).json({ error: "Work product not found" });
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    const product = await workProductsSvc.update(id, req.body);
+    const product = await workProductsSvc.update(normalizedWorkProductId, req.body);
     if (!product) {
       res.status(404).json({ error: "Work product not found" });
       return;
@@ -773,17 +774,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.delete("/work-products/:workProductId", async (req, res) => {
     const id = req.params.workProductId as string;
-    if (!isUuidLike(id)) {
+    const normalizedWorkProductId = typeof id === "string" ? id.trim().toLowerCase() : "";
+    if (!isUuidLike(normalizedWorkProductId)) {
       res.status(400).json({ error: "Invalid work product id" });
       return;
     }
-    const existing = await workProductsSvc.getById(id);
+    const existing = await workProductsSvc.getById(normalizedWorkProductId);
     if (!existing) {
       res.status(404).json({ error: "Work product not found" });
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    const removed = await workProductsSvc.remove(id);
+    const removed = await workProductsSvc.remove(normalizedWorkProductId);
     if (!removed) {
       res.status(404).json({ error: "Work product not found" });
       return;
@@ -881,7 +883,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
   router.delete("/issues/:id/approvals/:approvalId", async (req, res) => {
     const id = req.params.id as string;
     const approvalId = req.params.approvalId as string;
-    if (!isUuidLike(approvalId)) {
+    const normalizedApprovalId = typeof approvalId === "string" ? approvalId.trim().toLowerCase() : "";
+    if (!isUuidLike(normalizedApprovalId)) {
       res.status(400).json({ error: "Invalid approvalId" });
       return;
     }
@@ -892,7 +895,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
     if (!(await assertCanManageIssueApprovalLinks(req, res, issue.companyId))) return;
 
-    await issueApprovalsSvc.unlink(id, approvalId);
+    await issueApprovalsSvc.unlink(id, normalizedApprovalId);
 
     const actor = getActorInfo(req);
     await logActivity(db, {
@@ -904,7 +907,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       action: "issue.approval_unlinked",
       entityType: "issue",
       entityId: issue.id,
-      details: { approvalId },
+      details: { approvalId: normalizedApprovalId },
     });
 
     res.json({ ok: true });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -684,8 +684,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.status(201).json(product);
   });
 
-  router.patch("/work-products/:id", validate(updateIssueWorkProductSchema), async (req, res) => {
-    const id = req.params.id as string;
+  router.patch("/work-products/:workProductId", validate(updateIssueWorkProductSchema), async (req, res) => {
+    const id = req.params.workProductId as string;
+    if (!isUuidLike(id)) {
+      res.status(400).json({ error: "Invalid work product id" });
+      return;
+    }
     const existing = await workProductsSvc.getById(id);
     if (!existing) {
       res.status(404).json({ error: "Work product not found" });
@@ -712,8 +716,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
     res.json(product);
   });
 
-  router.delete("/work-products/:id", async (req, res) => {
-    const id = req.params.id as string;
+  router.delete("/work-products/:workProductId", async (req, res) => {
+    const id = req.params.workProductId as string;
+    if (!isUuidLike(id)) {
+      res.status(400).json({ error: "Invalid work product id" });
+      return;
+    }
     const existing = await workProductsSvc.getById(id);
     if (!existing) {
       res.status(404).json({ error: "Work product not found" });
@@ -1619,6 +1627,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.get("/attachments/:attachmentId/content", async (req, res, next) => {
     const attachmentId = req.params.attachmentId as string;
+    if (!isUuidLike(attachmentId)) {
+      res.status(400).json({ error: "Invalid attachmentId" });
+      return;
+    }
     const attachment = await svc.getAttachmentById(attachmentId);
     if (!attachment) {
       res.status(404).json({ error: "Attachment not found" });
@@ -1641,6 +1653,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.delete("/attachments/:attachmentId", async (req, res) => {
     const attachmentId = req.params.attachmentId as string;
+    if (!isUuidLike(attachmentId)) {
+      res.status(400).json({ error: "Invalid attachmentId" });
+      return;
+    }
     const attachment = await svc.getAttachmentById(attachmentId);
     if (!attachment) {
       res.status(404).json({ error: "Attachment not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1761,11 +1761,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.get("/attachments/:attachmentId/content", async (req, res, next) => {
     const attachmentId = req.params.attachmentId as string;
-    if (!isUuidLike(attachmentId)) {
+    const normalizedAttachmentId = typeof attachmentId === "string" ? attachmentId.trim().toLowerCase() : "";
+    if (!isUuidLike(normalizedAttachmentId)) {
       res.status(400).json({ error: "Invalid attachmentId" });
       return;
     }
-    const attachment = await svc.getAttachmentById(attachmentId);
+    const attachment = await svc.getAttachmentById(normalizedAttachmentId);
     if (!attachment) {
       res.status(404).json({ error: "Attachment not found" });
       return;
@@ -1787,11 +1788,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.delete("/attachments/:attachmentId", async (req, res) => {
     const attachmentId = req.params.attachmentId as string;
-    if (!isUuidLike(attachmentId)) {
+    const normalizedAttachmentId = typeof attachmentId === "string" ? attachmentId.trim().toLowerCase() : "";
+    if (!isUuidLike(normalizedAttachmentId)) {
       res.status(400).json({ error: "Invalid attachmentId" });
       return;
     }
-    const attachment = await svc.getAttachmentById(attachmentId);
+    const attachment = await svc.getAttachmentById(normalizedAttachmentId);
     if (!attachment) {
       res.status(404).json({ error: "Attachment not found" });
       return;
@@ -1801,10 +1803,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     try {
       await storage.deleteObject(attachment.companyId, attachment.objectKey);
     } catch (err) {
-      logger.warn({ err, attachmentId }, "storage delete failed while removing attachment");
+      logger.warn({ err, attachmentId: normalizedAttachmentId }, "storage delete failed while removing attachment");
     }
 
-    const removed = await svc.removeAttachment(attachmentId);
+    const removed = await svc.removeAttachment(normalizedAttachmentId);
     if (!removed) {
       res.status(404).json({ error: "Attachment not found" });
       return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1281,10 +1281,23 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    const afterCommentIdRaw = readQueryString(req.query.after) ?? readQueryString(req.query.afterCommentId);
-    const afterCommentId = afterCommentIdRaw && afterCommentIdRaw.trim().length > 0
-      ? afterCommentIdRaw.trim()
+    const afterCommentIdQueryRaw = readQueryString(req.query.after);
+    const afterCommentIdLegacyRaw = readQueryString(req.query.afterCommentId);
+    const afterCommentIdQuery = afterCommentIdQueryRaw && afterCommentIdQueryRaw.trim().length > 0
+      ? afterCommentIdQueryRaw.trim()
       : null;
+    const afterCommentIdLegacy = afterCommentIdLegacyRaw && afterCommentIdLegacyRaw.trim().length > 0
+      ? afterCommentIdLegacyRaw.trim()
+      : null;
+    if (
+      afterCommentIdQuery &&
+      afterCommentIdLegacy &&
+      afterCommentIdQuery !== afterCommentIdLegacy
+    ) {
+      res.status(400).json({ error: "Conflicting comment cursors: after and afterCommentId must match" });
+      return;
+    }
+    const afterCommentId = afterCommentIdQuery ?? afterCommentIdLegacy;
     if (afterCommentId && !isUuidLike(afterCommentId)) {
       res.status(400).json({ error: "Invalid after comment cursor" });
       return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -144,7 +144,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   function requireAgentRunId(req: Request, res: Response) {
     if (req.actor.type !== "agent") return null;
     const runId = typeof req.actor.runId === "string" ? req.actor.runId.trim() : "";
-    if (runId) return runId;
+    if (isUuidLike(runId)) return runId;
     res.status(401).json({ error: "Agent run id required" });
     return null;
   }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -75,6 +75,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return typeof value === "string" && value.trim().length > 0 && isUuidLike(value.trim());
   }
 
+  function assertValidCompanyId(res: Response, companyId: string) {
+    if (!isUuidLike(companyId)) {
+      res.status(400).json({ error: "Invalid companyId" });
+      return false;
+    }
+    return true;
+  }
+
   function withContentPath<T extends { id: string }>(attachment: T) {
     return {
       ...attachment,
@@ -249,6 +257,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.get("/companies/:companyId/issues", async (req, res) => {
     const companyId = req.params.companyId as string;
+    if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     const statusFilter = readQueryString(req.query.status);
     const assigneeAgentIdFilter = readQueryString(req.query.assigneeAgentId);
@@ -343,6 +352,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.get("/companies/:companyId/labels", async (req, res) => {
     const companyId = req.params.companyId as string;
+    if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     const result = await svc.listLabels(companyId);
     res.json(result);
@@ -350,6 +360,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.post("/companies/:companyId/labels", validate(createIssueLabelSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
+    if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     const label = await svc.createLabel(companyId, req.body);
     const actor = getActorInfo(req);
@@ -865,6 +876,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
+    if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
       await assertCanAssignTasks(req, companyId);
@@ -1556,6 +1568,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.post("/companies/:companyId/issues/:issueId/attachments", async (req, res) => {
     const companyId = req.params.companyId as string;
+    if (!assertValidCompanyId(res, companyId)) return;
     const issueId = req.params.issueId as string;
     assertCompanyAccess(req, companyId);
     const issue = await svc.getById(issueId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -415,17 +415,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
 
   router.delete("/labels/:labelId", async (req, res) => {
     const labelId = req.params.labelId as string;
-    if (!isUuidLike(labelId)) {
+    const normalizedLabelId = typeof labelId === "string" ? labelId.trim().toLowerCase() : "";
+    if (!isUuidLike(normalizedLabelId)) {
       res.status(400).json({ error: "Invalid labelId" });
       return;
     }
-    const existing = await svc.getLabelById(labelId);
+    const existing = await svc.getLabelById(normalizedLabelId);
     if (!existing) {
       res.status(404).json({ error: "Label not found" });
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    const removed = await svc.deleteLabel(labelId);
+    const removed = await svc.deleteLabel(normalizedLabelId);
     if (!removed) {
       res.status(404).json({ error: "Label not found" });
       return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -442,10 +442,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
     assertCompanyAccess(req, issue.companyId);
 
-    const wakeCommentId =
-      typeof req.query.wakeCommentId === "string" && req.query.wakeCommentId.trim().length > 0
-        ? req.query.wakeCommentId.trim()
-        : null;
+    const wakeCommentIdRaw = readQueryString(req.query.wakeCommentId);
+    const wakeCommentId = wakeCommentIdRaw && wakeCommentIdRaw.trim().length > 0
+      ? wakeCommentIdRaw.trim()
+      : null;
     if (wakeCommentId && !isUuidLike(wakeCommentId)) {
       res.status(400).json({ error: "Invalid wakeCommentId query parameter" });
       return;
@@ -1257,24 +1257,22 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    const afterCommentId =
-      typeof req.query.after === "string" && req.query.after.trim().length > 0
-        ? req.query.after.trim()
-        : typeof req.query.afterCommentId === "string" && req.query.afterCommentId.trim().length > 0
-          ? req.query.afterCommentId.trim()
-          : null;
+    const afterCommentIdRaw = readQueryString(req.query.after) ?? readQueryString(req.query.afterCommentId);
+    const afterCommentId = afterCommentIdRaw && afterCommentIdRaw.trim().length > 0
+      ? afterCommentIdRaw.trim()
+      : null;
     if (afterCommentId && !isUuidLike(afterCommentId)) {
       res.status(400).json({ error: "Invalid after comment cursor" });
       return;
     }
-    const order =
-      typeof req.query.order === "string" && req.query.order.trim().toLowerCase() === "asc"
-        ? "asc"
-        : "desc";
-    const limitRaw =
-      typeof req.query.limit === "string" && req.query.limit.trim().length > 0
-        ? Number(req.query.limit)
-        : null;
+    const orderRaw = readQueryString(req.query.order);
+    const order = orderRaw && orderRaw.trim().toLowerCase() === "asc"
+      ? "asc"
+      : "desc";
+    const limitRawString = readQueryString(req.query.limit);
+    const limitRaw = limitRawString && limitRawString.trim().length > 0
+      ? Number(limitRawString)
+      : null;
     const limit =
       limitRaw && Number.isFinite(limitRaw) && limitRaw > 0
         ? Math.min(Math.floor(limitRaw), MAX_ISSUE_COMMENT_LIMIT)

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8,6 +8,7 @@ import {
   createIssueLabelSchema,
   checkoutIssueSchema,
   createIssueSchema,
+  isUuidLike,
   linkIssueApprovalSchema,
   issueDocumentKeySchema,
   updateIssueWorkProductSchema,
@@ -64,6 +65,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return first;
     }
     return undefined;
+  }
+
+  function isNonEmptyUuid(value: string | null | undefined): value is string {
+    return typeof value === "string" && value.trim().length > 0 && isUuidLike(value.trim());
   }
 
   function withContentPath<T extends { id: string }>(attachment: T) {
@@ -176,6 +181,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       if (issue) {
         return issue.id;
       }
+      throw new HttpError(404, "Issue not found");
+    }
+    if (!isUuidLike(rawId)) {
+      throw new HttpError(400, "Invalid issue id. Use UUID or identifier like PAP-123.");
     }
     return rawId;
   }
@@ -274,6 +283,26 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
     if (unreadForUserFilterRaw === "me" && (!unreadForUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "unreadForUserId=me requires board authentication" });
+      return;
+    }
+    if (assigneeAgentIdFilter && !isNonEmptyUuid(assigneeAgentIdFilter)) {
+      res.status(400).json({ error: "Invalid assigneeAgentId filter" });
+      return;
+    }
+    if (participantAgentIdFilter && !isNonEmptyUuid(participantAgentIdFilter)) {
+      res.status(400).json({ error: "Invalid participantAgentId filter" });
+      return;
+    }
+    if (projectIdFilter && !isNonEmptyUuid(projectIdFilter)) {
+      res.status(400).json({ error: "Invalid projectId filter" });
+      return;
+    }
+    if (parentIdFilter && !isNonEmptyUuid(parentIdFilter)) {
+      res.status(400).json({ error: "Invalid parentId filter" });
+      return;
+    }
+    if (labelIdFilter && !isNonEmptyUuid(labelIdFilter)) {
+      res.status(400).json({ error: "Invalid labelId filter" });
       return;
     }
 
@@ -397,6 +426,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       typeof req.query.wakeCommentId === "string" && req.query.wakeCommentId.trim().length > 0
         ? req.query.wakeCommentId.trim()
         : null;
+    if (wakeCommentId && !isUuidLike(wakeCommentId)) {
+      res.status(400).json({ error: "Invalid wakeCommentId query parameter" });
+      return;
+    }
 
     const [{ project, goal }, ancestors, commentCursor, wakeComment] = await Promise.all([
       resolveIssueProjectAndGoal(issue),
@@ -1202,6 +1235,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
         : typeof req.query.afterCommentId === "string" && req.query.afterCommentId.trim().length > 0
           ? req.query.afterCommentId.trim()
           : null;
+    if (afterCommentId && !isUuidLike(afterCommentId)) {
+      res.status(400).json({ error: "Invalid after comment cursor" });
+      return;
+    }
     const order =
       typeof req.query.order === "string" && req.query.order.trim().toLowerCase() === "asc"
         ? "asc"
@@ -1231,6 +1268,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    if (!isUuidLike(commentId)) {
+      res.status(400).json({ error: "Invalid commentId" });
+      return;
+    }
     const comment = await svc.getComment(commentId);
     if (!comment || comment.issueId !== id) {
       res.status(404).json({ error: "Comment not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1092,9 +1092,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
     // Merge all wakeups from this update into one enqueue per agent to avoid duplicate runs.
     void (async () => {
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
+      const normalizedIssueAssigneeAgentId = typeof issue.assigneeAgentId === "string"
+        ? issue.assigneeAgentId.trim().toLowerCase()
+        : null;
+      const normalizedActorAgentId = actor.actorType === "agent" && typeof actor.actorId === "string"
+        ? actor.actorId.trim().toLowerCase()
+        : null;
 
-      if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
-        wakeups.set(issue.assigneeAgentId, {
+      if (assigneeChanged && normalizedIssueAssigneeAgentId && issue.status !== "backlog") {
+        wakeups.set(normalizedIssueAssigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",
           reason: "issue_assigned",
@@ -1105,8 +1111,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
         });
       }
 
-      if (!assigneeChanged && statusChangedFromBacklog && issue.assigneeAgentId) {
-        wakeups.set(issue.assigneeAgentId, {
+      if (!assigneeChanged && statusChangedFromBacklog && normalizedIssueAssigneeAgentId) {
+        wakeups.set(normalizedIssueAssigneeAgentId, {
           source: "automation",
           triggerDetail: "system",
           reason: "issue_status_changed",
@@ -1126,9 +1132,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
         }
 
         for (const mentionedId of mentionedIds) {
-          if (wakeups.has(mentionedId)) continue;
-          if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
-          wakeups.set(mentionedId, {
+          const normalizedMentionedId = typeof mentionedId === "string"
+            ? mentionedId.trim().toLowerCase()
+            : "";
+          if (!normalizedMentionedId) continue;
+          if (wakeups.has(normalizedMentionedId)) continue;
+          if (actor.actorType === "agent" && normalizedActorAgentId === normalizedMentionedId) continue;
+          wakeups.set(normalizedMentionedId, {
             source: "automation",
             triggerDetail: "system",
             reason: "issue_comment_mentioned",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -283,6 +283,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: `Invalid originKind filter: ${originKindFilter}` });
       return;
     }
+    if (originKindFilter === "routine_execution" && originIdFilter && !isNonEmptyUuid(originIdFilter)) {
+      res.status(400).json({ error: "Invalid originId filter for routine_execution originKind" });
+      return;
+    }
     const statusFilterNormalized = normalizedStatuses.length > 0 ? Array.from(new Set(normalizedStatuses)).join(",") : undefined;
 
     const assigneeUserId =

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -254,7 +254,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.get("/companies/:companyId/issues", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = (req.params.companyId as string).trim().toLowerCase();
     if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     const statusFilter = readQueryString(req.query.status)?.trim();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -67,6 +67,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return typeof value === "string" && value.trim().length > 0 && isUuidLike(value.trim());
   }
 
+  function normalizeUuidString(value: string): string {
+    return value.trim().toLowerCase();
+  }
+
   function assertValidCompanyId(res: Response, companyId: string) {
     if (!isUuidLike(companyId)) {
       res.status(400).json({ error: "Invalid companyId" });
@@ -269,7 +273,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const labelIdFilter = readQueryString(req.query.labelId);
     const originKindFilter = readQueryString(req.query.originKind)?.trim().toLowerCase();
     const originIdFilterRaw = readQueryString(req.query.originId);
-    const originIdFilter = originIdFilterRaw && originIdFilterRaw.trim().length > 0
+    const originIdFilterTrimmed = originIdFilterRaw && originIdFilterRaw.trim().length > 0
       ? originIdFilterRaw.trim()
       : undefined;
     const includeRoutineExecutionsFilter = readQueryString(req.query.includeRoutineExecutions);
@@ -285,10 +289,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
       res.status(400).json({ error: `Invalid originKind filter: ${originKindFilter}` });
       return;
     }
-    if (originKindFilter === "routine_execution" && originIdFilter && !isNonEmptyUuid(originIdFilter)) {
+    if (originKindFilter === "routine_execution" && originIdFilterTrimmed && !isNonEmptyUuid(originIdFilterTrimmed)) {
       res.status(400).json({ error: "Invalid originId filter for routine_execution originKind" });
       return;
     }
+    const originIdFilter =
+      originKindFilter === "routine_execution" && originIdFilterTrimmed
+        ? normalizeUuidString(originIdFilterTrimmed)
+        : originIdFilterTrimmed;
     const normalizedIncludeRoutineExecutions = includeRoutineExecutionsFilter?.trim().toLowerCase();
     if (
       normalizedIncludeRoutineExecutions &&

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -57,6 +57,15 @@ export function issueRoutes(db: Db, storage: StorageService) {
     limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
   });
 
+  function readQueryString(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      const first = value.find((entry): entry is string => typeof entry === "string");
+      return first;
+    }
+    return undefined;
+  }
+
   function withContentPath<T extends { id: string }>(attachment: T) {
     return {
       ...attachment,
@@ -228,9 +237,20 @@ export function issueRoutes(db: Db, storage: StorageService) {
   router.get("/companies/:companyId/issues", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const assigneeUserFilterRaw = req.query.assigneeUserId as string | undefined;
-    const touchedByUserFilterRaw = req.query.touchedByUserId as string | undefined;
-    const unreadForUserFilterRaw = req.query.unreadForUserId as string | undefined;
+    const statusFilter = readQueryString(req.query.status);
+    const assigneeAgentIdFilter = readQueryString(req.query.assigneeAgentId);
+    const participantAgentIdFilter = readQueryString(req.query.participantAgentId);
+    const assigneeUserFilterRaw = readQueryString(req.query.assigneeUserId);
+    const touchedByUserFilterRaw = readQueryString(req.query.touchedByUserId);
+    const unreadForUserFilterRaw = readQueryString(req.query.unreadForUserId);
+    const projectIdFilter = readQueryString(req.query.projectId);
+    const parentIdFilter = readQueryString(req.query.parentId);
+    const labelIdFilter = readQueryString(req.query.labelId);
+    const originKindFilter = readQueryString(req.query.originKind);
+    const originIdFilter = readQueryString(req.query.originId);
+    const includeRoutineExecutionsFilter = readQueryString(req.query.includeRoutineExecutions);
+    const searchFilter = readQueryString(req.query.q);
+
     const assigneeUserId =
       assigneeUserFilterRaw === "me" && req.actor.type === "board"
         ? req.actor.userId
@@ -258,20 +278,20 @@ export function issueRoutes(db: Db, storage: StorageService) {
     }
 
     const result = await svc.list(companyId, {
-      status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      status: statusFilter,
+      assigneeAgentId: assigneeAgentIdFilter,
+      participantAgentId: participantAgentIdFilter,
       assigneeUserId,
       touchedByUserId,
       unreadForUserId,
-      projectId: req.query.projectId as string | undefined,
-      parentId: req.query.parentId as string | undefined,
-      labelId: req.query.labelId as string | undefined,
-      originKind: req.query.originKind as string | undefined,
-      originId: req.query.originId as string | undefined,
+      projectId: projectIdFilter,
+      parentId: parentIdFilter,
+      labelId: labelIdFilter,
+      originKind: originKindFilter,
+      originId: originIdFilter,
       includeRoutineExecutions:
-        req.query.includeRoutineExecutions === "true" || req.query.includeRoutineExecutions === "1",
-      q: req.query.q as string | undefined,
+        includeRoutineExecutionsFilter === "true" || includeRoutineExecutionsFilter === "1",
+      q: searchFilter,
     });
     res.json(result);
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -185,17 +185,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
   }
 
   async function normalizeIssueIdentifier(rawId: string): Promise<string> {
-    if (/^[A-Z]+-\d+$/i.test(rawId)) {
-      const issue = await svc.getByIdentifier(rawId);
+    const normalizedRawId = typeof rawId === "string" ? rawId.trim() : "";
+    if (/^[A-Z]+-\d+$/i.test(normalizedRawId)) {
+      const issue = await svc.getByIdentifier(normalizedRawId);
       if (issue) {
         return issue.id;
       }
       throw new HttpError(404, "Issue not found");
     }
-    if (!isUuidLike(rawId)) {
+    if (!isUuidLike(normalizedRawId)) {
       throw new HttpError(400, "Invalid issue id. Use UUID or identifier like PAP-123.");
     }
-    return rawId.trim().toLowerCase();
+    return normalizedRawId.toLowerCase();
   }
 
   async function resolveIssueProjectAndGoal(issue: {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -380,7 +380,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.get("/companies/:companyId/labels", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = (req.params.companyId as string).trim().toLowerCase();
     if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     const result = await svc.listLabels(companyId);
@@ -388,7 +388,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.post("/companies/:companyId/labels", validate(createIssueLabelSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = (req.params.companyId as string).trim().toLowerCase();
     if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     const label = await svc.createLabel(companyId, req.body);
@@ -904,7 +904,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = (req.params.companyId as string).trim().toLowerCase();
     if (!assertValidCompanyId(res, companyId)) return;
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -79,6 +79,12 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return true;
   }
 
+  function normalizeCompanyIdPathParam(res: Response, rawCompanyId: unknown): string | null {
+    const companyId = typeof rawCompanyId === "string" ? rawCompanyId.trim().toLowerCase() : "";
+    if (!assertValidCompanyId(res, companyId)) return null;
+    return companyId;
+  }
+
   function withContentPath<T extends { id: string }>(attachment: T) {
     return {
       ...attachment,
@@ -254,8 +260,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.get("/companies/:companyId/issues", async (req, res) => {
-    const companyId = (req.params.companyId as string).trim().toLowerCase();
-    if (!assertValidCompanyId(res, companyId)) return;
+    const companyId = normalizeCompanyIdPathParam(res, req.params.companyId);
+    if (!companyId) return;
     assertCompanyAccess(req, companyId);
     const statusFilter = readQueryString(req.query.status)?.trim();
     const assigneeAgentIdFilter = readQueryString(req.query.assigneeAgentId);
@@ -380,16 +386,16 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.get("/companies/:companyId/labels", async (req, res) => {
-    const companyId = (req.params.companyId as string).trim().toLowerCase();
-    if (!assertValidCompanyId(res, companyId)) return;
+    const companyId = normalizeCompanyIdPathParam(res, req.params.companyId);
+    if (!companyId) return;
     assertCompanyAccess(req, companyId);
     const result = await svc.listLabels(companyId);
     res.json(result);
   });
 
   router.post("/companies/:companyId/labels", validate(createIssueLabelSchema), async (req, res) => {
-    const companyId = (req.params.companyId as string).trim().toLowerCase();
-    if (!assertValidCompanyId(res, companyId)) return;
+    const companyId = normalizeCompanyIdPathParam(res, req.params.companyId);
+    if (!companyId) return;
     assertCompanyAccess(req, companyId);
     const label = await svc.createLabel(companyId, req.body);
     const actor = getActorInfo(req);
@@ -904,8 +910,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.post("/companies/:companyId/issues", validate(createIssueSchema), async (req, res) => {
-    const companyId = (req.params.companyId as string).trim().toLowerCase();
-    if (!assertValidCompanyId(res, companyId)) return;
+    const companyId = normalizeCompanyIdPathParam(res, req.params.companyId);
+    if (!companyId) return;
     assertCompanyAccess(req, companyId);
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
       await assertCanAssignTasks(req, companyId);
@@ -1661,8 +1667,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
   });
 
   router.post("/companies/:companyId/issues/:issueId/attachments", async (req, res) => {
-    const companyId = (req.params.companyId as string).trim().toLowerCase();
-    if (!assertValidCompanyId(res, companyId)) return;
+    const companyId = normalizeCompanyIdPathParam(res, req.params.companyId);
+    if (!companyId) return;
     const issueId = req.params.issueId as string;
     assertCompanyAccess(req, companyId);
     const issue = await svc.getById(issueId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -457,6 +457,10 @@ export function issueRoutes(db: Db, storage: StorageService) {
       svc.getCommentCursor(issue.id),
       wakeCommentId ? svc.getComment(wakeCommentId) : null,
     ]);
+    if (wakeCommentId && (!wakeComment || wakeComment.issueId !== issue.id)) {
+      res.status(404).json({ error: "Wake comment not found on issue" });
+      return;
+    }
 
     res.json({
       issue: {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1305,19 +1305,22 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const afterCommentIdLegacy = afterCommentIdLegacyRaw && afterCommentIdLegacyRaw.trim().length > 0
       ? afterCommentIdLegacyRaw.trim()
       : null;
+    const normalizedAfterCommentIdQuery = afterCommentIdQuery?.toLowerCase() ?? null;
+    const normalizedAfterCommentIdLegacy = afterCommentIdLegacy?.toLowerCase() ?? null;
     if (
-      afterCommentIdQuery &&
-      afterCommentIdLegacy &&
-      afterCommentIdQuery !== afterCommentIdLegacy
+      normalizedAfterCommentIdQuery &&
+      normalizedAfterCommentIdLegacy &&
+      normalizedAfterCommentIdQuery !== normalizedAfterCommentIdLegacy
     ) {
       res.status(400).json({ error: "Conflicting comment cursors: after and afterCommentId must match" });
       return;
     }
-    const afterCommentId = afterCommentIdQuery ?? afterCommentIdLegacy;
-    if (afterCommentId && !isUuidLike(afterCommentId)) {
+    const afterCommentIdRaw = afterCommentIdQuery ?? afterCommentIdLegacy;
+    if (afterCommentIdRaw && !isUuidLike(afterCommentIdRaw)) {
       res.status(400).json({ error: "Invalid after comment cursor" });
       return;
     }
+    const afterCommentId = afterCommentIdRaw ? afterCommentIdRaw.toLowerCase() : null;
     const orderRaw = readQueryString(req.query.order);
     const normalizedOrder = orderRaw?.trim().toLowerCase();
     if (normalizedOrder && normalizedOrder !== "asc" && normalizedOrder !== "desc") {

--- a/server/src/routes/query-utils.ts
+++ b/server/src/routes/query-utils.ts
@@ -1,0 +1,8 @@
+export function readQueryString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const first = value.find((entry): entry is string => typeof entry === "string");
+    return first;
+  }
+  return undefined;
+}

--- a/server/src/routes/query-utils.ts
+++ b/server/src/routes/query-utils.ts
@@ -1,8 +1,10 @@
 export function readQueryString(value: unknown): string | undefined {
   if (typeof value === "string") return value;
   if (Array.isArray(value)) {
-    const first = value.find((entry): entry is string => typeof entry === "string");
-    return first;
+    const strings = value.filter((entry): entry is string => typeof entry === "string");
+    if (strings.length === 0) return undefined;
+    const firstNonEmpty = strings.find((entry) => entry.trim().length > 0);
+    return firstNonEmpty ?? strings[0];
   }
   return undefined;
 }

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -11,21 +11,13 @@ import {
 import { validate } from "../middleware/validate.js";
 import { accessService, logActivity, routineService } from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { readQueryString } from "./query-utils.js";
 import { forbidden, unauthorized } from "../errors.js";
 
 export function routineRoutes(db: Db) {
   const router = Router();
   const svc = routineService(db);
   const access = accessService(db);
-
-  function readQueryString(value: unknown): string | undefined {
-    if (typeof value === "string") return value;
-    if (Array.isArray(value)) {
-      const first = value.find((entry): entry is string => typeof entry === "string");
-      return first;
-    }
-    return undefined;
-  }
 
   async function assertBoardCanAssignTasks(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -18,6 +18,15 @@ export function routineRoutes(db: Db) {
   const svc = routineService(db);
   const access = accessService(db);
 
+  function readQueryString(value: unknown): string | undefined {
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      const first = value.find((entry): entry is string => typeof entry === "string");
+      return first;
+    }
+    return undefined;
+  }
+
   async function assertBoardCanAssignTasks(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type !== "board") return;
@@ -137,8 +146,13 @@ export function routineRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, routine.companyId);
-    const limit = Number(req.query.limit ?? 50);
-    const result = await svc.listRuns(routine.id, Number.isFinite(limit) ? limit : 50);
+    const limitRaw = readQueryString(req.query.limit);
+    const parsedLimit = limitRaw && limitRaw.trim().length > 0 ? Number(limitRaw) : 50;
+    if (!Number.isFinite(parsedLimit) || !Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+      res.status(400).json({ error: "Invalid limit query parameter. Use a positive integer." });
+      return;
+    }
+    const result = await svc.listRuns(routine.id, parsedLimit);
     res.json(result);
   });
 

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
+import { isUuidLike } from "@paperclipai/shared";
 
 export interface ActivityFilters {
   companyId: string;
@@ -93,6 +94,7 @@ export function activityService(db: Db) {
         .orderBy(desc(heartbeatRuns.createdAt)),
 
     issuesForRun: async (runId: string) => {
+      if (!isUuidLike(runId)) return [];
       const run = await db
         .select({
           companyId: heartbeatRuns.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1947,6 +1947,32 @@ export function heartbeatService(db: Db) {
           return null;
         }
 
+        const repairableIssue = await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, agent.companyId),
+              eq(issues.assigneeAgentId, agent.id),
+              isNull(issues.executionRunId),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (!repairableIssue) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "failed",
+              finishedAt: now,
+              error: "Queued wakeup could not be repaired because issue is no longer assigned and unlocked",
+              updatedAt: now,
+            })
+            .where(eq(agentWakeupRequests.id, current.id));
+
+          return null;
+        }
+
         // Repair issue-scoped orphaned wakeups so trading-org assignments/comments
         // are converted back into runnable heartbeats instead of waiting on timer drift.
         const newRun = await tx

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1830,15 +1830,183 @@ export function heartbeatService(db: Db) {
   }
 
   async function resumeQueuedRuns() {
+    const repairedRuns = await repairQueuedIssueWakeupsWithoutRuns();
     const queuedRuns = await db
       .select({ agentId: heartbeatRuns.agentId })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.status, "queued"));
 
-    const agentIds = [...new Set(queuedRuns.map((r) => r.agentId))];
+    const agentIds = [...new Set([
+      ...repairedRuns.map((run) => run.agentId),
+      ...queuedRuns.map((r) => r.agentId),
+    ])];
     for (const agentId of agentIds) {
       await startNextQueuedRunForAgent(agentId);
     }
+  }
+
+  async function repairQueuedIssueWakeupsWithoutRuns() {
+    const orphanedWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.status, "queued"),
+          sql`${agentWakeupRequests.runId} is null`,
+          sql`${agentWakeupRequests.payload} ->> 'issueId' is not null`,
+        ),
+      )
+      .orderBy(asc(agentWakeupRequests.requestedAt), asc(agentWakeupRequests.id));
+
+    const repairedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
+
+    for (const orphanedWakeup of orphanedWakeups) {
+      const payload = parseObject(orphanedWakeup.payload);
+      const issueId = readNonEmptyString(payload.issueId);
+      if (!issueId) continue;
+
+      const agent = await getAgent(orphanedWakeup.agentId);
+      if (!agent) {
+        await setWakeupStatus(orphanedWakeup.id, "failed", {
+          finishedAt: new Date(),
+          error: "Queued wakeup could not be repaired because the agent no longer exists",
+        });
+        continue;
+      }
+
+      const source =
+        (readNonEmptyString(orphanedWakeup.source) as WakeupOptions["source"]) ?? "on_demand";
+      const triggerDetail =
+        (readNonEmptyString(orphanedWakeup.triggerDetail) as WakeupOptions["triggerDetail"]) ?? null;
+      const reason = readNonEmptyString(orphanedWakeup.reason) ?? null;
+      const {
+        contextSnapshot,
+        taskKey,
+      } = enrichWakeContextSnapshot({
+        contextSnapshot: {},
+        reason,
+        source,
+        triggerDetail,
+        payload,
+      });
+      const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+      const agentNameKey = normalizeAgentNameKey(agent.name);
+
+      const repaired = await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select id from ${agentWakeupRequests} where id = ${orphanedWakeup.id} for update`,
+        );
+
+        const current = await tx
+          .select()
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, orphanedWakeup.id))
+          .then((rows) => rows[0] ?? null);
+        if (!current || current.status !== "queued" || current.runId) return null;
+
+        const existingRun = await tx
+          .select()
+          .from(heartbeatRuns)
+          .where(
+            and(
+              eq(heartbeatRuns.agentId, current.agentId),
+              inArray(heartbeatRuns.status, ["queued", "running"]),
+              sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            ),
+          )
+          .orderBy(
+            sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
+            asc(heartbeatRuns.createdAt),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+
+        const now = new Date();
+        if (existingRun) {
+          const mergedRun = await tx
+            .update(heartbeatRuns)
+            .set({
+              contextSnapshot: mergeCoalescedContextSnapshot(existingRun.contextSnapshot, contextSnapshot),
+              updatedAt: now,
+            })
+            .where(eq(heartbeatRuns.id, existingRun.id))
+            .returning()
+            .then((rows) => rows[0] ?? existingRun);
+
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "coalesced",
+              coalescedCount: (current.coalescedCount ?? 0) + 1,
+              runId: mergedRun.id,
+              finishedAt: now,
+              updatedAt: now,
+            })
+            .where(eq(agentWakeupRequests.id, current.id));
+
+          return null;
+        }
+
+        // Repair issue-scoped orphaned wakeups so trading-org assignments/comments
+        // are converted back into runnable heartbeats instead of waiting on timer drift.
+        const newRun = await tx
+          .insert(heartbeatRuns)
+          .values({
+            companyId: agent.companyId,
+            agentId: agent.id,
+            invocationSource: source,
+            triggerDetail,
+            status: "queued",
+            wakeupRequestId: current.id,
+            contextSnapshot,
+            sessionIdBefore: sessionBefore,
+          })
+          .returning()
+          .then((rows) => rows[0]);
+
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            runId: newRun.id,
+            updatedAt: now,
+          })
+          .where(eq(agentWakeupRequests.id, current.id));
+
+        await tx
+          .update(issues)
+          .set({
+            executionRunId: newRun.id,
+            executionAgentNameKey: agentNameKey,
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, agent.companyId),
+            ),
+          );
+
+        return newRun;
+      });
+
+      if (!repaired) continue;
+
+      publishLiveEvent({
+        companyId: repaired.companyId,
+        type: "heartbeat.run.queued",
+        payload: {
+          runId: repaired.id,
+          agentId: repaired.agentId,
+          invocationSource: repaired.invocationSource,
+          triggerDetail: repaired.triggerDetail,
+          wakeupRequestId: repaired.wakeupRequestId,
+        },
+      });
+      repairedRuns.push(repaired);
+    }
+
+    return repairedRuns;
   }
 
   async function updateRuntimeState(
@@ -3408,45 +3576,49 @@ export function heartbeatService(db: Db) {
       return mergedRun;
     }
 
-    const wakeupRequest = await db
-      .insert(agentWakeupRequests)
-      .values({
-        companyId: agent.companyId,
-        agentId,
-        source,
-        triggerDetail,
-        reason,
-        payload,
-        status: "queued",
-        requestedByActorType: opts.requestedByActorType ?? null,
-        requestedByActorId: opts.requestedByActorId ?? null,
-        idempotencyKey: opts.idempotencyKey ?? null,
-      })
-      .returning()
-      .then((rows) => rows[0]);
+    const newRun = await db.transaction(async (tx) => {
+      const wakeupRequest = await tx
+        .insert(agentWakeupRequests)
+        .values({
+          companyId: agent.companyId,
+          agentId,
+          source,
+          triggerDetail,
+          reason,
+          payload,
+          status: "queued",
+          requestedByActorType: opts.requestedByActorType ?? null,
+          requestedByActorId: opts.requestedByActorId ?? null,
+          idempotencyKey: opts.idempotencyKey ?? null,
+        })
+        .returning()
+        .then((rows) => rows[0]);
 
-    const newRun = await db
-      .insert(heartbeatRuns)
-      .values({
-        companyId: agent.companyId,
-        agentId,
-        invocationSource: source,
-        triggerDetail,
-        status: "queued",
-        wakeupRequestId: wakeupRequest.id,
-        contextSnapshot: enrichedContextSnapshot,
-        sessionIdBefore: sessionBefore,
-      })
-      .returning()
-      .then((rows) => rows[0]);
+      const createdRun = await tx
+        .insert(heartbeatRuns)
+        .values({
+          companyId: agent.companyId,
+          agentId,
+          invocationSource: source,
+          triggerDetail,
+          status: "queued",
+          wakeupRequestId: wakeupRequest.id,
+          contextSnapshot: enrichedContextSnapshot,
+          sessionIdBefore: sessionBefore,
+        })
+        .returning()
+        .then((rows) => rows[0]);
 
-    await db
-      .update(agentWakeupRequests)
-      .set({
-        runId: newRun.id,
-        updatedAt: new Date(),
-      })
-      .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          runId: createdRun.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+      return createdRun;
+    });
 
     publishLiveEvent({
       companyId: newRun.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType } from "@paperclipai/shared";
 import {
@@ -1984,6 +1984,8 @@ export function heartbeatService(db: Db) {
             and(
               eq(issues.id, issueId),
               eq(issues.companyId, agent.companyId),
+              eq(issues.assigneeAgentId, agent.id),
+              isNull(issues.executionRunId),
             ),
           );
 

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -29,6 +29,13 @@ export function queueIssueAssignmentWakeup(input: {
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  if (
+    input.requestedByActorType === "agent" &&
+    input.requestedByActorId &&
+    input.requestedByActorId === input.issue.assigneeAgentId
+  ) {
+    return;
+  }
 
   return input.heartbeat
     .wakeup(input.issue.assigneeAgentId, {

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -64,6 +64,9 @@ export function queueIssueAssignmentWakeup(input: {
   ) {
     return;
   }
+  const requestedByActorIdForPayload = input.requestedByActorType
+    ? normalizedRequestedByActorId
+    : null;
 
   return input.heartbeat
     .wakeup(normalizedAssigneeAgentId, {
@@ -72,7 +75,7 @@ export function queueIssueAssignmentWakeup(input: {
       reason: input.reason,
       payload: { issueId: normalizedIssueId || input.issue.id, mutation: input.mutation },
       requestedByActorType: input.requestedByActorType,
-      requestedByActorId: normalizedRequestedByActorId ?? null,
+      requestedByActorId: requestedByActorIdForPayload,
       contextSnapshot: { issueId: normalizedIssueId || input.issue.id, source: input.contextSource },
     })
     .catch((err) => {

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -31,6 +31,12 @@ export function queueIssueAssignmentWakeup(input: {
   const normalizedIssueStatus = typeof input.issue.status === "string"
     ? input.issue.status.trim().toLowerCase()
     : "";
+  const normalizedAssigneeAgentId = typeof input.issue.assigneeAgentId === "string"
+    ? input.issue.assigneeAgentId.trim().toLowerCase()
+    : null;
+  const normalizedRequestedByActorId = typeof input.requestedByActorId === "string"
+    ? input.requestedByActorId.trim().toLowerCase()
+    : null;
   if (
     !input.issue.assigneeAgentId ||
     normalizedIssueStatus === "backlog" ||
@@ -39,8 +45,9 @@ export function queueIssueAssignmentWakeup(input: {
   ) return;
   if (
     input.requestedByActorType === "agent" &&
-    input.requestedByActorId &&
-    input.requestedByActorId === input.issue.assigneeAgentId
+    normalizedRequestedByActorId &&
+    normalizedAssigneeAgentId &&
+    normalizedRequestedByActorId === normalizedAssigneeAgentId
   ) {
     return;
   }

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -38,7 +38,7 @@ export function queueIssueAssignmentWakeup(input: {
     ? input.requestedByActorId.trim().toLowerCase()
     : null;
   if (
-    !input.issue.assigneeAgentId ||
+    !normalizedAssigneeAgentId ||
     normalizedIssueStatus === "backlog" ||
     normalizedIssueStatus === "done" ||
     normalizedIssueStatus === "cancelled"
@@ -53,7 +53,7 @@ export function queueIssueAssignmentWakeup(input: {
   }
 
   return input.heartbeat
-    .wakeup(input.issue.assigneeAgentId, {
+    .wakeup(normalizedAssigneeAgentId, {
       source: "assignment",
       triggerDetail: "system",
       reason: input.reason,

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -1,4 +1,5 @@
 import { logger } from "../middleware/logger.js";
+import { isUuidLike } from "@paperclipai/shared";
 
 type WakeupTriggerDetail = "manual" | "ping" | "callback" | "system";
 type WakeupSource = "timer" | "assignment" | "on_demand" | "automation";
@@ -37,9 +38,12 @@ export function queueIssueAssignmentWakeup(input: {
   const normalizedAssigneeAgentId = typeof input.issue.assigneeAgentId === "string"
     ? input.issue.assigneeAgentId.trim().toLowerCase()
     : null;
-  const normalizedRequestedByActorId = typeof input.requestedByActorId === "string"
-    ? input.requestedByActorId.trim().toLowerCase()
+  const requestedByActorIdTrimmed = typeof input.requestedByActorId === "string"
+    ? input.requestedByActorId.trim()
     : null;
+  const normalizedRequestedByActorId = requestedByActorIdTrimmed && isUuidLike(requestedByActorIdTrimmed)
+    ? requestedByActorIdTrimmed.toLowerCase()
+    : requestedByActorIdTrimmed;
   if (
     !normalizedIssueId ||
     !normalizedAssigneeAgentId ||

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -41,9 +41,12 @@ export function queueIssueAssignmentWakeup(input: {
   const requestedByActorIdTrimmed = typeof input.requestedByActorId === "string"
     ? input.requestedByActorId.trim()
     : null;
-  const normalizedRequestedByActorId = requestedByActorIdTrimmed && isUuidLike(requestedByActorIdTrimmed)
-    ? requestedByActorIdTrimmed.toLowerCase()
-    : requestedByActorIdTrimmed;
+  const normalizedRequestedByActorId =
+    requestedByActorIdTrimmed == null || requestedByActorIdTrimmed.length === 0
+      ? null
+      : isUuidLike(requestedByActorIdTrimmed)
+        ? requestedByActorIdTrimmed.toLowerCase()
+        : requestedByActorIdTrimmed;
   if (
     !normalizedIssueId ||
     !normalizedAssigneeAgentId ||

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -28,7 +28,12 @@ export function queueIssueAssignmentWakeup(input: {
   requestedByActorId?: string | null;
   rethrowOnError?: boolean;
 }) {
-  if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  if (
+    !input.issue.assigneeAgentId ||
+    input.issue.status === "backlog" ||
+    input.issue.status === "done" ||
+    input.issue.status === "cancelled"
+  ) return;
   if (
     input.requestedByActorType === "agent" &&
     input.requestedByActorId &&

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -31,6 +31,9 @@ export function queueIssueAssignmentWakeup(input: {
   const normalizedIssueStatus = typeof input.issue.status === "string"
     ? input.issue.status.trim().toLowerCase()
     : "";
+  const normalizedIssueId = typeof input.issue.id === "string"
+    ? input.issue.id.trim().toLowerCase()
+    : "";
   const normalizedAssigneeAgentId = typeof input.issue.assigneeAgentId === "string"
     ? input.issue.assigneeAgentId.trim().toLowerCase()
     : null;
@@ -57,10 +60,10 @@ export function queueIssueAssignmentWakeup(input: {
       source: "assignment",
       triggerDetail: "system",
       reason: input.reason,
-      payload: { issueId: input.issue.id, mutation: input.mutation },
+      payload: { issueId: normalizedIssueId || input.issue.id, mutation: input.mutation },
       requestedByActorType: input.requestedByActorType,
-      requestedByActorId: input.requestedByActorId ?? null,
-      contextSnapshot: { issueId: input.issue.id, source: input.contextSource },
+      requestedByActorId: normalizedRequestedByActorId ?? null,
+      contextSnapshot: { issueId: normalizedIssueId || input.issue.id, source: input.contextSource },
     })
     .catch((err) => {
       logger.warn({ err, issueId: input.issue.id }, "failed to wake assignee on issue assignment");

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -64,7 +64,12 @@ export function queueIssueAssignmentWakeup(input: {
   ) {
     return;
   }
-  const requestedByActorIdForPayload = input.requestedByActorType
+  const requestedByActorTypeForPayload =
+    input.requestedByActorType === "agent" &&
+    !(normalizedRequestedByActorId && isUuidLike(normalizedRequestedByActorId))
+      ? undefined
+      : input.requestedByActorType;
+  const requestedByActorIdForPayload = requestedByActorTypeForPayload
     ? normalizedRequestedByActorId
     : null;
 
@@ -74,7 +79,7 @@ export function queueIssueAssignmentWakeup(input: {
       triggerDetail: "system",
       reason: input.reason,
       payload: { issueId: normalizedIssueId || input.issue.id, mutation: input.mutation },
-      requestedByActorType: input.requestedByActorType,
+      requestedByActorType: requestedByActorTypeForPayload,
       requestedByActorId: requestedByActorIdForPayload,
       contextSnapshot: { issueId: normalizedIssueId || input.issue.id, source: input.contextSource },
     })

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -41,6 +41,7 @@ export function queueIssueAssignmentWakeup(input: {
     ? input.requestedByActorId.trim().toLowerCase()
     : null;
   if (
+    !normalizedIssueId ||
     !normalizedAssigneeAgentId ||
     normalizedIssueStatus === "backlog" ||
     normalizedIssueStatus === "done" ||

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -47,6 +47,8 @@ export function queueIssueAssignmentWakeup(input: {
   if (
     !normalizedIssueId ||
     !normalizedAssigneeAgentId ||
+    !isUuidLike(normalizedIssueId) ||
+    !isUuidLike(normalizedAssigneeAgentId) ||
     normalizedIssueStatus === "backlog" ||
     normalizedIssueStatus === "done" ||
     normalizedIssueStatus === "cancelled"

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -28,11 +28,14 @@ export function queueIssueAssignmentWakeup(input: {
   requestedByActorId?: string | null;
   rethrowOnError?: boolean;
 }) {
+  const normalizedIssueStatus = typeof input.issue.status === "string"
+    ? input.issue.status.trim().toLowerCase()
+    : "";
   if (
     !input.issue.assigneeAgentId ||
-    input.issue.status === "backlog" ||
-    input.issue.status === "done" ||
-    input.issue.status === "cancelled"
+    normalizedIssueStatus === "backlog" ||
+    normalizedIssueStatus === "done" ||
+    normalizedIssueStatus === "cancelled"
   ) return;
   if (
     input.requestedByActorType === "agent" &&

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1386,7 +1386,7 @@ export function issueService(db: Db) {
     ) => {
       const order = opts?.order === "asc" ? "asc" : "desc";
       if (!isUuidLike(issueId)) return [];
-      const afterCommentId = opts?.afterCommentId?.trim() || null;
+      const afterCommentId = asNonEmptyString(opts?.afterCommentId) ?? null;
       const limit =
         opts?.limit && opts.limit > 0
           ? Math.min(Math.floor(opts.limit), MAX_ISSUE_COMMENT_PAGE_LIMIT)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -782,8 +782,10 @@ export function issueService(db: Db) {
     },
 
     markRead: async (companyId: string, issueId: string, userId: string, readAt: Date = new Date()) => {
-      if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
-      if (!isUuidLike(issueId)) throw notFound("Issue not found");
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) throw unprocessable("Invalid companyId");
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) throw notFound("Issue not found");
       if (typeof userId !== "string" || userId.trim().length === 0) throw unprocessable("Invalid userId");
       if (!(readAt instanceof Date) || Number.isNaN(readAt.getTime())) throw unprocessable("Invalid readAt");
       const normalizedUserId = userId.trim();
@@ -791,8 +793,8 @@ export function issueService(db: Db) {
       const [row] = await db
         .insert(issueReadStates)
         .values({
-          companyId,
-          issueId,
+          companyId: normalizedCompanyId,
+          issueId: normalizedIssueId,
           userId: normalizedUserId,
           lastReadAt: readAt,
           updatedAt: now,
@@ -809,11 +811,12 @@ export function issueService(db: Db) {
     },
 
     getById: async (id: string) => {
-      if (!isUuidLike(id)) return null;
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return null;
       const row = await db
         .select()
         .from(issues)
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedId))
         .then((rows) => rows[0] ?? null);
       if (!row) return null;
       const [enriched] = await withIssueLabels(db, [row]);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1589,25 +1589,29 @@ export function issueService(db: Db) {
       createdByAgentId?: string | null;
       createdByUserId?: string | null;
     }) => {
-      if (!isUuidLike(input.issueId)) {
+      const normalizedIssueId = asCanonicalUuid(input.issueId);
+      if (!normalizedIssueId) {
         throw notFound("Issue not found");
       }
-      if (input.issueCommentId && !isUuidLike(input.issueCommentId)) {
+      const normalizedIssueCommentId = input.issueCommentId == null
+        ? null
+        : asCanonicalUuid(input.issueCommentId);
+      if (input.issueCommentId && !normalizedIssueCommentId) {
         throw notFound("Issue comment not found");
       }
 
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
-        .where(eq(issues.id, input.issueId))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
       if (!issue) throw notFound("Issue not found");
 
-      if (input.issueCommentId) {
+      if (normalizedIssueCommentId) {
         const comment = await db
           .select({ id: issueComments.id, companyId: issueComments.companyId, issueId: issueComments.issueId })
           .from(issueComments)
-          .where(eq(issueComments.id, input.issueCommentId))
+          .where(eq(issueComments.id, normalizedIssueCommentId))
           .then((rows) => rows[0] ?? null);
         if (!comment) throw notFound("Issue comment not found");
         if (comment.companyId !== issue.companyId || comment.issueId !== issue.id) {
@@ -1637,7 +1641,7 @@ export function issueService(db: Db) {
             companyId: issue.companyId,
             issueId: issue.id,
             assetId: asset.id,
-            issueCommentId: input.issueCommentId ?? null,
+            issueCommentId: normalizedIssueCommentId,
           })
           .returning();
 
@@ -1662,7 +1666,8 @@ export function issueService(db: Db) {
     },
 
     listAttachments: async (issueId: string) => {
-      if (!isUuidLike(issueId)) return [];
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) return [];
       return db
         .select({
           id: issueAttachments.id,
@@ -1683,12 +1688,13 @@ export function issueService(db: Db) {
         })
         .from(issueAttachments)
         .innerJoin(assets, eq(issueAttachments.assetId, assets.id))
-        .where(eq(issueAttachments.issueId, issueId))
+        .where(eq(issueAttachments.issueId, normalizedIssueId))
         .orderBy(desc(issueAttachments.createdAt));
     },
 
     getAttachmentById: async (id: string) => {
-      if (!isUuidLike(id)) return null;
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return null;
       return db
         .select({
           id: issueAttachments.id,
@@ -1709,12 +1715,13 @@ export function issueService(db: Db) {
         })
         .from(issueAttachments)
         .innerJoin(assets, eq(issueAttachments.assetId, assets.id))
-        .where(eq(issueAttachments.id, id))
+        .where(eq(issueAttachments.id, normalizedId))
         .then((rows) => rows[0] ?? null);
     },
 
     removeAttachment: async (id: string) => {
-      if (!isUuidLike(id)) return null;
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return null;
       return db.transaction(async (tx) => {
         const existing = await tx
           .select({
@@ -1736,11 +1743,11 @@ export function issueService(db: Db) {
           })
           .from(issueAttachments)
           .innerJoin(assets, eq(issueAttachments.assetId, assets.id))
-          .where(eq(issueAttachments.id, id))
+          .where(eq(issueAttachments.id, normalizedId))
           .then((rows) => rows[0] ?? null);
         if (!existing) return null;
 
-        await tx.delete(issueAttachments).where(eq(issueAttachments.id, id));
+        await tx.delete(issueAttachments).where(eq(issueAttachments.id, normalizedId));
         await tx.delete(assets).where(eq(assets.id, existing.assetId));
         return existing;
       });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -763,6 +763,7 @@ export function issueService(db: Db) {
       if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
       if (!isUuidLike(issueId)) throw notFound("Issue not found");
       if (typeof userId !== "string" || userId.trim().length === 0) throw unprocessable("Invalid userId");
+      if (!(readAt instanceof Date) || Number.isNaN(readAt.getTime())) throw unprocessable("Invalid readAt");
       const now = new Date();
       const [row] = await db
         .insert(issueReadStates)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -744,6 +744,7 @@ export function issueService(db: Db) {
 
     countUnreadTouchedByUser: async (companyId: string, userId: string, status?: string) => {
       if (!isUuidLike(companyId)) return 0;
+      if (typeof userId !== "string" || userId.trim().length === 0) return 0;
       const conditions = [
         eq(issues.companyId, companyId),
         isNull(issues.hiddenAt),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -967,11 +967,12 @@ export function issueService(db: Db) {
     },
 
     update: async (id: string, data: Partial<typeof issues.$inferInsert> & { labelIds?: string[] }) => {
-      if (!isUuidLike(id)) return null;
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return null;
       const existing = await db
         .select()
         .from(issues)
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedId))
         .then((rows) => rows[0] ?? null);
       if (!existing) return null;
 
@@ -1066,7 +1067,7 @@ export function issueService(db: Db) {
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(eq(issues.id, id))
+          .where(eq(issues.id, normalizedId))
           .returning()
           .then((rows) => rows[0] ?? null);
         if (!updated) return null;
@@ -1078,23 +1079,22 @@ export function issueService(db: Db) {
       });
     },
 
-    remove: (id: string) =>
-      !isUuidLike(id)
-        ? Promise.resolve(null)
-        :
-      db.transaction(async (tx) => {
+    remove: (id: string) => {
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return Promise.resolve(null);
+      return db.transaction(async (tx) => {
         const attachmentAssetIds = await tx
           .select({ assetId: issueAttachments.assetId })
           .from(issueAttachments)
-          .where(eq(issueAttachments.issueId, id));
+          .where(eq(issueAttachments.issueId, normalizedId));
         const issueDocumentIds = await tx
           .select({ documentId: issueDocuments.documentId })
           .from(issueDocuments)
-          .where(eq(issueDocuments.issueId, id));
+          .where(eq(issueDocuments.issueId, normalizedId));
 
         const removedIssue = await tx
           .delete(issues)
-          .where(eq(issues.id, id))
+          .where(eq(issues.id, normalizedId))
           .returning()
           .then((rows) => rows[0] ?? null);
 
@@ -1113,7 +1113,8 @@ export function issueService(db: Db) {
         if (!removedIssue) return null;
         const [enriched] = await withIssueLabels(tx, [removedIssue]);
         return enriched;
-      }),
+      });
+    },
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
       const normalizedIssueId = asCanonicalUuid(id);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1368,6 +1368,13 @@ export function issueService(db: Db) {
     },
 
     getCommentCursor: async (issueId: string) => {
+      if (!isUuidLike(issueId)) {
+        return {
+          totalComments: 0,
+          latestCommentId: null,
+          latestCommentAt: null,
+        };
+      }
       const [latest, countRow] = await Promise.all([
         db
           .select({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1283,10 +1283,16 @@ export function issueService(db: Db) {
     },
 
     assertCheckoutOwner: async (id: string, actorAgentId: string, actorRunId: string | null) => {
-      if (!isUuidLike(id)) throw notFound("Issue not found");
-      if (!isUuidLike(actorAgentId)) throw conflict("Issue run ownership conflict");
-      if (actorRunId && !isUuidLike(actorRunId)) throw conflict("Issue run ownership conflict");
-      const normalizedActorRunId = actorRunId ? actorRunId.toLowerCase() : null;
+      const normalizedIssueId = asCanonicalUuid(id);
+      if (!normalizedIssueId) throw notFound("Issue not found");
+      const normalizedActorAgentId = asCanonicalUuid(actorAgentId);
+      if (!normalizedActorAgentId) throw conflict("Issue run ownership conflict");
+      let normalizedActorRunId: string | null = null;
+      if (actorRunId) {
+        const parsedActorRunId = asCanonicalUuid(actorRunId);
+        if (!parsedActorRunId) throw conflict("Issue run ownership conflict");
+        normalizedActorRunId = parsedActorRunId;
+      }
 
       const current = await db
         .select({
@@ -1296,14 +1302,14 @@ export function issueService(db: Db) {
           checkoutRunId: issues.checkoutRunId,
         })
         .from(issues)
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
 
       if (
         current.status === "in_progress" &&
-        current.assigneeAgentId === actorAgentId &&
+        current.assigneeAgentId === normalizedActorAgentId &&
         sameRunLock(current.checkoutRunId, normalizedActorRunId)
       ) {
         return { ...current, adoptedFromRunId: null as string | null };
@@ -1312,13 +1318,13 @@ export function issueService(db: Db) {
       if (
         normalizedActorRunId &&
         current.status === "in_progress" &&
-        current.assigneeAgentId === actorAgentId &&
+        current.assigneeAgentId === normalizedActorAgentId &&
         current.checkoutRunId &&
         current.checkoutRunId !== normalizedActorRunId
       ) {
         const adopted = await adoptStaleCheckoutRun({
-          issueId: id,
-          actorAgentId,
+          issueId: normalizedIssueId,
+          actorAgentId: normalizedActorAgentId,
           actorRunId: normalizedActorRunId,
           expectedCheckoutRunId: current.checkoutRunId,
         });
@@ -1336,31 +1342,37 @@ export function issueService(db: Db) {
         status: current.status,
         assigneeAgentId: current.assigneeAgentId,
         checkoutRunId: current.checkoutRunId,
-        actorAgentId,
+        actorAgentId: normalizedActorAgentId,
         actorRunId: normalizedActorRunId,
       });
     },
 
     release: async (id: string, actorAgentId?: string, actorRunId?: string | null) => {
-      if (!isUuidLike(id)) return null;
-      if (actorAgentId && !isUuidLike(actorAgentId)) throw conflict("Only assignee can release issue");
-      if (actorRunId && !isUuidLike(actorRunId)) throw conflict("Only checkout run can release issue");
-      const normalizedActorRunId = actorRunId ? actorRunId.toLowerCase() : null;
+      const normalizedIssueId = asCanonicalUuid(id);
+      if (!normalizedIssueId) return null;
+      const normalizedActorAgentId = actorAgentId ? asCanonicalUuid(actorAgentId) : null;
+      if (actorAgentId && !normalizedActorAgentId) throw conflict("Only assignee can release issue");
+      let normalizedActorRunId: string | null = null;
+      if (actorRunId) {
+        const parsedActorRunId = asCanonicalUuid(actorRunId);
+        if (!parsedActorRunId) throw conflict("Only checkout run can release issue");
+        normalizedActorRunId = parsedActorRunId;
+      }
 
       const existing = await db
         .select()
         .from(issues)
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
 
       if (!existing) return null;
-      if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
+      if (normalizedActorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== normalizedActorAgentId) {
         throw conflict("Only assignee can release issue");
       }
       if (
-        actorAgentId &&
+        normalizedActorAgentId &&
         existing.status === "in_progress" &&
-        existing.assigneeAgentId === actorAgentId &&
+        existing.assigneeAgentId === normalizedActorAgentId &&
         existing.checkoutRunId &&
         !sameRunLock(existing.checkoutRunId, normalizedActorRunId)
       ) {
@@ -1380,7 +1392,7 @@ export function issueService(db: Db) {
           checkoutRunId: null,
           updatedAt: new Date(),
         })
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedIssueId))
         .returning()
         .then((rows) => rows[0] ?? null);
       if (!updated) return null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -760,7 +760,9 @@ export function issueService(db: Db) {
     },
 
     markRead: async (companyId: string, issueId: string, userId: string, readAt: Date = new Date()) => {
+      if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
       if (!isUuidLike(issueId)) throw notFound("Issue not found");
+      if (typeof userId !== "string" || userId.trim().length === 0) throw unprocessable("Invalid userId");
       const now = new Date();
       const [row] = await db
         .insert(issueReadStates)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1310,6 +1310,9 @@ export function issueService(db: Db) {
       db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),
 
     getLabelById: (id: string) =>
+      !isUuidLike(id)
+        ? Promise.resolve(null)
+        :
       db
         .select()
         .from(labels)
@@ -1329,6 +1332,9 @@ export function issueService(db: Db) {
     },
 
     deleteLabel: async (id: string) =>
+      !isUuidLike(id)
+        ? null
+        :
       db
         .delete(labels)
         .where(eq(labels.id, id))

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -747,10 +747,11 @@ export function issueService(db: Db) {
     countUnreadTouchedByUser: async (companyId: string, userId: string, status?: string) => {
       if (!isUuidLike(companyId)) return 0;
       if (typeof userId !== "string" || userId.trim().length === 0) return 0;
+      const normalizedUserId = userId.trim();
       const conditions = [
         eq(issues.companyId, companyId),
         isNull(issues.hiddenAt),
-        unreadForUserCondition(companyId, userId),
+        unreadForUserCondition(companyId, normalizedUserId),
         ne(issues.originKind, "routine_execution"),
       ];
       const normalizedStatus = asNonEmptyString(status)?.toLowerCase();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1396,7 +1396,8 @@ export function issueService(db: Db) {
         limit?: number | null;
       },
     ) => {
-      const order = opts?.order === "asc" ? "asc" : "desc";
+      const orderRaw = asNonEmptyString(opts?.order)?.toLowerCase();
+      const order = orderRaw === "asc" ? "asc" : "desc";
       if (!isUuidLike(issueId)) return [];
       const afterCommentId = asNonEmptyString(opts?.afterCommentId) ?? null;
       const rawLimit = opts?.limit;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -900,6 +900,7 @@ export function issueService(db: Db) {
     },
 
     update: async (id: string, data: Partial<typeof issues.$inferInsert> & { labelIds?: string[] }) => {
+      if (!isUuidLike(id)) return null;
       const existing = await db
         .select()
         .from(issues)
@@ -1005,6 +1006,9 @@ export function issueService(db: Db) {
     },
 
     remove: (id: string) =>
+      !isUuidLike(id)
+        ? Promise.resolve(null)
+        :
       db.transaction(async (tx) => {
         const attachmentAssetIds = await tx
           .select({ assetId: issueAttachments.assetId })

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1100,7 +1100,7 @@ export function issueService(db: Db) {
       await assertAssignableAgent(issueCompany.companyId, agentId);
       const normalizedExpectedStatuses = (Array.isArray(expectedStatuses) ? expectedStatuses : [])
         .filter((status): status is string => typeof status === "string")
-        .map((status) => status.trim())
+        .map((status) => status.trim().toLowerCase())
         .filter((status): status is (typeof ALL_ISSUE_STATUSES)[number] =>
           ALL_ISSUE_STATUSES.includes(status as (typeof ALL_ISSUE_STATUSES)[number]),
         );

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1855,7 +1855,8 @@ export function issueService(db: Db) {
     },
 
     findMentionedProjectIds: async (issueId: string) => {
-      if (!isUuidLike(issueId)) return [];
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) return [];
       const issue = await db
         .select({
           companyId: issues.companyId,
@@ -1863,14 +1864,14 @@ export function issueService(db: Db) {
           description: issues.description,
         })
         .from(issues)
-        .where(eq(issues.id, issueId))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
       if (!issue) return [];
 
       const comments = await db
         .select({ body: issueComments.body })
         .from(issueComments)
-        .where(eq(issueComments.issueId, issueId));
+        .where(eq(issueComments.issueId, normalizedIssueId));
 
       const mentionedIds = new Set<string>();
       for (const source of [
@@ -1883,7 +1884,11 @@ export function issueService(db: Db) {
         }
       }
       if (mentionedIds.size === 0) return [];
-      const candidateProjectIds = [...mentionedIds].filter((projectId) => isUuidLike(projectId));
+      const candidateProjectIds = [...new Set(
+        [...mentionedIds]
+          .map((projectId) => asCanonicalUuid(projectId))
+          .filter((projectId): projectId is string => projectId != null),
+      )];
       if (candidateProjectIds.length === 0) return [];
 
       const rows = await db
@@ -1900,14 +1905,15 @@ export function issueService(db: Db) {
     },
 
     getAncestors: async (issueId: string) => {
-      if (!isUuidLike(issueId)) return [];
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) return [];
       const raw: Array<{
         id: string; identifier: string | null; title: string; description: string | null;
         status: string; priority: string;
         assigneeAgentId: string | null; projectId: string | null; goalId: string | null;
       }> = [];
-      const visited = new Set<string>([issueId]);
-      const start = await db.select().from(issues).where(eq(issues.id, issueId)).then(r => r[0] ?? null);
+      const visited = new Set<string>([normalizedIssueId]);
+      const start = await db.select().from(issues).where(eq(issues.id, normalizedIssueId)).then(r => r[0] ?? null);
       let currentId = start?.parentId ?? null;
       while (currentId && !visited.has(currentId) && raw.length < 50) {
         visited.add(currentId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -82,6 +82,13 @@ function asNonEmptyString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function assertOptionalUuidField(value: unknown, fieldName: string) {
+  if (value == null) return;
+  if (typeof value !== "string" || !isUuidLike(value.trim())) {
+    throw unprocessable(`Invalid ${fieldName}`);
+  }
+}
+
 type IssueRow = typeof issues.$inferSelect;
 type IssueLabelRow = typeof labels.$inferSelect;
 type IssueActiveRunRow = {
@@ -803,6 +810,12 @@ export function issueService(db: Db) {
       data: Omit<typeof issues.$inferInsert, "companyId"> & { labelIds?: string[] },
     ) => {
       const { labelIds: inputLabelIds, ...issueData } = data;
+      assertOptionalUuidField(issueData.projectId, "projectId");
+      assertOptionalUuidField(issueData.parentId, "parentId");
+      assertOptionalUuidField(issueData.goalId, "goalId");
+      assertOptionalUuidField(issueData.assigneeAgentId, "assigneeAgentId");
+      assertOptionalUuidField(issueData.projectWorkspaceId, "projectWorkspaceId");
+      assertOptionalUuidField(issueData.executionWorkspaceId, "executionWorkspaceId");
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -919,6 +932,12 @@ export function issueService(db: Db) {
       if (!existing) return null;
 
       const { labelIds: nextLabelIds, ...issueData } = data;
+      assertOptionalUuidField(issueData.projectId, "projectId");
+      assertOptionalUuidField(issueData.parentId, "parentId");
+      assertOptionalUuidField(issueData.goalId, "goalId");
+      assertOptionalUuidField(issueData.assigneeAgentId, "assigneeAgentId");
+      assertOptionalUuidField(issueData.projectWorkspaceId, "projectWorkspaceId");
+      assertOptionalUuidField(issueData.executionWorkspaceId, "executionWorkspaceId");
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1458,6 +1458,12 @@ export function issueService(db: Db) {
       if (typeof data?.color !== "string" || data.color.trim().length === 0) {
         throw unprocessable("Invalid label color");
       }
+      const company = await db
+        .select({ id: companies.id })
+        .from(companies)
+        .where(eq(companies.id, normalizedCompanyId))
+        .then((rows) => rows[0] ?? null);
+      if (!company) throw notFound("Company not found");
       const [created] = await db
         .insert(labels)
         .values({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1552,6 +1552,16 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!issue) throw notFound("Issue not found");
+      if (normalizedAuthorAgentId) {
+        const authorAgent = await db
+          .select({ id: agents.id, companyId: agents.companyId })
+          .from(agents)
+          .where(eq(agents.id, normalizedAuthorAgentId))
+          .then((rows) => rows[0] ?? null);
+        if (!authorAgent || authorAgent.companyId !== issue.companyId) {
+          throw unprocessable("Invalid authorAgentId");
+        }
+      }
 
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -721,8 +721,9 @@ export function issueService(db: Db) {
         unreadForUserCondition(companyId, userId),
         ne(issues.originKind, "routine_execution"),
       ];
-      if (status) {
-        const statuses = status.split(",").map((s) => s.trim()).filter(Boolean);
+      const normalizedStatus = asNonEmptyString(status);
+      if (normalizedStatus) {
+        const statuses = normalizedStatus.split(",").map((s) => s.trim()).filter(Boolean);
         if (statuses.length === 1) {
           conditions.push(eq(issues.status, statuses[0]));
         } else if (statuses.length > 1) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1482,6 +1482,7 @@ export function issueService(db: Db) {
 
     addComment: async (issueId: string, body: string, actor: { agentId?: string; userId?: string }) => {
       if (!isUuidLike(issueId)) throw notFound("Issue not found");
+      if (typeof body !== "string") throw unprocessable("Invalid comment body");
       const issue = await db
         .select({ companyId: issues.companyId })
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1193,6 +1193,10 @@ export function issueService(db: Db) {
     },
 
     assertCheckoutOwner: async (id: string, actorAgentId: string, actorRunId: string | null) => {
+      if (!isUuidLike(id)) throw notFound("Issue not found");
+      if (!isUuidLike(actorAgentId)) throw conflict("Issue run ownership conflict");
+      if (actorRunId && !isUuidLike(actorRunId)) throw conflict("Issue run ownership conflict");
+
       const current = await db
         .select({
           id: issues.id,
@@ -1247,6 +1251,10 @@ export function issueService(db: Db) {
     },
 
     release: async (id: string, actorAgentId?: string, actorRunId?: string | null) => {
+      if (!isUuidLike(id)) return null;
+      if (actorAgentId && !isUuidLike(actorAgentId)) throw conflict("Only assignee can release issue");
+      if (actorRunId && !isUuidLike(actorRunId)) throw conflict("Only checkout run can release issue");
+
       const existing = await db
         .select()
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -585,14 +585,14 @@ export function issueService(db: Db) {
       const normalizedCompanyId = asCanonicalUuid(companyId);
       if (!normalizedCompanyId) return [];
       const statusFilter = asNonEmptyString(filters?.status)?.toLowerCase();
-      const assigneeAgentIdFilter = asNonEmptyString(filters?.assigneeAgentId);
-      const participantAgentIdFilter = asNonEmptyString(filters?.participantAgentId);
+      const assigneeAgentIdFilterRaw = asNonEmptyString(filters?.assigneeAgentId);
+      const participantAgentIdFilterRaw = asNonEmptyString(filters?.participantAgentId);
       const assigneeUserIdFilter = asNonEmptyString(filters?.assigneeUserId);
       const touchedByUserIdFilter = asNonEmptyString(filters?.touchedByUserId);
       const unreadForUserIdFilter = asNonEmptyString(filters?.unreadForUserId);
-      const projectIdFilter = asNonEmptyString(filters?.projectId);
-      const parentIdFilter = asNonEmptyString(filters?.parentId);
-      const labelIdFilter = asNonEmptyString(filters?.labelId);
+      const projectIdFilterRaw = asNonEmptyString(filters?.projectId);
+      const parentIdFilterRaw = asNonEmptyString(filters?.parentId);
+      const labelIdFilterRaw = asNonEmptyString(filters?.labelId);
       const originKindFilter = asNonEmptyString(filters?.originKind)?.toLowerCase();
       const originIdFilterRaw = asNonEmptyString(filters?.originId);
       const originIdFilter =
@@ -607,11 +607,16 @@ export function issueService(db: Db) {
           (includeRoutineExecutionsRaw.trim().toLowerCase() === "true" ||
             includeRoutineExecutionsRaw.trim().toLowerCase() === "1"));
       const rawSearch = asNonEmptyString(filters?.q) ?? "";
-      if (assigneeAgentIdFilter && !isUuidLike(assigneeAgentIdFilter)) return [];
-      if (participantAgentIdFilter && !isUuidLike(participantAgentIdFilter)) return [];
-      if (projectIdFilter && !isUuidLike(projectIdFilter)) return [];
-      if (parentIdFilter && !isUuidLike(parentIdFilter)) return [];
-      if (labelIdFilter && !isUuidLike(labelIdFilter)) return [];
+      if (assigneeAgentIdFilterRaw && !isUuidLike(assigneeAgentIdFilterRaw)) return [];
+      if (participantAgentIdFilterRaw && !isUuidLike(participantAgentIdFilterRaw)) return [];
+      if (projectIdFilterRaw && !isUuidLike(projectIdFilterRaw)) return [];
+      if (parentIdFilterRaw && !isUuidLike(parentIdFilterRaw)) return [];
+      if (labelIdFilterRaw && !isUuidLike(labelIdFilterRaw)) return [];
+      const assigneeAgentIdFilter = assigneeAgentIdFilterRaw ? assigneeAgentIdFilterRaw.trim().toLowerCase() : null;
+      const participantAgentIdFilter = participantAgentIdFilterRaw ? participantAgentIdFilterRaw.trim().toLowerCase() : null;
+      const projectIdFilter = projectIdFilterRaw ? projectIdFilterRaw.trim().toLowerCase() : null;
+      const parentIdFilter = parentIdFilterRaw ? parentIdFilterRaw.trim().toLowerCase() : null;
+      const labelIdFilter = labelIdFilterRaw ? labelIdFilterRaw.trim().toLowerCase() : null;
       const conditions = [eq(issues.companyId, normalizedCompanyId)];
       const touchedByUserId = touchedByUserIdFilter;
       const unreadForUserId = unreadForUserIdFilter;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1483,6 +1483,8 @@ export function issueService(db: Db) {
     addComment: async (issueId: string, body: string, actor: { agentId?: string; userId?: string }) => {
       if (!isUuidLike(issueId)) throw notFound("Issue not found");
       if (typeof body !== "string") throw unprocessable("Invalid comment body");
+      if (actor.agentId != null && !isUuidLike(actor.agentId)) throw unprocessable("Invalid authorAgentId");
+      if (actor.userId != null && typeof actor.userId !== "string") throw unprocessable("Invalid authorUserId");
       const issue = await db
         .select({ companyId: issues.companyId })
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -576,7 +576,7 @@ export function issueService(db: Db) {
   return {
     list: async (companyId: string, filters?: IssueFilters) => {
       if (!isUuidLike(companyId)) return [];
-      const statusFilter = asNonEmptyString(filters?.status);
+      const statusFilter = asNonEmptyString(filters?.status)?.toLowerCase();
       const assigneeAgentIdFilter = asNonEmptyString(filters?.assigneeAgentId);
       const participantAgentIdFilter = asNonEmptyString(filters?.participantAgentId);
       const assigneeUserIdFilter = asNonEmptyString(filters?.assigneeUserId);
@@ -585,7 +585,7 @@ export function issueService(db: Db) {
       const projectIdFilter = asNonEmptyString(filters?.projectId);
       const parentIdFilter = asNonEmptyString(filters?.parentId);
       const labelIdFilter = asNonEmptyString(filters?.labelId);
-      const originKindFilter = asNonEmptyString(filters?.originKind);
+      const originKindFilter = asNonEmptyString(filters?.originKind)?.toLowerCase();
       const originIdFilter = asNonEmptyString(filters?.originId);
       const includeRoutineExecutionsRaw = filters?.includeRoutineExecutions as unknown;
       const includeRoutineExecutions =

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1032,6 +1032,10 @@ export function issueService(db: Db) {
       }),
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+      if (!isUuidLike(id)) throw notFound("Issue not found");
+      if (!isUuidLike(agentId)) throw unprocessable("Invalid agentId");
+      if (checkoutRunId && !isUuidLike(checkoutRunId)) throw unprocessable("Invalid checkoutRunId");
+
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1599,6 +1599,12 @@ export function issueService(db: Db) {
       if (input.issueCommentId && !normalizedIssueCommentId) {
         throw notFound("Issue comment not found");
       }
+      const normalizedCreatedByAgentId = input.createdByAgentId == null
+        ? null
+        : asCanonicalUuid(input.createdByAgentId);
+      if (input.createdByAgentId != null && !normalizedCreatedByAgentId) {
+        throw unprocessable("Invalid createdByAgentId");
+      }
 
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
@@ -1630,7 +1636,7 @@ export function issueService(db: Db) {
             byteSize: input.byteSize,
             sha256: input.sha256,
             originalFilename: input.originalFilename ?? null,
-            createdByAgentId: input.createdByAgentId ?? null,
+            createdByAgentId: normalizedCreatedByAgentId,
             createdByUserId: input.createdByUserId ?? null,
           })
           .returning();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1861,6 +1861,8 @@ export function issueService(db: Db) {
     },
 
     findMentionedAgents: async (companyId: string, body: string) => {
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) return [];
       const re = /\B@([^\s@,!?.]+)/g;
       const tokens = new Set<string>();
       let m: RegExpExecArray | null;
@@ -1869,10 +1871,12 @@ export function issueService(db: Db) {
         if (normalized) tokens.add(normalized.toLowerCase());
       }
 
-      const explicitAgentMentionIds = extractAgentMentionIds(body).filter((agentId) => isUuidLike(agentId));
+      const explicitAgentMentionIds = extractAgentMentionIds(body)
+        .map((agentId) => asCanonicalUuid(agentId))
+        .filter((agentId): agentId is string => agentId != null);
       if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
-        .from(agents).where(eq(agents.companyId, companyId));
+        .from(agents).where(eq(agents.companyId, normalizedCompanyId));
       const resolved = new Set<string>(explicitAgentMentionIds);
       for (const agent of rows) {
         if (tokens.has(agent.name.toLowerCase())) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -406,6 +406,7 @@ export function issueService(db: Db) {
   }
 
   async function assertAssignableAgent(companyId: string, agentId: string) {
+    if (!isUuidLike(agentId)) throw unprocessable("Invalid assigneeAgentId");
     const assignee = await db
       .select({
         id: agents.id,
@@ -447,6 +448,8 @@ export function issueService(db: Db) {
   }
 
   async function assertValidProjectWorkspace(companyId: string, projectId: string | null | undefined, projectWorkspaceId: string) {
+    if (!isUuidLike(projectWorkspaceId)) throw unprocessable("Invalid projectWorkspaceId");
+    if (projectId && !isUuidLike(projectId)) throw unprocessable("Invalid projectId");
     const workspace = await db
       .select({
         id: projectWorkspaces.id,
@@ -464,6 +467,8 @@ export function issueService(db: Db) {
   }
 
   async function assertValidExecutionWorkspace(companyId: string, projectId: string | null | undefined, executionWorkspaceId: string) {
+    if (!isUuidLike(executionWorkspaceId)) throw unprocessable("Invalid executionWorkspaceId");
+    if (projectId && !isUuidLike(projectId)) throw unprocessable("Invalid projectId");
     const workspace = await db
       .select({
         id: executionWorkspaces.id,
@@ -482,6 +487,9 @@ export function issueService(db: Db) {
 
   async function assertValidLabelIds(companyId: string, labelIds: string[], dbOrTx: any = db) {
     if (labelIds.length === 0) return;
+    if (labelIds.some((id) => !isUuidLike(id))) {
+      throw unprocessable("One or more labels must be valid UUIDs");
+    }
     const existing = await dbOrTx
       .select({ id: labels.id })
       .from(labels)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1005,6 +1005,12 @@ export function issueService(db: Db) {
       assertOptionalUuidField(issueData.assigneeAgentId, "assigneeAgentId");
       assertOptionalUuidField(issueData.projectWorkspaceId, "projectWorkspaceId");
       assertOptionalUuidField(issueData.executionWorkspaceId, "executionWorkspaceId");
+      if (issueData.projectId) issueData.projectId = issueData.projectId.trim().toLowerCase();
+      if (issueData.parentId) issueData.parentId = issueData.parentId.trim().toLowerCase();
+      if (issueData.goalId) issueData.goalId = issueData.goalId.trim().toLowerCase();
+      if (issueData.assigneeAgentId) issueData.assigneeAgentId = issueData.assigneeAgentId.trim().toLowerCase();
+      if (issueData.projectWorkspaceId) issueData.projectWorkspaceId = issueData.projectWorkspaceId.trim().toLowerCase();
+      if (issueData.executionWorkspaceId) issueData.executionWorkspaceId = issueData.executionWorkspaceId.trim().toLowerCase();
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -560,6 +560,7 @@ export function issueService(db: Db) {
 
   return {
     list: async (companyId: string, filters?: IssueFilters) => {
+      if (!isUuidLike(companyId)) return [];
       const statusFilter = asNonEmptyString(filters?.status);
       const assigneeAgentIdFilter = asNonEmptyString(filters?.assigneeAgentId);
       const participantAgentIdFilter = asNonEmptyString(filters?.participantAgentId);
@@ -720,6 +721,7 @@ export function issueService(db: Db) {
     },
 
     countUnreadTouchedByUser: async (companyId: string, userId: string, status?: string) => {
+      if (!isUuidLike(companyId)) return 0;
       const conditions = [
         eq(issues.companyId, companyId),
         isNull(issues.hiddenAt),
@@ -1307,6 +1309,9 @@ export function issueService(db: Db) {
     },
 
     listLabels: (companyId: string) =>
+      !isUuidLike(companyId)
+        ? Promise.resolve([])
+        :
       db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),
 
     getLabelById: (id: string) =>
@@ -1320,6 +1325,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null),
 
     createLabel: async (companyId: string, data: Pick<typeof labels.$inferInsert, "name" | "color">) => {
+      if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
       const [created] = await db
         .insert(labels)
         .values({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -766,6 +766,7 @@ export function issueService(db: Db) {
     },
 
     getById: async (id: string) => {
+      if (!isUuidLike(id)) return null;
       const row = await db
         .select()
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -755,13 +755,14 @@ export function issueService(db: Db) {
     },
 
     countUnreadTouchedByUser: async (companyId: string, userId: string, status?: string) => {
-      if (!isUuidLike(companyId)) return 0;
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) return 0;
       if (typeof userId !== "string" || userId.trim().length === 0) return 0;
       const normalizedUserId = userId.trim();
       const conditions = [
-        eq(issues.companyId, companyId),
+        eq(issues.companyId, normalizedCompanyId),
         isNull(issues.hiddenAt),
-        unreadForUserCondition(companyId, normalizedUserId),
+        unreadForUserCondition(normalizedCompanyId, normalizedUserId),
         ne(issues.originKind, "routine_execution"),
       ];
       const normalizedStatus = asNonEmptyString(status)?.toLowerCase();
@@ -1416,7 +1417,8 @@ export function issueService(db: Db) {
     ) => {
       const orderRaw = asNonEmptyString(opts?.order)?.toLowerCase();
       const order = orderRaw === "asc" ? "asc" : "desc";
-      if (!isUuidLike(issueId)) return [];
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) return [];
       const afterCommentIdRaw = asNonEmptyString(opts?.afterCommentId) ?? null;
       const afterCommentId = afterCommentIdRaw ? afterCommentIdRaw.toLowerCase() : null;
       const rawLimit = opts?.limit as unknown;
@@ -1438,7 +1440,7 @@ export function issueService(db: Db) {
             : null;
       if (afterCommentId && !isUuidLike(afterCommentId)) return [];
 
-      const conditions = [eq(issueComments.issueId, issueId)];
+      const conditions = [eq(issueComments.issueId, normalizedIssueId)];
       if (afterCommentId) {
         const anchor = await db
           .select({
@@ -1446,7 +1448,7 @@ export function issueService(db: Db) {
             createdAt: issueComments.createdAt,
           })
           .from(issueComments)
-          .where(and(eq(issueComments.issueId, issueId), eq(issueComments.id, afterCommentId)))
+          .where(and(eq(issueComments.issueId, normalizedIssueId), eq(issueComments.id, afterCommentId)))
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
@@ -1481,7 +1483,8 @@ export function issueService(db: Db) {
     },
 
     getCommentCursor: async (issueId: string) => {
-      if (!isUuidLike(issueId)) {
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) {
         return {
           totalComments: 0,
           latestCommentId: null,
@@ -1495,7 +1498,7 @@ export function issueService(db: Db) {
             latestCommentAt: issueComments.createdAt,
           })
           .from(issueComments)
-          .where(eq(issueComments.issueId, issueId))
+          .where(eq(issueComments.issueId, normalizedIssueId))
           .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
           .limit(1)
           .then((rows) => rows[0] ?? null),
@@ -1504,7 +1507,7 @@ export function issueService(db: Db) {
             totalComments: sql<number>`count(*)::int`,
           })
           .from(issueComments)
-          .where(eq(issueComments.issueId, issueId))
+          .where(eq(issueComments.issueId, normalizedIssueId))
           .then((rows) => rows[0] ?? null),
       ]);
 
@@ -1516,12 +1519,13 @@ export function issueService(db: Db) {
     },
 
     getComment: (commentId: string) => {
-      if (!isUuidLike(commentId)) return Promise.resolve(null);
+      const normalizedCommentId = asCanonicalUuid(commentId);
+      if (!normalizedCommentId) return Promise.resolve(null);
       return instanceSettings.getGeneral().then(({ censorUsernameInLogs }) =>
         db
           .select()
           .from(issueComments)
-          .where(eq(issueComments.id, commentId))
+          .where(eq(issueComments.id, normalizedCommentId))
           .then((rows) => {
             const comment = rows[0] ?? null;
             return comment ? redactIssueComment(comment, censorUsernameInLogs) : null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1461,6 +1461,13 @@ export function issueService(db: Db) {
       createdByAgentId?: string | null;
       createdByUserId?: string | null;
     }) => {
+      if (!isUuidLike(input.issueId)) {
+        throw notFound("Issue not found");
+      }
+      if (input.issueCommentId && !isUuidLike(input.issueCommentId)) {
+        throw notFound("Issue comment not found");
+      }
+
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -797,10 +797,12 @@ export function issueService(db: Db) {
     },
 
     getByIdentifier: async (identifier: string) => {
+      const normalizedIdentifier = asNonEmptyString(identifier);
+      if (!normalizedIdentifier) return null;
       const row = await db
         .select()
         .from(issues)
-        .where(eq(issues.identifier, identifier.toUpperCase()))
+        .where(eq(issues.identifier, normalizedIdentifier.toUpperCase()))
         .then((rows) => rows[0] ?? null);
       if (!row) return null;
       const [enriched] = await withIssueLabels(db, [row]);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1077,14 +1077,33 @@ export function issueService(db: Db) {
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
         current.checkoutRunId == null &&
-        (current.executionRunId == null || current.executionRunId === checkoutRunId) &&
         checkoutRunId
       ) {
+        const staleExecutionLock =
+          current.executionRunId !== null &&
+          current.executionRunId !== checkoutRunId &&
+          (await isTerminalOrMissingHeartbeatRun(current.executionRunId));
+        const executionCondition =
+          current.executionRunId == null || current.executionRunId === checkoutRunId
+            ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
+            : staleExecutionLock
+              ? eq(issues.executionRunId, current.executionRunId)
+              : null;
+        if (!executionCondition) {
+          throw conflict("Issue checkout conflict", {
+            issueId: current.id,
+            status: current.status,
+            assigneeAgentId: current.assigneeAgentId,
+            checkoutRunId: current.checkoutRunId,
+            executionRunId: current.executionRunId,
+          });
+        }
         const adopted = await db
           .update(issues)
           .set({
             checkoutRunId,
             executionRunId: checkoutRunId,
+            executionLockedAt: new Date(),
             updatedAt: new Date(),
           })
           .where(
@@ -1093,7 +1112,7 @@ export function issueService(db: Db) {
               eq(issues.status, "in_progress"),
               eq(issues.assigneeAgentId, agentId),
               isNull(issues.checkoutRunId),
-              or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId)),
+              executionCondition,
             ),
           )
           .returning()

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1038,6 +1038,15 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!issueCompany) throw notFound("Issue not found");
       await assertAssignableAgent(issueCompany.companyId, agentId);
+      const normalizedExpectedStatuses = (Array.isArray(expectedStatuses) ? expectedStatuses : [])
+        .filter((status): status is string => typeof status === "string")
+        .map((status) => status.trim())
+        .filter((status): status is (typeof ALL_ISSUE_STATUSES)[number] =>
+          ALL_ISSUE_STATUSES.includes(status as (typeof ALL_ISSUE_STATUSES)[number]),
+        );
+      if (normalizedExpectedStatuses.length === 0) {
+        throw unprocessable("expectedStatuses must include at least one valid issue status");
+      }
 
       const now = new Date();
       const sameRunAssigneeCondition = checkoutRunId
@@ -1063,7 +1072,7 @@ export function issueService(db: Db) {
         .where(
           and(
             eq(issues.id, id),
-            inArray(issues.status, expectedStatuses),
+            inArray(issues.status, normalizedExpectedStatuses),
             or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
             executionLockCondition,
           ),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -775,13 +775,14 @@ export function issueService(db: Db) {
       if (!isUuidLike(issueId)) throw notFound("Issue not found");
       if (typeof userId !== "string" || userId.trim().length === 0) throw unprocessable("Invalid userId");
       if (!(readAt instanceof Date) || Number.isNaN(readAt.getTime())) throw unprocessable("Invalid readAt");
+      const normalizedUserId = userId.trim();
       const now = new Date();
       const [row] = await db
         .insert(issueReadStates)
         .values({
           companyId,
           issueId,
-          userId,
+          userId: normalizedUserId,
           lastReadAt: readAt,
           updatedAt: now,
         })

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1400,28 +1400,33 @@ export function issueService(db: Db) {
       return enriched;
     },
 
-    listLabels: (companyId: string) =>
-      !isUuidLike(companyId)
-        ? Promise.resolve([])
-        :
-      db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),
-
-    getLabelById: (id: string) =>
-      !isUuidLike(id)
-        ? Promise.resolve(null)
-        :
-      db
+    listLabels: (companyId: string) => {
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) return Promise.resolve([]);
+      return db
         .select()
         .from(labels)
-        .where(eq(labels.id, id))
-        .then((rows) => rows[0] ?? null),
+        .where(eq(labels.companyId, normalizedCompanyId))
+        .orderBy(asc(labels.name), asc(labels.id));
+    },
+
+    getLabelById: (id: string) => {
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return Promise.resolve(null);
+      return db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, normalizedId))
+        .then((rows) => rows[0] ?? null);
+    },
 
     createLabel: async (companyId: string, data: Pick<typeof labels.$inferInsert, "name" | "color">) => {
-      if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) throw unprocessable("Invalid companyId");
       const [created] = await db
         .insert(labels)
         .values({
-          companyId,
+          companyId: normalizedCompanyId,
           name: data.name.trim(),
           color: data.color,
         })
@@ -1429,15 +1434,15 @@ export function issueService(db: Db) {
       return created;
     },
 
-    deleteLabel: async (id: string) =>
-      !isUuidLike(id)
-        ? null
-        :
-      db
+    deleteLabel: async (id: string) => {
+      const normalizedId = asCanonicalUuid(id);
+      if (!normalizedId) return null;
+      return db
         .delete(labels)
-        .where(eq(labels.id, id))
+        .where(eq(labels.id, normalizedId))
         .returning()
-        .then((rows) => rows[0] ?? null),
+        .then((rows) => rows[0] ?? null);
+    },
 
     listComments: async (
       issueId: string,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1863,6 +1863,7 @@ export function issueService(db: Db) {
     findMentionedAgents: async (companyId: string, body: string) => {
       const normalizedCompanyId = asCanonicalUuid(companyId);
       if (!normalizedCompanyId) return [];
+      if (typeof body !== "string") return [];
       const re = /\B@([^\s@,!?.]+)/g;
       const tokens = new Set<string>();
       let m: RegExpExecArray | null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1630,6 +1630,17 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!issue) throw notFound("Issue not found");
 
+      if (normalizedCreatedByAgentId) {
+        const createdByAgent = await db
+          .select({ id: agents.id, companyId: agents.companyId })
+          .from(agents)
+          .where(eq(agents.id, normalizedCreatedByAgentId))
+          .then((rows) => rows[0] ?? null);
+        if (!createdByAgent || createdByAgent.companyId !== issue.companyId) {
+          throw unprocessable("Invalid createdByAgentId");
+        }
+      }
+
       if (normalizedIssueCommentId) {
         const comment = await db
           .select({ id: issueComments.id, companyId: issueComments.companyId, issueId: issueComments.issueId })

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -884,6 +884,7 @@ export function issueService(db: Db) {
           .set({ issueCounter: sql`${companies.issueCounter} + 1` })
           .where(eq(companies.id, companyId))
           .returning({ issueCounter: companies.issueCounter, issuePrefix: companies.issuePrefix });
+        if (!company) throw notFound("Company not found");
 
         const issueNumber = company.issueCounter;
         const identifier = `${company.issuePrefix}-${issueNumber}`;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1536,14 +1536,19 @@ export function issueService(db: Db) {
     },
 
     addComment: async (issueId: string, body: string, actor: { agentId?: string; userId?: string }) => {
-      if (!isUuidLike(issueId)) throw notFound("Issue not found");
+      const normalizedIssueId = asCanonicalUuid(issueId);
+      if (!normalizedIssueId) throw notFound("Issue not found");
       if (typeof body !== "string") throw unprocessable("Invalid comment body");
-      if (actor.agentId != null && !isUuidLike(actor.agentId)) throw unprocessable("Invalid authorAgentId");
+      const normalizedAuthorAgentId =
+        actor.agentId == null
+          ? null
+          : asCanonicalUuid(actor.agentId);
+      if (actor.agentId != null && !normalizedAuthorAgentId) throw unprocessable("Invalid authorAgentId");
       if (actor.userId != null && typeof actor.userId !== "string") throw unprocessable("Invalid authorUserId");
       const issue = await db
         .select({ companyId: issues.companyId })
         .from(issues)
-        .where(eq(issues.id, issueId))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
 
       if (!issue) throw notFound("Issue not found");
@@ -1556,8 +1561,8 @@ export function issueService(db: Db) {
         .insert(issueComments)
         .values({
           companyId: issue.companyId,
-          issueId,
-          authorAgentId: actor.agentId ?? null,
+          issueId: normalizedIssueId,
+          authorAgentId: normalizedAuthorAgentId,
           authorUserId: actor.userId ?? null,
           body: redactedBody,
         })
@@ -1567,7 +1572,7 @@ export function issueService(db: Db) {
       await db
         .update(issues)
         .set({ updatedAt: new Date() })
-        .where(eq(issues.id, issueId));
+        .where(eq(issues.id, normalizedIssueId));
 
       return redactIssueComment(comment, currentUserRedactionOptions.enabled);
     },

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1690,7 +1690,7 @@ export function issueService(db: Db) {
         if (normalized) tokens.add(normalized.toLowerCase());
       }
 
-      const explicitAgentMentionIds = extractAgentMentionIds(body);
+      const explicitAgentMentionIds = extractAgentMentionIds(body).filter((agentId) => isUuidLike(agentId));
       if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -572,6 +572,11 @@ export function issueService(db: Db) {
       const originKindFilter = asNonEmptyString(filters?.originKind);
       const originIdFilter = asNonEmptyString(filters?.originId);
       const rawSearch = asNonEmptyString(filters?.q) ?? "";
+      if (assigneeAgentIdFilter && !isUuidLike(assigneeAgentIdFilter)) return [];
+      if (participantAgentIdFilter && !isUuidLike(participantAgentIdFilter)) return [];
+      if (projectIdFilter && !isUuidLike(projectIdFilter)) return [];
+      if (parentIdFilter && !isUuidLike(parentIdFilter)) return [];
+      if (labelIdFilter && !isUuidLike(labelIdFilter)) return [];
       const conditions = [eq(issues.companyId, companyId)];
       const touchedByUserId = touchedByUserIdFilter;
       const unreadForUserId = unreadForUserIdFilter;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -20,7 +20,7 @@ import {
   projectWorkspaces,
   projects,
 } from "@paperclipai/db";
-import { extractAgentMentionIds, extractProjectMentionIds } from "@paperclipai/shared";
+import { extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -1299,6 +1299,7 @@ export function issueService(db: Db) {
         opts?.limit && opts.limit > 0
           ? Math.min(Math.floor(opts.limit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
           : null;
+      if (afterCommentId && !isUuidLike(afterCommentId)) return [];
 
       const conditions = [eq(issueComments.issueId, issueId)];
       if (afterCommentId) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1533,8 +1533,9 @@ export function issueService(db: Db) {
       });
     },
 
-    listAttachments: async (issueId: string) =>
-      db
+    listAttachments: async (issueId: string) => {
+      if (!isUuidLike(issueId)) return [];
+      return db
         .select({
           id: issueAttachments.id,
           companyId: issueAttachments.companyId,
@@ -1555,10 +1556,12 @@ export function issueService(db: Db) {
         .from(issueAttachments)
         .innerJoin(assets, eq(issueAttachments.assetId, assets.id))
         .where(eq(issueAttachments.issueId, issueId))
-        .orderBy(desc(issueAttachments.createdAt)),
+        .orderBy(desc(issueAttachments.createdAt));
+    },
 
-    getAttachmentById: async (id: string) =>
-      db
+    getAttachmentById: async (id: string) => {
+      if (!isUuidLike(id)) return null;
+      return db
         .select({
           id: issueAttachments.id,
           companyId: issueAttachments.companyId,
@@ -1579,10 +1582,12 @@ export function issueService(db: Db) {
         .from(issueAttachments)
         .innerJoin(assets, eq(issueAttachments.assetId, assets.id))
         .where(eq(issueAttachments.id, id))
-        .then((rows) => rows[0] ?? null),
+        .then((rows) => rows[0] ?? null);
+    },
 
-    removeAttachment: async (id: string) =>
-      db.transaction(async (tx) => {
+    removeAttachment: async (id: string) => {
+      if (!isUuidLike(id)) return null;
+      return db.transaction(async (tx) => {
         const existing = await tx
           .select({
             id: issueAttachments.id,
@@ -1610,7 +1615,8 @@ export function issueService(db: Db) {
         await tx.delete(issueAttachments).where(eq(issueAttachments.id, id));
         await tx.delete(assets).where(eq(assets.id, existing.assetId));
         return existing;
-      }),
+      });
+    },
 
     findMentionedAgents: async (companyId: string, body: string) => {
       const re = /\B@([^\s@,!?.]+)/g;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -588,7 +588,11 @@ export function issueService(db: Db) {
       const parentIdFilter = asNonEmptyString(filters?.parentId);
       const labelIdFilter = asNonEmptyString(filters?.labelId);
       const originKindFilter = asNonEmptyString(filters?.originKind)?.toLowerCase();
-      const originIdFilter = asNonEmptyString(filters?.originId);
+      const originIdFilterRaw = asNonEmptyString(filters?.originId);
+      const originIdFilter =
+        originKindFilter === "routine_execution" && originIdFilterRaw && isUuidLike(originIdFilterRaw)
+          ? originIdFilterRaw.toLowerCase()
+          : originIdFilterRaw;
       const includeRoutineExecutionsRaw = filters?.includeRoutineExecutions as unknown;
       const includeRoutineExecutions =
         includeRoutineExecutionsRaw === true ||

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -117,8 +117,10 @@ type IssueUserContextInput = {
 type ProjectGoalReader = Pick<Db, "select">;
 
 function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
-  if (actorRunId) return checkoutRunId === actorRunId;
-  return checkoutRunId == null;
+  const normalizedCheckoutRunId = typeof checkoutRunId === "string" ? checkoutRunId.trim().toLowerCase() : null;
+  const normalizedActorRunId = typeof actorRunId === "string" ? actorRunId.trim().toLowerCase() : null;
+  if (normalizedActorRunId) return normalizedCheckoutRunId === normalizedActorRunId;
+  return normalizedCheckoutRunId == null;
 }
 
 const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
@@ -1090,6 +1092,7 @@ export function issueService(db: Db) {
       if (!isUuidLike(id)) throw notFound("Issue not found");
       if (!isUuidLike(agentId)) throw unprocessable("Invalid agentId");
       if (checkoutRunId && !isUuidLike(checkoutRunId)) throw unprocessable("Invalid checkoutRunId");
+      const normalizedCheckoutRunId = checkoutRunId ? checkoutRunId.toLowerCase() : null;
 
       const issueCompany = await db
         .select({ companyId: issues.companyId })
@@ -1109,22 +1112,22 @@ export function issueService(db: Db) {
       }
 
       const now = new Date();
-      const sameRunAssigneeCondition = checkoutRunId
+      const sameRunAssigneeCondition = normalizedCheckoutRunId
         ? and(
           eq(issues.assigneeAgentId, agentId),
-          or(isNull(issues.checkoutRunId), eq(issues.checkoutRunId, checkoutRunId)),
+          or(isNull(issues.checkoutRunId), eq(issues.checkoutRunId, normalizedCheckoutRunId)),
         )
         : and(eq(issues.assigneeAgentId, agentId), isNull(issues.checkoutRunId));
-      const executionLockCondition = checkoutRunId
-        ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
+      const executionLockCondition = normalizedCheckoutRunId
+        ? or(isNull(issues.executionRunId), eq(issues.executionRunId, normalizedCheckoutRunId))
         : isNull(issues.executionRunId);
       const updated = await db
         .update(issues)
         .set({
           assigneeAgentId: agentId,
           assigneeUserId: null,
-          checkoutRunId,
-          executionRunId: checkoutRunId,
+          checkoutRunId: normalizedCheckoutRunId,
+          executionRunId: normalizedCheckoutRunId,
           status: "in_progress",
           startedAt: now,
           updatedAt: now,
@@ -1163,15 +1166,15 @@ export function issueService(db: Db) {
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
         current.checkoutRunId == null &&
-        checkoutRunId
+        normalizedCheckoutRunId
       ) {
         const staleExecutionLock =
           current.executionRunId !== null &&
-          current.executionRunId !== checkoutRunId &&
+          current.executionRunId !== normalizedCheckoutRunId &&
           (await isTerminalOrMissingHeartbeatRun(current.executionRunId));
         const executionCondition =
-          current.executionRunId == null || current.executionRunId === checkoutRunId
-            ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
+          current.executionRunId == null || current.executionRunId === normalizedCheckoutRunId
+            ? or(isNull(issues.executionRunId), eq(issues.executionRunId, normalizedCheckoutRunId))
             : staleExecutionLock
               ? eq(issues.executionRunId, current.executionRunId)
               : null;
@@ -1187,8 +1190,8 @@ export function issueService(db: Db) {
         const adopted = await db
           .update(issues)
           .set({
-            checkoutRunId,
-            executionRunId: checkoutRunId,
+            checkoutRunId: normalizedCheckoutRunId,
+            executionRunId: normalizedCheckoutRunId,
             executionLockedAt: new Date(),
             updatedAt: new Date(),
           })
@@ -1207,16 +1210,16 @@ export function issueService(db: Db) {
       }
 
       if (
-        checkoutRunId &&
+        normalizedCheckoutRunId &&
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
         current.checkoutRunId &&
-        current.checkoutRunId !== checkoutRunId
+        current.checkoutRunId !== normalizedCheckoutRunId
       ) {
         const adopted = await adoptStaleCheckoutRun({
           issueId: id,
           actorAgentId: agentId,
-          actorRunId: checkoutRunId,
+          actorRunId: normalizedCheckoutRunId,
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (adopted) {
@@ -1230,7 +1233,7 @@ export function issueService(db: Db) {
       if (
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
-        sameRunLock(current.checkoutRunId, checkoutRunId)
+        sameRunLock(current.checkoutRunId, normalizedCheckoutRunId)
       ) {
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
         const [enriched] = await withIssueLabels(db, [row]);
@@ -1250,6 +1253,7 @@ export function issueService(db: Db) {
       if (!isUuidLike(id)) throw notFound("Issue not found");
       if (!isUuidLike(actorAgentId)) throw conflict("Issue run ownership conflict");
       if (actorRunId && !isUuidLike(actorRunId)) throw conflict("Issue run ownership conflict");
+      const normalizedActorRunId = actorRunId ? actorRunId.toLowerCase() : null;
 
       const current = await db
         .select({
@@ -1267,22 +1271,22 @@ export function issueService(db: Db) {
       if (
         current.status === "in_progress" &&
         current.assigneeAgentId === actorAgentId &&
-        sameRunLock(current.checkoutRunId, actorRunId)
+        sameRunLock(current.checkoutRunId, normalizedActorRunId)
       ) {
         return { ...current, adoptedFromRunId: null as string | null };
       }
 
       if (
-        actorRunId &&
+        normalizedActorRunId &&
         current.status === "in_progress" &&
         current.assigneeAgentId === actorAgentId &&
         current.checkoutRunId &&
-        current.checkoutRunId !== actorRunId
+        current.checkoutRunId !== normalizedActorRunId
       ) {
         const adopted = await adoptStaleCheckoutRun({
           issueId: id,
           actorAgentId,
-          actorRunId,
+          actorRunId: normalizedActorRunId,
           expectedCheckoutRunId: current.checkoutRunId,
         });
 
@@ -1300,7 +1304,7 @@ export function issueService(db: Db) {
         assigneeAgentId: current.assigneeAgentId,
         checkoutRunId: current.checkoutRunId,
         actorAgentId,
-        actorRunId,
+        actorRunId: normalizedActorRunId,
       });
     },
 
@@ -1308,6 +1312,7 @@ export function issueService(db: Db) {
       if (!isUuidLike(id)) return null;
       if (actorAgentId && !isUuidLike(actorAgentId)) throw conflict("Only assignee can release issue");
       if (actorRunId && !isUuidLike(actorRunId)) throw conflict("Only checkout run can release issue");
+      const normalizedActorRunId = actorRunId ? actorRunId.toLowerCase() : null;
 
       const existing = await db
         .select()
@@ -1324,13 +1329,13 @@ export function issueService(db: Db) {
         existing.status === "in_progress" &&
         existing.assigneeAgentId === actorAgentId &&
         existing.checkoutRunId &&
-        !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
+        !sameRunLock(existing.checkoutRunId, normalizedActorRunId)
       ) {
         throw conflict("Only checkout run can release issue", {
           issueId: existing.id,
           assigneeAgentId: existing.assigneeAgentId,
           checkoutRunId: existing.checkoutRunId,
-          actorRunId: actorRunId ?? null,
+          actorRunId: normalizedActorRunId,
         });
       }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1890,7 +1890,10 @@ export function issueService(db: Db) {
       if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, normalizedCompanyId));
-      const resolved = new Set<string>(explicitAgentMentionIds);
+      const companyAgentIds = new Set(rows.map((agent) => agent.id));
+      const resolved = new Set<string>(
+        explicitAgentMentionIds.filter((agentId) => companyAgentIds.has(agentId)),
+      );
       for (const agent of rows) {
         if (tokens.has(agent.name.toLowerCase())) {
           resolved.add(agent.id);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1399,7 +1399,8 @@ export function issueService(db: Db) {
       const orderRaw = asNonEmptyString(opts?.order)?.toLowerCase();
       const order = orderRaw === "asc" ? "asc" : "desc";
       if (!isUuidLike(issueId)) return [];
-      const afterCommentId = asNonEmptyString(opts?.afterCommentId) ?? null;
+      const afterCommentIdRaw = asNonEmptyString(opts?.afterCommentId) ?? null;
+      const afterCommentId = afterCommentIdRaw ? afterCommentIdRaw.toLowerCase() : null;
       const rawLimit = opts?.limit as unknown;
       const parsedLimit =
         typeof rawLimit === "number"
@@ -1425,15 +1426,18 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt = anchor.createdAt instanceof Date
+          ? anchor.createdAt.toISOString()
+          : anchor.createdAt;
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1671,6 +1671,7 @@ export function issueService(db: Db) {
     },
 
     findMentionedProjectIds: async (issueId: string) => {
+      if (!isUuidLike(issueId)) return [];
       const issue = await db
         .select({
           companyId: issues.companyId,
@@ -1713,6 +1714,7 @@ export function issueService(db: Db) {
     },
 
     getAncestors: async (issueId: string) => {
+      if (!isUuidLike(issueId)) return [];
       const raw: Array<{
         id: string; identifier: string | null; title: string; description: string | null;
         status: string; priority: string;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1392,9 +1392,10 @@ export function issueService(db: Db) {
       const order = opts?.order === "asc" ? "asc" : "desc";
       if (!isUuidLike(issueId)) return [];
       const afterCommentId = asNonEmptyString(opts?.afterCommentId) ?? null;
+      const rawLimit = opts?.limit;
       const limit =
-        opts?.limit && opts.limit > 0
-          ? Math.min(Math.floor(opts.limit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
+        typeof rawLimit === "number" && Number.isFinite(rawLimit) && rawLimit > 0
+          ? Math.min(Math.floor(rawLimit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
           : null;
       if (afterCommentId && !isUuidLike(afterCommentId)) return [];
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1111,18 +1111,24 @@ export function issueService(db: Db) {
       }),
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
-      if (!isUuidLike(id)) throw notFound("Issue not found");
-      if (!isUuidLike(agentId)) throw unprocessable("Invalid agentId");
-      if (checkoutRunId && !isUuidLike(checkoutRunId)) throw unprocessable("Invalid checkoutRunId");
-      const normalizedCheckoutRunId = checkoutRunId ? checkoutRunId.toLowerCase() : null;
+      const normalizedIssueId = asCanonicalUuid(id);
+      if (!normalizedIssueId) throw notFound("Issue not found");
+      const normalizedAgentId = asCanonicalUuid(agentId);
+      if (!normalizedAgentId) throw unprocessable("Invalid agentId");
+      let normalizedCheckoutRunId: string | null = null;
+      if (checkoutRunId != null) {
+        const parsedCheckoutRunId = asCanonicalUuid(checkoutRunId);
+        if (!parsedCheckoutRunId) throw unprocessable("Invalid checkoutRunId");
+        normalizedCheckoutRunId = parsedCheckoutRunId;
+      }
 
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
       if (!issueCompany) throw notFound("Issue not found");
-      await assertAssignableAgent(issueCompany.companyId, agentId);
+      await assertAssignableAgent(issueCompany.companyId, normalizedAgentId);
       const normalizedExpectedStatuses = (Array.isArray(expectedStatuses) ? expectedStatuses : [])
         .filter((status): status is string => typeof status === "string")
         .map((status) => status.trim().toLowerCase())
@@ -1136,17 +1142,17 @@ export function issueService(db: Db) {
       const now = new Date();
       const sameRunAssigneeCondition = normalizedCheckoutRunId
         ? and(
-          eq(issues.assigneeAgentId, agentId),
+          eq(issues.assigneeAgentId, normalizedAgentId),
           or(isNull(issues.checkoutRunId), eq(issues.checkoutRunId, normalizedCheckoutRunId)),
         )
-        : and(eq(issues.assigneeAgentId, agentId), isNull(issues.checkoutRunId));
+        : and(eq(issues.assigneeAgentId, normalizedAgentId), isNull(issues.checkoutRunId));
       const executionLockCondition = normalizedCheckoutRunId
         ? or(isNull(issues.executionRunId), eq(issues.executionRunId, normalizedCheckoutRunId))
         : isNull(issues.executionRunId);
       const updated = await db
         .update(issues)
         .set({
-          assigneeAgentId: agentId,
+          assigneeAgentId: normalizedAgentId,
           assigneeUserId: null,
           checkoutRunId: normalizedCheckoutRunId,
           executionRunId: normalizedCheckoutRunId,
@@ -1156,7 +1162,7 @@ export function issueService(db: Db) {
         })
         .where(
           and(
-            eq(issues.id, id),
+            eq(issues.id, normalizedIssueId),
             inArray(issues.status, normalizedExpectedStatuses),
             or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
             executionLockCondition,
@@ -1179,13 +1185,13 @@ export function issueService(db: Db) {
           executionRunId: issues.executionRunId,
         })
         .from(issues)
-        .where(eq(issues.id, id))
+        .where(eq(issues.id, normalizedIssueId))
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
 
       if (
-        current.assigneeAgentId === agentId &&
+        current.assigneeAgentId === normalizedAgentId &&
         current.status === "in_progress" &&
         current.checkoutRunId == null &&
         normalizedCheckoutRunId
@@ -1219,9 +1225,9 @@ export function issueService(db: Db) {
           })
           .where(
             and(
-              eq(issues.id, id),
+              eq(issues.id, normalizedIssueId),
               eq(issues.status, "in_progress"),
-              eq(issues.assigneeAgentId, agentId),
+              eq(issues.assigneeAgentId, normalizedAgentId),
               isNull(issues.checkoutRunId),
               executionCondition,
             ),
@@ -1233,19 +1239,19 @@ export function issueService(db: Db) {
 
       if (
         normalizedCheckoutRunId &&
-        current.assigneeAgentId === agentId &&
+        current.assigneeAgentId === normalizedAgentId &&
         current.status === "in_progress" &&
         current.checkoutRunId &&
         current.checkoutRunId !== normalizedCheckoutRunId
       ) {
         const adopted = await adoptStaleCheckoutRun({
-          issueId: id,
-          actorAgentId: agentId,
+          issueId: normalizedIssueId,
+          actorAgentId: normalizedAgentId,
           actorRunId: normalizedCheckoutRunId,
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (adopted) {
-          const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
+          const row = await db.select().from(issues).where(eq(issues.id, normalizedIssueId)).then((rows) => rows[0]!);
           const [enriched] = await withIssueLabels(db, [row]);
           return enriched;
         }
@@ -1253,11 +1259,11 @@ export function issueService(db: Db) {
 
       // If this run already owns it and it's in_progress, return it (no self-409)
       if (
-        current.assigneeAgentId === agentId &&
+        current.assigneeAgentId === normalizedAgentId &&
         current.status === "in_progress" &&
         sameRunLock(current.checkoutRunId, normalizedCheckoutRunId)
       ) {
-        const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
+        const row = await db.select().from(issues).where(eq(issues.id, normalizedIssueId)).then((rows) => rows[0]!);
         const [enriched] = await withIssueLabels(db, [row]);
         return enriched;
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1452,12 +1452,18 @@ export function issueService(db: Db) {
     createLabel: async (companyId: string, data: Pick<typeof labels.$inferInsert, "name" | "color">) => {
       const normalizedCompanyId = asCanonicalUuid(companyId);
       if (!normalizedCompanyId) throw unprocessable("Invalid companyId");
+      if (typeof data?.name !== "string" || data.name.trim().length === 0) {
+        throw unprocessable("Invalid label name");
+      }
+      if (typeof data?.color !== "string" || data.color.trim().length === 0) {
+        throw unprocessable("Invalid label color");
+      }
       const [created] = await db
         .insert(labels)
         .values({
           companyId: normalizedCompanyId,
           name: data.name.trim(),
-          color: data.color,
+          color: data.color.trim(),
         })
         .returning();
       return created;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -788,6 +788,12 @@ export function issueService(db: Db) {
       if (!normalizedIssueId) throw notFound("Issue not found");
       if (typeof userId !== "string" || userId.trim().length === 0) throw unprocessable("Invalid userId");
       if (!(readAt instanceof Date) || Number.isNaN(readAt.getTime())) throw unprocessable("Invalid readAt");
+      const issue = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(and(eq(issues.id, normalizedIssueId), eq(issues.companyId, normalizedCompanyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!issue) throw notFound("Issue not found");
       const normalizedUserId = userId.trim();
       const now = new Date();
       const [row] = await db

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -738,6 +738,7 @@ export function issueService(db: Db) {
     },
 
     markRead: async (companyId: string, issueId: string, userId: string, readAt: Date = new Date()) => {
+      if (!isUuidLike(issueId)) throw notFound("Issue not found");
       const now = new Date();
       const [row] = await db
         .insert(issueReadStates)
@@ -1421,6 +1422,7 @@ export function issueService(db: Db) {
     },
 
     addComment: async (issueId: string, body: string, actor: { agentId?: string; userId?: string }) => {
+      if (!isUuidLike(issueId)) throw notFound("Issue not found");
       const issue = await db
         .select({ companyId: issues.companyId })
         .from(issues)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -809,6 +809,7 @@ export function issueService(db: Db) {
       companyId: string,
       data: Omit<typeof issues.$inferInsert, "companyId"> & { labelIds?: string[] },
     ) => {
+      if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
       const { labelIds: inputLabelIds, ...issueData } = data;
       assertOptionalUuidField(issueData.projectId, "projectId");
       assertOptionalUuidField(issueData.parentId, "parentId");

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -587,6 +587,13 @@ export function issueService(db: Db) {
       const labelIdFilter = asNonEmptyString(filters?.labelId);
       const originKindFilter = asNonEmptyString(filters?.originKind);
       const originIdFilter = asNonEmptyString(filters?.originId);
+      const includeRoutineExecutionsRaw = filters?.includeRoutineExecutions as unknown;
+      const includeRoutineExecutions =
+        includeRoutineExecutionsRaw === true ||
+        includeRoutineExecutionsRaw === 1 ||
+        (typeof includeRoutineExecutionsRaw === "string" &&
+          (includeRoutineExecutionsRaw.trim().toLowerCase() === "true" ||
+            includeRoutineExecutionsRaw.trim().toLowerCase() === "1"));
       const rawSearch = asNonEmptyString(filters?.q) ?? "";
       if (assigneeAgentIdFilter && !isUuidLike(assigneeAgentIdFilter)) return [];
       if (participantAgentIdFilter && !isUuidLike(participantAgentIdFilter)) return [];
@@ -656,7 +663,7 @@ export function issueService(db: Db) {
           )!,
         );
       }
-      if (!filters?.includeRoutineExecutions && !filters?.originKind && !filters?.originId) {
+      if (!includeRoutineExecutions && !originKindFilter && !originIdFilter) {
         conditions.push(ne(issues.originKind, "routine_execution"));
       }
       conditions.push(isNull(issues.hiddenAt));

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -76,6 +76,12 @@ export interface IssueFilters {
   q?: string;
 }
 
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 type IssueRow = typeof issues.$inferSelect;
 type IssueLabelRow = typeof labels.$inferSelect;
 type IssueActiveRunRow = {
@@ -554,11 +560,22 @@ export function issueService(db: Db) {
 
   return {
     list: async (companyId: string, filters?: IssueFilters) => {
+      const statusFilter = asNonEmptyString(filters?.status);
+      const assigneeAgentIdFilter = asNonEmptyString(filters?.assigneeAgentId);
+      const participantAgentIdFilter = asNonEmptyString(filters?.participantAgentId);
+      const assigneeUserIdFilter = asNonEmptyString(filters?.assigneeUserId);
+      const touchedByUserIdFilter = asNonEmptyString(filters?.touchedByUserId);
+      const unreadForUserIdFilter = asNonEmptyString(filters?.unreadForUserId);
+      const projectIdFilter = asNonEmptyString(filters?.projectId);
+      const parentIdFilter = asNonEmptyString(filters?.parentId);
+      const labelIdFilter = asNonEmptyString(filters?.labelId);
+      const originKindFilter = asNonEmptyString(filters?.originKind);
+      const originIdFilter = asNonEmptyString(filters?.originId);
+      const rawSearch = asNonEmptyString(filters?.q) ?? "";
       const conditions = [eq(issues.companyId, companyId)];
-      const touchedByUserId = filters?.touchedByUserId?.trim() || undefined;
-      const unreadForUserId = filters?.unreadForUserId?.trim() || undefined;
+      const touchedByUserId = touchedByUserIdFilter;
+      const unreadForUserId = unreadForUserIdFilter;
       const contextUserId = unreadForUserId ?? touchedByUserId;
-      const rawSearch = filters?.q?.trim() ?? "";
       const hasSearch = rawSearch.length > 0;
       const escapedSearch = hasSearch ? escapeLikePattern(rawSearch) : "";
       const startsWithPattern = `${escapedSearch}%`;
@@ -577,18 +594,18 @@ export function issueService(db: Db) {
             AND ${issueComments.body} ILIKE ${containsPattern} ESCAPE '\\'
         )
       `;
-      if (filters?.status) {
-        const statuses = filters.status.split(",").map((s) => s.trim());
+      if (statusFilter) {
+        const statuses = statusFilter.split(",").map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) {
-        conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+      if (assigneeAgentIdFilter) {
+        conditions.push(eq(issues.assigneeAgentId, assigneeAgentIdFilter));
       }
-      if (filters?.participantAgentId) {
-        conditions.push(participatedByAgentCondition(companyId, filters.participantAgentId));
+      if (participantAgentIdFilter) {
+        conditions.push(participatedByAgentCondition(companyId, participantAgentIdFilter));
       }
-      if (filters?.assigneeUserId) {
-        conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));
+      if (assigneeUserIdFilter) {
+        conditions.push(eq(issues.assigneeUserId, assigneeUserIdFilter));
       }
       if (touchedByUserId) {
         conditions.push(touchedByUserCondition(companyId, touchedByUserId));
@@ -596,15 +613,15 @@ export function issueService(db: Db) {
       if (unreadForUserId) {
         conditions.push(unreadForUserCondition(companyId, unreadForUserId));
       }
-      if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
-      if (filters?.parentId) conditions.push(eq(issues.parentId, filters.parentId));
-      if (filters?.originKind) conditions.push(eq(issues.originKind, filters.originKind));
-      if (filters?.originId) conditions.push(eq(issues.originId, filters.originId));
-      if (filters?.labelId) {
+      if (projectIdFilter) conditions.push(eq(issues.projectId, projectIdFilter));
+      if (parentIdFilter) conditions.push(eq(issues.parentId, parentIdFilter));
+      if (originKindFilter) conditions.push(eq(issues.originKind, originKindFilter));
+      if (originIdFilter) conditions.push(eq(issues.originId, originIdFilter));
+      if (labelIdFilter) {
         const labeledIssueIds = await db
           .select({ issueId: issueLabels.issueId })
           .from(issueLabels)
-          .where(and(eq(issueLabels.companyId, companyId), eq(issueLabels.labelId, filters.labelId)));
+          .where(and(eq(issueLabels.companyId, companyId), eq(issueLabels.labelId, labelIdFilter)));
         if (labeledIssueIds.length === 0) return [];
         conditions.push(inArray(issues.id, labeledIssueIds.map((row) => row.issueId)));
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1320,6 +1320,7 @@ export function issueService(db: Db) {
       },
     ) => {
       const order = opts?.order === "asc" ? "asc" : "desc";
+      if (!isUuidLike(issueId)) return [];
       const afterCommentId = opts?.afterCommentId?.trim() || null;
       const limit =
         opts?.limit && opts.limit > 0
@@ -1394,16 +1395,18 @@ export function issueService(db: Db) {
       };
     },
 
-    getComment: (commentId: string) =>
-      instanceSettings.getGeneral().then(({ censorUsernameInLogs }) =>
+    getComment: (commentId: string) => {
+      if (!isUuidLike(commentId)) return Promise.resolve(null);
+      return instanceSettings.getGeneral().then(({ censorUsernameInLogs }) =>
         db
-        .select()
-        .from(issueComments)
-        .where(eq(issueComments.id, commentId))
-        .then((rows) => {
-          const comment = rows[0] ?? null;
-          return comment ? redactIssueComment(comment, censorUsernameInLogs) : null;
-        })),
+          .select()
+          .from(issueComments)
+          .where(eq(issueComments.id, commentId))
+          .then((rows) => {
+            const comment = rows[0] ?? null;
+            return comment ? redactIssueComment(comment, censorUsernameInLogs) : null;
+          }));
+    },
 
     addComment: async (issueId: string, body: string, actor: { agentId?: string; userId?: string }) => {
       const issue = await db

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -750,9 +750,9 @@ export function issueService(db: Db) {
         unreadForUserCondition(companyId, userId),
         ne(issues.originKind, "routine_execution"),
       ];
-      const normalizedStatus = asNonEmptyString(status);
+      const normalizedStatus = asNonEmptyString(status)?.toLowerCase();
       if (normalizedStatus) {
-        const statuses = normalizedStatus.split(",").map((s) => s.trim()).filter(Boolean);
+        const statuses = normalizedStatus.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
         if (statuses.length === 1) {
           conditions.push(eq(issues.status, statuses[0]));
         } else if (statuses.length > 1) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1732,6 +1732,8 @@ export function issueService(db: Db) {
         }
       }
       if (mentionedIds.size === 0) return [];
+      const candidateProjectIds = [...mentionedIds].filter((projectId) => isUuidLike(projectId));
+      if (candidateProjectIds.length === 0) return [];
 
       const rows = await db
         .select({ id: projects.id })
@@ -1739,11 +1741,11 @@ export function issueService(db: Db) {
         .where(
           and(
             eq(projects.companyId, issue.companyId),
-            inArray(projects.id, [...mentionedIds]),
+            inArray(projects.id, candidateProjectIds),
           ),
         );
       const valid = new Set(rows.map((row) => row.id));
-      return [...mentionedIds].filter((projectId) => valid.has(projectId));
+      return candidateProjectIds.filter((projectId) => valid.has(projectId));
     },
 
     getAncestors: async (issueId: string) => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -82,6 +82,11 @@ function asNonEmptyString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function asCanonicalUuid(value: unknown): string | undefined {
+  if (typeof value !== "string" || !isUuidLike(value)) return undefined;
+  return value.trim().toLowerCase();
+}
+
 function assertOptionalUuidField(value: unknown, fieldName: string) {
   if (value == null) return;
   if (typeof value !== "string" || !isUuidLike(value.trim())) {
@@ -577,7 +582,8 @@ export function issueService(db: Db) {
 
   return {
     list: async (companyId: string, filters?: IssueFilters) => {
-      if (!isUuidLike(companyId)) return [];
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) return [];
       const statusFilter = asNonEmptyString(filters?.status)?.toLowerCase();
       const assigneeAgentIdFilter = asNonEmptyString(filters?.assigneeAgentId);
       const participantAgentIdFilter = asNonEmptyString(filters?.participantAgentId);
@@ -606,7 +612,7 @@ export function issueService(db: Db) {
       if (projectIdFilter && !isUuidLike(projectIdFilter)) return [];
       if (parentIdFilter && !isUuidLike(parentIdFilter)) return [];
       if (labelIdFilter && !isUuidLike(labelIdFilter)) return [];
-      const conditions = [eq(issues.companyId, companyId)];
+      const conditions = [eq(issues.companyId, normalizedCompanyId)];
       const touchedByUserId = touchedByUserIdFilter;
       const unreadForUserId = unreadForUserIdFilter;
       const contextUserId = unreadForUserId ?? touchedByUserId;
@@ -624,7 +630,7 @@ export function issueService(db: Db) {
           SELECT 1
           FROM ${issueComments}
           WHERE ${issueComments.issueId} = ${issues.id}
-            AND ${issueComments.companyId} = ${companyId}
+            AND ${issueComments.companyId} = ${normalizedCompanyId}
             AND ${issueComments.body} ILIKE ${containsPattern} ESCAPE '\\'
         )
       `;
@@ -636,16 +642,16 @@ export function issueService(db: Db) {
         conditions.push(eq(issues.assigneeAgentId, assigneeAgentIdFilter));
       }
       if (participantAgentIdFilter) {
-        conditions.push(participatedByAgentCondition(companyId, participantAgentIdFilter));
+        conditions.push(participatedByAgentCondition(normalizedCompanyId, participantAgentIdFilter));
       }
       if (assigneeUserIdFilter) {
         conditions.push(eq(issues.assigneeUserId, assigneeUserIdFilter));
       }
       if (touchedByUserId) {
-        conditions.push(touchedByUserCondition(companyId, touchedByUserId));
+        conditions.push(touchedByUserCondition(normalizedCompanyId, touchedByUserId));
       }
       if (unreadForUserId) {
-        conditions.push(unreadForUserCondition(companyId, unreadForUserId));
+        conditions.push(unreadForUserCondition(normalizedCompanyId, unreadForUserId));
       }
       if (projectIdFilter) conditions.push(eq(issues.projectId, projectIdFilter));
       if (parentIdFilter) conditions.push(eq(issues.parentId, parentIdFilter));
@@ -655,7 +661,7 @@ export function issueService(db: Db) {
         const labeledIssueIds = await db
           .select({ issueId: issueLabels.issueId })
           .from(issueLabels)
-          .where(and(eq(issueLabels.companyId, companyId), eq(issueLabels.labelId, labelIdFilter)));
+          .where(and(eq(issueLabels.companyId, normalizedCompanyId), eq(issueLabels.labelId, labelIdFilter)));
         if (labeledIssueIds.length === 0) return [];
         conditions.push(inArray(issues.id, labeledIssueIds.map((row) => row.issueId)));
       }
@@ -717,7 +723,7 @@ export function issueService(db: Db) {
         .from(issueComments)
         .where(
           and(
-            eq(issueComments.companyId, companyId),
+            eq(issueComments.companyId, normalizedCompanyId),
             inArray(issueComments.issueId, issueIds),
           ),
         )
@@ -730,7 +736,7 @@ export function issueService(db: Db) {
         .from(issueReadStates)
         .where(
           and(
-            eq(issueReadStates.companyId, companyId),
+            eq(issueReadStates.companyId, normalizedCompanyId),
             eq(issueReadStates.userId, contextUserId),
             inArray(issueReadStates.issueId, issueIds),
           ),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -420,7 +420,9 @@ export function issueService(db: Db) {
   }
 
   async function assertAssignableAgent(companyId: string, agentId: string) {
-    if (!isUuidLike(agentId)) throw unprocessable("Invalid assigneeAgentId");
+    const normalizedAgentId = asCanonicalUuid(agentId);
+    if (!normalizedAgentId) throw unprocessable("Invalid assigneeAgentId");
+    const normalizedCompanyId = asCanonicalUuid(companyId) ?? companyId;
     const assignee = await db
       .select({
         id: agents.id,
@@ -428,11 +430,11 @@ export function issueService(db: Db) {
         status: agents.status,
       })
       .from(agents)
-      .where(eq(agents.id, agentId))
+      .where(eq(agents.id, normalizedAgentId))
       .then((rows) => rows[0] ?? null);
 
     if (!assignee) throw notFound("Assignee agent not found");
-    if (assignee.companyId !== companyId) {
+    if (assignee.companyId !== normalizedCompanyId) {
       throw unprocessable("Assignee must belong to same company");
     }
     if (assignee.status === "pending_approval") {
@@ -462,8 +464,11 @@ export function issueService(db: Db) {
   }
 
   async function assertValidProjectWorkspace(companyId: string, projectId: string | null | undefined, projectWorkspaceId: string) {
-    if (!isUuidLike(projectWorkspaceId)) throw unprocessable("Invalid projectWorkspaceId");
-    if (projectId && !isUuidLike(projectId)) throw unprocessable("Invalid projectId");
+    const normalizedProjectWorkspaceId = asCanonicalUuid(projectWorkspaceId);
+    if (!normalizedProjectWorkspaceId) throw unprocessable("Invalid projectWorkspaceId");
+    const normalizedProjectId = projectId == null ? null : asCanonicalUuid(projectId);
+    if (projectId && !normalizedProjectId) throw unprocessable("Invalid projectId");
+    const normalizedCompanyId = asCanonicalUuid(companyId) ?? companyId;
     const workspace = await db
       .select({
         id: projectWorkspaces.id,
@@ -471,18 +476,21 @@ export function issueService(db: Db) {
         projectId: projectWorkspaces.projectId,
       })
       .from(projectWorkspaces)
-      .where(eq(projectWorkspaces.id, projectWorkspaceId))
+      .where(eq(projectWorkspaces.id, normalizedProjectWorkspaceId))
       .then((rows) => rows[0] ?? null);
     if (!workspace) throw notFound("Project workspace not found");
-    if (workspace.companyId !== companyId) throw unprocessable("Project workspace must belong to same company");
-    if (projectId && workspace.projectId !== projectId) {
+    if (workspace.companyId !== normalizedCompanyId) throw unprocessable("Project workspace must belong to same company");
+    if (normalizedProjectId && workspace.projectId !== normalizedProjectId) {
       throw unprocessable("Project workspace must belong to the selected project");
     }
   }
 
   async function assertValidExecutionWorkspace(companyId: string, projectId: string | null | undefined, executionWorkspaceId: string) {
-    if (!isUuidLike(executionWorkspaceId)) throw unprocessable("Invalid executionWorkspaceId");
-    if (projectId && !isUuidLike(projectId)) throw unprocessable("Invalid projectId");
+    const normalizedExecutionWorkspaceId = asCanonicalUuid(executionWorkspaceId);
+    if (!normalizedExecutionWorkspaceId) throw unprocessable("Invalid executionWorkspaceId");
+    const normalizedProjectId = projectId == null ? null : asCanonicalUuid(projectId);
+    if (projectId && !normalizedProjectId) throw unprocessable("Invalid projectId");
+    const normalizedCompanyId = asCanonicalUuid(companyId) ?? companyId;
     const workspace = await db
       .select({
         id: executionWorkspaces.id,
@@ -490,27 +498,31 @@ export function issueService(db: Db) {
         projectId: executionWorkspaces.projectId,
       })
       .from(executionWorkspaces)
-      .where(eq(executionWorkspaces.id, executionWorkspaceId))
+      .where(eq(executionWorkspaces.id, normalizedExecutionWorkspaceId))
       .then((rows) => rows[0] ?? null);
     if (!workspace) throw notFound("Execution workspace not found");
-    if (workspace.companyId !== companyId) throw unprocessable("Execution workspace must belong to same company");
-    if (projectId && workspace.projectId !== projectId) {
+    if (workspace.companyId !== normalizedCompanyId) throw unprocessable("Execution workspace must belong to same company");
+    if (normalizedProjectId && workspace.projectId !== normalizedProjectId) {
       throw unprocessable("Execution workspace must belong to the selected project");
     }
   }
 
   async function assertValidLabelIds(companyId: string, labelIds: string[], dbOrTx: any = db) {
     if (labelIds.length === 0) return;
-    if (labelIds.some((id) => !isUuidLike(id))) {
+    const normalizedCompanyId = asCanonicalUuid(companyId) ?? companyId;
+    const normalizedLabelIds = labelIds.map((id) => asCanonicalUuid(id));
+    if (normalizedLabelIds.some((id) => !id)) {
       throw unprocessable("One or more labels must be valid UUIDs");
     }
+    const canonicalLabelIds = normalizedLabelIds.filter((id): id is string => id != null);
     const existing = await dbOrTx
       .select({ id: labels.id })
       .from(labels)
-      .where(and(eq(labels.companyId, companyId), inArray(labels.id, labelIds)));
-    if (existing.length !== new Set(labelIds).size) {
+      .where(and(eq(labels.companyId, normalizedCompanyId), inArray(labels.id, canonicalLabelIds)));
+    if (existing.length !== new Set(canonicalLabelIds).size) {
       throw unprocessable("One or more labels are invalid for this company");
     }
+    return canonicalLabelIds;
   }
 
   async function syncIssueLabels(
@@ -520,11 +532,11 @@ export function issueService(db: Db) {
     dbOrTx: any = db,
   ) {
     const deduped = [...new Set(labelIds)];
-    await assertValidLabelIds(companyId, deduped, dbOrTx);
+    const normalizedLabelIds = await assertValidLabelIds(companyId, deduped, dbOrTx);
     await dbOrTx.delete(issueLabels).where(eq(issueLabels.issueId, issueId));
-    if (deduped.length === 0) return;
+    if (!normalizedLabelIds || normalizedLabelIds.length === 0) return;
     await dbOrTx.insert(issueLabels).values(
-      deduped.map((labelId) => ({
+      normalizedLabelIds.map((labelId) => ({
         issueId,
         labelId,
         companyId,
@@ -851,7 +863,8 @@ export function issueService(db: Db) {
       companyId: string,
       data: Omit<typeof issues.$inferInsert, "companyId"> & { labelIds?: string[] },
     ) => {
-      if (!isUuidLike(companyId)) throw unprocessable("Invalid companyId");
+      const normalizedCompanyId = asCanonicalUuid(companyId);
+      if (!normalizedCompanyId) throw unprocessable("Invalid companyId");
       const { labelIds: inputLabelIds, ...issueData } = data;
       assertOptionalUuidField(issueData.projectId, "projectId");
       assertOptionalUuidField(issueData.parentId, "parentId");
@@ -859,40 +872,46 @@ export function issueService(db: Db) {
       assertOptionalUuidField(issueData.assigneeAgentId, "assigneeAgentId");
       assertOptionalUuidField(issueData.projectWorkspaceId, "projectWorkspaceId");
       assertOptionalUuidField(issueData.executionWorkspaceId, "executionWorkspaceId");
+      if (issueData.projectId) issueData.projectId = issueData.projectId.trim().toLowerCase();
+      if (issueData.parentId) issueData.parentId = issueData.parentId.trim().toLowerCase();
+      if (issueData.goalId) issueData.goalId = issueData.goalId.trim().toLowerCase();
+      if (issueData.assigneeAgentId) issueData.assigneeAgentId = issueData.assigneeAgentId.trim().toLowerCase();
+      if (issueData.projectWorkspaceId) issueData.projectWorkspaceId = issueData.projectWorkspaceId.trim().toLowerCase();
+      if (issueData.executionWorkspaceId) issueData.executionWorkspaceId = issueData.executionWorkspaceId.trim().toLowerCase();
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
         delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }
-      if (data.assigneeAgentId && data.assigneeUserId) {
+      if (issueData.assigneeAgentId && issueData.assigneeUserId) {
         throw unprocessable("Issue can only have one assignee");
       }
-      if (data.assigneeAgentId) {
-        await assertAssignableAgent(companyId, data.assigneeAgentId);
+      if (issueData.assigneeAgentId) {
+        await assertAssignableAgent(normalizedCompanyId, issueData.assigneeAgentId);
       }
-      if (data.assigneeUserId) {
-        await assertAssignableUser(companyId, data.assigneeUserId);
+      if (issueData.assigneeUserId) {
+        await assertAssignableUser(normalizedCompanyId, issueData.assigneeUserId);
       }
-      if (data.projectWorkspaceId) {
-        await assertValidProjectWorkspace(companyId, data.projectId, data.projectWorkspaceId);
+      if (issueData.projectWorkspaceId) {
+        await assertValidProjectWorkspace(normalizedCompanyId, issueData.projectId, issueData.projectWorkspaceId);
       }
-      if (data.executionWorkspaceId) {
-        await assertValidExecutionWorkspace(companyId, data.projectId, data.executionWorkspaceId);
+      if (issueData.executionWorkspaceId) {
+        await assertValidExecutionWorkspace(normalizedCompanyId, issueData.projectId, issueData.executionWorkspaceId);
       }
-      if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
+      if (issueData.status === "in_progress" && !issueData.assigneeAgentId && !issueData.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
       return db.transaction(async (tx) => {
-        const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
-        const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
+        const defaultCompanyGoal = await getDefaultCompanyGoal(tx, normalizedCompanyId);
+        const projectGoalId = await getProjectDefaultGoalId(tx, normalizedCompanyId, issueData.projectId);
         let executionWorkspaceSettings =
           (issueData.executionWorkspaceSettings as Record<string, unknown> | null | undefined) ?? null;
         if (executionWorkspaceSettings == null && issueData.projectId) {
           const project = await tx
             .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
             .from(projects)
-            .where(and(eq(projects.id, issueData.projectId), eq(projects.companyId, companyId)))
+            .where(and(eq(projects.id, issueData.projectId), eq(projects.companyId, normalizedCompanyId)))
             .then((rows) => rows[0] ?? null);
           executionWorkspaceSettings =
             defaultIssueExecutionWorkspaceSettingsForProject(
@@ -909,7 +928,7 @@ export function issueService(db: Db) {
               executionWorkspacePolicy: projects.executionWorkspacePolicy,
             })
             .from(projects)
-            .where(and(eq(projects.id, issueData.projectId), eq(projects.companyId, companyId)))
+            .where(and(eq(projects.id, issueData.projectId), eq(projects.companyId, normalizedCompanyId)))
             .then((rows) => rows[0] ?? null);
           const projectPolicy = parseProjectExecutionWorkspacePolicy(project?.executionWorkspacePolicy);
           projectWorkspaceId = projectPolicy?.defaultProjectWorkspaceId ?? null;
@@ -917,7 +936,10 @@ export function issueService(db: Db) {
             projectWorkspaceId = await tx
               .select({ id: projectWorkspaces.id })
               .from(projectWorkspaces)
-              .where(and(eq(projectWorkspaces.projectId, issueData.projectId), eq(projectWorkspaces.companyId, companyId)))
+              .where(and(
+                eq(projectWorkspaces.projectId, issueData.projectId),
+                eq(projectWorkspaces.companyId, normalizedCompanyId),
+              ))
               .orderBy(desc(projectWorkspaces.isPrimary), asc(projectWorkspaces.createdAt), asc(projectWorkspaces.id))
               .then((rows) => rows[0]?.id ?? null);
           }
@@ -925,7 +947,7 @@ export function issueService(db: Db) {
         const [company] = await tx
           .update(companies)
           .set({ issueCounter: sql`${companies.issueCounter} + 1` })
-          .where(eq(companies.id, companyId))
+          .where(eq(companies.id, normalizedCompanyId))
           .returning({ issueCounter: companies.issueCounter, issuePrefix: companies.issuePrefix });
         if (!company) throw notFound("Company not found");
 
@@ -943,7 +965,7 @@ export function issueService(db: Db) {
           }),
           ...(projectWorkspaceId ? { projectWorkspaceId } : {}),
           ...(executionWorkspaceSettings ? { executionWorkspaceSettings } : {}),
-          companyId,
+          companyId: normalizedCompanyId,
           issueNumber,
           identifier,
         } as typeof issues.$inferInsert;
@@ -959,7 +981,7 @@ export function issueService(db: Db) {
 
         const [issue] = await tx.insert(issues).values(values).returning();
         if (inputLabelIds) {
-          await syncIssueLabels(issue.id, companyId, inputLabelIds, tx);
+          await syncIssueLabels(issue.id, normalizedCompanyId, inputLabelIds, tx);
         }
         const [enriched] = await withIssueLabels(tx, [issue]);
         return enriched;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1608,6 +1608,20 @@ export function issueService(db: Db) {
       if (input.createdByUserId != null && typeof input.createdByUserId !== "string") {
         throw unprocessable("Invalid createdByUserId");
       }
+      const normalizedProvider = asNonEmptyString(input.provider);
+      if (!normalizedProvider) throw unprocessable("Invalid provider");
+      const normalizedObjectKey = asNonEmptyString(input.objectKey);
+      if (!normalizedObjectKey) throw unprocessable("Invalid objectKey");
+      const normalizedContentType = asNonEmptyString(input.contentType);
+      if (!normalizedContentType) throw unprocessable("Invalid contentType");
+      if (typeof input.byteSize !== "number" || !Number.isFinite(input.byteSize) || input.byteSize < 0) {
+        throw unprocessable("Invalid byteSize");
+      }
+      const normalizedSha256 = asNonEmptyString(input.sha256);
+      if (!normalizedSha256) throw unprocessable("Invalid sha256");
+      if (input.originalFilename != null && typeof input.originalFilename !== "string") {
+        throw unprocessable("Invalid originalFilename");
+      }
 
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
@@ -1633,11 +1647,11 @@ export function issueService(db: Db) {
           .insert(assets)
           .values({
             companyId: issue.companyId,
-            provider: input.provider,
-            objectKey: input.objectKey,
-            contentType: input.contentType,
+            provider: normalizedProvider,
+            objectKey: normalizedObjectKey,
+            contentType: normalizedContentType,
             byteSize: input.byteSize,
-            sha256: input.sha256,
+            sha256: normalizedSha256,
             originalFilename: input.originalFilename ?? null,
             createdByAgentId: normalizedCreatedByAgentId,
             createdByUserId: input.createdByUserId ?? null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1605,6 +1605,9 @@ export function issueService(db: Db) {
       if (input.createdByAgentId != null && !normalizedCreatedByAgentId) {
         throw unprocessable("Invalid createdByAgentId");
       }
+      if (input.createdByUserId != null && typeof input.createdByUserId !== "string") {
+        throw unprocessable("Invalid createdByUserId");
+      }
 
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1400,10 +1400,16 @@ export function issueService(db: Db) {
       const order = orderRaw === "asc" ? "asc" : "desc";
       if (!isUuidLike(issueId)) return [];
       const afterCommentId = asNonEmptyString(opts?.afterCommentId) ?? null;
-      const rawLimit = opts?.limit;
+      const rawLimit = opts?.limit as unknown;
+      const parsedLimit =
+        typeof rawLimit === "number"
+          ? rawLimit
+          : typeof rawLimit === "string" && rawLimit.trim().length > 0
+            ? Number(rawLimit.trim())
+            : null;
       const limit =
-        typeof rawLimit === "number" && Number.isFinite(rawLimit) && rawLimit > 0
-          ? Math.min(Math.floor(rawLimit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
+        typeof parsedLimit === "number" && Number.isFinite(parsedLimit) && parsedLimit > 0
+          ? Math.min(Math.floor(parsedLimit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
           : null;
       if (afterCommentId && !isUuidLike(afterCommentId)) return [];
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1403,6 +1403,10 @@ export function issueService(db: Db) {
       const afterCommentIdRaw = asNonEmptyString(opts?.afterCommentId) ?? null;
       const afterCommentId = afterCommentIdRaw ? afterCommentIdRaw.toLowerCase() : null;
       const rawLimit = opts?.limit as unknown;
+      const hasExplicitLimit =
+        rawLimit !== undefined &&
+        rawLimit !== null &&
+        !(typeof rawLimit === "string" && rawLimit.trim().length === 0);
       const parsedLimit =
         typeof rawLimit === "number"
           ? rawLimit
@@ -1412,7 +1416,9 @@ export function issueService(db: Db) {
       const limit =
         typeof parsedLimit === "number" && Number.isFinite(parsedLimit) && parsedLimit > 0
           ? Math.min(Math.floor(parsedLimit), MAX_ISSUE_COMMENT_PAGE_LIMIT)
-          : null;
+          : hasExplicitLimit
+            ? MAX_ISSUE_COMMENT_PAGE_LIMIT
+            : null;
       if (afterCommentId && !isUuidLike(afterCommentId)) return [];
 
       const conditions = [eq(issueComments.issueId, issueId)];

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -11,6 +11,7 @@ import type {
   PluginWorkspace,
   IssueComment,
 } from "@paperclipai/plugin-sdk";
+import { isUuidLike } from "@paperclipai/shared";
 import { companyService } from "./companies.js";
 import { agentService } from "./agents.js";
 import { projectService } from "./projects.js";
@@ -464,6 +465,7 @@ export function buildHostServices(
 
   const ensureCompanyId = (companyId?: string) => {
     if (!companyId) throw new Error("companyId is required for this operation");
+    if (!isUuidLike(companyId)) throw new Error("Invalid companyId");
     return companyId;
   };
 

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1102,7 +1102,8 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
     },
 
     listRuns: async (routineId: string, limit = 50): Promise<RoutineRunSummary[]> => {
-      const cappedLimit = Math.max(1, Math.min(limit, 200));
+      const normalizedLimit = Number.isFinite(limit) ? Math.floor(limit) : 50;
+      const cappedLimit = Math.max(1, Math.min(normalizedLimit, 200));
       const rows = await db
         .select({
           id: routineRuns.id,


### PR DESCRIPTION
## Summary
- recover same-assignee checkout when an in-progress issue has a stale execution run lock and no checkout lock
- treat a terminal/missing execution run as adoptable and rebind checkout/execution lock to the active actor run
- add regression coverage to prevent reintroducing release-lead checkout conflicts

## Trading-program impact
Prevents release-lead remediation tasks from getting stuck behind stale execution locks, reducing overnight ownership churn and checkout friction.

## Validation
- pnpm test:run server/src/__tests__/issues-service.test.ts
- pnpm -r typecheck
- pnpm test:run
- pnpm build
