### PR TITLE
fix(server): complete FK dependency cleanup in company delete

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -306,7 +306,7 @@ export function companyService(db: Db) {
         await tx.delete(documentRevisions).where(eq(documentRevisions.companyId, id));
         await tx.delete(documents).where(eq(documents.companyId, id));
 
-        // --- Tables referencing approvals ---
+        // --- Tables referencing approvals and/or budget_policies ---
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(budgetIncidents).where(eq(budgetIncidents.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));

--- a/tests/e2e/company-lifecycle.spec.ts
+++ b/tests/e2e/company-lifecycle.spec.ts
@@ -7,21 +7,30 @@ import { test, expect } from "@playwright/test";
  * and confirms all data is removed from the database.
  */
 
-const COMPANY_NAME = `E2E-Lifecycle-${Date.now()}`;
-
 test.describe("Company lifecycle", () => {
+  let companyId: string | null = null;
+
+  test.afterEach(async ({ request, baseURL }) => {
+    if (companyId) {
+      await request.delete(`${baseURL}/api/companies/${companyId}`);
+      companyId = null;
+    }
+  });
+
   test("creates and deletes a company via API", async ({ request, baseURL }) => {
+    const companyName = `E2E-Lifecycle-${Date.now()}`;
+
     // --- Create a company ---
     const createRes = await request.post(`${baseURL}/api/companies`, {
-      data: { name: COMPANY_NAME },
+      data: { name: companyName },
     });
     expect(createRes.ok()).toBe(true);
     const company = await createRes.json();
-    expect(company.name).toBe(COMPANY_NAME);
+    expect(company.name).toBe(companyName);
     expect(company.id).toBeTruthy();
     expect(company.issuePrefix).toBeTruthy();
 
-    const companyId = company.id;
+    companyId = company.id;
 
     // --- Verify it appears in the list ---
     const listRes = await request.get(`${baseURL}/api/companies`);
@@ -59,14 +68,17 @@ test.describe("Company lifecycle", () => {
     const deleteBody = await deleteRes.json();
     expect(deleteBody.ok).toBe(true);
 
+    // Mark as cleaned up so afterEach doesn't retry
+    companyId = null;
+
     // --- Verify company is gone from the list ---
     const listAfterRes = await request.get(`${baseURL}/api/companies`);
     expect(listAfterRes.ok()).toBe(true);
     const companiesAfter = await listAfterRes.json();
-    expect(companiesAfter.some((c: { id: string }) => c.id === companyId)).toBe(false);
+    expect(companiesAfter.some((c: { id: string }) => c.id === company.id)).toBe(false);
 
     // --- Verify agent is gone (endpoint may return empty list or 404) ---
-    const agentAfterRes = await request.get(`${baseURL}/api/companies/${companyId}/agents`);
+    const agentAfterRes = await request.get(`${baseURL}/api/companies/${company.id}/agents`);
     if (agentAfterRes.ok()) {
       const agentsAfter = await agentAfterRes.json();
       expect(agentsAfter).toHaveLength(0);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Companies are the top-level entity — agents, issues, projects, documents, workspaces, and more all belong to a company
> - When a company is deleted, all child data must be removed first to satisfy FK constraints
> - But the `remove()` method in `companyService` was only deleting from ~10 tables
> - The schema has grown to 30+ tables with `companyId` foreign keys over time
> - So deleting any company with non-trivial data fails with FK constraint violations
> - This PR adds all missing table deletions in strict FK dependency order
> - It also adds an E2E test that exercises the full create→delete lifecycle

Fixes #2096

## What Changed

### `server/src/services/companies.ts`
- Expanded `remove()` to delete from all 30+ child tables in correct FK dependency order
- Organized deletions into logical groups (heartbeat, issues, workspaces, documents, approvals, agents, projects, etc.)
- Added missing imports for all newly-referenced tables

### `tests/e2e/company-lifecycle.spec.ts` (new)
- E2E test covering: company create → verify exists → create agent → create issue → delete company → verify all data removed

## How to Verify

1. Start the server locally
2. Create a company with agents, issues, and other related data
3. Delete the company via `DELETE /api/companies/:id`
4. Confirm it succeeds without FK errors
5. Run the E2E test: `pnpm playwright test tests/e2e/company-lifecycle.spec.ts`

## Risks

- Low risk: changes are additive (only adds more DELETE statements in the transaction)
- If new tables with `companyId` FK are added in the future, they'll need to be added here too

🤖 Generated with [Claude Code](https://claude.com/claude-code)