### PR TITLE
CMP-263: fix execution lock recontamination on issue update/release

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -71,6 +71,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     processPid?: number | null;
     processLossRetryCount?: number;
     includeIssue?: boolean;
+    issueStatus?: "in_progress" | "todo" | "blocked";
     runErrorCode?: string | null;
     runError?: string | null;
   }) {
@@ -136,7 +137,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         id: issueId,
         companyId,
         title: "Recover local adapter after lost process",
-        status: "in_progress",
+        status: input?.issueStatus ?? "in_progress",
         priority: "medium",
         assigneeAgentId: agentId,
         checkoutRunId: runId,
@@ -251,5 +252,91 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const run = await heartbeat.getRun(runId);
     expect(run?.errorCode).toBeNull();
     expect(run?.error).toBeNull();
+  });
+
+  it("cancels deferred issue wakeups instead of promoting when the issue is not in_progress", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      runStatus: "queued",
+      issueStatus: "todo",
+    });
+    const heartbeat = heartbeatService(db);
+    const deferredWakeId = randomUUID();
+
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeId,
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      payload: { issueId },
+      status: "deferred_issue_execution",
+      runId: null,
+    });
+
+    await heartbeat.cancelRun(runId);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.executionAgentNameKey).toBeNull();
+    expect(issue?.executionLockedAt).toBeNull();
+
+    const deferredWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredWakeId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredWake?.status).toBe("cancelled");
+    expect(deferredWake?.runId).toBeNull();
+
+    const extraRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId));
+    expect(extraRuns).toHaveLength(0);
+  });
+
+  it("suppresses deferred promotion when cancelRun is called with suppressDeferredPromotion", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      runStatus: "queued",
+      issueStatus: "in_progress",
+    });
+    const heartbeat = heartbeatService(db);
+    const deferredWakeId = randomUUID();
+
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeId,
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      payload: { issueId },
+      status: "deferred_issue_execution",
+      runId: null,
+    });
+
+    await heartbeat.cancelRun(runId, { suppressDeferredPromotion: true });
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.executionAgentNameKey).toBeNull();
+    expect(issue?.executionLockedAt).toBeNull();
+
+    const deferredWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredWakeId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredWake?.status).toBe("cancelled");
+    expect(deferredWake?.runId).toBeNull();
   });
 });

