### PR TITLE
fix: clear execution lock fields on issue release and auto-recover stale locks on checkout (VOX-343)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRuns,
   issueComments,
   issueInboxArchives,
   issues,
@@ -312,5 +313,172 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       archivedIssueId,
       resurfacedIssueId,
     ]));
+  });
+});
+
+describeEmbeddedPostgres("issueService checkout/release execution lock semantics", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-exec-lock-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture(input?: { runStatus?: string }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleRunId = randomUUID();
+    const freshRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "TestCo",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: input?.runStatus ?? "succeeded",
+        contextSnapshot: {},
+        startedAt: new Date("2026-03-29T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-29T00:00:00.000Z"),
+      },
+      {
+        id: freshRunId,
+        companyId,
+        agentId,
+        invocationSource: "on_demand",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: {},
+        startedAt: new Date("2026-03-29T01:00:00.000Z"),
+        updatedAt: new Date("2026-03-29T01:00:00.000Z"),
+      },
+    ]);
+
+    return { companyId, agentId, staleRunId, freshRunId };
+  }
+
+  it("release clears executionRunId, executionAgentNameKey, executionLockedAt", async () => {
+    const { companyId, agentId, staleRunId } = await seedFixture({ runStatus: "succeeded" });
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Locked issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: staleRunId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "testagent",
+      executionLockedAt: new Date("2026-03-29T00:00:00.000Z"),
+      issueNumber: 1,
+      identifier: "T-1",
+    });
+
+    const released = await svc.release(issueId, agentId, staleRunId);
+    expect(released).toBeTruthy();
+    expect(released!.status).toBe("todo");
+    expect(released!.assigneeAgentId).toBeNull();
+    expect(released!.checkoutRunId).toBeNull();
+    expect(released!.executionRunId).toBeNull();
+    expect(released!.executionAgentNameKey).toBeNull();
+    expect(released!.executionLockedAt).toBeNull();
+  });
+
+  it("checkout recovers from stale execution lock held by a succeeded run", async () => {
+    const { companyId, agentId, staleRunId, freshRunId } = await seedFixture({ runStatus: "succeeded" });
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale lock issue",
+      status: "todo",
+      priority: "medium",
+      executionRunId: staleRunId,
+      executionAgentNameKey: "testagent",
+      executionLockedAt: new Date("2026-03-29T00:00:00.000Z"),
+      issueNumber: 1,
+      identifier: "T-1",
+    });
+
+    const result = await svc.checkout(issueId, agentId, ["todo"], freshRunId);
+    expect(result).toBeTruthy();
+    expect(result!.status).toBe("in_progress");
+    expect(result!.assigneeAgentId).toBe(agentId);
+    expect(result!.checkoutRunId).toBe(freshRunId);
+    expect(result!.executionRunId).toBe(freshRunId);
+  });
+
+  it("checkout does not steal issue from another agent even with stale execution lock", async () => {
+    const { companyId, agentId, staleRunId, freshRunId } = await seedFixture({ runStatus: "succeeded" });
+    const otherAgentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Assigned to other agent",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: otherAgentId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "otheragent",
+      executionLockedAt: new Date("2026-03-29T00:00:00.000Z"),
+      issueNumber: 1,
+      identifier: "T-1",
+    });
+
+    await expect(
+      svc.checkout(issueId, agentId, ["todo", "in_progress"], freshRunId),
+    ).rejects.toThrow();
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -481,4 +481,26 @@ describeEmbeddedPostgres("issueService checkout/release execution lock semantics
       svc.checkout(issueId, agentId, ["todo", "in_progress"], freshRunId),
     ).rejects.toThrow();
   });
+
+  it("checkout does not recover execution lock when run is still running", async () => {
+    const { companyId, agentId, staleRunId, freshRunId } = await seedFixture({ runStatus: "running" });
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Active lock issue",
+      status: "todo",
+      priority: "medium",
+      executionRunId: staleRunId,
+      executionAgentNameKey: "testagent",
+      executionLockedAt: new Date("2026-03-29T00:00:00.000Z"),
+      issueNumber: 1,
+      identifier: "T-1",
+    });
+
+    await expect(
+      svc.checkout(issueId, agentId, ["todo"], freshRunId),
+    ).rejects.toThrow();
+  });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1218,7 +1218,7 @@ export function issueService(db: Db) {
         return enriched;
       }
 
