### PR TITLE
fix(a11y): proper checkbox semantics for Show terminated toggle

### DIFF
--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -165,6 +165,8 @@ export function Agents() {
             {filtersOpen && (
               <div className="absolute right-0 top-full mt-1 z-50 w-48 border border-border bg-popover shadow-md p-1">
                 <button
+                  role="checkbox"
+                  aria-checked={showTerminated}
                   className="flex items-center gap-2 w-full px-2 py-1.5 text-xs text-left hover:bg-accent/50 transition-colors"
                   onClick={() => setShowTerminated(!showTerminated)}
                 >


### PR DESCRIPTION
## Problem

On the Agents page, there is a "Show terminated" filter toggle that look like a checkbox (square with checkmark inside) but is actually a plain \`<button>\` element. Screen reader users hear "Show terminated, button" but they cannot tell:
- That it's a checkbox (toggle control)
- Whether it's currently checked or unchecked

The button visually show a checkmark when active, but this is only a visual indicator with no semantic meaning for assistive technology.

## What I changed

Added two ARIA attributes to the button:
- \`role="checkbox"\` - tell screen readers this is a checkbox control, not a regular button
- \`aria-checked={showTerminated}\` - announce whether the checkbox is checked or not

Now screen readers announce: "Show terminated, checkbox, not checked" or "Show terminated, checkbox, checked" which is the correct behavior for a toggle filter.

## How to test

1. Go to Agents page
2. Click the Filters button to open the dropdown
3. Use screen reader (VoiceOver Cmd+F5) and navigate to "Show terminated"
4. Should announce "Show terminated, checkbox, not checked"
5. Click it - should announce "Show terminated, checkbox, checked"

1 file, 2 lines added.