### PR TITLE
fix(adapter-utils): handle EPIPE on child process stdio streams

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -762,6 +762,10 @@ export async function runChildProcess(
         const startedAt = new Date().toISOString();
 
         if (opts.stdin != null && child.stdin) {
+          child.stdin.on("error", (err: NodeJS.ErrnoException) => {
+            // EPIPE / ECONNRESET when the child dies before we finish writing — non-fatal.
+            onLogError(err, runId, `stdin write error (${err.code})`);
+          });
           child.stdin.write(opts.stdin);
           child.stdin.end();
         }
@@ -791,6 +795,17 @@ export async function runChildProcess(
                 }, Math.max(1, opts.graceSec) * 1000);
               }, opts.timeoutSec * 1000)
             : null;
+
+        // Attach error handlers to stdout/stderr BEFORE data handlers.
+        // Without these, an EPIPE or ECONNRESET emitted on a stdio stream
+        // (e.g. when the child process dies unexpectedly) becomes an unhandled
+        // 'error' event that crashes the entire Node.js process.
+        child.stdout?.on("error", (err: NodeJS.ErrnoException) => {
+          onLogError(err, runId, `stdout stream error (${err.code})`);
+        });
+        child.stderr?.on("error", (err: NodeJS.ErrnoException) => {
+          onLogError(err, runId, `stderr stream error (${err.code})`);
+        });
 
         child.stdout?.on("data", (chunk: unknown) => {
           const text = String(chunk);


### PR DESCRIPTION
## Summary

- Add `.on("error")` handlers to `child.stdin`, `child.stdout`, and `child.stderr` in `runChildProcess()` (`packages/adapter-utils/src/server-utils.ts`)
- Errors are logged at warn level via the existing `onLogError` callback — non-fatal, no server crash
- Without these handlers, an EPIPE emitted when a child process dies unexpectedly becomes an unhandled exception that crashes the entire Paperclip server

Fixes #741

## Context

`runChildProcess()` handles `child.on("error")` (spawn failures) and `child.on("close")`, but the individual stdio **streams** (`stdin`, `stdout`, `stderr`) had no error listeners. When a child process dies (OOM, timeout, network drop), its stdio streams can emit `EPIPE` or `ECONNRESET`. Node.js treats unhandled `error` events on EventEmitters as uncaught exceptions and terminates the process.

This affects all adapters that use `runChildProcess()` — `claude_local`, `codex_local`, and any custom adapters.

## Reproduction

1. Start Paperclip with a `claude_local` agent
2. Let the agent's Claude CLI session run past its timeout (or kill the process manually)
3. The next heartbeat attempts to interact with the dead process's stdio
4. Server crashes with `Error: write EPIPE` at `node:internal/stream_base_commons`

## Test plan

- [ ] TypeScript compiles cleanly (`pnpm build` in `packages/adapter-utils`)
- [ ] Existing tests pass
- [ ] Manual: kill a running agent's Claude process mid-heartbeat — server should log a warning instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)