### PR TITLE
fix(codex): sanitize sandbox=elevated in managed Codex home config

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -4,9 +4,34 @@ import path from "node:path";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
-const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
+const COPIED_SHARED_FILES = ["config.json", "instructions.md"] as const;
+const SANITIZED_COPIED_FILES = ["config.toml"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const DEFAULT_PAPERCLIP_INSTANCE_ID = "default";
+
+/**
+ * Remove `sandbox = "elevated"` (or `'elevated'` / bare `elevated`) from a
+ * Codex config.toml.  The elevated sandbox requires admin privileges which
+ * Paperclip-spawned processes don't have, causing "Access is denied.
+ * (os error 5)" on Windows.
+ *
+ * If removing the key leaves an empty `[windows]` section, the section
+ * header is removed as well.
+ */
+export function sanitizeConfigToml(content: string): string {
+  // In practice this key only appears under [windows] in Codex config; a
+  // full TOML-section-aware match would require a parser we don't carry.
+  const sandboxRe = /^[ \t]*sandbox\s*=\s*(?:"elevated"|'elevated'|elevated)[ \t]*\r?\n?/gm;
+  let result = content.replace(sandboxRe, "");
+
+  // Remove [windows] header only if it's now empty
+  result = result.replace(
+    /^([ \t]*\[windows\][ \t]*\r?\n)((?:[ \t]*\r?\n)*)(?=\[|$)/gm,
+    (_match, _header, blanks) => blanks,
+  );
+
+  return result.replace(/\n{3,}/g, "\n\n");
+}
 
 function nonEmpty(value: string | undefined): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -93,6 +118,26 @@ export async function prepareManagedCodexHome(
     const source = path.join(sourceHome, name);
     if (!(await pathExists(source))) continue;
     await ensureCopiedFile(path.join(targetHome, name), source);
+  }
+
+  for (const name of SANITIZED_COPIED_FILES) {
+    const target = path.join(targetHome, name);
+    const source = path.join(sourceHome, name);
+    const targetExists = await pathExists(target);
+    const sourceExists = await pathExists(source);
+
+    if (targetExists) {
+      // Re-sanitize existing file (fixes managed homes created before this patch)
+      const existing = await fs.readFile(target, "utf-8");
+      const sanitized = sanitizeConfigToml(existing);
+      if (sanitized !== existing) {
+        await fs.writeFile(target, sanitized, "utf-8");
+      }
+    } else if (sourceExists) {
+      const raw = await fs.readFile(source, "utf-8");
+      await ensureParentDir(target);
+      await fs.writeFile(target, sanitizeConfigToml(raw), "utf-8");
+    }
   }
 
   await onLog(

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -19,8 +19,11 @@ const DEFAULT_PAPERCLIP_INSTANCE_ID = "default";
  * header is removed as well.
  */
 export function sanitizeConfigToml(content: string): string {
-  // In practice this key only appears under [windows] in Codex config; a
-  // full TOML-section-aware match would require a parser we don't carry.
+  // `sandbox` is a [windows]-specific key in Codex config.toml and does not
+  // appear as a meaningful top-level key in any other section.  A global
+  // match is therefore safe and avoids the complexity of a full TOML parser.
+  // If a future Codex version adds `sandbox` keys in other sections this
+  // function will need to become section-aware.
   const sandboxRe = /^[ \t]*sandbox\s*=\s*(?:"elevated"|'elevated'|elevated)[ \t]*\r?\n?/gm;
   let result = content.replace(sandboxRe, "");
 
@@ -30,6 +33,9 @@ export function sanitizeConfigToml(content: string): string {
     (_match, _header, blanks) => blanks,
   );
 
+  // Normalize CRLF to LF first so that consecutive \r\n sequences (where \r
+  // sits between the \n chars) are correctly collapsed to a single blank line.
+  result = result.replace(/\r\n/g, "\n");
   return result.replace(/\n{3,}/g, "\n\n");
 }
 

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -5,8 +5,39 @@ import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-utils/server-utils";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
-const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
+const COPIED_SHARED_FILES = ["config.json", "instructions.md"] as const;
+const SANITIZED_COPIED_FILES = ["config.toml"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
+
+/**
+ * Remove `sandbox = "elevated"` (or `'elevated'` / bare `elevated`) from a
+ * Codex config.toml.  The elevated sandbox requires admin privileges which
+ * Paperclip-spawned processes don't have, causing "Access is denied.
+ * (os error 5)" on Windows.
+ *
+ * If removing the key leaves an empty `[windows]` section, the section
+ * header is removed as well.
+ */
+export function sanitizeConfigToml(content: string): string {
+  // `sandbox` is a [windows]-specific key in Codex config.toml and does not
+  // appear as a meaningful top-level key in any other section.  A global
+  // match is therefore safe and avoids the complexity of a full TOML parser.
+  // If a future Codex version adds `sandbox` keys in other sections this
+  // function will need to become section-aware.
+  const sandboxRe = /^[ \t]*sandbox\s*=\s*(?:"elevated"|'elevated'|elevated)[ \t]*\r?\n?/gm;
+  let result = content.replace(sandboxRe, "");
+
+  // Remove [windows] header only if it's now empty
+  result = result.replace(
+    /^([ \t]*\[windows\][ \t]*\r?\n)((?:[ \t]*\r?\n)*)(?=\[|$)/gm,
+    (_match, _header, blanks) => blanks,
+  );
+
+  // Normalize CRLF to LF first so that consecutive \r\n sequences (where \r
+  // sits between the \n chars) are correctly collapsed to a single blank line.
+  result = result.replace(/\r\n/g, "\n");
+  return result.replace(/\n{3,}/g, "\n\n");
+}
 
 function nonEmpty(value: string | undefined): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -154,6 +185,26 @@ export async function prepareManagedCodexHome(
       "stdout",
       `[paperclip] Wrote API-key auth.json into Codex home "${targetHome}" from configured OPENAI_API_KEY.\n`,
     );
+  }
+
+  for (const name of SANITIZED_COPIED_FILES) {
+    const target = path.join(targetHome, name);
+    const source = path.join(sourceHome, name);
+    const targetExists = await pathExists(target);
+    const sourceExists = await pathExists(source);
+
+    if (targetExists) {
+      // Re-sanitize existing file (fixes managed homes created before this patch)
+      const existing = await fs.readFile(target, "utf-8");
+      const sanitized = sanitizeConfigToml(existing);
+      if (sanitized !== existing) {
+        await fs.writeFile(target, sanitized, "utf-8");
+      }
+    } else if (sourceExists) {
+      const raw = await fs.readFile(source, "utf-8");
+      await ensureParentDir(target);
+      await fs.writeFile(target, sanitizeConfigToml(raw), "utf-8");
+    }
   }
 
   return targetHome;

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -13,6 +13,7 @@ export {
   fetchWithTimeout,
   codexHomeDir,
 } from "./quota.js";
+export { sanitizeConfigToml, prepareManagedCodexHome } from "./codex-home.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
 
 function readNonEmptyString(value: unknown): string | null {

--- a/server/src/__tests__/codex-local-codex-home.test.ts
+++ b/server/src/__tests__/codex-local-codex-home.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { sanitizeConfigToml } from "@paperclipai/adapter-codex-local/server";
+import { prepareManagedCodexHome } from "@paperclipai/adapter-codex-local/server";
+
+describe("sanitizeConfigToml", () => {
+  it("removes sandbox = \"elevated\" from [windows] section", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    const result = sanitizeConfigToml(input);
+
+    expect(result).not.toContain('sandbox = "elevated"');
+    expect(result).toContain('model = "gpt-5.4"');
+    expect(result).toContain("[mcp_servers.foo]");
+    expect(result).toContain('command = "bar"');
+  });
+
+  it("removes empty [windows] section after sanitization", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    const result = sanitizeConfigToml(input);
+    expect(result).not.toContain("[windows]");
+  });
+
+  it("preserves [windows] section with other keys besides sandbox", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      'some_other_key = "value"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    const result = sanitizeConfigToml(input);
+
+    expect(result).not.toContain('sandbox = "elevated"');
+    expect(result).toContain("[windows]");
+    expect(result).toContain('some_other_key = "value"');
+  });
+
+  it("returns input unchanged when no sandbox = elevated", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    expect(sanitizeConfigToml(input)).toBe(input);
+  });
+
+  it("handles sandbox with single quotes", () => {
+    const input = "[windows]\nsandbox = 'elevated'\n";
+    const result = sanitizeConfigToml(input);
+    expect(result).not.toContain("sandbox");
+  });
+
+  it("handles sandbox without quotes (bare value)", () => {
+    const input = "[windows]\nsandbox = elevated\n";
+    const result = sanitizeConfigToml(input);
+    expect(result).not.toContain("sandbox");
+  });
+
+  it("handles CRLF line endings", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\r\n");
+
+    const result = sanitizeConfigToml(input);
+
+    expect(result).not.toContain('sandbox = "elevated"');
+    expect(result).not.toContain("[windows]");
+    expect(result).toContain("[mcp_servers.foo]");
+  });
+});
+
+describe("prepareManagedCodexHome", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = path.join(
+      os.tmpdir(),
+      `paperclip-codex-home-test-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    await fs.mkdir(root, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("sanitizes sandbox=elevated in copied config.toml", async () => {
+    const sourceHome = path.join(root, "source-codex");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceHome, "config.toml"),
+      'model = "gpt-5.4"\n\n[windows]\nsandbox = "elevated"\n\n[mcp_servers.foo]\ncommand = "bar"\n',
+    );
+
+    const env: NodeJS.ProcessEnv = {
+      CODEX_HOME: sourceHome,
+      PAPERCLIP_HOME: root,
+      PAPERCLIP_INSTANCE_ID: "test",
+    };
+
+    const resultHome = await prepareManagedCodexHome(
+      { ...process.env, ...env },
+      async () => {},
+      "test-company",
+    );
+
+    const configContent = await fs.readFile(path.join(resultHome, "config.toml"), "utf-8");
+    expect(configContent).not.toContain('sandbox = "elevated"');
+    expect(configContent).toContain('model = "gpt-5.4"');
+    expect(configContent).toContain("[mcp_servers.foo]");
+  });
+
+  it("re-sanitizes existing config.toml with sandbox=elevated", async () => {
+    const sourceHome = path.join(root, "source-codex");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(path.join(sourceHome, "config.toml"), 'model = "gpt-5.4"\n');
+
+    const env: NodeJS.ProcessEnv = {
+      CODEX_HOME: sourceHome,
+      PAPERCLIP_HOME: root,
+      PAPERCLIP_INSTANCE_ID: "test",
+    };
+
+    const onLog = async () => {};
+
+    const resultHome = await prepareManagedCodexHome(
+      { ...process.env, ...env },
+      onLog,
+      "test-company",
+    );
+
+    // Simulate: config was copied before fix with sandbox=elevated
+    await fs.writeFile(
+      path.join(resultHome, "config.toml"),
+      'model = "gpt-5.4"\n\n[windows]\nsandbox = "elevated"\n',
+    );
+
+    // Re-run should sanitize the existing config
+    await prepareManagedCodexHome({ ...process.env, ...env }, onLog, "test-company");
+
+    const configContent = await fs.readFile(path.join(resultHome, "config.toml"), "utf-8");
+    expect(configContent).not.toContain('sandbox = "elevated"');
+  });
+});

--- a/server/src/__tests__/codex-local-codex-home.test.ts
+++ b/server/src/__tests__/codex-local-codex-home.test.ts
@@ -2,8 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { sanitizeConfigToml } from "@paperclipai/adapter-codex-local/server";
-import { prepareManagedCodexHome } from "@paperclipai/adapter-codex-local/server";
+import { sanitizeConfigToml, prepareManagedCodexHome } from "@paperclipai/adapter-codex-local/server";
 
 describe("sanitizeConfigToml", () => {
   it("removes sandbox = \"elevated\" from [windows] section", () => {

--- a/server/src/__tests__/codex-local-codex-home.test.ts
+++ b/server/src/__tests__/codex-local-codex-home.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { sanitizeConfigToml, prepareManagedCodexHome } from "@paperclipai/adapter-codex-local/server";
+
+describe("sanitizeConfigToml", () => {
+  it("removes sandbox = \"elevated\" from [windows] section", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    const result = sanitizeConfigToml(input);
+
+    expect(result).not.toContain('sandbox = "elevated"');
+    expect(result).toContain('model = "gpt-5.4"');
+    expect(result).toContain("[mcp_servers.foo]");
+    expect(result).toContain('command = "bar"');
+  });
+
+  it("removes empty [windows] section after sanitization", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    const result = sanitizeConfigToml(input);
+    expect(result).not.toContain("[windows]");
+  });
+
+  it("preserves [windows] section with other keys besides sandbox", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      'some_other_key = "value"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    const result = sanitizeConfigToml(input);
+
+    expect(result).not.toContain('sandbox = "elevated"');
+    expect(result).toContain("[windows]");
+    expect(result).toContain('some_other_key = "value"');
+  });
+
+  it("returns input unchanged when no sandbox = elevated", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\n");
+
+    expect(sanitizeConfigToml(input)).toBe(input);
+  });
+
+  it("handles sandbox with single quotes", () => {
+    const input = "[windows]\nsandbox = 'elevated'\n";
+    const result = sanitizeConfigToml(input);
+    expect(result).not.toContain("sandbox");
+  });
+
+  it("handles sandbox without quotes (bare value)", () => {
+    const input = "[windows]\nsandbox = elevated\n";
+    const result = sanitizeConfigToml(input);
+    expect(result).not.toContain("sandbox");
+  });
+
+  it("handles CRLF line endings", () => {
+    const input = [
+      'model = "gpt-5.4"',
+      "",
+      "[windows]",
+      'sandbox = "elevated"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+    ].join("\r\n");
+
+    const result = sanitizeConfigToml(input);
+
+    expect(result).not.toContain('sandbox = "elevated"');
+    expect(result).not.toContain("[windows]");
+    expect(result).toContain("[mcp_servers.foo]");
+  });
+});
+
+describe("prepareManagedCodexHome", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = path.join(
+      os.tmpdir(),
+      `paperclip-codex-home-test-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    await fs.mkdir(root, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("sanitizes sandbox=elevated in copied config.toml", async () => {
+    const sourceHome = path.join(root, "source-codex");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceHome, "config.toml"),
+      'model = "gpt-5.4"\n\n[windows]\nsandbox = "elevated"\n\n[mcp_servers.foo]\ncommand = "bar"\n',
+    );
+
+    const env: NodeJS.ProcessEnv = {
+      CODEX_HOME: sourceHome,
+      PAPERCLIP_HOME: root,
+      PAPERCLIP_INSTANCE_ID: "test",
+    };
+
+    const resultHome = await prepareManagedCodexHome(
+      { ...process.env, ...env },
+      async () => {},
+      "test-company",
+    );
+
+    const configContent = await fs.readFile(path.join(resultHome, "config.toml"), "utf-8");
+    expect(configContent).not.toContain('sandbox = "elevated"');
+    expect(configContent).toContain('model = "gpt-5.4"');
+    expect(configContent).toContain("[mcp_servers.foo]");
+  });
+
+  it("re-sanitizes existing config.toml with sandbox=elevated", async () => {
+    const sourceHome = path.join(root, "source-codex");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(path.join(sourceHome, "config.toml"), 'model = "gpt-5.4"\n');
+
+    const env: NodeJS.ProcessEnv = {
+      CODEX_HOME: sourceHome,
+      PAPERCLIP_HOME: root,
+      PAPERCLIP_INSTANCE_ID: "test",
+    };
+
+    const onLog = async () => {};
+
+    const resultHome = await prepareManagedCodexHome(
+      { ...process.env, ...env },
+      onLog,
+      "test-company",
+    );
+
+    // Simulate: config was copied before fix with sandbox=elevated
+    await fs.writeFile(
+      path.join(resultHome, "config.toml"),
+      'model = "gpt-5.4"\n\n[windows]\nsandbox = "elevated"\n',
+    );
+
+    // Re-run should sanitize the existing config
+    await prepareManagedCodexHome({ ...process.env, ...env }, onLog, "test-company");
+
+    const configContent = await fs.readFile(path.join(resultHome, "config.toml"), "utf-8");
+    expect(configContent).not.toContain('sandbox = "elevated"');
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip creates managed Codex home directories per company, seeded from the user's `~/.codex`
> - `config.toml` is copied verbatim, inheriting any user-specific settings
> - On Windows, users may have `[windows] sandbox = "elevated"` in their Codex config
> - When Paperclip spawns `codex` as a child process, it runs without elevation
> - The elevated sandbox setting causes "Access is denied. (os error 5)" on every heartbeat
> - The fix strips `sandbox = "elevated"` during copy and re-sanitizes existing configs retroactively
> - This is separate from the symlink→junction/hardlink fix in #872 — both are needed on Windows

## Summary

- Add `sanitizeConfigToml()` to strip `sandbox = "elevated"` from `config.toml` when copying to managed Codex home
- Move `config.toml` from `COPIED_SHARED_FILES` to `SANITIZED_COPIED_FILES` so it goes through the sanitization path
- Re-sanitize existing managed configs on each heartbeat (fixes homes created before this patch)
- 9 new tests covering sanitization (double-quoted, single-quoted, bare values, CRLF, section cleanup, retroactive fix)

Companion to #872 which handles the symlink permission issue separately.

## Test plan

- [x] 9 unit tests pass (`codex-local-codex-home.test.ts`)
- [x] Existing codex adapter tests unaffected
- [x] Manual: verify Codex agent heartbeat succeeds on Windows with user config containing `sandbox = "elevated"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)