### PR TITLE
fix(skills): correct file inventory paths when SKILL.md is at root

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -956,9 +956,17 @@ async function readLocalSkillImports(companyId: string, sourcePath: string): Pro
   for (const skillPath of skillPaths) {
     const skillDir = path.posix.dirname(skillPath);
     const inventory = allFiles
-      .filter((entry) => entry === skillPath || entry.startsWith(`${skillDir}/`))
+      .filter((entry) => {
+        if (entry === skillPath) return true;
+        if (skillDir === "." || skillDir === "") return true; // SKILL.md at root, include all files
+        return entry.startsWith(`${skillDir}/`);
+      })
       .map((entry) => {
-        const relative = entry === skillPath ? "SKILL.md" : entry.slice(skillDir.length + 1);
+        const relative = entry === skillPath
+          ? "SKILL.md"
+          : (skillDir === "." || skillDir === "")
+            ? entry // SKILL.md at root, use path as-is
+            : entry.slice(skillDir.length + 1);
         return {
           path: normalizePortablePath(relative),
           kind: classifyInventoryKind(relative),


### PR DESCRIPTION
## Summary

Fixes file inventory path calculation when importing skills where SKILL.md is located at the directory root level.

## Problem

When importing a skill from a directory where SKILL.md is at the root level:

1. **Filter issue**: `path.posix.dirname('SKILL.md')` returns `'.'`, making the filter condition `entry.startsWith('./')`. But `walkLocalFiles` returns paths like `references/file.md` (without `./` prefix), so all non-SKILL.md files were incorrectly filtered out.

2. **Path truncation issue**: `entry.slice(skillDir.length + 1)` with `skillDir='.'` sliced off the first 2 characters, turning:
   - `references/xxx` → `ferences/xxx`
   - `scripts/xxx` → `ripts/xxx`

## Solution

Updated both the `.filter()` and `.map()` logic in `readLocalSkillImports` to explicitly handle when `skillDir` is `'.'` or empty string:

- **Filter**: When skill is at root, include all files
- **Map**: When skill is at root, use the entry path as-is without slicing

## Testing

- Type check passes
- Unit tests pass

## Related

Fixes skill import issue where only SKILL.md was included in file inventory when skill files were at the root directory level.