### PR TITLE
fix: extra args field mangles comma-separated values during typing

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -831,7 +831,6 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       ? set!({ extraArgs: v })
                       : mark("adapterConfig", "extraArgs", v ? parseCommaArgs(v) : undefined)
                   }
-                  immediate
                   className={inputClass}
                   placeholder="e.g. --verbose, --foo=bar"
                 />


### PR DESCRIPTION
### Thinking Path

- Paperclip manages AI agent configuration via `AgentConfigForm`
- Agents can be given extra CLI args via a comma-separated input field
- `DraftInput` with `immediate` mode commits on every keystroke
- The `parseCommaArgs` → `formatArgList` round-trip resets the draft via `useEffect`, corrupting mid-edit input
- Removing `immediate` defers parsing to blur, fixing the corruption
- This matches how all other transformed fields in the form already behave

### What changed

Removed the `immediate` prop from the Extra args `DraftInput` so the value is only parsed on blur instead of every keystroke.

### Note

Upon further investigation, the bug only affects **typing** into the field character by character — the round-trip reformats on each keystroke and corrupts the value. **Copy-pasting** works fine on master since it's a single input event. Still worth fixing since users who type args manually (or edit an existing value) will hit the corruption.

### Test plan

- [ ] Go to any agent's Configuration tab
- [ ] **Type** comma-separated args character by character in the "Extra args" field (e.g. `--verbose, --foo=bar`)
- [ ] Click elsewhere to blur, then Save
- [ ] Verify via API that `adapterConfig.extraArgs` is a properly split array (not a mangled single string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Before
trying to type in a comma -> will not appear
copy paste into element -> i guess this works out
![dunder-extra-args-before](https://github.com/user-attachments/assets/1a1b37d3-ce25-4998-972e-c98d3d382a33)

### After
typing works and copy paste works as well
![dunder-extra-args-after](https://github.com/user-attachments/assets/1aad368d-e5d8-4c37-9ab3-8f72470bdfbc)




