### PR TITLE
fix(ui): horizontal scroll for wide markdown tables on mobile

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -692,6 +692,8 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
 
 .paperclip-markdown table {
   width: 100%;
+  display: block;
+  overflow-x: auto;
 }
 
 .paperclip-markdown th {


### PR DESCRIPTION
## Problem

When markdown content have a table with many columns, on mobile or narrow browser window the table overflow the content area and break the page layout. The table just extend past the edge of the container with no way to scroll to see the hidden columns.

Mermaid diagrams already have this protection (line 708: \`.paperclip-mermaid { overflow-x: auto }\`) but tables was missing it. We also added \`overflow-x-auto\` to the main MarkdownBody container in earlier PR, but that make the entire content scroll together. Individual tables should scroll independently.

## What I changed

Added two CSS properties to \`.paperclip-markdown table\`:

- \`display: block\` - needed because \`overflow-x\` properties don't work on elements with \`display: table\` (the browser default for \`<table>\`). This change from table to block display while keeping all the table children rendering normally.
- \`overflow-x: auto\` - show horizontal scrollbar when table is wider than container

## How to test

1. Open any issue or agent with markdown containing a wide table (6+ columns)
2. Resize browser to narrow width or view on mobile
3. The table should now scroll horizontally within its container instead of overflowing the page

Example markdown to test:

\`\`\`
| Col 1 | Col 2 | Col 3 | Col 4 | Col 5 | Col 6 | Col 7 | Col 8 |
|-------|-------|-------|-------|-------|-------|-------|-------|
| data  | data  | data  | data  | data  | data  | data  | data  |
\`\`\`

1 file, 2 lines added.