### PR TITLE
fix(ui): styled empty state for agent API keys tab

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -4021,7 +4021,10 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       {isLoading && <p className="text-sm text-muted-foreground">Loading keys...</p>}
 
       {!isLoading && activeKeys.length === 0 && !newToken && (
-        <p className="text-sm text-muted-foreground">No active API keys.</p>
+        <div className="rounded-lg border border-dashed border-border p-8 text-center">
+          <p className="text-sm text-muted-foreground">No active API keys</p>
+          <p className="text-xs text-muted-foreground/60 mt-1">Create a key above to allow external services to authenticate as this agent</p>
+        </div>
       )}
 
       {activeKeys.length > 0 && (


### PR DESCRIPTION
## Problem

The Keys tab in agent detail show plain text "No active API keys." when there are no keys. Just a bare paragraph floating in the page with no container or visual structure. Inconsistent with the styled empty states we use everywhere else in the app (agent runs, routine runs, comment threads, kanban columns all have dashed-border containers with guidance text).

## What I changed

Replaced the plain text with a proper empty state container:
- Dashed border rounded box (same pattern as other empty states)
- Centered text
- Added subtitle explaining what API keys are for: "Create a key above to allow external services to authenticate as this agent"

This help new users who don't know what API keys do or when they need one.

## How to test

1. Go to any agent > Keys tab (when there are no keys)
2. Should see a bordered empty state box with guidance text instead of floating paragraph

1 file, 4 lines added / 1 removed.