### PR TITLE
feat: heartbeat model override via runtimeConfig.heartbeat.model

### DIFF
--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -144,6 +144,7 @@ export interface InstanceSchedulerHeartbeatAgent {
   adapterType: string;
   intervalSec: number;
   heartbeatEnabled: boolean;
+  heartbeatModel: string | null;
   schedulerActive: boolean;
   lastHeartbeatAt: Date | null;
 }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -510,9 +510,11 @@ export function agentRoutes(db: Db) {
 
   function parseSchedulerHeartbeatPolicy(runtimeConfig: unknown) {
     const heartbeat = asRecord(asRecord(runtimeConfig)?.heartbeat) ?? {};
+    const rawModel = heartbeat.model;
     return {
       enabled: parseBooleanLike(heartbeat.enabled) ?? false,
       intervalSec: Math.max(0, parseNumberLike(heartbeat.intervalSec) ?? 0),
+      model: typeof rawModel === "string" && rawModel.trim().length > 0 ? rawModel.trim() : null,
     };
   }
 
@@ -1098,6 +1100,7 @@ export function agentRoutes(db: Db) {
           adapterType: row.adapterType,
           intervalSec: policy.intervalSec,
           heartbeatEnabled: policy.enabled,
+          heartbeatModel: policy.model,
           schedulerActive: statusEligible && policy.enabled && policy.intervalSec > 0,
           lastHeartbeatAt: row.lastHeartbeatAt,
         };

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2069,6 +2069,24 @@ export function agentRoutes(db: Db) {
       );
     }
 
+    if (Object.prototype.hasOwnProperty.call(patchData, "runtimeConfig")) {
+      const existingRuntimeConfig = asRecord(existing.runtimeConfig) ?? {};
+      const incomingRuntimeConfig = asRecord(patchData.runtimeConfig) ?? {};
+      const mergedRuntimeConfig = { ...existingRuntimeConfig };
+      for (const [key, value] of Object.entries(incomingRuntimeConfig)) {
+        const existingValue = existingRuntimeConfig[key];
+        if (
+          typeof value === "object" && value !== null && !Array.isArray(value) &&
+          typeof existingValue === "object" && existingValue !== null && !Array.isArray(existingValue)
+        ) {
+          mergedRuntimeConfig[key] = { ...existingValue as Record<string, unknown>, ...value as Record<string, unknown> };
+        } else {
+          mergedRuntimeConfig[key] = value;
+        }
+      }
+      patchData.runtimeConfig = mergedRuntimeConfig;
+    }
+
     const actor = getActorInfo(req);
     const agent = await svc.update(id, patchData, {
       recordRevision: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3066,6 +3066,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      model: typeof heartbeat.model === "string" && heartbeat.model.trim().length > 0 ? heartbeat.model.trim() : null,
     };
   }
 
