### PR TITLE
fix(server): call unref() on background setInterval timers to allow clean process exit

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -574,7 +574,7 @@ export async function startServer(): Promise<StartedServer> {
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");
       });
-    setInterval(() => {
+    const timerInterval = setInterval(() => {
       void heartbeat
         .tickTimers(new Date())
         .then((result) => {
@@ -606,6 +606,7 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
     }, config.heartbeatSchedulerIntervalMs);
+    if (timerInterval.unref) timerInterval.unref();
   }
   
   if (config.databaseBackupEnabled) {
@@ -651,9 +652,10 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Automatic database backups enabled",
     );
-    setInterval(() => {
+    const backupInterval = setInterval(() => {
       void runScheduledBackup();
     }, backupIntervalMs);
+    if (backupInterval.unref) backupInterval.unref();
   }
   
   await new Promise<void>((resolveListen, rejectListen) => {

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -197,6 +197,7 @@ export function setupLiveEventsWebSocketServer(
       socket.ping();
     }
   }, 30000);
+  if (pingInterval.unref) pingInterval.unref();
 
   wss.on("connection", (socket: WsSocket, req: IncomingMessage) => {
     const context = (req as IncomingMessageWithContext).paperclipUpgradeContext;

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -698,6 +698,7 @@ export function createPluginJobScheduler(
     tickTimer = setInterval(() => {
       void tick();
     }, tickIntervalMs);
+    if (tickTimer.unref) tickTimer.unref();
 
     log.info(
       { tickIntervalMs, maxConcurrentJobs },

--- a/server/src/services/plugin-log-retention.ts
+++ b/server/src/services/plugin-log-retention.ts
@@ -76,6 +76,7 @@ export function startPluginLogRetention(
       logger.warn({ err }, "Plugin log retention sweep failed");
     });
   }, intervalMs);
+  if (timer.unref) timer.unref();
 
   // Run once immediately on startup
   prunePluginLogs(db, retentionDays).catch((err) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, running as a long-lived Node.js server process
> - The server registers several background `setInterval` loops for housekeeping: heartbeat ticks, scheduled database backups, plugin job scheduling, and WebSocket keep-alive pings
> - For clean shutdown — whether during integration-test teardown or when embedding the server programmatically — Node.js needs the event loop to drain once all primary handles (HTTP server, DB connections) are closed
> - However, active `setInterval` timers are ref'd by default, which keeps the event loop alive indefinitely even after the server closes
> - This means the process hangs on exit, breaking test runners and any programmatic embedding that expects graceful shutdown
> - Calling `.unref()` on these background timers tells Node.js they should not, by themselves, keep the process alive
> - This pull request adds `.unref()` to the four long-running `setInterval` calls so the process can exit cleanly once primary work is done
> - The benefit is cleaner test-runner hygiene, faster developer feedback loops, and correct behavior when the server is embedded as a library

## What Changed

- Added `.unref()` to the heartbeat tick `setInterval` in the server bootstrap
- Added `.unref()` to the `runScheduledBackup` interval
- Added `.unref()` to the `plugin_job_scheduler` interval
- Added `.unref()` to the WebSocket (`live-events-ws`) ping interval

## Verification

- Start the Paperclip server, then call `server.close()` programmatically — the process should exit without hanging
- Run the integration test suite (`yarn test` / `npm test`) — the Jest/Vitest process should terminate on its own after tests complete
- Verify background tasks (heartbeat, backup, plugin scheduler, WS ping) still fire normally during regular server operation, since `.unref()` only affects shutdown behavior

## Risks

- **Low risk overall.** `.unref()` does not cancel or alter timer execution — it only tells Node.js not to keep the event loop alive solely for that timer.
- If the process exits while a database backup is in flight, the in-progress backup file could be left in a partial state. This is a pre-existing risk not introduced by this change; a proper `SIGTERM` handler with graceful drain would be the longer-term fix.

## Model Used

- **Provider:** Anthropic Claude
- **Model ID:** claude-opus-4-6 (Opus 4.6)
- **Context:** 200K tokens
- **Capabilities:** Extended thinking, tool use, code execution
- **Tooling:** Refactored via [0-editor](https://github.com/0-protocol/0-editor)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting re-review