### PR TITLE
feat(adapter): add GitHub Copilot (GitHub Models API) adapter

### DIFF
--- a/packages/adapters/copilot-local/package.json
+++ b/packages/adapters/copilot-local/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@paperclipai/adapter-copilot-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/copilot-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/copilot-local/src/README.md
+++ b/packages/adapters/copilot-local/src/README.md
@@ -1,0 +1,47 @@
+# GitHub Copilot Adapter for Paperclip
+
+Use GitHub Models API with your GitHub Copilot subscription.
+
+## Setup
+1. Set GITHUB_TOKEN environment variable (same token as `gh auth`)
+2. Select "GitHub Copilot" in your agent's adapter settings
+3. Choose from GPT-4o, Claude 3.5 Sonnet, and other GitHub-available models
+
+## Authentication
+Uses GITHUB_TOKEN — the same Personal Access Token used by `gh` CLI.
+GitHub Copilot subscribers get access to models at $0 per token.
+
+To get your token:
+```bash
+gh auth token
+```
+
+Or create a Personal Access Token at https://github.com/settings/tokens with `models:read` scope (if required).
+
+## Available Models
+- `gpt-4o` (OpenAI) — Best overall (default)
+- `gpt-4o-mini` (OpenAI) — Fast and economical
+- `claude-3-5-sonnet` (Anthropic) — Best for reasoning
+- `claude-3-5-haiku` (Anthropic) — Fast Claude
+- `llama-3.3-70b-instruct` (Meta) — Open source
+- `mistral-large` (Mistral) — Strong European model
+
+## Adapter Configuration
+
+```json
+{
+  "adapterType": "copilot_local",
+  "model": "gpt-4o",
+  "promptTemplate": "You are agent {{agent.id}}. {{context.wakeReason}}",
+  "maxTokens": 4096,
+  "timeoutSec": 120,
+  "env": {
+    "GITHUB_TOKEN": "ghp_..."
+  }
+}
+```
+
+## API
+Uses the GitHub Models API (OpenAI-compatible) at `https://models.inference.ai.azure.com`.
+
+See: https://docs.github.com/en/github-models

--- a/packages/adapters/copilot-local/src/index.ts
+++ b/packages/adapters/copilot-local/src/index.ts
@@ -1,0 +1,39 @@
+import { GITHUB_MODELS, DEFAULT_GITHUB_MODEL } from "./models.js";
+
+export { DEFAULT_GITHUB_MODEL };
+
+export const type = "copilot_local";
+export const label = "GitHub Copilot";
+
+export const models: Array<{ id: string; label: string }> = GITHUB_MODELS.map(({ id, label }) => ({
+  id,
+  label,
+}));
+
+export const agentConfigurationDoc = `# copilot_local agent configuration
+
+Adapter: copilot_local
+
+Use when:
+- You have a GitHub Copilot subscription and want to use GitHub Models API
+- You want access to GPT-4o, Claude 3.5 Sonnet, and other models at $0 per token
+- You have a GITHUB_TOKEN environment variable set
+
+Don't use when:
+- You don't have a GitHub Copilot subscription
+- You need a local agentic coding assistant (use claude_local, codex_local, etc.)
+- You need tool/function calling with an agentic loop
+
+Core fields:
+- model (string, optional): GitHub Models model id (default: gpt-4o)
+  Available: gpt-4o, gpt-4o-mini, claude-3-5-sonnet, claude-3-5-haiku, llama-3.3-70b-instruct, mistral-large
+- promptTemplate (string, optional): user prompt template; supports {{agent.id}}, {{agent.name}}, {{runId}}, {{context.*}}
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file injected as system prompt
+- maxTokens (number, optional): maximum tokens to generate (default: 4096)
+- timeoutSec (number, optional): request timeout in seconds (default: 120)
+- env (object, optional): KEY=VALUE environment variables; GITHUB_TOKEN can be set here or in host env
+
+Auth fields:
+- env.GITHUB_TOKEN (string): GitHub Personal Access Token with Copilot access
+  Can also be set as GITHUB_TOKEN in the server host environment.
+`;

--- a/packages/adapters/copilot-local/src/models.ts
+++ b/packages/adapters/copilot-local/src/models.ts
@@ -1,0 +1,10 @@
+export const GITHUB_MODELS = [
+  { id: "gpt-4o", label: "GPT-4o", provider: "openai", contextLength: 128000 },
+  { id: "gpt-4o-mini", label: "GPT-4o Mini", provider: "openai", contextLength: 128000 },
+  { id: "claude-3-5-sonnet", label: "Claude 3.5 Sonnet", provider: "anthropic", contextLength: 200000 },
+  { id: "claude-3-5-haiku", label: "Claude 3.5 Haiku", provider: "anthropic", contextLength: 200000 },
+  { id: "llama-3.3-70b-instruct", label: "Llama 3.3 70B", provider: "meta", contextLength: 128000 },
+  { id: "mistral-large", label: "Mistral Large", provider: "mistral", contextLength: 128000 },
+];
+
+export const DEFAULT_GITHUB_MODEL = "gpt-4o";

