### PR TITLE
fix: add copilot_cli (and fill gaps) in instruction bundle adapter whitelists

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,8 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "copilot_cli",
+  "gemini_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -66,7 +66,9 @@ export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
     claude_local: "instructionsFilePath",
     codex_local: "instructionsFilePath",
+    copilot_cli: "instructionsFilePath",
     gemini_local: "instructionsFilePath",
+    hermes_local: "instructionsFilePath",
     opencode_local: "instructionsFilePath",
     cursor: "instructionsFilePath",
     pi_local: "instructionsFilePath",

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -312,6 +312,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const isLocal =
     adapterType === "claude_local" ||
     adapterType === "codex_local" ||
+    adapterType === "copilot_cli" ||
     adapterType === "gemini_local" ||
     adapterType === "hermes_local" ||
     adapterType === "opencode_local" ||

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1652,6 +1652,8 @@ function PromptsTab({
   const isLocal =
     agent.adapterType === "claude_local" ||
     agent.adapterType === "codex_local" ||
+    agent.adapterType === "copilot_cli" ||
+    agent.adapterType === "gemini_local" ||
     agent.adapterType === "opencode_local" ||
     agent.adapterType === "pi_local" ||
     agent.adapterType === "hermes_local" ||


### PR DESCRIPTION
## Problem

The Paperclip UI shows "Instructions bundles are only available for local adapters" for agents using the `copilot_cli` adapter, even though it runs locally and already loads instructions from the managed bundle filesystem path.

The root cause is three independent adapter-type whitelists that had drifted out of sync:

| Location | Was missing |
|---|---|
| `server/src/routes/agents.ts` `DEFAULT_INSTRUCTIONS_PATH_KEYS` | `copilot_cli`, `hermes_local` |
| `ui/src/pages/AgentDetail.tsx` `isLocal` | `copilot_cli`, `gemini_local` |
| `ui/src/components/AgentConfigForm.tsx` `isLocal` | `copilot_cli` |

## Fix

Added the missing adapter types so all three whitelists now contain the same complete set:
`claude_local`, `codex_local`, `copilot_cli`, `cursor`, `gemini_local`, `hermes_local`, `opencode_local`, `pi_local`

## Verification

- `pnpm tsc --noEmit` — no new errors (pre-existing plugin-sdk errors only)
- `pnpm vitest run` — all 486 tests pass (2 pre-existing file-level failures from missing plugin-sdk)