### PR TITLE
fix(opencode): add providerBaseUrl field for MiniMax and custom OpenAI-compatible providers

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -343,6 +343,7 @@ export interface CreateConfigValues {
   envVars: string;
   envBindings: Record<string, unknown>;
   url: string;
+  providerBaseUrl?: string;
   bootstrapPrompt: string;
   payloadTemplateJson?: string;
   workspaceStrategyType?: string;

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+import { asBoolean, asNonEmptyString } from "@paperclipai/adapter-utils/server-utils";
 
 type PreparedOpenCodeRuntimeConfig = {
   env: Record<string, string>;
@@ -76,11 +76,19 @@ export async function prepareOpenCodeRuntimeConfig(input: {
   };
   await fs.writeFile(runtimeConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
 
+  const env: Record<string, string> = {
+    ...input.env,
+    XDG_CONFIG_HOME: runtimeConfigHome,
+  };
+  // Inject OPENAI_BASE_URL if providerBaseUrl is configured.
+  // This allows MiniMax and other OpenAI-compatible providers to work
+  // when the server process doesn't have access to the user's opencode.json.
+  const baseUrl = asNonEmptyString(input.config.providerBaseUrl);
+  if (baseUrl) {
+    env.OPENAI_BASE_URL = baseUrl;
+  }
   return {
-    env: {
-      ...input.env,
-      XDG_CONFIG_HOME: runtimeConfigHome,
-    },
+    env,
     notes: [
       "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
     ],

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -70,7 +70,12 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
       env[key] = { type: "plain", value };
     }
   }
-  if (Object.keys(env).length > 0) ac.env = env;
+  if (Object.keys(env).length > 0 || v.providerBaseUrl) {
+    if (v.providerBaseUrl) {
+      env["OPENAI_BASE_URL"] = { type: "plain", value: v.providerBaseUrl };
+    }
+    ac.env = env;
+  }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
   return ac;

--- a/ui/src/adapters/opencode-local/config-fields.tsx
+++ b/ui/src/adapters/opencode-local/config-fields.tsx
@@ -49,6 +49,23 @@ export function OpenCodeLocalConfigFields({
           </div>
         </Field>
       )}
+      <Field label="Provider base URL" hint="MiniMax, Groq, OpenRouter — leave empty to use default OpenAI. Only needed for custom OpenAI-compatible providers.">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.providerBaseUrl ?? ""
+              : eff("adapterConfig", "providerBaseUrl", String(config.providerBaseUrl ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ providerBaseUrl: v || undefined })
+              : mark("adapterConfig", "providerBaseUrl", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="https://api.minimax.chat/v1"
+        />
+      </Field>
       <ToggleField
         label="Skip permissions"
         hint={help.dangerouslySkipPermissions}


### PR DESCRIPTION
## Summary

MiniMax (and other OpenAI-compatible providers) show 'No models found' in the model selector even though `opencode models` works in the terminal.

This PR adds a **Provider Base URL** field to the OpenCode adapter UI which injects `OPENAI_BASE_URL` into the subprocess environment, allowing Paperclip to discover and use MiniMax models.

## Root Cause

When OpenCode runs `opencode models` in the Paperclip server process, it may not have access to the user's config file (`~/.config/opencode/opencode.json`) where provider credentials are stored. The standard way to pass a provider base URL per-invocation is via the `OPENAI_BASE_URL` environment variable — but this was not being injected.

## Changes

4 files changed, 37 insertions, 6 deletions:

### 1. `packages/adapter-utils/src/types.ts`
Added `providerBaseUrl?: string` to `CreateConfigValues` interface.

### 2. `packages/adapters/opencode-local/src/ui/build-config.ts`
Pass `providerBaseUrl` as `OPENAI_BASE_URL` in env bindings.

### 3. `packages/adapters/opencode-local/src/server/runtime-config.ts`
Inject `OPENAI_BASE_URL` into the subprocess environment when `providerBaseUrl` is configured.

### 4. `ui/src/adapters/opencode-local/config-fields.tsx`
Added UI field:


## Testing

1. Set Provider base URL: `https://api.minimax.chat/v1`
2. Open model dropdown → MiniMax models appear ✅
3. Create agent using MiniMax model → runs successfully ✅

## Related Issue

Fixes #1934