### PR TITLE
Use per-agent Paperclip API key hints for OpenClaw wakes

### DIFF
--- a/.learnings/ERRORS.md
+++ b/.learnings/ERRORS.md
@@ -1,0 +1,19 @@
+# Errors
+
+## [ERR-20260330-001] openclaw-gateway-global-claimed-key
+
+**Logged**: 2026-03-30T13:39:30+01:00
+**Priority**: high
+**Status**: fixed-local
+**Area**: adapters/openclaw-gateway
+
+### Summary
+Paperclip's OpenClaw gateway wake text instructed every agent to load a single global claimed API key file (`~/.openclaw/workspace/paperclip-claimed-api-key.json`). When that file belonged to Atlas, other agents such as Quill/Scout/Plutus woke with their own `PAPERCLIP_AGENT_ID` but Atlas's API token, causing checkout failures: `Agent can only checkout as itself`.
+
+### Fix
+Use per-agent key files under `~/.openclaw/workspace/paperclip-agent-keys/<agent>.json` in wake instructions, with the legacy global file only as fallback.
+
+### Files
+- `packages/adapters/openclaw-gateway/src/server/execute.ts`
+
+---

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -336,7 +336,9 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
 }
 
 function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const agentName = (paperclipEnv.PAPERCLIP_AGENT_NAME ?? "agent").trim().toLowerCase();
+  const legacyClaimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const perAgentApiKeyPath = `~/.openclaw/workspace/paperclip-agent-keys/${agentName}.json`;
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -367,9 +369,10 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     "",
     "Set these values in your run context:",
     ...envLines,
-    `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
+    `PAPERCLIP_API_KEY=<token from ${perAgentApiKeyPath}>`,
     "",
-    `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    `Load PAPERCLIP_API_KEY from ${perAgentApiKeyPath} for this agent.`,
+    `If that file does not exist, fall back to ${legacyClaimedApiKeyPath}.`,
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -320,6 +320,10 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
     PAPERCLIP_RUN_ID: ctx.runId,
   };
 
+  if (ctx.agent.name) {
+    paperclipEnv.PAPERCLIP_AGENT_NAME = ctx.agent.name;
+  }
+
   if (paperclipApiUrlOverride) {
     paperclipEnv.PAPERCLIP_API_URL = paperclipApiUrlOverride;
   }


### PR DESCRIPTION
## Summary
- point OpenClaw wake instructions at per-agent Paperclip API key cache files
- keep the legacy single claimed-key file only as fallback
- reduce checkout failures where an agent wakes with its own `PAPERCLIP_AGENT_ID` but a different agent's saved API token

## Why
OpenClaw gateway wake text previously directed every agent to load the same global claimed key file:

- `~/.openclaw/workspace/paperclip-claimed-api-key.json`

If that file belonged to another agent (for example A), wake runs for agents like B/C/D could try to check out issues with the correct agent ID but the wrong API token, causing:

- `Agent can only checkout as itself`

This patch changes the wake instructions to prefer:

- `~/.openclaw/workspace/paperclip-agent-keys/<agent>.json`

and only fall back to the legacy file if the per-agent file does not exist.

## Notes
- this keeps backward compatibility for existing setups still using the legacy claimed-key cache
- verified locally against a Paperclip + OpenClaw setup with multiple agents
