### PR TITLE
[codex] fix local adapter workspace env regressions

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -306,6 +306,25 @@ export function ensurePathInEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return { ...env, PATH: defaultPathForPlatform() };
 }
 
+export function deriveAgentHomeFromInstructionsFilePath(
+  instructionsFilePath: string,
+  cwd = process.cwd(),
+): string | null {
+  const trimmed = instructionsFilePath.trim();
+  if (!trimmed) return null;
+  const resolved = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  return path.dirname(resolved);
+}
+
+function stripAmbientPaperclipEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const stripped: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith("PAPERCLIP_")) continue;
+    stripped[key] = value;
+  }
+  return stripped;
+}
+
 export async function ensureAbsoluteDirectory(
   cwd: string,
   opts: { createIfMissing?: boolean } = {},
@@ -733,7 +752,10 @@ export async function runChildProcess(
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
 
   return new Promise<RunProcessResult>((resolve, reject) => {
-    const rawMerged: NodeJS.ProcessEnv = { ...process.env, ...opts.env };
+    const rawMerged: NodeJS.ProcessEnv = {
+      ...stripAmbientPaperclipEnv(process.env),
+      ...opts.env,
+    };
 
     // Strip Claude Code nesting-guard env vars so spawned `claude` processes
     // don't refuse to start with "cannot be launched inside another session".

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -18,6 +18,7 @@ import {
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePathInEnv,
+  deriveAgentHomeFromInstructionsFilePath,
   renderTemplate,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -230,6 +231,13 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
   if (runtimePrimaryUrl) {
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
+  const derivedAgentHome = deriveAgentHomeFromInstructionsFilePath(
+    asString(config.instructionsFilePath, ""),
+    cwd,
+  );
+  if (derivedAgentHome && !env.AGENT_HOME) {
+    env.AGENT_HOME = derivedAgentHome;
   }
 
   for (const [key, value] of Object.entries(envConfig)) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -133,9 +133,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 
   const envConfig = parseObject(config.env);
@@ -186,8 +184,8 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   if (linkedIssueIds.length > 0) {
     env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceCwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -114,6 +114,8 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "") || null;
   const workspaceRepoRef = asString(workspaceContext.repoRef, "") || null;
   const workspaceBranch = asString(workspaceContext.branchName, "") || null;
+  const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "") || null;
+  const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "") || null;
   const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
   const agentHome = asString(workspaceContext.agentHome, "") || null;
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
@@ -204,6 +206,12 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
   if (workspaceBranch) {
     env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  }
+  if (workspaceObservedBranch) {
+    env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
+  }
+  if (workspaceObservedHead) {
+    env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
   }
   if (workspaceWorktreePath) {
     env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -257,9 +257,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   const envConfig = parseObject(config.env);
   const configuredCodexHome =
     typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
@@ -330,8 +328,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) {
     env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceCwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -16,6 +16,7 @@ import {
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  deriveAgentHomeFromInstructionsFilePath,
   renderTemplate,
   joinPromptSections,
   runChildProcess,
@@ -374,6 +375,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (runtimePrimaryUrl) {
     env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+  }
+  const derivedAgentHome = deriveAgentHomeFromInstructionsFilePath(
+    asString(config.instructionsFilePath, ""),
+    cwd,
+  );
+  if (derivedAgentHome && !env.AGENT_HOME) {
+    env.AGENT_HOME = derivedAgentHome;
   }
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -238,6 +238,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
   const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
+  const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
   const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
@@ -348,6 +350,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (workspaceBranch) {
     env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  }
+  if (workspaceObservedBranch) {
+    env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
+  }
+  if (workspaceObservedHead) {
+    env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
   }
   if (workspaceWorktreePath) {
     env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -180,9 +180,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const cursorSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredCursorSkillNames = resolvePaperclipDesiredSkillNames(config, cursorSkillEntries);
@@ -236,8 +234,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) {
     env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   }
-  if (effectiveWorkspaceCwd) {
-    env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceCwd) {
+    env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   }
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -17,6 +17,7 @@ import {
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
   removeMaintainerOnlySkillSymlinks,
+  deriveAgentHomeFromInstructionsFilePath,
   renderTemplate,
   joinPromptSections,
   runChildProcess,
@@ -274,6 +275,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (workspaceHints.length > 0) {
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  }
+  const derivedAgentHome = deriveAgentHomeFromInstructionsFilePath(
+    asString(config.instructionsFilePath, ""),
+    cwd,
+  );
+  if (derivedAgentHome && !env.AGENT_HOME) {
+    env.AGENT_HOME = derivedAgentHome;
   }
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -170,11 +170,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
   const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
   const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -242,6 +245,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceSource) {
     env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   }
+  if (workspaceStrategy) {
+    env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
+  }
   if (workspaceId) {
     env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   }
@@ -251,11 +257,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceRepoRef) {
     env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
   }
+  if (workspaceBranch) {
+    env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
+  }
   if (workspaceObservedBranch) {
     env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
   }
   if (workspaceObservedHead) {
     env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
+  }
+  if (workspaceWorktreePath) {
+    env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   }
   if (agentHome) {
     env.AGENT_HOME = agentHome;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -173,6 +173,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
+  const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -248,6 +250,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (workspaceRepoRef) {
     env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  }
+  if (workspaceObservedBranch) {
+    env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
+  }
+  if (workspaceObservedHead) {
+    env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
   }
   if (agentHome) {
     env.AGENT_HOME = agentHome;

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -146,11 +146,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
   const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
   const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -200,11 +203,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
   if (workspaceObservedBranch) env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
   if (workspaceObservedHead) env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
 

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -149,6 +149,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
+  const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -201,6 +203,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceObservedBranch) env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
+  if (workspaceObservedHead) env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
 

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -156,9 +156,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const geminiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredGeminiSkillNames = resolvePaperclipDesiredSkillNames(config, geminiSkillEntries);
@@ -198,7 +196,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  deriveAgentHomeFromInstructionsFilePath,
   renderTemplate,
   runChildProcess,
   readPaperclipRuntimeSkillEntries,
@@ -173,6 +174,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  const derivedAgentHome = deriveAgentHomeFromInstructionsFilePath(
+    asString(config.instructionsFilePath, ""),
+    cwd,
+  );
+  if (derivedAgentHome && !env.AGENT_HOME) env.AGENT_HOME = derivedAgentHome;
 
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -105,6 +105,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
+  const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -161,6 +163,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceObservedBranch) env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
+  if (workspaceObservedHead) env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
 

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -102,11 +102,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
   const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
   const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -160,11 +163,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
   if (workspaceObservedBranch) env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
   if (workspaceObservedHead) env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
 

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -112,9 +112,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredOpenCodeSkillNames = resolvePaperclipDesiredSkillNames(config, openCodeSkillEntries);
@@ -158,7 +156,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -123,11 +123,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
   const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
   const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
+  const workspaceWorktreePath = asString(workspaceContext.worktreePath, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -185,11 +188,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceStrategy) env.PAPERCLIP_WORKSPACE_STRATEGY = workspaceStrategy;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceBranch) env.PAPERCLIP_WORKSPACE_BRANCH = workspaceBranch;
   if (workspaceObservedBranch) env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
   if (workspaceObservedHead) env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
+  if (workspaceWorktreePath) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspaceWorktreePath;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
 

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -133,9 +133,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   
   // Ensure sessions directory exists

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -126,6 +126,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceObservedBranch = asString(workspaceContext.observedBranchName, "");
+  const workspaceObservedHead = asString(workspaceContext.observedHeadSha, "");
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -186,6 +188,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
   if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (workspaceObservedBranch) env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH = workspaceObservedBranch;
+  if (workspaceObservedHead) env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD = workspaceObservedHead;
   if (agentHome) env.AGENT_HOME = agentHome;
   if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
 

--- a/server/src/__tests__/local-adapter-workspace-env-parity.test.ts
+++ b/server/src/__tests__/local-adapter-workspace-env-parity.test.ts
@@ -1,0 +1,357 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { execute as executeClaude } from "@paperclipai/adapter-claude-local/server";
+import { execute as executeCodex } from "@paperclipai/adapter-codex-local/server";
+import { execute as executeCursor } from "@paperclipai/adapter-cursor-local/server";
+import { execute as executeGemini } from "@paperclipai/adapter-gemini-local/server";
+import { execute as executeOpenCode } from "@paperclipai/adapter-opencode-local/server";
+import { execute as executePi } from "@paperclipai/adapter-pi-local/server";
+
+const CAPTURE_KEYS = [
+  "PAPERCLIP_WORKSPACE_CWD",
+  "PAPERCLIP_WORKSPACE_SOURCE",
+  "PAPERCLIP_WORKSPACE_STRATEGY",
+  "PAPERCLIP_WORKSPACE_ID",
+  "PAPERCLIP_WORKSPACE_REPO_URL",
+  "PAPERCLIP_WORKSPACE_REPO_REF",
+  "PAPERCLIP_WORKSPACE_BRANCH",
+  "PAPERCLIP_WORKSPACE_WORKTREE_PATH",
+] as const;
+
+type CaptureKey = (typeof CAPTURE_KEYS)[number];
+
+type CapturePayload = {
+  env: Partial<Record<CaptureKey, string>>;
+};
+
+type TestExecute = typeof executeClaude;
+
+type AdapterCase = {
+  name: string;
+  adapterType: string;
+  commandName: string;
+  execute: TestExecute;
+  commandMode: "claude" | "codex" | "cursor" | "gemini" | "opencode" | "pi";
+  config?: Record<string, unknown>;
+  setupEnv?: (root: string) => Promise<() => void>;
+};
+
+async function writeExecutable(commandPath: string, script: string): Promise<void> {
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+async function writeCaptureCommand(
+  commandPath: string,
+  mode: AdapterCase["commandMode"],
+): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const capture = () => {
+  if (!capturePath) return;
+  fs.writeFileSync(
+    capturePath,
+    JSON.stringify({
+      env: Object.fromEntries(
+        ${JSON.stringify([...CAPTURE_KEYS])}
+          .filter((key) => typeof process.env[key] === "string" && process.env[key].length > 0)
+          .map((key) => [key, process.env[key]]),
+      ),
+    }),
+    "utf8",
+  );
+};
+
+if (${JSON.stringify(mode)} === "opencode") {
+  if (args[0] === "models") {
+    console.log("openai/gpt-5.4 ready");
+    process.exit(0);
+  }
+  if (args[0] === "run") {
+    capture();
+    fs.readFileSync(0, "utf8");
+    console.log(JSON.stringify({ type: "step_start", sessionID: "opencode-session-1" }));
+    console.log(JSON.stringify({ type: "text", part: { type: "text", text: "opencode ok" } }));
+    console.log(JSON.stringify({
+      type: "step_finish",
+      part: {
+        reason: "stop",
+        cost: 0.00042,
+        tokens: { input: 10, output: 5, cache: { read: 2, write: 0 } },
+      },
+    }));
+    process.exit(0);
+  }
+  console.error("unexpected opencode args", args.join(" "));
+  process.exit(1);
+}
+
+if (${JSON.stringify(mode)} === "pi") {
+  if (args.includes("--list-models")) {
+    console.log("provider  model");
+    console.log("openai    gpt-4.1-mini");
+    process.exit(0);
+  }
+  capture();
+  console.log(JSON.stringify({
+    type: "session",
+    version: 3,
+    id: "session-1",
+    timestamp: new Date().toISOString(),
+    cwd: process.cwd(),
+  }));
+  console.log(JSON.stringify({ type: "agent_start" }));
+  console.log(JSON.stringify({ type: "turn_start" }));
+  console.log(JSON.stringify({
+    type: "turn_end",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "pi ok" }],
+      usage: { input: 1, output: 1, cacheRead: 0, cost: { total: 0 } },
+    },
+    toolResults: [],
+  }));
+  process.exit(0);
+}
+
+capture();
+
+if (${JSON.stringify(mode)} === "codex") {
+  fs.readFileSync(0, "utf8");
+  console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-1" }));
+  console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "codex ok" } }));
+  console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
+  process.exit(0);
+}
+
+if (${JSON.stringify(mode)} === "claude") {
+  fs.readFileSync(0, "utf8");
+  console.log(JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "claude-session-1",
+    model: "sonnet",
+  }));
+  console.log(JSON.stringify({
+    type: "assistant",
+    session_id: "claude-session-1",
+    message: { content: [{ type: "text", text: "claude ok" }] },
+  }));
+  console.log(JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: "claude-session-1",
+    usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+    total_cost_usd: 0.01,
+    result: "claude ok",
+  }));
+  process.exit(0);
+}
+
+if (${JSON.stringify(mode)} === "cursor") {
+  fs.readFileSync(0, "utf8");
+  console.log(JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "cursor-session-1",
+    model: "auto",
+  }));
+  console.log(JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "output_text", text: "cursor ok" }] },
+  }));
+  console.log(JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: "cursor-session-1",
+    result: "cursor ok",
+  }));
+  process.exit(0);
+}
+
+if (${JSON.stringify(mode)} === "gemini") {
+  console.log(JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "gemini-session-1",
+    model: "gemini-2.5-pro",
+  }));
+  console.log(JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "output_text", text: "gemini ok" }] },
+  }));
+  console.log(JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: "gemini-session-1",
+    result: "gemini ok",
+  }));
+  process.exit(0);
+}
+
+console.error("unexpected mode");
+process.exit(1);
+`;
+  await writeExecutable(commandPath, script);
+}
+
+async function setupHome(root: string): Promise<() => void> {
+  const previousHome = process.env.HOME;
+  process.env.HOME = root;
+  return async () => {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+  };
+}
+
+async function setupCodexEnv(root: string): Promise<() => void> {
+  const restoreHome = await setupHome(root);
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = path.join(root, "codex-home");
+  return async () => {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    await restoreHome();
+  };
+}
+
+const ADAPTER_CASES: AdapterCase[] = [
+  {
+    name: "claude_local",
+    adapterType: "claude_local",
+    commandName: "claude",
+    execute: executeClaude,
+    commandMode: "claude",
+    setupEnv: setupHome,
+  },
+  {
+    name: "codex_local",
+    adapterType: "codex_local",
+    commandName: "codex",
+    execute: executeCodex,
+    commandMode: "codex",
+    setupEnv: setupCodexEnv,
+  },
+  {
+    name: "cursor",
+    adapterType: "cursor",
+    commandName: "agent",
+    execute: executeCursor,
+    commandMode: "cursor",
+    config: { model: "auto" },
+    setupEnv: setupHome,
+  },
+  {
+    name: "gemini_local",
+    adapterType: "gemini_local",
+    commandName: "gemini",
+    execute: executeGemini,
+    commandMode: "gemini",
+    config: { model: "gemini-2.5-pro" },
+    setupEnv: setupHome,
+  },
+  {
+    name: "opencode_local",
+    adapterType: "opencode_local",
+    commandName: "opencode",
+    execute: executeOpenCode,
+    commandMode: "opencode",
+    config: { model: "openai/gpt-5.4" },
+    setupEnv: setupHome,
+  },
+  {
+    name: "pi_local",
+    adapterType: "pi_local",
+    commandName: "pi",
+    execute: executePi,
+    commandMode: "pi",
+    config: { model: "openai/gpt-4.1-mini" },
+    setupEnv: setupHome,
+  },
+];
+
+describe("local adapter workspace env parity", () => {
+  for (const adapter of ADAPTER_CASES) {
+    it(`${adapter.name} injects the shared workspace env contract`, async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), `paperclip-${adapter.name}-workspace-env-`));
+      const workspaceCwd = path.join(root, "workspace");
+      const worktreePath = path.join(root, ".paperclip", "worktrees", "GRA-1881-test-branch");
+      const commandPath = path.join(root, adapter.commandName);
+      const capturePath = path.join(root, "capture.json");
+      await fs.mkdir(workspaceCwd, { recursive: true });
+      await writeCaptureCommand(commandPath, adapter.commandMode);
+
+      const restoreEnv = adapter.setupEnv ? await adapter.setupEnv(root) : async () => {};
+      try {
+        const result = await adapter.execute({
+          runId: "run-1",
+          agent: {
+            id: "agent-1",
+            companyId: "company-1",
+            name: `${adapter.name} agent`,
+            adapterType: adapter.adapterType,
+            adapterConfig: {},
+          },
+          runtime: {
+            sessionId: null,
+            sessionParams: null,
+            sessionDisplayId: null,
+            taskKey: null,
+          },
+          config: {
+            command: commandPath,
+            cwd: workspaceCwd,
+            env: {
+              PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            },
+            promptTemplate: "Continue your Paperclip work.",
+            ...adapter.config,
+          },
+          context: {
+            paperclipWorkspace: {
+              cwd: workspaceCwd,
+              source: "project_primary",
+              strategy: "git_worktree",
+              workspaceId: "workspace-1",
+              repoUrl: "https://github.com/paperclipai/paperclip",
+              repoRef: "main",
+              branchName: "GRA-1881-test-branch",
+              worktreePath,
+            },
+          },
+          authToken: "run-jwt-token",
+          onLog: async () => {},
+          onMeta: async () => {},
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.errorMessage).toBeNull();
+
+        const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+        expect(capture.env).toEqual({
+          PAPERCLIP_WORKSPACE_CWD: workspaceCwd,
+          PAPERCLIP_WORKSPACE_SOURCE: "project_primary",
+          PAPERCLIP_WORKSPACE_STRATEGY: "git_worktree",
+          PAPERCLIP_WORKSPACE_ID: "workspace-1",
+          PAPERCLIP_WORKSPACE_REPO_URL: "https://github.com/paperclipai/paperclip",
+          PAPERCLIP_WORKSPACE_REPO_REF: "main",
+          PAPERCLIP_WORKSPACE_BRANCH: "GRA-1881-test-branch",
+          PAPERCLIP_WORKSPACE_WORKTREE_PATH: worktreePath,
+        });
+      } finally {
+        await restoreEnv();
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/server/src/__tests__/local-agent-api-key-injection.test.ts
+++ b/server/src/__tests__/local-agent-api-key-injection.test.ts
@@ -1,0 +1,523 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import detectPort from "detect-port";
+import EmbeddedPostgres from "embedded-postgres";
+import {
+  agents,
+  applyPendingMigrations,
+  companies,
+  createDb,
+  ensurePostgresDatabase,
+  issues,
+  projects,
+  projectWorkspaces,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const CAPTURE_KEYS = [
+  "PAPERCLIP_AGENT_ID",
+  "PAPERCLIP_API_KEY",
+  "PAPERCLIP_API_URL",
+  "PAPERCLIP_COMPANY_ID",
+  "PAPERCLIP_RUN_ID",
+  "PAPERCLIP_TASK_ID",
+  "PAPERCLIP_WAKE_COMMENT_ID",
+  "PAPERCLIP_WAKE_REASON",
+  "PAPERCLIP_WORKSPACE_CWD",
+  "PAPERCLIP_WORKSPACE_SOURCE",
+  "PAPERCLIP_WORKSPACE_REPO_REF",
+  "PAPERCLIP_WORKSPACE_BRANCH",
+  "PAPERCLIP_WORKSPACE_OBSERVED_BRANCH",
+  "PAPERCLIP_WORKSPACE_OBSERVED_HEAD",
+] as const;
+
+type CaptureKey = (typeof CAPTURE_KEYS)[number];
+
+type CapturePayload = {
+  argv: string[];
+  prompt: string;
+  env: Partial<Record<CaptureKey, string>>;
+};
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(cwd: string, args: string[]) {
+  await execFileAsync("git", args, { cwd, encoding: "utf8" });
+}
+
+async function gitStdout(cwd: string, args: string[]) {
+  return (await execFileAsync("git", args, { cwd, encoding: "utf8" })).stdout.trim();
+}
+
+async function createGitWorkspace(root: string) {
+  const repoRoot = join(root, "project-workspace");
+  await mkdir(repoRoot, { recursive: true });
+  await runGit(repoRoot, ["init"]);
+  await runGit(repoRoot, ["config", "user.email", "paperclip-tests@example.com"]);
+  await runGit(repoRoot, ["config", "user.name", "Paperclip Tests"]);
+  await runGit(repoRoot, ["checkout", "-b", "main"]);
+  await writeFile(join(repoRoot, "README.md"), "# workspace\n", "utf8");
+  await runGit(repoRoot, ["add", "README.md"]);
+  await runGit(repoRoot, ["commit", "-m", "initial"]);
+  await runGit(repoRoot, ["checkout", "-b", "feature/live-checkout"]);
+  await writeFile(join(repoRoot, "feature.txt"), "live checkout\n", "utf8");
+  await runGit(repoRoot, ["add", "feature.txt"]);
+  await runGit(repoRoot, ["commit", "-m", "feature"]);
+
+  return {
+    repoRoot,
+    branchName: "feature/live-checkout",
+    headSha: await gitStdout(repoRoot, ["rev-parse", "HEAD"]),
+  };
+}
+
+async function writeFakeCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  argv: process.argv.slice(2),
+  prompt: fs.readFileSync(0, "utf8"),
+  env: Object.fromEntries(
+    [
+      "PAPERCLIP_AGENT_ID",
+      "PAPERCLIP_API_KEY",
+      "PAPERCLIP_API_URL",
+      "PAPERCLIP_COMPANY_ID",
+      "PAPERCLIP_RUN_ID",
+      "PAPERCLIP_TASK_ID",
+      "PAPERCLIP_WAKE_COMMENT_ID",
+      "PAPERCLIP_WAKE_REASON",
+      "PAPERCLIP_WORKSPACE_CWD",
+      "PAPERCLIP_WORKSPACE_SOURCE",
+      "PAPERCLIP_WORKSPACE_REPO_REF",
+      "PAPERCLIP_WORKSPACE_BRANCH",
+      "PAPERCLIP_WORKSPACE_OBSERVED_BRANCH",
+      "PAPERCLIP_WORKSPACE_OBSERVED_HEAD",
+    ]
+      .filter((key) => typeof process.env[key] === "string" && process.env[key].length > 0)
+      .map((key) => [key, process.env[key]]),
+  ),
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-thread-1" }));
+console.log(
+  JSON.stringify({
+    type: "item.completed",
+    item: { type: "agent_message", text: "codex ok" },
+  }),
+);
+console.log(
+  JSON.stringify({
+    type: "turn.completed",
+    usage: { input_tokens: 11, cached_input_tokens: 2, output_tokens: 7 },
+  }),
+);
+`;
+  await writeFile(commandPath, script, "utf8");
+  await chmod(commandPath, 0o755);
+}
+
+async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  argv: process.argv.slice(2),
+  prompt: fs.readFileSync(0, "utf8"),
+  env: Object.fromEntries(
+    [
+      "PAPERCLIP_AGENT_ID",
+      "PAPERCLIP_API_KEY",
+      "PAPERCLIP_API_URL",
+      "PAPERCLIP_COMPANY_ID",
+      "PAPERCLIP_RUN_ID",
+      "PAPERCLIP_TASK_ID",
+      "PAPERCLIP_WAKE_COMMENT_ID",
+      "PAPERCLIP_WAKE_REASON",
+      "PAPERCLIP_WORKSPACE_CWD",
+      "PAPERCLIP_WORKSPACE_SOURCE",
+      "PAPERCLIP_WORKSPACE_REPO_REF",
+      "PAPERCLIP_WORKSPACE_BRANCH",
+      "PAPERCLIP_WORKSPACE_OBSERVED_BRANCH",
+      "PAPERCLIP_WORKSPACE_OBSERVED_HEAD",
+    ]
+      .filter((key) => typeof process.env[key] === "string" && process.env[key].length > 0)
+      .map((key) => [key, process.env[key]]),
+  ),
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log(
+  JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "claude-session-1",
+    model: "sonnet",
+  }),
+);
+console.log(
+  JSON.stringify({
+    type: "assistant",
+    session_id: "claude-session-1",
+    message: { content: [{ type: "text", text: "claude ok" }] },
+  }),
+);
+console.log(
+  JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: "claude-session-1",
+    usage: {
+      input_tokens: 13,
+      cache_read_input_tokens: 3,
+      output_tokens: 5,
+    },
+    total_cost_usd: 0.01,
+    result: "claude ok",
+  }),
+);
+`;
+  await writeFile(commandPath, script, "utf8");
+  await chmod(commandPath, 0o755);
+}
+
+async function waitForRun(
+  svc: ReturnType<typeof heartbeatService>,
+  runId: string,
+  timeoutMs = 10_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const run = await svc.getRun(runId);
+    if (run && run.status !== "queued" && run.status !== "running") {
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for heartbeat run ${runId}`);
+}
+
+describe("local agent PAPERCLIP_API_KEY injection", () => {
+  let databaseDir = "";
+  let databaseUrl = "";
+  let db: ReturnType<typeof createDb>;
+  let embeddedPostgres: EmbeddedPostgres;
+  let companyId = "";
+  let issueNumber = 1;
+  const heartbeat = () => heartbeatService(db);
+  const originalJwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  const originalBetterAuthSecret = process.env.BETTER_AUTH_SECRET;
+  const originalCodexHome = process.env.CODEX_HOME;
+
+  beforeAll(async () => {
+    delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    delete process.env.BETTER_AUTH_SECRET;
+
+    databaseDir = await mkdtemp(join(tmpdir(), "paperclip-heartbeat-auth-"));
+    const port = await detectPort(55433);
+    embeddedPostgres = new EmbeddedPostgres({
+      databaseDir,
+      user: "paperclip",
+      password: "paperclip",
+      port,
+      persistent: false,
+      onLog: () => {},
+      onError: () => {},
+    });
+
+    await embeddedPostgres.initialise();
+    await embeddedPostgres.start();
+
+    const adminUrl = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+    await ensurePostgresDatabase(adminUrl, "paperclip");
+
+    databaseUrl = `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
+    await applyPendingMigrations(databaseUrl);
+    db = createDb(databaseUrl);
+
+    companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Heartbeat Auth Test Company",
+      issuePrefix: "HBT",
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (originalJwtSecret === undefined) {
+      delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    } else {
+      process.env.PAPERCLIP_AGENT_JWT_SECRET = originalJwtSecret;
+    }
+    if (originalBetterAuthSecret === undefined) {
+      delete process.env.BETTER_AUTH_SECRET;
+    } else {
+      process.env.BETTER_AUTH_SECRET = originalBetterAuthSecret;
+    }
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
+    }
+    await db.$client.end({ timeout: 0 });
+    await embeddedPostgres.stop();
+    await rm(databaseDir, { recursive: true, force: true });
+  }, 120_000);
+
+  async function seedIssue(
+    agentId: string,
+    opts?: { projectId?: string | null; projectWorkspaceId?: string | null },
+  ) {
+    const issueId = randomUUID();
+    const currentIssueNumber = issueNumber;
+    issueNumber += 1;
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: `Wake Issue ${currentIssueNumber}`,
+      status: "todo",
+      priority: "high",
+      projectId: opts?.projectId ?? null,
+      projectWorkspaceId: opts?.projectWorkspaceId ?? null,
+      assigneeAgentId: agentId,
+      createdByAgentId: agentId,
+      issueNumber: currentIssueNumber,
+      identifier: `HBT-${currentIssueNumber}`,
+    });
+
+    return issueId;
+  }
+
+  async function runWakeCase(input: {
+    adapterType: "claude_local" | "codex_local";
+    wake:
+      | { source: "timer"; triggerDetail: "system" }
+      | {
+          source: "assignment";
+          triggerDetail: "system";
+          reason: "issue_assigned";
+        }
+      | {
+          source: "automation";
+          triggerDetail: "system";
+          reason: "issue_comment_mentioned";
+        };
+    projectWorkspace?: {
+      cwd: string;
+      repoRef?: string | null;
+    };
+  }) {
+    const root = await mkdtemp(join(tmpdir(), `paperclip-${input.adapterType}-wake-`));
+    const workspace = join(root, "workspace");
+    const commandPath = join(root, "agent");
+    const capturePath = join(root, "capture.json");
+    await mkdir(workspace, { recursive: true });
+
+    const previousCodexHome = process.env.CODEX_HOME;
+    if (input.adapterType === "codex_local") {
+      process.env.CODEX_HOME = join(root, "codex-home");
+      await writeFakeCodexCommand(commandPath);
+    } else {
+      await writeFakeClaudeCommand(commandPath);
+    }
+
+    const agentId = randomUUID();
+    const agentName =
+      input.adapterType === "codex_local" ? "Codex Platform Engineer" : "Claude Platform Engineer";
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: agentName,
+      role: "platform",
+      status: "active",
+      adapterType: input.adapterType,
+      adapterConfig: {
+        command: commandPath,
+        cwd: workspace,
+        env: {
+          PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+        },
+      },
+    });
+
+    let issueId: string | null = null;
+    let projectId: string | null = null;
+    let projectWorkspaceId: string | null = null;
+    if (input.projectWorkspace) {
+      projectId = randomUUID();
+      projectWorkspaceId = randomUUID();
+      await db.insert(projects).values({
+        id: projectId,
+        companyId,
+        name: `Workspace Project ${projectId.slice(0, 8)}`,
+        status: "active",
+      });
+      await db.insert(projectWorkspaces).values({
+        id: projectWorkspaceId,
+        companyId,
+        projectId,
+        name: "Primary Workspace",
+        sourceType: "local_path",
+        cwd: input.projectWorkspace.cwd,
+        repoRef: input.projectWorkspace.repoRef ?? null,
+        isPrimary: true,
+      });
+    }
+    if (input.wake.source !== "timer") {
+      issueId = await seedIssue(agentId, {
+        projectId,
+        projectWorkspaceId,
+      });
+    }
+
+    const wakeup =
+      input.wake.source === "timer"
+        ? await heartbeat().wakeup(agentId, {
+            source: "timer",
+            triggerDetail: "system",
+          })
+        : input.wake.reason === "issue_assigned"
+          ? await heartbeat().wakeup(agentId, {
+              source: "assignment",
+              triggerDetail: "system",
+              reason: "issue_assigned",
+              payload: { issueId, mutation: "create" },
+              contextSnapshot: { issueId, source: "issue.create" },
+            })
+          : await heartbeat().wakeup(agentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "issue_comment_mentioned",
+              payload: { issueId, commentId: "comment-1" },
+              contextSnapshot: { issueId, source: "comment.mention" },
+            });
+
+    try {
+      expect(wakeup).not.toBeNull();
+      const run = await waitForRun(heartbeat(), wakeup!.id);
+      const capture = JSON.parse(await readFile(capturePath, "utf8")) as CapturePayload;
+      return { capture, run, issueId };
+    } finally {
+      if (input.adapterType === "codex_local") {
+        if (previousCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = previousCodexHome;
+        }
+      }
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+
+  for (const adapterType of ["codex_local", "claude_local"] as const) {
+    describe(adapterType, () => {
+      it("injects PAPERCLIP_API_KEY on timer wakes without issue context", async () => {
+        const { capture, run } = await runWakeCase({
+          adapterType,
+          wake: { source: "timer", triggerDetail: "system" },
+        });
+
+        expect(run.status).toBe("succeeded");
+        expect(capture.env.PAPERCLIP_API_KEY).toMatch(/\S+/);
+        expect(capture.env.PAPERCLIP_RUN_ID).toMatch(/\S+/);
+        expect(capture.env.PAPERCLIP_AGENT_ID).toMatch(/\S+/);
+        expect(capture.env.PAPERCLIP_COMPANY_ID).toBe(companyId);
+        expect(capture.env.PAPERCLIP_TASK_ID).toBeUndefined();
+        expect(capture.env.PAPERCLIP_WAKE_COMMENT_ID).toBeUndefined();
+      });
+
+      it("injects PAPERCLIP_API_KEY and task wake context on assignment wakes", async () => {
+        const { capture, run, issueId } = await runWakeCase({
+          adapterType,
+          wake: {
+            source: "assignment",
+            triggerDetail: "system",
+            reason: "issue_assigned",
+          },
+        });
+
+        expect(run.status).toBe("succeeded");
+        expect(capture.env.PAPERCLIP_API_KEY).toMatch(/\S+/);
+        expect(capture.env.PAPERCLIP_TASK_ID).toBe(issueId);
+        expect(capture.env.PAPERCLIP_WAKE_REASON).toBe("issue_assigned");
+      });
+
+      it("injects PAPERCLIP_API_KEY and comment wake context on mention wakes", async () => {
+        const { capture, run, issueId } = await runWakeCase({
+          adapterType,
+          wake: {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_comment_mentioned",
+          },
+        });
+
+        expect(run.status).toBe("succeeded");
+        expect(capture.env.PAPERCLIP_API_KEY).toMatch(/\S+/);
+        expect(capture.env.PAPERCLIP_TASK_ID).toBe(issueId);
+        expect(capture.env.PAPERCLIP_WAKE_REASON).toBe("issue_comment_mentioned");
+        expect(capture.env.PAPERCLIP_WAKE_COMMENT_ID).toBe("comment-1");
+      });
+
+      it("captures observed git provenance for shared project workspaces", async () => {
+        const root = await mkdtemp(join(tmpdir(), `paperclip-${adapterType}-workspace-provenance-`));
+        try {
+          const workspaceRepo = await createGitWorkspace(root);
+          const { capture, run } = await runWakeCase({
+            adapterType,
+            wake: {
+              source: "assignment",
+              triggerDetail: "system",
+              reason: "issue_assigned",
+            },
+            projectWorkspace: {
+              cwd: workspaceRepo.repoRoot,
+              repoRef: "main",
+            },
+          });
+
+          expect(run.status).toBe("succeeded");
+          expect(capture.env.PAPERCLIP_WORKSPACE_CWD).toBe(workspaceRepo.repoRoot);
+          expect(capture.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("project_primary");
+          expect(capture.env.PAPERCLIP_WORKSPACE_REPO_REF).toBe("main");
+          expect(capture.env.PAPERCLIP_WORKSPACE_BRANCH).toBeUndefined();
+          expect(capture.env.PAPERCLIP_WORKSPACE_OBSERVED_BRANCH).toBe(workspaceRepo.branchName);
+          expect(capture.env.PAPERCLIP_WORKSPACE_OBSERVED_HEAD).toBe(workspaceRepo.headSha);
+
+          const contextSnapshot =
+            typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
+              ? run.contextSnapshot as Record<string, unknown>
+              : null;
+          const paperclipWorkspace =
+            contextSnapshot && typeof contextSnapshot.paperclipWorkspace === "object" && contextSnapshot.paperclipWorkspace !== null
+              ? contextSnapshot.paperclipWorkspace as Record<string, unknown>
+              : null;
+
+          expect(paperclipWorkspace).toMatchObject({
+            cwd: workspaceRepo.repoRoot,
+            source: "project_primary",
+            repoRef: "main",
+            branchName: null,
+            observedBranchName: workspaceRepo.branchName,
+            observedHeadSha: workspaceRepo.headSha,
+          });
+        } finally {
+          await rm(root, { recursive: true, force: true });
+        }
+      });
+    });
+  }
+});

--- a/server/src/__tests__/local-agent-api-key-injection.test.ts
+++ b/server/src/__tests__/local-agent-api-key-injection.test.ts
@@ -45,6 +45,24 @@ type CapturePayload = {
 };
 
 const execFileAsync = promisify(execFile);
+const SANITIZED_ENV_KEYS = [
+  "AGENT_HOME",
+  "PAPERCLIP_AGENT_ID",
+  "PAPERCLIP_API_KEY",
+  "PAPERCLIP_API_URL",
+  "PAPERCLIP_COMPANY_ID",
+  "PAPERCLIP_RUN_ID",
+  "PAPERCLIP_TASK_ID",
+  "PAPERCLIP_WAKE_COMMENT_ID",
+  "PAPERCLIP_WAKE_REASON",
+  "PAPERCLIP_WORKSPACE_CWD",
+  "PAPERCLIP_WORKSPACE_SOURCE",
+  "PAPERCLIP_WORKSPACE_REPO_REF",
+  "PAPERCLIP_WORKSPACE_BRANCH",
+  "PAPERCLIP_WORKSPACE_OBSERVED_BRANCH",
+  "PAPERCLIP_WORKSPACE_OBSERVED_HEAD",
+  "PAPERCLIP_WORKSPACES_JSON",
+] as const;
 
 async function runGit(cwd: string, args: string[]) {
   await execFileAsync("git", args, { cwd, encoding: "utf8" });
@@ -74,6 +92,26 @@ async function createGitWorkspace(root: string) {
     branchName: "feature/live-checkout",
     headSha: await gitStdout(repoRoot, ["rev-parse", "HEAD"]),
   };
+}
+
+async function withSanitizedEnv<T>(run: () => Promise<T>): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of SANITIZED_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  try {
+    return await run();
+  } finally {
+    for (const key of SANITIZED_ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
 }
 
 async function writeFakeCodexCommand(commandPath: string): Promise<void> {
@@ -221,7 +259,7 @@ describe("local agent PAPERCLIP_API_KEY injection", () => {
   const originalCodexHome = process.env.CODEX_HOME;
 
   beforeAll(async () => {
-    delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "paperclip-test-local-agent-jwt-secret";
     delete process.env.BETTER_AUTH_SECRET;
 
     databaseDir = await mkdtemp(join(tmpdir(), "paperclip-heartbeat-auth-"));
@@ -383,33 +421,35 @@ describe("local agent PAPERCLIP_API_KEY injection", () => {
       });
     }
 
-    const wakeup =
-      input.wake.source === "timer"
-        ? await heartbeat().wakeup(agentId, {
-            source: "timer",
-            triggerDetail: "system",
-          })
-        : input.wake.reason === "issue_assigned"
-          ? await heartbeat().wakeup(agentId, {
-              source: "assignment",
-              triggerDetail: "system",
-              reason: "issue_assigned",
-              payload: { issueId, mutation: "create" },
-              contextSnapshot: { issueId, source: "issue.create" },
-            })
-          : await heartbeat().wakeup(agentId, {
-              source: "automation",
-              triggerDetail: "system",
-              reason: "issue_comment_mentioned",
-              payload: { issueId, commentId: "comment-1" },
-              contextSnapshot: { issueId, source: "comment.mention" },
-            });
-
     try {
-      expect(wakeup).not.toBeNull();
-      const run = await waitForRun(heartbeat(), wakeup!.id);
-      const capture = JSON.parse(await readFile(capturePath, "utf8")) as CapturePayload;
-      return { capture, run, issueId };
+      return await withSanitizedEnv(async () => {
+        const wakeup =
+          input.wake.source === "timer"
+            ? await heartbeat().wakeup(agentId, {
+                source: "timer",
+                triggerDetail: "system",
+              })
+            : input.wake.reason === "issue_assigned"
+              ? await heartbeat().wakeup(agentId, {
+                  source: "assignment",
+                  triggerDetail: "system",
+                  reason: "issue_assigned",
+                  payload: { issueId, mutation: "create" },
+                  contextSnapshot: { issueId, source: "issue.create" },
+                })
+              : await heartbeat().wakeup(agentId, {
+                  source: "automation",
+                  triggerDetail: "system",
+                  reason: "issue_comment_mentioned",
+                  payload: { issueId, commentId: "comment-1" },
+                  contextSnapshot: { issueId, source: "comment.mention" },
+                });
+
+        expect(wakeup).not.toBeNull();
+        const run = await waitForRun(heartbeat(), wakeup!.id);
+        const capture = JSON.parse(await readFile(capturePath, "utf8")) as CapturePayload;
+        return { capture, run, issueId };
+      });
     } finally {
       if (input.adapterType === "codex_local") {
         if (previousCodexHome === undefined) {

--- a/server/src/__tests__/local-agent-home-injection.test.ts
+++ b/server/src/__tests__/local-agent-home-injection.test.ts
@@ -19,6 +19,21 @@ type CapturePayload = {
 
 type TestExecute = typeof executeClaude;
 
+const SANITIZED_ENV_KEYS = [
+  "AGENT_HOME",
+  "PAPERCLIP_AGENT_ID",
+  "PAPERCLIP_API_KEY",
+  "PAPERCLIP_API_URL",
+  "PAPERCLIP_COMPANY_ID",
+  "PAPERCLIP_RUN_ID",
+  "PAPERCLIP_TASK_ID",
+  "PAPERCLIP_WAKE_COMMENT_ID",
+  "PAPERCLIP_WAKE_REASON",
+  "PAPERCLIP_WORKSPACE_CWD",
+  "PAPERCLIP_WORKSPACE_SOURCE",
+  "PAPERCLIP_WORKSPACES_JSON",
+] as const;
+
 async function writeExecutable(commandPath: string, script: string): Promise<void> {
   await fs.writeFile(commandPath, script, "utf8");
   await fs.chmod(commandPath, 0o755);
@@ -26,6 +41,26 @@ async function writeExecutable(commandPath: string, script: string): Promise<voi
 
 async function readCapture(capturePath: string): Promise<CapturePayload> {
   return JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+}
+
+async function withSanitizedEnv<T>(run: () => Promise<T>): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of SANITIZED_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  try {
+    return await run();
+  } finally {
+    for (const key of SANITIZED_ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
 }
 
 async function writeFakeCodexCommand(commandPath: string): Promise<void> {
@@ -193,41 +228,43 @@ async function expectAgentHomeInjected(input: {
   config?: Record<string, unknown>;
   context?: Record<string, unknown>;
 }): Promise<CapturePayload> {
-  const result = await input.execute({
-    runId: "run-1",
-    agent: {
-      id: "agent-1",
-      companyId: "company-1",
-      name: "Test Agent",
-      adapterType: "codex_local",
-      adapterConfig: {},
-    },
-    runtime: {
-      sessionId: null,
-      sessionParams: null,
-      sessionDisplayId: null,
-      taskKey: null,
-    },
-    config: {
-      command: input.commandPath,
-      cwd: input.cwd,
-      instructionsFilePath: input.instructionsFilePath,
-      promptTemplate: "Continue your Paperclip work.",
-      env: {
-        PAPERCLIP_TEST_CAPTURE_PATH: input.capturePath,
+  const result = await withSanitizedEnv(() =>
+    input.execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Test Agent",
+        adapterType: "codex_local",
+        adapterConfig: {},
       },
-      ...input.config,
-    },
-    context: {
-      paperclipWorkspace: {
-        source: "agent_home",
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
       },
-      ...input.context,
-    },
-    authToken: "run-jwt-token",
-    onLog: async () => {},
-    onMeta: async () => {},
-  });
+      config: {
+        command: input.commandPath,
+        cwd: input.cwd,
+        instructionsFilePath: input.instructionsFilePath,
+        promptTemplate: "Continue your Paperclip work.",
+        env: {
+          PAPERCLIP_TEST_CAPTURE_PATH: input.capturePath,
+        },
+        ...input.config,
+      },
+      context: {
+        paperclipWorkspace: {
+          source: "agent_home",
+        },
+        ...input.context,
+      },
+      authToken: "run-jwt-token",
+      onLog: async () => {},
+      onMeta: async () => {},
+    }),
+  );
 
   expect(result.exitCode).toBe(0);
   expect(result.errorMessage).toBeNull();

--- a/server/src/__tests__/local-agent-home-injection.test.ts
+++ b/server/src/__tests__/local-agent-home-injection.test.ts
@@ -1,0 +1,549 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute as executeClaude } from "@paperclipai/adapter-claude-local/server";
+import { execute as executeCodex } from "@paperclipai/adapter-codex-local/server";
+import { execute as executeCursor } from "@paperclipai/adapter-cursor-local/server";
+import { execute as executeOpenCode } from "@paperclipai/adapter-opencode-local/server";
+
+type CapturePayload = {
+  argv: string[];
+  cwd: string;
+  env: {
+    AGENT_HOME?: string;
+    PAPERCLIP_WORKSPACE_CWD?: string;
+    PAPERCLIP_WORKSPACE_SOURCE?: string;
+  };
+};
+
+type TestExecute = typeof executeClaude;
+
+async function writeExecutable(commandPath: string, script: string): Promise<void> {
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+async function readCapture(capturePath: string): Promise<CapturePayload> {
+  return JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+}
+
+async function writeFakeCodexCommand(commandPath: string): Promise<void> {
+  await writeExecutable(
+    commandPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({
+    argv: process.argv.slice(2),
+    cwd: process.cwd(),
+    env: {
+      AGENT_HOME: process.env.AGENT_HOME,
+      PAPERCLIP_WORKSPACE_CWD: process.env.PAPERCLIP_WORKSPACE_CWD,
+      PAPERCLIP_WORKSPACE_SOURCE: process.env.PAPERCLIP_WORKSPACE_SOURCE,
+    },
+  }), "utf8");
+}
+fs.readFileSync(0, "utf8");
+console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-thread-1" }));
+console.log(JSON.stringify({
+  type: "item.completed",
+  item: { type: "agent_message", text: "codex ok" },
+}));
+console.log(JSON.stringify({
+  type: "turn.completed",
+  usage: { input_tokens: 11, cached_input_tokens: 2, output_tokens: 7 },
+}));
+`,
+  );
+}
+
+async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
+  await writeExecutable(
+    commandPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({
+    argv: process.argv.slice(2),
+    cwd: process.cwd(),
+    env: {
+      AGENT_HOME: process.env.AGENT_HOME,
+      PAPERCLIP_WORKSPACE_CWD: process.env.PAPERCLIP_WORKSPACE_CWD,
+      PAPERCLIP_WORKSPACE_SOURCE: process.env.PAPERCLIP_WORKSPACE_SOURCE,
+    },
+  }), "utf8");
+}
+fs.readFileSync(0, "utf8");
+console.log(JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "claude-session-1",
+  model: "sonnet",
+}));
+console.log(JSON.stringify({
+  type: "assistant",
+  session_id: "claude-session-1",
+  message: { content: [{ type: "text", text: "claude ok" }] },
+}));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "success",
+  session_id: "claude-session-1",
+  usage: {
+    input_tokens: 13,
+    cache_read_input_tokens: 3,
+    output_tokens: 5,
+  },
+  total_cost_usd: 0.01,
+  result: "claude ok",
+}));
+`,
+  );
+}
+
+async function writeFakeCursorCommand(commandPath: string): Promise<void> {
+  await writeExecutable(
+    commandPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify({
+    argv: process.argv.slice(2),
+    cwd: process.cwd(),
+    env: {
+      AGENT_HOME: process.env.AGENT_HOME,
+      PAPERCLIP_WORKSPACE_CWD: process.env.PAPERCLIP_WORKSPACE_CWD,
+      PAPERCLIP_WORKSPACE_SOURCE: process.env.PAPERCLIP_WORKSPACE_SOURCE,
+    },
+  }), "utf8");
+}
+fs.readFileSync(0, "utf8");
+console.log(JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "cursor-session-1",
+  model: "auto",
+}));
+console.log(JSON.stringify({
+  type: "assistant",
+  message: { content: [{ type: "output_text", text: "cursor ok" }] },
+}));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "success",
+  session_id: "cursor-session-1",
+  result: "cursor ok",
+}));
+`,
+  );
+}
+
+async function writeFakeOpenCodeCommand(commandPath: string): Promise<void> {
+  await writeExecutable(
+    commandPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === "models") {
+  console.log("openai/gpt-5.4 ready");
+  process.exit(0);
+}
+if (args[0] === "run") {
+  const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+  if (capturePath) {
+    fs.writeFileSync(capturePath, JSON.stringify({
+      argv: args,
+      cwd: process.cwd(),
+      env: {
+        AGENT_HOME: process.env.AGENT_HOME,
+        PAPERCLIP_WORKSPACE_CWD: process.env.PAPERCLIP_WORKSPACE_CWD,
+        PAPERCLIP_WORKSPACE_SOURCE: process.env.PAPERCLIP_WORKSPACE_SOURCE,
+      },
+    }), "utf8");
+  }
+  fs.readFileSync(0, "utf8");
+  console.log(JSON.stringify({ type: "step_start", sessionID: "opencode-session-1" }));
+  console.log(JSON.stringify({ type: "text", part: { type: "text", text: "opencode ok" } }));
+  console.log(JSON.stringify({
+    type: "step_finish",
+    part: {
+      reason: "stop",
+      cost: 0.00042,
+      tokens: { input: 10, output: 5, cache: { read: 2, write: 0 } },
+    },
+  }));
+  process.exit(0);
+}
+console.error("unexpected command", args.join(" "));
+process.exit(1);
+`,
+  );
+}
+
+async function expectAgentHomeInjected(input: {
+  execute: TestExecute;
+  commandPath: string;
+  cwd: string;
+  instructionsFilePath: string;
+  capturePath: string;
+  config?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}): Promise<CapturePayload> {
+  const result = await input.execute({
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Test Agent",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: input.commandPath,
+      cwd: input.cwd,
+      instructionsFilePath: input.instructionsFilePath,
+      promptTemplate: "Continue your Paperclip work.",
+      env: {
+        PAPERCLIP_TEST_CAPTURE_PATH: input.capturePath,
+      },
+      ...input.config,
+    },
+    context: {
+      paperclipWorkspace: {
+        source: "agent_home",
+      },
+      ...input.context,
+    },
+    authToken: "run-jwt-token",
+    onLog: async () => {},
+    onMeta: async () => {},
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.errorMessage).toBeNull();
+
+  const capture = await readCapture(input.capturePath);
+  expect(capture.env.AGENT_HOME).toBe(path.dirname(input.instructionsFilePath));
+  return capture;
+}
+
+async function expectAgentHomeWorkspaceCwdUsed(input: {
+  execute: TestExecute;
+  commandPath: string;
+  configuredCwd: string;
+  workspaceCwd: string;
+  instructionsFilePath: string;
+  capturePath: string;
+  config?: Record<string, unknown>;
+}) {
+  const capture = await expectAgentHomeInjected({
+    execute: input.execute,
+    commandPath: input.commandPath,
+    cwd: input.configuredCwd,
+    instructionsFilePath: input.instructionsFilePath,
+    capturePath: input.capturePath,
+    config: input.config,
+    context: {
+      paperclipWorkspace: {
+        source: "agent_home",
+        cwd: input.workspaceCwd,
+      },
+    },
+  });
+
+  expect(capture.cwd).toBe(input.workspaceCwd);
+  expect(capture.env.PAPERCLIP_WORKSPACE_CWD).toBe(input.workspaceCwd);
+  expect(capture.env.PAPERCLIP_WORKSPACE_SOURCE).toBe("agent_home");
+}
+
+describe("local adapter AGENT_HOME injection", () => {
+  it("injects AGENT_HOME for codex runs from instructionsFilePath", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-agent-home-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeCodexCommand(commandPath);
+
+    process.env.CODEX_HOME = path.join(root, ".codex");
+
+    try {
+      await expectAgentHomeInjected({
+        execute: executeCodex,
+        commandPath,
+        cwd: workspace,
+        instructionsFilePath,
+        capturePath,
+      });
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = previousCodexHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the resolved agent_home workspace cwd for codex runs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-agent-home-cwd-"));
+    const configuredCwd = path.join(root, "configured-workspace");
+    const workspaceCwd = path.join(root, "agent-home-workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    await fs.mkdir(configuredCwd, { recursive: true });
+    await fs.mkdir(workspaceCwd, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeCodexCommand(commandPath);
+
+    process.env.CODEX_HOME = path.join(root, ".codex");
+
+    try {
+      await expectAgentHomeWorkspaceCwdUsed({
+        execute: executeCodex,
+        commandPath,
+        configuredCwd,
+        workspaceCwd,
+        instructionsFilePath,
+        capturePath,
+      });
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = previousCodexHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects AGENT_HOME for claude runs from instructionsFilePath", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-agent-home-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      await expectAgentHomeInjected({
+        execute: executeClaude,
+        commandPath,
+        cwd: workspace,
+        instructionsFilePath,
+        capturePath,
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the resolved agent_home workspace cwd for claude runs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-agent-home-cwd-"));
+    const configuredCwd = path.join(root, "configured-workspace");
+    const workspaceCwd = path.join(root, "agent-home-workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+
+    await fs.mkdir(configuredCwd, { recursive: true });
+    await fs.mkdir(workspaceCwd, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      await expectAgentHomeWorkspaceCwdUsed({
+        execute: executeClaude,
+        commandPath,
+        configuredCwd,
+        workspaceCwd,
+        instructionsFilePath,
+        capturePath,
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects AGENT_HOME for cursor runs from instructionsFilePath", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cursor-agent-home-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+    const previousHome = process.env.HOME;
+
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeCursorCommand(commandPath);
+
+    process.env.HOME = root;
+
+    try {
+      await expectAgentHomeInjected({
+        execute: executeCursor,
+        commandPath,
+        cwd: workspace,
+        instructionsFilePath,
+        capturePath,
+        config: {
+          model: "auto",
+        },
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the resolved agent_home workspace cwd for cursor runs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cursor-agent-home-cwd-"));
+    const configuredCwd = path.join(root, "configured-workspace");
+    const workspaceCwd = path.join(root, "agent-home-workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+    const previousHome = process.env.HOME;
+
+    await fs.mkdir(configuredCwd, { recursive: true });
+    await fs.mkdir(workspaceCwd, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeCursorCommand(commandPath);
+
+    process.env.HOME = root;
+
+    try {
+      await expectAgentHomeWorkspaceCwdUsed({
+        execute: executeCursor,
+        commandPath,
+        configuredCwd,
+        workspaceCwd,
+        instructionsFilePath,
+        capturePath,
+        config: {
+          model: "auto",
+        },
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects AGENT_HOME for opencode runs from instructionsFilePath", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-agent-home-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "opencode");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+    const previousHome = process.env.HOME;
+
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeOpenCodeCommand(commandPath);
+
+    process.env.HOME = root;
+
+    try {
+      await expectAgentHomeInjected({
+        execute: executeOpenCode,
+        commandPath,
+        cwd: workspace,
+        instructionsFilePath,
+        capturePath,
+        config: {
+          model: "openai/gpt-5.4",
+        },
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the resolved agent_home workspace cwd for opencode runs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-agent-home-cwd-"));
+    const configuredCwd = path.join(root, "configured-workspace");
+    const workspaceCwd = path.join(root, "agent-home-workspace");
+    const commandPath = path.join(root, "opencode");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsDir = path.join(root, "agents", "ceo");
+    const instructionsFilePath = path.join(instructionsDir, "AGENTS.md");
+    const previousHome = process.env.HOME;
+
+    await fs.mkdir(configuredCwd, { recursive: true });
+    await fs.mkdir(workspaceCwd, { recursive: true });
+    await fs.mkdir(instructionsDir, { recursive: true });
+    await fs.writeFile(instructionsFilePath, "# Instructions\n", "utf8");
+    await writeFakeOpenCodeCommand(commandPath);
+
+    process.env.HOME = root;
+
+    try {
+      await expectAgentHomeWorkspaceCwdUsed({
+        execute: executeOpenCode,
+        commandPath,
+        configuredCwd,
+        workspaceCwd,
+        instructionsFilePath,
+        capturePath,
+        config: {
+          model: "openai/gpt-5.4",
+        },
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -265,6 +265,44 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+type ObservedWorkspaceGitProvenance = {
+  repoRoot: string | null;
+  branchName: string | null;
+  headSha: string | null;
+};
+
+async function readGitOutput(cwd: string, args: string[]) {
+  try {
+    const { stdout } = await execFile("git", ["-C", cwd, ...args], { cwd });
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function observeWorkspaceGitProvenance(cwd: string): Promise<ObservedWorkspaceGitProvenance> {
+  const repoRoot = await readGitOutput(cwd, ["rev-parse", "--show-toplevel"]);
+  if (!repoRoot) {
+    return {
+      repoRoot: null,
+      branchName: null,
+      headSha: null,
+    };
+  }
+
+  const [branchName, headSha] = await Promise.all([
+    readGitOutput(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]),
+    readGitOutput(cwd, ["rev-parse", "--verify", "HEAD"]),
+  ]);
+
+  return {
+    repoRoot: path.resolve(repoRoot),
+    branchName: readNonEmptyString(branchName),
+    headSha: readNonEmptyString(headSha),
+  };
+}
+
 function normalizeLedgerBillingType(value: unknown): BillingType {
   const raw = readNonEmptyString(value);
   switch (raw) {
@@ -2259,6 +2297,7 @@ export function heartbeatService(db: Db) {
           ]
         : []),
     ];
+    const observedWorkspaceGit = await observeWorkspaceGitProvenance(executionWorkspace.cwd);
     context.paperclipWorkspace = {
       cwd: executionWorkspace.cwd,
       source: executionWorkspace.source,
@@ -2269,6 +2308,9 @@ export function heartbeatService(db: Db) {
       repoUrl: executionWorkspace.repoUrl,
       repoRef: executionWorkspace.repoRef,
       branchName: executionWorkspace.branchName,
+      observedRepoRoot: observedWorkspaceGit.repoRoot,
+      observedBranchName: observedWorkspaceGit.branchName,
+      observedHeadSha: observedWorkspaceGit.headSha,
       worktreePath: executionWorkspace.worktreePath,
       agentHome: await (async () => {
         const home = resolveDefaultAgentWorkspaceDir(agent.id);


### PR DESCRIPTION
## What changed
- replay the clean local-adapter workspace-env commit chain into a fresh branch based on current upstream master
- restore the missing `deriveAgentHomeFromInstructionsFilePath` and ambient `PAPERCLIP_*` env stripping in `adapter-utils`
- keep Claude, Codex, Cursor, and OpenCode local adapters deriving `AGENT_HOME` from `instructionsFilePath`
- harden the local adapter regression tests so they do not inherit this heartbeat's ambient Paperclip env

## Why
The original workspace-env regression work existed only in a dirty local branch/workspace, which blocked clean GitHub traceability for [GRA-1883]. Replaying it in a clean Paperclip worktree exposed two missing shared-runtime pieces in this tree:
- `adapter-utils` was missing the `deriveAgentHomeFromInstructionsFilePath` helper
- child process spawning was still inheriting ambient `PAPERCLIP_*` env from the parent process

Without those fixes, the regression tests were not hermetic in a real Paperclip heartbeat and the local adapter `AGENT_HOME` path coverage failed in the clean checkout.

## Impact
- local adapter runs now derive `AGENT_HOME` consistently from `instructionsFilePath` when the workspace does not already provide one
- spawned local adapter processes no longer inherit unrelated ambient `PAPERCLIP_*` env from the parent shell/server
- the workspace-env regression suite passes from a clean Paperclip repo checkout

## Validation
- `pnpm -C /home/jake/vault/projects/paperclip-gra-1883 exec vitest run server/src/__tests__/local-agent-home-injection.test.ts server/src/__tests__/local-agent-api-key-injection.test.ts server/src/__tests__/local-adapter-workspace-env-parity.test.ts`
- `pnpm -C /home/jake/vault/projects/paperclip-gra-1883 -r typecheck`
- `pnpm -C /home/jake/vault/projects/paperclip-gra-1883 build`
- `pnpm -C /home/jake/vault/projects/paperclip-gra-1883 test:run` (fails outside this slice on pre-existing suites: `server/src/__tests__/app-hmr-port.test.ts`, `server/src/__tests__/assets.test.ts`, and `server/src/__tests__/company-portability.test.ts`)
