### PR TITLE
Promote Claude/Codex in onboarding, mark OpenClaw as legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 # Open-source orchestration for zero-human companies
 
-**If OpenClaw is an _employee_, Paperclip is the _company_**
+**Paperclip is the company. Claude, Codex, and your other agents are the employees.**
 
 Paperclip is a Node.js server and React UI that orchestrates a team of AI agents to run a business. Bring your own agents, assign goals, and track your agents' work and costs from one dashboard.
 
@@ -51,7 +51,6 @@ It looks like a task manager — but under the hood it has org charts, budgets, 
 <table>
   <tr>
     <td align="center"><strong>Works<br/>with</strong></td>
-    <td align="center"><img src="doc/assets/logos/openclaw.svg" width="32" alt="OpenClaw" /><br/><sub>OpenClaw</sub></td>
     <td align="center"><img src="doc/assets/logos/claude.svg" width="32" alt="Claude" /><br/><sub>Claude Code</sub></td>
     <td align="center"><img src="doc/assets/logos/codex.svg" width="32" alt="Codex" /><br/><sub>Codex</sub></td>
     <td align="center"><img src="doc/assets/logos/cursor.svg" width="32" alt="Cursor" /><br/><sub>Cursor</sub></td>
@@ -69,7 +68,7 @@ It looks like a task manager — but under the hood it has org charts, budgets, 
 ## Paperclip is right for you if
 
 - ✅ You want to build **autonomous AI companies**
-- ✅ You **coordinate many different agents** (OpenClaw, Codex, Claude, Cursor) toward a common goal
+- ✅ You **coordinate many different agents** (Codex, Claude, Cursor, remote runtimes) toward a common goal
 - ✅ You have **20 simultaneous Claude Code terminals** open and lose track of what everyone is doing
 - ✅ You want agents running **autonomously 24/7**, but still want to audit work and chime in when needed
 - ✅ You want to **monitor costs** and enforce budgets
@@ -204,16 +203,16 @@ If you're a solo-entreprenuer you can use Tailscale to access Paperclip on the g
 **Can I run multiple companies?**
 Yes. A single deployment can run an unlimited number of companies with complete data isolation.
 
-**How is Paperclip different from agents like OpenClaw or Claude Code?**
+**How is Paperclip different from agents like Claude Code or Codex?**
 Paperclip _uses_ those agents. It orchestrates them into a company — with org charts, budgets, goals, governance, and accountability.
 
-**Why should I use Paperclip instead of just pointing my OpenClaw to Asana or Trello?**
+**Why should I use Paperclip instead of wiring Codex straight into Asana or Trello?**
 Agent orchestration has subtleties in how you coordinate who has work checked out, how to maintain sessions, monitoring costs, establishing governance - Paperclip does this for you.
 
 (Bring-your-own-ticket-system is on the Roadmap)
 
 **Do agents run continuously?**
-By default, agents run on scheduled heartbeats and event-based triggers (task assignment, @-mentions). You can also hook in continuous agents like OpenClaw. You bring your agent and Paperclip coordinates.
+By default, agents run on scheduled heartbeats and event-based triggers (task assignment, @-mentions). Paperclip promotes local Claude and Codex paths first, while other runtimes remain advanced/manual integrations. You bring your agent and Paperclip coordinates.
 
 <br/>
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -395,13 +395,15 @@ pnpm paperclipai dashboard get
 
 See full command reference in `doc/CLI.md`.
 
-## OpenClaw Invite Onboarding Endpoints
+## Agent Invite Onboarding Endpoints
 
 Agent-oriented invite onboarding now exposes machine-readable API docs:
 
 - `GET /api/invites/:token` returns invite summary plus onboarding and skills index links.
-- `GET /api/invites/:token/onboarding` returns onboarding manifest details (registration endpoint, claim endpoint template, skill install hints).
+- `GET /api/invites/:token/onboarding` returns onboarding manifest details (registration endpoint, claim endpoint template, skill install hints, recommended adapter type, and onboarding template).
 - `GET /api/invites/:token/onboarding.txt` returns a plain-text onboarding doc intended for both human operators and agents (llm.txt-style handoff), including optional inviter message and suggested network host candidates.
+- Generic invites now default to remote-agent guidance with `adapterType=http`.
+- The legacy `POST /api/companies/:companyId/openclaw/invite-prompt` route still stamps invites with an explicit OpenClaw onboarding template so existing gateway flows keep their WebSocket/token instructions.
 - `GET /api/skills/index` lists available skill documents.
 - `GET /api/skills/paperclip` returns the Paperclip heartbeat skill markdown.
 

