### PR TITLE
fix: serialize Date to ISO string in comment delta query

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1379,15 +1379,16 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorTs = anchor.createdAt instanceof Date ? anchor.createdAt.toISOString() : String(anchor.createdAt);
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorTs}
+                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorTs}
+                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Problem

The comment delta endpoint (`GET /api/issues/:id/comments?after=:commentId&order=asc`) throws a 500 error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Function.byteLength (node:buffer:781:11)
    at Function.str (.../postgres/src/bytes.js:22:27)
    at .../postgres/src/connection.js:964:16
```

## Cause

In `listComments`, the anchor row's `createdAt` is a JS `Date` object (returned by Drizzle's `select()`). When interpolated into the `sql` template literal for the keyset pagination comparison, the `postgres` driver receives a `Date` instead of a string/Buffer, causing the TypeError.

## Fix

Convert `anchor.createdAt` to an ISO string before interpolation. One-liner with a type guard for safety.

## Testing

Verified against the exact failing request on a live instance — 500 → 200 with correct results.