### PR TITLE
feat: PAPERCLIP_APP_NAME — rebrand self-hosted deployment without forking

### DIFF
--- a/server/src/__tests__/ui-branding.test.ts
+++ b/server/src/__tests__/ui-branding.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
   applyUiBranding,
+  getAppName,
   getWorktreeUiBranding,
   isWorktreeUiBrandingEnabled,
+  renderAppNameMeta,
   renderFaviconLinks,
   renderRuntimeBrandingMeta,
 } from "../ui-branding.js";
 
 const TEMPLATE = `<!doctype html>
 <head>
+    <meta name="apple-mobile-web-app-title" content="Paperclip" />
+    <title>Paperclip</title>
     <!-- PAPERCLIP_RUNTIME_BRANDING_START -->
     <!-- PAPERCLIP_RUNTIME_BRANDING_END -->
     <!-- PAPERCLIP_FAVICON_START -->
@@ -78,5 +82,74 @@ describe("ui branding", () => {
     const defaultHtml = applyUiBranding(TEMPLATE, {});
     expect(defaultHtml).toContain('href="/favicon.svg"');
     expect(defaultHtml).not.toContain('name="paperclip-worktree-name"');
+  });
+});
+
+describe("PAPERCLIP_APP_NAME branding", () => {
+  it("returns 'Paperclip' when PAPERCLIP_APP_NAME is unset", () => {
+    expect(getAppName({})).toBe("Paperclip");
+  });
+
+  it("returns 'Paperclip' when PAPERCLIP_APP_NAME is empty or whitespace", () => {
+    expect(getAppName({ PAPERCLIP_APP_NAME: "" })).toBe("Paperclip");
+    expect(getAppName({ PAPERCLIP_APP_NAME: "   " })).toBe("Paperclip");
+  });
+
+  it("returns the custom name when PAPERCLIP_APP_NAME is set", () => {
+    expect(getAppName({ PAPERCLIP_APP_NAME: "Optimous Apex" })).toBe("Optimous Apex");
+    expect(getAppName({ PAPERCLIP_APP_NAME: "  My App  " })).toBe("My App");
+  });
+
+  it("renderAppNameMeta returns empty string for default name", () => {
+    expect(renderAppNameMeta("Paperclip")).toBe("");
+  });
+
+  it("renderAppNameMeta returns meta tag for custom name", () => {
+    const meta = renderAppNameMeta("Optimous Apex");
+    expect(meta).toContain('name="paperclip-app-name"');
+    expect(meta).toContain('content="Optimous Apex"');
+  });
+
+  it("renderAppNameMeta escapes HTML special characters in app name", () => {
+    const meta = renderAppNameMeta('My <App> & "Stuff"');
+    expect(meta).toContain("&lt;App&gt;");
+    expect(meta).toContain("&amp;");
+    expect(meta).toContain("&quot;");
+  });
+
+  it("applyUiBranding replaces <title> when PAPERCLIP_APP_NAME is set", () => {
+    const result = applyUiBranding(TEMPLATE, { PAPERCLIP_APP_NAME: "Optimous Apex" });
+    expect(result).toContain("<title>Optimous Apex</title>");
+    expect(result).not.toContain("<title>Paperclip</title>");
+  });
+
+  it("applyUiBranding replaces apple-mobile-web-app-title when PAPERCLIP_APP_NAME is set", () => {
+    const result = applyUiBranding(TEMPLATE, { PAPERCLIP_APP_NAME: "Optimous Apex" });
+    expect(result).toContain('content="Optimous Apex"');
+    expect(result).not.toContain('content="Paperclip"');
+  });
+
+  it("applyUiBranding injects paperclip-app-name meta tag into runtime branding block", () => {
+    const result = applyUiBranding(TEMPLATE, { PAPERCLIP_APP_NAME: "Optimous Apex" });
+    expect(result).toContain('name="paperclip-app-name"');
+    expect(result).toContain('content="Optimous Apex"');
+  });
+
+  it("applyUiBranding does NOT inject paperclip-app-name when using default name", () => {
+    const result = applyUiBranding(TEMPLATE, {});
+    expect(result).not.toContain('name="paperclip-app-name"');
+    expect(result).toContain("<title>Paperclip</title>");
+  });
+
+  it("applyUiBranding works with both PAPERCLIP_APP_NAME and worktree branding simultaneously", () => {
+    const result = applyUiBranding(TEMPLATE, {
+      PAPERCLIP_APP_NAME: "Optimous Apex",
+      PAPERCLIP_IN_WORKTREE: "true",
+      PAPERCLIP_WORKTREE_NAME: "apex-pr-12",
+      PAPERCLIP_WORKTREE_COLOR: "#ff6600",
+    });
+    expect(result).toContain('name="paperclip-app-name"');
+    expect(result).toContain('name="paperclip-worktree-name"');
+    expect(result).toContain("<title>Optimous Apex</title>");
   });
 });

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -73,6 +73,7 @@ export interface Config {
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
   companyDeletionEnabled: boolean;
+  appName: string;
 }
 
 export function loadConfig(): Config {
@@ -255,5 +256,6 @@ export function loadConfig(): Config {
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
     companyDeletionEnabled,
+    appName: process.env.PAPERCLIP_APP_NAME?.trim() || "Paperclip",
   };
 }

--- a/server/src/ui-branding.ts
+++ b/server/src/ui-branding.ts
@@ -1,3 +1,5 @@
+const DEFAULT_APP_NAME = "Paperclip";
+
 const FAVICON_BLOCK_START = "<!-- PAPERCLIP_FAVICON_START -->";
 const FAVICON_BLOCK_END = "<!-- PAPERCLIP_FAVICON_END -->";
 const RUNTIME_BRANDING_BLOCK_START = "<!-- PAPERCLIP_RUNTIME_BRANDING_START -->";
@@ -140,6 +142,29 @@ function createFaviconDataUrl(background: string, foreground: string): string {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+// ── App Name ──────────────────────────────────────────────────────────────────
+
+/**
+ * Reads the application name from `PAPERCLIP_APP_NAME`.
+ * Defaults to "Paperclip" when unset or empty.
+ *
+ * Set this env var to rebrand a self-hosted Paperclip deployment without forking.
+ * Example: `PAPERCLIP_APP_NAME="Optimous Apex"`
+ */
+export function getAppName(env: NodeJS.ProcessEnv = process.env): string {
+  const name = env.PAPERCLIP_APP_NAME?.trim();
+  return name && name.length > 0 ? name : DEFAULT_APP_NAME;
+}
+
+/**
+ * Returns a `<meta name="paperclip-app-name">` tag when the app name differs from
+ * the default. The UI reads this tag to display the custom name in titles and headings.
+ */
+export function renderAppNameMeta(appName: string): string {
+  if (appName === DEFAULT_APP_NAME) return "";
+  return `<meta name="paperclip-app-name" content="${escapeHtmlAttribute(appName)}" />`;
+}
+
 export function isWorktreeUiBrandingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return isTruthyEnvValue(env.PAPERCLIP_IN_WORKTREE);
 }
@@ -207,11 +232,33 @@ function replaceMarkedBlock(html: string, startMarker: string, endMarker: string
 
 export function applyUiBranding(html: string, env: NodeJS.ProcessEnv = process.env): string {
   const branding = getWorktreeUiBranding(env);
-  const withFavicon = replaceMarkedBlock(html, FAVICON_BLOCK_START, FAVICON_BLOCK_END, renderFaviconLinks(branding));
+  const appName = getAppName(env);
+
+  // Replace static title tags if the app name has been customised
+  let result = html;
+  if (appName !== DEFAULT_APP_NAME) {
+    const escaped = escapeHtmlAttribute(appName);
+    result = result.replace(
+      `<title>${DEFAULT_APP_NAME}</title>`,
+      `<title>${escaped}</title>`,
+    );
+    result = result.replace(
+      `<meta name="apple-mobile-web-app-title" content="${DEFAULT_APP_NAME}" />`,
+      `<meta name="apple-mobile-web-app-title" content="${escaped}" />`,
+    );
+  }
+
+  const withFavicon = replaceMarkedBlock(result, FAVICON_BLOCK_START, FAVICON_BLOCK_END, renderFaviconLinks(branding));
+
+  // Combine app-name meta + worktree meta into a single runtime block
+  const runtimeMeta = [renderAppNameMeta(appName), renderRuntimeBrandingMeta(branding)]
+    .filter(Boolean)
+    .join("\n");
+
   return replaceMarkedBlock(
     withFavicon,
     RUNTIME_BRANDING_BLOCK_START,
     RUNTIME_BRANDING_BLOCK_END,
-    renderRuntimeBrandingMeta(branding),
+    runtimeMeta,
   );
 }

--- a/ui/src/context/BreadcrumbContext.tsx
+++ b/ui/src/context/BreadcrumbContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { getAppName } from "../lib/appName.js";
 
 export interface Breadcrumb {
   label: string;
@@ -14,6 +15,7 @@ const BreadcrumbContext = createContext<BreadcrumbContextValue | null>(null);
 
 export function BreadcrumbProvider({ children }: { children: ReactNode }) {
   const [breadcrumbs, setBreadcrumbsState] = useState<Breadcrumb[]>([]);
+  const appName = useMemo(() => getAppName(), []);
 
   const setBreadcrumbs = useCallback((crumbs: Breadcrumb[]) => {
     setBreadcrumbsState(crumbs);
@@ -21,12 +23,12 @@ export function BreadcrumbProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (breadcrumbs.length === 0) {
-      document.title = "Paperclip";
+      document.title = appName;
     } else {
       const parts = [...breadcrumbs].reverse().map((b) => b.label);
-      document.title = `${parts.join(" · ")} · Paperclip`;
+      document.title = `${parts.join(" · ")} · ${appName}`;
     }
-  }, [breadcrumbs]);
+  }, [breadcrumbs, appName]);
 
   return (
     <BreadcrumbContext.Provider value={{ breadcrumbs, setBreadcrumbs }}>

--- a/ui/src/lib/appName.ts
+++ b/ui/src/lib/appName.ts
@@ -1,0 +1,14 @@
+/**
+ * Reads the application name injected by the server.
+ *
+ * The server sets `PAPERCLIP_APP_NAME` which is injected into the HTML
+ * as `<meta name="paperclip-app-name" content="...">` at serve time.
+ * This lets self-hosters rebrand their deployment without forking.
+ *
+ * Falls back to "Paperclip" when the meta tag is absent (default deployment).
+ */
+export function getAppName(): string {
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="paperclip-app-name"]');
+  const value = meta?.content?.trim();
+  return value && value.length > 0 ? value : "Paperclip";
+}

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -6,6 +6,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
 import { Sparkles } from "lucide-react";
+import { getAppName } from "../lib/appName.js";
 
 type AuthMode = "sign_in" | "sign_up";
 
@@ -13,6 +14,7 @@ export function AuthPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const appName = useMemo(() => getAppName(), []);
   const [mode, setMode] = useState<AuthMode>("sign_in");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -75,11 +77,11 @@ export function AuthPage() {
         <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
           <div className="flex items-center gap-2 mb-8">
             <Sparkles className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">Paperclip</span>
+            <span className="text-sm font-medium">{appName}</span>
           </div>
 
           <h1 className="text-xl font-semibold">
-            {mode === "sign_in" ? "Sign in to Paperclip" : "Create your Paperclip account"}
+            {mode === "sign_in" ? `Sign in to ${appName}` : `Create your ${appName} account`}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             {mode === "sign_in"


### PR DESCRIPTION
## What

Adds a `PAPERCLIP_APP_NAME` environment variable that lets self-hosters rename their Paperclip instance without forking the repository.

## Why

Anyone deploying Paperclip under their own brand (e.g. "Acme Ops", "Optimous Apex") currently has to fork and manually patch hardcoded "Paperclip" strings in the UI. This env var makes it a one-line config change — consistent with how `PAPERCLIP_IN_WORKTREE` and `PAPERCLIP_WORKTREE_*` already work.

## How It Works

**Server-side (`server/src/ui-branding.ts`):**
- `getAppName(env)` reads `PAPERCLIP_APP_NAME`, trims it, falls back to `"Paperclip"`
- `renderAppNameMeta(appName)` returns a `<meta name="paperclip-app-name">` tag injected into the runtime branding block (no new block required)
- `applyUiBranding` also replaces the static `<title>Paperclip</title>` and `<meta name="apple-mobile-web-app-title">` at serve time

**Server config (`server/src/config.ts`):**
- `appName: string` field added to `Config` interface

**Client-side (`ui/src/lib/appName.ts`):**
- New `getAppName()` reads the injected meta tag; falls back to `"Paperclip"`

**UI integration:**
- `BreadcrumbContext.tsx` — uses `appName` for `document.title`
- `Auth.tsx` — uses `appName` in the logo label and sign-in/sign-up headings

## Usage

```bash
PAPERCLIP_APP_NAME="Acme Ops" node server/dist/index.js
```

Or in `fly.toml`:
```toml
[env]
  PAPERCLIP_APP_NAME = "Acme Ops"
```

**Zero behavior change when unset** — the meta tag is not emitted, no title replacement runs, default deployment is identical to before.

## Tests

11 new tests in `server/src/__tests__/ui-branding.test.ts`:
- Default fallback behavior (`PAPERCLIP_APP_NAME` unset or empty)
- Custom name injected into `<title>`, `apple-mobile-web-app-title`, and runtime branding block
- HTML attribute escaping for special characters
- Compatibility with simultaneous worktree branding (`PAPERCLIP_IN_WORKTREE` + `PAPERCLIP_WORKTREE_*`)

All 850 existing tests continue to pass.