--- a/doc/OPENCLAW_ONBOARDING.md
+++ b/doc/OPENCLAW_ONBOARDING.md
@@ -1,4 +1,9 @@
-Use this exact checklist.
+Legacy guide: this checklist exists only for migrating older OpenClaw installs.
+New agent setups should prefer `claude_local` or `codex_local`; use the
+generic `http` adapter only for advanced/manual remote bridges.
+
+Use this exact checklist only if you still need to keep an existing OpenClaw
+agent alive during migration.
 
 1. Start Paperclip in auth mode.
 ```bash

--- a/doc/plans/2026-03-30-hermes-cutover.md
+++ b/doc/plans/2026-03-30-hermes-cutover.md
@@ -1,0 +1,169 @@
+# Claude/Codex Promotion and OpenClaw Legacy Plan
+
+## Overview
+
+Paperclip should clearly promote two supported day-one agent paths:
+
+1. `claude_local`
+2. `codex_local`
+
+Generic remote HTTP remains available as an advanced/manual integration path,
+but it is no longer part of the primary product story. OpenClaw remains legacy
+until it can be removed safely.
+
+## Goals
+
+1. Make the Paperclip product story reflect `Claude + Codex` as the promoted
+   paths.
+2. Keep the generic `http` adapter available without presenting it as a
+   first-class onboarding recommendation.
+3. Keep existing `openclaw_gateway` agents readable and editable long enough to
+   migrate them.
+4. Delete OpenClaw-specific docs, routes, packages, smoke tests, and tests once
+   the replacement path is settled.
+
+## Non-Goals
+
+1. Shipping a dedicated Hermes adapter right now.
+2. Auto-migrating existing OpenClaw agents without operator review.
+3. Reworking every remote-agent workflow before OpenClaw cleanup lands.
+
+## Key Decisions
+
+1. `claude_local` and `codex_local` are the only promoted agent paths.
+2. The generic `http` adapter remains supported only for advanced/manual remote
+   integrations.
+3. `openclaw_gateway` is treated as a legacy adapter during the transition.
+4. Hermes work is deferred until the Hermes API server is actually deployed on
+   the host and ready to integrate.
+
+## Execution Phases
+
+### Phase 1: Story and Defaults
+
+Update the repo so the visible product story matches the intended stack.
+
+Scope:
+
+- Rewrite README and adapter docs around Claude and Codex as the primary paths.
+- Keep generic `http` available in advanced/manual configuration only.
+- Mark OpenClaw labels as legacy instead of presenting them as current.
+- Remove Hermes-specific copy from promoted UI, onboarding, and skill guidance.
+
+Success criteria:
+
+- No primary new-agent path recommends OpenClaw.
+- README no longer frames Hermes as a primary Paperclip path.
+- Existing OpenClaw agents still render cleanly in the UI.
+
+### Phase 1.5: Backend Generalization
+
+Close the gap between the simplified Claude/Codex story and the still
+OpenClaw-shaped runtime surfaces.
+
+Scope:
+
+- Generalize the invite/bootstrap path so remote-agent onboarding is not tied to
+  `/companies/:companyId/openclaw/invite-prompt`.
+- Update `skills/paperclip/SKILL.md` so agents do not treat OpenClaw as the
+  normal remote-agent flow.
+- Keep generic `http` onboarding text adapter-agnostic.
+- Define replacement remote-agent smoke coverage before removing OpenClaw smoke
+  scripts.
+- Decide whether any additional Docker/runtime install path is needed for future
+  remote integrations.
+
+Success criteria:
+
+- Remote-agent onboarding is adapter-agnostic.
+- Paperclip skills no longer teach OpenClaw as the normal remote-agent path.
+- The repo clearly distinguishes promoted paths from advanced/manual ones.
+
+### Phase 2: Legacy Removal
+
+Remove OpenClaw-specific runtime and onboarding infrastructure.
+
+Scope:
+
+- Delete OpenClaw invite/onboarding docs and replace them with migration notes.
+- Remove OpenClaw-specific server invite flows and helper logic.
+- Remove `packages/adapters/openclaw-gateway`.
+- Remove OpenClaw smoke scripts, fixtures, and tests.
+- Remove OpenClaw-specific adapter registry entries and constants.
+
+Success criteria:
+
+- No code path can create or execute `openclaw_gateway`.
+- No docs instruct operators to onboard OpenClaw.
+- Test suite and build pass without the OpenClaw package.
+
+### Deferred: Future Hermes Work
+
+Hermes is not part of the current promoted scope. If Hermes becomes relevant
+again later:
+
+- do not build `hermes_remote` until the Hermes API server is actually deployed
+  on the host
+- verify the live auth and protocol shape against the deployed host, not just
+  docs
+- decide then whether Paperclip should talk to Hermes directly or through an
+  operator-managed bridge
+
+## File Inventory
+
+### First-Wave Files
+
+- `README.md`
+- `docs/adapters/overview.md`
+- `ui/src/components/NewAgentDialog.tsx`
+- `ui/src/components/OnboardingWizard.tsx`
+- `ui/src/components/AgentConfigForm.tsx`
+- `ui/src/components/AgentProperties.tsx`
+- `ui/src/components/agent-config-primitives.tsx`
+- `ui/src/pages/NewAgent.tsx`
+- `ui/src/pages/Agents.tsx`
+- `ui/src/pages/InviteLanding.tsx`
+
+### Legacy Removal Targets
+
+- `doc/OPENCLAW_ONBOARDING.md`
+- `docs/guides/openclaw-docker-setup.md`
+- `server/src/routes/access.ts`
+- `server/src/routes/agents.ts`
+- `server/src/adapters/registry.ts`
+- `ui/src/adapters/openclaw-gateway/*`
+- `packages/adapters/openclaw-gateway/*`
+- `scripts/smoke/openclaw-*`
+- `docker/openclaw-smoke/*`
+- OpenClaw-specific tests under `server/src/__tests__`
+
+### Wave 1.5 Targets
+
+- `server/src/routes/access.ts`
+- `skills/paperclip/SKILL.md`
+- `scripts/smoke/openclaw-*`
+- `Dockerfile`
+
+## Verified Wave 1.5 Gaps
+
+1. The invite prompt endpoint is OpenClaw-specific:
+   `/api/companies/{companyId}/openclaw/invite-prompt`.
+2. The OpenClaw join path includes WebSocket-specific config, device signing,
+   and `sessionKeyStrategy`, which are not covered by generic `http`.
+3. Non-local adapters do not get Paperclip JWTs automatically; remote adapter
+   auth must still be designed explicitly when needed.
+4. `skills/paperclip/SKILL.md` still needs to keep OpenClaw isolated as a
+   legacy-only flow.
+5. Four OpenClaw smoke scripts still define the current remote-agent regression
+   coverage.
+6. The runtime/Docker story currently installs local CLIs but has no future
+   remote-runtime install path.
+
+## Verification
+
+Before considering Phase 1 complete:
+
+1. `http` remains available through advanced/manual flows.
+2. Hermes no longer appears in promoted onboarding or skill copy.
+3. OpenClaw is no longer recommended anywhere in README or primary docs.
+4. Existing `openclaw_gateway` agents still show a clear legacy label.

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -20,14 +20,14 @@ When a heartbeat fires, Paperclip:
 |---------|----------|-------------|
 | [Claude Local](/adapters/claude-local) | `claude_local` | Runs Claude Code CLI locally |
 | [Codex Local](/adapters/codex-local) | `codex_local` | Runs OpenAI Codex CLI locally |
-| [Gemini Local](/adapters/gemini-local) | `gemini_local` | Runs Gemini CLI locally (experimental — adapter package exists, not yet in stable type enum) |
+| [Gemini Local](/adapters/gemini-local) | `gemini_local` | Runs Gemini CLI locally |
 | OpenCode Local | `opencode_local` | Runs OpenCode CLI locally (multi-provider `provider/model`) |
 | Hermes Local | `hermes_local` | Runs Hermes CLI locally |
 | Cursor | `cursor` | Runs Cursor in background mode |
 | Pi Local | `pi_local` | Runs an embedded Pi agent locally |
-| OpenClaw Gateway | `openclaw_gateway` | Connects to an OpenClaw gateway endpoint |
+| OpenClaw Gateway (legacy) | `openclaw_gateway` | Legacy gateway adapter retained only for migration of older OpenClaw installs |
 | [Process](/adapters/process) | `process` | Executes arbitrary shell commands |
-| [HTTP](/adapters/http) | `http` | Sends webhooks to external agents |
+| [HTTP](/adapters/http) | `http` | Sends Paperclip's JSON wake payload to generic remote HTTP endpoints and bridge services |
 
 ## Adapter Architecture
 
@@ -58,7 +58,9 @@ Three registries consume these modules:
 
 ## Choosing an Adapter
 
-- **Need a coding agent?** Use `claude_local`, `codex_local`, `opencode_local`, or `hermes_local`
+- **Promoted paths:** use `claude_local` or `codex_local` first
+- **Need another coding agent?** Use `gemini_local`, `opencode_local`, or `hermes_local`
+- **Need a generic remote HTTP endpoint or bridge?** Use `http` in advanced/manual configuration
 - **Need to run a script or command?** Use `process`
-- **Need to call an external service?** Use `http`
+- **Need to keep an old OpenClaw install alive during migration?** Use `openclaw_gateway` only as a temporary bridge
 - **Need something custom?** [Create your own adapter](/adapters/creating-an-adapter)

--- a/docs/guides/openclaw-docker-setup.md
+++ b/docs/guides/openclaw-docker-setup.md
@@ -1,5 +1,9 @@
 # Running OpenClaw in Docker (Local Development)
 
+Legacy guide: this exists for older OpenClaw adapter testing only. New remote
+agent setups should use the promoted Claude/Codex paths first and treat generic
+remote HTTP work as advanced/manual setup, not this OpenClaw flow.
+
 How to get OpenClaw running in a Docker container for local development and testing the Paperclip OpenClaw adapter integration.
 
 ## Automated Join Smoke Test (Recommended First)

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Request } from "express";
-import { buildInviteOnboardingTextDocument } from "../routes/access.js";
+import {
+  buildInviteOnboardingManifest,
+  buildInviteOnboardingTextDocument,
+} from "../routes/access.js";
 
 function buildReq(host: string): Request {
   return {
@@ -13,7 +16,7 @@ function buildReq(host: string): Request {
 }
 
 describe("buildInviteOnboardingTextDocument", () => {
-  it("renders a plain-text onboarding doc with expected endpoint references", () => {
+  it("renders a generic remote-agent onboarding doc by default", () => {
     const req = buildReq("localhost:3100");
     const invite = {
       id: "invite-1",
@@ -37,22 +40,21 @@ describe("buildInviteOnboardingTextDocument", () => {
       allowedHostnames: [],
     });
 
-    expect(text).toContain("Paperclip OpenClaw Gateway Onboarding");
+    expect(text).toContain("Paperclip Remote Agent Onboarding");
     expect(text).toContain("/api/invites/token-123/accept");
     expect(text).toContain("/api/join-requests/{requestId}/claim-api-key");
     expect(text).toContain("/api/invites/token-123/onboarding.txt");
     expect(text).toContain("Suggested Paperclip base URLs to try");
     expect(text).toContain("http://localhost:3100");
     expect(text).toContain("host.docker.internal");
-    expect(text).toContain("paperclipApiUrl");
-    expect(text).toContain("adapterType \"openclaw_gateway\"");
-    expect(text).toContain("headers.x-openclaw-token");
-    expect(text).toContain("Do NOT use /v1/responses or /hooks/*");
-    expect(text).toContain("set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl");
-    expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+    expect(text).toContain("adapterType \"http\"");
+    expect(text).toContain("Remote HTTP agents should gather");
+    expect(text).toContain("timeoutMs");
+    expect(text).toContain("Use the first reachable candidate for invite, claim, and skill bootstrap calls");
+    expect(text).toContain("~/paperclip/paperclip-claimed-api-key.json");
     expect(text).toContain("PAPERCLIP_API_KEY");
-    expect(text).toContain("saved token field");
-    expect(text).toContain("Gateway token unexpectedly short");
+    expect(text).not.toContain("headers.x-openclaw-token");
+    expect(text).not.toContain("Gateway token unexpectedly short");
   });
 
   it("includes loopback diagnostics for authenticated/private onboarding", () => {
@@ -112,5 +114,71 @@ describe("buildInviteOnboardingTextDocument", () => {
 
     expect(text).toContain("Message from inviter");
     expect(text).toContain("prioritize flaky test triage first");
+  });
+
+  it("keeps the legacy OpenClaw onboarding text when invite metadata requests it", () => {
+    const req = buildReq("localhost:3100");
+    const invite = {
+      id: "invite-4",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: {
+        onboardingTemplate: "openclaw_gateway",
+        recommendedAdapterType: "openclaw_gateway",
+      },
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-openclaw", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(text).toContain("Paperclip OpenClaw Gateway Onboarding");
+    expect(text).toContain("adapterType \"openclaw_gateway\"");
+    expect(text).toContain("headers.x-openclaw-token");
+    expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
+});
+
+describe("buildInviteOnboardingManifest", () => {
+  it("defaults invite onboarding manifests to generic remote-agent guidance", () => {
+    const req = buildReq("localhost:3100");
+    const invite = {
+      id: "invite-manifest-1",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: null,
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const manifest = buildInviteOnboardingManifest(req, "token-manifest", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(manifest.onboarding.template).toBe("remote_agent");
+    expect(manifest.onboarding.recommendedAdapterType).toBe("http");
+    expect(manifest.onboarding.instructions).toContain("generic remote HTTP endpoints");
+    expect(manifest.onboarding.requiredFields.adapterType).toContain("generic remote HTTP or webhook endpoints");
+    expect(manifest.onboarding.skill.installPath).toContain("$CODEX_HOME/skills/paperclip/SKILL.md");
   });
 });

--- a/server/src/__tests__/openclaw-invite-prompt-route.test.ts
+++ b/server/src/__tests__/openclaw-invite-prompt-route.test.ts
@@ -45,25 +45,30 @@ vi.mock("../services/index.js", () => ({
 }));
 
 function createDbStub() {
-  const createdInvite = {
-    id: "invite-1",
-    companyId: "company-1",
-    inviteType: "company_join",
-    allowedJoinTypes: "agent",
-    defaultsPayload: null,
-    expiresAt: new Date("2026-03-07T00:10:00.000Z"),
-    invitedByUserId: null,
-    tokenHash: "hash",
-    revokedAt: null,
-    acceptedAt: null,
-    createdAt: new Date("2026-03-07T00:00:00.000Z"),
-    updatedAt: new Date("2026-03-07T00:00:00.000Z"),
-  };
-  const returning = vi.fn().mockResolvedValue([createdInvite]);
+  const returning = vi.fn().mockImplementation(async () => {
+    const insertValues = values.mock.calls.at(-1)?.[0] ?? {};
+    return [
+      {
+        id: "invite-1",
+        companyId: "company-1",
+        inviteType: "company_join",
+        allowedJoinTypes: "agent",
+        defaultsPayload: insertValues.defaultsPayload ?? null,
+        expiresAt: new Date("2026-03-07T00:10:00.000Z"),
+        invitedByUserId: null,
+        tokenHash: "hash",
+        revokedAt: null,
+        acceptedAt: null,
+        createdAt: new Date("2026-03-07T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-07T00:00:00.000Z"),
+      },
+    ];
+  });
   const values = vi.fn().mockReturnValue({ returning });
   const insert = vi.fn().mockReturnValue({ values });
   return {
     insert,
+    values,
   };
 }
 
@@ -142,8 +147,22 @@ describe("POST /companies/:companyId/openclaw/invite-prompt", () => {
 
     expect(res.status).toBe(201);
     expect(res.body.allowedJoinTypes).toBe("agent");
+    expect(res.body.defaultsPayload).toMatchObject({
+      onboardingTemplate: "openclaw_gateway",
+      recommendedAdapterType: "openclaw_gateway",
+      agentMessage: "Join and configure OpenClaw gateway.",
+    });
     expect(typeof res.body.token).toBe("string");
     expect(res.body.onboardingTextPath).toContain("/api/invites/");
+    expect(db.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultsPayload: expect.objectContaining({
+          onboardingTemplate: "openclaw_gateway",
+          recommendedAdapterType: "openclaw_gateway",
+          agentMessage: "Join and configure OpenClaw gateway.",
+        }),
+      }),
+    );
   });
 
   it("allows board callers with invite permission", async () => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -18,6 +18,7 @@ import {
   joinRequests
 } from "@paperclipai/db";
 import {
+  AGENT_ADAPTER_TYPES,
   acceptInviteSchema,
   createCliAuthChallengeSchema,
   claimJoinRequestApiKeySchema,
@@ -29,7 +30,11 @@ import {
   updateUserCompanyAccessSchema,
   PERMISSION_KEYS
 } from "@paperclipai/shared";
-import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+import type {
+  AgentAdapterType,
+  DeploymentExposure,
+  DeploymentMode
+} from "@paperclipai/shared";
 import {
   forbidden,
   conflict,
@@ -62,6 +67,11 @@ const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
 const INVITE_TOKEN_SUFFIX_LENGTH = 8;
 const INVITE_TOKEN_MAX_RETRIES = 5;
 const COMPANY_INVITE_TTL_MS = 10 * 60 * 1000;
+const INVITE_ONBOARDING_TEMPLATES = [
+  "remote_agent",
+  "openclaw_gateway"
+] as const;
+type InviteOnboardingTemplate = (typeof INVITE_ONBOARDING_TEMPLATES)[number];
 
 function createInviteToken() {
   const bytes = randomBytes(INVITE_TOKEN_SUFFIX_LENGTH);
@@ -225,6 +235,47 @@ type JoinDiagnostic = {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function inviteDefaultsRecord(
+  invite: typeof invites.$inferSelect
+): Record<string, unknown> | null {
+  return isPlainObject(invite.defaultsPayload)
+    ? (invite.defaultsPayload as Record<string, unknown>)
+    : null;
+}
+
+function extractInviteOnboardingTemplate(
+  invite: typeof invites.$inferSelect
+): InviteOnboardingTemplate {
+  const defaults = inviteDefaultsRecord(invite);
+  const rawTemplate = defaults?.onboardingTemplate;
+  if (
+    typeof rawTemplate === "string" &&
+    (INVITE_ONBOARDING_TEMPLATES as readonly string[]).includes(rawTemplate)
+  ) {
+    return rawTemplate as InviteOnboardingTemplate;
+  }
+  return "remote_agent";
+}
+
+function extractInviteRecommendedAdapterType(
+  invite: typeof invites.$inferSelect
+): AgentAdapterType {
+  const defaults = inviteDefaultsRecord(invite);
+  const rawAdapterType =
+    typeof defaults?.recommendedAdapterType === "string"
+      ? defaults.recommendedAdapterType
+      : null;
+  if (
+    rawAdapterType &&
+    (AGENT_ADAPTER_TYPES as readonly string[]).includes(rawAdapterType)
+  ) {
+    return rawAdapterType as AgentAdapterType;
+  }
+  return extractInviteOnboardingTemplate(invite) === "openclaw_gateway"
+    ? "openclaw_gateway"
+    : "http";
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -988,7 +1039,7 @@ function buildOnboardingConnectionCandidates(input: {
   return Array.from(candidates);
 }
 
-function buildInviteOnboardingManifest(
+export function buildInviteOnboardingManifest(
   req: Request,
   token: string,
   invite: typeof invites.$inferSelect,
@@ -1022,21 +1073,33 @@ function buildInviteOnboardingManifest(
     bindHost: opts.bindHost,
     allowedHostnames: opts.allowedHostnames
   });
+  const onboardingTemplate = extractInviteOnboardingTemplate(invite);
+  const recommendedAdapterType = extractInviteRecommendedAdapterType(invite);
+  const genericSkillInstallPath =
+    "Runtime-specific skills directory (for example $CODEX_HOME/skills/paperclip/SKILL.md or ~/.claude/skills/paperclip/SKILL.md)";
 
   return {
     invite: toInviteSummaryResponse(req, token, invite),
     onboarding: {
+      template: onboardingTemplate,
       instructions:
-        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
+        onboardingTemplate === "openclaw_gateway"
+          ? "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth)."
+          : "Join as a remote agent, save your one-time claim secret, wait for board approval, then claim your API key. For generic remote HTTP endpoints, submit adapterType='http', set agentDefaultsPayload.url to your reachable http(s) endpoint, and include any auth headers or shared secrets your runtime expects.",
       inviteMessage: extractInviteMessage(invite),
-      recommendedAdapterType: "openclaw_gateway",
+      recommendedAdapterType,
       requiredFields: {
         requestType: "agent",
         agentName: "Display name for this agent",
-        adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
+        adapterType:
+          onboardingTemplate === "openclaw_gateway"
+            ? "Use 'openclaw_gateway' for OpenClaw Gateway agents"
+            : "Use 'http' for generic remote HTTP or webhook endpoints. Other adapter types should only be used when your operator has configured them explicitly.",
         capabilities: "Optional capability summary",
         agentDefaultsPayload:
-          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
+          onboardingTemplate === "openclaw_gateway"
+            ? "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). Optional fields: paperclipApiUrl, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, disableDeviceAuth, devicePrivateKeyPem."
+            : "Adapter config for remote HTTP agents. MUST include url (http:// or https://). Optional fields: method, headers, payloadTemplate, timeoutMs. Configure any runtime-specific auth headers or shared secrets here."
       },
       registrationEndpoint: {
         method: "POST",
@@ -1059,10 +1122,15 @@ function buildInviteOnboardingManifest(
         connectionCandidates,
         diagnostics: discoveryDiagnostics,
         guidance:
-          opts.deploymentMode === "authenticated" &&
-          opts.deploymentExposure === "private"
-            ? "If OpenClaw runs on another machine, ensure the Paperclip hostname is reachable and allowed via `pnpm paperclipai allowed-hostname <host>`."
-            : "Ensure OpenClaw can reach this Paperclip API base URL for invite, claim, and skill bootstrap calls."
+          onboardingTemplate === "openclaw_gateway"
+            ? opts.deploymentMode === "authenticated" &&
+              opts.deploymentExposure === "private"
+              ? "If OpenClaw runs on another machine, ensure the Paperclip hostname is reachable and allowed via `pnpm paperclipai allowed-hostname <host>`."
+              : "Ensure OpenClaw can reach this Paperclip API base URL for invite, claim, and skill bootstrap calls."
+            : opts.deploymentMode === "authenticated" &&
+                opts.deploymentExposure === "private"
+              ? "If the remote agent runs on another machine, ensure the Paperclip hostname is reachable and allowed via `pnpm paperclipai allowed-hostname <host>`."
+              : "Ensure the remote agent can reach this Paperclip API base URL for invite, claim, and skill bootstrap calls."
       },
       textInstructions: {
         path: onboardingTextPath,
@@ -1073,7 +1141,10 @@ function buildInviteOnboardingManifest(
         name: "paperclip",
         path: skillPath,
         url: skillUrl,
-        installPath: "~/.openclaw/skills/paperclip/SKILL.md"
+        installPath:
+          onboardingTemplate === "openclaw_gateway"
+            ? "~/.openclaw/skills/paperclip/SKILL.md"
+            : genericSkillInstallPath
       }
     }
   };
@@ -1092,7 +1163,9 @@ export function buildInviteOnboardingTextDocument(
 ) {
   const manifest = buildInviteOnboardingManifest(req, token, invite, opts);
   const onboarding = manifest.onboarding as {
+    template?: string;
     inviteMessage?: string | null;
+    recommendedAdapterType?: string;
     registrationEndpoint: { method: string; path: string; url: string };
     claimEndpointTemplate: { method: string; path: string };
     textInstructions: { path: string; url: string };
@@ -1104,6 +1177,17 @@ export function buildInviteOnboardingTextDocument(
       testResolutionEndpoint?: { method?: string; path?: string; url?: string };
     };
   };
+  const onboardingTemplate =
+    onboarding.template === "openclaw_gateway"
+      ? "openclaw_gateway"
+      : "remote_agent";
+  const recommendedAdapterType =
+    typeof onboarding.recommendedAdapterType === "string" &&
+    onboarding.recommendedAdapterType.trim().length > 0
+      ? onboarding.recommendedAdapterType.trim()
+      : onboardingTemplate === "openclaw_gateway"
+        ? "openclaw_gateway"
+        : "http";
   const diagnostics = Array.isArray(onboarding.connectivity?.diagnostics)
     ? onboarding.connectivity.diagnostics
     : [];
@@ -1123,7 +1207,11 @@ export function buildInviteOnboardingTextDocument(
   };
 
   appendBlock(`
-    # Paperclip OpenClaw Gateway Onboarding
+    # ${
+      onboardingTemplate === "openclaw_gateway"
+        ? "Paperclip OpenClaw Gateway Onboarding"
+        : "Paperclip Remote Agent Onboarding"
+    }
 
     This document is meant to be readable by both humans and agents.
 
@@ -1140,133 +1228,222 @@ export function buildInviteOnboardingTextDocument(
     `);
   }
 
-  appendBlock(`
-    ## Step 0
+  if (onboardingTemplate === "openclaw_gateway") {
+    appendBlock(`
+      ## Step 0
 
-    Get the OpenClaw gateway auth token (THIS MUST BE SENT)
-    Token lives in:
+      Get the OpenClaw gateway auth token (THIS MUST BE SENT)
+      Token lives in:
 
-    ~/.openclaw/openclaw.json -> gateway.auth.token
-    Extract:
+      ~/.openclaw/openclaw.json -> gateway.auth.token
+      Extract:
 
-    TOKEN="$(node -p 'require(process.env.HOME+\"/.openclaw/openclaw.json\").gateway.auth.token')"
-    test -n "$TOKEN" || (echo "Missing TOKEN" && exit 1)
-    test "\${#TOKEN}" -ge 16 || (echo "Gateway token unexpectedly short (\${#TOKEN})" && exit 1)
+      TOKEN="$(node -p 'require(process.env.HOME+\"/.openclaw/openclaw.json\").gateway.auth.token')"
+      test -n "$TOKEN" || (echo "Missing TOKEN" && exit 1)
+      test "\${#TOKEN}" -ge 16 || (echo "Gateway token unexpectedly short (\${#TOKEN})" && exit 1)
 
-    3) IMPORTANT: Don't accidentally drop the token when generating JSON
-    If you build JSON with Node, pass the token explicitly (argv), don't rely on an un-exported env var.
+      3) IMPORTANT: Don't accidentally drop the token when generating JSON
+      If you build JSON with Node, pass the token explicitly (argv), don't rely on an un-exported env var.
 
-    Safe payload build looks sort of like this (substitute where necessary):
+      Safe payload build looks sort of like this (substitute where necessary):
 
-    BODY="$(node -e '
-      const token = process.argv[1];
-      if (!token) process.exit(2);
-      const body = {
-        requestType: "agent",
-        agentName: "OpenClaw",
-        adapterType: "openclaw_gateway",
-        capabilities: "OpenClaw agent adapter",
-        agentDefaultsPayload: {
-          url: "ws://127.0.0.1:18789",
-          paperclipApiUrl: "http://host.docker.internal:3100",
-          headers: { "x-openclaw-token": token },
-          waitTimeoutMs: 120000,
-          sessionKeyStrategy: "issue",
-          role: "operator",
-          scopes: ["operator.admin"]
+      BODY="$(node -e '
+        const token = process.argv[1];
+        if (!token) process.exit(2);
+        const body = {
+          requestType: "agent",
+          agentName: "OpenClaw",
+          adapterType: "openclaw_gateway",
+          capabilities: "OpenClaw agent adapter",
+          agentDefaultsPayload: {
+            url: "ws://127.0.0.1:18789",
+            paperclipApiUrl: "http://host.docker.internal:3100",
+            headers: { "x-openclaw-token": token },
+            waitTimeoutMs: 120000,
+            sessionKeyStrategy: "issue",
+            role: "operator",
+            scopes: ["operator.admin"]
+          }
+        };
+        process.stdout.write(JSON.stringify(body));
+      ' "$TOKEN")"
+
+      ## Step 1: Submit agent join request
+      ${onboarding.registrationEndpoint.method} ${
+      onboarding.registrationEndpoint.url
+    }
+
+      IMPORTANT: You MUST include agentDefaultsPayload.headers.x-openclaw-token with your gateway token.
+      Legacy x-openclaw-auth is also accepted, but x-openclaw-token is preferred.
+      Use adapterType "openclaw_gateway" and a ws:// or wss:// gateway URL.
+      Pairing mode requirement:
+      - Keep device auth enabled (recommended). If devicePrivateKeyPem is omitted, Paperclip generates and persists one during join so pairing approvals are stable.
+      - You may set disableDeviceAuth=true only for special environments that cannot support pairing.
+      - First run may return "pairing required" once; approve the pending pairing request in OpenClaw, then retry.
+      Do NOT use /v1/responses or /hooks/* in this gateway join flow.
+
+      Body (JSON):
+      {
+        "requestType": "agent",
+        "agentName": "My OpenClaw Agent",
+        "adapterType": "openclaw_gateway",
+        "capabilities": "Optional summary",
+        "agentDefaultsPayload": {
+          "url": "wss://your-openclaw-gateway.example",
+          "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
+          "headers": { "x-openclaw-token": "replace-me" },
+          "waitTimeoutMs": 120000,
+          "sessionKeyStrategy": "issue",
+          "role": "operator",
+          "scopes": ["operator.admin"]
         }
-      };
-      process.stdout.write(JSON.stringify(body));
-    ' "$TOKEN")"
-
-    ## Step 1: Submit agent join request
-    ${onboarding.registrationEndpoint.method} ${
-    onboarding.registrationEndpoint.url
-  }
-
-    IMPORTANT: You MUST include agentDefaultsPayload.headers.x-openclaw-token with your gateway token.
-    Legacy x-openclaw-auth is also accepted, but x-openclaw-token is preferred.
-    Use adapterType "openclaw_gateway" and a ws:// or wss:// gateway URL.
-    Pairing mode requirement:
-    - Keep device auth enabled (recommended). If devicePrivateKeyPem is omitted, Paperclip generates and persists one during join so pairing approvals are stable.
-    - You may set disableDeviceAuth=true only for special environments that cannot support pairing.
-    - First run may return "pairing required" once; approve the pending pairing request in OpenClaw, then retry.
-    Do NOT use /v1/responses or /hooks/* in this gateway join flow.
-
-    Body (JSON):
-    {
-      "requestType": "agent",
-      "agentName": "My OpenClaw Agent",
-      "adapterType": "openclaw_gateway",
-      "capabilities": "Optional summary",
-      "agentDefaultsPayload": {
-        "url": "wss://your-openclaw-gateway.example",
-        "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
-        "headers": { "x-openclaw-token": "replace-me" },
-        "waitTimeoutMs": 120000,
-        "sessionKeyStrategy": "issue",
-        "role": "operator",
-        "scopes": ["operator.admin"]
       }
+
+      Expected response includes:
+      - request id
+      - one-time claimSecret
+      - claimApiKeyPath
+
+      ## Step 2: Wait for board approval
+      The board approves the join request in Paperclip before key claim is allowed.
+
+      ## Step 3: Claim API key (one-time)
+      ${
+        onboarding.claimEndpointTemplate.method
+      } /api/join-requests/{requestId}/claim-api-key
+
+      Body (JSON):
+      {
+        "claimSecret": "<one-time-claim-secret>"
+      }
+
+      On successful claim, save the full JSON response to:
+
+      - ~/.openclaw/workspace/paperclip-claimed-api-key.json
+      chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+
+      And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
+      https://docs.openclaw.ai/help/environment
+
+      e.g.
+
+      {
+        env: {
+          PAPERCLIP_API_KEY: "...",
+          PAPERCLIP_API_URL: "...",
+        },
+      }
+
+      Then set PAPERCLIP_API_KEY and PAPERCLIP_API_URL from the saved token field for every heartbeat run.
+
+      Important:
+      - claim secrets expire
+      - claim secrets are single-use
+      - claim fails before board approval
+
+      ## Step 4: Install Paperclip skill in OpenClaw
+      GET ${onboarding.skill.url}
+      Install path: ${onboarding.skill.installPath}
+
+      Be sure to prepend your PAPERCLIP_API_URL to the top of your skill and note the path to your PAPERCLIP_API_URL
+
+      ## Text onboarding URL
+      ${onboarding.textInstructions.url}
+
+      ## Connectivity guidance
+      ${
+        onboarding.connectivity?.guidance ??
+        "Ensure Paperclip is reachable from your OpenClaw runtime."
+      }
+    `);
+  } else {
+    appendBlock(`
+      ## Step 0
+
+      Choose the adapter you plan to use.
+      Recommended default: adapterType "${recommendedAdapterType}".
+
+      Remote HTTP agents should gather:
+      - a reachable http(s) endpoint that accepts Paperclip's JSON wake payload
+      - any auth headers or shared secrets the runtime expects for inbound requests
+      - a writable location where the claimed PAPERCLIP_API_KEY / PAPERCLIP_API_URL can be stored securely
+
+      ## Step 1: Submit agent join request
+      ${onboarding.registrationEndpoint.method} ${
+      onboarding.registrationEndpoint.url
     }
 
-    Expected response includes:
-    - request id
-    - one-time claimSecret
-    - claimApiKeyPath
+      Use adapterType "${recommendedAdapterType}" for the default remote HTTP path.
+      For HTTP agents:
+      - agentDefaultsPayload.url MUST be an absolute http:// or https:// endpoint
+      - optional fields: method, headers, payloadTemplate, timeoutMs
+      - the endpoint must accept Paperclip's JSON wake payload \`{ agentId, runId, context, ...payloadTemplate }\`
+      - configure your own webhook auth headers or shared secrets; Paperclip does not mint them for you
 
-    ## Step 2: Wait for board approval
-    The board approves the join request in Paperclip before key claim is allowed.
+      Body (JSON):
+      {
+        "requestType": "agent",
+        "agentName": "My Remote Agent",
+        "adapterType": "http",
+        "capabilities": "Optional summary",
+        "agentDefaultsPayload": {
+          "url": "https://remote-agent.example/hooks/paperclip",
+          "method": "POST",
+          "headers": { "authorization": "Bearer replace-me" },
+          "timeoutMs": 15000
+        }
+      }
 
-    ## Step 3: Claim API key (one-time)
-    ${
-      onboarding.claimEndpointTemplate.method
-    } /api/join-requests/{requestId}/claim-api-key
+      Expected response includes:
+      - request id
+      - one-time claimSecret
+      - claimApiKeyPath
 
-    Body (JSON):
-    {
-      "claimSecret": "<one-time-claim-secret>"
-    }
+      ## Step 2: Wait for board approval
+      The board approves the join request in Paperclip before key claim is allowed.
 
-    On successful claim, save the full JSON response to:
+      ## Step 3: Claim API key (one-time)
+      ${
+        onboarding.claimEndpointTemplate.method
+      } /api/join-requests/{requestId}/claim-api-key
 
-    - ~/.openclaw/workspace/paperclip-claimed-api-key.json
-    chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+      Body (JSON):
+      {
+        "claimSecret": "<one-time-claim-secret>"
+      }
 
-    And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
-    https://docs.openclaw.ai/help/environment
+      On successful claim, save the full JSON response somewhere only your runtime can read, for example:
 
-    e.g. 
+      - ~/paperclip/paperclip-claimed-api-key.json
+      chmod 600 ~/paperclip/paperclip-claimed-api-key.json
 
-    {
-      env: {
-        PAPERCLIP_API_KEY: "...",
-        PAPERCLIP_API_URL: "...",
-      },
-    }
+      Then set PAPERCLIP_API_KEY and PAPERCLIP_API_URL from the claim response before each heartbeat run.
+      Keep any separate inbound webhook auth secret in your runtime config; the Paperclip claim response does not replace it.
 
-    Then set PAPERCLIP_API_KEY and PAPERCLIP_API_URL from the saved token field for every heartbeat run.
+      Important:
+      - claim secrets expire
+      - claim secrets are single-use
+      - claim fails before board approval
 
-    Important:
-    - claim secrets expire
-    - claim secrets are single-use
-    - claim fails before board approval
+      ## Step 4: Install Paperclip skill or runtime instructions
+      GET ${onboarding.skill.url}
+      Install path: ${onboarding.skill.installPath}
 
-    ## Step 4: Install Paperclip skill in OpenClaw
-    GET ${onboarding.skill.url}
-    Install path: ${onboarding.skill.installPath}
+      Suggested locations:
+      - Codex: $CODEX_HOME/skills/paperclip/SKILL.md
+      - Claude Code: ~/.claude/skills/paperclip/SKILL.md
+      - Other runtimes: place the skill/instructions wherever that runtime expects operator-provided startup guidance.
 
-    Be sure to prepend your PAPERCLIP_API_URL to the top of your skill and note the path to your PAPERCLIP_API_URL
+      ## Text onboarding URL
+      ${onboarding.textInstructions.url}
 
-    ## Text onboarding URL
-    ${onboarding.textInstructions.url}
-
-    ## Connectivity guidance
-    ${
-      onboarding.connectivity?.guidance ??
-      "Ensure Paperclip is reachable from your OpenClaw runtime."
-    }
-  `);
+      ## Connectivity guidance
+      ${
+        onboarding.connectivity?.guidance ??
+        "Ensure Paperclip is reachable from your remote runtime."
+      }
+    `);
+  }
 
   const connectionCandidates = Array.isArray(
     onboarding.connectivity?.connectionCandidates
@@ -1281,17 +1458,31 @@ export function buildInviteOnboardingTextDocument(
     for (const candidate of connectionCandidates) {
       lines.push(`- ${candidate}`);
     }
-    appendBlock(`
+    if (onboardingTemplate === "openclaw_gateway") {
+      appendBlock(`
 
-      Test each candidate with:
-      - GET <candidate>/api/health
-      - set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl when submitting your join request
+        Test each candidate with:
+        - GET <candidate>/api/health
+        - set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl when submitting your join request
 
-      If none are reachable: ask your human operator for a reachable hostname/address and help them update network configuration.
-      For authenticated/private mode, they may need:
-      - pnpm paperclipai allowed-hostname <host>
-      - then restart Paperclip and retry onboarding.
-    `);
+        If none are reachable: ask your human operator for a reachable hostname/address and help them update network configuration.
+        For authenticated/private mode, they may need:
+        - pnpm paperclipai allowed-hostname <host>
+        - then restart Paperclip and retry onboarding.
+      `);
+    } else {
+      appendBlock(`
+
+        Test each candidate with:
+        - GET <candidate>/api/health
+        - Use the first reachable candidate for invite, claim, and skill bootstrap calls from your remote runtime
+
+        If none are reachable: ask your human operator for a reachable hostname/address and help them update network configuration.
+        For authenticated/private mode, they may need:
+        - pnpm paperclipai allowed-hostname <host>
+        - then restart Paperclip and retry onboarding.
+      `);
+    }
   }
 
   if (diagnostics.length > 0) {
@@ -1965,7 +2156,10 @@ export function accessRoutes(
           req,
           companyId,
           allowedJoinTypes: "agent",
-          defaultsPayload: null,
+          defaultsPayload: {
+            onboardingTemplate: "openclaw_gateway",
+            recommendedAdapterType: "openclaw_gateway"
+          },
           agentMessage: req.body.agentMessage ?? null
         });
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -100,9 +100,22 @@ Workspace rules:
 - For repo-only setup, omit `cwd` and provide `repoUrl`.
 - Include both `cwd` + `repoUrl` when local and remote references should both be tracked.
 
-## OpenClaw Invite Workflow (CEO)
+## Remote Agent Onboarding (Transition State)
 
-Use this when asked to invite a new OpenClaw employee.
+Preferred defaults:
+
+- Use `claude_local` or `codex_local` for normal local operators.
+- Use the generic `http` adapter only for remote runtimes that already expose a
+  Paperclip-compatible HTTP endpoint or bridge.
+- Do not use the OpenClaw invite prompt route unless you are explicitly
+  preserving a legacy OpenClaw employee.
+
+The OpenClaw workflow below is legacy and should only be used when asked to
+keep an existing `openclaw_gateway` employee alive during migration.
+
+## OpenClaw Invite Workflow (Legacy CEO Path)
+
+Use this only when asked to invite or preserve a legacy OpenClaw employee.
 
 1. Generate a fresh OpenClaw invite prompt:
 

--- a/ui/src/adapters/http/index.ts
+++ b/ui/src/adapters/http/index.ts
@@ -5,7 +5,7 @@ import { buildHttpConfig } from "./build-config";
 
 export const httpUIAdapter: UIAdapterModule = {
   type: "http",
-  label: "HTTP Webhook",
+  label: "Remote Agent (HTTP)",
   parseStdoutLine: parseHttpStdoutLine,
   ConfigFields: HttpConfigFields,
   buildAdapterConfig: buildHttpConfig,

--- a/ui/src/adapters/openclaw-gateway/index.ts
+++ b/ui/src/adapters/openclaw-gateway/index.ts
@@ -5,7 +5,7 @@ import { OpenClawGatewayConfigFields } from "./config-fields";
 
 export const openClawGatewayUIAdapter: UIAdapterModule = {
   type: "openclaw_gateway",
-  label: "OpenClaw Gateway",
+  label: "Legacy OpenClaw Gateway",
   parseStdoutLine: parseOpenClawGatewayStdoutLine,
   ConfigFields: OpenClawGatewayConfigFields,
   buildAdapterConfig: buildOpenClawGatewayConfig,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1022,7 +1022,16 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_ADAPTER_TYPES = new Set([
+  "claude_local",
+  "codex_local",
+  "gemini_local",
+  "opencode_local",
+  "pi_local",
+  "cursor",
+  "hermes_local",
+  "http",
+]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -19,10 +19,10 @@ const adapterLabels: Record<string, string> = {
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
   opencode_local: "OpenCode (local)",
-  openclaw_gateway: "OpenClaw Gateway",
+  openclaw_gateway: "Legacy OpenClaw Gateway",
   cursor: "Cursor (local)",
   process: "Process",
-  http: "HTTP",
+  http: "Remote Agent (HTTP)",
 };
 
 const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -21,7 +21,6 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
-import { HermesIcon } from "./HermesIcon";
 
 type AdvancedAdapterType =
   | "claude_local"
@@ -30,8 +29,7 @@ type AdvancedAdapterType =
   | "opencode_local"
   | "pi_local"
   | "cursor"
-  | "openclaw_gateway"
-  | "hermes_local";
+  | "http";
 
 const ADVANCED_ADAPTER_OPTIONS: Array<{
   value: AdvancedAdapterType;
@@ -55,6 +53,12 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     recommended: true,
   },
   {
+    value: "http",
+    label: "Remote Agent (HTTP)",
+    icon: Bot,
+    desc: "Generic remote HTTP or webhook bridge",
+  },
+  {
     value: "gemini_local",
     label: "Gemini CLI",
     icon: Gem,
@@ -64,12 +68,6 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     value: "opencode_local",
     label: "OpenCode",
     icon: OpenCodeLogoIcon,
-    desc: "Local multi-provider agent",
-  },
-  {
-    value: "hermes_local",
-    label: "Hermes Agent",
-    icon: HermesIcon,
     desc: "Local multi-provider agent",
   },
   {
@@ -83,12 +81,6 @@ const ADVANCED_ADAPTER_OPTIONS: Array<{
     label: "Cursor",
     icon: MousePointer2,
     desc: "Local Cursor agent",
-  },
-  {
-    value: "openclaw_gateway",
-    label: "OpenClaw Gateway",
-    icon: Bot,
-    desc: "Invoke OpenClaw via gateway protocol",
   },
 ];
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { useEffect, useState, useRef, useCallback, useMemo, type ComponentType } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
@@ -56,7 +56,6 @@ import {
   ChevronDown,
   X
 } from "lucide-react";
-import { HermesIcon } from "./HermesIcon";
 
 type Step = 1 | 2 | 3 | 4;
 type AdapterType =
@@ -281,6 +280,44 @@ export function OnboardingWizard() {
         entries: [...entries].sort((a, b) => a.id.localeCompare(b.id))
       }));
   }, [filteredModels, adapterType]);
+
+  const moreAdapterOptions: Array<{
+    value: AdapterType;
+    label: string;
+    icon: ComponentType<{ className?: string }>;
+    desc: string;
+  }> = [
+    {
+      value: "http",
+      label: "Remote Agent (HTTP)",
+      icon: Bot,
+      desc: "Generic remote HTTP or webhook bridge"
+    },
+    {
+      value: "gemini_local",
+      label: "Gemini CLI",
+      icon: Gem,
+      desc: "Local Gemini agent"
+    },
+    {
+      value: "opencode_local",
+      label: "OpenCode",
+      icon: OpenCodeLogoIcon,
+      desc: "Local multi-provider agent"
+    },
+    {
+      value: "pi_local",
+      label: "Pi",
+      icon: Terminal,
+      desc: "Local Pi agent"
+    },
+    {
+      value: "cursor",
+      label: "Cursor",
+      icon: MousePointer2,
+      desc: "Local Cursor agent"
+    }
+  ];
 
   function reset() {
     setStep(1);
@@ -823,59 +860,16 @@ export function OnboardingWizard() {
 
                     {showMoreAdapters && (
                       <div className="grid grid-cols-2 gap-2 mt-2">
-                        {[
-                          {
-                            value: "gemini_local" as const,
-                            label: "Gemini CLI",
-                            icon: Gem,
-                            desc: "Local Gemini agent"
-                          },
-                          {
-                            value: "opencode_local" as const,
-                            label: "OpenCode",
-                            icon: OpenCodeLogoIcon,
-                            desc: "Local multi-provider agent"
-                          },
-                          {
-                            value: "pi_local" as const,
-                            label: "Pi",
-                            icon: Terminal,
-                            desc: "Local Pi agent"
-                          },
-                          {
-                            value: "cursor" as const,
-                            label: "Cursor",
-                            icon: MousePointer2,
-                            desc: "Local Cursor agent"
-                          },
-                          {
-                            value: "hermes_local" as const,
-                            label: "Hermes Agent",
-                            icon: HermesIcon,
-                            desc: "Local multi-provider agent"
-                          },
-                          {
-                            value: "openclaw_gateway" as const,
-                            label: "OpenClaw Gateway",
-                            icon: Bot,
-                            desc: "Invoke OpenClaw via gateway protocol",
-                            comingSoon: true,
-                            disabledLabel: "Configure OpenClaw within the App"
-                          }
-                        ].map((opt) => (
+                        {moreAdapterOptions.map((opt) => (
                           <button
                             key={opt.value}
-                            disabled={!!opt.comingSoon}
                             className={cn(
                               "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
-                              opt.comingSoon
-                                ? "border-border opacity-40 cursor-not-allowed"
-                                : adapterType === opt.value
+                              adapterType === opt.value
                                 ? "border-foreground bg-accent"
                                 : "border-border hover:bg-accent/50"
                             )}
                             onClick={() => {
-                              if (opt.comingSoon) return;
                               const nextType = opt.value as AdapterType;
                               setAdapterType(nextType);
                               if (nextType === "gemini_local" && !model) {
@@ -898,10 +892,7 @@ export function OnboardingWizard() {
                             <opt.icon className="h-4 w-4" />
                             <span className="font-medium">{opt.label}</span>
                             <span className="text-muted-foreground text-[10px]">
-                              {opt.comingSoon
-                                ? (opt as { disabledLabel?: string })
-                                    .disabledLabel ?? "Coming soon"
-                                : opt.desc}
+                              {opt.desc}
                             </span>
                           </button>
                         ))}

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -24,7 +24,7 @@ export const help: Record<string, string> = {
   role: "Organizational role. Determines position and capabilities.",
   reportsTo: "The agent this one reports to in the org hierarchy.",
   capabilities: "Describes what this agent can do. Shown in the org chart and used for task routing.",
-  adapterType: "How this agent runs: local CLI (Claude/Codex/OpenCode), OpenClaw Gateway, spawned process, or generic HTTP webhook.",
+  adapterType: "How this agent runs: local CLI (Claude/Codex/OpenCode), a generic remote HTTP endpoint or bridge, or a spawned process.",
   cwd: "Deprecated legacy working directory fallback for local adapters. Existing agents may still carry this value, but new configurations should use project workspaces instead.",
   promptTemplate: "Sent on every heartbeat. Keep this small and dynamic. Use it for current-task framing, not large static instructions. Supports {{ agent.id }}, {{ agent.name }}, {{ agent.role }} and other template variables.",
   model: "Override the default model used by the adapter.",
@@ -46,7 +46,7 @@ export const help: Record<string, string> = {
   envVars: "Environment variables injected into the adapter process. Use plain values or secret references.",
   bootstrapPrompt: "Only sent when Paperclip starts a fresh session. Use this for stable setup guidance that should not be repeated on every heartbeat.",
   payloadTemplateJson: "Optional JSON merged into remote adapter request payloads before Paperclip adds its standard wake and workspace fields.",
-  webhookUrl: "The URL that receives POST requests when the agent is invoked.",
+  webhookUrl: "The URL that receives POST requests when the agent is invoked. Use this for a remote HTTP endpoint or bridge that understands Paperclip's wake payload.",
   heartbeatInterval: "Run this agent automatically on a timer. Useful for periodic tasks like checking for new work.",
   intervalSec: "Seconds between automatic heartbeat invocations.",
   timeoutSec: "Maximum seconds a run can take before being terminated. 0 means no timeout.",
@@ -62,11 +62,11 @@ export const adapterLabels: Record<string, string> = {
   codex_local: "Codex (local)",
   gemini_local: "Gemini CLI (local)",
   opencode_local: "OpenCode (local)",
-  openclaw_gateway: "OpenClaw Gateway",
+  openclaw_gateway: "Legacy OpenClaw Gateway",
   cursor: "Cursor (local)",
   hermes_local: "Hermes Agent",
   process: "Process",
-  http: "HTTP",
+  http: "Remote Agent (HTTP)",
 };
 
 export const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -27,9 +27,9 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode",
   cursor: "Cursor",
   hermes_local: "Hermes",
-  openclaw_gateway: "OpenClaw Gateway",
+  openclaw_gateway: "Legacy OpenClaw Gateway",
   process: "Process",
-  http: "HTTP",
+  http: "Remote Agent (HTTP)",
 };
 
 const roleLabels = AGENT_ROLE_LABELS as Record<string, string>;

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -10,7 +10,12 @@ import { AGENT_ADAPTER_TYPES } from "@paperclipai/shared";
 import type { AgentAdapterType, JoinRequest } from "@paperclipai/shared";
 
 type JoinType = "human" | "agent";
-const joinAdapterOptions: AgentAdapterType[] = [...AGENT_ADAPTER_TYPES];
+const joinAdapterOptions: AgentAdapterType[] = AGENT_ADAPTER_TYPES.filter(
+  (type): type is AgentAdapterType =>
+    type !== "process" &&
+    type !== "hermes_local" &&
+    type !== "openclaw_gateway"
+);
 
 const adapterLabels: Record<string, string> = {
   claude_local: "Claude (local)",
@@ -18,14 +23,21 @@ const adapterLabels: Record<string, string> = {
   gemini_local: "Gemini CLI (local)",
   opencode_local: "OpenCode (local)",
   pi_local: "Pi (local)",
-  openclaw_gateway: "OpenClaw Gateway",
+  openclaw_gateway: "Legacy OpenClaw Gateway",
   cursor: "Cursor (local)",
-  hermes_local: "Hermes Agent",
   process: "Process",
-  http: "HTTP",
+  http: "Remote Agent (HTTP)",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_INVITE_ADAPTERS = new Set([
+  "claude_local",
+  "codex_local",
+  "gemini_local",
+  "opencode_local",
+  "pi_local",
+  "cursor",
+  "http",
+]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();
@@ -47,6 +59,7 @@ export function InviteLandingPage() {
   const [joinType, setJoinType] = useState<JoinType>("human");
   const [agentName, setAgentName] = useState("");
   const [adapterType, setAdapterType] = useState<AgentAdapterType>("claude_local");
+  const [remoteWebhookUrl, setRemoteWebhookUrl] = useState("");
   const [capabilities, setCapabilities] = useState("");
   const [result, setResult] = useState<{ kind: "bootstrap" | "join"; payload: unknown } | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -101,6 +114,14 @@ export function InviteLandingPage() {
         agentName: agentName.trim(),
         adapterType,
         capabilities: capabilities.trim() || null,
+        agentDefaultsPayload:
+          adapterType === "http"
+            ? {
+                url: remoteWebhookUrl.trim(),
+                method: "POST",
+                timeoutMs: 15000,
+              }
+            : undefined,
       });
     },
     onSuccess: async (payload) => {
@@ -167,6 +188,9 @@ export function InviteLandingPage() {
     };
     const claimSecret = typeof payload.claimSecret === "string" ? payload.claimSecret : null;
     const claimApiKeyPath = typeof payload.claimApiKeyPath === "string" ? payload.claimApiKeyPath : null;
+    const joinedAdapterType =
+      typeof payload.adapterType === "string" ? payload.adapterType : null;
+    const isLegacyOpenClawJoin = joinedAdapterType === "openclaw_gateway";
     const onboardingSkillUrl = readNestedString(payload.onboarding, ["skill", "url"]);
     const onboardingSkillPath = readNestedString(payload.onboarding, ["skill", "path"]);
     const onboardingInstallPath = readNestedString(payload.onboarding, ["skill", "installPath"]);
@@ -183,6 +207,13 @@ export function InviteLandingPage() {
           <div className="mt-4 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
             Request ID: <span className="font-mono">{payload.id}</span>
           </div>
+          {joinedAdapterType === "http" && (
+            <div className="mt-3 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+              Remote agent join submitted with the provided webhook URL. Configure
+              any extra headers or bootstrap details in agent settings after
+              approval.
+            </div>
+          )}
           {claimSecret && claimApiKeyPath && (
             <div className="mt-3 space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
               <p className="font-medium text-foreground">One-time claim secret (save now)</p>
@@ -190,7 +221,8 @@ export function InviteLandingPage() {
               <p className="font-mono break-all">POST {claimApiKeyPath}</p>
             </div>
           )}
-          {(onboardingSkillUrl || onboardingSkillPath || onboardingInstallPath) && (
+          {isLegacyOpenClawJoin &&
+            (onboardingSkillUrl || onboardingSkillPath || onboardingInstallPath) && (
             <div className="mt-3 space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
               <p className="font-medium text-foreground">Paperclip skill bootstrap</p>
               {onboardingSkillUrl && <p className="font-mono break-all">GET {onboardingSkillUrl}</p>}
@@ -198,14 +230,14 @@ export function InviteLandingPage() {
               {onboardingInstallPath && <p className="font-mono break-all">Install to {onboardingInstallPath}</p>}
             </div>
           )}
-          {(onboardingTextUrl || onboardingTextPath) && (
+          {isLegacyOpenClawJoin && (onboardingTextUrl || onboardingTextPath) && (
             <div className="mt-3 space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
               <p className="font-medium text-foreground">Agent-readable onboarding text</p>
               {onboardingTextUrl && <p className="font-mono break-all">GET {onboardingTextUrl}</p>}
               {!onboardingTextUrl && onboardingTextPath && <p className="font-mono break-all">GET {onboardingTextPath}</p>}
             </div>
           )}
-          {diagnostics.length > 0 && (
+          {isLegacyOpenClawJoin && diagnostics.length > 0 && (
             <div className="mt-3 space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
               <p className="font-medium text-foreground">Connectivity diagnostics</p>
               {diagnostics.map((diag, idx) => (
@@ -269,11 +301,27 @@ export function InviteLandingPage() {
               >
                 {joinAdapterOptions.map((type) => (
                   <option key={type} value={type} disabled={!ENABLED_INVITE_ADAPTERS.has(type)}>
-                    {adapterLabels[type]}{!ENABLED_INVITE_ADAPTERS.has(type) ? " (Coming soon)" : ""}
+                    {adapterLabels[type]}
+                    {!ENABLED_INVITE_ADAPTERS.has(type) ? " (Coming soon)" : ""}
                   </option>
                 ))}
               </select>
             </label>
+            {adapterType === "http" && (
+              <label className="block text-sm">
+                <span className="mb-1 block text-muted-foreground">Webhook URL</span>
+                <input
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono"
+                  placeholder="https://agent.example/webhook"
+                  value={remoteWebhookUrl}
+                  onChange={(event) => setRemoteWebhookUrl(event.target.value)}
+                />
+                <span className="mt-1 block text-xs text-muted-foreground">
+                  Use the inbound HTTP or bridge URL for the remote agent.
+                  Additional headers can be configured after approval.
+                </span>
+              </label>
+            )}
             <label className="block text-sm">
               <span className="mb-1 block text-muted-foreground">Capabilities (optional)</span>
               <textarea
@@ -304,6 +352,10 @@ export function InviteLandingPage() {
           disabled={
             acceptMutation.isPending ||
             (joinType === "agent" && invite.inviteType !== "bootstrap_ceo" && agentName.trim().length === 0) ||
+            (joinType === "agent" &&
+              invite.inviteType !== "bootstrap_ceo" &&
+              adapterType === "http" &&
+              remoteWebhookUrl.trim().length === 0) ||
             requiresAuthForHuman
           }
           onClick={() => acceptMutation.mutate()}

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -35,8 +35,7 @@ const SUPPORTED_ADVANCED_ADAPTER_TYPES = new Set<CreateConfigValues["adapterType
   "opencode_local",
   "pi_local",
   "cursor",
-  "hermes_local",
-  "openclaw_gateway",
+  "http",
 ]);
 
 function createValuesForAdapterType(

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -123,9 +123,9 @@ const adapterLabels: Record<string, string> = {
   opencode_local: "OpenCode",
   cursor: "Cursor",
   hermes_local: "Hermes",
-  openclaw_gateway: "OpenClaw Gateway",
+  openclaw_gateway: "Legacy OpenClaw Gateway",
   process: "Process",
-  http: "HTTP",
+  http: "Remote Agent (HTTP)",
 };
 
 const statusDotColor: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Default onboarding and UI now promote `claude_local` and `codex_local`
- Generic `http` adapter available for advanced/manual remote setups
- `openclaw_gateway` labeled as legacy across UI, docs, and invite flow
- Invite onboarding generalized so new invites default to remote-agent HTTP guidance

## Validation

- typecheck, build, and test:run all passing (738 tests passed, 1 skipped)