### PR TITLE
feat(ui): show credit amounts in green on finance cards

### DIFF
--- a/ui/src/components/FinanceBillerCard.tsx
+++ b/ui/src/components/FinanceBillerCard.tsx
@@ -31,7 +31,7 @@ export function FinanceBillerCard({ row }: FinanceBillerCardProps) {
           </div>
           <div className="border border-border p-3">
             <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">credits</div>
-            <div className="mt-1 font-medium tabular-nums">{formatCents(row.creditCents)}</div>
+            <div className="mt-1 font-medium tabular-nums text-emerald-600 dark:text-emerald-400">{formatCents(row.creditCents)}</div>
           </div>
           <div className="border border-border p-3">
             <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">estimated</div>

--- a/ui/src/components/FinanceTimelineCard.tsx
+++ b/ui/src/components/FinanceTimelineCard.tsx
@@ -57,7 +57,7 @@ export function FinanceTimelineCard({
                   )}
                 </div>
                 <div className="text-right tabular-nums">
-                  <div className="text-sm font-semibold">{formatCents(row.amountCents)}</div>
+                  <div className={`text-sm font-semibold ${row.direction === "credit" ? "text-emerald-600 dark:text-emerald-400" : ""}`}>{formatCents(row.amountCents)}</div>
                   <div className="text-xs text-muted-foreground">{row.currency}</div>
                   {row.estimated ? <div className="text-[11px] uppercase tracking-[0.12em] text-amber-600">estimated</div> : null}
                 </div>


### PR DESCRIPTION
## Problem

On the Costs page, debit amounts and credit amounts look exactly the same - same text color, same font weight. The only way to tell them apart is reading the label text above ("debits" vs "credits"). When scanning financial data quickly, this make it hard to distinguish money going out vs coming back.

In every financial application I use (banking, accounting software, even Excel), credits/refunds are shown in green to instantly distinguish them from debits. This visual convention was missing here.

## What I changed

Added green color (\`text-emerald-600\` for light mode, \`dark:text-emerald-400\` for dark mode) to credit amounts in two components:

**FinanceBillerCard.tsx:**
- The "credits" summary value now render in green

**FinanceTimelineCard.tsx:**
- Individual event amounts now render in green when the event direction is "credit"
- Debit events keep the default text color

## How to test

1. Go to Costs page > expand any biller card
2. The "credits" number should be green while "debits" and "estimated" stay default color
3. Scroll to the timeline section - credit events should show green amounts
4. Check both light and dark mode

2 files, 2 lines changed (inline class additions).