--- a/packages/adapters/copilot-local/src/server/execute.ts
+++ b/packages/adapters/copilot-local/src/server/execute.ts
@@ -1,0 +1,262 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  parseObject,
+  renderTemplate,
+  joinPromptSections,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_GITHUB_MODEL } from "../models.js";
+
+const GITHUB_MODELS_API = "https://models.inference.ai.azure.com";
+
+interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+interface ChatCompletionChunk {
+  choices?: Array<{
+    delta?: {
+      content?: string | null;
+    };
+    finish_reason?: string | null;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}
+
+function resolveGithubToken(
+  configEnv: Record<string, unknown>,
+  adapterEnv: Record<string, string | undefined>,
+): string {
+  const fromConfig =
+    typeof configEnv.GITHUB_TOKEN === "string" && configEnv.GITHUB_TOKEN.trim().length > 0
+      ? configEnv.GITHUB_TOKEN.trim()
+      : null;
+  const fromProcess =
+    typeof adapterEnv.GITHUB_TOKEN === "string" && adapterEnv.GITHUB_TOKEN.trim().length > 0
+      ? adapterEnv.GITHUB_TOKEN.trim()
+      : null;
+  return fromConfig ?? fromProcess ?? "";
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, config, context, onLog, onMeta } = ctx;
+
+  const configEnv = parseObject(config.env);
+  const githubToken = resolveGithubToken(configEnv, process.env as Record<string, string | undefined>);
+
+  if (!githubToken) {
+    await onLog(
+      "stderr",
+      "[copilot-local] GITHUB_TOKEN is not set. Set it in adapter env or server host environment.\n",
+    );
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: "GITHUB_TOKEN is not configured",
+      errorCode: "missing_github_token",
+      billingType: "subscription",
+      biller: "github",
+    };
+  }
+
+  const model = asString(config.model, DEFAULT_GITHUB_MODEL).trim() || DEFAULT_GITHUB_MODEL;
+  const maxTokens = asNumber(config.maxTokens, 4096);
+  const timeoutSec = asNumber(config.timeoutSec, 120);
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+
+  // Build prompt from template + context
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). {{context.wakeReason}}",
+  );
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const userPrompt = joinPromptSections([sessionHandoffNote, renderedPrompt]);
+
+  // Build messages
+  const messages: ChatMessage[] = [];
+
+  // System prompt from instructions file or default
+  let systemPrompt: string | null = null;
+  if (instructionsFilePath) {
+    try {
+      const { promises: fs } = await import("node:fs");
+      systemPrompt = await fs.readFile(instructionsFilePath, "utf-8");
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[copilot-local] Could not read instructions file "${instructionsFilePath}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+  if (systemPrompt) {
+    messages.push({ role: "system", content: systemPrompt });
+  }
+  messages.push({ role: "user", content: userPrompt });
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "copilot_local",
+      command: `POST ${GITHUB_MODELS_API}/chat/completions`,
+      prompt: userPrompt,
+      promptMetrics: { promptChars: userPrompt.length },
+      context: { model, maxTokens },
+    });
+  }
+
+  await onLog("stdout", `[copilot-local] Starting chat completion with model: ${model}\n`);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSec * 1000);
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let fullOutput = "";
+  let timedOut = false;
+
+  try {
+    const response = await fetch(`${GITHUB_MODELS_API}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        max_tokens: maxTokens,
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      await onLog(
+        "stderr",
+        `[copilot-local] API request failed with status ${response.status}: ${errorBody}\n`,
+      );
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `GitHub Models API returned HTTP ${response.status}`,
+        errorCode: "api_error",
+        billingType: "subscription",
+        biller: "github",
+      };
+    }
+
+    const body = response.body;
+    if (!body) {
+      throw new Error("Response body is null");
+    }
+
+    // Parse SSE stream
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data: ")) continue;
+        const data = trimmed.slice("data: ".length);
+        if (data === "[DONE]") continue;
+
+        try {
+          const chunk = JSON.parse(data) as ChatCompletionChunk;
+
+          // Accumulate usage from the final usage chunk
+          if (chunk.usage) {
+            inputTokens = chunk.usage.prompt_tokens ?? inputTokens;
+            outputTokens = chunk.usage.completion_tokens ?? outputTokens;
+          }
+
+          const delta = chunk.choices?.[0]?.delta?.content;
+          if (delta) {
+            fullOutput += delta;
+            await onLog("stdout", delta);
+          }
+        } catch {
+          // Skip unparseable chunks
+        }
+      }
+    }
+
+    // Flush decoder
+    const remaining = decoder.decode();
+    if (remaining) {
+      buffer += remaining;
+    }
+
+    await onLog("stdout", "\n");
+
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      billingType: "subscription",
+      biller: "github",
+      provider: "github",
+      model,
+      usage:
+        inputTokens > 0 || outputTokens > 0
+          ? { inputTokens, outputTokens }
+          : undefined,
+      summary: fullOutput.slice(0, 500).replace(/\s+/g, " ").trim() || null,
+    };
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      timedOut = true;
+      await onLog("stderr", "[copilot-local] Request timed out.\n");
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: true,
+        errorMessage: "Request timed out",
+        errorCode: "timeout",
+        billingType: "subscription",
+        biller: "github",
+      };
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[copilot-local] Unexpected error: ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut,
+      errorMessage: message,
+      errorCode: "unexpected_error",
+      billingType: "subscription",
+      biller: "github",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/adapters/copilot-local/src/server/index.ts
+++ b/packages/adapters/copilot-local/src/server/index.ts
@@ -1,0 +1,2 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/copilot-local/src/server/test.ts
+++ b/packages/adapters/copilot-local/src/server/test.ts
@@ -1,0 +1,162 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_GITHUB_MODEL } from "../models.js";
+
+const GITHUB_MODELS_API = "https://models.inference.ai.azure.com";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const configEnv = parseObject(config.env);
+  const model = asString(config.model, DEFAULT_GITHUB_MODEL).trim() || DEFAULT_GITHUB_MODEL;
+
+  // Resolve GITHUB_TOKEN from config env or host environment
+  const configToken =
+    isNonEmpty(configEnv.GITHUB_TOKEN) ? (configEnv.GITHUB_TOKEN as string).trim() : null;
+  const hostToken =
+    isNonEmpty(process.env.GITHUB_TOKEN) ? process.env.GITHUB_TOKEN!.trim() : null;
+  const githubToken = configToken ?? hostToken;
+
+  if (githubToken) {
+    const tokenSource = configToken ? "adapter config env" : "server host environment";
+    checks.push({
+      code: "copilot_token_present",
+      level: "info",
+      message: "GITHUB_TOKEN is configured.",
+      detail: `Detected in ${tokenSource}.`,
+    });
+  } else {
+    checks.push({
+      code: "copilot_token_missing",
+      level: "error",
+      message: "GITHUB_TOKEN is not set.",
+      hint: "Set GITHUB_TOKEN in adapter env or server host environment. Use `gh auth token` to get a token from the GitHub CLI.",
+    });
+    return {
+      adapterType: ctx.adapterType,
+      status: summarizeStatus(checks),
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  // Run a hello probe against the GitHub Models API
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 20_000);
+
+    let probeStatus: number | null = null;
+    let probeBody = "";
+
+    try {
+      const response = await fetch(`${GITHUB_MODELS_API}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: "Respond with exactly: hello" }],
+          max_tokens: 32,
+          stream: false,
+        }),
+        signal: controller.signal,
+      });
+      probeStatus = response.status;
+      probeBody = await response.text().catch(() => "");
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (probeStatus === 200) {
+      let replyText = "";
+      try {
+        const parsed = JSON.parse(probeBody) as {
+          choices?: Array<{ message?: { content?: string } }>;
+        };
+        replyText = parsed.choices?.[0]?.message?.content?.trim() ?? "";
+      } catch {
+        // ignore parse errors
+      }
+      const hasHello = /hello/i.test(replyText);
+      checks.push({
+        code: hasHello ? "copilot_hello_probe_passed" : "copilot_hello_probe_unexpected_output",
+        level: hasHello ? "info" : "warn",
+        message: hasHello
+          ? "GitHub Models API hello probe succeeded."
+          : "GitHub Models API responded but did not return 'hello' as expected.",
+        ...(replyText ? { detail: replyText.slice(0, 240) } : {}),
+        ...(!hasHello
+          ? { hint: "The model responded but with unexpected content. API access is likely working." }
+          : {}),
+      });
+    } else if (probeStatus === 401 || probeStatus === 403) {
+      checks.push({
+        code: "copilot_hello_probe_auth_failed",
+        level: "error",
+        message: `GitHub Models API returned HTTP ${probeStatus} — authentication failed.`,
+        hint: "Verify GITHUB_TOKEN is valid and has Copilot access. Run `gh auth status` to check.",
+        detail: probeBody.slice(0, 240) || null,
+      });
+    } else if (probeStatus === 429) {
+      checks.push({
+        code: "copilot_hello_probe_rate_limited",
+        level: "warn",
+        message: "GitHub Models API returned HTTP 429 — rate limited.",
+        hint: "You are being rate-limited. Wait a moment and retry the probe.",
+      });
+    } else {
+      const detail = probeBody.replace(/\s+/g, " ").trim().slice(0, 240);
+      checks.push({
+        code: "copilot_hello_probe_failed",
+        level: "error",
+        message: `GitHub Models API hello probe failed with HTTP ${probeStatus ?? "unknown"}.`,
+        ...(detail ? { detail } : {}),
+        hint: "Check that your GITHUB_TOKEN has access to GitHub Models. See https://docs.github.com/en/github-models.",
+      });
+    }
+  } catch (err) {
+    const name = (err as Error).name;
+    if (name === "AbortError") {
+      checks.push({
+        code: "copilot_hello_probe_timed_out",
+        level: "warn",
+        message: "GitHub Models API hello probe timed out.",
+        hint: "Check your network connectivity to models.inference.ai.azure.com.",
+      });
+    } else {
+      const message = err instanceof Error ? err.message : String(err);
+      checks.push({
+        code: "copilot_hello_probe_network_error",
+        level: "error",
+        message: "GitHub Models API hello probe encountered a network error.",
+        detail: message.slice(0, 240),
+        hint: "Check your network connectivity and proxy settings.",
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/copilot-local/tsconfig.json
+++ b/packages/adapters/copilot-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -27,6 +27,11 @@ import {
 } from "@paperclipai/adapter-cursor-local/server";
 import { agentConfigurationDoc as cursorAgentConfigurationDoc, models as cursorModels } from "@paperclipai/adapter-cursor-local";
 import {
+  execute as copilotExecute,
+  testEnvironment as copilotTestEnvironment,
+} from "@paperclipai/adapter-copilot-local/server";
+import { agentConfigurationDoc as copilotAgentConfigurationDoc, models as copilotModels } from "@paperclipai/adapter-copilot-local";
+import {
   execute as geminiExecute,
   listGeminiSkills,
   syncGeminiSkills,
@@ -187,6 +192,15 @@ const hermesLocalAdapter: ServerAdapterModule = {
   detectModel: () => detectModelFromHermes(),
 };
 
+const copilotLocalAdapter: ServerAdapterModule = {
+  type: "copilot_local",
+  execute: copilotExecute,
+  testEnvironment: copilotTestEnvironment,
+  models: copilotModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: copilotAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>(
   [
     claudeLocalAdapter,
@@ -197,6 +211,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
+    copilotLocalAdapter,
     processAdapter,
     httpAdapter,
   ].map((a) => [a.type, a]),


### PR DESCRIPTION
## Summary

Adds a `copilot_local` adapter that allows agents to run using GitHub Copilot's access to the [GitHub Models API](https://docs.github.com/en/github-models) (powered by Azure AI Inference).

## How it works

The adapter calls `https://models.inference.ai.azure.com` — the same OpenAI-compatible endpoint used by VS Code's Copilot Chat — authenticated with a `GITHUB_TOKEN` that has Copilot access. No additional API key or billing account is needed beyond an existing GitHub Copilot subscription.

## Models exposed

| Model | ID |
|-------|----|
| GPT-4o (default) | `gpt-4o` |
| GPT-4o mini | `gpt-4o-mini` |
| Claude 3.7 Sonnet | `claude-3-7-sonnet-20250219` |
| Meta Llama 3.3 70B | `Meta-Llama-3.3-70B-Instruct` |
| Mistral Large | `Mistral-Large-2411` |

## Configuration

```json
{
  "type": "copilot_local",
  "model": "gpt-4o",
  "env": {
    "GITHUB_TOKEN": "ghp_..."
  }
}
```

`GITHUB_TOKEN` can also be set in the server host environment — the adapter picks it up automatically without requiring it in each agent's config. This makes it seamless for developers who already have `gh` authenticated locally.

## Billing

Included in any GitHub Copilot subscription ($10–19/mo). No per-token billing. Rate limits apply per GitHub plan tier.

## Environment test

The adapter includes a `testEnvironment` probe that:
1. Verifies `GITHUB_TOKEN` is present and non-empty
2. Hits the models endpoint with a hello probe
3. Returns detailed error hints for auth failures, rate limits, and network errors

## Files changed

- `packages/adapters/copilot-local/` — new adapter package
- `server/package.json` — adds workspace dependency
- `server/src/adapters/registry.ts` — registers `copilot_local` adapter