### PR TITLE
feat(plugins): add connector-github bidirectional sync plugin

### DIFF
--- a/packages/plugins/examples/connector-github/package.json
+++ b/packages/plugins/examples/connector-github/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@paperclipai/connector-github",
+  "version": "0.1.0",
+  "description": "GitHub bidirectional sync connector for Paperclip: issues, pull requests, and webhook-triggered agent wakeups",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc && node ./scripts/build-ui.mjs",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.3",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/connector-github/scripts/build-ui.mjs
+++ b/packages/plugins/examples/connector-github/scripts/build-ui.mjs
@@ -1,0 +1,24 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});

--- a/packages/plugins/examples/connector-github/src/constants.ts
+++ b/packages/plugins/examples/connector-github/src/constants.ts
@@ -18,10 +18,31 @@ export const GH_CLOSED_STATUSES = new Set(["closed", "deleted"]);
 export const GH_EVENTS = {
   issues: "issues",
   issueComment: "issue_comment",
+  milestone: "milestone",
   pullRequest: "pull_request",
   pullRequestReview: "pull_request_review",
   push: "push",
 } as const;
+
+// Label prefix used to encode Paperclip priority on GitHub issues.
+// e.g. "priority:high" maps to IssuePriority "high".
+export const PRIORITY_LABEL_PREFIX = "priority:";
+
+// Map from Paperclip IssuePriority → GitHub label name
+export const PRIORITY_TO_LABEL: Record<string, string> = {
+  critical: "priority:critical",
+  high: "priority:high",
+  medium: "priority:medium",
+  low: "priority:low",
+};
+
+// Map from GitHub label name → Paperclip IssuePriority
+export const LABEL_TO_PRIORITY: Record<string, string> = {
+  "priority:critical": "critical",
+  "priority:high": "high",
+  "priority:medium": "medium",
+  "priority:low": "low",
+};
 
 export const SLOT_IDS = {
   settingsPage: "connector-github-settings",

--- a/packages/plugins/examples/connector-github/src/constants.ts
+++ b/packages/plugins/examples/connector-github/src/constants.ts
@@ -1,0 +1,32 @@
+export const PLUGIN_ID = "paperclip-connector-github";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const WEBHOOK_KEYS = {
+  github: "github-events",
+} as const;
+
+// State namespace prefix for all persisted mapping keys
+export const STATE_NS = "github";
+
+// Echo-dedup TTL in milliseconds (30 seconds)
+export const ECHO_TTL_MS = 30_000;
+
+// Mapping of GitHub issue/PR actions to Paperclip issue statuses
+export const GH_CLOSED_STATUSES = new Set(["closed", "deleted"]);
+
+// GitHub event names sent in the X-GitHub-Event header
+export const GH_EVENTS = {
+  issues: "issues",
+  issueComment: "issue_comment",
+  pullRequest: "pull_request",
+  pullRequestReview: "pull_request_review",
+  push: "push",
+} as const;
+
+export const SLOT_IDS = {
+  settingsPage: "connector-github-settings",
+} as const;
+
+export const EXPORT_NAMES = {
+  settingsPage: "GitHubConnectorSettingsPage",
+} as const;

--- a/packages/plugins/examples/connector-github/src/echo.ts
+++ b/packages/plugins/examples/connector-github/src/echo.ts
@@ -1,0 +1,54 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { ECHO_TTL_MS } from "./constants.js";
+
+type EchoRecord = { ts: number };
+
+function isValidEchoRecord(value: unknown): value is EchoRecord {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).ts === "number" &&
+    Number.isFinite((value as EchoRecord).ts)
+  );
+}
+
+/**
+ * Echo-dedup guard backed by ctx.state (instance scope) so it survives worker restarts.
+ *
+ * Returns true  → delivery already seen within TTL; caller should suppress processing.
+ * Returns false → delivery is new; caller should proceed.
+ *
+ * CONCURRENCY NOTE: The plugin SDK does not expose an atomic compare-and-swap
+ * operation. Under concurrent webhook deliveries with the same ID, both requests
+ * can observe a "not seen" state before either writes, so dedup can fail.
+ * This is an eventual-consistency limitation of the current SDK surface.
+ * Mitigation: GitHub retries are typically spaced ≥5 s apart; the probability
+ * of a true concurrent collision on the same delivery ID is negligible in practice.
+ * Do NOT rely on this guard for financial-grade exactly-once semantics.
+ *
+ * STATE CORRUPTION GUARD: If the stored record has a non-numeric ts (corrupted
+ * state), we treat the delivery as new (fail open) rather than suppressing it.
+ */
+export async function isDuplicateDelivery(ctx: PluginContext, entityId: string): Promise<boolean> {
+  const stateKey = `echo:${entityId}`;
+  const raw = await ctx.state.get({ scopeKind: "instance", stateKey });
+  const now = Date.now();
+
+  if (isValidEchoRecord(raw) && now - raw.ts < ECHO_TTL_MS) {
+    return true;
+  }
+
+  // Best-effort write — if this throws, the delivery proceeds unguarded this time.
+  // On the next delivery the state will still be absent, so dedup stays best-effort.
+  await ctx.state.set({ scopeKind: "instance", stateKey }, { ts: now });
+  return false;
+}
+
+/**
+ * Record that we are about to push an entity to GitHub so the inbound webhook
+ * handler can suppress the echo when GitHub fires back at us.
+ */
+export async function markOutboundEcho(ctx: PluginContext, entityId: string): Promise<void> {
+  const stateKey = `echo:${entityId}`;
+  await ctx.state.set({ scopeKind: "instance", stateKey }, { ts: Date.now() });
+}

--- a/packages/plugins/examples/connector-github/src/github-api.ts
+++ b/packages/plugins/examples/connector-github/src/github-api.ts
@@ -68,6 +68,33 @@ export async function updateGitHubIssue(
   return await res.json() as GitHubIssueResponse;
 }
 
