### PR TITLE
fix: merge adapterConfig on PATCH instead of replacing

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1710,9 +1710,18 @@ export function agentRoutes(db: Db) {
       Object.prototype.hasOwnProperty.call(patchData, "adapterType") ||
       Object.prototype.hasOwnProperty.call(patchData, "adapterConfig");
     if (touchesAdapterConfiguration) {
-      const rawEffectiveAdapterConfig = Object.prototype.hasOwnProperty.call(patchData, "adapterConfig")
+      const existingAdapterConfig = asRecord(existing.adapterConfig) ?? {};
+      const incomingAdapterConfig = Object.prototype.hasOwnProperty.call(patchData, "adapterConfig")
         ? (asRecord(patchData.adapterConfig) ?? {})
-        : (asRecord(existing.adapterConfig) ?? {});
+        : existingAdapterConfig;
+      // Merge incoming config with existing so that fields not managed by the
+      // UI (e.g. dangerouslySkipPermissions, instructionsRootPath) are preserved.
+      // When adapter type changes, skip the merge — old fields are meaningless.
+      const isAdapterTypeChange = Object.prototype.hasOwnProperty.call(patchData, "adapterType") &&
+        patchData.adapterType !== existing.adapterType;
+      const rawEffectiveAdapterConfig = isAdapterTypeChange
+        ? incomingAdapterConfig
+        : { ...existingAdapterConfig, ...incomingAdapterConfig };
       const effectiveAdapterConfig = applyCreateDefaultsByAdapterType(
         requestedAdapterType,
         rawEffectiveAdapterConfig,


### PR DESCRIPTION
## Summary

- When updating an agent via `PATCH /agents/:id`, the `adapterConfig` was being fully replaced with the incoming value
- This caused fields not managed by the UI (e.g. `dangerouslySkipPermissions`, `instructionsRootPath`, `instructionsFilePath`) to be silently dropped whenever an agent was edited through the dashboard
- Now the incoming `adapterConfig` is shallow-merged with the existing config, preserving fields the UI doesn't know about
- When the adapter type changes, the merge is skipped since old adapter fields are meaningless for the new type

## Repro

1. Create an agent with `dangerouslySkipPermissions: true` in adapterConfig (via API)
2. Edit the agent name or model in the dashboard UI
3. Check adapterConfig — `dangerouslySkipPermissions` is gone

## Test plan

- [ ] Edit agent in UI without changing adapter type — verify non-UI fields are preserved
- [ ] Change adapter type in UI — verify old config is replaced (not merged)
- [ ] API PATCH with partial adapterConfig — verify merge with existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)