### PR TITLE
fix(ui): constrain markdown images to container width

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -688,6 +688,8 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
 .paperclip-markdown img {
   border-radius: calc(var(--radius) + 2px);
   box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--foreground) 10%, transparent);
+  max-width: 100%;
+  height: auto;
 }
 
 .paperclip-markdown table {


### PR DESCRIPTION
## Problem

Images in rendered markdown content had no max-width constraint. The CSS only had border-radius and box-shadow styling but nothing to prevent large images from overflowing.

When someone paste a large screenshot (like 2000px wide) or a high-res diagram into an issue description, agent instructions, or a comment, the image render at full size and overflow the content area. This break the page layout and create horizontal scrollbar on the whole page.

## What I changed

Added two standard responsive image CSS properties:

- \`max-width: 100%\` - image scale down to fit container, never overflow
- \`height: auto\` - maintain aspect ratio when scaling

This is a very basic CSS pattern that every web app should have on user-uploaded images. Not sure how it was missing from the markdown styles.

## How to test

1. Open any issue or agent with a large image in markdown description
2. The image should fit within the content area without overflow
3. Small images should be unaffected (they display at natural size)

1 file, 2 lines added.