+/**
+ * Replace all priority:* labels on a GitHub issue with the given set.
+ * Non-priority labels are preserved — only labels matching PRIORITY_LABEL_PREFIX are touched.
+ */
+export async function syncGitHubPriorityLabels(
+  ctx: PluginContext,
+  token: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  priorityLabel: string | null,
+): Promise<void> {
+  // Fetch current labels
+  const res = await ghFetch(ctx, token, "GET", `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/labels`);
+  if (!res.ok) {
+    throw new Error(`GitHub getLabels failed: ${res.status} ${await res.text()}`);
+  }
+  const current = await res.json() as Array<{ name: string }>;
+  const nonPriority = current.map(l => l.name).filter(n => !n.startsWith("priority:"));
+  const next = priorityLabel ? [...nonPriority, priorityLabel] : nonPriority;
+
+  const setRes = await ghFetch(ctx, token, "PUT", `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/labels`, { labels: next });
+  if (!setRes.ok) {
+    throw new Error(`GitHub setLabels failed: ${setRes.status} ${await setRes.text()}`);
+  }
+}
+
 export async function createGitHubComment(
   ctx: PluginContext,
   token: string,

--- a/packages/plugins/examples/connector-github/src/github-api.ts
+++ b/packages/plugins/examples/connector-github/src/github-api.ts
@@ -1,0 +1,85 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+type GitHubIssuePayload = {
+  title: string;
+  body?: string;
+  state?: "open" | "closed";
+};
+
+type GitHubCommentPayload = {
+  body: string;
+};
+
+type GitHubIssueResponse = {
+  number: number;
+  html_url: string;
+};
+
+type GitHubCommentResponse = {
+  id: number;
+  html_url: string;
+};
+
+async function ghFetch(
+  ctx: PluginContext,
+  token: string,
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<Response> {
+  return await ctx.http.fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+export async function createGitHubIssue(
+  ctx: PluginContext,
+  token: string,
+  owner: string,
+  repo: string,
+  payload: GitHubIssuePayload,
+): Promise<GitHubIssueResponse> {
+  const res = await ghFetch(ctx, token, "POST", `https://api.github.com/repos/${owner}/${repo}/issues`, payload);
+  if (!res.ok) {
+    throw new Error(`GitHub createIssue failed: ${res.status} ${await res.text()}`);
+  }
+  return await res.json() as GitHubIssueResponse;
+}
+
+export async function updateGitHubIssue(
+  ctx: PluginContext,
+  token: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  payload: Partial<GitHubIssuePayload>,
+): Promise<GitHubIssueResponse> {
+  const res = await ghFetch(ctx, token, "PATCH", `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`, payload);
+  if (!res.ok) {
+    throw new Error(`GitHub updateIssue failed: ${res.status} ${await res.text()}`);
+  }
+  return await res.json() as GitHubIssueResponse;
+}
+
+export async function createGitHubComment(
+  ctx: PluginContext,
+  token: string,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<GitHubCommentResponse> {
+  const payload: GitHubCommentPayload = { body };
+  const res = await ghFetch(ctx, token, "POST", `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`, payload);
+  if (!res.ok) {
+    throw new Error(`GitHub createComment failed: ${res.status} ${await res.text()}`);
+  }
+  return await res.json() as GitHubCommentResponse;
+}

--- a/packages/plugins/examples/connector-github/src/index.ts
+++ b/packages/plugins/examples/connector-github/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as plugin } from "./worker.js";

--- a/packages/plugins/examples/connector-github/src/manifest.ts
+++ b/packages/plugins/examples/connector-github/src/manifest.ts
@@ -15,6 +15,9 @@ const manifest: PaperclipPluginManifestV1 = {
     "issues.create",
     "issues.update",
     "issue.comments.create",
+    "goals.read",
+    "goals.create",
+    "goals.update",
     "events.subscribe",
     "http.outbound",
     "secrets.read-ref",
@@ -70,13 +73,19 @@ const manifest: PaperclipPluginManifestV1 = {
         items: { type: "string" },
         default: [],
       },
+      prCreatesIssue: {
+        type: "boolean",
+        title: "PR creates Paperclip issue",
+        description: "When true, a pull_request:opened event with no 'Fixes #N' link creates a new Paperclip issue. Default: false.",
+        default: false,
+      },
     },
   },
   webhooks: [
     {
       endpointKey: WEBHOOK_KEYS.github,
       displayName: "GitHub Events",
-      description: "Receives issues, pull_request, issue_comment, pull_request_review, and push events from GitHub.",
+      description: "Receives issues, pull_request, issue_comment, milestone, pull_request_review, and push events from GitHub.",
     },
   ],
   ui: {

--- a/packages/plugins/examples/connector-github/src/manifest.ts
+++ b/packages/plugins/examples/connector-github/src/manifest.ts
@@ -1,0 +1,94 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import { EXPORT_NAMES, PLUGIN_ID, PLUGIN_VERSION, SLOT_IDS, WEBHOOK_KEYS } from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "GitHub Connector",
+  description: "Bidirectional sync between GitHub issues/PRs and Paperclip issues, with webhook-triggered agent wakeups on PR reviews and pushes.",
+  author: "Paperclip",
+  categories: ["connector", "automation"],
+  capabilities: [
+    "webhooks.receive",
+    "issues.read",
+    "issues.create",
+    "issues.update",
+    "issue.comments.create",
+    "events.subscribe",
+    "http.outbound",
+    "secrets.read-ref",
+    "agents.invoke",
+    "plugin.state.read",
+    "plugin.state.write",
+    "instance.settings.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    required: ["webhookSecret", "owner", "repo"],
+    properties: {
+      webhookSecret: {
+        type: "string",
+        title: "Webhook Secret",
+        description: "The secret used to sign GitHub webhook deliveries (X-Hub-Signature-256). Required.",
+      },
+      githubTokenRef: {
+        type: "string",
+        title: "GitHub Token Secret Reference",
+        description: "Secret reference for a GitHub personal access token or app token used for outbound API calls.",
+      },
+      owner: {
+        type: "string",
+        title: "Repository Owner",
+        description: "GitHub organisation or user name (e.g. 'acme-corp').",
+      },
+      repo: {
+        type: "string",
+        title: "Repository Name",
+        description: "GitHub repository name (e.g. 'my-project').",
+      },
+      defaultProjectId: {
+        type: "string",
+        title: "Default Paperclip Project ID",
+        description: "Paperclip project to create issues in when no project can be inferred from context.",
+      },
+      triggerAgentIds: {
+        type: "array",
+        title: "Trigger Agent IDs",
+        description: "Agents to wake on pull_request_review and push events.",
+        items: { type: "string" },
+        default: [],
+      },
+      watchedRepos: {
+        type: "array",
+        title: "Watched Repositories",
+        description: "Filter: only handle events from these repos (owner/repo). Empty = handle all configured repo.",
+        items: { type: "string" },
+        default: [],
+      },
+    },
+  },
+  webhooks: [
+    {
+      endpointKey: WEBHOOK_KEYS.github,
+      displayName: "GitHub Events",
+      description: "Receives issues, pull_request, issue_comment, pull_request_review, and push events from GitHub.",
+    },
+  ],
+  ui: {
+    slots: [
+      {
+        type: "settingsPage",
+        id: SLOT_IDS.settingsPage,
+        displayName: "GitHub Connector Settings",
+        exportName: EXPORT_NAMES.settingsPage,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/connector-github/src/mapping.ts
+++ b/packages/plugins/examples/connector-github/src/mapping.ts
@@ -2,15 +2,25 @@ import type { PluginContext } from "@paperclipai/plugin-sdk";
 import { STATE_NS } from "./constants.js";
 
 type IssueMapping = { paperclipIssueId: string };
+export type IssueMappingReverse = { owner: string; repo: string; ghNumber: number };
 type PrMapping = { paperclipIssueId: string };
+type MilestoneMapping = { paperclipGoalId: string };
 type OutboundEchoRecord = { ts: number };
 
 function issueKey(owner: string, repo: string, ghNumber: number): string {
   return `${STATE_NS}:issue:${owner}/${repo}:${ghNumber}`;
 }
 
+function issueReverseKey(paperclipIssueId: string): string {
+  return `${STATE_NS}:issue-reverse:${paperclipIssueId}`;
+}
+
 function prKey(owner: string, repo: string, prNumber: number): string {
   return `${STATE_NS}:pr:${owner}/${repo}:${prNumber}`;
+}
+
+function milestoneKey(owner: string, repo: string, milestoneNumber: number): string {
+  return `${STATE_NS}:milestone:${owner}/${repo}:${milestoneNumber}`;
 }
 
 function outboundEchoKey(owner: string, repo: string, ghNumber: number): string {
@@ -40,6 +50,21 @@ export async function setIssueMapping(
     { scopeKind: "instance", stateKey: issueKey(owner, repo, ghNumber) },
     { paperclipIssueId },
   );
+  // Reverse index: paperclipId → {owner, repo, ghNumber} for outbound updates
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: issueReverseKey(paperclipIssueId) },
+    { owner, repo, ghNumber } satisfies IssueMappingReverse,
+  );
+}
+
+export async function getIssueMappingReverse(
+  ctx: PluginContext,
+  paperclipIssueId: string,
+): Promise<IssueMappingReverse | null> {
+  return await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: issueReverseKey(paperclipIssueId),
+  }) as IssueMappingReverse | null;
 }
 
 export async function getPrMapping(
@@ -64,6 +89,31 @@ export async function setPrMapping(
   await ctx.state.set(
     { scopeKind: "instance", stateKey: prKey(owner, repo, prNumber) },
     { paperclipIssueId },
+  );
+}
+
+export async function getMilestoneMapping(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  milestoneNumber: number,
+): Promise<MilestoneMapping | null> {
+  return await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: milestoneKey(owner, repo, milestoneNumber),
+  }) as MilestoneMapping | null;
+}
+
+export async function setMilestoneMapping(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  milestoneNumber: number,
+  paperclipGoalId: string,
+): Promise<void> {
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: milestoneKey(owner, repo, milestoneNumber) },
+    { paperclipGoalId } satisfies MilestoneMapping,
   );
 }
 

--- a/packages/plugins/examples/connector-github/src/mapping.ts
+++ b/packages/plugins/examples/connector-github/src/mapping.ts
@@ -3,6 +3,7 @@ import { STATE_NS } from "./constants.js";
 
 type IssueMapping = { paperclipIssueId: string };
 type PrMapping = { paperclipIssueId: string };
+type OutboundEchoRecord = { ts: number };
 
 function issueKey(owner: string, repo: string, ghNumber: number): string {
   return `${STATE_NS}:issue:${owner}/${repo}:${ghNumber}`;
@@ -10,6 +11,10 @@ function issueKey(owner: string, repo: string, ghNumber: number): string {
 
 function prKey(owner: string, repo: string, prNumber: number): string {
   return `${STATE_NS}:pr:${owner}/${repo}:${prNumber}`;
+}
+
+function outboundEchoKey(owner: string, repo: string, ghNumber: number): string {
+  return `${STATE_NS}:outbound-echo:${owner}/${repo}:${ghNumber}`;
 }
 
 export async function getIssueMapping(
@@ -60,4 +65,47 @@ export async function setPrMapping(
     { scopeKind: "instance", stateKey: prKey(owner, repo, prNumber) },
     { paperclipIssueId },
   );
+}
+
+/**
+ * Record that a Paperclip issue was successfully pushed to GitHub.
+ * Written AFTER the GitHub API call succeeds so that a failed API call
+ * does not silently block retries.
+ *
+ * Keyed by owner/repo/ghNumber so the inbound webhook handler can match it
+ * against the real GitHub issue number instead of an internal Paperclip UUID.
+ */
+export async function markOutboundIssueEcho(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  ghNumber: number,
+): Promise<void> {
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: outboundEchoKey(owner, repo, ghNumber) },
+    { ts: Date.now() } satisfies OutboundEchoRecord,
+  );
+}
+
+/**
+ * Check and consume an outbound-echo marker.
+ *
+ * Returns true  → the inbound "issues:opened" webhook is our own echo; skip issue creation.
+ * Returns false → this is a genuine external event; proceed normally.
+ *
+ * The marker is deleted on first consumption (single-use) to avoid suppressing
+ * legitimate subsequent events for the same issue number.
+ */
+export async function consumeOutboundIssueEcho(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  ghNumber: number,
+): Promise<boolean> {
+  const key = outboundEchoKey(owner, repo, ghNumber);
+  const raw = await ctx.state.get({ scopeKind: "instance", stateKey: key }) as OutboundEchoRecord | null;
+  if (!raw || typeof raw.ts !== "number" || !Number.isFinite(raw.ts)) return false;
+  if (Date.now() - raw.ts > 30_000) return false; // TTL expired — treat as genuine event
+  await ctx.state.delete({ scopeKind: "instance", stateKey: key }); // consume once
+  return true;
 }

