### PR TITLE
fix(ui): add error feedback to inbox mark read/unread mutations

### DIFF
--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -932,6 +932,9 @@ export function Inbox() {
     onSuccess: () => {
       invalidateInboxIssueQueries();
     },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to mark as read");
+    },
     onSettled: (_data, _error, id) => {
       setTimeout(() => {
         setFadingOutIssues((prev) => {
@@ -972,6 +975,9 @@ export function Inbox() {
     mutationFn: (id: string) => issuesApi.markUnread(id),
     onSuccess: () => {
       invalidateInboxIssueQueries();
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to mark as unread");
     },
   });
 


### PR DESCRIPTION
## Problem

Two inbox mutations added in the recent update was missing error handlers:

### markReadMutation (line 927)
This one is specially bad because it has an \`onMutate\` callback that start fading out the issue (line 930: \`setFadingOutIssues\`). If the API call fail, the issue visually fade out and then come back 300ms later via \`onSettled\`, but user get no error message explaining what happen. It just look like a weird visual glitch.

### markUnreadMutation (line 971)
Simpler case - just no error feedback at all. User click "mark unread" and nothing happen if it fail.

Other mutations in the same file (approve, reject, retry, archiveIssue, markAllRead) all properly set \`actionError\` on failure. These two was missed.

## What I changed

Added \`onError\` callback to both mutations that set \`actionError\` with the error message, matching the pattern used by all other mutations in the same file.

## How to test

1. Try to mark an issue as read when network is disconnected
2. Should see error message instead of silent failure
3. Same for mark unread

1 file, 6 lines added.