### PR TITLE
fix(issues): prevent race condition in issue identifier generation

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -34,6 +34,47 @@ import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallbac
 import { getDefaultCompanyGoal } from "./goals.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+
+const MAX_RETRIES = 5;
+const INITIAL_RETRY_DELAY_MS = 10;
+
+type TransactionContext = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+async function withSerializableTransaction<T>(
+  db: Db,
+  callback: (tx: TransactionContext) => Promise<T>,
+): Promise<T> {
+  let attempt = 0;
+  let delay = INITIAL_RETRY_DELAY_MS;
+
+  while (attempt < MAX_RETRIES) {
+    try {
+      return await db.transaction(async (tx) => {
+        return await callback(tx);
+      });
+    } catch (error) {
+      // Check for deadlock (40P01) or unique violation (23505)
+      // Note: With FOR UPDATE locking, we shouldn't get 23505, but keep it as safety net
+      const pgError = error as { code?: string };
+      console.error(`[ISSUE CREATE RETRY] attempt=${attempt}, code=${pgError.code}, error=${(error as Error).message}`);
+      if (pgError.code === "40P01" || pgError.code === "23505") {
+        attempt++;
+        if (attempt >= MAX_RETRIES) {
+          console.error(`[ISSUE CREATE RETRY] Max retries reached, throwing error`);
+          throw error;
+        }
+        // Exponential backoff with jitter
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay = Math.min(delay * 2, 1000) + Math.random() * 10;
+        console.error(`[ISSUE CREATE RETRY] Retrying after ${delay}ms...`);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error("Transaction failed after max retries");
+}
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 
 function assertTransition(from: string, to: string) {
@@ -878,7 +919,41 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      return db.transaction(async (tx) => {
+      console.error(`[ISSUE CREATE] Calling withSerializableTransaction for company=${companyId}`);
+
+      // Pre-allocate issue number OUTSIDE the main transaction using advisory lock
+      // This ensures the counter increment survives even if the main transaction rolls back
+      const issueNumber = await db.transaction(async (tx) => {
+        // Acquire advisory lock to serialize counter increments
+        let lockHash = 0;
+        for (let i = 0; i < companyId.length; i++) {
+          const char = companyId.charCodeAt(i);
+          lockHash = ((lockHash << 5) - lockHash) + char;
+          lockHash = lockHash & lockHash;
+        }
+        const lockId = Math.abs(lockHash) % 2147483647;
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(${lockId})`);
+
+        const [company] = await tx
+          .update(companies)
+          .set({ issueCounter: sql`${companies.issueCounter} + 1` })
+          .where(eq(companies.id, companyId))
+          .returning({ issueCounter: companies.issueCounter });
+
+        return company.issueCounter;
+      });
+
+      // Now get the issue prefix in a separate query (doesn't need to be in the same transaction)
+      const companyPrefix = await db
+        .select({ issuePrefix: companies.issuePrefix })
+        .from(companies)
+        .where(eq(companies.id, companyId))
+        .then((rows) => rows[0]?.issuePrefix ?? "ISSUE");
+
+      const identifier = `${companyPrefix}-${issueNumber}`;
+      console.error(`[ISSUE CREATE] Pre-allocated identifier: ${identifier}`);
+
+      return withSerializableTransaction(db, async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let executionWorkspaceSettings =
@@ -917,14 +992,6 @@ export function issueService(db: Db) {
               .then((rows) => rows[0]?.id ?? null);
           }
         }
-        const [company] = await tx
-          .update(companies)
-          .set({ issueCounter: sql`${companies.issueCounter} + 1` })
-          .where(eq(companies.id, companyId))
-          .returning({ issueCounter: companies.issueCounter, issuePrefix: companies.issuePrefix });
-
-        const issueNumber = company.issueCounter;
-        const identifier = `${company.issuePrefix}-${issueNumber}`;
 
         const values = {
           ...issueData,


### PR DESCRIPTION
## Summary
Fix duplicate key violation (23505) errors when creating issues concurrently.

## Root Cause
Multiple concurrent transactions could read the same `issueCounter` value, increment it to the same number, and generate duplicate identifiers like "AIM-22". When one transaction committed, others would fail with unique constraint violation.

The key insight: when a transaction rolls back due to 23505 error, the `UPDATE companies SET issueCounter = issueCounter + 1` is also rolled back. So retries would get the *same* counter value again.

## Solution
1. **Pre-allocate issue number** in a separate transaction with advisory lock
   - Counter increment is committed immediately, surviving main transaction rollback
   - Uses `pg_advisory_xact_lock()` for per-company serialization
2. **Generate identifier** using pre-allocated number
3. **Main transaction** uses pre-computed identifier (counter is now read-only)

## Changes
- Add `withSerializableTransaction` helper with retry logic for deadlocks
- Pre-compute `issueNumber` and `identifier` before main transaction
- Remove counter increment from main transaction

## Test Plan
- [ ] Create multiple issues concurrently via API/scripts
- [ ] Verify no "duplicate key value violates unique constraint" errors
- [ ] Verify identifiers are sequential with no gaps (e.g., AIM-1, AIM-2, AIM-3)

## Related
Fixes: duplicate key value violates unique constraint "issues_identifier_idx" (23505)