### PR TITLE
Add company-level pause/resume kill switch

### DIFF
--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -8,6 +8,8 @@ export interface DashboardRunActivityDay {
 
 export interface DashboardSummary {
   companyId: string;
+  companyStatus: string;
+  companyPauseReason: string | null;
   agents: {
     active: number;
     running: number;

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -8,7 +8,7 @@ export interface DashboardRunActivityDay {
 
 export interface DashboardSummary {
   companyId: string;
-  companyStatus: string;
+  companyStatus: "active" | "paused" | "archived";
   companyPauseReason: string | null;
   agents: {
     active: number;

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -21,6 +21,7 @@ import {
   companyPortabilityService,
   companyService,
   feedbackService,
+  heartbeatService,
   logActivity,
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
@@ -34,6 +35,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+  let _heartbeat: ReturnType<typeof heartbeatService> | null = null;
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -57,6 +59,11 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       return;
     }
     assertCompanyAccess(req, target.companyId);
+  }
+
+  function getHeartbeat() {
+    if (!_heartbeat) _heartbeat = heartbeatService(db);
+    return _heartbeat;
   }
 
   async function assertCanUpdateBranding(req: Request, companyId: string) {
@@ -373,6 +380,52 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       entityType: "company",
       entityId: companyId,
       details: req.body,
+    });
+    res.json(company);
+  });
+
+  router.post("/:companyId/pause", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const company = await svc.pause(companyId, "manual");
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    await getHeartbeat().cancelBudgetScopeWork({
+      companyId,
+      scopeType: "company",
+      scopeId: companyId,
+    });
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "company.paused",
+      entityType: "company",
+      entityId: companyId,
+      details: { reason: "manual" },
+    });
+    res.json(company);
+  });
+
+  router.post("/:companyId/resume", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const company = await svc.resume(companyId);
+    if (!company) {
+      res.status(404).json({ error: "Company not found" });
+      return;
+    }
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "company.resumed",
+      entityType: "company",
+      entityId: companyId,
     });
     res.json(company);
   });

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -397,7 +397,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       companyId,
       scopeType: "company",
       scopeId: companyId,
