### PR TITLE
feat(ui): add toggle to show/hide archived projects

### DIFF
--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
@@ -17,6 +17,7 @@ export function Projects() {
   const { selectedCompanyId } = useCompany();
   const { openNewProject } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const [showArchived, setShowArchived] = useState(false);
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Projects" }]);
@@ -27,9 +28,10 @@ export function Projects() {
     queryFn: () => projectsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
+  const archivedCount = useMemo(() => (allProjects ?? []).filter((p) => p.archivedAt).length, [allProjects]);
   const projects = useMemo(
-    () => (allProjects ?? []).filter((p) => !p.archivedAt),
-    [allProjects],
+    () => (allProjects ?? []).filter((p) => showArchived || !p.archivedAt),
+    [allProjects, showArchived],
   );
 
   if (!selectedCompanyId) {
@@ -42,7 +44,17 @@ export function Projects() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-end gap-2">
+        {archivedCount > 0 && (
+          <button
+            role="checkbox"
+            aria-checked={showArchived}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowArchived(!showArchived)}
+          >
+            {showArchived ? `Hide ${archivedCount} archived` : `Show ${archivedCount} archived`}
+          </button>
+        )}
         <Button size="sm" variant="outline" onClick={openNewProject}>
           <Plus className="h-4 w-4 mr-1" />
           Add Project


### PR DESCRIPTION
## Problem

Archived projects was completely invisible on the Projects page. The code at line 31 filter them out with \`.filter((p) => !p.archivedAt)\` and there was no way to show them again. If I need to check an old archived project or unarchive it, I had to use the API directly or know the exact URL.

The Agents page already have this pattern - "Show terminated" toggle in the filter dropdown let you see terminated agents. But Projects page had no equivalent.

## What I changed

Added a toggle link that appear when there are archived projects:

- **Hidden by default**: "Show 3 archived" text appear next to Add Project button
- **Click to show**: archived projects appear in the list, text change to "Hide 3 archived"
- **Click again**: archived projects hidden again
- **No archived**: toggle don't appear at all (clean UI when there is nothing to show)

The toggle use \`role="checkbox"\` and \`aria-checked\` for screen reader accessibility.

Also added \`archivedCount\` memo to efficiently count archived projects without recalculating on every render.

## How to test

1. Go to Projects page
2. If you have archived projects, should see "Show X archived" link next to Add Project button
3. Click it - archived projects appear in the list
4. Click "Hide X archived" - they disappear again
5. If no archived projects exist, the toggle should not show

1 file, 16 lines added.