### PR TITLE
feat(ui): make agent name clickable in dashboard active agents panel

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -108,7 +108,9 @@ function AgentRunCard({
               ) : (
                 <span className="inline-flex h-2.5 w-2.5 rounded-full bg-muted-foreground/35" />
               )}
-              <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
+              <Link to={`/agents/${run.agentId}`} className="no-underline text-inherit hover:text-foreground transition-colors">
+                <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
+              </Link>
             </div>
             <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
               <span>{isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}</span>


### PR DESCRIPTION
## Problem

In the Dashboard "Active Agents" panel, each card show an agent name and a small external link icon button. But the agent name itself was just text - not clickable. Only the tiny icon button on the right side navigate to the run detail page.

Most of the time when I see an active agent on the dashboard, I want to go to the agent overview page to check its status, config, or other runs. But I have to click the small icon (which go to a specific run, not the agent page) or manually navigate through the sidebar. The agent name sitting right there but doing nothing is misleading.

## What I changed

Wrapped the \`Identity\` component (agent name display) in a \`Link\` to \`/agents/{agentId}\`. Now clicking the agent name navigate to the agent detail page.

The existing external link icon button still navigate to the specific run detail page (\`/agents/{agentId}/runs/{runId}\`) for when user need to see that particular run.

So now there are two navigation targets on each card:
- **Agent name** -> agent detail page (new)
- **External link icon** -> specific run detail (existing)

## How to test

1. Go to Dashboard
2. Look at the Active Agents panel (need at least one agent with recent runs)
3. Click on the agent name text - should navigate to the agent detail page
4. Click on the small link icon - should navigate to the specific run

1 file, 3 lines added.