### PR TITLE
feat: add GitHub Copilot CLI adapter (copilot_local)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
+COPY packages/adapters/copilot-local/package.json packages/adapters/copilot-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,6 +39,7 @@
     "@clack/prompts": "^0.10.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { printCopilotStreamEvent } from "@paperclipai/adapter-copilot-local/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -44,6 +45,11 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const copilotLocalCLIAdapter: CLIAdapterModule = {
+  type: "copilot_local",
+  formatStdoutEvent: printCopilotStreamEvent,
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
@@ -52,6 +58,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,
+    copilotLocalCLIAdapter,
     openclawGatewayCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,

--- a/packages/adapters/copilot-local/package.json
+++ b/packages/adapters/copilot-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-copilot-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/copilot-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/adapters/copilot-local/src/cli/format-event.ts
+++ b/packages/adapters/copilot-local/src/cli/format-event.ts
@@ -5,14 +5,23 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function safeNum(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return fallback;
+}
+
 export function printCopilotStreamEvent(raw: string, debug: boolean): void {
   const line = raw.trim();
   if (!line) return;
 
   let parsed: Record<string, unknown> | null = null;
   try {
-    parsed = JSON.parse(line) as Record<string, unknown>;
+    parsed = asRecord(JSON.parse(line));
   } catch {
+    console.log(line);
+    return;
+  }
+  if (!parsed) {
     console.log(line);
     return;
   }
@@ -99,11 +108,11 @@ export function printCopilotStreamEvent(raw: string, debug: boolean): void {
   // Final result
   if (type === "result") {
     const sessionId = typeof parsed.sessionId === "string" ? parsed.sessionId : "";
-    const exitCode = Number(parsed.exitCode ?? 0);
+    const exitCode = safeNum(parsed.exitCode);
     const usageObj = asRecord(parsed.usage) ?? {};
-    const premiumRequests = Number(usageObj.premiumRequests ?? 0);
-    const totalApiDurationMs = Number(usageObj.totalApiDurationMs ?? 0);
-    const sessionDurationMs = Number(usageObj.sessionDurationMs ?? 0);
+    const premiumRequests = safeNum(usageObj.premiumRequests);
+    const totalApiDurationMs = safeNum(usageObj.totalApiDurationMs);
+    const sessionDurationMs = safeNum(usageObj.sessionDurationMs);
 
     if (sessionId) console.log(pc.blue(`session: ${sessionId}`));
     console.log(

--- a/packages/adapters/copilot-local/src/cli/format-event.ts
+++ b/packages/adapters/copilot-local/src/cli/format-event.ts
@@ -1,0 +1,121 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function printCopilotStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    console.log(line);
+    return;
+  }
+
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+  const data = asRecord(parsed.data) ?? {};
+
+  // Model init
+  if (type === "session.tools_updated") {
+    const model = typeof data.model === "string" ? data.model : "unknown";
+    console.log(pc.blue(`Copilot initialized (model: ${model})`));
+    return;
+  }
+
+  // User message
+  if (type === "user.message") {
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content && debug) {
+      console.log(pc.gray(`user: ${content.slice(0, 200)}`));
+    }
+    return;
+  }
+
+  // Assistant reasoning (thinking)
+  if (type === "assistant.reasoning") {
+    if (debug) {
+      const text = typeof data.reasoningText === "string" ? data.reasoningText : "";
+      if (text) console.log(pc.gray(`thinking: ${text.slice(0, 200)}`));
+    }
+    return;
+  }
+
+  // Assistant message
+  if (type === "assistant.message") {
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content) console.log(pc.green(`assistant: ${content}`));
+
+    // Copilot: toolRequests[].name at top level, not nested under .function
+    const toolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : [];
+    for (const rawReq of toolRequests) {
+      const req = asRecord(rawReq);
+      if (!req) continue;
+      const name = typeof req.name === "string" ? req.name : "unknown";
+      console.log(pc.yellow(`tool_call: ${name}`));
+      if (req.arguments !== undefined && debug) {
+        const argStr =
+          typeof req.arguments === "string"
+            ? req.arguments
+            : JSON.stringify(req.arguments, null, 2);
+        console.log(pc.gray(argStr));
+      }
+    }
+    return;
+  }
+
+  // Streaming delta
+  if (type === "assistant.message_delta") {
+    const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+    if (deltaContent) process.stdout.write(pc.green(deltaContent));
+    return;
+  }
+
+  // Tool execution start
+  if (type === "tool.execution_start") {
+    const name = typeof data.toolName === "string" ? data.toolName : "unknown";
+    console.log(pc.yellow(`tool_start: ${name}`));
+    return;
+  }
+
+  // Tool execution complete: uses data.success (not data.isError)
+  if (type === "tool.execution_complete") {
+    const name = typeof data.toolName === "string" ? data.toolName : "unknown";
+    const isError = data.success === false;
+    if (isError) {
+      const errObj = asRecord(data.error);
+      const errMsg = errObj && typeof errObj.message === "string" ? errObj.message : "";
+      console.log(pc.red(`tool_error: ${name}${errMsg ? ` — ${errMsg}` : ""}`));
+    } else {
+      console.log(pc.cyan(`tool_done: ${name}`));
+    }
+    return;
+  }
+
+  // Final result
+  if (type === "result") {
+    const sessionId = typeof parsed.sessionId === "string" ? parsed.sessionId : "";
+    const exitCode = Number(parsed.exitCode ?? 0);
+    const usageObj = asRecord(parsed.usage) ?? {};
+    const premiumRequests = Number(usageObj.premiumRequests ?? 0);
+    const totalApiDurationMs = Number(usageObj.totalApiDurationMs ?? 0);
+    const sessionDurationMs = Number(usageObj.sessionDurationMs ?? 0);
+
+    if (sessionId) console.log(pc.blue(`session: ${sessionId}`));
+    console.log(
+      pc.blue(
+        `usage: premiumRequests=${premiumRequests} apiDuration=${totalApiDurationMs}ms sessionDuration=${sessionDurationMs}ms exit=${exitCode}`,
+      ),
+    );
+    return;
+  }
+
+  // Debug: show everything else
+  if (debug) {
+    console.log(pc.gray(line));
+  }
+}

--- a/packages/adapters/copilot-local/src/cli/index.ts
+++ b/packages/adapters/copilot-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printCopilotStreamEvent } from "./format-event.js";

--- a/packages/adapters/copilot-local/src/index.ts
+++ b/packages/adapters/copilot-local/src/index.ts
@@ -1,0 +1,36 @@
+export const type = "copilot_local";
+export const label = "GitHub Copilot CLI (local)";
+
+export const models = [
+  { id: "claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+  { id: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  { id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
+  { id: "gpt-5.4", label: "GPT 5.4" },
+  { id: "gpt-5.4-mini", label: "GPT 5.4 Mini" },
+  { id: "gpt-5.2", label: "GPT 5.2" },
+  { id: "gemini-3-pro-preview", label: "Gemini 3 Pro Preview" },
+];
+
+export const agentConfigurationDoc = `# copilot_local agent configuration
+
+Adapter: copilot_local
+
+Core fields:
+- cwd (string, optional): default absolute working directory for the agent process
+- model (string, optional): model id (e.g. claude-sonnet-4.6, gpt-5.4)
+- effort (string, optional): reasoning effort (low|medium|high|xhigh)
+- promptTemplate (string, optional): run prompt template
+- dangerouslySkipPermissions (boolean, optional): pass --allow-all / --yolo
+- command (string, optional): defaults to "copilot"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Copilot CLI must be installed and authenticated via GitHub.
+- Uses --output-format json for structured JSONL output.
+- Session resume is supported via --resume=<sessionId>.
+`;

--- a/packages/adapters/copilot-local/src/index.ts
+++ b/packages/adapters/copilot-local/src/index.ts
@@ -2,13 +2,12 @@ export const type = "copilot_local";
 export const label = "GitHub Copilot CLI (local)";
 
 export const models = [
-  { id: "claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
-  { id: "claude-opus-4.6", label: "Claude Opus 4.6" },
-  { id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
   { id: "gpt-5.4", label: "GPT 5.4" },
   { id: "gpt-5.4-mini", label: "GPT 5.4 Mini" },
   { id: "gpt-5.2", label: "GPT 5.2" },
-  { id: "gemini-3-pro-preview", label: "Gemini 3 Pro Preview" },
+  { id: "claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+  { id: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  { id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
 ];
 
 export const agentConfigurationDoc = `# copilot_local agent configuration
@@ -17,7 +16,7 @@ Adapter: copilot_local
 
 Core fields:
 - cwd (string, optional): default absolute working directory for the agent process
-- model (string, optional): model id (e.g. claude-sonnet-4.6, gpt-5.4)
+- model (string, optional): model id (e.g. gpt-5.4, claude-sonnet-4.6)
 - effort (string, optional): reasoning effort (low|medium|high|xhigh)
 - promptTemplate (string, optional): run prompt template
 - dangerouslySkipPermissions (boolean, optional): pass --allow-all / --yolo

--- a/packages/adapters/copilot-local/src/server/execute.ts
+++ b/packages/adapters/copilot-local/src/server/execute.ts
@@ -1,0 +1,242 @@
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import {
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+  joinPromptSections,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  parseCopilotJsonl,
+  describeCopilotFailure,
+  detectCopilotAuthRequired,
+  isCopilotUnknownSessionError,
+} from "./parse.js";
+
+interface CopilotRuntimeConfig {
+  command: string;
+  cwd: string;
+  env: Record<string, string>;
+  timeoutSec: number;
+  graceSec: number;
+  extraArgs: string[];
+}
+
+async function buildCopilotRuntimeConfig(input: {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  context: Record<string, unknown>;
+}): Promise<CopilotRuntimeConfig> {
+  const { runId, agent, config, context } = input;
+
+  const command = asString(config.command, "copilot");
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const configuredCwd = asString(config.cwd, "");
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  return { command, cwd, env, timeoutSec, graceSec, extraArgs };
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const model = asString(config.model, "");
+  const effort = asString(config.effort, "");
+  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, false);
+
+  const runtimeConfig = await buildCopilotRuntimeConfig({
+    runId,
+    agent,
+    config,
+    context,
+  });
+  const { command, cwd, env, timeoutSec, graceSec, extraArgs } = runtimeConfig;
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Copilot session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const prompt = joinPromptSections([sessionHandoffNote, renderedPrompt]);
+
+  const buildCopilotArgs = (resumeSessionId: string | null) => {
+    const args = ["-p", prompt, "--output-format", "json", "-s", "--no-color"];
+    if (resumeSessionId) args.push(`--resume=${resumeSessionId}`);
+    if (dangerouslySkipPermissions) args.push("--allow-all");
+    else args.push("--allow-all-tools");
+    if (model) args.push("--model", model);
+    if (effort) args.push("--effort", effort);
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildCopilotArgs(resumeSessionId);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "copilot_local",
+        command,
+        cwd,
+        commandArgs: args,
+        env: redactEnvForLogs(env),
+        prompt,
+        context,
+      });
+    }
+
+    const proc = await runChildProcess(runId, command, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onLog,
+    });
+
+    const parsedStream = parseCopilotJsonl(proc.stdout);
+    return { proc, parsedStream };
+  };
+
+  const toAdapterResult = (
+    attempt: {
+      proc: RunProcessResult;
+      parsedStream: ReturnType<typeof parseCopilotJsonl>;
+    },
+    opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
+  ): AdapterExecutionResult => {
+    const { proc, parsedStream } = attempt;
+    const authMeta = detectCopilotAuthRequired({
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+    });
+
+    if (proc.timedOut) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: "timeout",
+        clearSession: Boolean(opts.clearSessionOnMissingSession),
+      };
+    }
+
+    const resolvedSessionId = parsedStream.sessionId ?? opts.fallbackSessionId;
+    const resolvedSessionParams = resolvedSessionId
+      ? ({ sessionId: resolvedSessionId, cwd } as Record<string, unknown>)
+      : null;
+
+    // Build error message from stderr (where Copilot puts its errors) and parsed result.
+    const errorMessage =
+      (proc.exitCode ?? 0) === 0
+        ? null
+        : describeCopilotFailure(parsedStream.resultJson, proc.stderr);
+
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: false,
+      errorMessage,
+      errorCode: authMeta.requiresLogin ? "copilot_auth_required" : null,
+      usage: parsedStream.usage ?? undefined,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "github",
+      biller: "github",
+      model: parsedStream.model || model,
+      billingType: "subscription",
+      costUsd: null, // subscription-based, no per-run cost
+      resultJson: parsedStream.resultJson,
+      summary: parsedStream.summary,
+      // Include stderr excerpt in resultJson when there's no JSONL output (error cases)
+      ...(proc.stderr && !parsedStream.resultJson
+        ? {
+            resultJson: {
+              stderr: proc.stderr,
+              stdout: proc.stdout,
+            },
+          }
+        : {}),
+      clearSession: Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+    };
+  };
+
+  // Run the initial attempt, with session resume if available.
+  const initial = await runAttempt(sessionId ?? null);
+
+  // Copilot outputs session errors to stderr with zero JSONL on stdout.
+  // Check stderr (not parsed result) for unknown session detection.
+  if (
+    sessionId &&
+    !initial.proc.timedOut &&
+    (initial.proc.exitCode ?? 0) !== 0 &&
+    isCopilotUnknownSessionError(initial.proc.stderr)
+  ) {
+    await onLog(
+      "stdout",
+      `[paperclip] Copilot resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+    );
+    const retry = await runAttempt(null);
+    return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+  }
+
+  return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+}

--- a/packages/adapters/copilot-local/src/server/index.ts
+++ b/packages/adapters/copilot-local/src/server/index.ts
@@ -1,0 +1,47 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseCopilotJsonl,
+  describeCopilotFailure,
+  isCopilotUnknownSessionError,
+  detectCopilotAuthRequired,
+} from "./parse.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};

--- a/packages/adapters/copilot-local/src/server/parse.test.ts
+++ b/packages/adapters/copilot-local/src/server/parse.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCopilotJsonl,
+  describeCopilotFailure,
+  isCopilotUnknownSessionError,
+  detectCopilotAuthRequired,
+} from "./parse.js";
+
+const SAMPLE_OUTPUT = [
+  '{"type":"session.mcp_server_status_changed","data":{"serverName":"notion","status":"connected"},"id":"44e92345","timestamp":"2026-03-29T07:47:51.203Z","parentId":"604aceed","ephemeral":true}',
+  '{"type":"session.tools_updated","data":{"model":"gpt-5.4"},"id":"aae3898e","timestamp":"2026-03-29T07:47:52.669Z","parentId":"ff8fb69d","ephemeral":true}',
+  '{"type":"user.message","data":{"content":"Respond with just the word hello.","attachments":[],"interactionId":"25ad8a5b"},"id":"846db770","timestamp":"2026-03-29T07:47:52.670Z"}',
+  '{"type":"assistant.turn_start","data":{"turnId":"0","interactionId":"25ad8a5b"},"id":"e9b2c186","timestamp":"2026-03-29T07:47:52.672Z"}',
+  '{"type":"assistant.message","data":{"messageId":"c46b7398","content":"hello","toolRequests":[],"interactionId":"25ad8a5b","phase":"final_answer","outputTokens":31},"id":"f6f819d5","timestamp":"2026-03-29T07:47:59.311Z"}',
+  '{"type":"assistant.turn_end","data":{"turnId":"0"},"id":"f1784f6a","timestamp":"2026-03-29T07:47:59.311Z"}',
+  '{"type":"result","timestamp":"2026-03-29T07:47:59.313Z","sessionId":"efc9f463-38c1-464a-8c7f-d28ac8993ffa","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":6046,"sessionDurationMs":9803,"codeChanges":{"linesAdded":0,"linesRemoved":0,"filesModified":[]}}}',
+].join("\n");
+
+describe("parseCopilotJsonl", () => {
+  it("extracts sessionId from result event", () => {
+    const result = parseCopilotJsonl(SAMPLE_OUTPUT);
+    expect(result.sessionId).toBe("efc9f463-38c1-464a-8c7f-d28ac8993ffa");
+  });
+
+  it("extracts model from session.tools_updated", () => {
+    const result = parseCopilotJsonl(SAMPLE_OUTPUT);
+    expect(result.model).toBe("gpt-5.4");
+  });
+
+  it("extracts assistant text as summary", () => {
+    const result = parseCopilotJsonl(SAMPLE_OUTPUT);
+    expect(result.summary).toBe("hello");
+  });
+
+  it("tracks output tokens from assistant.message", () => {
+    const result = parseCopilotJsonl(SAMPLE_OUTPUT);
+    expect(result.usage?.outputTokens).toBe(31);
+  });
+
+  it("extracts premiumRequests from usage", () => {
+    const result = parseCopilotJsonl(SAMPLE_OUTPUT);
+    expect(result.premiumRequests).toBe(1);
+  });
+
+  it("extracts totalApiDurationMs", () => {
+    const result = parseCopilotJsonl(SAMPLE_OUTPUT);
+    expect(result.totalApiDurationMs).toBe(6046);
+  });
+
+  it("returns null resultJson when no result event", () => {
+    const result = parseCopilotJsonl(
+      '{"type":"assistant.message","data":{"content":"hi","outputTokens":5}}',
+    );
+    expect(result.resultJson).toBeNull();
+    expect(result.summary).toBe("hi");
+  });
+
+  it("handles empty stdout", () => {
+    const result = parseCopilotJsonl("");
+    expect(result.sessionId).toBeNull();
+    expect(result.model).toBe("");
+    expect(result.summary).toBe("");
+  });
+
+  it("handles multi-message conversation", () => {
+    const lines = [
+      '{"type":"assistant.message","data":{"content":"first","outputTokens":10}}',
+      '{"type":"assistant.message","data":{"content":"second","outputTokens":20}}',
+      '{"type":"result","sessionId":"abc","exitCode":0,"usage":{"premiumRequests":2,"totalApiDurationMs":1000,"sessionDurationMs":2000}}',
+    ].join("\n");
+    const result = parseCopilotJsonl(lines);
+    expect(result.summary).toBe("first\n\nsecond");
+    expect(result.usage?.outputTokens).toBe(30);
+    expect(result.premiumRequests).toBe(2);
+  });
+
+  it("ignores malformed JSON lines gracefully", () => {
+    const lines = [
+      "this is not json",
+      '{"type":"assistant.message","data":{"content":"ok","outputTokens":5}}',
+      "{broken json",
+      '{"type":"result","sessionId":"x","exitCode":0,"usage":{"premiumRequests":1}}',
+    ].join("\n");
+    const result = parseCopilotJsonl(lines);
+    expect(result.summary).toBe("ok");
+    expect(result.sessionId).toBe("x");
+  });
+});
+
+describe("describeCopilotFailure", () => {
+  it("returns null for exit code 0", () => {
+    expect(describeCopilotFailure({ exitCode: 0 }, "")).toBeNull();
+  });
+
+  it("includes stderr in error message", () => {
+    const msg = describeCopilotFailure(
+      { exitCode: 1 },
+      "Error: No session or task matched 'FAKE-ID'\nThe value is not a valid UUID.",
+    );
+    expect(msg).toContain("No session or task matched");
+    expect(msg).toContain("code 1");
+  });
+
+  it("falls back to exit code when stderr is empty", () => {
+    expect(describeCopilotFailure({ exitCode: 1 }, "")).toBe("Copilot exited with code 1");
+  });
+
+  it("handles null parsed result", () => {
+    const msg = describeCopilotFailure(null, "something went wrong");
+    expect(msg).toContain("something went wrong");
+  });
+});
+
+describe("isCopilotUnknownSessionError", () => {
+  it("detects 'No session or task matched' in stderr", () => {
+    expect(
+      isCopilotUnknownSessionError(
+        "Error: No session or task matched 'abc-123'\nThe value is not a valid UUID.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects 'session not found'", () => {
+    expect(isCopilotUnknownSessionError("session abc not found")).toBe(true);
+  });
+
+  it("returns false for normal errors", () => {
+    expect(isCopilotUnknownSessionError("network timeout")).toBe(false);
+  });
+
+  it("returns false for empty stderr", () => {
+    expect(isCopilotUnknownSessionError("")).toBe(false);
+  });
+});
+
+describe("detectCopilotAuthRequired", () => {
+  it("detects login required in stderr", () => {
+    const result = detectCopilotAuthRequired({
+      stdout: "",
+      stderr: "Error: not logged in. Run `copilot login`",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("detects 'copilot login' hint", () => {
+    const result = detectCopilotAuthRequired({
+      stdout: "",
+      stderr: "Please run copilot login to authenticate",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("returns false for normal output", () => {
+    const result = detectCopilotAuthRequired({
+      stdout: '{"type":"result","exitCode":0}',
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(false);
+  });
+});

--- a/packages/adapters/copilot-local/src/server/parse.test.ts
+++ b/packages/adapters/copilot-local/src/server/parse.test.ts
@@ -85,6 +85,43 @@ describe("parseCopilotJsonl", () => {
     expect(result.summary).toBe("ok");
     expect(result.sessionId).toBe("x");
   });
+
+  it("handles Windows-style line endings", () => {
+    const lines = [
+      '{"type":"assistant.message","data":{"content":"win","outputTokens":3}}',
+      '{"type":"result","sessionId":"w","exitCode":0,"usage":{"premiumRequests":1}}',
+    ].join("\r\n");
+    const result = parseCopilotJsonl(lines);
+    expect(result.summary).toBe("win");
+    expect(result.sessionId).toBe("w");
+  });
+
+  it("handles JSON lines that are not objects (arrays, primitives)", () => {
+    const lines = [
+      "42",
+      '"hello"',
+      "[1,2,3]",
+      '{"type":"assistant.message","data":{"content":"ok","outputTokens":1}}',
+    ].join("\n");
+    const result = parseCopilotJsonl(lines);
+    expect(result.summary).toBe("ok");
+  });
+
+  it("last model wins when multiple session.tools_updated events", () => {
+    const lines = [
+      '{"type":"session.tools_updated","data":{"model":"gpt-5.2"}}',
+      '{"type":"session.tools_updated","data":{"model":"gpt-5.4"}}',
+    ].join("\n");
+    const result = parseCopilotJsonl(lines);
+    expect(result.model).toBe("gpt-5.4");
+  });
+
+  it("handles result event with missing usage fields", () => {
+    const lines = '{"type":"result","sessionId":"s","exitCode":0,"usage":{}}';
+    const result = parseCopilotJsonl(lines);
+    expect(result.premiumRequests).toBe(0);
+    expect(result.totalApiDurationMs).toBe(0);
+  });
 });
 
 describe("describeCopilotFailure", () => {
@@ -108,6 +145,23 @@ describe("describeCopilotFailure", () => {
   it("handles null parsed result", () => {
     const msg = describeCopilotFailure(null, "something went wrong");
     expect(msg).toContain("something went wrong");
+  });
+
+  it("extracts first meaningful stderr line when first lines are blank", () => {
+    const msg = describeCopilotFailure(
+      { exitCode: 1 },
+      "\n\n  \nActual error message here\nMore details",
+    );
+    expect(msg).toContain("Actual error message here");
+    expect(msg).not.toContain("More details");
+  });
+
+  it("detects auth required in stdout", () => {
+    const result = detectCopilotAuthRequired({
+      stdout: "not logged in",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
   });
 });
 

--- a/packages/adapters/copilot-local/src/server/parse.ts
+++ b/packages/adapters/copilot-local/src/server/parse.ts
@@ -1,0 +1,143 @@
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
+
+const MAX_EXCERPT_BYTES = 32 * 1024;
+
+/**
+ * Parse Copilot CLI JSONL output into a structured result.
+ *
+ * Copilot JSONL events use a `type` field. Key non-ephemeral events:
+ * - session.tools_updated: carries the resolved model name
+ * - user.message: user prompt (with transformedContent)
+ * - assistant.message: response text + toolRequests[] + outputTokens
+ * - tool.execution_start: { toolCallId, toolName, arguments }
+ * - tool.execution_complete: { toolCallId, success, result | error }
+ * - result: session summary with sessionId, exitCode, usage
+ *
+ * Error cases (invalid session, auth failure) produce **zero** JSONL on stdout;
+ * the error text lands in stderr as plain text.  Always pass stderr to
+ * `describeCopilotFailure` and `isCopilotUnknownSessionError`.
+ */
+export function parseCopilotJsonl(stdout: string) {
+  let sessionId: string | null = null;
+  let model = "";
+  let resultEvent: Record<string, unknown> | null = null;
+  let totalOutputTokens = 0;
+  const assistantTexts: string[] = [];
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) continue;
+
+    const type = asString(event.type, "");
+    const data = parseObject(event.data);
+
+    if (type === "session.tools_updated") {
+      model = asString(data.model, model);
+      continue;
+    }
+
+    if (type === "assistant.message") {
+      const content = asString(data.content, "");
+      if (content) assistantTexts.push(content);
+      const tokens = asNumber(data.outputTokens, 0);
+      if (tokens > 0) totalOutputTokens += tokens;
+      continue;
+    }
+
+    if (type === "result") {
+      resultEvent = event;
+      sessionId = asString(event.sessionId, sessionId ?? "") || sessionId;
+      continue;
+    }
+  }
+
+  if (!resultEvent) {
+    return {
+      sessionId,
+      model,
+      costUsd: null as number | null,
+      usage: null as UsageSummary | null,
+      summary: assistantTexts.join("\n\n").trim(),
+      resultJson: null as Record<string, unknown> | null,
+    };
+  }
+
+  sessionId = asString(resultEvent.sessionId, sessionId ?? "") || sessionId;
+  const usageObj = parseObject(resultEvent.usage);
+  const usage: UsageSummary = {
+    inputTokens: 0, // Copilot CLI does not report input tokens
+    outputTokens: totalOutputTokens,
+  };
+
+  return {
+    sessionId,
+    model,
+    costUsd: null as number | null, // subscription billing — no per-run dollar cost
+    usage,
+    summary: assistantTexts.join("\n\n").trim(),
+    resultJson: resultEvent,
+    premiumRequests: asNumber(usageObj.premiumRequests, 0),
+    totalApiDurationMs: asNumber(usageObj.totalApiDurationMs, 0),
+    sessionDurationMs: asNumber(usageObj.sessionDurationMs, 0),
+  };
+}
+
+/**
+ * Build a human-readable error message from a failed Copilot run.
+ *
+ * Copilot errors land in **stderr** as plain text (no JSONL).  The JSONL
+ * result event only carries exitCode, which is rarely informative alone.
+ * Always pass stderr so the caller gets actionable context.
+ */
+export function describeCopilotFailure(
+  parsed: Record<string, unknown> | null,
+  stderr: string,
+): string | null {
+  const exitCode = parsed ? asNumber(parsed.exitCode, -1) : -1;
+  if (exitCode === 0) return null;
+
+  // Prefer the first meaningful line from stderr — that's where Copilot puts its errors.
+  const stderrLine = stderr
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (stderrLine) {
+    const excerpt =
+      stderrLine.length > MAX_EXCERPT_BYTES
+        ? stderrLine.slice(0, MAX_EXCERPT_BYTES - 1) + "…"
+        : stderrLine;
+    return `Copilot exited with code ${exitCode}: ${excerpt}`;
+  }
+
+  return `Copilot exited with code ${exitCode}`;
+}
+
+/**
+ * Detect whether a Copilot failure was caused by an unknown/invalid session ID.
+ *
+ * Copilot outputs "No session or task matched '<id>'" to stderr with exit
+ * code 1 and **zero JSONL** on stdout when a resume target is unavailable.
+ * We must check stderr, not stdout or the parsed result.
+ */
+export function isCopilotUnknownSessionError(stderr: string): boolean {
+  return /no session or task matched|session.*not found|unknown session/i.test(stderr);
+}
+
+/**
+ * Detect whether Copilot is asking the user to authenticate with GitHub.
+ */
+export function detectCopilotAuthRequired(input: {
+  stdout: string;
+  stderr: string;
+}): { requiresLogin: boolean } {
+  const combined = `${input.stdout}\n${input.stderr}`;
+  const requiresLogin =
+    /not\s+logged\s+in|please\s+log\s+in|login\s+required|authentication\s+required|gh auth login|copilot login/i.test(
+      combined,
+    );
+  return { requiresLogin };
+}

--- a/packages/adapters/copilot-local/src/server/test.ts
+++ b/packages/adapters/copilot-local/src/server/test.ts
@@ -1,0 +1,185 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import path from "node:path";
+import { parseCopilotJsonl, detectCopilotAuthRequired } from "./parse.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "copilot");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({
+      code: "copilot_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "copilot_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "copilot_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "copilot_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+      hint: "Install Copilot CLI: npm install -g @githubnext/github-copilot-cli, then run `copilot login`.",
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "copilot_cwd_invalid" && check.code !== "copilot_command_unresolvable");
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "copilot")) {
+      checks.push({
+        code: "copilot_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `copilot`.",
+        detail: command,
+      });
+    } else {
+      const model = asString(config.model, "").trim();
+      const effort = asString(config.effort, "").trim();
+      const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, false);
+      const extraArgs = (() => {
+        const fromExtraArgs = asStringArray(config.extraArgs);
+        if (fromExtraArgs.length > 0) return fromExtraArgs;
+        return asStringArray(config.args);
+      })();
+
+      const args = ["-p", "Respond with hello.", "--output-format", "json", "-s", "--no-color"];
+      if (dangerouslySkipPermissions) args.push("--allow-all");
+      else args.push("--allow-all-tools");
+      if (model) args.push("--model", model);
+      if (effort) args.push("--effort", effort);
+      if (extraArgs.length > 0) args.push(...extraArgs);
+
+      const probe = await runChildProcess(
+        `copilot-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command,
+        args,
+        {
+          cwd,
+          env,
+          timeoutSec: 60,
+          graceSec: 5,
+          onLog: async () => {},
+        },
+      );
+
+      const parsedStream = parseCopilotJsonl(probe.stdout);
+      const authMeta = detectCopilotAuthRequired({
+        stdout: probe.stdout,
+        stderr: probe.stderr,
+      });
+      const detail = summarizeProbeDetail(probe.stdout, probe.stderr);
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "copilot_hello_probe_timed_out",
+          level: "warn",
+          message: "Copilot hello probe timed out.",
+          hint: "Retry the probe. If this persists, verify Copilot can run from this directory manually.",
+        });
+      } else if (authMeta.requiresLogin) {
+        checks.push({
+          code: "copilot_hello_probe_auth_required",
+          level: "warn",
+          message: "Copilot CLI is installed, but GitHub authentication is required.",
+          ...(detail ? { detail } : {}),
+          hint: "Run `copilot login` or `gh auth login` to authenticate with GitHub.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        const summary = parsedStream.summary.trim();
+        const hasHello = /\bhello\b/i.test(summary);
+        checks.push({
+          code: hasHello ? "copilot_hello_probe_passed" : "copilot_hello_probe_unexpected_output",
+          level: hasHello ? "info" : "warn",
+          message: hasHello
+            ? "Copilot hello probe succeeded."
+            : "Copilot probe ran but did not return `hello` as expected.",
+          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+        });
+      } else {
+        checks.push({
+          code: "copilot_hello_probe_failed",
+          level: "error",
+          message: "Copilot hello probe failed.",
+          ...(detail ? { detail } : {}),
+          hint: 'Run `copilot -p "Respond with hello." --output-format json -s --no-color --allow-all-tools` manually to debug.',
+        });
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/copilot-local/src/server/test.ts
+++ b/packages/adapters/copilot-local/src/server/test.ts
@@ -87,7 +87,7 @@ export async function testEnvironment(
       level: "error",
       message: err instanceof Error ? err.message : "Command is not executable",
       detail: command,
-      hint: "Install Copilot CLI: npm install -g @githubnext/github-copilot-cli, then run `copilot login`.",
+      hint: "Install GitHub Copilot CLI (https://docs.github.com/copilot/how-tos/copilot-cli), then run `copilot login`.",
     });
   }
 

--- a/packages/adapters/copilot-local/src/ui/build-config.ts
+++ b/packages/adapters/copilot-local/src/ui/build-config.ts
@@ -1,0 +1,73 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildCopilotLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.model) ac.model = v.model;
+  if (v.thinkingEffort) ac.effort = v.thinkingEffort;
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  ac.dangerouslySkipPermissions = v.dangerouslySkipPermissions;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/copilot-local/src/ui/index.ts
+++ b/packages/adapters/copilot-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseCopilotStdoutLine } from "./parse-stdout.js";
+export { buildCopilotLocalConfig } from "./build-config.js";

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.test.ts
@@ -46,6 +46,23 @@ describe("parseCopilotStdoutLine", () => {
     });
   });
 
+  it("parses assistant.message with both text and tool requests", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: {
+        content: "I'll run ls for you.",
+        toolRequests: [
+          { toolCallId: "call-1", name: "shell", arguments: { command: "ls" }, type: "function" },
+        ],
+        outputTokens: 15,
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ kind: "assistant", text: "I'll run ls for you." });
+    expect(entries[1]).toMatchObject({ kind: "tool_call", name: "shell", toolUseId: "call-1" });
+  });
+
   it("parses assistant.message with string arguments in tool requests", () => {
     const line = JSON.stringify({
       type: "assistant.message",
@@ -64,6 +81,25 @@ describe("parseCopilotStdoutLine", () => {
       name: "read_file",
       toolUseId: "call-2",
       input: { path: "/tmp/foo.txt" },
+    });
+  });
+
+  it("wraps malformed string arguments in { raw: ... }", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: {
+        content: "",
+        toolRequests: [
+          { toolCallId: "call-3", name: "test", arguments: "not valid json{", type: "function" },
+        ],
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "tool_call",
+      name: "test",
+      input: { raw: "not valid json{" },
     });
   });
 
@@ -88,11 +124,10 @@ describe("parseCopilotStdoutLine", () => {
     expect(entries[0]).toMatchObject({ kind: "thinking", text: "reasoning chunk", delta: true });
   });
 
-  it("parses tool.execution_start with data.arguments", () => {
+  it("skips tool.execution_start (deduplication with assistant.message toolRequests)", () => {
     const line = '{"type":"tool.execution_start","data":{"toolName":"shell","toolCallId":"call-1","arguments":{"command":"ls"}}}';
     const entries = parseCopilotStdoutLine(line, ts);
-    expect(entries).toHaveLength(1);
-    expect(entries[0]).toMatchObject({ kind: "tool_call", name: "shell", toolUseId: "call-1", input: { command: "ls" } });
+    expect(entries).toHaveLength(0);
   });
 
   it("parses tool.execution_complete success with result.content", () => {
@@ -137,6 +172,35 @@ describe("parseCopilotStdoutLine", () => {
     });
   });
 
+  it("handles tool.execution_complete error without message field", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolCallId: "call-3",
+        success: false,
+        error: { code: "UNKNOWN" },
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "tool_result", isError: true });
+    // Falls back to JSON.stringify(errObj)
+    expect((entries[0] as Record<string, unknown>).content).toContain("UNKNOWN");
+  });
+
+  it("handles tool.execution_complete success without result object", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolCallId: "call-4",
+        success: true,
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "tool_result", isError: false, content: "" });
+  });
+
   it("parses result event", () => {
     const line = '{"type":"result","sessionId":"abc-123","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":5000,"sessionDurationMs":8000}}';
     const entries = parseCopilotStdoutLine(line, ts);
@@ -157,6 +221,7 @@ describe("parseCopilotStdoutLine", () => {
       subtype: "error",
       isError: true,
     });
+    expect((entries[0] as Record<string, unknown>).errors).toContain("Copilot exited with code 1");
   });
 
   it("skips ephemeral events silently", () => {
@@ -169,5 +234,67 @@ describe("parseCopilotStdoutLine", () => {
     const entries = parseCopilotStdoutLine("plain text output", ts);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ kind: "stdout", text: "plain text output" });
+  });
+
+  // Edge cases
+
+  it("handles empty string input", () => {
+    const entries = parseCopilotStdoutLine("", ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout", text: "" });
+  });
+
+  it("handles valid JSON that is not an object (number)", () => {
+    const entries = parseCopilotStdoutLine("42", ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout", text: "42" });
+  });
+
+  it("handles valid JSON that is not an object (array)", () => {
+    const entries = parseCopilotStdoutLine("[1,2,3]", ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout", text: "[1,2,3]" });
+  });
+
+  it("handles JSON null", () => {
+    const entries = parseCopilotStdoutLine("null", ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout", text: "null" });
+  });
+
+  it("handles event with missing data field", () => {
+    const line = '{"type":"assistant.message"}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    // No content, no toolRequests → falls through to stdout
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout" });
+  });
+
+  it("handles assistant.message with empty content and empty toolRequests", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: { content: "", toolRequests: [] },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    // No entries produced → falls through to stdout
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout" });
+  });
+
+  it("handles user.message with empty content", () => {
+    const line = JSON.stringify({
+      type: "user.message",
+      data: { content: "" },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout" });
+  });
+
+  it("handles unrecognized event type", () => {
+    const line = '{"type":"some.future.event","data":{"foo":"bar"}}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout", text: line });
   });
 });

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { parseCopilotStdoutLine } from "./parse-stdout.js";
+
+const ts = "2026-03-29T00:00:00.000Z";
+
+describe("parseCopilotStdoutLine", () => {
+  it("parses session.tools_updated as init", () => {
+    const line = '{"type":"session.tools_updated","data":{"model":"gpt-5.4"},"ephemeral":true}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "init", model: "gpt-5.4" });
+  });
+
+  it("parses user.message", () => {
+    const line = '{"type":"user.message","data":{"content":"hello world","attachments":[]}}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "user", text: "hello world" });
+  });
+
+  it("parses assistant.message with text", () => {
+    const line = '{"type":"assistant.message","data":{"content":"hello","toolRequests":[],"outputTokens":5}}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "assistant", text: "hello" });
+  });
+
+  it("parses assistant.message with tool requests (Copilot format)", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: {
+        content: "",
+        toolRequests: [
+          { toolCallId: "call-1", name: "shell", arguments: { command: "ls" }, type: "function" },
+        ],
+        outputTokens: 10,
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "tool_call",
+      name: "shell",
+      toolUseId: "call-1",
+      input: { command: "ls" },
+    });
+  });
+
+  it("parses assistant.message with string arguments in tool requests", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: {
+        content: "",
+        toolRequests: [
+          { toolCallId: "call-2", name: "read_file", arguments: '{"path":"/tmp/foo.txt"}', type: "function" },
+        ],
+        outputTokens: 5,
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "tool_call",
+      name: "read_file",
+      toolUseId: "call-2",
+      input: { path: "/tmp/foo.txt" },
+    });
+  });
+
+  it("parses assistant.message_delta as streaming assistant", () => {
+    const line = '{"type":"assistant.message_delta","data":{"deltaContent":"chunk"},"ephemeral":true}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "assistant", text: "chunk", delta: true });
+  });
+
+  it("parses assistant.reasoning as thinking", () => {
+    const line = '{"type":"assistant.reasoning","data":{"reasoningText":"Let me think about this..."},"ephemeral":true}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "thinking", text: "Let me think about this..." });
+  });
+
+  it("parses assistant.reasoning_delta as streaming thinking", () => {
+    const line = '{"type":"assistant.reasoning_delta","data":{"deltaContent":"reasoning chunk"},"ephemeral":true}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "thinking", text: "reasoning chunk", delta: true });
+  });
+
+  it("parses tool.execution_start with data.arguments", () => {
+    const line = '{"type":"tool.execution_start","data":{"toolName":"shell","toolCallId":"call-1","arguments":{"command":"ls"}}}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "tool_call", name: "shell", toolUseId: "call-1", input: { command: "ls" } });
+  });
+
+  it("parses tool.execution_complete success with result.content", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolName: "shell",
+        toolCallId: "call-1",
+        success: true,
+        result: { content: "file1.txt\nfile2.txt" },
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "tool_result",
+      toolUseId: "call-1",
+      toolName: "shell",
+      content: "file1.txt\nfile2.txt",
+      isError: false,
+    });
+  });
+
+  it("parses tool.execution_complete failure with error.message", () => {
+    const line = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolName: "shell",
+        toolCallId: "call-2",
+        success: false,
+        error: { message: "Permission denied", code: "EPERM" },
+      },
+    });
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "tool_result",
+      toolUseId: "call-2",
+      toolName: "shell",
+      content: "Permission denied",
+      isError: true,
+    });
+  });
+
+  it("parses result event", () => {
+    const line = '{"type":"result","sessionId":"abc-123","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":5000,"sessionDurationMs":8000}}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "result",
+      subtype: "success",
+      isError: false,
+    });
+  });
+
+  it("parses result with non-zero exit as error", () => {
+    const line = '{"type":"result","sessionId":"abc-123","exitCode":1,"usage":{"premiumRequests":0}}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "result",
+      subtype: "error",
+      isError: true,
+    });
+  });
+
+  it("skips ephemeral events silently", () => {
+    const line = '{"type":"session.mcp_server_status_changed","data":{"serverName":"notion","status":"connected"},"ephemeral":true}';
+    const entries = parseCopilotStdoutLine(line, ts);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("returns stdout for non-JSON lines", () => {
+    const entries = parseCopilotStdoutLine("plain text output", ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "stdout", text: "plain text output" });
+  });
+});

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.ts
@@ -112,11 +112,11 @@ export function parseCopilotStdoutLine(line: string, ts: string): TranscriptEntr
     return [];
   }
 
-  // Tool execution start: { toolCallId, toolName, arguments }
+  // Tool execution start is skipped — assistant.message already emits tool_call entries
+  // from toolRequests[]. Emitting here too would produce duplicate transcript rows for
+  // the same tool invocation.
   if (type === "tool.execution_start") {
-    const name = typeof data.toolName === "string" ? data.toolName : "unknown";
-    const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : undefined;
-    return [{ kind: "tool_call", ts, name, toolUseId: toolCallId, input: data.arguments ?? {} }];
+    return [];
   }
 
   // Tool execution complete: { toolCallId, success, result?: { content }, error?: { message, code } }

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.ts
@@ -1,0 +1,174 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a single Copilot CLI JSONL line into TranscriptEntry[].
+ *
+ * Real Copilot JSONL event structures (verified against CLI 1.0.12):
+ *
+ * - session.tools_updated:        { data: { model } }
+ * - user.message:                 { data: { content } }
+ * - assistant.message:            { data: { content, toolRequests: [{ toolCallId, name, arguments, type }], outputTokens } }
+ * - assistant.message_delta:      { data: { deltaContent } }
+ * - assistant.reasoning:          { data: { reasoningText } }   (ephemeral)
+ * - assistant.reasoning_delta:    { data: { deltaContent } }    (ephemeral)
+ * - tool.execution_start:         { data: { toolCallId, toolName, arguments } }
+ * - tool.execution_complete:      { data: { toolCallId, toolName?, success, result?: { content }, error?: { message, code } } }
+ * - result:                       { sessionId, exitCode, usage: { premiumRequests, totalApiDurationMs, sessionDurationMs } }
+ *
+ * Error cases produce zero JSONL (errors go to stderr as plain text).
+ */
+export function parseCopilotStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+  const data = asRecord(parsed.data) ?? {};
+
+  // Init event — model detected from session.tools_updated
+  if (type === "session.tools_updated") {
+    const model = typeof data.model === "string" ? data.model : "unknown";
+    return [{ kind: "init", ts, model, sessionId: "" }];
+  }
+
+  // User message
+  if (type === "user.message") {
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content) return [{ kind: "user", ts, text: content }];
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  // Assistant reasoning (thinking)
+  if (type === "assistant.reasoning") {
+    const text = typeof data.reasoningText === "string" ? data.reasoningText : "";
+    if (text) return [{ kind: "thinking", ts, text }];
+    return [];
+  }
+
+  // Streaming reasoning delta
+  if (type === "assistant.reasoning_delta") {
+    const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+    if (deltaContent) return [{ kind: "thinking", ts, text: deltaContent, delta: true }];
+    return [];
+  }
+
+  // Assistant message — may contain text and/or tool requests
+  if (type === "assistant.message") {
+    const entries: TranscriptEntry[] = [];
+    const content = typeof data.content === "string" ? data.content : "";
+    if (content) {
+      entries.push({ kind: "assistant", ts, text: content });
+    }
+
+    // Copilot toolRequests: [{ toolCallId, name, arguments (object), type: "function" }]
+    const toolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : [];
+    for (const rawReq of toolRequests) {
+      const req = asRecord(rawReq);
+      if (!req) continue;
+
+      // name is at the top level of each tool request (not nested under .function)
+      const name = typeof req.name === "string" ? req.name : "unknown";
+      const toolCallId = typeof req.toolCallId === "string" ? req.toolCallId : undefined;
+
+      // arguments is an object (not a stringified JSON like OpenAI API)
+      let input: unknown = {};
+      if (typeof req.arguments === "object" && req.arguments !== null) {
+        input = req.arguments;
+      } else if (typeof req.arguments === "string") {
+        try {
+          input = JSON.parse(req.arguments);
+        } catch {
+          input = { raw: req.arguments };
+        }
+      }
+
+      entries.push({ kind: "tool_call", ts, name, toolUseId: toolCallId, input });
+    }
+    return entries.length > 0 ? entries : [{ kind: "stdout", ts, text: line }];
+  }
+
+  // Streaming text delta
+  if (type === "assistant.message_delta") {
+    const deltaContent = typeof data.deltaContent === "string" ? data.deltaContent : "";
+    if (deltaContent) return [{ kind: "assistant", ts, text: deltaContent, delta: true }];
+    return [];
+  }
+
+  // Tool execution start: { toolCallId, toolName, arguments }
+  if (type === "tool.execution_start") {
+    const name = typeof data.toolName === "string" ? data.toolName : "unknown";
+    const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : undefined;
+    return [{ kind: "tool_call", ts, name, toolUseId: toolCallId, input: data.arguments ?? {} }];
+  }
+
+  // Tool execution complete: { toolCallId, success, result?: { content }, error?: { message, code } }
+  if (type === "tool.execution_complete") {
+    const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId : "";
+    const toolName = typeof data.toolName === "string" ? data.toolName : undefined;
+    const isError = data.success === false;
+
+    let content = "";
+    if (isError) {
+      const errObj = asRecord(data.error);
+      content = errObj
+        ? (typeof errObj.message === "string" ? errObj.message : JSON.stringify(errObj))
+        : "Tool execution failed";
+    } else {
+      const resultObj = asRecord(data.result);
+      if (resultObj) {
+        content =
+          typeof resultObj.content === "string"
+            ? resultObj.content
+            : JSON.stringify(resultObj);
+      }
+    }
+
+    return [{ kind: "tool_result", ts, toolUseId: toolCallId, toolName, content, isError }];
+  }
+
+  // Final result
+  if (type === "result") {
+    const sessionId = typeof parsed.sessionId === "string" ? parsed.sessionId : "";
+    const exitCode = asNumber(parsed.exitCode);
+
+    return [
+      {
+        kind: "result",
+        ts,
+        text: sessionId ? `Session: ${sessionId}` : "",
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+        costUsd: 0,
+        subtype: exitCode === 0 ? "success" : "error",
+        isError: exitCode !== 0,
+        errors: exitCode !== 0 ? [`Copilot exited with code ${exitCode}`] : [],
+      },
+    ];
+  }
+
+  // Skip ephemeral events silently (MCP server status, background tasks, etc.)
+  if (parsed.ephemeral === true) {
+    return [];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/copilot-local/tsconfig.json
+++ b/packages/adapters/copilot-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/copilot-local/vitest.config.ts
+++ b/packages/adapters/copilot-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "copilot_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -133,6 +136,25 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+
+  packages/adapters/copilot-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/adapters/cursor-local:
     dependencies:
@@ -446,6 +468,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -600,6 +625,9 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
+      '@paperclipai/adapter-copilot-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
-      '@paperclipai/adapter-copilot-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -136,25 +133,6 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
-
-  packages/adapters/copilot-local:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/adapters/cursor-local:
     dependencies:
@@ -468,9 +446,6 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
-      '@paperclipai/adapter-copilot-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
@@ -625,9 +600,6 @@ importers:
       '@paperclipai/adapter-codex-local':
         specifier: workspace:*
         version: link:../packages/adapters/codex-local
-      '@paperclipai/adapter-copilot-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/copilot-local
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -78,6 +78,12 @@ import {
   agentConfigurationDoc as hermesAgentConfigurationDoc,
   models as hermesModels,
 } from "hermes-paperclip-adapter";
+import {
+  execute as copilotExecute,
+  testEnvironment as copilotTestEnvironment,
+  sessionCodec as copilotSessionCodec,
+} from "@paperclipai/adapter-copilot-local/server";
+import { agentConfigurationDoc as copilotAgentConfigurationDoc, models as copilotModels } from "@paperclipai/adapter-copilot-local";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
 
@@ -187,6 +193,16 @@ const hermesLocalAdapter: ServerAdapterModule = {
   detectModel: () => detectModelFromHermes(),
 };
 
+const copilotLocalAdapter: ServerAdapterModule = {
+  type: "copilot_local",
+  execute: copilotExecute,
+  testEnvironment: copilotTestEnvironment,
+  sessionCodec: copilotSessionCodec,
+  models: copilotModels,
+  supportsLocalAgentJwt: false,
+  agentConfigurationDoc: copilotAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
@@ -195,6 +211,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     piLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    copilotLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
     processAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@mdxeditor/editor": "^3.52.4",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/ui/src/adapters/copilot-local/config-fields.tsx
+++ b/ui/src/adapters/copilot-local/config-fields.tsx
@@ -1,0 +1,66 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  ToggleField,
+  help,
+} from "../../components/agent-config-primitives";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+
+export function CopilotLocalConfigFields({
+  mode,
+  isCreate,
+  adapterType,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
+  );
+}
+
+export function CopilotLocalAdvancedFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <ToggleField
+        label="Skip permissions (--allow-all)"
+        hint={help.dangerouslySkipPermissions}
+        checked={
+          isCreate
+            ? values!.dangerouslySkipPermissions
+            : eff(
+                "adapterConfig",
+                "dangerouslySkipPermissions",
+                config.dangerouslySkipPermissions !== false,
+              )
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ dangerouslySkipPermissions: v })
+            : mark("adapterConfig", "dangerouslySkipPermissions", v)
+        }
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/copilot-local/index.ts
+++ b/ui/src/adapters/copilot-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseCopilotStdoutLine } from "@paperclipai/adapter-copilot-local/ui";
+import { CopilotLocalConfigFields } from "./config-fields";
+import { buildCopilotLocalConfig } from "@paperclipai/adapter-copilot-local/ui";
+
+export const copilotLocalUIAdapter: UIAdapterModule = {
+  type: "copilot_local",
+  label: "GitHub Copilot CLI (local)",
+  parseStdoutLine: parseCopilotStdoutLine,
+  ConfigFields: CopilotLocalConfigFields,
+  buildAdapterConfig: buildCopilotLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -7,6 +7,7 @@ import { hermesLocalUIAdapter } from "./hermes-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
+import { copilotLocalUIAdapter } from "./copilot-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 
@@ -18,6 +19,7 @@ const uiAdapters: UIAdapterModule[] = [
   openCodeLocalUIAdapter,
   piLocalUIAdapter,
   cursorLocalUIAdapter,
+  copilotLocalUIAdapter,
   openClawGatewayUIAdapter,
   processUIAdapter,
   httpUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -313,6 +313,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const isLocal =
     adapterType === "claude_local" ||
     adapterType === "codex_local" ||
+    adapterType === "copilot_local" ||
     adapterType === "gemini_local" ||
     adapterType === "hermes_local" ||
     adapterType === "opencode_local" ||
@@ -1026,7 +1027,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local", "copilot_local"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -41,6 +41,7 @@ import {
 import { defaultCreateValues } from "./agent-config-defaults";
 import { getUIAdapter } from "../adapters";
 import { ClaudeLocalAdvancedFields } from "../adapters/claude-local/config-fields";
+import { CopilotLocalAdvancedFields } from "../adapters/copilot-local/config-fields";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
@@ -817,6 +818,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               )}
               {adapterType === "claude_local" && (
                 <ClaudeLocalAdvancedFields {...adapterFieldProps} />
+              )}
+              {adapterType === "copilot_local" && (
+                <CopilotLocalAdvancedFields {...adapterFieldProps} />
               )}
 
               <Field label="Extra args (comma-separated)" hint={help.extraArgs}>

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -25,7 +25,7 @@ const adapterLabels: Record<string, string> = {
   http: "HTTP",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local", "copilot_local"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/db", "packages/adapters/opencode-local", "server", "ui", "cli"],
+    projects: ["packages/db", "packages/adapters/opencode-local", "packages/adapters/copilot-local", "server", "ui", "cli"],
   },
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - It supports many local CLI-based AI agents through adapters (Claude Code, Codex, Gemini, Cursor, etc.)
> - But GitHub Copilot CLI — one of the most widely deployed AI coding tools — has no adapter
> - Users running Copilot CLI alongside other agents can't manage them through Paperclip's dashboard, org charts, budgets, or audit trails
> - This pull request adds a complete `copilot_local` adapter following the established 3-layer pattern (server/ui/cli)
> - The benefit is full parity: Copilot agents can now be created, configured, monitored, and managed alongside Claude/Codex/Gemini agents in a single Paperclip deployment

Closes #2092

## What Changed

- **New package** `@paperclipai/adapter-copilot-local` with 12 source files across server/ui/cli layers
- **Server**: `execute()` spawns Copilot CLI with JSONL output, handles session resume with stale session retry, parses usage/billing, detects auth failures via stderr (Copilot emits zero JSONL on errors)
- **Server**: `testEnvironment()` validates cwd, command resolution, GitHub auth, and runs a hello probe
- **Server**: `parseCopilotJsonl()` extracts sessionId, model, summary, outputTokens, premiumRequests from JSONL events
- **UI**: `parseCopilotStdoutLine()` maps all Copilot JSONL event types (including reasoning, tool calls, tool results) to `TranscriptEntry[]` for the live transcript viewer. `tool.execution_start` is intentionally skipped to avoid duplicate `tool_call` entries (assistant.message already provides these via `toolRequests[]`)
- **UI**: Config form with `LocalWorkspaceRuntimeFields` + skip-permissions toggle in advanced fields
- **CLI**: `printCopilotStreamEvent()` for colored terminal output with safe numeric coercion
- **Shared**: Added `"copilot_local"` to `AGENT_ADAPTER_TYPES` constant and `AgentAdapterType` union
- **Registries**: Registered in all 3 registries (server, UI, CLI) + enabled in `ENABLED_ADAPTER_TYPES` and `ENABLED_INVITE_ADAPTERS`
- **Workspace deps**: Added `@paperclipai/adapter-copilot-local: workspace:*` to server, UI, and CLI packages

## Verification

```sh
# Adapter tests (54 pass)
pnpm --filter @paperclipai/adapter-copilot-local exec vitest run

# Monorepo typecheck (clean)
pnpm -r typecheck

# Full test suite (736 tests, 139 files, 0 failures)
pnpm test:run
```

**Verified against real Copilot CLI 1.0.12:**
- All 6 model IDs tested: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`, `claude-sonnet-4.6`, `claude-opus-4.6`, `claude-haiku-4.5`
- All CLI flags verified: `-p`, `--output-format json`, `-s`, `--no-color`, `--allow-all`, `--allow-all-tools`, `--model`, `--effort` (low|medium|high|xhigh), `--resume=<sessionId>`
- JSONL event structures verified against real CLI output (success, tool calls, errors)
- `gemini-3-pro-preview` was initially included but removed after verification showed it's not available through Copilot

## Risks

- **Low risk** — follows established adapter patterns exactly. No database migrations. No breaking changes to existing adapters.
- **Model list may need updates** — Available models depend on the user's GitHub Copilot subscription tier. The 6 listed models were verified on a Copilot Enterprise account. Some may not be available on lower tiers.
- **Note**: `gemini_local` is present in master's UI code and server registry but missing from `AGENT_ADAPTER_TYPES` in shared constants — this pre-existing issue is not addressed in this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (UI changes are minimal — adds Copilot to adapter dropdown and a skip-permissions toggle; no novel UI components)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)