### PR TITLE
fix: preserve session continuity for timer/heartbeat wakes

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -4,6 +4,7 @@ import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-lo
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
   buildExplicitResumeSessionOverride,
+  deriveTaskKeyWithHeartbeatFallback,
   formatRuntimeWorkspaceWarningLog,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
@@ -181,6 +182,34 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("deriveTaskKeyWithHeartbeatFallback", () => {
+  it("returns explicit taskKey when present", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ taskKey: "issue-123" }, null)).toBe("issue-123");
+  });
+
+  it("returns explicit issueId when no taskKey", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ issueId: "issue-456" }, null)).toBe("issue-456");
+  });
+
+  it("returns __heartbeat__ for timer wakes with no explicit key", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer" }, null)).toBe("__heartbeat__");
+  });
+
+  it("prefers explicit key over heartbeat fallback even on timer wakes", () => {
+    expect(
+      deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer", taskKey: "issue-789" }, null),
+    ).toBe("issue-789");
+  });
+
+  it("returns null for non-timer wakes with no explicit key", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "on_demand" }, null)).toBeNull();
+  });
+
+  it("returns null for empty context", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({}, null)).toBeNull();
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -524,6 +524,14 @@ function parseIssueAssigneeAdapterOverrides(
   };
 }
 
+/**
+ * Synthetic task key for timer/heartbeat wakes that have no issue context.
+ * This allows timer wakes to participate in the `agentTaskSessions` system
+ * and benefit from robust session resume, instead of relying solely on the
+ * simpler `agentRuntimeState.sessionId` fallback.
+ */
+const HEARTBEAT_TASK_KEY = "__heartbeat__";
+
 function deriveTaskKey(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
@@ -537,6 +545,28 @@ function deriveTaskKey(
     readNonEmptyString(payload?.issueId) ??
     null
   );
+}
+
+/**
+ * Extended task key derivation that falls back to a stable synthetic key
+ * for timer/heartbeat wakes. This ensures timer wakes can resume their
+ * previous session via `agentTaskSessions` instead of starting fresh.
+ *
+ * The synthetic key is only used when:
+ * - No explicit task/issue key exists in the context
+ * - The wake source is "timer" (scheduled heartbeat)
+ */
+export function deriveTaskKeyWithHeartbeatFallback(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+  payload: Record<string, unknown> | null | undefined,
+) {
+  const explicit = deriveTaskKey(contextSnapshot, payload);
+  if (explicit) return explicit;
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  if (wakeSource === "timer") return HEARTBEAT_TASK_KEY;
+
+  return null;
 }
 
 export function shouldResetTaskSessionForWake(
@@ -1512,7 +1542,7 @@ export function heartbeatService(db: Db) {
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
-    const taskKey = deriveTaskKey(contextSnapshot, null);
+    const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot = {
       ...contextSnapshot,
@@ -1967,7 +1997,7 @@ export function heartbeatService(db: Db) {
 
     const runtime = await ensureRuntimeState(agent);
     const context = parseObject(run.contextSnapshot);
-    const taskKey = deriveTaskKey(context, null);
+    const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);
     const issueContext = issueId


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents via a heartbeat system that wakes agents on timers or events
> - Each wake triggers a run, and runs can resume a previous Claude session via `--resume <sessionId>`
> - Session resume is managed through `agentTaskSessions`, keyed by `(agentId, adapterType, taskKey)`
> - Timer wakes (scheduled heartbeats) are the dominant execution path (~6,587 of ~11,360 runs in local data)
> - But timer wakes have no issue context, so `deriveTaskKey()` returns null for them
> - With no `taskKey`, the run can't look up or save sessions in `agentTaskSessions`
> - It falls back to the weaker `agentRuntimeState.sessionId` which doesn't track session params like `cwd`
> - Result: only ~15% of timer wakes successfully resumed a prior session
> - This PR gives timer wakes a stable synthetic `__heartbeat__` task key so they participate in the full session system
> - The benefit is consistent session reuse on the most common heartbeat path, preserving context and prompt cache locality

## Summary

Timer wakes (the dominant heartbeat path) had no `taskKey`, so they couldn't participate in the `agentTaskSessions` system for robust session resume. They relied solely on the weaker `agentRuntimeState.sessionId` fallback, which doesn't track session params like `cwd`.

This adds a synthetic stable `__heartbeat__` task key for timer wakes, enabling full session management:

- **Session saved** after each timer run with complete params (including `cwd`)
- **Session resumed** on next timer wake via `--resume <sessionId>`
- **No conflict** with issue-specific sessions (separate task keys in the unique index)
- **No side effects** — synthetic key is derived at execution time only, never persisted in context snapshots

## Context

The [TOKEN-OPTIMIZATION-PLAN](doc/plans/2026-03-13-TOKEN-OPTIMIZATION-PLAN.md) identifies this as a priority (Phase 2, Engineering Task #3):

> *"Only ~976 of ~6,587 timer runs had a prior session"* (~15% reuse rate)

## Changes

- `server/src/services/heartbeat.ts`:
  - Added `HEARTBEAT_TASK_KEY` constant (`"__heartbeat__"`)
  - Added `deriveTaskKeyWithHeartbeatFallback()` — extends `deriveTaskKey()` with timer wake fallback
  - Updated `executeRun()` and process-recovery retry path to use the new function
  - Original `deriveTaskKey()` unchanged (still used in `normalizeWakeupContextSnapshot` where we don't want synthetic keys persisted)
- `server/src/__tests__/heartbeat-workspace-session.test.ts`:
  - 6 new unit tests covering all three branches of `deriveTaskKeyWithHeartbeatFallback()`

## Risks

- **Low risk:** The `__heartbeat__` key is namespaced with double underscores to avoid collision with real issue IDs (UUIDs). The unique index on `agentTaskSessions` ensures one session per `(agentId, adapterType, taskKey)`, so heartbeat sessions are isolated from issue sessions.
- **Session compaction:** For `claude_local`, session compaction thresholds default to 0 (disabled/native), so long-lived heartbeat sessions won't trigger unexpected rotation. If compaction is enabled per-agent, the `__heartbeat__` session will be subject to the same rotation policy as any other — this is desirable.
- **Backward compatible:** Existing timer wakes that previously had no session will simply start building one. No migration needed.

## Verification

- [x] All 27 existing heartbeat tests pass + 6 new dedicated tests
- [ ] In staging: assign a `claude_local` agent with a heartbeat interval, let it run 3+ timer cycles, then query `agentTaskSessions` for `taskKey = '__heartbeat__'` — should see a session entry with `sessionParamsJson` containing `cwd` and `sessionId`
- [ ] Verify the agent's Claude process shows `--resume` on subsequent timer wakes (check run logs for `[paperclip] Claude session` messages)
- [ ] Confirm issue-assigned wakes still create their own session under the issue's task key (no cross-contamination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)