--- a/packages/plugins/examples/connector-github/src/mapping.ts
+++ b/packages/plugins/examples/connector-github/src/mapping.ts
@@ -1,0 +1,63 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { STATE_NS } from "./constants.js";
+
+type IssueMapping = { paperclipIssueId: string };
+type PrMapping = { paperclipIssueId: string };
+
+function issueKey(owner: string, repo: string, ghNumber: number): string {
+  return `${STATE_NS}:issue:${owner}/${repo}:${ghNumber}`;
+}
+
+function prKey(owner: string, repo: string, prNumber: number): string {
+  return `${STATE_NS}:pr:${owner}/${repo}:${prNumber}`;
+}
+
+export async function getIssueMapping(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  ghNumber: number,
+): Promise<IssueMapping | null> {
+  return await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: issueKey(owner, repo, ghNumber),
+  }) as IssueMapping | null;
+}
+
+export async function setIssueMapping(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  ghNumber: number,
+  paperclipIssueId: string,
+): Promise<void> {
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: issueKey(owner, repo, ghNumber) },
+    { paperclipIssueId },
+  );
+}
+
+export async function getPrMapping(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<PrMapping | null> {
+  return await ctx.state.get({
+    scopeKind: "instance",
+    stateKey: prKey(owner, repo, prNumber),
+  }) as PrMapping | null;
+}
+
+export async function setPrMapping(
+  ctx: PluginContext,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  paperclipIssueId: string,
+): Promise<void> {
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: prKey(owner, repo, prNumber) },
+    { paperclipIssueId },
+  );
+}

--- a/packages/plugins/examples/connector-github/src/ui/index.tsx
+++ b/packages/plugins/examples/connector-github/src/ui/index.tsx
@@ -1,0 +1,37 @@
+import {
+  useHostContext,
+  type PluginSettingsPageProps,
+} from "@paperclipai/plugin-sdk/ui";
+import { PLUGIN_ID } from "../constants.js";
+
+export function GitHubConnectorSettingsPage(_props: PluginSettingsPageProps) {
+  const { companyId } = useHostContext();
+
+  return (
+    <div style={{ padding: "1.5rem", fontFamily: "sans-serif", maxWidth: 640 }}>
+      <h2 style={{ marginTop: 0 }}>GitHub Connector</h2>
+      <p style={{ color: "#555" }}>
+        Bidirectional sync between GitHub issues / pull requests and Paperclip issues.
+        Agent wakeups are triggered on <code>pull_request_review</code> and <code>push</code> events.
+      </p>
+
+      <section style={{ marginTop: "1.5rem" }}>
+        <h3>Setup checklist</h3>
+        <ol>
+          <li>Create a GitHub webhook pointing at the Paperclip webhook URL for this plugin.</li>
+          <li>Set the webhook secret and enter it in the <strong>Webhook Secret</strong> config field.</li>
+          <li>
+            Create a GitHub personal access token (or app token) with <code>repo</code> scope,
+            store it as a Paperclip secret, and enter the secret reference in <strong>GitHub Token Secret Reference</strong>.
+          </li>
+          <li>Fill in <strong>Repository Owner</strong> and <strong>Repository Name</strong>.</li>
+          <li>Optionally add agent IDs to <strong>Trigger Agent IDs</strong> for PR-review and push wakeups.</li>
+        </ol>
+      </section>
+
+      <section style={{ marginTop: "1.5rem", fontSize: "0.85rem", color: "#888" }}>
+        Plugin ID: {PLUGIN_ID} — Company: {companyId ?? "—"}
+      </section>
+    </div>
+  );
+}

--- a/packages/plugins/examples/connector-github/src/verify.ts
+++ b/packages/plugins/examples/connector-github/src/verify.ts
@@ -1,0 +1,45 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// GitHub HMAC-SHA256 signatures are always "sha256=" + 64 hex chars = 71 bytes.
+const EXPECTED_SIG_BYTE_LEN = 71;
+
+/**
+ * Verify the X-Hub-Signature-256 header GitHub sends with every webhook delivery.
+ *
+ * Timing-safety contract:
+ *   - `timingSafeEqual` requires equal-length buffers; throwing on mismatch would
+ *     itself leak length information. We encode `signatureHeader` as UTF-8 bytes and
+ *     compare against the expected bytes. When lengths differ, both buffers are
+ *     built before comparison so no early-exit short-circuits the constant-time path.
+ *
+ * Empty-secret guard:
+ *   - An empty secret produces a deterministic HMAC that any attacker can forge.
+ *     Reject before HMAC computation to fail closed.
+ */
+export function verifyGitHubSignature(
+  rawBody: string,
+  secret: string,
+  signatureHeader: string | null,
+): boolean {
+  if (!signatureHeader) return false;
+  if (!secret) return false;
+
+  const expected = Buffer.from(
+    `sha256=${createHmac("sha256", secret).update(rawBody, "utf8").digest("hex")}`,
+    "utf8",
+  );
+
+  // Build the candidate buffer to the same length as expected so timingSafeEqual
+  // never throws. Pad with a null byte if shorter; truncate if longer.
+  // After timingSafeEqual returns, the lengths differ → false regardless.
+  const candidate = Buffer.alloc(expected.byteLength, 0);
+  const raw = Buffer.from(signatureHeader, "utf8");
+  raw.copy(candidate, 0, 0, Math.min(raw.byteLength, candidate.byteLength));
+
+  const equal = timingSafeEqual(expected, candidate);
+  // A matching comparison is only valid when the actual byte lengths are identical.
+  return equal && raw.byteLength === expected.byteLength;
+}
+
+/** Expected byte length of a valid GitHub SHA-256 signature header. Exported for tests. */
+export const GITHUB_SIG_BYTE_LEN = EXPECTED_SIG_BYTE_LEN;

--- a/packages/plugins/examples/connector-github/src/worker.ts
+++ b/packages/plugins/examples/connector-github/src/worker.ts
@@ -7,18 +7,21 @@ import {
   type PluginWebhookInput,
 } from "@paperclipai/plugin-sdk";
 import type { Issue } from "@paperclipai/shared";
-import { GH_CLOSED_STATUSES, GH_EVENTS, WEBHOOK_KEYS } from "./constants.js";
+import { GH_CLOSED_STATUSES, GH_EVENTS, LABEL_TO_PRIORITY, PRIORITY_TO_LABEL, WEBHOOK_KEYS } from "./constants.js";
 import { verifyGitHubSignature } from "./verify.js";
-import { isDuplicateDelivery } from "./echo.js";
+import { isDuplicateDelivery, markOutboundEcho } from "./echo.js";
 import {
   getIssueMapping,
+  getIssueMappingReverse,
   setIssueMapping,
   getPrMapping,
   setPrMapping,
+  getMilestoneMapping,
+  setMilestoneMapping,
   markOutboundIssueEcho,
   consumeOutboundIssueEcho,
 } from "./mapping.js";
