### PR TITLE
fix(server): use tsx/cli export instead of tsx/dist/cli.mjs

### DIFF
--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Developers need `pnpm dev` to work reliably to contribute
> - `server/scripts/dev-watch.ts` resolves the tsx CLI path using `require.resolve("tsx/dist/cli.mjs")`
> - Node.js 22+ strictly enforces the `exports` field in package.json, and `tsx/dist/cli.mjs` is not a public export
> - This causes `ERR_PACKAGE_PATH_NOT_EXPORTED` on startup, blocking all local development on Node 22+
> - This PR switches to the public `tsx/cli` export, which resolves to the same file
> - The benefit is that `pnpm dev` works on Node.js 20, 22, and 25

## What changed

One-line fix in `server/scripts/dev-watch.ts`:

```diff
-const tsxCliPath = require.resolve("tsx/dist/cli.mjs");
+const tsxCliPath = require.resolve("tsx/cli");
```

## Why

tsx 4.21.0 exports `./cli` → `./dist/cli.mjs` in its package.json. Using `require.resolve("tsx/dist/cli.mjs")` bypasses the exports map, which Node.js 22+ rejects with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Verification

```bash
pnpm dev
curl http://localhost:3100/api/health  # {"status":"ok"}
```

Tested on Node.js v22.17.0 — server starts and health check returns OK.

Closes #2000

🤖 Generated with [Claude Code](https://claude.com/claude-code)