### PR TITLE
feat(ui): display project ID with click-to-copy in project detail

### DIFF
--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -510,12 +510,22 @@ export function ProjectDetail() {
           />
         </div>
         <div className="min-w-0 space-y-2">
-          <InlineEditor
-            value={project.name}
-            onSave={(name) => updateProject.mutate({ name })}
-            as="h2"
-            className="text-xl font-bold"
-          />
+          <div className="flex items-center gap-2">
+            <InlineEditor
+              value={project.name}
+              onSave={(name) => updateProject.mutate({ name })}
+              as="h2"
+              className="text-xl font-bold"
+            />
+            <button
+              type="button"
+              className="text-xs font-mono text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer shrink-0"
+              title="Click to copy project ID"
+              onClick={() => { navigator.clipboard.writeText(project.id); pushToast({ title: "Project ID copied", tone: "success" }); }}
+            >
+              {project.id.slice(0, 8)}
+            </button>
+          </div>
           {project.pauseReason === "budget" ? (
             <div className="inline-flex items-center gap-2 rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-red-200">
               <span className="h-2 w-2 rounded-full bg-red-400" />


### PR DESCRIPTION
## Problem

Project detail was the last entity type that didn't show its ID anywhere in the header. All other entity detail pages now have visible copyable IDs:
- Issues: show identifier like PAP-123
- Goals: show first 8 chars of ID
- Agents: show first 8 chars in subtitle
- Routines: show first 8 chars before title
- Companies: show full UUID in settings

But on project detail page, when I need the project ID for API calls or debugging, I have to extract it from the URL path manually.

## What I changed

Added a small monospaced ID button next to the project name in the header. Show first 8 characters of the project UUID. Click to copy the full ID with "Project ID copied" success toast.

Uses very subtle styling (\`text-muted-foreground/50\`) so it don't compete with the editable project name. Wrapped both the InlineEditor and the ID button in a flex container for proper alignment.

## How to test

1. Go to any project detail page
2. Next to the project name, should see a short ID like "a1b2c3d4"
3. Hover - text become more visible
4. Click - full project ID copied to clipboard with toast

1 file, 16 lines added / 6 removed. This complete the ID visibility pattern across all entity types in the app.