-      if (current.executionRunId && checkoutRunId && current.executionRunId !== checkoutRunId) {
+      if (current.executionRunId && (!checkoutRunId || current.executionRunId !== checkoutRunId)) {
         const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
         if (stale) {
           await db
@@ -1235,6 +1235,23 @@ export function issueService(db: Db) {
                 eq(issues.executionRunId, current.executionRunId),
               ),
             );
+          const retryPredicates = [
+            eq(issues.id, id),
+            inArray(issues.status, expectedStatuses),
+            isNull(issues.executionRunId),
+            or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
+          ];
+          if (checkoutRunId) {
+            retryPredicates.push(
+              or(
+                isNull(issues.checkoutRunId),
+                and(
+                  eq(issues.checkoutRunId, checkoutRunId),
+                  eq(issues.assigneeAgentId, agentId),
+                ),
+              ),
+            );
+          }
           const retried = await db
             .update(issues)
             .set({
@@ -1246,21 +1263,7 @@ export function issueService(db: Db) {
               startedAt: new Date(),
               updatedAt: new Date(),
             })
-            .where(
-              and(
-                eq(issues.id, id),
-                inArray(issues.status, expectedStatuses),
-                isNull(issues.executionRunId),
-                or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
-                or(
-                  isNull(issues.checkoutRunId),
-                  and(
-                    eq(issues.checkoutRunId, checkoutRunId),
-                    eq(issues.assigneeAgentId, agentId),
-                  ),
-                ),
-              ),
-            )
+            .where(and(...retryPredicates))
             .returning()
             .then((rows) => rows[0] ?? null);
           if (retried) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1218,6 +1218,58 @@ export function issueService(db: Db) {
         return enriched;
       }
 
+      if (current.executionRunId && checkoutRunId && current.executionRunId !== checkoutRunId) {
+        const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
+        if (stale) {
+          await db
+            .update(issues)
+            .set({
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(issues.id, id),
+                eq(issues.executionRunId, current.executionRunId),
+              ),
+            );
+          const retried = await db
+            .update(issues)
+            .set({
+              assigneeAgentId: agentId,
+              assigneeUserId: null,
+              checkoutRunId,
+              executionRunId: checkoutRunId,
+              status: "in_progress",
+              startedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(issues.id, id),
+                inArray(issues.status, expectedStatuses),
+                isNull(issues.executionRunId),
+                or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
+                or(
+                  isNull(issues.checkoutRunId),
+                  and(
+                    eq(issues.checkoutRunId, checkoutRunId),
+                    eq(issues.assigneeAgentId, agentId),
+                  ),
+                ),
+              ),
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (retried) {
+            const [enriched] = await withIssueLabels(db, [retried]);
+            return enriched;
+          }
+        }
+      }
+
       throw conflict("Issue checkout conflict", {
         issueId: current.id,
         status: current.status,
@@ -1313,6 +1365,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

Fixes a deadlock where issues retain `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` after a run completes, preventing subsequent runs from checking out the issue.

## Root Cause

`release()` cleared `checkoutRunId` but left the three execution lock fields dangling. Since `checkout()` requires `executionRunId` to be NULL or match the caller's run ID, any issue with a stale `executionRunId` from a prior run would permanently fail checkout.

## Changes

1. **`release()` now clears all execution lock fields** — `executionRunId`, `executionAgentNameKey`, `executionLockedAt` are set to null alongside `checkoutRunId`.

2. **`checkout()` auto-recovers stale execution locks (defense-in-depth)** — When the primary checkout fails due to a non-matching `executionRunId`, the code checks if the associated heartbeat run is in a terminal status (`succeeded`, `failed`, `cancelled`, `timed_out`) or missing. If so, it clears the stale lock and retries the checkout.

3. **TOCTOU-safe compare-and-swap** — The stale lock clear uses `WHERE executionRunId = <observed_value>` to prevent racing with concurrent valid checkouts.

4. **Assignee predicate guards** — The retry checkout preserves assignee/checkout predicates from the primary checkout to prevent stealing issues from other agents.

## Tests

- `release clears executionRunId, executionAgentNameKey, executionLockedAt`
- `checkout recovers from stale execution lock held by a succeeded run`
- `checkout does not steal issue from another agent even with stale execution lock`