### PR TITLE
fix(openclaw-gateway): prefix session keys with configured agent id

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionKey } from "./execute.js";
+
+describe("resolveSessionKey", () => {
+  it("prefixes run-scoped session keys with the configured agent", () => {
+    expect(
+      resolveSessionKey({
+        strategy: "run",
+        configuredSessionKey: null,
+        agentId: "meridian",
+        runId: "run-123",
+        issueId: null,
+      }),
+    ).toBe("agent:meridian:paperclip:run:run-123");
+  });
+
+  it("prefixes issue-scoped session keys with the configured agent", () => {
+    expect(
+      resolveSessionKey({
+        strategy: "issue",
+        configuredSessionKey: null,
+        agentId: "meridian",
+        runId: "run-123",
+        issueId: "issue-456",
+      }),
+    ).toBe("agent:meridian:paperclip:issue:issue-456");
+  });
+
+  it("prefixes fixed session keys with the configured agent", () => {
+    expect(
+      resolveSessionKey({
+        strategy: "fixed",
+        configuredSessionKey: "paperclip",
+        agentId: "meridian",
+        runId: "run-123",
+        issueId: null,
+      }),
+    ).toBe("agent:meridian:paperclip");
+  });
+
+  it("does not double-prefix an already-routed session key", () => {
+    expect(
+      resolveSessionKey({
+        strategy: "fixed",
+        configuredSessionKey: "agent:meridian:paperclip",
+        agentId: "meridian",
+        runId: "run-123",
+        issueId: null,
+      }),
+    ).toBe("agent:meridian:paperclip");
+  });
+});

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -126,16 +126,26 @@ function normalizeSessionKeyStrategy(value: unknown): SessionKeyStrategy {
   return "issue";
 }
 
-function resolveSessionKey(input: {
+function prefixSessionKeyForAgent(sessionKey: string, agentId: string | null): string {
+  if (!agentId || sessionKey.startsWith("agent:")) return sessionKey;
+  return `agent:${agentId}:${sessionKey}`;
+}
+
+export function resolveSessionKey(input: {
   strategy: SessionKeyStrategy;
   configuredSessionKey: string | null;
+  agentId: string | null;
   runId: string;
   issueId: string | null;
 }): string {
   const fallback = input.configuredSessionKey ?? "paperclip";
-  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
-  if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
-  return fallback;
+  if (input.strategy === "run") {
+    return prefixSessionKeyForAgent(`paperclip:run:${input.runId}`, input.agentId);
+  }
+  if (input.strategy === "issue" && input.issueId) {
+    return prefixSessionKeyForAgent(`paperclip:issue:${input.issueId}`, input.agentId);
+  }
+  return prefixSessionKeyForAgent(fallback, input.agentId);
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -1060,6 +1070,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionKey = resolveSessionKey({
     strategy: sessionKeyStrategy,
     configuredSessionKey,
+    agentId: nonEmpty(ctx.config.agentId),
     runId: ctx.runId,
     issueId: wakePayload.issueId,
   });


### PR DESCRIPTION
### Thinking Path

- Paperclip orchestrates teams of AI agents across different runtimes and adapters
- The OpenClaw gateway adapter is responsible for routing Paperclip work to the correct OpenClaw agent
- In multi-agent gateway setups, the gateway uses the session key to determine which agent owns a session
- This adapter was already sending `agentId` in the outbound payload
- But the resolved session key did not include the required `agent:<id>:` prefix
- That caused the gateway to infer `main` for the session while Paperclip explicitly requested another agent such as `meridian`
- So this PR prefixes resolved session keys with the configured agent id so multi-agent routing stays consistent

## What changed

This PR updates the OpenClaw gateway adapter session key resolver to include the configured `agentId` when building session keys.

Specifically:
- run-scoped session keys now resolve to `agent:<agentId>:paperclip:run:<runId>`
- issue-scoped session keys now resolve to `agent:<agentId>:paperclip:issue:<issueId>`
- fixed session keys are also prefixed when an agent id is configured
- already-prefixed fixed session keys are left unchanged to avoid double-prefixing

## Why this matters

Without the prefix, the gateway falls back to `main` when parsing the session key, which can cause requests to fail with an agent/session mismatch even though the adapter payload includes the correct `agentId`.

This makes multi-agent OpenClaw gateway routing work correctly for Paperclip-managed sessions.

## Root cause

`resolveSessionKey()` generated issue, run, and fixed session keys without considering `ctx.config.agentId`, while `agentParams.agentId` was populated later in the same request. That mismatch let the gateway infer `main` from the unprefixed session key while Paperclip explicitly requested another agent.

## How to verify

1. Configure the OpenClaw gateway adapter with a non-main `agentId`
2. Trigger a run or heartbeat that uses the adapter
3. Confirm the outbound session key includes `agent:<agentId>:...`
4. Confirm the gateway accepts the request instead of rejecting it with an agent/session mismatch

## Validation

- `pnpm exec vitest run --config /tmp/openclaw-gateway-vitest.config.ts`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`

## Risks

This change is narrowly scoped to session key construction in the OpenClaw gateway adapter. It does not change transport, auth, wait handling, or payload fields other than the resolved `sessionKey`.

Closes #2131
