### PR TITLE
feat(ui): show active and paused routine count in header

### DIFF
--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -235,6 +235,11 @@ export function Routines() {
           </h1>
           <p className="text-sm text-muted-foreground">
             Recurring work definitions that materialize into auditable execution issues.
+            {routines && routines.length > 0 && (() => {
+              const active = routines.filter((r) => r.status === "active").length;
+              const paused = routines.filter((r) => r.status === "paused").length;
+              return <span className="ml-1.5 tabular-nums">{active} active{paused > 0 ? `, ${paused} paused` : ""}</span>;
+            })()}
           </p>
         </div>
         <Button onClick={() => setComposerOpen(true)}>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - Routines are recurring work definitions that materialize into execution issues for agents
> - Humans need to quickly understand how many routines are running vs paused, especially when they have many routines
> - Other list pages already show counts (Agents tabs, Inbox tabs, Issues group headers) but Routines page had no summary at all
> - This PR adds inline active/paused counts to the Routines page header description text
> - Now users can see at a glance "5 active, 2 paused" without scrolling through the table, and the page is consistent with other list pages

## Problem

The Routines page header show "Routines" with a Beta badge and a description about what routines are. But there is no count telling how many routines are active vs paused.

We already added counts to other list page headers:
- Agents page: tabs show "Active (5)", "Paused (2)", "Error (1)"
- Inbox page: tabs show "Mine (3)", "Unread (7)"
- Issues page: group headers show item counts

But Routines page had zero summary. When I have 10+ routines I want to quickly know "how many are actually running" without scrolling through the table.

## What I changed

Added inline count to the description text: "5 active, 2 paused" (or just "5 active" if none are paused). The count:
- Only show after routines data is loaded
- Only show when list is not empty
- Show paused count only if there are paused routines
- Uses tabular-nums for consistent width

## How to test

1. Go to Routines page with some routines
2. The description should show counts like "...auditable execution issues. 5 active, 2 paused"
3. Pause/activate a routine and the count should update

1 file, 5 lines added.