### PR TITLE
fix: add missing meta description to index.html

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Paperclip" />
+    <meta name="description" content="Open-source orchestration for AI agent teams. Manage goals, budgets, and agent coordination from one dashboard." />
     <title>Paperclip</title>
     <!-- PAPERCLIP_RUNTIME_BRANDING_START -->
     <!-- PAPERCLIP_RUNTIME_BRANDING_END -->


### PR DESCRIPTION
## Problem

The \`index.html\` had all the meta tags for mobile web app (theme-color, apple-mobile-web-app, viewport) but was missing the basic \`<meta name="description">\` tag.

This mean when someone share a Paperclip URL on Slack, Discord, Twitter, or LinkedIn, the link preview show just "Paperclip" as title with no description text. Same for browser history and bookmark list - both use meta description as the summary text.

It also affect search engine indexing for public instances.

## What I changed

Added one line:
\`\`\`html
<meta name="description" content="Open-source orchestration for AI agent teams. Manage goals, budgets, and agent coordination from one dashboard." />
\`\`\`

The description text come from the project tagline in the README. Short enough for search engine snippets (under 160 chars) but descriptive enough to be useful in link previews.

## How to test

1. Check the page source - should see the meta description tag
2. Share a Paperclip URL on Slack/Discord - preview should now include the description
3. Inspect with browser dev tools > Elements > head section

1 file, 1 line added.