-import { createGitHubIssue, updateGitHubIssue, createGitHubComment } from "./github-api.js";
+import { createGitHubIssue, updateGitHubIssue, createGitHubComment, syncGitHubPriorityLabels } from "./github-api.js";
 
 type GitHubConfig = {
   webhookSecret: string;
@@ -28,6 +31,7 @@ type GitHubConfig = {
   defaultProjectId?: string;
   triggerAgentIds?: string[];
   watchedRepos?: string[];
+  prCreatesIssue?: boolean;
 };
 
 let currentContext: PluginContext | null = null;
@@ -76,8 +80,7 @@ async function handleIssuesEvent(
     // The outbound handler writes a marker keyed by owner/repo/ghNumber after a
     // successful createGitHubIssue call; we consume it here (single-use).
     if (await consumeOutboundIssueEcho(ctx, owner, repo, ghNumber)) {
-      // Still store the mapping — the reverse lookup already wrote it outbound,
-      // but calling setIssueMapping here is idempotent and keeps both paths consistent.
+      // Mapping was already stored by the outbound handler; nothing more to do.
       return;
     }
     const issue = await ctx.issues.create({
@@ -86,6 +89,9 @@ async function handleIssuesEvent(
       title: readString(ghIssue.title),
       description: readString(ghIssue.body),
     });
+    // Mark the new Paperclip issue ID so the outbound issue.created handler
+    // skips pushing it back to GitHub (preventing a duplicate issue loop).
+    await markOutboundEcho(ctx, issue.id);
     await setIssueMapping(ctx, owner, repo, ghNumber, issue.id);
     return;
   }
@@ -103,6 +109,16 @@ async function handleIssuesEvent(
     if (ghIssue.title !== undefined) patch.title = readString(ghIssue.title);
     if (ghIssue.body !== undefined) patch.description = readString(ghIssue.body);
     await ctx.issues.update(mapping.paperclipIssueId, patch, companyId);
+    return;
+  }
+
+  if (action === "labeled" || action === "unlabeled") {
+    // Re-derive priority from the full label set on the issue (not just the event label)
+    // to handle rapid label changes correctly.
+    const labels = ghIssue.labels as Array<Record<string, unknown>> | undefined ?? [];
+    const priorityLabel = labels.map(l => readString(l.name)).find(n => n in LABEL_TO_PRIORITY);
+    const priority = priorityLabel ? LABEL_TO_PRIORITY[priorityLabel] as Issue["priority"] : null;
+    await ctx.issues.update(mapping.paperclipIssueId, { priority }, companyId);
   }
 }
 
@@ -138,7 +154,64 @@ async function handleIssueCommentEvent(
   const companyId = companies[0]?.id;
   if (!companyId) return;
 
-  await ctx.issues.createComment(mapping.paperclipIssueId, body, companyId);
+  const comment = await ctx.issues.createComment(mapping.paperclipIssueId, body, companyId);
+  // Mark the new comment ID so the outbound issue.comment.created handler
+  // suppresses it and avoids an infinite comment loop.
+  if (comment?.id) {
+    await markOutboundEcho(ctx, `outbound:${comment.id}`);
+  }
+}
+
+async function handleMilestoneEvent(
+  ctx: PluginContext,
+  config: GitHubConfig,
+  payload: Record<string, unknown>,
+  deliveryId: string,
+): Promise<void> {
+  const action = readString(payload.action);
+  if (action !== "created" && action !== "edited" && action !== "closed" && action !== "deleted") return;
+
+  const milestone = payload.milestone as Record<string, unknown> | undefined;
+  if (!milestone) return;
+
+  const milestoneNumber = readNumber(milestone.number);
+  if (milestoneNumber === null) return;
+
+  const repository = payload.repository as Record<string, unknown> | undefined;
+  const owner = readString((repository?.owner as Record<string, unknown> | undefined)?.login ?? config.owner);
+  const repo = readString(repository?.name ?? config.repo);
+
+  if (await isDuplicateDelivery(ctx, deliveryId)) return;
+
+  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
+  const companyId = companies[0]?.id;
+  if (!companyId) return;
+
+  const title = readString(milestone.title);
+  const description = readString(milestone.description);
+
+  if (action === "created") {
+    const goal = await ctx.goals.create({ companyId, title, description: description || undefined, level: "task" });
+    await setMilestoneMapping(ctx, owner, repo, milestoneNumber, goal.id);
+    return;
+  }
+
+  const mapping = await getMilestoneMapping(ctx, owner, repo, milestoneNumber);
+  if (!mapping) return;
+
+  if (action === "edited") {
+    await ctx.goals.update(mapping.paperclipGoalId, { title, description: description || undefined }, companyId);
+    return;
+  }
+
+  if (action === "closed") {
+    await ctx.goals.update(mapping.paperclipGoalId, { status: "achieved" }, companyId);
+    return;
+  }
+
+  if (action === "deleted") {
+    await ctx.goals.update(mapping.paperclipGoalId, { status: "cancelled" }, companyId);
+  }
 }
 
 async function handlePullRequestEvent(
@@ -165,6 +238,7 @@ async function handlePullRequestEvent(
   if (!companyId) return;
 
   if (action === "opened") {
+    if (!config.prCreatesIssue) return;
     const issue = await ctx.issues.create({
       companyId,
       projectId: config.defaultProjectId,
@@ -282,15 +356,14 @@ async function registerOutboundHandlers(ctx: PluginContext): Promise<void> {
     const issueId = typeof payload.issueId === "string" ? payload.issueId : null;
     if (!issueId) return;
 
-    if (await isDuplicateDelivery(ctx, issueId)) return;
+    if (await isDuplicateDelivery(ctx, `outbound:${issueId}`)) return;
 
     const issue = await ctx.issues.get(issueId, event.companyId);
     if (!issue) return;
 
-    // Find the GH issue number by scanning state — we need a reverse lookup.
-    // We stored mapping as github:issue:{owner}/{repo}:{ghNumber} → { paperclipIssueId }
-    // but we don't have a reverse index. For now, skip outbound updates without a known GH number.
-    // Full reverse index can be added as a follow-up.
+    const reverse = await getIssueMappingReverse(ctx, issueId);
+    if (!reverse) return; // Issue not synced to GitHub — skip silently.
+
     const token = await ctx.secrets.resolve(config.githubTokenRef);
     const patch: { title?: string; body?: string; state?: "open" | "closed" } = {
       title: issue.title,
@@ -298,9 +371,11 @@ async function registerOutboundHandlers(ctx: PluginContext): Promise<void> {
     };
     if (issue.status === "done") patch.state = "closed";
 
-    // We don't know the GH number here without a reverse index; log and skip.
-    ctx.logger.info("issue.updated outbound: reverse GH number lookup not yet implemented — skipping sync", { issueId });
-    void token; void patch; // suppress unused-variable warnings until reverse index is implemented
+    await updateGitHubIssue(ctx, token, reverse.owner, reverse.repo, reverse.ghNumber, patch);
+
+    // Sync priority label if present
+    const priorityLabel = issue.priority ? PRIORITY_TO_LABEL[issue.priority] ?? null : null;
+    await syncGitHubPriorityLabels(ctx, token, reverse.owner, reverse.repo, reverse.ghNumber, priorityLabel);
   });
 
   ctx.events.on("issue.comment.created", async (event: PluginEvent) => {
@@ -313,11 +388,13 @@ async function registerOutboundHandlers(ctx: PluginContext): Promise<void> {
     const body = typeof payload.body === "string" ? payload.body : null;
     if (!commentId || !issueId || !body) return;
 
-    if (await isDuplicateDelivery(ctx, commentId)) return;
+    if (await isDuplicateDelivery(ctx, `outbound:${commentId}`)) return;
+
+    const reverse = await getIssueMappingReverse(ctx, issueId);
+    if (!reverse) return; // Issue not synced to GitHub — skip silently.
 
     const token = await ctx.secrets.resolve(config.githubTokenRef);
-    ctx.logger.info("issue.comment.created outbound: reverse GH number lookup not yet implemented — skipping sync", { issueId });
-    void token; // suppress unused-variable warning until reverse index is implemented
+    await createGitHubComment(ctx, token, reverse.owner, reverse.repo, reverse.ghNumber, body);
   });
 }
 
@@ -388,6 +465,9 @@ const plugin: PaperclipPlugin = definePlugin({
         break;
       case GH_EVENTS.issueComment:
         await handleIssueCommentEvent(ctx, config, payload, deliveryId);
+        break;
+      case GH_EVENTS.milestone:
+        await handleMilestoneEvent(ctx, config, payload, deliveryId);
         break;
       case GH_EVENTS.pullRequest:
         await handlePullRequestEvent(ctx, config, payload, deliveryId);

--- a/packages/plugins/examples/connector-github/src/worker.ts
+++ b/packages/plugins/examples/connector-github/src/worker.ts
@@ -9,8 +9,15 @@ import {
 import type { Issue } from "@paperclipai/shared";
 import { GH_CLOSED_STATUSES, GH_EVENTS, WEBHOOK_KEYS } from "./constants.js";
 import { verifyGitHubSignature } from "./verify.js";
-import { isDuplicateDelivery, markOutboundEcho } from "./echo.js";
-import { getIssueMapping, setIssueMapping, getPrMapping, setPrMapping } from "./mapping.js";
+import { isDuplicateDelivery } from "./echo.js";
+import {
+  getIssueMapping,
+  setIssueMapping,
+  getPrMapping,
+  setPrMapping,
+  markOutboundIssueEcho,
+  consumeOutboundIssueEcho,
+} from "./mapping.js";
 import { createGitHubIssue, updateGitHubIssue, createGitHubComment } from "./github-api.js";
 
 type GitHubConfig = {
@@ -65,6 +72,14 @@ async function handleIssuesEvent(
   if (!companyId) return;
 
   if (action === "opened") {
+    // Suppress issues:opened webhooks that we ourselves triggered by pushing to GitHub.
+    // The outbound handler writes a marker keyed by owner/repo/ghNumber after a
+    // successful createGitHubIssue call; we consume it here (single-use).
+    if (await consumeOutboundIssueEcho(ctx, owner, repo, ghNumber)) {
+      // Still store the mapping — the reverse lookup already wrote it outbound,
+      // but calling setIssueMapping here is idempotent and keeps both paths consistent.
+      return;
+    }
     const issue = await ctx.issues.create({
       companyId,
       projectId: config.defaultProjectId,
@@ -173,7 +188,10 @@ async function handlePullRequestReviewEvent(
   ctx: PluginContext,
   config: GitHubConfig,
   payload: Record<string, unknown>,
+  deliveryId: string,
 ): Promise<void> {
+  if (await isDuplicateDelivery(ctx, deliveryId)) return;
+
   const repository = payload.repository as Record<string, unknown> | undefined;
   const repoFullName = readString(repository?.full_name);
   const pr = payload.pull_request as Record<string, unknown> | undefined;
@@ -198,7 +216,10 @@ async function handlePushEvent(
   ctx: PluginContext,
   config: GitHubConfig,
   payload: Record<string, unknown>,
+  deliveryId: string,
 ): Promise<void> {
+  if (await isDuplicateDelivery(ctx, deliveryId)) return;
+
   const repository = payload.repository as Record<string, unknown> | undefined;
   const repoFullName = readString(repository?.full_name);
   const ref = readString(payload.ref);
@@ -239,11 +260,15 @@ async function registerOutboundHandlers(ctx: PluginContext): Promise<void> {
 
     const token = await ctx.secrets.resolve(config.githubTokenRef);
 
-    await markOutboundEcho(ctx, issueId);
     const ghIssue = await createGitHubIssue(ctx, token, config.owner, config.repo, {
       title: issue.title,
       body: issue.description ?? undefined,
     });
+
+    // Mark echo AFTER a successful API call so that a failed call does not
+    // silently block retries (BUG 3 fix). The key is owner/repo/ghNumber so
+    // the inbound handler can match it by the real GitHub issue number (BUG 1 fix).
+    await markOutboundIssueEcho(ctx, config.owner, config.repo, ghIssue.number);
 
     // Store reverse mapping so updates can find the GH issue number
     await setIssueMapping(ctx, config.owner, config.repo, ghIssue.number, issueId);
@@ -273,7 +298,6 @@ async function registerOutboundHandlers(ctx: PluginContext): Promise<void> {
     };
     if (issue.status === "done") patch.state = "closed";
 
-    await markOutboundEcho(ctx, issueId);
     // We don't know the GH number here without a reverse index; log and skip.
     ctx.logger.info("issue.updated outbound: reverse GH number lookup not yet implemented — skipping sync", { issueId });
     void token; void patch; // suppress unused-variable warnings until reverse index is implemented
@@ -369,10 +393,10 @@ const plugin: PaperclipPlugin = definePlugin({
         await handlePullRequestEvent(ctx, config, payload, deliveryId);
         break;
       case GH_EVENTS.pullRequestReview:
-        await handlePullRequestReviewEvent(ctx, config, payload);
+        await handlePullRequestReviewEvent(ctx, config, payload, deliveryId);
         break;
       case GH_EVENTS.push:
-        await handlePushEvent(ctx, config, payload);
+        await handlePushEvent(ctx, config, payload, deliveryId);
         break;
       default:
         ctx.logger.info(`GitHub connector: ignoring unhandled event "${event}"`);

--- a/packages/plugins/examples/connector-github/src/worker.ts
+++ b/packages/plugins/examples/connector-github/src/worker.ts
@@ -1,0 +1,388 @@
+import {
+  definePlugin,
+  runWorker,
+  type PaperclipPlugin,
+  type PluginContext,
+  type PluginEvent,
+  type PluginWebhookInput,
+} from "@paperclipai/plugin-sdk";
+import type { Issue } from "@paperclipai/shared";
+import { GH_CLOSED_STATUSES, GH_EVENTS, WEBHOOK_KEYS } from "./constants.js";
+import { verifyGitHubSignature } from "./verify.js";
+import { isDuplicateDelivery, markOutboundEcho } from "./echo.js";
+import { getIssueMapping, setIssueMapping, getPrMapping, setPrMapping } from "./mapping.js";
+import { createGitHubIssue, updateGitHubIssue, createGitHubComment } from "./github-api.js";
+
+type GitHubConfig = {
+  webhookSecret: string;
+  githubTokenRef?: string;
+  owner: string;
+  repo: string;
+  defaultProjectId?: string;
+  triggerAgentIds?: string[];
+  watchedRepos?: string[];
+};
+
+let currentContext: PluginContext | null = null;
+
+async function getConfig(ctx: PluginContext): Promise<GitHubConfig> {
+  return await ctx.config.get() as GitHubConfig;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+// ---------------------------------------------------------------------------
+// Inbound: GitHub → Paperclip
+// ---------------------------------------------------------------------------
+
+async function handleIssuesEvent(
+  ctx: PluginContext,
+  config: GitHubConfig,
+  payload: Record<string, unknown>,
+  deliveryId: string,
+): Promise<void> {
+  const action = readString(payload.action);
+  const ghIssue = payload.issue as Record<string, unknown> | undefined;
+  if (!ghIssue) return;
+
+  const ghNumber = readNumber(ghIssue.number);
+  if (ghNumber === null) return;
+
+  const repository = payload.repository as Record<string, unknown> | undefined;
+  const owner = readString((repository?.owner as Record<string, unknown> | undefined)?.login ?? config.owner);
+  const repo = readString(repository?.name ?? config.repo);
+
+  if (await isDuplicateDelivery(ctx, deliveryId)) return;
+
+  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
+  const companyId = companies[0]?.id;
+  if (!companyId) return;
+
+  if (action === "opened") {
+    const issue = await ctx.issues.create({
+      companyId,
+      projectId: config.defaultProjectId,
+      title: readString(ghIssue.title),
+      description: readString(ghIssue.body),
+    });
+    await setIssueMapping(ctx, owner, repo, ghNumber, issue.id);
+    return;
+  }
+
+  const mapping = await getIssueMapping(ctx, owner, repo, ghNumber);
+  if (!mapping) return;
+
+  if (GH_CLOSED_STATUSES.has(action)) {
+    await ctx.issues.update(mapping.paperclipIssueId, { status: "done" as Issue["status"] }, companyId);
+    return;
+  }
+
+  if (action === "edited") {
+    const patch: Partial<Pick<Issue, "title" | "description">> = {};
+    if (ghIssue.title !== undefined) patch.title = readString(ghIssue.title);
+    if (ghIssue.body !== undefined) patch.description = readString(ghIssue.body);
+    await ctx.issues.update(mapping.paperclipIssueId, patch, companyId);
+  }
+}
+
+async function handleIssueCommentEvent(
+  ctx: PluginContext,
+  config: GitHubConfig,
+  payload: Record<string, unknown>,
+  deliveryId: string,
+): Promise<void> {
+  const action = readString(payload.action);
+  if (action !== "created") return;
+
+  const ghIssue = payload.issue as Record<string, unknown> | undefined;
+  if (!ghIssue) return;
+
+  const ghNumber = readNumber(ghIssue.number);
+  if (ghNumber === null) return;
+
+  const repository = payload.repository as Record<string, unknown> | undefined;
+  const owner = readString((repository?.owner as Record<string, unknown> | undefined)?.login ?? config.owner);
+  const repo = readString(repository?.name ?? config.repo);
+
+  const comment = payload.comment as Record<string, unknown> | undefined;
+  const body = readString(comment?.body);
+  if (!body) return;
+
+  if (await isDuplicateDelivery(ctx, deliveryId)) return;
+
+  const mapping = await getIssueMapping(ctx, owner, repo, ghNumber);
+  if (!mapping) return;
+
+  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
+  const companyId = companies[0]?.id;
+  if (!companyId) return;
+
+  await ctx.issues.createComment(mapping.paperclipIssueId, body, companyId);
+}
+
+async function handlePullRequestEvent(
+  ctx: PluginContext,
+  config: GitHubConfig,
+  payload: Record<string, unknown>,
+  deliveryId: string,
+): Promise<void> {
+  const action = readString(payload.action);
+  const pr = payload.pull_request as Record<string, unknown> | undefined;
+  if (!pr) return;
+
+  const prNumber = readNumber(pr.number);
+  if (prNumber === null) return;
+
+  const repository = payload.repository as Record<string, unknown> | undefined;
+  const owner = readString((repository?.owner as Record<string, unknown> | undefined)?.login ?? config.owner);
+  const repo = readString(repository?.name ?? config.repo);
+
+  if (await isDuplicateDelivery(ctx, deliveryId)) return;
+
+  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
+  const companyId = companies[0]?.id;
+  if (!companyId) return;
+
+  if (action === "opened") {
+    const issue = await ctx.issues.create({
+      companyId,
+      projectId: config.defaultProjectId,
+      title: readString(pr.title),
+      description: readString(pr.body),
+    });
+    await setPrMapping(ctx, owner, repo, prNumber, issue.id);
+    return;
+  }
+
+  const mapping = await getPrMapping(ctx, owner, repo, prNumber);
+  if (!mapping) return;
+
+  // closed with merged = done; closed without merged = also done (rejected/abandoned)
+  if (action === "closed") {
+    await ctx.issues.update(mapping.paperclipIssueId, { status: "done" as Issue["status"] }, companyId);
+  }
+}
+
+async function handlePullRequestReviewEvent(
+  ctx: PluginContext,
+  config: GitHubConfig,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const repository = payload.repository as Record<string, unknown> | undefined;
+  const repoFullName = readString(repository?.full_name);
+  const pr = payload.pull_request as Record<string, unknown> | undefined;
+  const prTitle = readString(pr?.title);
+
+  const agentIds = config.triggerAgentIds ?? [];
+  if (agentIds.length === 0) return;
+
+  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
+  const companyId = companies[0]?.id;
+  if (!companyId) return;
+
+  for (const agentId of agentIds) {
+    await ctx.agents.invoke(agentId, companyId, {
+      prompt: `GitHub pull_request_review: ${repoFullName} — ${prTitle}`,
+      reason: "github:pull_request_review",
+    });
+  }
+}
+
+async function handlePushEvent(
+  ctx: PluginContext,
+  config: GitHubConfig,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const repository = payload.repository as Record<string, unknown> | undefined;
+  const repoFullName = readString(repository?.full_name);
+  const ref = readString(payload.ref);
+
+  const agentIds = config.triggerAgentIds ?? [];
+  if (agentIds.length === 0) return;
+
+  const companies = await ctx.companies.list({ limit: 1, offset: 0 });
+  const companyId = companies[0]?.id;
+  if (!companyId) return;
+
+  for (const agentId of agentIds) {
+    await ctx.agents.invoke(agentId, companyId, {
+      prompt: `GitHub push: ${repoFullName} — ${ref}`,
+      reason: "github:push",
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Outbound: Paperclip → GitHub
+// ---------------------------------------------------------------------------
+
+async function registerOutboundHandlers(ctx: PluginContext): Promise<void> {
+  ctx.events.on("issue.created", async (event: PluginEvent) => {
+    const config = await getConfig(ctx);
+    if (!config.githubTokenRef) return;
+
+    const payload = event.payload as Record<string, unknown>;
+    const issueId = typeof payload.issueId === "string" ? payload.issueId : null;
+    if (!issueId) return;
+
+    // Suppress echoes from inbound GitHub events
+    if (await isDuplicateDelivery(ctx, issueId)) return;
+
+    const issue = await ctx.issues.get(issueId, event.companyId);
+    if (!issue) return;
+
+    const token = await ctx.secrets.resolve(config.githubTokenRef);
+
+    await markOutboundEcho(ctx, issueId);
+    const ghIssue = await createGitHubIssue(ctx, token, config.owner, config.repo, {
+      title: issue.title,
+      body: issue.description ?? undefined,
+    });
+
+    // Store reverse mapping so updates can find the GH issue number
+    await setIssueMapping(ctx, config.owner, config.repo, ghIssue.number, issueId);
+  });
+
+  ctx.events.on("issue.updated", async (event: PluginEvent) => {
+    const config = await getConfig(ctx);
+    if (!config.githubTokenRef) return;
+
+    const payload = event.payload as Record<string, unknown>;
+    const issueId = typeof payload.issueId === "string" ? payload.issueId : null;
+    if (!issueId) return;
+
+    if (await isDuplicateDelivery(ctx, issueId)) return;
+
+    const issue = await ctx.issues.get(issueId, event.companyId);
+    if (!issue) return;
+
+    // Find the GH issue number by scanning state — we need a reverse lookup.
+    // We stored mapping as github:issue:{owner}/{repo}:{ghNumber} → { paperclipIssueId }
+    // but we don't have a reverse index. For now, skip outbound updates without a known GH number.
+    // Full reverse index can be added as a follow-up.
+    const token = await ctx.secrets.resolve(config.githubTokenRef);
+    const patch: { title?: string; body?: string; state?: "open" | "closed" } = {
+      title: issue.title,
+      body: issue.description ?? undefined,
+    };
+    if (issue.status === "done") patch.state = "closed";
+
+    await markOutboundEcho(ctx, issueId);
+    // We don't know the GH number here without a reverse index; log and skip.
+    ctx.logger.info("issue.updated outbound: reverse GH number lookup not yet implemented — skipping sync", { issueId });
+    void token; void patch; // suppress unused-variable warnings until reverse index is implemented
+  });
+
+  ctx.events.on("issue.comment.created", async (event: PluginEvent) => {
+    const config = await getConfig(ctx);
+    if (!config.githubTokenRef) return;
+
+    const payload = event.payload as Record<string, unknown>;
+    const commentId = typeof payload.commentId === "string" ? payload.commentId : null;
+    const issueId = typeof payload.issueId === "string" ? payload.issueId : null;
+    const body = typeof payload.body === "string" ? payload.body : null;
+    if (!commentId || !issueId || !body) return;
+
+    if (await isDuplicateDelivery(ctx, commentId)) return;
+
+    const token = await ctx.secrets.resolve(config.githubTokenRef);
+    ctx.logger.info("issue.comment.created outbound: reverse GH number lookup not yet implemented — skipping sync", { issueId });
+    void token; // suppress unused-variable warning until reverse index is implemented
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+const plugin: PaperclipPlugin = definePlugin({
+  async setup(ctx) {
+    currentContext = ctx;
+    await registerOutboundHandlers(ctx);
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "GitHub connector ready" };
+  },
+
+  async onValidateConfig(config) {
+    const typed = config as Partial<GitHubConfig>;
+    const errors: string[] = [];
+
+    if (!typed.webhookSecret || typed.webhookSecret.trim().length === 0) {
+      errors.push("webhookSecret is required");
+    }
+    if (!typed.owner || typed.owner.trim().length === 0) {
+      errors.push("owner is required");
+    }
+    if (!typed.repo || typed.repo.trim().length === 0) {
+      errors.push("repo is required");
+    }
+
+    return { ok: errors.length === 0, errors, warnings: [] };
+  },
+
+  async onWebhook(input: PluginWebhookInput) {
+    if (input.endpointKey !== WEBHOOK_KEYS.github) {
+      throw new Error(`Unsupported webhook endpoint "${input.endpointKey}"`);
+    }
+
+    const ctx = currentContext;
+    if (!ctx) throw new Error("Plugin context not initialised");
+
+    const config = await getConfig(ctx);
+
+    // Verify HMAC-SHA256 signature before any processing
+    const signature = readString(input.headers?.["x-hub-signature-256"]);
+    if (!verifyGitHubSignature(input.rawBody, config.webhookSecret, signature)) {
+      // Do not log the payload on invalid signature
+      ctx.logger.warn("GitHub webhook: signature verification failed — delivery rejected");
+      return;
+    }
+
+    const event = readString(input.headers?.["x-github-event"]);
+    const deliveryId = readString(input.headers?.["x-github-delivery"] ?? input.requestId);
+    const payload = input.parsedBody as Record<string, unknown> ?? {};
+
+    // Repository filter: if watchedRepos is configured, only process matching repos
+    const watchedRepos = config.watchedRepos ?? [];
+    if (watchedRepos.length > 0) {
+      const repository = payload.repository as Record<string, unknown> | undefined;
+      const fullName = readString(repository?.full_name);
+      if (!watchedRepos.includes(fullName)) return;
+    }
+
+    switch (event) {
+      case GH_EVENTS.issues:
+        await handleIssuesEvent(ctx, config, payload, deliveryId);
+        break;
+      case GH_EVENTS.issueComment:
+        await handleIssueCommentEvent(ctx, config, payload, deliveryId);
+        break;
+      case GH_EVENTS.pullRequest:
+        await handlePullRequestEvent(ctx, config, payload, deliveryId);
+        break;
+      case GH_EVENTS.pullRequestReview:
+        await handlePullRequestReviewEvent(ctx, config, payload);
+        break;
+      case GH_EVENTS.push:
+        await handlePushEvent(ctx, config, payload);
+        break;
+      default:
+        ctx.logger.info(`GitHub connector: ignoring unhandled event "${event}"`);
+    }
+  },
+
+  async onShutdown() {
+    currentContext = null;
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/connector-github/tests/connector-github.spec.ts
+++ b/packages/plugins/examples/connector-github/tests/connector-github.spec.ts
@@ -257,6 +257,55 @@ describe("mapping helpers", () => {
 });
 
 // ---------------------------------------------------------------------------
+// markOutboundIssueEcho / consumeOutboundIssueEcho (BUG 1 fix)
+// ---------------------------------------------------------------------------
+
+describe("outbound issue echo helpers", () => {
+  it("consumeOutboundIssueEcho returns false when no marker exists", async () => {
+    const { consumeOutboundIssueEcho } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 1)).toBe(false);
+  });
+
+  it("markOutboundIssueEcho then consumeOutboundIssueEcho returns true", async () => {
+    const { markOutboundIssueEcho, consumeOutboundIssueEcho } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await markOutboundIssueEcho(ctx, "acme", "repo", 42);
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 42)).toBe(true);
+  });
+
+  it("consume is single-use: second call returns false", async () => {
+    const { markOutboundIssueEcho, consumeOutboundIssueEcho } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await markOutboundIssueEcho(ctx, "acme", "repo", 7);
+    await consumeOutboundIssueEcho(ctx, "acme", "repo", 7); // first consume
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 7)).toBe(false); // second is false
+  });
+
+  it("returns false for expired marker (ts > 30s ago)", async () => {
+    const { consumeOutboundIssueEcho } = await import("../src/mapping.js");
+    const staleTs = Date.now() - 31_000;
+    // Manually seed stale state matching the outbound-echo key format
+    const ctx = makeMockCtx({ "github:outbound-echo:acme/repo:5": { ts: staleTs } });
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 5)).toBe(false);
+  });
+
+  it("returns false for corrupted ts", async () => {
+    const { consumeOutboundIssueEcho } = await import("../src/mapping.js");
+    const ctx = makeMockCtx({ "github:outbound-echo:acme/repo:3": { ts: "not-a-number" } });
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 3)).toBe(false);
+  });
+
+  it("different gh numbers have distinct markers", async () => {
+    const { markOutboundIssueEcho, consumeOutboundIssueEcho } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await markOutboundIssueEcho(ctx, "acme", "repo", 10);
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 11)).toBe(false);
+    expect(await consumeOutboundIssueEcho(ctx, "acme", "repo", 10)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Manifest assertions (security contract)
 // ---------------------------------------------------------------------------
 

--- a/packages/plugins/examples/connector-github/tests/connector-github.spec.ts
+++ b/packages/plugins/examples/connector-github/tests/connector-github.spec.ts
@@ -241,9 +241,11 @@ describe("mapping helpers", () => {
     await setIssueMapping(ctx, "org", "myrepo", 1, "issue-id");
     await setPrMapping(ctx, "org", "myrepo", 1, "pr-id");
     const calls = (ctx.state.set as ReturnType<typeof vi.fn>).mock.calls as [{ stateKey: string }, unknown][];
-    expect(calls[0][0].stateKey).not.toEqual(calls[1][0].stateKey);
-    expect(calls[0][0].stateKey).toContain("issue");
-    expect(calls[1][0].stateKey).toContain("pr");
+    const allKeys = calls.map(c => c[0].stateKey);
+    expect(allKeys.some(k => k.includes("issue"))).toBe(true);
+    expect(allKeys.some(k => k.includes("pr"))).toBe(true);
+    // All keys must be distinct
+    expect(new Set(allKeys).size).toBe(allKeys.length);
   });
 
   it("different GH numbers produce different state keys", async () => {
@@ -362,5 +364,98 @@ describe("manifest security contract", () => {
     // We only declare what we actually use
     expect(caps).not.toContain("issues.delete");
     expect(caps).not.toContain("agents.create");
+  });
+
+  it("declares goals.create and goals.update capabilities", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.capabilities).toContain("goals.create");
+    expect(manifest.capabilities).toContain("goals.update");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Labels ↔ Priority mapping
+// ---------------------------------------------------------------------------
+
+describe("LABEL_TO_PRIORITY / PRIORITY_TO_LABEL constants", () => {
+  it("covers all four priority levels inbound", async () => {
+    const { LABEL_TO_PRIORITY } = await import("../src/constants.js");
+    expect(LABEL_TO_PRIORITY["priority:critical"]).toBe("critical");
+    expect(LABEL_TO_PRIORITY["priority:high"]).toBe("high");
+    expect(LABEL_TO_PRIORITY["priority:medium"]).toBe("medium");
+    expect(LABEL_TO_PRIORITY["priority:low"]).toBe("low");
+  });
+
+  it("round-trips through PRIORITY_TO_LABEL then LABEL_TO_PRIORITY", async () => {
+    const { LABEL_TO_PRIORITY, PRIORITY_TO_LABEL } = await import("../src/constants.js");
+    for (const priority of ["critical", "high", "medium", "low"]) {
+      const label = PRIORITY_TO_LABEL[priority]!;
+      expect(LABEL_TO_PRIORITY[label]).toBe(priority);
+    }
+  });
+
+  it("unknown label is not in LABEL_TO_PRIORITY", async () => {
+    const { LABEL_TO_PRIORITY } = await import("../src/constants.js");
+    expect(LABEL_TO_PRIORITY["bug"]).toBeUndefined();
+    expect(LABEL_TO_PRIORITY["enhancement"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reverse index (getIssueMappingReverse)
+// ---------------------------------------------------------------------------
+
+describe("reverse issue mapping", () => {
+  it("setIssueMapping writes a retrievable reverse entry", async () => {
+    const { setIssueMapping, getIssueMappingReverse } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setIssueMapping(ctx, "acme", "myrepo", 42, "pc-issue-abc");
+    const reverse = await getIssueMappingReverse(ctx, "pc-issue-abc");
+    expect(reverse).toEqual({ owner: "acme", repo: "myrepo", ghNumber: 42 });
+  });
+
+  it("getIssueMappingReverse returns null for unknown paperclipId", async () => {
+    const { getIssueMappingReverse } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    expect(await getIssueMappingReverse(ctx, "unknown-id")).toBeNull();
+  });
+
+  it("two different issues get distinct reverse keys", async () => {
+    const { setIssueMapping, getIssueMappingReverse } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setIssueMapping(ctx, "acme", "repo", 1, "pc-1");
+    await setIssueMapping(ctx, "acme", "repo", 2, "pc-2");
+    expect(await getIssueMappingReverse(ctx, "pc-1")).toEqual({ owner: "acme", repo: "repo", ghNumber: 1 });
+    expect(await getIssueMappingReverse(ctx, "pc-2")).toEqual({ owner: "acme", repo: "repo", ghNumber: 2 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Milestone ↔ Goal mapping
+// ---------------------------------------------------------------------------
+
+describe("milestone mapping helpers", () => {
+  it("setMilestoneMapping / getMilestoneMapping round-trips", async () => {
+    const { setMilestoneMapping, getMilestoneMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setMilestoneMapping(ctx, "acme", "repo", 3, "goal-uuid-1");
+    expect(await getMilestoneMapping(ctx, "acme", "repo", 3)).toEqual({ paperclipGoalId: "goal-uuid-1" });
+  });
+
+  it("getMilestoneMapping returns null for unknown milestone", async () => {
+    const { getMilestoneMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    expect(await getMilestoneMapping(ctx, "acme", "repo", 99)).toBeNull();
+  });
+
+  it("milestone key is distinct from issue key for same number", async () => {
+    const { setIssueMapping, setMilestoneMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setIssueMapping(ctx, "acme", "repo", 1, "issue-1");
+    await setMilestoneMapping(ctx, "acme", "repo", 1, "goal-1");
+    const calls = (ctx.state.set as ReturnType<typeof vi.fn>).mock.calls as [{ stateKey: string }, unknown][];
+    const allKeys = calls.map(c => c[0].stateKey);
+    expect(allKeys.some(k => k.includes("milestone"))).toBe(true);
+    expect(new Set(allKeys).size).toBe(allKeys.length);
   });
 });

--- a/packages/plugins/examples/connector-github/tests/connector-github.spec.ts
+++ b/packages/plugins/examples/connector-github/tests/connector-github.spec.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "node:crypto";
+import { verifyGitHubSignature } from "../src/verify.js";
+import { isDuplicateDelivery, markOutboundEcho } from "../src/echo.js";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeSignature(body: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body, "utf8").digest("hex")}`;
+}
+
+/** Make a PluginContext mock backed by a real Map so state ops are coherent. */
+function makeMockCtx(initialState: Record<string, unknown> = {}): PluginContext {
+  const store = new Map<string, unknown>(Object.entries(initialState));
+  return {
+    state: {
+      get: vi.fn(async ({ stateKey }: { stateKey: string }) => store.get(stateKey) ?? null),
+      set: vi.fn(async ({ stateKey }: { stateKey: string }, value: unknown) => {
+        store.set(stateKey, value);
+      }),
+      delete: vi.fn(async ({ stateKey }: { stateKey: string }) => {
+        store.delete(stateKey);
+      }),
+    },
+  } as unknown as PluginContext;
+}
+
+// ---------------------------------------------------------------------------
+// verifyGitHubSignature — timing-safe HMAC verification
+// ---------------------------------------------------------------------------
+
+describe("verifyGitHubSignature", () => {
+  it("accepts a valid signature", () => {
+    const body = '{"action":"opened"}';
+    const secret = "my-webhook-secret";
+    expect(verifyGitHubSignature(body, secret, makeSignature(body, secret))).toBe(true);
+  });
+
+  it("rejects null header", () => {
+    expect(verifyGitHubSignature("{}", "secret", null)).toBe(false);
+  });
+
+  it("rejects empty string header", () => {
+    expect(verifyGitHubSignature("{}", "secret", "")).toBe(false);
+  });
+
+  it("rejects wrong secret", () => {
+    const body = '{"x":1}';
+    const sig = makeSignature(body, "correct-secret");
+    expect(verifyGitHubSignature(body, "wrong-secret", sig)).toBe(false);
+  });
+
+  it("rejects tampered body", () => {
+    const secret = "s";
+    const sig = makeSignature('{"action":"opened"}', secret);
+    expect(verifyGitHubSignature('{"action":"closed"}', secret, sig)).toBe(false);
+  });
+
+  it("rejects sha1= prefix instead of sha256=", () => {
+    const body = "hello";
+    const secret = "s";
+    const hash = createHmac("sha256", secret).update(body, "utf8").digest("hex");
+    expect(verifyGitHubSignature(body, secret, `sha1=${hash}`)).toBe(false);
+  });
+
+  it("rejects short candidate (no early-exit that bypasses constant-time path)", () => {
+    // "sha256=short" is 12 bytes vs 71 bytes — should be false, no crash
+    expect(verifyGitHubSignature("body", "secret", "sha256=short")).toBe(false);
+  });
+
+  it("rejects longer-than-expected candidate", () => {
+    const body = "body";
+    const secret = "s";
+    const sig = makeSignature(body, secret) + "extra";
+    expect(verifyGitHubSignature(body, secret, sig)).toBe(false);
+  });
+
+  // CRITICAL-5 regression: empty secret must be rejected before HMAC computation
+  it("rejects empty secret (fail-closed on misconfiguration)", () => {
+    const body = "{}";
+    // Even if someone forges a correct HMAC with empty secret, we reject early
+    const sig = makeSignature(body, "");
+    expect(verifyGitHubSignature(body, "", sig)).toBe(false);
+  });
+
+  it("handles unicode body correctly", () => {
+    const body = '{"title":"héllo wörld"}';
+    const secret = "unicode-secret";
+    expect(verifyGitHubSignature(body, secret, makeSignature(body, secret))).toBe(true);
+  });
+
+  it("handles empty body", () => {
+    const body = "";
+    const secret = "s";
+    expect(verifyGitHubSignature(body, secret, makeSignature(body, secret))).toBe(true);
+  });
+
+  it("rejects uppercase hex in candidate (case-sensitive)", () => {
+    const body = "test";
+    const secret = "s";
+    const hash = createHmac("sha256", secret).update(body, "utf8").digest("hex").toUpperCase();
+    expect(verifyGitHubSignature(body, secret, `sha256=${hash}`)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDuplicateDelivery / markOutboundEcho
+// ---------------------------------------------------------------------------
+
+describe("isDuplicateDelivery", () => {
+  it("returns false for a first-seen delivery and records it", async () => {
+    const ctx = makeMockCtx();
+    expect(await isDuplicateDelivery(ctx, "delivery-abc")).toBe(false);
+    expect(ctx.state.set).toHaveBeenCalledOnce();
+  });
+
+  it("returns true for a delivery seen within TTL", async () => {
+    const ctx = makeMockCtx();
+    await isDuplicateDelivery(ctx, "delivery-xyz");
+    expect(await isDuplicateDelivery(ctx, "delivery-xyz")).toBe(true);
+  });
+
+  it("returns false and refreshes state when existing record is older than TTL", async () => {
+    const staleTs = Date.now() - 60_000; // 60 s ago — past 30 s TTL
+    const ctx = makeMockCtx({ "echo:delivery-old": { ts: staleTs } });
+    expect(await isDuplicateDelivery(ctx, "delivery-old")).toBe(false);
+    // State must be refreshed with a new timestamp
+    expect(ctx.state.set).toHaveBeenCalledWith(
+      expect.objectContaining({ stateKey: "echo:delivery-old" }),
+      expect.objectContaining({ ts: expect.any(Number) }),
+    );
+    const ts = (ctx.state.set as ReturnType<typeof vi.fn>).mock.calls[0][1].ts as number;
+    expect(ts).toBeGreaterThanOrEqual(staleTs + 1);
+  });
+
+  it("uses state key prefixed with 'echo:'", async () => {
+    const ctx = makeMockCtx();
+    await isDuplicateDelivery(ctx, "my-delivery");
+    expect(ctx.state.get).toHaveBeenCalledWith(
+      expect.objectContaining({ stateKey: "echo:my-delivery" }),
+    );
+  });
+
+  // WARNING-6 regression: corrupted ts must not produce NaN comparisons
+  it("treats corrupted ts (non-number) as expired and processes delivery", async () => {
+    const ctx = makeMockCtx({ "echo:corrupt": { ts: "not-a-number" } });
+    expect(await isDuplicateDelivery(ctx, "corrupt")).toBe(false);
+  });
+
+  it("treats corrupted ts (null) as expired", async () => {
+    const ctx = makeMockCtx({ "echo:null-ts": { ts: null } });
+    expect(await isDuplicateDelivery(ctx, "null-ts")).toBe(false);
+  });
+
+  it("treats corrupted ts (Infinity) as expired", async () => {
+    const ctx = makeMockCtx({ "echo:inf-ts": { ts: Infinity } });
+    expect(await isDuplicateDelivery(ctx, "inf-ts")).toBe(false);
+  });
+
+  // Concurrency note: documented limitation, but test shows mock doesn't hide it
+  it("documents TOCTOU limitation: concurrent calls with same ID both return false on mock", async () => {
+    // Both calls hit state.get before either writes — this is the known SDK limitation.
+    const ctx = makeMockCtx();
+    // Simulate the race: intercept set so the second get sees nothing
+    let firstGetDone = false;
+    const originalGet = ctx.state.get as ReturnType<typeof vi.fn>;
+    const originalSet = ctx.state.set as ReturnType<typeof vi.fn>;
+    // Sequential mock — in real I/O both awaits can interleave
+    const [r1, r2] = await Promise.all([
+      isDuplicateDelivery(ctx, "concurrent"),
+      isDuplicateDelivery(ctx, "concurrent"),
+    ]);
+    // At least one should return false (new delivery) — both false indicates the race
+    // This test documents, not prevents, the race.
+    expect(r1).toBe(false); // first one is always new
+    // r2 may be true (if set was called before second get) or false (race)
+    // We just verify no crash occurs
+    expect(typeof r2).toBe("boolean");
+  });
+});
+
+describe("markOutboundEcho", () => {
+  it("sets state with current timestamp", async () => {
+    const ctx = makeMockCtx();
+    const before = Date.now();
+    await markOutboundEcho(ctx, "issue-123");
+    const after = Date.now();
+    expect(ctx.state.set).toHaveBeenCalledWith(
+      expect.objectContaining({ stateKey: "echo:issue-123" }),
+      expect.objectContaining({ ts: expect.any(Number) }),
+    );
+    const ts = (ctx.state.set as ReturnType<typeof vi.fn>).mock.calls[0][1].ts as number;
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("causes isDuplicateDelivery to return true for the same entity", async () => {
+    const ctx = makeMockCtx();
+    await markOutboundEcho(ctx, "entity-99");
+    expect(await isDuplicateDelivery(ctx, "entity-99")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+describe("mapping helpers", () => {
+  it("getIssueMapping returns null when not set", async () => {
+    const { getIssueMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    expect(await getIssueMapping(ctx, "acme", "repo", 42)).toBeNull();
+  });
+
+  it("setIssueMapping / getIssueMapping round-trips", async () => {
+    const { getIssueMapping, setIssueMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setIssueMapping(ctx, "acme", "repo", 7, "paperclip-uuid-1");
+    expect(await getIssueMapping(ctx, "acme", "repo", 7)).toEqual({ paperclipIssueId: "paperclip-uuid-1" });
+  });
+
+  it("getPrMapping returns null when not set", async () => {
+    const { getPrMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    expect(await getPrMapping(ctx, "acme", "repo", 99)).toBeNull();
+  });
+
+  it("setPrMapping / getPrMapping round-trips", async () => {
+    const { getPrMapping, setPrMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setPrMapping(ctx, "acme", "repo", 15, "pc-uuid-2");
+    expect(await getPrMapping(ctx, "acme", "repo", 15)).toEqual({ paperclipIssueId: "pc-uuid-2" });
+  });
+
+  it("issue and PR mappings for the same number use distinct state keys", async () => {
+    const { setIssueMapping, setPrMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setIssueMapping(ctx, "org", "myrepo", 1, "issue-id");
+    await setPrMapping(ctx, "org", "myrepo", 1, "pr-id");
+    const calls = (ctx.state.set as ReturnType<typeof vi.fn>).mock.calls as [{ stateKey: string }, unknown][];
+    expect(calls[0][0].stateKey).not.toEqual(calls[1][0].stateKey);
+    expect(calls[0][0].stateKey).toContain("issue");
+    expect(calls[1][0].stateKey).toContain("pr");
+  });
+
+  it("different GH numbers produce different state keys", async () => {
+    const { setIssueMapping } = await import("../src/mapping.js");
+    const ctx = makeMockCtx();
+    await setIssueMapping(ctx, "org", "repo", 1, "id-1");
+    await setIssueMapping(ctx, "org", "repo", 2, "id-2");
+    const calls = (ctx.state.set as ReturnType<typeof vi.fn>).mock.calls as [{ stateKey: string }, unknown][];
+    expect(calls[0][0].stateKey).not.toEqual(calls[1][0].stateKey);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manifest assertions (security contract)
+// ---------------------------------------------------------------------------
+
+describe("manifest security contract", () => {
+  it("webhookSecret is in required array", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.instanceConfigSchema?.required as string[]).toContain("webhookSecret");
+  });
+
+  it("owner is in required array", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.instanceConfigSchema?.required as string[]).toContain("owner");
+  });
+
+  it("repo is in required array", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.instanceConfigSchema?.required as string[]).toContain("repo");
+  });
+
+  it("declares webhooks.receive capability", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.capabilities).toContain("webhooks.receive");
+  });
+
+  it("declares agents.invoke capability", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.capabilities).toContain("agents.invoke");
+  });
+
+  it("declares plugin.state.write capability (echo dedup persistence)", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.capabilities).toContain("plugin.state.write");
+  });
+
+  it("declares http.outbound capability", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.capabilities).toContain("http.outbound");
+  });
+
+  it("declares secrets.read-ref capability (GitHub token)", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.capabilities).toContain("secrets.read-ref");
+  });
+
+  it("has a webhook endpoint keyed 'github-events'", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    expect(manifest.webhooks?.find((w) => w.endpointKey === "github-events")).toBeDefined();
+  });
+
+  it("does NOT declare approval buttons or unimplemented features", async () => {
+    const { default: manifest } = await import("../src/manifest.js");
+    // Regression: Slack connector was flagged for declaring features it didn't implement
+    const caps = manifest.capabilities ?? [];
+    // We only declare what we actually use
+    expect(caps).not.toContain("issues.delete");
+    expect(caps).not.toContain("agents.create");
+  });
+});

--- a/packages/plugins/examples/connector-github/tsconfig.json
+++ b/packages/plugins/examples/connector-github/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/examples/connector-github/vitest.config.ts
+++ b/packages/plugins/examples/connector-github/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `connector-github` plugin: bidirectional GitHub ↔ Paperclip sync
- Labels ↔ priority mapping, milestones ↔ goals sync
- Echo deduplication to prevent sync loops (inbound and outbound)
- HMAC webhook signature verification
- Wakeup deduplication to prevent redundant agent runs

## Changes

- `packages/plugins/examples/connector-github/` — new plugin
- `outbound` echo mark placed **after** successful GitHub API call (fixes ordering bug)
- No double-write: `issue.updated` / `issue.comment.created` use `isDuplicateDelivery` only, `markOutboundEcho` not called again

## Review comments addressed

- ✅ `markOutboundIssueEcho` timing: called after `createGitHubIssue` succeeds, not before
- ✅ No double-write in update/comment handlers: they use `outbound:` prefix dedup, no redundant echo mark

## Notes

- `pnpm-lock.yaml` intentionally excluded per CI policy