### PR TITLE
chore: add Cursor BugBot rules (.cursor/bugbot.json)

### DIFF
--- a/.cursor/bugbot.json
+++ b/.cursor/bugbot.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    "Every mutation must write an activity_log entry",
+    "All domain entities must be company-scoped",
+    "No hardcoded credentials — use env vars",
+    "Tests must pass before merge",
+    "TypeScript strict mode — no any types without justification",
+    "All API endpoints must validate input",
+    "Budget operations require board approval flags"
+  ]
+}


### PR DESCRIPTION
Adds BugBot rules file for the Cursor BugBot integration.

## Rules added
- Every mutation must write an activity_log entry
- All domain entities must be company-scoped
- No hardcoded credentials — use env vars
- Tests must pass before merge
- TypeScript strict mode — no any types without justification
- All API endpoints must validate input
- Budget operations require board approval flags

This completes WEI-15 (Enable Cursor BugBot on all repos). Once this PR is merged and BugBot is connected at cursor.com/bugbot for the paperclipai org, the issue can be closed.