### PR TITLE
fix: Issues filter Clear button now resets projects filter

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -424,7 +424,7 @@ export function IssuesList({
                   {activeFilterCount > 0 && (
                     <button
                       className="text-xs text-muted-foreground hover:text-foreground"
-                      onClick={() => updateView({ statuses: [], priorities: [], assignees: [], labels: [] })}
+                      onClick={() => updateView({ statuses: [], priorities: [], assignees: [], labels: [], projects: [] })}
                     >
                       Clear
                     </button>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans oversee agent work through the Issues page with filtering capabilities
> - The Issues filter popover has a "Clear" button to reset all active filters
> - But the Clear button was only resetting statuses, priorities, assignees, and labels
> - It missed the `projects` filter, so clicking Clear with an active project filter had no visible effect
> - This PR adds `projects: []` to the Clear button handler so all filters are properly reset

## What Changed

One-line fix in `ui/src/components/IssuesList.tsx` — added `projects: []` to the `updateView` call in the Clear button `onClick` handler.

## How to Verify

1. Go to Issues page
2. Open filter popover → select a project filter
3. Click "Clear"
4. ✅ Project filter should now be cleared (previously it stayed active)

## Risk

Minimal — single line, no new dependencies, no API changes.