### PR TITLE
fix: use tsx/cli public export instead of private tsx/dist/cli.mjs path

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 


### PR DESCRIPTION
## Thinking Path

> - The server uses `tsx` to spawn a child `tsx watch` process in `dev-watch.ts`
> - The CLI path was resolved via `require.resolve("tsx/dist/cli.mjs")` — a direct internal file path not listed in tsx's `exports` field
> - When tsx ≥4 runs as an ESM loader hook it enforces the exports field during `require.resolve`
> - On Node.js v22+, this raises `ERR_PACKAGE_PATH_NOT_EXPORTED` and crashes `pnpm dev` before the server starts
> - This PR replaces the private path with `tsx/cli`, the officially exported public subpath that maps to the same file
> - The benefit is spec-compliant resolution that works on Node.js v22+ without errors

## What Changed

- `server/scripts/dev-watch.ts`: replaced `require.resolve("tsx/dist/cli.mjs")` with `require.resolve("tsx/cli")`

## Reproduction

1. Clone the repo on Node.js v22+
2. `pnpm install`
3. `pnpm dev`
4. Observe `ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './dist/cli.mjs' is not defined by "exports" in .../tsx/package.json`

## Verification

Run `pnpm dev` on Node.js v22+ after the fix — server starts cleanly. The `tsx/cli` export resolves to the same `dist/cli.mjs` binary so runtime behaviour is identical.

## Risks

Low risk. One-line change in a dev-only script. No logic, no dependencies, no behaviour changes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge