### PR TITLE
feat(evals): add Claude Code CLI provider to promptfoo

### DIFF
--- a/evals/promptfoo/promptfooconfig.yaml
+++ b/evals/promptfoo/promptfooconfig.yaml
@@ -27,6 +27,8 @@ providers:
     label: codex-5.4
   - id: openrouter:google/gemini-2.5-pro
     label: gemini-2.5-pro
+  - id: file://providers/claude-cli.cjs
+    label: claude-code-cli
 
 defaultTest:
   options:

--- a/evals/promptfoo/providers/claude-cli.cjs
+++ b/evals/promptfoo/providers/claude-cli.cjs
@@ -1,0 +1,34 @@
+// Promptfoo custom script provider using Claude Code CLI.
+const { execFileSync } = require('child_process');
+
+class ClaudeCliProvider {
+  constructor() {
+    this.providerId = 'claude-code-local';
+  }
+
+  id() {
+    return this.providerId;
+  }
+
+  async callApi(prompt) {
+    try {
+      const env = { ...process.env };
+      delete env.CLAUDECODE;
+
+      const claudePath = process.env.CLAUDE_BIN || 'claude';
+      const output = execFileSync(claudePath, ['--print', '--model', 'sonnet', '--permission-mode', 'plan'], {
+        input: prompt,
+        encoding: 'utf-8',
+        timeout: 180_000,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+
+      return { output };
+    } catch (err) {
+      return { error: err.message };
+    }
+  }
+}
+
+module.exports = ClaudeCliProvider;

--- a/evals/promptfoo/providers/claude-cli.sh
+++ b/evals/promptfoo/providers/claude-cli.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Promptfoo exec provider using Claude Code CLI.
+# Promptfoo passes the rendered prompt via the PROMPT env var.
+unset CLAUDECODE
+echo "$PROMPT" | claude --print --model sonnet 2>/dev/null


### PR DESCRIPTION
## Summary

- Add Claude Code CLI custom script provider (`providers/claude-cli.cjs`) that wraps `claude --print` via `execFileSync`
- Add shell-based provider (`providers/claude-cli.sh`) as a simpler alternative
- Register `claude-code-cli` provider in `promptfooconfig.yaml`
- Binary resolved from `PATH` or `CLAUDE_BIN` env var (no hardcoded paths)

Closes #2091

## Test plan

- [ ] Run `cd evals/promptfoo && promptfoo eval --providers file://providers/claude-cli.cjs` to verify CLI provider works
- [ ] Run `promptfoo validate` to confirm config is valid
- [ ] Verify `CLAUDE_BIN` override works when `claude` is not on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)