### PR TITLE
feat(server): adapter failover across providers

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4,7 +4,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import type { BillingType } from "@paperclipai/shared";
+import type { AgentAdapterType, BillingType } from "@paperclipai/shared";
 import {
   agents,
   agentRuntimeState,
@@ -20,7 +20,7 @@ import { conflict, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
-import { getServerAdapter, runningProcesses } from "../adapters/index.js";
+import { findServerAdapter, getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
@@ -57,6 +57,17 @@ import {
   resolveSessionCompactionPolicy,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
+
+/**
+ * Maps each adapter type to its failover target. When the primary adapter
+ * fails, the heartbeat executor will automatically retry with the fallback
+ * adapter before marking the run as failed. Only one failover attempt is
+ * made — if the fallback also fails the run is marked failed as normal.
+ */
+const ADAPTER_FAILOVER_MAP: Partial<Record<AgentAdapterType, AgentAdapterType>> = {
+  claude_local: "codex_local",
+  codex_local: "claude_local",
+};
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
@@ -2512,7 +2523,7 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
-      const adapterResult = await adapter.execute({
+      let adapterResult = await adapter.execute({
         runId: run.id,
         agent,
         runtime: runtimeForAdapter,
@@ -2600,6 +2611,63 @@ export function heartbeatService(db: Db) {
       } else {
         outcome = "failed";
       }
+
+      // ── Adapter failover ──────────────────────────────────────────────
+      // When the primary adapter fails, try the configured fallback adapter
+      // exactly once. If the fallback also fails, the run is marked failed
+      // with the fallback's error. This provides resilience when one
+      // provider is temporarily unavailable.
+      const failoverTarget = ADAPTER_FAILOVER_MAP[agent.adapterType as AgentAdapterType];
+      if (outcome === "failed" && failoverTarget && findServerAdapter(failoverTarget)) {
+        const primaryError = adapterResult.errorMessage ?? "Adapter failed";
+        await onLog(
+          "stderr",
+          `[paperclip] Primary adapter "${agent.adapterType}" failed: ${primaryError}. Attempting failover to "${failoverTarget}"...\n`,
+        );
+        try {
+          const fallbackAdapter = getServerAdapter(failoverTarget);
+          const fallbackAuthToken = fallbackAdapter.supportsLocalAgentJwt
+            ? createLocalAgentJwt(agent.id, agent.companyId, failoverTarget, run.id)
+            : null;
+          const fallbackResult = await fallbackAdapter.execute({
+            runId: run.id,
+            agent: { ...agent, adapterType: failoverTarget },
+            runtime: runtimeForAdapter,
+            config: runtimeConfig,
+            context,
+            onLog,
+            onMeta: onAdapterMeta,
+            onSpawn: async (meta) => {
+              await persistRunProcessMetadata(run.id, meta);
+            },
+            authToken: fallbackAuthToken ?? undefined,
+          });
+          // Re-evaluate outcome with the fallback result
+          const latestRunFb = await getRun(run.id);
+          if (latestRunFb?.status === "cancelled") {
+            outcome = "cancelled";
+          } else if (fallbackResult.timedOut) {
+            outcome = "timed_out";
+          } else if ((fallbackResult.exitCode ?? 0) === 0 && !fallbackResult.errorMessage) {
+            outcome = "succeeded";
+            await onLog("stderr", `[paperclip] Failover to "${failoverTarget}" succeeded.\n`);
+          } else {
+            outcome = "failed";
+            await onLog(
+              "stderr",
+              `[paperclip] Failover to "${failoverTarget}" also failed: ${fallbackResult.errorMessage ?? "unknown error"}. Giving up.\n`,
+            );
+          }
+          // Use the fallback result for the rest of the run finalization
+          adapterResult = fallbackResult;
+        } catch (fbErr) {
+          await onLog(
+            "stderr",
+            `[paperclip] Failover to "${failoverTarget}" threw: ${fbErr instanceof Error ? fbErr.message : String(fbErr)}. Keeping original failure.\n`,
+          );
+        }
+      }
+      // ── End adapter failover ──────────────────────────────────────────
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {


### PR DESCRIPTION
### Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents are powered by different LLM providers via adapter types (claude_local, codex_local, etc.)
> - But LLM providers can fail — rate limits, auth token expiry, temporary outages
> - When the primary adapter fails, the entire run fails and the agent stalls
> - So we need automatic failover across compatible adapters
> - This PR adds a one-shot failover mechanism: when the primary adapter fails, the executor retries with a configured fallback adapter
> - The benefit is uninterrupted agent operation when one provider is temporarily unavailable, without manual intervention

## Summary

- Adds `ADAPTER_FAILOVER_MAP` in `server/src/services/heartbeat.ts` mapping `claude_local ↔ codex_local`
- After the primary adapter returns a failure outcome, the executor checks for a fallback adapter and retries once
- If the fallback succeeds, its result is used for the rest of run finalization
- If the fallback also fails, the run is marked failed as normal (no infinite loops)
- All failover activity is logged to stderr with `[paperclip]` prefix for observability

## Changes

**`server/src/services/heartbeat.ts`** (1 file, ~70 lines added):
- Import `AgentAdapterType` from shared, `findServerAdapter` from adapters
- `ADAPTER_FAILOVER_MAP` constant defining failover pairs
- Failover block after outcome determination in `executeRun()` — tries fallback adapter with fresh auth token, re-evaluates outcome, and reassigns `adapterResult`
- `const adapterResult` → `let adapterResult` to allow reassignment on failover

## Design decisions

- **One-shot only**: exactly one failover attempt per run to avoid cascading retries
- **Map-based config**: `ADAPTER_FAILOVER_MAP` is easy to extend with new adapter pairs
- **Guard via `findServerAdapter`**: failover is skipped if the target adapter isn't registered (e.g. missing package)
- **Fresh session**: failover starts a new session rather than trying to resume the primary's session, since session formats are adapter-specific

## How to verify

1. Configure an agent with `adapter_type = 'claude_local'`
2. Trigger a run that will fail on Claude (e.g. invalid auth, or stop the Claude CLI)
3. Observe in run logs: `[paperclip] Primary adapter "claude_local" failed: ... Attempting failover to "codex_local"...`
4. If Codex succeeds: run completes, logs show `Failover to "codex_local" succeeded.`
5. If both fail: run fails, logs show `Failover to "codex_local" also failed: ... Giving up.`

## Risks

- Failover adds latency (full second adapter execution) on failure — acceptable since the alternative is a failed run
- Session state from the primary adapter is not carried over to the fallback (by design — adapter session formats differ)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>