### PR TITLE
feat(ui): display routine ID with click-to-copy in routine detail

### DIFF
--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -612,6 +612,14 @@ export function RoutineDetail() {
     <div className="max-w-2xl space-y-6">
       {/* Header: editable title + actions */}
       <div className="flex items-start gap-4">
+        <button
+          type="button"
+          className="text-xs font-mono text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer shrink-0 pt-2"
+          title="Click to copy routine ID"
+          onClick={() => { navigator.clipboard.writeText(routine.id); pushToast({ title: "Routine ID copied", tone: "success" }); }}
+        >
+          {routine.id.slice(0, 8)}
+        </button>
         <textarea
           ref={titleInputRef}
           className="flex-1 min-w-0 resize-none overflow-hidden bg-transparent text-xl font-bold outline-none placeholder:text-muted-foreground/50"


### PR DESCRIPTION
## Problem

Every entity detail page in the app now show a visible, copyable ID except routine detail:
- Issues: show identifier like PAP-123 (clickable to copy)
- Goals: show first 8 chars of goal ID (clickable)
- Agents: show first 8 chars of agent ID in header subtitle (clickable)
- Companies: show full UUID in settings page (clickable)

But routine detail was the only one missing. When I need the routine ID for API calls or debugging, I had to dig through network requests or inspect the URL.

## What I changed

Added a small monospaced ID button before the title textarea in the routine header. Show first 8 characters of the routine UUID. Click to copy the full ID with "Routine ID copied" success toast.

The styling is very subtle (\`text-muted-foreground/50\`) so it don't distract from the editable title next to it. It become more visible on hover with \`hover:text-muted-foreground\`.

## How to test

1. Go to any routine detail page
2. Before the title text, should see a short ID like "a1b2c3d4"
3. Hover - text become more visible
4. Click - full routine ID copied to clipboard with toast

1 file, 8 lines added. Complete the ID visibility pattern across all entity types.