### PR TITLE
Fix dev server restart shutdown on Windows

### DIFF
--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
@@ -14,7 +15,9 @@ const autoRestartPollIntervalMs = 2500;
 const gracefulShutdownTimeoutMs = 10_000;
 const changedPathSampleLimit = 5;
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const serverRoot = path.join(repoRoot, "server");
 const devServerStatusFilePath = path.join(repoRoot, ".paperclip", "dev-server-status.json");
+const require = createRequire(import.meta.url);
 
 const watchedDirectories = [
   "cli",
@@ -111,6 +114,31 @@ let child = null;
 let childExitPromise = null;
 let scanTimer = null;
 let autoRestartTimer = null;
+
+function resolveTsxCliPath() {
+  const candidateRequires = [
+    require,
+    createRequire(path.join(serverRoot, "package.json")),
+  ];
+
+  for (const requireFn of candidateRequires) {
+    try {
+      const tsxRoot = path.dirname(requireFn.resolve("tsx/package.json"));
+      const tsxCliCandidates = [
+        path.resolve(tsxRoot, "dist", "cli.mjs"),
+        path.resolve(tsxRoot, "dist", "cli.js"),
+      ];
+      const tsxCliPath = tsxCliCandidates.find((candidate) => existsSync(candidate));
+      if (tsxCliPath) {
+        return tsxCliPath;
+      }
+    } catch {
+      // Keep trying fallback resolution strategies.
+    }
+  }
+
+  throw new Error("Failed to locate tsx CLI entrypoint for server dev process");
+}
 
 function toError(error, context = "Dev runner command failed") {
   if (error instanceof Error) return error;
@@ -455,11 +483,12 @@ async function stopChildForRestart() {
 async function startServerChild() {
   await buildPluginSdk();
 
-  const serverScript = mode === "watch" ? "dev:watch" : "dev";
+  const tsxCliPath = resolveTsxCliPath();
+  const serverEntryPoint = mode === "watch" ? "./scripts/dev-watch.ts" : "src/index.ts";
   child = spawn(
-    pnpmBin,
-    ["--filter", "@paperclipai/server", serverScript, ...forwardedArgs],
-    { stdio: "inherit", env, shell: process.platform === "win32" },
+    process.execPath,
+    [tsxCliPath, serverEntryPoint, ...forwardedArgs],
+    { stdio: "inherit", env, cwd: serverRoot },
   );
 
   childExitPromise = new Promise((resolve, reject) => {

--- a/server/scripts/dev-watch.ts
+++ b/server/scripts/dev-watch.ts
@@ -1,11 +1,29 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveServerDevWatchIgnorePaths } from "../src/dev-watch-ignore.ts";
 
 const require = createRequire(import.meta.url);
-const tsxCliPath = require.resolve("tsx/cli");
+const gracefulShutdownTimeoutMs = 10_000;
+
+let tsxCliPath: string;
+try {
+  tsxCliPath = require.resolve("tsx/cli");
+} catch {
+  // Older installs may not expose tsx/cli; fall back to the package root lookup.
+  const tsxRoot = path.dirname(require.resolve("tsx/package.json"));
+  const tsxCliCandidates = [
+    path.resolve(tsxRoot, "dist", "cli.mjs"),
+    path.resolve(tsxRoot, "dist", "cli.js"),
+  ];
+  const fallbackTsxCliPath = tsxCliCandidates.find((candidate) => existsSync(candidate));
+  if (!fallbackTsxCliPath) {
+    throw new Error(`Failed to locate tsx CLI entrypoint under ${tsxRoot}`);
+  }
+  tsxCliPath = fallbackTsxCliPath;
+}
 const serverRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ignoreArgs = resolveServerDevWatchIgnorePaths(serverRoot).flatMap((ignorePath) => ["--exclude", ignorePath]);
 
@@ -19,12 +37,64 @@ const child = spawn(
   },
 );
 
+let shuttingDown = false;
+let childExitWasExpected = false;
+let childExited = false;
+
+function exitForSignal(signal: NodeJS.Signals): never {
+  if (signal === "SIGINT") process.exit(130);
+  if (signal === "SIGTERM") process.exit(143);
+  process.exit(1);
+}
+
+const childExitPromise = new Promise<{ code: number; signal: NodeJS.Signals | null }>((resolve) => {
+  child.on("exit", (code, signal) => {
+    childExited = true;
+    resolve({ code: code ?? 0, signal });
+  });
+});
+
 child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
+  const expected = childExitWasExpected;
+  childExitWasExpected = false;
+
+  if (shuttingDown || expected) {
     return;
   }
+  if (signal) {
+    exitForSignal(signal);
+  }
   process.exit(code ?? 0);
+});
+
+async function shutdown(signal: NodeJS.Signals) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  childExitWasExpected = true;
+  child.kill(signal);
+  const killTimer = setTimeout(() => {
+    if (!childExited) {
+      child.kill("SIGKILL");
+    }
+  }, gracefulShutdownTimeoutMs);
+
+  try {
+    const exit = await childExitPromise;
+    if (exit.signal) {
+      exitForSignal(exit.signal);
+    }
+    process.exit(exit.code);
+  } finally {
+    clearTimeout(killTimer);
+  }
+}
+
+process.on("SIGINT", () => {
+  void shutdown("SIGINT");
+});
+
+process.on("SIGTERM", () => {
+  void shutdown("SIGTERM");
 });
 
 child.on("error", (error) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local development depends on a watch-mode control loop that restarts the server process as code changes
> - Embedded PostgreSQL is the default local database, so smooth dev restarts depend on the process tree shutting down cleanly
> - On Windows, the dev runner and the server watch wrapper could leave child processes alive across restarts
> - That stale process state leaves embedded Postgres running without consistent lock-file state, and the next boot can fail with shared memory errors
> - This pull request makes the dev runner spawn the server directly and forwards shutdown signals through the watch wrapper
> - The benefit is more reliable pnpm dev restarts and cleaner embedded PostgreSQL recovery in local development

## What Changed

- scripts/dev-runner.mjs now resolves the server-local 	sx CLI and launches the server entrypoint directly with Node instead of keeping a long-lived pnpm wrapper in the process tree.
- server/scripts/dev-watch.ts now forwards SIGINT/SIGTERM to its child watcher, waits for orderly exit, and escalates to SIGKILL only after a timeout.
- server/scripts/dev-watch.ts prefers 	sx/cli but falls back to the older dist/cli.{mjs,js} lookup so the restart fix still works across different 	sx package layouts.

## Verification

- 
ode --check scripts/dev-runner.mjs
- pnpm --filter @paperclipai/server typecheck

## Risks

- Low risk: the changes are scoped to dev-only runner/watch scripts and do not affect production server startup.
- The main behavioral change is process spawning and signal propagation during local dev restarts, so any regression should be limited to pnpm dev / pnpm dev:watch behavior.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge