### PR TITLE
feat(ui): color budget remaining amount red/amber based on status

### DIFF
--- a/ui/src/components/BudgetPolicyCard.tsx
+++ b/ui/src/components/BudgetPolicyCard.tsx
@@ -97,7 +97,9 @@ export function BudgetPolicyCard({
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>Remaining</span>
-        <span>{summary.amount > 0 ? formatCents(summary.remainingAmount) : "Unlimited"}</span>
+        <span className={summary.status === "hard_stop" ? "text-red-400 font-medium" : summary.status === "warning" ? "text-amber-300 font-medium" : ""}>
+          {summary.amount > 0 ? formatCents(summary.remainingAmount) : "Unlimited"}
+        </span>
       </div>
       <div className={cn("h-2 overflow-hidden rounded-full", isPlain ? "bg-border/70" : "bg-muted/70")}>
         <div


### PR DESCRIPTION
## Problem

In the BudgetPolicyCard, the progress bar already change color to indicate budget status:
- Green when healthy
- Amber when at warning threshold
- Red when at hard stop

But the "Remaining" amount text next to the progress bar was always gray regardless of status. So the bar is screaming "danger" in red but the number right above it look calm and normal. The two visual elements should agree about the severity.

## What I changed

Added conditional color to the remaining amount text:
- **Hard stop**: text turn red (\`text-red-400\`) with medium font weight
- **Warning**: text turn amber (\`text-amber-300\`) with medium font weight  
- **Healthy**: keep default muted color (no change)

Now when a budget is at 95% utilization and in hard_stop status, both the progress bar AND the remaining dollar amount show in red. Same for warning at amber.

## How to test

1. Go to any agent or project with a budget configured
2. When budget is healthy (under warning threshold), remaining show in default gray
3. When budget is at warning level, remaining show in amber
4. When budget hit hard stop, remaining show in red

1 file, 3 lines added / 1 removed.