### PR TITLE
feat(ui): add headers with counts to agent skills sections

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2682,6 +2682,11 @@ function AgentSkillsTab({
               <>
                 {optionalSkillRows.length > 0 && (
                   <section className="border-y border-border">
+                    <div className="border-b border-border bg-muted/40 px-3 py-2">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        Agent skills ({optionalSkillRows.length})
+                      </span>
+                    </div>
                     {optionalSkillRows.map(renderSkillRow)}
                   </section>
                 )}
@@ -2690,7 +2695,7 @@ function AgentSkillsTab({
                   <section className="border-y border-border">
                     <div className="border-b border-border bg-muted/40 px-3 py-2">
                       <span className="text-xs font-medium text-muted-foreground">
-                        Required by Paperclip
+                        Required by Paperclip ({requiredSkillRows.length})
                       </span>
                     </div>
                     {requiredSkillRows.map(renderSkillRow)}


### PR DESCRIPTION
## Problem

The agent Skills tab had three sections of skills but they was styled inconsistently:

- **Optional skills**: no header at all - just skill rows starting immediately. User don't know what category these skills belong to.
- **Required skills**: header "Required by Paperclip" but no count showing how many required skills there are.
- **Unmanaged skills**: header "(3) User-installed skills, not managed by Paperclip" WITH a count. This is the only section that tell user how many items it contain.

The inconsistency make it confusing specially when all three sections are visible together.

## What I changed

- **Optional skills**: Added a header with "Agent skills (5)" label using the same \`bg-muted/40\` background pattern as the other section headers
- **Required skills**: Added count to existing header: "Required by Paperclip (2)" 
- **Unmanaged skills**: No change (already had count)

Now all three sections have consistent visual structure: header with label and count, followed by skill rows.

## How to test

1. Go to any agent > Skills tab
2. Each skills section should now have a labeled header with count
3. "Agent skills (X)" for the main skills
4. "Required by Paperclip (Y)" for system-required skills

1 file, 6 lines added.