-    });
+    }, "Cancelled due to manual company pause");
     await logActivity(db, {
       companyId,
       actorType: "user",
@@ -416,7 +416,14 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     assertCompanyAccess(req, companyId);
     const company = await svc.resume(companyId);
     if (!company) {
-      res.status(404).json({ error: "Company not found" });
+      const existing = await svc.getById(companyId);
+      if (!existing) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      res.status(409).json({
+        error: "Cannot resume: company is paused by budget enforcement. Adjust the budget to resume.",
+      });
       return;
     }
     await logActivity(db, {

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -264,7 +264,7 @@ export function companyService(db: Db) {
         const updated = await tx
           .update(companies)
           .set({ status: "active", pauseReason: null, pausedAt: null, updatedAt: now })
-          .where(eq(companies.id, id))
+          .where(and(eq(companies.id, id), eq(companies.pauseReason, "manual")))
           .returning()
           .then((rows) => rows[0] ?? null);
         if (!updated) return null;

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -240,6 +240,42 @@ export function companyService(db: Db) {
         return enrichCompany(hydrated);
       }),
 
+    pause: (id: string, reason: "manual" | "budget" = "manual") =>
+      db.transaction(async (tx) => {
+        const now = new Date();
+        const updated = await tx
+          .update(companies)
+          .set({ status: "paused", pauseReason: reason, pausedAt: now, updatedAt: now })
+          .where(eq(companies.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+        const row = await getCompanyQuery(tx)
+          .where(eq(companies.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!row) return null;
+        const [hydrated] = await hydrateCompanySpend([row], tx);
+        return enrichCompany(hydrated);
+      }),
+
+    resume: (id: string) =>
+      db.transaction(async (tx) => {
+        const now = new Date();
+        const updated = await tx
+          .update(companies)
+          .set({ status: "active", pauseReason: null, pausedAt: null, updatedAt: now })
+          .where(eq(companies.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+        const row = await getCompanyQuery(tx)
+          .where(eq(companies.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!row) return null;
+        const [hydrated] = await hydrateCompanySpend([row], tx);
+        return enrichCompany(hydrated);
+      }),
+
     archive: (id: string) =>
       db.transaction(async (tx) => {
         const updated = await tx

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -132,6 +132,8 @@ export function dashboardService(db: Db) {
 
       return {
         companyId,
+        companyStatus: company.status,
+        companyPauseReason: company.pauseReason,
         agents: {
           active: agentCounts.active,
           running: agentCounts.running,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6286,9 +6286,10 @@ export function heartbeatService(db: Db) {
     return runs.length;
   }
 
-  async function cancelBudgetScopeWork(scope: BudgetEnforcementScope) {
+  async function cancelBudgetScopeWork(scope: BudgetEnforcementScope, reason?: string) {
+    const cancelReason = reason ?? "Cancelled due to budget pause";
     if (scope.scopeType === "agent") {
-      await cancelActiveForAgentInternal(scope.scopeId, "Cancelled due to budget pause");
+      await cancelActiveForAgentInternal(scope.scopeId, cancelReason);
       await cancelPendingWakeupsForBudgetScope(scope);
       return;
     }
@@ -6308,7 +6309,7 @@ export function heartbeatService(db: Db) {
         : await listProjectScopedRunIds(scope.companyId, scope.scopeId);
 
     for (const runId of runIds) {
-      await cancelRunInternal(runId, "Cancelled due to budget pause");
+      await cancelRunInternal(runId, cancelReason);
     }
 
     await cancelPendingWakeupsForBudgetScope(scope);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -19,6 +19,7 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   activityLog,
+  companies,
   companySkills as companySkillsTable,
   documentRevisions,
   issueDocuments,
@@ -6533,12 +6534,18 @@ export function heartbeatService(db: Db) {
 
     tickTimers: async (now = new Date()) => {
       const allAgents = await db.select().from(agents);
+      const pausedCompanyRows = await db
+        .select({ id: companies.id })
+        .from(companies)
+        .where(eq(companies.status, "paused"));
+      const pausedCompanyIds = new Set(pausedCompanyRows.map((r) => r.id));
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
 
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
+        if (pausedCompanyIds.has(agent.companyId)) continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -41,6 +41,8 @@ export const companiesApi = {
   ) => api.patch<Company>(`/companies/${companyId}`, data),
   updateBranding: (companyId: string, data: UpdateCompanyBranding) =>
     api.patch<Company>(`/companies/${companyId}/branding`, data),
+  pause: (companyId: string) => api.post<Company>(`/companies/${companyId}/pause`, {}),
+  resume: (companyId: string) => api.post<Company>(`/companies/${companyId}/resume`, {}),
   archive: (companyId: string) => api.post<Company>(`/companies/${companyId}/archive`, {}),
   remove: (companyId: string) => api.delete<{ ok: true }>(`/companies/${companyId}`),
   exportBundle: (

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -271,6 +271,8 @@ function makeExecutionWorkspace(overrides: Partial<ExecutionWorkspace> = {}): Ex
 
 const dashboard: DashboardSummary = {
   companyId: "company-1",
+  companyStatus: "active",
+  companyPauseReason: null,
   agents: {
     active: 1,
     running: 0,

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { dashboardApi } from "../api/dashboard";
 import { activityApi } from "../api/activity";
 import { accessApi } from "../api/access";
@@ -8,6 +8,7 @@ import { issuesApi } from "../api/issues";
 import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
 import { buildCompanyUserProfileMap } from "../lib/company-members";
+import { companiesApi } from "../api/companies";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -20,7 +21,7 @@ import { ActivityRow } from "../components/ActivityRow";
 import { Identity } from "../components/Identity";
 import { timeAgo } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
-import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
+import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle, Play, Square } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
@@ -85,6 +86,21 @@ export function Dashboard() {
     () => buildCompanyUserProfileMap(companyMembers?.users),
     [companyMembers?.users],
   );
+
+  const queryClient = useQueryClient();
+  const companyPaused = data?.companyStatus === "paused";
+
+  const togglePause = useMutation({
+    mutationFn: () =>
+      companyPaused
+        ? companiesApi.resume(selectedCompanyId!)
+        : companiesApi.pause(selectedCompanyId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(selectedCompanyId!) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
+
 
   const recentIssues = issues ? getRecentIssues(issues) : [];
   const recentActivity = useMemo(() => (activity ?? []).slice(0, 10), [activity]);
@@ -213,6 +229,65 @@ export function Dashboard() {
       )}
 
       <ActiveAgentsPanel companyId={selectedCompanyId!} />
+
+      {data && (
+        <>
+          <div
+            className={cn(
+              "flex items-center justify-between gap-3 rounded-xl border px-4 py-3",
+              companyPaused
+                ? "border-red-500/30 bg-[linear-gradient(180deg,rgba(255,60,60,0.10),rgba(255,255,255,0.02))]"
+                : "border-border bg-card",
+            )}
+          >
+            <div className="flex items-center gap-4">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground shrink-0">
+                Company Kill Switch
+              </span>
+              <div className="flex items-center gap-2.5">
+                {companyPaused ? (
+                  <Square className="h-4 w-4 shrink-0 text-red-400" />
+                ) : (
+                  <Play className="h-4 w-4 shrink-0 text-green-400" />
+                )}
+                <div>
+                  <p className={cn("text-sm font-medium", companyPaused ? "text-red-50" : "text-foreground")}>
+                    {companyPaused ? "All heartbeats paused" : "Heartbeats active"}
+                  </p>
+                  {companyPaused && data.companyPauseReason && (
+                    <p className="text-xs text-red-100/70">
+                      Paused by {data.companyPauseReason === "budget" ? "budget hard-stop" : "board operator"}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => togglePause.mutate()}
+              disabled={togglePause.isPending}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                companyPaused
+                  ? "bg-green-600 text-white hover:bg-green-500"
+                  : "bg-red-600 text-white hover:bg-red-500",
+                togglePause.isPending && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              {companyPaused ? (
+                <>
+                  <Play className="h-3.5 w-3.5" />
+                  Resume All
+                </>
+              ) : (
+                <>
+                  <Square className="h-3.5 w-3.5" />
+                  Pause All
+                </>
+              )}
+            </button>
+          </div>
+        </>
+      )}
 
       {data && (
         <>


### PR DESCRIPTION
## Summary

- Adds `POST /companies/:id/pause` and `POST /companies/:id/resume` endpoints for board operators to manually pause/resume all heartbeats for a company
- Heartbeat scheduler `tickTimers()` now skips agents belonging to paused companies
- Dashboard displays a "Company Kill Switch" banner with a toggle button (Pause All / Resume All)
- Pausing cancels all active and queued heartbeat runs via existing `cancelBudgetScopeWork` infrastructure
- Leverages existing `company.status`, `pauseReason`, and `pausedAt` schema fields (no migrations needed)
- Adds `companyStatus` and `companyPauseReason` to `DashboardSummary` type

## Test plan

- [ ] Verify `POST /companies/:id/pause` sets company status to "paused" and cancels active runs
- [ ] Verify `POST /companies/:id/resume` restores company status to "active"
- [ ] Verify heartbeat scheduler does not enqueue runs for agents in paused companies
- [ ] Verify dashboard shows kill switch banner with correct state
- [ ] Verify clicking "Pause All" pauses company and UI updates
- [ ] Verify clicking "Resume All" resumes company and UI updates
- [ ] Verify budget-initiated pauses still work alongside manual pauses
- [ ] All existing tests pass (137 files, 682 tests)