### PR TITLE
fix(server): delete finance rows before removing agent runs

### DIFF
--- a/server/src/__tests__/agent-remove-service.test.ts
+++ b/server/src/__tests__/agent-remove-service.test.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  agents,
+  companies,
+  costEvents,
+  createDb,
+  financeEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent removal tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agentService.remove", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof agentService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-remove-");
+    db = createDb(tempDb.connectionString);
+    svc = agentService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(financeEvents);
+    await db.delete(costEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("removes finance and cost rows before deleting heartbeat runs", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `P${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Motion Video Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "succeeded",
+      startedAt: new Date("2026-03-28T10:00:00.000Z"),
+      finishedAt: new Date("2026-03-28T10:01:00.000Z"),
+    });
+
+    const [costEvent] = await db
+      .insert(costEvents)
+      .values({
+        companyId,
+        agentId,
+        heartbeatRunId: runId,
+        provider: "openai",
+        biller: "openai",
+        billingType: "metered",
+        model: "gpt-5.4",
+        inputTokens: 10,
+        outputTokens: 20,
+        cachedInputTokens: 0,
+        costCents: 42,
+        occurredAt: new Date("2026-03-28T10:01:00.000Z"),
+      })
+      .returning();
+
+    await db.insert(financeEvents).values({
+      companyId,
+      agentId,
+      heartbeatRunId: runId,
+      costEventId: costEvent!.id,
+      eventKind: "usage_charge",
+      direction: "debit",
+      biller: "openai",
+      provider: "openai",
+      model: "gpt-5.4",
+      amountCents: 42,
+      occurredAt: new Date("2026-03-28T10:01:00.000Z"),
+    });
+
+    const removed = await svc.remove(agentId);
+
+    expect(removed?.id).toBe(agentId);
+    await expect(db.select().from(agents).where(eq(agents.id, agentId))).resolves.toHaveLength(0);
+    await expect(db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId))).resolves.toHaveLength(0);
+    await expect(db.select().from(costEvents).where(eq(costEvents.agentId, agentId))).resolves.toHaveLength(0);
+    await expect(db.select().from(financeEvents).where(eq(financeEvents.agentId, agentId))).resolves.toHaveLength(0);
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { and, desc, eq, gte, inArray, lt, ne, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -9,6 +9,7 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   costEvents,
+  financeEvents,
   heartbeatRunEvents,
   heartbeatRuns,
 } from "@paperclipai/db";
@@ -473,9 +474,37 @@ export function agentService(db: Db) {
       if (!existing) return null;
 
       return db.transaction(async (tx) => {
+        const runIds = await tx
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, id))
+          .then((rows) => rows.map((row) => row.id));
+
+        const costEventIds = await tx
+          .select({ id: costEvents.id })
+          .from(costEvents)
+          .where(eq(costEvents.agentId, id))
+          .then((rows) => rows.map((row) => row.id));
+
+        const financeDeleteConditions = [eq(financeEvents.agentId, id)];
+        if (runIds.length > 0) {
+          financeDeleteConditions.push(inArray(financeEvents.heartbeatRunId, runIds));
+        }
+        if (costEventIds.length > 0) {
+          financeDeleteConditions.push(inArray(financeEvents.costEventId, costEventIds));
+        }
+
         await tx.update(agents).set({ reportsTo: null }).where(eq(agents.reportsTo, id));
+        await tx
+          .delete(financeEvents)
+          .where(
+            financeDeleteConditions.length === 1
+              ? financeDeleteConditions[0]!
+              : or(...financeDeleteConditions)!,
+          );
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.agentId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.agentId, id));
+        await tx.delete(costEvents).where(eq(costEvents.agentId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.agentId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));


### PR DESCRIPTION
## Summary
- delete `finance_events` rows that still reference an agent, its `heartbeat_runs`, or its `cost_events` before removing the runs
- keep the existing `cost_events` cleanup, then delete runs safely
- add a regression test that reproduces the FK failure path through `agentService.remove`

## Why
This is a focused follow-up to #654.

#654 already improves agent deletion by clearing dependent rows and deleting `cost_events` before `heartbeat_runs`. In local testing, agent deletion could still fail when `finance_events` retained foreign-key references to the same `heartbeat_runs` or `cost_events`.

That leaves `DELETE /api/agents/:id` vulnerable to FK violations even after `cost_events` cleanup.

## What changed
- extend `agentService.remove` to gather the agent's `heartbeat_run` ids and `cost_event` ids
- delete matching `finance_events` first using any of:
  - `finance_events.agent_id = agent id`
  - `finance_events.heartbeat_run_id IN agent run ids`
  - `finance_events.cost_event_id IN agent cost event ids`
- preserve the existing agent deletion flow after that cleanup
- add an embedded-Postgres regression test covering the finance-event FK path

## Validation
- `pnpm exec vitest run server/src/__tests__/agent-remove-service.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Related
- Follow-up to #654
