### PR TITLE
fix: prevent sharp install failure when global libvips is present

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=true
+sharp_ignore_global_libvips=1


### PR DESCRIPTION
## Summary

`pnpm install` fails with `ELIFECYCLE` on machines that have libvips installed globally (e.g. through Homebrew). Sharp's install script detects the system libvips, skips its prebuilt binary, and tries to compile from source via node-gyp. This fails because `node-addon-api` is not in the dependency tree.

Adding `sharp_ignore_global_libvips=1` to `.npmrc` tells sharp to always use its bundled prebuilt binary regardless of what's installed on the host.

## Test plan

- [ ] Run `pnpm install` on a machine with Homebrew's `vips` installed, confirm it completes without errors
- [ ] Run `pnpm install` on a machine without global libvips, confirm no regressions