@@ -4534,8 +4535,16 @@ export function heartbeatService(db: Db) {
       runScopedMentionedSkillKeys,
     );
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
+    const heartbeatModelOverride = (() => {
+      if (run.invocationSource !== "timer") return null;
+      const rc = parseObject(agent.runtimeConfig);
+      const hb = parseObject(rc.heartbeat);
+      const model = typeof hb.model === "string" && hb.model.trim().length > 0 ? hb.model.trim() : null;
+      return model;
+    })();
     const runtimeConfig = {
       ...effectiveResolvedConfig,
+      ...(heartbeatModelOverride ? { model: heartbeatModelOverride } : {}),
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4535,13 +4535,8 @@ export function heartbeatService(db: Db) {
       runScopedMentionedSkillKeys,
     );
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
-    const heartbeatModelOverride = (() => {
-      if (run.invocationSource !== "timer") return null;
-      const rc = parseObject(agent.runtimeConfig);
-      const hb = parseObject(rc.heartbeat);
-      const model = typeof hb.model === "string" && hb.model.trim().length > 0 ? hb.model.trim() : null;
-      return model;
-    })();
+    const heartbeatModelOverride =
+      run.invocationSource === "timer" ? parseHeartbeatPolicy(agent).model : null;
     const runtimeConfig = {
       ...effectiveResolvedConfig,
       ...(heartbeatModelOverride ? { model: heartbeatModelOverride } : {}),

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -909,6 +909,15 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 numberHint={help.intervalSec}
                 showNumber={eff("heartbeat", "enabled", heartbeat.enabled === true)}
               />
+              <Field label="Heartbeat model" hint={help.heartbeatModel}>
+                <input
+                  type="text"
+                  className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                  placeholder="e.g. claude-haiku-4-5 (empty = use agent model)"
+                  value={eff("heartbeat", "model", (heartbeat.model as string) ?? "") as string}
+                  onChange={(e) => mark("heartbeat", "model", e.target.value || null)}
+                />
+              </Field>
             </div>
             <CollapsibleSection
               title="Advanced Run Policy"

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -50,6 +50,7 @@ export const help: Record<string, string> = {
   payloadTemplateJson: "Optional JSON merged into remote adapter request payloads before Paperclip adds its standard wake and workspace fields.",
   webhookUrl: "The URL that receives POST requests when the agent is invoked.",
   heartbeatInterval: "Run this agent automatically on a timer. Useful for periodic tasks like checking for new work.",
+  heartbeatModel: "Override the model used for timer heartbeat runs. Leave empty to use the agent's default model. Use a cheaper model (e.g. Haiku) to reduce rate limit pressure and cost.",
   intervalSec: "Seconds between automatic heartbeat invocations.",
   timeoutSec: "Maximum seconds a run can take before being terminated. 0 means no timeout.",
   graceSec: "Seconds to wait after sending interrupt before force-killing the process.",


### PR DESCRIPTION
## Problem

Heartbeat runs use the same model as on-demand task execution. For companies running many agents with frequent heartbeat intervals (30s–300s), this burns through rate limits and API budget on expensive models (Opus, Sonnet) for what is essentially a check-in — the agent reads its inbox, sees no work, and exits.

A typical heartbeat run consumes a full model session just to determine there's nothing to do. At 28 agents with 30–60s intervals, that's hundreds of Opus/Sonnet sessions per hour that could be served by a lighter model like Haiku.

## Solution

Adds an optional `model` field to `runtimeConfig.heartbeat`:

```json
{
  "runtimeConfig": {
    "heartbeat": {
      "enabled": true,
      "intervalSec": 60,
      "model": "claude-haiku-4-5"
    }
  }
}
```

When set, **timer-triggered** heartbeat runs override `adapterConfig.model` with the heartbeat model. On-demand runs, assignment-triggered runs, and all other invocation sources continue using the agent's primary model from `adapterConfig.model`.

This lets operators use a cheap, fast model (e.g. Haiku) for heartbeat polling while keeping the full-capability model (Opus/Sonnet) for actual task execution — reducing rate limit pressure and cost without sacrificing work quality.

## Changes

- **`server/src/services/heartbeat.ts`**: `executeRun()` checks `runtimeConfig.heartbeat.model` when `invocationSource === "timer"` and overrides the adapter config model. `parseHeartbeatPolicy()` now parses the `model` field.
- **`server/src/routes/agents.ts`**: `parseSchedulerHeartbeatPolicy()` includes `model` field. Instance scheduler endpoint exposes `heartbeatModel` for monitoring.
- **`packages/shared/src/types/heartbeat.ts`**: `InstanceSchedulerHeartbeatAgent` type includes `heartbeatModel: string | null`.

## Usage

Set via API for a single agent:
```bash
curl -X PATCH http://localhost:3101/api/agents/<id> \
  -H 'Content-Type: application/json' \
  -d '{"runtimeConfig":{"heartbeat":{"model":"claude-haiku-4-5"}}}'
```

Or bulk-set for all agents in a company:
```bash
# For each agent, set heartbeat model to haiku
curl -s "http://localhost:3101/api/companies/<companyId>/agents" | \
  python3 -c "..." # iterate and PATCH each
```

## Test plan

- [ ] Agent with `runtimeConfig.heartbeat.model` set: timer heartbeat uses override model
- [ ] Same agent invoked on-demand: uses `adapterConfig.model` (not heartbeat override)
- [ ] Agent without heartbeat model set: timer heartbeat uses `adapterConfig.model` as before
- [ ] Instance scheduler endpoint shows `heartbeatModel` field
- [ ] All existing tests pass (137 files, 682 tests)