### PR TITLE
feat(ui): show adapter type in agent detail header subtitle

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -821,6 +821,8 @@ export function AgentDetail() {
             <p className="text-sm text-muted-foreground truncate">
               {roleLabels[agent.role] ?? agent.role}
               {agent.title ? ` - ${agent.title}` : ""}
+              <span className="mx-1.5 opacity-30">·</span>
+              <span className="text-xs">{adapterLabels[agent.adapterType] ?? agent.adapterType}</span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Problem

When looking at an agent detail page, you can see the agent name, role, and title in the header. But the adapter type (which engine the agent use - Claude, Codex, Cursor, Hermes, etc) was only visible inside the Configuration tab.

When I manage multiple agents with different adapters, I want to quickly see which adapter each one use without opening the config section every time. Specially when debugging why an agent behave differently - first thing I check is "which adapter is this one using?"

## What I changed

Added the adapter label to the subtitle line in the agent header, after the role/title text. Separated by a dot for visual clarity. Uses the existing \`adapterLabels\` map (already imported from agent-config-primitives) which give nice display names:
- "claude_local" -> "Claude"
- "codex_local" -> "Codex"
- "cursor" -> "Cursor"
- "hermes_local" -> "Hermes"
- etc.

So the subtitle now look like: "Engineer - Build systems · Claude" instead of just "Engineer - Build systems".

## How to test

1. Go to any agent detail page
2. Below the agent name, the subtitle should now include the adapter name after a dot separator
3. Check different agents with different adapters - each should show the correct adapter label

1 file, 2 lines added.