### PR TITLE
fix: restore root paperclipai script tsx path

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "secrets:migrate-inline-env": "tsx scripts/migrate-inline-env-secrets.ts",
     "db:backup": "./scripts/backup-db.sh",
-    "paperclipai": "tsx cli/src/index.ts",
+    "paperclipai": "node cli/node_modules/tsx/dist/cli.mjs cli/src/index.ts",
     "build:npm": "./scripts/build-npm.sh",
     "release": "./scripts/release.sh",
     "release:canary": "./scripts/release.sh canary",


### PR DESCRIPTION
## Summary
- revert the repo-root `paperclipai` script to the explicit `cli/node_modules/tsx/dist/cli.mjs` path
- restore CI behavior for environments where `tsx` is not installed at the repo root

## Verification
- `pnpm test:run cli/src/__tests__/company-import-export-e2e.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` *(targeted regression fixed; one unrelated local-environment failure remains in `cli/src/__tests__/worktree.test.ts` because port `3102` is already occupied by a live local `node/tsx` process)*