### PR TITLE
feat: add button to show properties panel in GoalDetail component

### DIFF
--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -18,14 +18,14 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { projectUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus } from "lucide-react";
+import { Plus, SlidersHorizontal } from "lucide-react";
 import type { Goal, Project } from "@paperclipai/shared";
 
 export function GoalDetail() {
   const { goalId } = useParams<{ goalId: string }>();
   const { selectedCompanyId, setSelectedCompanyId } = useCompany();
   const { openNewGoal } = useDialog();
-  const { openPanel, closePanel } = usePanel();
+  const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
 
@@ -122,6 +122,17 @@ export function GoalDetail() {
             {goal.level}
           </span>
           <StatusBadge status={goal.status} />
+          {!panelVisible && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="hidden md:inline-flex ml-auto gap-1.5"
+              onClick={() => setPanelVisible(true)}
+              title="Show properties"
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+            </Button>
+          )}
         </div>
 
         <InlineEditor


### PR DESCRIPTION

## What Changed

- Added `panelVisible` / `setPanelVisible` usage in `GoalDetail` so the page can react to properties panel visibility
- Added a ghost button with a sliders icon in the goal header that appears only when the properties panel is hidden
- Wired the button to reopen the properties panel and hide itself again once the panel is visible
- Kept the control desktop-only to avoid changing the smaller-screen layout

## Verification

- Ran `pnpm --filter @paperclipai/ui typecheck`
- Manually open a goal detail page, hide the properties panel, and confirm a "show properties" button appears in the header
- Click the button and confirm the properties panel reopens
- Confirm the button is hidden again once the properties panel is visible

## Risks

- Low risk: this is a small, isolated UI change in `GoalDetail`
- Behavior depends on `PanelContext` visibility state, so any existing panel visibility edge cases would also affect this button
- The control is intentionally hidden on smaller screens, so it does not improve panel recovery there

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge


Before: 
<img width="1195" height="737" alt="Screenshot 2026-03-30 at 17 07 23" src="https://github.com/user-attachments/assets/31613e97-e952-4c9f-a81b-62dff9259d6e" />

After: 
<img width="1197" height="761" alt="Screenshot 2026-03-30 at 16 54 21" src="https://github.com/user-attachments/assets/81025ee5-3b32-4879-aaa8-745957c0a303" />



