### PR TITLE
fix: discard stale session when agent adapter type changes

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2293,7 +2293,13 @@ export function heartbeatService(db: Db) {
     if (executionWorkspace.projectId && !readNonEmptyString(context.projectId)) {
       context.projectId = executionWorkspace.projectId;
     }
-    const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
+    const adapterChanged = runtime.adapterType !== agent.adapterType;
+    const runtimeSessionFallback = taskKey || resetTaskSession || adapterChanged ? null : runtime.sessionId;
+    if (adapterChanged && runtime.sessionId) {
+      runtimeWorkspaceWarnings.push(
+        `Adapter changed from ${runtime.adapterType} to ${agent.adapterType} — discarding previous session to start fresh.`,
+      );
+    }
     let previousSessionDisplayId = truncateDisplayId(
       explicitResumeSessionDisplayId ??
         taskSessionForRun?.sessionDisplayId ??


### PR DESCRIPTION
## Thinking Path

> - Agents in Paperclip run via adapters (claude_local, codex_local, etc.)
> - Each adapter maintains a session ID that lets it resume prior conversation context
> - Session IDs are adapter-specific — a Claude session ID means nothing to Codex and vice versa
> - When a user switches an agent from one adapter to another, agent_runtime_state still holds the previous adapter session ID
> - On the next run, heartbeat.ts passes that stale ID as runtimeSessionFallback to the new adapter
> - Codex receives a Claude UUID, calls codex exec resume uuid, finds no matching rollout, and crashes with ERR_ADAPTER_FAILED
> - This PR checks whether runtime.adapterType matches agent.adapterType before using the stored session
> - If they differ, the session is discarded and a fresh one is started instead
> - A warning is added to runtimeWorkspaceWarnings so operators can see the adapter switch in the run log

## What Changed

- server/src/services/heartbeat.ts: before assigning runtimeSessionFallback, compare runtime.adapterType with agent.adapterType; if they differ, treat the fallback as null and push a warning to runtimeWorkspaceWarnings

## Reproduction

1. Configure an agent with claude_local and run it until it has a stored session
2. Switch the agent adapter to codex_local
3. Trigger a new run
4. Observe: thread/resume: thread/resume failed: no rollout found for thread id uuid (adapter_failed)

## Verification

1. Apply this fix and repeat the reproduction steps
2. The run now starts cleanly with no resume attempt against the wrong adapter
3. The run log shows: Adapter changed from claude_local to codex_local, discarding previous session to start fresh

## Risks

Low risk. The change only affects the runtimeSessionFallback path. If the adapter matches (the normal case) behaviour is identical to before. The only new behaviour is discarding a session that would have crashed the run anyway.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
