### PR TITLE
fix(ui): style GFM task list checkboxes in markdown content

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -626,6 +626,47 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
   color: var(--muted-foreground);
 }
 
+.paperclip-markdown .contains-task-list {
+  list-style: none;
+  padding-left: 0.25rem;
+}
+
+.paperclip-markdown .task-list-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.paperclip-markdown .task-list-item input[type="checkbox"] {
+  appearance: none;
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 1.5px solid var(--border);
+  border-radius: 3px;
+  background: transparent;
+  flex-shrink: 0;
+  position: relative;
+  top: 0.125rem;
+  cursor: default;
+}
+
+.paperclip-markdown .task-list-item input[type="checkbox"]:checked {
+  background-color: var(--primary);
+  border-color: var(--primary);
+}
+
+.paperclip-markdown .task-list-item input[type="checkbox"]:checked::after {
+  content: "";
+  position: absolute;
+  left: 2.5px;
+  top: 0.5px;
+  width: 5px;
+  height: 8px;
+  border: solid var(--primary-foreground);
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(45deg);
+}
+
 .paperclip-markdown h1,
 .paperclip-markdown h2,
 .paperclip-markdown h3,


### PR DESCRIPTION
## Problem

The markdown renderer already support GFM task lists because remark-gfm is loaded. So when someone write this in agent instructions or issue descriptions:

\`\`\`markdown
- [ ] Deploy to staging
- [x] Write unit tests
- [ ] Update documentation
\`\`\`

It render as a list with checkboxes. But the checkboxes was completely unstyled - just the bare browser default checkbox input. On some browsers it look tiny and ugly, on others it have the old Windows-style checkbox look. Very out of place with the rest of the polished UI.

Also the task list items was showing bullet markers next to the checkboxes which look wrong (you don't want both a bullet and a checkbox).

## What I changed

Added CSS styling for GFM task list elements:

**Container (\`.contains-task-list\`):**
- Remove list bullets since checkboxes replace them
- Reduce left padding

**Task item (\`.task-list-item\`):**
- Flex layout for proper checkbox-text alignment
- Small gap between checkbox and text

**Checkbox (\`input[type="checkbox"]\`):**
- Custom appearance (hide browser default)
- 14px square with rounded corners
- Border using \`--border\` theme variable
- Proper vertical alignment with text baseline

**Checked state:**
- Background fill using \`--primary\` color
- White checkmark drawn with CSS borders (rotated L shape)
- Border color match the fill

All colors use CSS variables so it work correctly in both light and dark mode.

## How to test

Create or view any content with GFM task lists:

\`\`\`markdown
- [ ] Not done item
- [x] Completed item
\`\`\`

Should see styled checkboxes that match the app design instead of browser defaults.

1 file, 41 CSS lines added.