### PR TITLE
fix(heartbeat): don't resume agent-level session for issueless runs

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2315,8 +2315,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
     }
 
-    const runtimeForRun = await getRuntimeState(agent.id);
-    return runtimeForRun?.sessionId ?? null;
+    // No task/issue context — issueless heartbeats are stateless by nature.
+    // Resuming the agent-level session would accumulate context across independent
+    // heartbeat cycles until the context window fills up. Return null so each
+    // issueless run starts fresh.
+    return null;
   }
 
   async function resolveExplicitResumeSessionOverride(


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Agents wake up via heartbeats — either triggered by issue assignment/comment, or on a timer with no issue context
- When an agent runs, it resumes a session (Claude Code conversation history) to preserve context across work sessions on a given task
- Sessions are scoped per agent×issue (`taskKey`) so each issue gets its own conversation thread — this is correct and intentional
- But when there is **no issue context** (issueless/timer heartbeats), the code fell back to the agent-level `agentRuntimeState.sessionId` — a single shared session for the whole agent
- This means every timer heartbeat appended to the same conversation history, accumulating tool calls and responses from all prior heartbeat cycles
- The session grew until context limits forced compaction, and worse: the agent could read its own prior-run thoughts and mistakenly conclude it had already completed the current cycle's work
- Issueless heartbeats are **stateless by nature** — each cycle is independent (scan → act → exit), so there is no benefit to resuming the prior session and significant cost
- This PR fixes `resolveSessionBeforeForWakeup` to return `null` when `taskKey` is null, so issueless runs always start with a fresh context

---

## What & Why

When a heartbeat agent wakes with no issue context (e.g. a timer-triggered dispatcher), the session resolution in `resolveSessionBeforeForWakeup` fell through to:

```typescript
const runtimeForRun = await getRuntimeState(agent.id);
return runtimeForRun?.sessionId ?? null;
```

This returned the agent's persistent runtime session — meaning **every issueless run resumed the same Claude Code conversation**, appending to it indefinitely.

## Evidence

Run history for the Heartbeat Dispatcher agent shows `sessionReused=True` and rapidly growing `rawCachedInputTokens` across independent timer runs:

| Run | Status | `sessionReused` | `rawCachedInputTokens` |
|-----|--------|-----------------|------------------------|
| `bda85073` | succeeded | `true` | 259,321 |
| `80dd5a48` | succeeded | `true` | 65,006 |
| `197d91ce` | succeeded | `true` | 20,659 |
| `ddd59e3f` | succeeded | `true` | 20,659 |

The agent's own thinking block from run `197d91ce` shows the direct consequence — it read its prior-run history and concluded it had already done the work:

> *"The user is **again** asking me to 'Continue your Paperclip work' as the Heartbeat Dispatcher. I've **already completed one heartbeat cycle**.*
> *1. I scanned all open issues*
> *2. Found 1 stalled task (AGE-15)*
> *3. Posted a nudge comment*
> *4. My inbox is empty*
> *...I think the appropriate response is to acknowledge that I've completed my heartbeat work and am standing by for the next one."*

The agent made **zero tool calls** (`num_turns: 1`, only 10 input tokens) — it just summarised work it did in a previous run and exited. The heartbeat cycle was effectively a no-op.

## Why heartbeats don't need appended session context

For **issue-scoped** runs, resuming the session is correct: the agent is working a long-running task across multiple wakeups and needs to remember decisions, edits, and reasoning from prior sessions on that same issue.

For **issueless** runs (timer heartbeats, no task context):
- Each cycle is a discrete, stateless operation (e.g. scan for stalled issues, nudge, exit)
- There is no ongoing task to remember — the cycle completes fully each time
- The system prompt (AGENT.md via `--append-system-prompt-file`) is always injected fresh regardless of session, so instructions are never lost
- Accumulated history only adds noise, token cost, and the risk of the agent treating prior-run observations as current state

## Fix

```typescript
// Before
const runtimeForRun = await getRuntimeState(agent.id);
return runtimeForRun?.sessionId ?? null;

// After
// No task/issue context — issueless heartbeats are stateless by nature.
// Resuming the agent-level session would accumulate context across independent
// heartbeat cycles until the context window fills up. Return null so each
// issueless run starts fresh.
return null;
```

One file changed, 5 lines (+2 removed / +5 added).

## Verification

- Trigger a manual heartbeat run on an issueless agent (no issue context in wakeup)
- Confirm `usageJson.freshSession === true` and `sessionReused === false` in the run record
- Confirm the agent executes its full scan logic with tool calls rather than replying from cached context
- Issue-scoped runs (assignment/comment wakeups with an `issueId`) are unaffected — they still correctly resume their per-issue task session

## Risks

- Any issueless heartbeat agent that was **intentionally** relying on cross-run session continuity will now start fresh each time. In practice this seems unlikely — issueless heartbeats are designed for stateless scanning patterns — but worth noting.
- The agent-level `agentRuntimeState.sessionId` field is no longer populated from issueless runs. Any downstream code reading that field for issueless agents will see `null`. (This was already the case after a manual session reset.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)