### PR TITLE
feat(ui): display agent ID in detail page header

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -526,6 +526,7 @@ export function AgentDetail() {
   const { closePanel } = usePanel();
   const { openNewIssue } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const { pushToast } = useToast();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [actionError, setActionError] = useState<string | null>(null);
@@ -821,6 +822,15 @@ export function AgentDetail() {
             <p className="text-sm text-muted-foreground truncate">
               {roleLabels[agent.role] ?? agent.role}
               {agent.title ? ` - ${agent.title}` : ""}
+              <span className="mx-1.5 opacity-30">·</span>
+              <button
+                type="button"
+                className="font-mono text-xs hover:text-foreground transition-colors cursor-pointer"
+                title="Click to copy agent ID"
+                onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(agent.id); pushToast({ title: "Agent ID copied", tone: "success" }); }}
+              >
+                {agent.id.slice(0, 8)}
+              </button>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Problem

The agent ID was hidden inside the overflow menu (three dots > "Copy Agent ID"). You could copy it from there but you could never see it on the page itself. When I need to reference an agent ID for API calls, debugging, or sharing with teammate, I had to open the menu every time.

We already show visible IDs for issues (the identifier like PAP-123) and goals (first 8 chars of goal ID) - but agent detail was the only entity detail page that was not showing the ID in the header.

## What I changed

Added the first 8 characters of the agent ID inline with the role/title subtitle in the header. Separated from the role text by a subtle dot separator. The ID is:
- Monospace font for easy reading
- Muted color that get darker on hover
- Click to copy the full agent ID to clipboard
- Success toast "Agent ID copied" on copy

Also added \`useToast()\` hook to the main AgentDetail function (it was only in the AgentConfigForm sub-component before).

## How to test

1. Go to any agent detail page
2. Below the agent name, next to the role label, should see a short ID like "a1b2c3d4"
3. Hover - text should darken
4. Click - full ID copied to clipboard with toast

1 file, 10 lines added.