### PR TITLE
fix(ui): show error when model detection fails in agent config

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1359,6 +1359,7 @@ function ModelDropdown({
 }) {
   const [modelSearch, setModelSearch] = useState("");
   const [detectingModel, setDetectingModel] = useState(false);
+  const [detectError, setDetectError] = useState<string | null>(null);
   const selected = models.find((m) => m.id === value);
   const manualModel = modelSearch.trim();
   const canCreateManualModel = Boolean(
@@ -1405,13 +1406,18 @@ function ModelDropdown({
   async function handleDetectModel() {
     if (!onDetectModel) return;
     setDetectingModel(true);
+    setDetectError(null);
     try {
       const nextModel = await onDetectModel();
       if (nextModel) {
         onChange(nextModel);
         onOpenChange(false);
         setModelSearch("");
+      } else {
+        setDetectError("No model found in config");
       }
+    } catch (err) {
+      setDetectError(err instanceof Error ? err.message : "Detection failed");
     } finally {
       setDetectingModel(false);
     }
@@ -1473,6 +1479,9 @@ function ModelDropdown({
               </svg>
               {detectingModel ? "Detecting..." : (detectModelLabel ?? "Detect from config")}
             </button>
+          )}
+          {detectError && (
+            <p className="px-2 py-1 text-xs text-destructive">{detectError}</p>
           )}
           {value && !models.some((m) => m.id === value) && (
             <button


### PR DESCRIPTION
## Problem

The new "Detect from Hermes config" button in the model picker (added in the recent Hermes adapter update) silently swallow all errors. When detection fail for any reason:

- Config file not found -> button go back to normal, nothing happen
- Network error -> same, zero feedback
- Invalid config format -> same
- Detection return null (no model found) -> same

User click the button, see "Detecting..." for a moment, then it go back to "Detect from Hermes config" and they have no idea what went wrong. Maybe they think it work and start looking for the detected model in the list.

## What I changed

Added error handling to the `handleDetectModel()` function:

1. **Catch errors**: When the Promise reject, capture the error message and show it
2. **Handle null result**: When detection return null (no model found), show "No model found in config"
3. **Inline error display**: Show red text below the detect button with the error message
4. **Auto-clear**: Error message clear when user click detect again

## How to test

1. Set up an agent with hermes_local adapter
2. Try to detect model when Hermes is not configured -> should see error message
3. Try with valid config -> should detect normally (error clear if there was one before)

1 file, 9 lines added.

Note: the existing TS error on \`hermes-paperclip-adapter/ui\` module is pre-existing on master (module not yet published) and not related to this change.