### PR TITLE
fix(ui): show JSON validation error on payload template field

### DIFF
--- a/ui/src/adapters/runtime-json-fields.tsx
+++ b/ui/src/adapters/runtime-json-fields.tsx
@@ -89,6 +89,18 @@ export function RuntimeServicesJsonField({
   );
 }
 
+function jsonError(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return "Must be a JSON object";
+    return null;
+  } catch (e) {
+    return e instanceof SyntaxError ? e.message : "Invalid JSON";
+  }
+}
+
 export function PayloadTemplateJsonField({
   isCreate,
   values,
@@ -104,11 +116,12 @@ export function PayloadTemplateJsonField({
   }, [existing, isCreate]);
 
   const value = isCreate ? values?.payloadTemplateJson ?? "" : draft;
+  const error = jsonError(value);
 
   return (
     <Field label="Payload template JSON" hint={help.payloadTemplateJson}>
       <textarea
-        className={`${inputClass} min-h-[132px]`}
+        className={`${inputClass} min-h-[132px] ${error ? "border-destructive" : ""}`}
         value={value}
         onChange={(e) => {
           const next = e.target.value;
@@ -116,7 +129,9 @@ export function PayloadTemplateJsonField({
           updateJsonConfig(isCreate, "payloadTemplateJson", next, set, mark, "payloadTemplate");
         }}
         placeholder={`{\n  "agentId": "remote-agent-123",\n  "metadata": {\n    "team": "platform"\n  }\n}`}
+        aria-invalid={!!error}
       />
+      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
     </Field>
   );
 }


### PR DESCRIPTION
## Problem

The Payload Template JSON textarea in agent adapter config silently reject invalid JSON. When user type broken JSON like missing a comma or a closing brace, the input just keep the local draft but never actually save the value. There is zero feedback - no red border, no error message, nothing. The comment in code say "Keep local draft until JSON is valid" but user don't know this is happening.

I spent 10 minutes once trying to figure out why my payload template was not saving. Turns out I had a syntax error in the JSON and the field was just ignoring my input without telling me.

## What I changed

Added a \`jsonError()\` helper function that validate the input in real time:
- Check JSON.parse() syntax - show the browser's native parse error message which is usually helpful (like "Expected property name at position 42")
- Check that parsed result is an object (not array or primitive)
- Return null when input is empty or valid

Then in the component:
- Red border (\`border-destructive\`) on textarea when invalid
- Error message below textarea showing the exact parse error
- \`aria-invalid\` attribute for screen readers
- Everything clear instantly when user fix the JSON

## How to test

1. Go to any agent config > find Payload Template JSON field
2. Type invalid JSON like \`{ "key": }\`
3. Should see red border and error message like "Expected property name or '}'"
4. Fix the JSON to valid \`{ "key": "value" }\`
5. Red border and error disappear immediately

1 file, 16 lines added.