### PR TITLE
feat(ui): display total goal count on Goals page

### DIFF
--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -49,7 +49,8 @@ export function Goals() {
 
       {goals && goals.length > 0 && (
         <>
-          <div className="flex items-center justify-start">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground tabular-nums">{goals.length} {goals.length === 1 ? "goal" : "goals"}</span>
             <Button size="sm" variant="outline" onClick={() => openNewGoal()}>
               <Plus className="h-3.5 w-3.5 mr-1.5" />
               New Goal


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - But humans want to watch the agents and oversee their work
> - Humans use the dashboard UI to monitor goals, agents, routines, issues etc.
> - Most list pages already show item counts in their headers (Agents show "Active (5)", Inbox show "Mine (3)", Routines show counts)
> - But the Goals page had no count at all - you had to visually count goals in the tree
> - This PR adds a total goal count label ("12 goals") to the Goals page action bar
> - Now users can quickly see how many goals exist without counting them manually, and the Goals page is consistent with other list pages

## Problem

The Goals page show a tree of goals with a "New Goal" button but no indication of how many goals exist. Every other list page in the app now show counts:
- Agents: tab counts like "Active (5)"
- Inbox: tab counts like "Mine (3)", "Unread (7)"
- Routines: "5 active, 2 paused" in header
- Issues: group header counts

But Goals page had nothing. When you have a complex goal tree with nested goals, it's useful to know "there are 12 goals total" without counting them visually.

## What I changed

Added a count label on the left side of the action bar: "12 goals" (or "1 goal" for singular). Changed the flex container from `justify-start` to `justify-between` so the count sit on the left and the "New Goal" button stay on the right.

## How to test

1. Go to Goals page with some goals
2. Above the goal tree, should see "X goals" on the left and "New Goal" button on the right
3. Add or delete goals - count should update

1 file, 2 lines changed.