### PR TITLE
feat(ui): show uploading indicator when pasting images in editor

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -202,6 +202,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
   const ref = useRef<MDXEditorMethods>(null);
   const latestValueRef = useRef(value);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
   const dragDepthRef = useRef(0);
 
@@ -249,6 +250,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       ? async (file: File) => {
           const handler = imageUploadHandlerRef.current;
           if (!handler) throw new Error("No image upload handler");
+          setIsUploading(true);
           try {
             const src = await handler(file);
             setUploadError(null);
@@ -275,6 +277,8 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
             const message = err instanceof Error ? err.message : "Image upload failed";
             setUploadError(message);
             throw err;
+          } finally {
+            setIsUploading(false);
           }
         }
       : undefined;
@@ -612,6 +616,9 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         >
           Drop image to upload
         </div>
+      )}
+      {isUploading && (
+        <p className="px-3 pb-2 text-xs text-muted-foreground animate-pulse">Uploading image...</p>
       )}
       {uploadError && (
         <p className="px-3 pb-2 text-xs text-destructive">{uploadError}</p>


### PR DESCRIPTION
## Problem

When you paste an image or drag-drop a file into the markdown editor (issue description, agent instructions, comments, etc), there is zero feedback while the image upload. The file go to the server, take 1-3 seconds depending on size and network, and then suddenly the image appear in the editor.

During those few seconds, user don't know if anything is happening. I paste image many time and thought it didn't work because nothing visible change. So I paste again and get duplicate images. Had to manually delete the extra one.

The editor already had error handling (\`uploadError\` state that show red text when upload fail) but no loading state.

## What I changed

Added \`isUploading\` state that:
- Set to \`true\` when the image handler start processing
- Set to \`false\` in the \`finally\` block (both success and error)
- Render a pulsing "Uploading image..." text below the editor while active

The indicator appear in the same position and with similar styling as the upload error message, just using muted text color instead of red.

## How to test

1. Open any markdown editor (issue description, agent instructions, etc)
2. Paste an image from clipboard (screenshot or copied image)
3. Should see "Uploading image..." text pulsing below the editor
4. After upload complete, the text disappear and image appear in the editor
5. If upload fail, the uploading text disappear and error message show instead

1 file, 7 lines added.