### PR TITLE
fix(plugin-loader): convert paths to file:// URLs for Windows ESM compatibility

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
@@ -927,7 +927,8 @@ export function pluginLoader(
 
     try {
       // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const mod = await import(manifestPath) as Record<string, unknown>;
+      const importUrl = pathToFileURL(manifestPath).href;
+      const mod = await import(importUrl) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {
@@ -1738,7 +1739,7 @@ export function pluginLoader(
       // (for example @paperclipai/shared exports). Run those workers through
       // the tsx loader so first-party example plugins work in development.
       if (plugin.packagePath && existsSync(DEV_TSX_LOADER_PATH)) {
-        workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];
+        workerOptions.execArgv = ["--import", pathToFileURL(DEV_TSX_LOADER_PATH).href];
       }
 
       await workerManager.startWorker(pluginId, workerOptions);


### PR DESCRIPTION
## Problem

On Windows, `plugin-loader.ts` fails to load any plugin due to two ESM path handling bugs. Dynamic `import()` and the `--import` Node flag both require `file://` URLs on Windows — bare absolute paths (e.g. `C:\Users\...`) throw `ERR_UNSUPPORTED_ESM_URL_SCHEME`.

Closes #2057

## Changes

**`server/src/services/plugin-loader.ts`** — 3 lines changed

### Fix 1 — `loadManifestFromPath`: bare path in `import()`

```ts
// Before
const mod = await import(manifestPath) as Record<string, unknown>;

// After
const importUrl = pathToFileURL(manifestPath).href;
const mod = await import(importUrl) as Record<string, unknown>;
```

### Fix 2 — `activatePlugin`: bare path in `--import` flag

```ts
// Before
workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];

// After
workerOptions.execArgv = ["--import", pathToFileURL(DEV_TSX_LOADER_PATH).href];
```

### Import

`pathToFileURL` added to the existing `node:url` import (alongside `fileURLToPath` which was already there).

## Safety

`pathToFileURL()` on POSIX simply prepends `file://` — behaviour is identical to before on Linux/macOS. This is safe cross-platform.

## Testing

Verified on Windows 11 Pro 10.0.26100, Node v24.14.0 with `paperclip-plugin-discord` v0.3.1. Plugin loads and activates successfully after this fix.