### PR TITLE
feat(ui): prompt for decision note when approving or rejecting

### DIFF
--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -85,7 +85,7 @@ export function ApprovalDetail() {
   };
 
   const approveMutation = useMutation({
-    mutationFn: () => approvalsApi.approve(approvalId!),
+    mutationFn: (note?: string) => approvalsApi.approve(approvalId!, note || undefined),
     onSuccess: () => {
       setError(null);
       refresh();
@@ -95,7 +95,7 @@ export function ApprovalDetail() {
   });
 
   const rejectMutation = useMutation({
-    mutationFn: () => approvalsApi.reject(approvalId!),
+    mutationFn: (note?: string) => approvalsApi.reject(approvalId!, note || undefined),
     onSuccess: () => {
       setError(null);
       refresh();
@@ -104,7 +104,7 @@ export function ApprovalDetail() {
   });
 
   const revisionMutation = useMutation({
-    mutationFn: () => approvalsApi.requestRevision(approvalId!),
+    mutationFn: (note?: string) => approvalsApi.requestRevision(approvalId!, note || undefined),
     onSuccess: () => {
       setError(null);
       refresh();
@@ -266,7 +266,7 @@ export function ApprovalDetail() {
               <Button
                 size="sm"
                 className="bg-green-700 hover:bg-green-600 text-white"
-                onClick={() => approveMutation.mutate()}
+                onClick={() => { const note = window.prompt("Add a note (optional):"); if (note !== null) approveMutation.mutate(note); }}
                 disabled={approveMutation.isPending}
               >
                 Approve
@@ -274,7 +274,7 @@ export function ApprovalDetail() {
               <Button
                 variant="destructive"
                 size="sm"
-                onClick={() => rejectMutation.mutate()}
+                onClick={() => { const note = window.prompt("Reason for rejection (optional):"); if (note !== null) rejectMutation.mutate(note); }}
                 disabled={rejectMutation.isPending}
               >
                 Reject
@@ -290,7 +290,7 @@ export function ApprovalDetail() {
             <Button
               size="sm"
               variant="outline"
-              onClick={() => revisionMutation.mutate()}
+              onClick={() => { const note = window.prompt("What should be revised? (optional):"); if (note !== null) revisionMutation.mutate(note); }}
               disabled={revisionMutation.isPending}
             >
               Request revision


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - Agents sometimes need human approval before taking certain actions
> - The approvals system let humans approve, reject, or request revision on agent actions
> - The API already support a decisionNote parameter on all three endpoints so agents can understand why a human made that decision
> - But the UI was never collecting this note - buttons just called the API with no note
> - This is a real gap because when rejecting, the agent need to know WHY so it can adjust its approach
> - This PR adds window.prompt() dialogs to the Approve, Reject, and Request revision buttons so humans can optionally explain their decision
> - Now agents get the context they need to act on human feedback, and the existing decisionNote display in ApprovalCard actually has data to show

## Problem

The approvals API already support `decisionNote` parameter on approve, reject, and request-revision endpoints. You can see it in `ui/src/api/approvals.ts` lines 12-17 - all three functions accept an optional `decisionNote` string.

But the UI was NEVER collecting this note. When user click Approve or Reject, it just call the API with no note at all. The `decisionNote` field exist on the Approval type and even get displayed if present (line 67 in ApprovalCard.tsx show "Note: ...") but the UI had no way to set it.

This is a real gap because when rejecting an approval, the requesting agent need to know WHY it was rejected so it can adjust its approach. Same for requesting revision - the agent need to know what to revise.

## What I changed

Updated the three action buttons (Approve, Reject, Request revision) to show a `window.prompt()` dialog before calling the mutation:

- **Approve**: "Add a note (optional):"
- **Reject**: "Reason for rejection (optional):"  
- **Request revision**: "What should be revised? (optional):"

The prompt is optional - user can just click OK with empty text and the note will be undefined. If user click Cancel, the action is cancelled entirely (the mutation is not called).

Updated the mutation `mutationFn` signatures to accept an optional note string and pass it to the API.

## How to test

1. Go to any pending approval detail page
2. Click "Approve" - should see prompt asking for optional note
3. Type something and click OK - approval succeed with note stored
4. Or just click OK with empty text - approval succeed without note
5. Click Cancel - nothing happen, approval not performed
6. Same flow for Reject and Request revision

1 file, 6 lines changed (inline replacements).