### PR TITLE
fix: convert Date to ISO string for comment pagination cursor

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1383,12 +1383,12 @@ export function issueService(db: Db) {
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchorCreatedAt}
-                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAt}::timestamptz AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchorCreatedAt}
-                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}::timestamptz
+                OR (${issueComments.createdAt} = ${anchorCreatedAt}::timestamptz AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1379,15 +1379,16 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Thinking Path

Paperclip issues have comments. Comments are paginated via cursor (`after` param). The cursor lookup fetches the anchor comment by ID, then uses `anchor.createdAt` in a keyset pagination SQL clause. Drizzle ORM returns `createdAt` as a JavaScript `Date` object. The `sql` tagged template passes parameters to the `postgres` driver, which calls `Buffer.byteLength()` on each -- this expects `string | Buffer`, not `Date`. Result: `TypeError [ERR_INVALID_ARG_TYPE]` on every paginated comment fetch.

**Fix:** Convert `anchor.createdAt` to ISO 8601 string via `.toISOString()` before interpolation. Added explicit `::timestamptz` cast in the SQL template so PostgreSQL does not rely on implicit text-to-timestamp conversion.

**Why it matters:** Without this fix, any issue with enough comments to paginate crashes the API. The heartbeat loop fetches comments to sync agent work -- a crash here stalls execution runs.

**Risks:** None. `.toISOString()` produces RFC 3339 / ISO 8601 output which PostgreSQL parses deterministically. The `::timestamptz` cast is explicit about intent. No logic changes beyond serialisation.

## Summary

- `listComments` cursor pagination passes `anchor.createdAt` (a Date object from Drizzle) directly into a `sql` template literal
- The `postgres` driver's `Bind` phase calls `Buffer.byteLength()` on parameters, which throws `TypeError [ERR_INVALID_ARG_TYPE]` for Date objects
- Fix: call `.toISOString()` before passing the anchor timestamp to SQL, with explicit `::timestamptz` cast

## Error

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string 
or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Buffer.byteLength (node:buffer:779:11)
    at reset.str (postgres/src/bytes.js:22:27)
```

Triggered by: `GET /api/issues/:id/comments?after=<uuid>&order=asc`

## Verification

- Fetch issue comments with `after` cursor and `order=asc` -- should return paginated results without 500
- Fetch issue comments with `after` cursor and `order=desc` -- same
- Fetch issue comments without `after` -- unchanged behaviour