### PR TITLE
fix(ui): correct Last checked timestamp in workspace close dialog

### DIFF
--- a/ui/src/components/ExecutionWorkspaceCloseDialog.tsx
+++ b/ui/src/components/ExecutionWorkspaceCloseDialog.tsx
@@ -286,7 +286,7 @@ export function ExecutionWorkspaceCloseDialog({
             ) : null}
 
             <div className="text-xs text-muted-foreground">
-              Last checked {formatDateTime(new Date())}
+              Last checked {formatDateTime(new Date(readinessQuery.dataUpdatedAt))}
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
## Problem

In the ExecutionWorkspaceCloseDialog, the "Last checked" timestamp was using \`new Date()\` which show the current render time, not when the readiness check API call actually completed.

\`\`\`tsx
Last checked {formatDateTime(new Date())} // always NOW
\`\`\`

This mean every time React re-render the component (which happen frequently), the timestamp update to the current moment. User see "Last checked 2:45:30 PM" and think the check just ran, but actually it might have ran 30 seconds ago. The timestamp is lying.

## What I changed

Changed from \`new Date()\` to \`new Date(readinessQuery.dataUpdatedAt)\` which is the actual timestamp from React Query tracking when the API response was last received.

\`\`\`tsx
Last checked {formatDateTime(new Date(readinessQuery.dataUpdatedAt))} // actual check time
\`\`\`

Now the timestamp accurately show when the close readiness check was performed. It stay stable between re-renders until the query actually refetch.

## How to test

1. Open an execution workspace > click Close button to open the dialog
2. The "Last checked" timestamp should show when the API call completed
3. Wait a few seconds - timestamp should NOT update (it's the query time, not render time)
4. Click "Recheck" or trigger refetch - timestamp should update to new fetch time

1 file, 1 line changed.