--- a/server/src/__tests__/issue-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-execution-lock-routes.test.ts
@@ -1,0 +1,135 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  release: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  cancelRun: vi.fn(),
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      runId: null,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(status: "in_progress" | "todo" | "blocked" = "in_progress") {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    status,
+    assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+    assigneeUserId: null,
+    checkoutRunId: "run-1",
+    executionRunId: "run-1",
+    createdByUserId: "local-board",
+    identifier: "PAP-581",
+    title: "Execution run lock cleanup",
+  };
+}
+
+function makeRun(status: "queued" | "running" | "cancelled" = "queued") {
+  return {
+    id: "run-1",
+    companyId: "company-1",
+    agentId: "22222222-2222-4222-8222-222222222222",
+    status,
+  };
+}
+
+describe("issue execution lock cleanup routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHeartbeatService.getRun.mockResolvedValue(makeRun("queued"));
+    mockHeartbeatService.cancelRun.mockResolvedValue(makeRun("cancelled"));
+  });
+
+  it("cancels stale queued run when PATCH leaves in_progress", async () => {
+    const existing = makeIssue("in_progress");
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue({
+      ...existing,
+      status: "blocked",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(existing.id, { status: "blocked" });
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1", { suppressDeferredPromotion: true });
+  });
+
+  it("cancels stale queued run on release", async () => {
+    const existing = makeIssue("todo");
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.release.mockResolvedValue({
+      ...existing,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const res = await request(createApp()).post(`/api/issues/${existing.id}/release`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith(existing.id, undefined, null);
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1", { suppressDeferredPromotion: true });
+  });
+});

--- a/server/src/__tests__/issue-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-execution-lock-routes.test.ts
@@ -2,12 +2,18 @@ import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { issueRoutes } from "../routes/issues.js";
+import { conflict } from "../errors.js";
 import { errorHandler } from "../middleware/index.js";
 
 const mockIssueService = vi.hoisted(() => ({
+  assertCheckoutOwner: vi.fn(),
   getById: vi.fn(),
   update: vi.fn(),
   release: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -24,9 +30,7 @@ vi.mock("../services/index.js", () => ({
     canUser: vi.fn(),
     hasPermission: vi.fn(),
   }),
-  agentService: () => ({
-    getById: vi.fn(),
-  }),
+  agentService: () => mockAgentService,
   documentService: () => ({}),
   executionWorkspaceService: () => ({}),
   goalService: () => ({}),
@@ -41,11 +45,11 @@ vi.mock("../services/index.js", () => ({
   workProductService: () => ({}),
 }));
 
-function createApp() {
+function createApp(actor?: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
+    (req as any).actor = actor ?? {
       type: "board",
       userId: "local-board",
       companyIds: ["company-1"],
@@ -87,6 +91,8 @@ function makeRun(status: "queued" | "running" | "cancelled" = "queued") {
 describe("issue execution lock cleanup routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockAgentService.getById.mockResolvedValue(null);
     mockHeartbeatService.getRun.mockResolvedValue(makeRun("queued"));
     mockHeartbeatService.cancelRun.mockResolvedValue(makeRun("cancelled"));
   });
@@ -129,7 +135,105 @@ describe("issue execution lock cleanup routes", () => {
     const res = await request(createApp()).post(`/api/issues/${existing.id}/release`);
 
     expect(res.status).toBe(200);
-    expect(mockIssueService.release).toHaveBeenCalledWith(existing.id, undefined, null);
+    expect(mockIssueService.release).toHaveBeenCalledWith(existing.id, undefined, null, { allowAnyIssueRelease: false });
     expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1", { suppressDeferredPromotion: true });
+  });
+
+  it("cancels current agent run on release to prevent lock recontamination", async () => {
+    const existing = makeIssue("todo");
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.release.mockResolvedValue({
+      ...existing,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      companyId: "company-1",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      runId: "run-1",
+    })).post(`/api/issues/${existing.id}/release`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith(
+      existing.id,
+      "22222222-2222-4222-8222-222222222222",
+      "run-1",
+      { allowAnyIssueRelease: false },
+    );
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1", { suppressDeferredPromotion: true });
+  });
+
+  it("passes CEO override when releasing another agent's issue", async () => {
+    const existing = {
+      ...makeIssue("in_progress"),
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      checkoutRunId: "run-assignee",
+      executionRunId: "run-assignee",
+    };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.release.mockResolvedValue({
+      ...existing,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+    mockAgentService.getById.mockResolvedValue({
+      id: "ceo-agent",
+      companyId: "company-1",
+      role: "ceo",
+      permissions: null,
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      companyId: "company-1",
+      agentId: "ceo-agent",
+      runId: "run-ceo",
+    })).post(`/api/issues/${existing.id}/release`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith(existing.id, "ceo-agent", "run-ceo", {
+      allowAnyIssueRelease: true,
+    });
+  });
+
+  it("keeps non-CEO agent release under assignee-only rule", async () => {
+    const existing = {
+      ...makeIssue("in_progress"),
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      checkoutRunId: "run-assignee",
+      executionRunId: "run-assignee",
+    };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.release.mockRejectedValue(conflict("Only assignee can release issue"));
+    mockAgentService.getById.mockResolvedValue({
+      id: "worker-agent",
+      companyId: "company-1",
+      role: "engineer",
+      permissions: null,
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      companyId: "company-1",
+      agentId: "worker-agent",
+      runId: "run-worker",
+    })).post(`/api/issues/${existing.id}/release`);
+
+    expect(mockIssueService.release).toHaveBeenCalledWith(existing.id, "worker-agent", "run-worker", {
+      allowAnyIssueRelease: false,
+    });
+    expect(res.status).toBe(409);
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -316,6 +316,136 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     ]));
   });
 
+  it("clears execution lock fields when issue leaves in_progress", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const assigneeRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "AssigneeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: assigneeRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: null,
+      status: "running",
+      contextSnapshot: {},
+    });
+
+    for (const status of ["blocked", "todo"] as const) {
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: `Lock cleanup (${status})`,
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId,
+        checkoutRunId: assigneeRunId,
+        executionRunId: assigneeRunId,
+        executionAgentNameKey: "assigneeagent",
+        executionLockedAt: new Date("2026-03-30T04:00:00.000Z"),
+      });
+
+      const updated = await svc.update(issueId, { status });
+      expect(updated).toMatchObject({
+        id: issueId,
+        status,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      });
+    }
+  });
+
+  it("clears execution lock fields when assignee changes", async () => {
+    const companyId = randomUUID();
+    const currentAssigneeAgentId = randomUUID();
+    const nextAssigneeAgentId = randomUUID();
+    const assigneeRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: currentAssigneeAgentId,
+        companyId,
+        name: "CurrentAssignee",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAssigneeAgentId,
+        companyId,
+        name: "NextAssignee",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values({
+      id: assigneeRunId,
+      companyId,
+      agentId: currentAssigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: null,
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Lock cleanup on reassignment",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: currentAssigneeAgentId,
+      checkoutRunId: assigneeRunId,
+      executionRunId: assigneeRunId,
+      executionAgentNameKey: "currentassignee",
+      executionLockedAt: new Date("2026-03-30T04:01:00.000Z"),
+    });
+
+    const updated = await svc.update(issueId, { assigneeAgentId: nextAssigneeAgentId });
+    expect(updated).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId: nextAssigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+  });
+
   it("clears execution lock fields on release", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRuns,
   issueComments,
   issueInboxArchives,
   issues,
@@ -40,6 +41,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -312,5 +314,154 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       archivedIssueId,
       resurfacedIssueId,
     ]));
+  });
+
+  it("clears execution lock fields on release", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const issueId = randomUUID();
+    const assigneeRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "AssigneeAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: assigneeRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: null,
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Release lock cleanup",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      checkoutRunId: assigneeRunId,
+      executionRunId: assigneeRunId,
+      executionAgentNameKey: "assigneeagent",
+      executionLockedAt: new Date("2026-03-29T20:00:00.000Z"),
+    });
+
+    const released = await svc.release(issueId, assigneeAgentId, assigneeRunId);
+    expect(released).not.toBeNull();
+    expect(released).toMatchObject({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+  });
+
+  it("keeps assignee-only release for ordinary agents, but allows CEO override", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const ordinaryAgentId = randomUUID();
+    const ceoAgentId = randomUUID();
+    const issueId = randomUUID();
+    const assigneeRunId = randomUUID();
+    const workerRunId = randomUUID();
+    const ceoRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "AssigneeAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: ordinaryAgentId,
+        companyId,
+        name: "WorkerAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: ceoAgentId,
+        companyId,
+        name: "CeoAgent",
+        role: "ceo",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values({
+      id: assigneeRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: null,
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "CEO override release",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      checkoutRunId: assigneeRunId,
+      executionRunId: assigneeRunId,
+      executionAgentNameKey: "assigneeagent",
+      executionLockedAt: new Date("2026-03-29T20:01:00.000Z"),
+    });
+
+    await expect(svc.release(issueId, ordinaryAgentId, workerRunId)).rejects.toMatchObject({
+      status: 409,
+      message: "Only assignee can release issue",
+    });
+
+    const released = await svc.release(issueId, ceoAgentId, ceoRunId, { allowAnyIssueRelease: true });
+    expect(released).not.toBeNull();
+    expect(released).toMatchObject({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -504,6 +504,216 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
   });
 
+  it("recovers stale execution lock on checkout when referenced run is terminal", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: null,
+        status: "succeeded",
+        contextSnapshot: {},
+      },
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: null,
+        status: "running",
+        contextSnapshot: {},
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale checkout lock",
+      status: "todo",
+      priority: "medium",
+      executionRunId: staleRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], checkoutRunId);
+
+    expect(checkedOut.status).toBe("in_progress");
+    expect(checkedOut.assigneeAgentId).toBe(agentId);
+    expect(checkedOut.checkoutRunId).toBe(checkoutRunId);
+    expect(checkedOut.executionRunId).toBe(checkoutRunId);
+    expect(checkedOut.executionAgentNameKey).toBeNull();
+    expect(checkedOut.executionLockedAt).toBeNull();
+  });
+
+  it("keeps execution lock when checkout sees an active run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const activeExecutionRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: activeExecutionRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: null,
+        status: "running",
+        contextSnapshot: {},
+      },
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: null,
+        status: "running",
+        contextSnapshot: {},
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Active lock",
+      status: "todo",
+      priority: "medium",
+      executionRunId: activeExecutionRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["todo"], checkoutRunId)).rejects.toThrow("Issue checkout conflict");
+
+    const latest = await svc.getById(issueId);
+    expect(latest?.executionRunId).toBe(activeExecutionRunId);
+  });
+
+  it("does not steal issue assigned to another agent during stale lock recovery", async () => {
+    const companyId = randomUUID();
+    const callerAgentId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: callerAgentId,
+        companyId,
+        name: "Caller",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "Assignee",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        invocationSource: "assignment",
+        triggerDetail: null,
+        status: "succeeded",
+        contextSnapshot: {},
+      },
+      {
+        id: checkoutRunId,
+        companyId,
+        agentId: callerAgentId,
+        invocationSource: "assignment",
+        triggerDetail: null,
+        status: "running",
+        contextSnapshot: {},
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Assigned elsewhere",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "assignee",
+      executionLockedAt: new Date(),
+    });
+
+    await expect(svc.checkout(issueId, callerAgentId, ["todo", "in_progress"], checkoutRunId)).rejects.toThrow(
+      "Issue checkout conflict",
+    );
+
+    const latest = await svc.getById(issueId);
+    expect(latest?.assigneeAgentId).toBe(assigneeAgentId);
+    expect(latest?.status).toBe("in_progress");
+    expect(latest?.executionRunId).toBe(staleRunId);
+  });
+
   it("keeps assignee-only release for ordinary agents, but allows CEO override", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -115,6 +115,14 @@ export function issueRoutes(db: Db, storage: StorageService) {
     throw unauthorized();
   }
 
+  async function canReleaseAnyIssue(req: Request, companyId: string) {
+    if (req.actor.type !== "agent") return false;
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) return false;
+    const actorAgent = await agentsSvc.getById(actorAgentId);
+    return Boolean(actorAgent && actorAgent.companyId === companyId && actorAgent.role === "ceo");
+  }
+
   function requireAgentRunId(req: Request, res: Response) {
     if (req.actor.type !== "agent") return null;
     const runId = req.actor.runId?.trim();
@@ -1263,11 +1271,13 @@ export function issueRoutes(db: Db, storage: StorageService) {
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;
+    const allowAnyIssueRelease = await canReleaseAnyIssue(req, existing.companyId);
 
     const released = await svc.release(
       id,
       req.actor.type === "agent" ? req.actor.agentId : undefined,
       actorRunId,
+      { allowAnyIssueRelease },
     );
     if (!released) {
       res.status(404).json({ error: "Issue not found" });
@@ -1286,7 +1296,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       entityId: released.id,
     });
 
-    if (existing.executionRunId && existing.executionRunId !== actor.runId) {
+    if (existing.executionRunId) {
       await cancelStaleExecutionRun({
         runId: existing.executionRunId,
         issueId: released.id,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -161,6 +161,41 @@ export function issueRoutes(db: Db, storage: StorageService) {
     return true;
   }
 
+  async function cancelStaleExecutionRun(input: {
+    runId: string | null | undefined;
+    issueId: string;
+    companyId: string;
+    actor: ReturnType<typeof getActorInfo>;
+    source: "issue.update" | "issue.release";
+  }) {
+    const runId = input.runId?.trim();
+    if (!runId) return null;
+
+    const run = await heartbeat.getRun(runId);
+    if (!run || run.companyId !== input.companyId) return null;
+    if (run.status !== "queued" && run.status !== "running") return null;
+
+    const cancelled = await heartbeat.cancelRun(run.id, { suppressDeferredPromotion: true });
+    if (!cancelled) return null;
+
+    await logActivity(db, {
+      companyId: cancelled.companyId,
+      actorType: input.actor.actorType,
+      actorId: input.actor.actorId,
+      agentId: input.actor.agentId,
+      runId: input.actor.runId,
+      action: "heartbeat.cancelled",
+      entityType: "heartbeat_run",
+      entityId: cancelled.id,
+      details: {
+        agentId: cancelled.agentId,
+        source: input.source,
+        issueId: input.issueId,
+      },
+    });
+
+    return cancelled;
+  }
   async function normalizeIssueIdentifier(rawId: string): Promise<string> {
     if (/^[A-Z]+-\d+$/i.test(rawId)) {
       const issue = await svc.getByIdentifier(rawId);
@@ -962,6 +997,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
         logger.warn({ err, runId: actor.runId }, "failed to clear detached run warning after issue activity"));
     }
 
+    const statusLeavesInProgress = req.body.status !== undefined && req.body.status !== "in_progress";
+    if (existing.executionRunId && existing.executionRunId !== actor.runId && (assigneeWillChange || statusLeavesInProgress)) {
+      await cancelStaleExecutionRun({
+        runId: existing.executionRunId,
+        issueId: issue.id,
+        companyId: issue.companyId,
+        actor,
+        source: "issue.update",
+      }).catch((err) =>
+        logger.warn({ err, issueId: issue.id, runId: existing.executionRunId }, "failed to cancel stale execution run"));
+    }
+
     // Build activity details with previous values for changed fields
     const previous: Record<string, unknown> = {};
     for (const key of Object.keys(updateFields)) {
@@ -1238,6 +1285,17 @@ export function issueRoutes(db: Db, storage: StorageService) {
       entityType: "issue",
       entityId: released.id,
     });
+
+    if (existing.executionRunId && existing.executionRunId !== actor.runId) {
+      await cancelStaleExecutionRun({
+        runId: existing.executionRunId,
+        issueId: released.id,
+        companyId: released.companyId,
+        actor,
+        source: "issue.release",
+      }).catch((err) =>
+        logger.warn({ err, issueId: released.id, runId: existing.executionRunId }, "failed to cancel stale execution run on release"));
+    }
 
     res.json(released);
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1577,7 +1577,14 @@ export function heartbeatService(db: Db) {
             executionLockedAt: now,
             updatedAt: now,
           })
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              eq(issues.executionRunId, run.id),
+              eq(issues.status, "in_progress"),
+            ),
+          );
       }
 
       return retryRun;
@@ -2816,7 +2823,33 @@ export function heartbeatService(db: Db) {
         }
   }
 
