### PR TITLE
fix(adapter-openclaw-gateway): prefix session keys with agent: for valid OpenClaw gateway format

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -129,12 +129,14 @@ function normalizeSessionKeyStrategy(value: unknown): SessionKeyStrategy {
 function resolveSessionKey(input: {
   strategy: SessionKeyStrategy;
   configuredSessionKey: string | null;
+  agentId: string | null;
   runId: string;
   issueId: string | null;
 }): string {
   const fallback = input.configuredSessionKey ?? "paperclip";
-  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
-  if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
+  if (!input.agentId) return fallback;
+  if (input.strategy === "run") return `agent:${input.agentId}:paperclip:run:${input.runId}`;
+  if (input.strategy === "issue" && input.issueId) return `agent:${input.agentId}:paperclip:issue:${input.issueId}`;
   return fallback;
 }
 
@@ -1060,6 +1062,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionKey = resolveSessionKey({
     strategy: sessionKeyStrategy,
     configuredSessionKey,
+    agentId: nonEmpty(ctx.config.agentId),
     runId: ctx.runId,
     issueId: wakePayload.issueId,
   });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1062,7 +1062,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionKey = resolveSessionKey({
     strategy: sessionKeyStrategy,
     configuredSessionKey,
-    agentId: nonEmpty(ctx.config.agentId),
+    agentId: ctx.agent.id,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
   });


### PR DESCRIPTION
## Summary

`sessionKeyStrategy "run"` generated session keys like `paperclip:run:{id}` — but the OpenClaw gateway requires the `agent:{agentId}:*` prefix. This caused all tickets to fall back to the fixed session, accumulating unbounded context (1MB+) and causing silent model failures.

## Root Cause

`resolveSessionKey()` in `execute.ts` generated invalid keys without the required `agent:` prefix. The `agentId` parameter was also missing from the function.

## Fix

- Added `agentId: string | null` parameter to `resolveSessionKey()`
- Prefixed keys with `agent:` for "run" and "issue" strategies
- Passes `agentId` at the call site with null guard

## Files Changed

`packages/adapters/openclaw-gateway/src/server/execute.ts` (+5 lines, -2 lines)

Closes #2165