### PR TITLE
fix: restore goal view properties toggle

### DIFF
--- a/ui/src/pages/GoalDetail.test.tsx
+++ b/ui/src/pages/GoalDetail.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GoalPropertiesToggleButton } from "./GoalDetail";
+
+describe("GoalPropertiesToggleButton", () => {
+  it("shows the reopen control when the properties panel is hidden", () => {
+    const html = renderToStaticMarkup(
+      <GoalPropertiesToggleButton panelVisible={false} onShowProperties={() => {}} />,
+    );
+
+    expect(html).toContain('title="Show properties"');
+    expect(html).toContain("opacity-100");
+  });
+
+  it("collapses the reopen control while the properties panel is already visible", () => {
+    const html = renderToStaticMarkup(
+      <GoalPropertiesToggleButton panelVisible onShowProperties={() => {}} />,
+    );
+
+    expect(html).toContain("opacity-0");
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain("w-0");
+  });
+});

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -15,17 +15,42 @@ import { StatusBadge } from "../components/StatusBadge";
 import { InlineEditor } from "../components/InlineEditor";
 import { EntityRow } from "../components/EntityRow";
 import { PageSkeleton } from "../components/PageSkeleton";
-import { projectUrl } from "../lib/utils";
+import { cn, projectUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus } from "lucide-react";
+import { Plus, SlidersHorizontal } from "lucide-react";
 import type { Goal, Project } from "@paperclipai/shared";
+
+interface GoalPropertiesToggleButtonProps {
+  panelVisible: boolean;
+  onShowProperties: () => void;
+}
+
+export function GoalPropertiesToggleButton({
+  panelVisible,
+  onShowProperties,
+}: GoalPropertiesToggleButtonProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      className={cn(
+        "hidden md:inline-flex shrink-0 transition-opacity duration-200",
+        panelVisible ? "opacity-0 pointer-events-none w-0 overflow-hidden" : "opacity-100",
+      )}
+      onClick={onShowProperties}
+      title="Show properties"
+    >
+      <SlidersHorizontal className="h-4 w-4" />
+    </Button>
+  );
+}
 
 export function GoalDetail() {
   const { goalId } = useParams<{ goalId: string }>();
   const { selectedCompanyId, setSelectedCompanyId } = useCompany();
   const { openNewGoal } = useDialog();
-  const { openPanel, closePanel } = usePanel();
+  const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
 
@@ -122,6 +147,12 @@ export function GoalDetail() {
             {goal.level}
           </span>
           <StatusBadge status={goal.status} />
+          <div className="ml-auto">
+            <GoalPropertiesToggleButton
+              panelVisible={panelVisible}
+              onShowProperties={() => setPanelVisible(true)}
+            />
+          </div>
         </div>
 
         <InlineEditor


### PR DESCRIPTION
### Thinking Path

- Paperclip is the control plane for autonomous AI companies
- The board UI needs to make important company objects easy to inspect and manage
- Goals already use the shared Properties panel for that metadata
- But if the panel is closed in Goal view, the page had no local way to reopen it
- Issue view already solves this with a small "Show properties" control tied to shared panel visibility
- This pull request brings the same behavior to Goal view
- That keeps Goal view self-contained and removes the unnecessary detour through another page

## What changed

- Added a Goal view properties toggle that appears when the shared properties panel is hidden
- Wired the button to `setPanelVisible(true)` so the existing panel content reopens immediately
- Added focused coverage for the hidden vs visible button states

## Why this matters

Closing the properties panel in Goal view previously trapped the user with no direct way to reopen it from the same screen. This change restores that workflow and matches the behavior users already get in Issue view.

## Root cause

`GoalDetail` opened the shared properties panel content but did not expose any control tied to `panelVisible`, so once the panel was hidden there was no in-view way to show it again.

## Verification

- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`

## Risks

This is a small UI-only change scoped to Goal detail. It does not change server behavior, routing, or data contracts.

Closes #2110
