### PR TITLE
fix(plugin-host): use dns.resolve4 to avoid OS resolver false-positives on Windows

### DIFF
--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -28,7 +28,7 @@ import { pluginStateStore } from "./plugin-state-store.js";
 import { createPluginSecretsHandler } from "./plugin-secrets-handler.js";
 import { logActivity } from "./activity-log.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
-import { lookup as dnsLookup } from "node:dns/promises";
+import { lookup as dnsLookup, resolve4 as dnsResolve4 } from "node:dns/promises";
 import type { IncomingMessage, RequestOptions as HttpRequestOptions } from "node:http";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
@@ -128,7 +128,22 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
 
   // Race the DNS lookup against a timeout to prevent indefinite hangs
   // when DNS is misconfigured or unresponsive.
-  const dnsPromise = dnsLookup(originalHostname, { all: true });
+  //
+  // Use dns.resolve4 (c-ares, queries DNS server directly) as the primary
+  // resolver because dns.lookup / getaddrinfo can return incorrect results on
+  // Windows hosts running Docker Desktop or VPN software that intercept OS-level
+  // name resolution and may return private/internal IP addresses for public
+  // hostnames. dns.resolve4 bypasses the OS resolver cache and those shims.
+  // Fall back to dns.lookup if resolve4 fails (e.g. IPv6-only hosts).
+  const dnsPromise = dnsResolve4(originalHostname)
+    .then((addrs): Array<{ address: string }> => addrs.map(addr => ({ address: addr })))
+    .catch((resolve4Err: unknown) => {
+      logger.debug(
+        { hostname: originalHostname, err: resolve4Err },
+        "dns.resolve4 failed, falling back to dns.lookup",
+      );
+      return dnsLookup(originalHostname, { all: true });
+    });
   const timeoutPromise = new Promise<never>((_, reject) => {
     setTimeout(
       () => reject(new Error(`DNS lookup timed out after ${DNS_LOOKUP_TIMEOUT_MS}ms for ${originalHostname}`)),


### PR DESCRIPTION
## Thinking Path

> - Paperclip plugins use `ctx.http.fetch` which goes through the plugin-host SSRF guard
> - The SSRF guard calls `dns.lookup()` (libuv/getaddrinfo) to resolve hostnames before checking for private IPs
> - On Windows hosts running Docker Desktop or VPN software, `dns.lookup()` can return private/internal IPs for public hostnames like `api.telegram.org`
> - Docker's network bridge shims and VPN split-DNS tunnels intercept OS-level name resolution
> - This causes the SSRF filter to reject legitimate outbound plugin requests with a false positive
> - `dns.resolve4()` uses Node's c-ares client which queries the DNS server directly, bypassing OS resolver caches and those shims
> - So switching to `dns.resolve4()` (with `dns.lookup()` as a fallback) fixes the false positive

## What

Switch the SSRF DNS resolution in `plugin-host-services.ts` from `dns.lookup()` to `dns.resolve4()` as the primary resolver, with `dns.lookup()` as a fallback for IPv6-only hosts and atypical network configurations.

## Why

On Windows hosts running **Docker Desktop** or **VPN software**, `dns.lookup()` (which delegates to the OS resolver via libuv `getaddrinfo`) can return private/internal IP addresses for public hostnames such as `api.telegram.org`. Docker's network bridge shims and VPN split-DNS tunnels intercept OS-level name resolution, causing the SSRF private-IP filter to incorrectly reject outbound plugin requests with:

```
All resolved IPs for api.telegram.org are in private/reserved ranges
```

`dns.resolve4()` uses Node's c-ares DNS client, which queries the configured DNS server **directly**, bypassing the OS resolver cache and those shims. This produces correct public IPs for public hostnames.

This was specifically observed with the `paperclip-plugin-telegram` plugin failing on Windows with Docker Desktop.

## How to verify

1. On a Windows host with Docker Desktop running (or any VPN), install `paperclip-plugin-telegram` and attempt to send a message — it should succeed without the SSRF private-IP rejection error.
2. Unit test: the logic is a simple `.catch()` fallback — `dns.resolve4()` is tried first, and if it throws (e.g., on an IPv6-only host), `dns.lookup()` is used instead.

## Risks

- **IPv6 hosts**: `dns.resolve4()` will fail on IPv6-only hosts (no A records). The fallback to `dns.lookup()` handles this case.
- **Split-horizon DNS** where private IPs are legitimately expected for public names: the fallback would re-introduce the false-positive, but this is an edge case acceptable for a security-guard context where public hostnames genuinely resolving to private IPs is already suspicious.
- Change is minimal (1 file, ~11 lines).