### PR TITLE
feat(ui): show project color swatch in projects list page

### DIFF
--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -65,6 +65,7 @@ export function Projects() {
           {projects.map((project) => (
             <EntityRow
               key={project.id}
+              leading={<span className="shrink-0 h-3 w-3 rounded-sm" style={{ backgroundColor: project.color ?? "#6366f1" }} />}
               title={project.name}
               subtitle={project.description ?? undefined}
               to={projectUrl(project)}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - Work is organized into projects, and each project have a user-customizable color
> - This color already show in the sidebar, routines table, and issue properties - it is how users visually identify projects
> - But the main Projects list page was not showing the color at all, just plain text rows
> - This PR adds a small colored square swatch to each project row using the existing color value
> - Now the Projects page is visually consistent with everywhere else project colors appear, and users can quickly find projects by color

## Problem

Every project in Paperclip have a color that user can customize. This color show in the sidebar next to the project name, in the routines table project column, and in issue properties. But the main Projects list page was not showing the color at all - just plain text rows with name, description, and status badge.

When I have many projects, the color is how I quickly find the one I need. But on the projects page itself I had to read every name because the visual color identifier was missing.

## What I changed

Added a small colored square to each project row using the `leading` prop on EntityRow. The square use the project's color (falling back to the default indigo #6366f1 if no color set).

Uses `rounded-sm` (square with slight rounding) to match the same swatch pattern used in the Routines table project column and sidebar project list.

## How to test

1. Go to Projects page
2. Each project row should now have a small colored square before the name
3. The color should match what you see in the sidebar for the same project

1 file, 1 line added.