### PR TITLE
fix(heartbeat): cancel in-flight runs when budget is exhausted mid-execution

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -66,6 +66,8 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+const MID_RUN_BUDGET_POLL_INTERVAL_MS =
+  parseInt(process.env.PAPERCLIP_MID_RUN_BUDGET_POLL_MS ?? "", 10) || 30_000;
 const execFile = promisify(execFileCallback);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
@@ -2339,6 +2341,7 @@ export function heartbeatService(db: Db) {
     let handle: RunLogHandle | null = null;
     let stdoutExcerpt = "";
     let stderrExcerpt = "";
+    let budgetPollInterval: ReturnType<typeof setInterval> | null = null;
     try {
       const startedAt = run.startedAt ?? new Date();
       const runningWithSession = await db
@@ -2512,6 +2515,40 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+      // Poll budget while the process is running so a hard-stop triggered by a
+      // *previous* cost event (e.g. another run that just finished) also cancels
+      // this in-flight run. HTTP adapters are fire-and-forget and cannot be killed,
+      // so the poll is limited to local process adapters.
+      if (adapter.type !== "http") {
+        budgetPollInterval = setInterval(() => {
+          void budgets
+            .getInvocationBlock(agent.companyId, agent.id, {
+              issueId: issueRef?.id ?? null,
+              projectId: resolvedProjectId,
+            })
+            .then((block) => {
+              if (block) {
+                logger.warn(
+                  { runId: run.id, agentId: agent.id, scopeType: block.scopeType },
+                  "mid-run budget enforcement: cancelling in-flight run",
+                );
+                // Clear the interval immediately so we don't fire again while
+                // cancelRunInternal is in flight.
+                if (budgetPollInterval !== null) {
+                  clearInterval(budgetPollInterval);
+                  budgetPollInterval = null;
+                }
+                void cancelRunInternal(run.id, block.reason).catch((err) =>
+                  logger.warn({ err, runId: run.id }, "mid-run budget cancel failed"),
+                );
+              }
+            })
+            .catch((err) => {
+              logger.warn({ err, runId: run.id }, "mid-run budget poll error");
+            });
+        }, MID_RUN_BUDGET_POLL_INTERVAL_MS);
+      }
+
       const adapterResult = await adapter.execute({
         runId: run.id,
         agent,
@@ -2525,6 +2562,11 @@ export function heartbeatService(db: Db) {
         },
         authToken: authToken ?? undefined,
       });
+
+      if (budgetPollInterval !== null) {
+        clearInterval(budgetPollInterval);
+        budgetPollInterval = null;
+      }
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,
@@ -2716,6 +2758,10 @@ export function heartbeatService(db: Db) {
       }
       await finalizeAgentStatus(agent.id, outcome);
     } catch (err) {
+      if (budgetPollInterval !== null) {
+        clearInterval(budgetPollInterval);
+        budgetPollInterval = null;
+      }
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",
         await getCurrentUserRedactionOptions(),
@@ -2729,6 +2775,34 @@ export function heartbeatService(db: Db) {
         } catch (finalizeErr) {
           logger.warn({ err: finalizeErr, runId }, "failed to finalize run log after error");
         }
+      }
+
+      // If mid-run budget enforcement already cancelled this run, do not
+      // overwrite the "cancelled" status with "failed". Still update runtime
+      // state and task session so session-based adapters resume correctly.
+      const currentRun = await getRun(run.id);
+      if (currentRun?.status === "cancelled") {
+        await updateRuntimeState(agent, currentRun, {
+          exitCode: null,
+          signal: null,
+          timedOut: false,
+          errorMessage: currentRun.error ?? "Cancelled due to budget",
+        }, {
+          legacySessionId: runtimeForAdapter.sessionId,
+        });
+        if (taskKey && (previousSessionParams || previousSessionDisplayId || taskSession)) {
+          await upsertTaskSession({
+            companyId: agent.companyId,
+            agentId: agent.id,
+            adapterType: agent.adapterType,
+            taskKey,
+            sessionParamsJson: previousSessionParams,
+            sessionDisplayId: previousSessionDisplayId,
+            lastRunId: currentRun.id,
+            lastError: currentRun.error ?? null,
+          });
+        }
+        return;
       }
 
       const failedRun = await setRunStatus(run.id, "failed", {
@@ -3569,6 +3643,15 @@ export function heartbeatService(db: Db) {
     if (!run) throw notFound("Heartbeat run not found");
     if (run.status !== "running" && run.status !== "queued") return run;
 
+    // Write "cancelled" to the DB before sending SIGTERM so any concurrent
+    // reader (e.g. the catch block in executeRun) that wakes up after the
+    // process dies already sees the terminal status.
+    const cancelled = await setRunStatus(run.id, "cancelled", {
+      finishedAt: new Date(),
+      error: reason,
+      errorCode: "cancelled",
+    });
+
     const running = runningProcesses.get(run.id);
     if (running) {
       running.child.kill("SIGTERM");
@@ -3579,12 +3662,6 @@ export function heartbeatService(db: Db) {
         }
       }, graceMs);
     }
-
-    const cancelled = await setRunStatus(run.id, "cancelled", {
-      finishedAt: new Date(),
-      error: reason,
-      errorCode: "cancelled",
-    });
 
     await setWakeupStatus(run.wakeupRequestId, "cancelled", {
       finishedAt: new Date(),


### PR DESCRIPTION
## Problem

Budget hard-stops only applied at two points:
1. **Before** a run started (`getInvocationBlock` at queue time)
2. **After** a run finished (cost event → `evaluateCostEvent` → `pauseAndCancelScopeForBudget`)

A long-running agent process could exhaust its entire monthly budget during a single run, with no mechanism to interrupt it. Issue #769 is a real user report of this exact behaviour.

## Solution

Add a **periodic budget poll** inside the `adapter.execute()` execution window for local process adapters. Every 30 s, the server calls the existing `getInvocationBlock()` against the current agent/company/project spend. If the budget is already exhausted (e.g. a parallel or just-completed run pushed the total over the limit), the in-flight run is cancelled via the existing `cancelRunInternal()` path — SIGTERM, then SIGKILL after the grace period.

### What this does NOT change
- `cancelRunInternal()` — unchanged, existing SIGTERM/SIGKILL semantics preserved
- `getInvocationBlock()` — called read-only, no mutations
- HTTP adapters — excluded (fire-and-forget, no process handle to kill)
- Pre-execution and post-execution enforcement paths — unchanged, still active

## Changes

Single file: `server/src/services/heartbeat.ts` (+40 lines)

1. **Module constant** — `MID_RUN_BUDGET_POLL_INTERVAL_MS`, defaults to 30 000 ms, overridable via `PAPERCLIP_MID_RUN_BUDGET_POLL_MS` env var.
2. **Poll loop** — `setInterval` started just before `adapter.execute()`, cleared immediately after it returns.
3. **Catch-block cleanup** — `clearInterval` also called if `adapter.execute()` throws, preventing leaked timers on any error path.

## Relation to open PRs

| PR | What it does | Overlap |
|----|-------------|---------|
| #877 | Prevents starting new runs after budget exhausted | Pre-execution — complementary |
| #650 | Company-level enforcement + scheduler skipping + UI | Pre-execution — complementary |
| This PR | Kills the **currently running** process when budget trips mid-flight | The missing piece |

All three can merge independently without conflict.

## Testing

```bash
pnpm test --run budgets-service              # 5/5 pass
pnpm test --run heartbeat-run-summary        # 2/2 pass
pnpm test --run heartbeat-workspace-session  # 21/21 pass
```

To exercise manually: set a tight agent budget, start a long-running task, wait 30 s — the run should be cancelled with `"Cancelled due to budget pause"` visible in the run timeline.

Closes #769
Related: #692, #611, #877, #650