### PR TITLE
fix: prefix openclaw session keys with agent ID for multi-agent routing

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1067,7 +1067,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     configuredSessionKey,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
-    agentId: configuredAgentId ?? null,
+    agentId: configuredAgentId,
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);


### PR DESCRIPTION
Closing in favor of #2167 which addresses the same issue.

Original description: The OpenClaw gateway adapter generates session keys without the `agent:<agentId>:` prefix that OpenClaw expects for multi-agent routing.