### PR TITLE
feat(ui): amber dot on config tabs when agent has unsaved changes

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -909,9 +909,9 @@ export function AgentDetail() {
           <PageTabBar
             items={[
               { value: "dashboard", label: "Dashboard" },
-              { value: "instructions", label: "Instructions" },
+              { value: "instructions", label: configDirty ? <span>Instructions <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" /></span> : "Instructions" },
               { value: "skills", label: "Skills" },
-              { value: "configuration", label: "Configuration" },
+              { value: "configuration", label: configDirty ? <span>Configuration <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" /></span> : "Configuration" },
               { value: "runs", label: "Runs" },
               { value: "budget", label: "Budget" },
             ]}


### PR DESCRIPTION
## Problem

When editing agent instructions or configuration, the app show a floating save/cancel bar at the bottom of the page. But if user switch to another tab (like Dashboard or Runs), the save bar disappear and there is no visual indication that they have unsaved changes in the config tabs.

I did this several times - edit some config, switch to Runs tab to check something, then navigate to another agent completely forgetting I had unsaved changes. The \`useBeforeUnload\` hook catch navigation away from the page, but switching tabs within the same agent doesn't trigger it.

## What I changed

When \`configDirty\` is true (unsaved changes exist), the "Instructions" and "Configuration" tab labels now show a small amber dot next to the text. This is a very common UI pattern for indicating unsaved state (like the dot on document tabs in VS Code).

The dot:
- Small amber circle (1.5px, \`bg-amber-400\`)
- Appear on both Instructions and Configuration tabs since both share the same dirty state
- Disappear automatically when user save or cancel (configDirty reset to false)
- Use inline-block so it don't affect tab alignment

## How to test

1. Go to any agent > Instructions or Configuration tab
2. Make a change (edit instructions text, change a setting)
3. Switch to Dashboard or Runs tab
4. The "Instructions" and "Configuration" tabs should show a small amber dot
5. Go back and save - dot should disappear

1 file, 2 lines changed.