### PR TITLE
fix: validate parentId on issue create (#2064)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -314,3 +314,115 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     ]));
   });
 });
+
+describeEmbeddedPostgres("issueService.create parentId", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-parentid-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("creates an issue with parentId set in a single call", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Create the parent issue first
+    const parent = await svc.create(companyId, {
+      title: "Parent task",
+      status: "todo",
+      priority: "high",
+    });
+
+    // Create a subtask with parentId in a single POST
+    const child = await svc.create(companyId, {
+      title: "Subtask",
+      status: "todo",
+      priority: "medium",
+      parentId: parent.id,
+    });
+
+    expect(child.parentId).toBe(parent.id);
+
+    // Verify the value persisted in the database
+    const fetched = await svc.getById(child.id);
+    expect(fetched!.parentId).toBe(parent.id);
+  });
+
+  it("rejects parentId pointing to a non-existent issue", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await expect(
+      svc.create(companyId, {
+        title: "Orphan subtask",
+        status: "todo",
+        priority: "medium",
+        parentId: randomUUID(),
+      }),
+    ).rejects.toThrow("Parent issue not found");
+  });
+
+  it("rejects parentId from a different company", async () => {
+    const companyA = randomUUID();
+    const companyB = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyA,
+        name: "Company A",
+        issuePrefix: `A${companyA.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: companyB,
+        name: "Company B",
+        issuePrefix: `B${companyB.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    const parentInA = await svc.create(companyA, {
+      title: "Parent in company A",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.create(companyB, {
+        title: "Child in company B",
+        status: "todo",
+        priority: "medium",
+        parentId: parentInA.id,
+      }),
+    ).rejects.toThrow("Parent issue must belong to the same company");
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -878,6 +878,15 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      if (issueData.parentId) {
+        const parent = await db
+          .select({ id: issues.id, companyId: issues.companyId })
+          .from(issues)
+          .where(eq(issues.id, issueData.parentId))
+          .then((rows) => rows[0] ?? null);
+        if (!parent) throw notFound("Parent issue not found");
+        if (parent.companyId !== companyId) throw unprocessable("Parent issue must belong to the same company");
+      }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -878,16 +878,16 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      if (issueData.parentId) {
-        const parent = await db
-          .select({ id: issues.id, companyId: issues.companyId })
-          .from(issues)
-          .where(eq(issues.id, issueData.parentId))
-          .then((rows) => rows[0] ?? null);
-        if (!parent) throw notFound("Parent issue not found");
-        if (parent.companyId !== companyId) throw unprocessable("Parent issue must belong to the same company");
-      }
       return db.transaction(async (tx) => {
+        if (issueData.parentId) {
+          const parent = await tx
+            .select({ id: issues.id, companyId: issues.companyId })
+            .from(issues)
+            .where(eq(issues.id, issueData.parentId))
+            .then((rows) => rows[0] ?? null);
+          if (!parent) throw notFound("Parent issue not found");
+          if (parent.companyId !== companyId) throw unprocessable("Parent issue must belong to the same company");
+        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let executionWorkspaceSettings =


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents decompose work by creating subtasks via POST /api/companies/:companyId/issues
> - Subtasks need a parentId to maintain the task hierarchy
> - parentId is accepted by the Zod schema and DB schema, but there was no server-side validation that the parent issue actually exists
> - When an agent sent an invalid parentId, the FK constraint threw a generic 500 "Internal server error"
> - Agents interpreted this as "parentId silently rejected" and fell back to a 2-step create + PATCH workflow
> - This pull request adds explicit parent existence and same-company validation with clear 404/422 error messages
> - The benefit is agents can create subtasks with parentId in a single API call and get actionable errors when the parent is invalid

## What Changed

- Added parent issue existence check in `issueService.create()` before the DB insert (`server/src/services/issues.ts`)
- Returns 404 "Parent issue not found" for non-existent parentId
- Returns 422 "Parent issue must belong to the same company" for cross-company parentId
- Added 3 new tests covering: successful parentId create, non-existent parent rejection, cross-company rejection (`server/src/__tests__/issues-service.test.ts`)

## Verification

- `cd server && npx vitest run src/__tests__/issues-service.test.ts` — all 6 tests pass (3 existing + 3 new)

## Risks

- Low risk. This is a small, additive validation check before an existing insert. No schema or migration changes. The only behavioral change is that invalid parentId now returns a clear error instead of a 500.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge