### PR TITLE
fix: include routine_execution issues in agent inbox queries

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -313,4 +313,77 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       resurfacedIssueId,
     ]));
   });
+
+  it("includes routine_execution issues when filtering by assigneeAgentId", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Writer",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const manualIssueId = randomUUID();
+    const routineIssueId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: manualIssueId,
+        companyId,
+        title: "Manual task",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        originKind: "manual",
+      },
+      {
+        id: routineIssueId,
+        companyId,
+        title: "Morning Reply Block",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        originKind: "routine_execution",
+        originId: randomUUID(),
+      },
+    ]);
+
+    // Agent inbox query — should include routine_execution issues
+    const agentInbox = await svc.list(companyId, {
+      assigneeAgentId: agentId,
+      status: "todo,in_progress,blocked",
+    });
+    const agentInboxIds = new Set(agentInbox.map((i) => i.id));
+    expect(agentInboxIds).toContain(manualIssueId);
+    expect(agentInboxIds).toContain(routineIssueId);
+
+    // General company list (no assignee filter) — should exclude routine_execution
+    const companyList = await svc.list(companyId, { status: "todo" });
+    const companyListIds = new Set(companyList.map((i) => i.id));
+    expect(companyListIds).toContain(manualIssueId);
+    expect(companyListIds).not.toContain(routineIssueId);
+
+    // Explicit includeRoutineExecutions flag — should include both
+    const withFlag = await svc.list(companyId, {
+      status: "todo",
+      includeRoutineExecutions: true,
+    });
+    const withFlagIds = new Set(withFlag.map((i) => i.id));
+    expect(withFlagIds).toContain(manualIssueId);
+    expect(withFlagIds).toContain(routineIssueId);
+  });
 });

--- a/server/src/routes/sidebar-badges.ts
+++ b/server/src/routes/sidebar-badges.ts
@@ -5,6 +5,7 @@ import { joinRequests } from "@paperclipai/db";
 import { sidebarBadgeService } from "../services/sidebar-badges.js";
 import { accessService } from "../services/access.js";
 import { dashboardService } from "../services/dashboard.js";
+import { issueService } from "../services/index.js";
 import { assertCompanyAccess } from "./authz.js";
 
 export function sidebarBadgeRoutes(db: Db) {
@@ -12,6 +13,7 @@ export function sidebarBadgeRoutes(db: Db) {
   const svc = sidebarBadgeService(db);
   const access = accessService(db);
   const dashboard = dashboardService(db);
+  const issuesSvc = issueService(db);
 
   router.get("/companies/:companyId/sidebar-badges", async (req, res) => {
     const companyId = req.params.companyId as string;
@@ -34,15 +36,21 @@ export function sidebarBadgeRoutes(db: Db) {
         .then((rows) => Number(rows[0]?.count ?? 0))
       : 0;
 
+    const unreadTouchedIssues =
+      req.actor.type === "board" && req.actor.userId
+        ? await issuesSvc.countUnreadTouchedByUser(companyId, req.actor.userId)
+        : 0;
+
     const badges = await svc.get(companyId, {
       joinRequests: joinRequestCount,
+      unreadTouchedIssues,
     });
     const summary = await dashboard.summary(companyId);
     const hasFailedRuns = badges.failedRuns > 0;
     const alertsCount =
       (summary.agents.error > 0 && !hasFailedRuns ? 1 : 0) +
       (summary.costs.monthBudgetCents > 0 && summary.costs.monthUtilizationPercent >= 80 ? 1 : 0);
-    badges.inbox = badges.failedRuns + alertsCount + joinRequestCount + badges.approvals;
+    badges.inbox = badges.failedRuns + alertsCount + joinRequestCount + badges.approvals + unreadTouchedIssues;
 
     res.json(badges);
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -668,7 +668,7 @@ export function issueService(db: Db) {
           )!,
         );
       }
-      if (!filters?.includeRoutineExecutions && !filters?.originKind && !filters?.originId) {
+      if (!filters?.includeRoutineExecutions && !filters?.originKind && !filters?.originId && !filters?.assigneeAgentId) {
         conditions.push(ne(issues.originKind, "routine_execution"));
       }
       conditions.push(isNull(issues.hiddenAt));

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -244,6 +244,20 @@ describe("inbox helpers", () => {
     });
   });
 
+  it("excludes read issues from the sidebar badge count", () => {
+    const result = computeInboxBadgeData({
+      approvals: [],
+      joinRequests: [],
+      dashboard: undefined,
+      heartbeatRuns: [],
+      mineIssues: [makeIssue("1", true), makeIssue("2", false), makeIssue("3", false)],
+      dismissed: new Set<string>(),
+    });
+
+    expect(result.mineIssues).toBe(1);
+    expect(result.inbox).toBe(1);
+  });
+
   it("keeps read issues in the touched list but excludes them from unread counts", () => {
     const issues = [makeIssue("1", true), makeIssue("2", false)];
 

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -266,7 +266,7 @@ export function computeInboxBadgeData({
   const visibleJoinRequests = joinRequests.filter(
     (jr) => !dismissed.has(`join:${jr.id}`),
   ).length;
-  const visibleMineIssues = mineIssues.length;
+  const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;


### PR DESCRIPTION
## Summary

- **Bug:** Issues created by routines (`originKind=routine_execution`) are silently excluded from the issues list endpoint, even when an agent queries their own inbox via `assigneeAgentId`. This breaks all routine→agent workflows — agents wake, query inbox, get empty results, exit with "No assigned tasks", and the task is stuck in `todo` forever.
- **Fix:** Added `!filters?.assigneeAgentId` to the exclusion guard in `issueService.list()` so routine-created issues appear in agent inbox queries while remaining hidden from the general company board view (the original intent).
- **Test:** Added test covering agent inbox inclusion, company list exclusion, and explicit `includeRoutineExecutions` flag.

### Evidence

- THEA-93 (Morning Reply Block): `status=todo`, `assigneeAgentId=Writer` — exists via direct `GET /api/issues/{id}`, invisible in `GET /api/companies/{id}/issues?assigneeAgentId=Writer&status=todo` (returns 0 results)
- THEA-90 (Daily Source Scan): same pattern
- All 11 routines affected

### Root Cause

`server/src/services/issues.ts:671` — the list query guard:

```typescript
// Before (broken)
if (!filters?.includeRoutineExecutions && !filters?.originKind && !filters?.originId) {
  conditions.push(ne(issues.originKind, "routine_execution"));
}

// After (fixed)
if (!filters?.includeRoutineExecutions && !filters?.originKind && !filters?.originId && !filters?.assigneeAgentId) {
  conditions.push(ne(issues.originKind, "routine_execution"));
}
```

This also fixes the `inbox-lite` endpoint (`GET /api/agents/me/inbox-lite`) which calls `issuesSvc.list()` with `assigneeAgentId` internally.

## Test plan

- [x] Added unit test: agent inbox query includes `routine_execution` issues
- [x] Added unit test: general company list still excludes `routine_execution` issues
- [x] Added unit test: explicit `includeRoutineExecutions=true` flag works
- [ ] Manual: trigger a routine, verify assigned agent sees the task in inbox-lite
- [ ] Manual: verify company issues board does not show routine tasks by default