### PR TITLE
Add sign out button to company settings page

### DIFF
--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -183,7 +183,7 @@ export function CompanySettings() {
       window.location.href = "/auth";
     },
     onError: () => {
-      pushToast("Sign out failed. Please try again.", "error");
+      pushToast({ title: "Sign out failed. Please try again.", tone: "error" });
     },
   });
 


### PR DESCRIPTION
## Summary
- Adds an "Account" section to the company settings page with a "Sign out" button
- Uses the existing `authApi.signOut()` method which was previously only available via CLI
- After signing out, redirects the user to the `/auth` page

## Thinking path

**Why this feature is needed:** In authenticated mode, there is no way to sign out from the web UI. The `authApi.signOut()` endpoint exists server-side but was never exposed in the interface, forcing users to manually clear cookies.

**Why it matters:** Multi-user deployments (e.g. self-hosted instances with multiple accounts) need a way to switch users or end sessions. Without a sign out button, users have no clean way to do this.

**Risks:** Minimal — the change is additive (new UI section) and uses an existing API. The sign out mutation follows the same `useMutation` + `isPending` + toast pattern used throughout the file, so behavior is consistent.

## Screenshots

_Before:_ Settings page has no account/session management — only General, Appearance, Hiring, Invites, Company Packages, and Danger Zone sections.

_After:_ New "Account" section appears above "Danger Zone" with a "Sign out" button that disables and shows "Signing out..." during the request. On failure, an error toast is shown.

## Test plan
- [ ] Navigate to `/:boardSlug/company/settings`
- [ ] Verify the "Account" section appears above the "Danger Zone"
- [ ] Click "Sign out" and confirm the button shows "Signing out..." and is disabled
- [ ] Confirm you are redirected to the `/auth` page
- [ ] Verify the session is cleared (revisiting a protected route should redirect to auth)
- [ ] Simulate a network failure and verify the error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)