### PR TITLE
fix(heartbeat): add SIGKILL fallback to cancelActiveForAgent

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3628,7 +3628,13 @@ export function heartbeatService(db: Db) {
       const running = runningProcesses.get(run.id);
       if (running) {
         running.child.kill("SIGTERM");
-        runningProcesses.delete(run.id);
+        const graceMs = Math.max(1, running.graceSec) * 1000;
+        setTimeout(() => {
+          if (!running.child.killed) {
+            running.child.kill("SIGKILL");
+          }
+          runningProcesses.delete(run.id);
+        }, graceMs);
       }
       await releaseIssueExecutionAndPromote(run);
     }


### PR DESCRIPTION
`cancelActiveForAgentInternal` sends SIGTERM but immediately deletes the process from `runningProcesses` without a SIGKILL fallback. If the child process ignores SIGTERM, it becomes an orphaned zombie that is never reaped.\n\n`cancelRunInternal` already handles this correctly with a grace period + SIGKILL escalation (lines 3574-3580). This patch applies the same pattern to `cancelActiveForAgentInternal`.\n\n## The bug\n\n```typescript\n// Before (cancelActiveForAgentInternal) — no SIGKILL fallback\nrunning.child.kill(\"SIGTERM\");\nrunningProcesses.delete(run.id); // immediately orphans the process\n```\n\n```typescript\n// After — mirrors cancelRunInternal pattern\nrunning.child.kill(\"SIGTERM\");\nconst graceMs = Math.max(1, running.graceSec) * 1000;\nsetTimeout(() => {\n  if (!running.child.killed) {\n    running.child.kill(\"SIGKILL\");\n  }\n  runningProcesses.delete(run.id);\n}, graceMs);\n```\n\n## Impact\n\nWithout this fix, every agent pause/cancel via `cancelActiveForAgent` can leave zombie processes. In our Docker deployment, we observed 195+ zombie processes accumulating from the Paperclip server's child process management.\n\nFixes #1403