-  async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
+  async function cancelPendingIssueExecutionWakeups(
+    tx: any,
+    input: { companyId: string; issueId: string; reason: string },
+  ) {
+    const now = new Date();
+    await tx
+      .update(agentWakeupRequests)
+      .set({
+        status: "cancelled",
+        finishedAt: now,
+        error: input.reason,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, input.companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.runId} is null`,
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+        ),
+      );
+  }
+
+  async function releaseIssueExecutionAndPromote(
+    run: typeof heartbeatRuns.$inferSelect,
+    options?: { suppressDeferredPromotion?: boolean },
+  ) {
     const promotedRun = await db.transaction(async (tx) => {
       await tx.execute(
         sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
@@ -2826,6 +2859,8 @@ export function heartbeatService(db: Db) {
         .select({
           id: issues.id,
           companyId: issues.companyId,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
         })
         .from(issues)
         .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
@@ -2842,6 +2877,15 @@ export function heartbeatService(db: Db) {
           updatedAt: new Date(),
         })
         .where(eq(issues.id, issue.id));
+
+      if (options?.suppressDeferredPromotion || issue.status !== "in_progress" || !issue.assigneeAgentId) {
+        await cancelPendingIssueExecutionWakeups(tx, {
+          companyId: issue.companyId,
+          issueId: issue.id,
+          reason: "Cancelled because issue is no longer executable",
+        });
+        return null;
+      }
 
       while (true) {
         const deferred = await tx
@@ -3166,7 +3210,7 @@ export function heartbeatService(db: Db) {
                 executionLockedAt: new Date(),
                 updatedAt: new Date(),
               })
-              .where(eq(issues.id, issue.id));
+              .where(and(eq(issues.id, issue.id), eq(issues.status, "in_progress")));
           }
         }
 
@@ -3331,7 +3375,7 @@ export function heartbeatService(db: Db) {
             executionLockedAt: new Date(),
             updatedAt: new Date(),
           })
-          .where(eq(issues.id, issue.id));
+          .where(and(eq(issues.id, issue.id), eq(issues.status, "in_progress")));
 
         return { kind: "queued" as const, run: newRun };
       });
@@ -3564,7 +3608,11 @@ export function heartbeatService(db: Db) {
     return wakeupIds.length;
   }
 
-  async function cancelRunInternal(runId: string, reason = "Cancelled by control plane") {
+  async function cancelRunInternal(
+    runId: string,
+    reason = "Cancelled by control plane",
+    options?: { suppressDeferredPromotion?: boolean },
+  ) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
     if (run.status !== "running" && run.status !== "queued") return run;
@@ -3598,7 +3646,7 @@ export function heartbeatService(db: Db) {
         level: "warn",
         message: "run cancelled",
       });
-      await releaseIssueExecutionAndPromote(cancelled);
+      await releaseIssueExecutionAndPromote(cancelled, options);
     }
 
     runningProcesses.delete(run.id);
@@ -3838,7 +3886,8 @@ export function heartbeatService(db: Db) {
       return { checked, enqueued, skipped };
     },
 
-    cancelRun: (runId: string) => cancelRunInternal(runId),
+    cancelRun: (runId: string, options?: { suppressDeferredPromotion?: boolean }) =>
+      cancelRunInternal(runId, "Cancelled by control plane", options),
 
     cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1281,7 +1281,12 @@ export function issueService(db: Db) {
       });
     },
 
-    release: async (id: string, actorAgentId?: string, actorRunId?: string | null) => {
+    release: async (
+      id: string,
+      actorAgentId?: string,
+      actorRunId?: string | null,
+      opts?: { allowAnyIssueRelease?: boolean },
+    ) => {
       const existing = await db
         .select()
         .from(issues)
@@ -1289,10 +1294,12 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!existing) return null;
-      if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
+      const allowAnyIssueRelease = opts?.allowAnyIssueRelease === true;
+      if (!allowAnyIssueRelease && actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
         throw conflict("Only assignee can release issue");
       }
       if (
+        !allowAnyIssueRelease &&
         actorAgentId &&
         existing.status === "in_progress" &&
         existing.assigneeAgentId === actorAgentId &&
@@ -1313,6 +1320,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1213,6 +1213,54 @@ export function issueService(db: Db) {
         }
       }
 
+      if (current.executionRunId && (!checkoutRunId || current.executionRunId !== checkoutRunId)) {
+        const staleExecutionLock = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
+        if (staleExecutionLock) {
+          await db
+            .update(issues)
+            .set({
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(issues.id, id),
+                eq(issues.executionRunId, current.executionRunId),
+                or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
+              ),
+            );
+
+          const retried = await db
+            .update(issues)
+            .set({
+              assigneeAgentId: agentId,
+              assigneeUserId: null,
+              checkoutRunId,
+              executionRunId: checkoutRunId,
+              status: "in_progress",
+              startedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(issues.id, id),
+                inArray(issues.status, expectedStatuses),
+                or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
+                isNull(issues.executionRunId),
+              ),
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+
+          if (retried) {
+            const [enriched] = await withIssueLabels(db, [retried]);
+            return enriched;
+          }
+        }
+      }
+
       // If this run already owns it and it's in_progress, return it (no self-409)
       if (
         current.assigneeAgentId === agentId &&

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1023,12 +1023,18 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary
- prevent lock recontamination when issue status/assignee mutation cancels stale queued or running heartbeat runs
- suppress deferred issue-execution wakeup promotion in issue mutation cancel paths
- only write `issues.executionRunId` lock metadata while the issue is still `in_progress`
- add regression tests for route-level stale-run cancellation and heartbeat deferred wakeup cleanup

## Validation
- pnpm test:run -- server/src/__tests__/issue-execution-lock-routes.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts
- pnpm test:run -- server/src/__tests__/issues-service.test.ts
- pnpm test:run -- server/src/__tests__/issue-execution-lock-routes.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/issues-service.test.ts

## Related
- CMP-263
- CMP-268
- CMP-276
