### PR TITLE
[codex] Handle missing Codex rollout records on resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,18 @@ Before making changes, read in this order:
 `doc/SPEC.md` is long-horizon product context.
 `doc/SPEC-implementation.md` is the concrete V1 build contract.
 
+## 2.5 Operator Memory
+
+Before starting technical work, check Darwin Brain tenant `codex-cli` for relevant environment, repo, and recovery memory when that tool is available.
+
+Use it for durable operator context such as:
+- local Paperclip/OpenClaw runtime quirks
+- known recovery procedures
+- Darwin bridge integration facts
+- repo-specific engineering gotchas
+
+Do not treat `codex-cli` as a source of truth over the codebase. It is a fast context layer to reduce repeated mistakes and re-discovery.
+
 ## 3. Repo Map
 
 - `server/`: Express REST API and orchestration services

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+Guidance for Claude and other AI contributors working in this repository.
+
+## Operator Memory
+
+Before starting technical work, check Darwin Brain tenant `codex-cli` for relevant environment, repo, and recovery memory when that tool is available.
+
+Use it for durable operator context such as:
+- local Paperclip/OpenClaw runtime quirks
+- known recovery procedures
+- Darwin bridge integration facts
+- repo-specific engineering gotchas
+
+Do not treat `codex-cli` as a source of truth over the codebase. It is a fast context layer to reduce repeated mistakes and re-discovery.
+
+## Core Docs
+
+Read these first:
+1. `doc/GOAL.md`
+2. `doc/PRODUCT.md`
+3. `doc/SPEC-implementation.md`
+4. `doc/DEVELOPING.md`
+5. `doc/DATABASE.md`

--- a/doc/plans/2026-03-30-darwin-brain-paperclip-bridge-implementation.md
+++ b/doc/plans/2026-03-30-darwin-brain-paperclip-bridge-implementation.md
@@ -1,0 +1,263 @@
+# 2026-03-30 Darwin Brain Paperclip Bridge Implementation Plan
+
+Status: Proposed
+Date: 2026-03-30
+Audience: Product and engineering
+Related:
+- `docs/superpowers/specs/2026-03-30-darwin-brain-paperclip-bridge-design.md`
+- `doc/plugins/PLUGIN_SPEC.md`
+- `packages/plugins/examples/plugin-kitchen-sink-example/`
+- `/Users/jamie/Projects/skootle/skootle-demos/docs/darwin-semantic-search-mcp.md`
+
+## 1. Purpose
+
+This plan turns the approved Darwin Brain bridge spec into an implementable phase 1 plugin for Paperclip.
+
+The outcome is a plugin that lets selected Paperclip agents search and store Darwin Brain knowledge with namespace-aware defaults and minimal governance controls.
+
+## 2. Product Outcome
+
+When phase 1 is complete:
+
+1. Paperclip can install a Darwin Brain plugin from the repo workspace.
+2. The plugin registers Darwin agent tools.
+3. The plugin can call the existing Darwin MCP server over stdio.
+4. Operators can configure default namespace and access mode.
+5. Tenant-scoped agents can read and write in their own namespace.
+6. Trusted agents can promote learnings into shared Darwin memory.
+
+## 3. Scope
+
+### In scope
+
+- a new Paperclip plugin package
+- Darwin MCP stdio client adapter inside the plugin worker
+- four plugin tools:
+  - `darwin.search`
+  - `darwin.searchTenant`
+  - `darwin.store`
+  - `darwin.info`
+- minimal instance and policy settings
+- company and optional agent override resolution
+- test coverage for tool behavior and access enforcement
+
+### Out of scope
+
+- deep plugin UI
+- analytics or dashboards
+- automatic promotion workflows
+- bulk sync jobs
+- changes to Darwin MCP protocol
+- changes to Paperclip core governance
+
+## 4. Build Strategy
+
+Phase 1 should be built as a small dedicated plugin package in the Paperclip repo, following the current first-party example patterns.
+
+The plugin should:
+
+- use the worker entrypoint to register tools
+- use instance config for Darwin service settings
+- use plugin state for policy records if needed in phase 1
+- add a small settings page only if required by current host wiring
+
+The build should stay inside the plugin boundary rather than modifying Paperclip core.
+
+## 5. Workstreams
+
+## 5.1 Plugin scaffold
+
+Create a new plugin package, tentatively:
+
+- `packages/plugins/examples/plugin-darwin-brain-bridge`
+
+Files:
+
+- `package.json`
+- `tsconfig.json`
+- `src/manifest.ts`
+- `src/worker.ts`
+- `src/index.ts`
+- `src/constants.ts`
+- optional `src/ui/index.tsx`
+- `README.md`
+
+The initial scaffold should stay close to the kitchen-sink example but omit unrelated surfaces.
+
+## 5.2 Darwin MCP client adapter
+
+Build a small worker-side client module that:
+
+- launches the Darwin MCP server as a child process
+- performs MCP initialize handshake
+- calls Darwin tools with JSON-RPC over stdio
+- normalizes Darwin responses into Paperclip tool results
+- surfaces clear upstream errors
+
+Phase 1 should prefer a simple per-call or short-lived client path over a complex pooled process manager unless profiling shows that startup cost is unacceptable.
+
+Inputs:
+
+- Darwin MCP entrypoint path
+- Upstash URL/token env var values or secret references
+
+## 5.3 Tool registration
+
+Register four tools through `ctx.tools.register`.
+
+### `darwin.search`
+
+- general semantic search
+- available to any agent with plugin tool access
+- intended for broad discovery
+
+### `darwin.searchTenant`
+
+- resolves namespace from policy
+- default search path for operating agents
+- fails closed if no namespace is configured
+
+### `darwin.store`
+
+- writes knowledge into resolved namespace
+- allowed only for `read-write` or `promote`
+- may target shared namespace only with `promote`
+
+### `darwin.info`
+
+- verifies Darwin service availability
+- returns health/diagnostic information
+
+## 5.4 Policy and settings resolution
+
+Phase 1 needs a minimal but explicit policy model.
+
+Recommended storage:
+
+- plugin instance config for Darwin service connection and shared namespace
+- plugin state records for company defaults and agent overrides
+
+Policy fields:
+
+- `companyId`
+- `defaultNamespace`
+- `defaultAccessMode`
+- optional `agentId`
+- optional `namespaceOverride`
+- optional `accessModeOverride`
+
+Resolution order:
+
+1. agent override
+2. company default
+3. fail closed
+
+Access modes:
+
+- `read`
+- `read-write`
+- `promote`
+
+## 5.5 Minimal settings surface
+
+If the current host wiring supports plugin settings pages cleanly, add a minimal page for:
+
+- Darwin MCP entrypoint
+- shared namespace
+- company default namespace
+- company default access mode
+- per-agent overrides for the first rollout companies
+
+If UI wiring becomes a blocker, phase 1 may ship with config/state seeded through tests or operator tooling first, but the code should keep the settings model isolated so a UI can be added immediately after.
+
+## 5.6 Tests
+
+Add focused tests for:
+
+- plugin manifest loading
+- tool registration smoke test
+- Darwin MCP handshake
+- successful `darwin.search`
+- successful `darwin.searchTenant`
+- denied `darwin.store` for `read`
+- allowed `darwin.store` for `read-write`
+- denied shared promotion for non-`promote`
+- allowed shared promotion for `promote`
+- missing namespace rejection
+
+Mock Darwin responses where possible. Add one integration-style test around the MCP transport seam.
+
+## 6. Rollout Order
+
+### Step 1
+
+Scaffold the plugin package and register placeholder tools.
+
+### Step 2
+
+Implement Darwin MCP transport and make `darwin.info` work end-to-end.
+
+### Step 3
+
+Implement search tools.
+
+### Step 4
+
+Implement policy resolution and guarded store behavior.
+
+### Step 5
+
+Add minimal settings/config support.
+
+### Step 6
+
+Add tests and verify local plugin build/install flow.
+
+### Step 7
+
+Install on the active instance and enable for:
+
+- `The Monitor Agency`
+- Lua marketing
+
+## 7. Risks
+
+### MCP process lifecycle
+
+If stdio lifecycle is brittle, tool calls may hang or leak child processes.
+
+Mitigation:
+
+- keep client adapter small
+- use explicit timeouts
+- close child processes deterministically
+
+### Settings UX friction
+
+If the plugin settings UI is not sufficiently mounted in the host, configuration may be awkward.
+
+Mitigation:
+
+- keep the storage model independent from UI
+- ship the worker path first
+
+### Shared-memory misuse
+
+A wrong default could write into shared/global memory unintentionally.
+
+Mitigation:
+
+- fail closed
+- default to tenant namespace only
+- require explicit `promote` for shared writes
+
+## 8. Success Criteria
+
+This plan is complete when:
+
+- the plugin builds successfully
+- Paperclip can install it locally
+- Monitor Agency can search/store in `monitor-agency`
+- Lua marketing can search/store in `lua-marketing`
+- shared promotion is limited to trusted agents
+- the plugin requires no Paperclip core coupling for Darwin behavior

--- a/docs/superpowers/specs/2026-03-30-darwin-brain-paperclip-bridge-design.md
+++ b/docs/superpowers/specs/2026-03-30-darwin-brain-paperclip-bridge-design.md
@@ -1,0 +1,220 @@
+# Darwin Brain Paperclip Bridge Design
+
+Date: 2026-03-30
+Status: approved design for phase 1
+
+## Goal
+
+Expose Darwin Brain semantic memory to Paperclip agents through the Paperclip plugin system, with tenant-aware defaults and minimal governance controls.
+
+Phase 1 must let selected agents:
+
+- search Darwin Brain
+- search a tenant namespace
+- store knowledge in an allowed namespace
+- inspect Darwin Brain health/info
+
+Phase 1 must also give the operator a small settings surface for:
+
+- default namespace per company
+- optional per-agent namespace override
+- access mode per company or agent
+- whether shared-memory promotion is allowed
+
+This should ship as a plugin boundary, not as a Paperclip core change.
+
+## Why This Shape
+
+Darwin Brain already exists as a standalone MCP server in `skootle-demos`. Paperclip already has a plugin runtime that supports agent tools and plugin settings. The cleanest integration is to bridge those two systems rather than reimplement Darwin search logic inside Paperclip or hardcode Darwin behavior into core models.
+
+This gives the Darwin ecosystem compounding memory while keeping Paperclip governance intact:
+
+- agencies keep local semantic memory
+- trusted agents can promote durable learnings upward
+- shared/global memory does not become an ungoverned dumping ground
+
+## Scope
+
+In scope for phase 1:
+
+- one installable Paperclip plugin
+- agent tools for Darwin Brain search and storage
+- minimal operator settings for namespace and permission defaults
+- tenant-safe defaults for existing companies such as `lua-marketing` and `monitor-agency`
+- enforcement of read/write/promote policy at the plugin layer
+- tests for tool execution, config enforcement, and Darwin MCP connectivity
+
+Out of scope for phase 1:
+
+- rich dashboards
+- plugin-side analytics
+- automatic knowledge promotion workflows
+- long-running sync jobs
+- direct edits to Paperclip core governance behavior
+- changing the Darwin MCP server protocol
+
+## Architecture
+
+The bridge has four pieces.
+
+### 1. Plugin manifest and worker
+
+A new Paperclip plugin will be added under the plugin examples/workspace pattern and later promoted into the real plugin package layout if it proves stable. The plugin worker will register Darwin Brain tools through the existing `agent.tools.register` capability.
+
+The plugin stays out of Paperclip core logic. It owns Darwin-specific execution, validation, and configuration lookup.
+
+### 2. Darwin client adapter
+
+Inside the plugin worker, a small Darwin client adapter will talk to the existing Darwin MCP server from `skootle-demos`.
+
+Phase 1 recommendation:
+
+- invoke the Darwin MCP server as a stdio subprocess from the plugin worker
+- keep Upstash credentials in environment variables
+- translate plugin tool calls into Darwin MCP tool calls
+
+This avoids duplicating Darwin vector logic and keeps Darwin as the source of truth.
+
+### 3. Settings and policy layer
+
+The plugin will store operator-managed settings for:
+
+- company default namespace
+- optional per-agent namespace override
+- access mode: `read`, `read-write`, or `promote`
+- shared namespace name
+- allowed shared-promotion agents
+
+Resolution order:
+
+1. explicit agent override
+2. company default
+3. fail closed
+
+If no namespace can be resolved, `searchTenant` and `store` must reject the call.
+
+### 4. Agent tool surface
+
+The plugin will expose four tools:
+
+- `darwin.search`
+  - general semantic search
+  - allowed for any agent with plugin access
+- `darwin.searchTenant`
+  - semantic search against resolved tenant namespace
+  - default entry point for most operating agents
+- `darwin.store`
+  - store knowledge in the resolved namespace
+  - only available to agents with `read-write` or `promote`
+- `darwin.info`
+  - Darwin health and namespace diagnostics
+  - available for operators and debugging
+
+Phase 1 deliberately does not expose a generic "write anywhere" tool.
+
+## Data Flow
+
+### Search flow
+
+1. Agent calls `darwin.search` or `darwin.searchTenant`
+2. Plugin resolves the calling company and agent context
+3. Plugin loads effective namespace and access policy
+4. Plugin invokes the Darwin MCP server tool
+5. Plugin returns normalized results to the agent run
+
+### Store flow
+
+1. Agent calls `darwin.store`
+2. Plugin resolves namespace and effective access mode
+3. Plugin rejects the call unless access mode allows writes
+4. Plugin invokes Darwin MCP `darwin_store`
+5. Plugin returns a compact confirmation payload
+
+### Promotion flow
+
+Phase 1 handles promotion as a guarded variant of `darwin.store`.
+
+- only agents with `promote` access may target shared/global namespace
+- promotion still goes through the same `store` path
+- default behavior is deny
+
+This keeps phase 1 small while still supporting trusted strategic agents.
+
+## Configuration Model
+
+The plugin settings model should support:
+
+- shared Darwin service config
+  - MCP server entrypoint
+  - environment variable names or secret references for Upstash URL/token
+  - shared namespace identifier
+- company policy records
+  - company id
+  - default Darwin namespace
+  - default access mode
+- optional agent policy records
+  - agent id
+  - namespace override
+  - access mode override
+
+Initial recommended defaults:
+
+- Lua marketing company default namespace: `lua-marketing`
+- Monitor Agency company default namespace: `monitor-agency`
+- shared namespace: Darwin global/shared namespace already used by the Darwin ecosystem
+
+Initial recommended access:
+
+- marketing specialists: `read-write`
+- Monitor Agency scouts: `read-write`
+- `THEO`, trusted CEOs, and selected escalation agents: `promote`
+- everyone else: `read`
+
+## Error Handling
+
+The plugin must fail safely and clearly.
+
+- If Darwin MCP cannot start or respond, tool calls return a clear runtime error without crashing the agent run host.
+- If namespace config is missing, tenant-scoped actions fail with a configuration error.
+- If an agent attempts a disallowed write or promotion, the plugin returns an authorization error.
+- If Darwin returns malformed data, the plugin returns a sanitized upstream error and logs plugin diagnostics.
+
+The plugin must never silently fall back to shared/global writes.
+
+## Testing
+
+Phase 1 test coverage should include:
+
+- Darwin MCP handshake from the plugin worker
+- tool registration smoke test
+- `darwin.search` success path
+- `darwin.searchTenant` with resolved company default
+- `darwin.store` allowed for `read-write`
+- `darwin.store` rejected for `read`
+- promotion rejected without `promote`
+- promotion allowed for `promote`
+- missing namespace fails closed
+
+Tests should run against the plugin boundary, not require invasive Paperclip core changes.
+
+## Rollout
+
+Phase 1 rollout should be conservative:
+
+1. build the plugin in the Paperclip repo
+2. validate in isolated dev usage
+3. install locally on the active Paperclip instance
+4. enable for `The Monitor Agency` and Lua marketing first
+5. keep promotion access limited to trusted agents
+
+Only after that proves stable should broader companies get Darwin access.
+
+## Success Criteria
+
+Phase 1 is successful when:
+
+- a Monitor Agency agent can search and store in `monitor-agency`
+- a Lua marketing agent can search and store in `lua-marketing`
+- a trusted strategic agent can promote a learning into shared Darwin memory
+- namespace and permission mistakes fail closed
+- the bridge is implemented as a plugin, not as Paperclip core coupling

--- a/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
+++ b/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
@@ -1,0 +1,298 @@
+# The Monitor Agency Design
+
+Date: 2026-03-30
+Status: Approved design
+Scope: Autonomous monitoring company inside the existing Paperclip instance
+
+## Plain-English Summary
+
+`The Monitor Agency` is a separate company inside Paperclip whose job is to watch the outside world so you do not have to.
+
+In simple terms:
+
+- It watches the tools, services, and competitors that could affect your business.
+- It decides what changed and whether the change matters.
+- It prepares work automatically: issues, plans, draft pull requests, tests, and low-risk merges.
+- It stays quiet unless a change is important enough that a human decision is actually needed.
+
+This is not a second Paperclip server. It is a new company living inside the same Paperclip you already use.
+
+## Why This Exists
+
+Right now, staying current requires a human to remember to check:
+
+- GitHub releases
+- dependency updates
+- provider pricing changes
+- API deprecations
+- model retirements
+- competitor launches
+- industry news
+
+That creates two problems:
+
+1. Important changes get missed.
+2. Even when changes are noticed, someone still has to read them, interpret them, and decide what to do next.
+
+`The Monitor Agency` solves that by making monitoring part of operations instead of a manual chore.
+
+## What It Is
+
+`The Monitor Agency` is a dedicated Paperclip company with its own:
+
+- projects
+- agents
+- routines
+- issues
+- plans
+- pull request workflow
+
+It is separate from your other companies so its work does not clutter normal product work.
+
+## What It Watches
+
+The company has two major lanes of work.
+
+### 1. Platform Monitoring
+
+This lane watches technical changes that can affect your systems:
+
+- `paperclip`
+- `openclaw`
+- adapter repos
+- dependencies
+- GitHub Actions and CI changes
+- infrastructure and deployment tooling
+- provider API changes
+- pricing changes
+- policy changes
+- model launches and retirements
+- security-relevant announcements
+
+### 2. Strategic Monitoring
+
+This lane watches business and market changes:
+
+- competitor launches
+- competitor feature changes
+- major industry news
+- ecosystem shifts
+- partnerships
+- other market signals that suggest a strategy change
+
+## How It Works In Plain English
+
+Think of it like a small operations team.
+
+### Step 1. Watch
+
+The company checks the sources it has been assigned on a schedule.
+
+Examples:
+
+- GitHub releases
+- upstream commit history
+- changelogs
+- provider docs
+- pricing pages
+- product announcements
+- industry sources
+
+### Step 2. Understand
+
+When something changes, it does not just forward a link.
+
+It asks:
+
+- What changed?
+- Does this affect us?
+- Is this small, risky, urgent, or strategic?
+- Does it need code, planning, or no action at all?
+
+### Step 3. Act
+
+Depending on the answer, it can:
+
+- do nothing and log the event
+- create an internal issue
+- draft a plan
+- open a draft pull request
+- run tests
+- merge low-risk updates automatically
+- create a major-decision escalation for you
+
+### Step 4. Escalate Only When Needed
+
+You should not be asked to judge technical details.
+
+You should only be interrupted when the system has already translated the problem into plain English and a real decision is needed.
+
+Examples:
+
+- `This update is low risk and ready to merge.`
+- `This upstream change is likely breaking authentication.`
+- `This competitor move may require a pricing response.`
+- `This provider change creates new cost exposure.`
+
+## Company Structure
+
+Company name:
+
+- `The Monitor Agency`
+
+Projects:
+
+- `Platform Monitoring`
+- `Strategic Monitoring`
+- `Escalations`
+
+## Agent Roles
+
+### Upstream Scout
+
+Finds new technical changes in repos, releases, changelogs, providers, and tooling.
+
+### Dependency Triage
+
+Figures out whether those changes matter and how risky they are.
+
+### PR Operator
+
+Creates dedicated update branches, opens draft pull requests, runs validation, and merges low-risk updates when allowed.
+
+### Provider Watch
+
+Monitors model providers, APIs, pricing, policy shifts, and platform changes.
+
+### Market Intel
+
+Tracks competitor and industry changes and turns those into strategy work when useful.
+
+### Executive Escalation
+
+Produces the few messages that should reach you, in plain language, when a real decision is needed.
+
+## Branching and Pull Requests
+
+Automated update work should use clearly separate branch names such as:
+
+- `monitor/paperclip/release-0-3-2`
+- `monitor/openclaw/auth-changes-2026-03-30`
+
+Why:
+
+- easy to identify
+- easy to filter
+- safer to review
+- separate from normal product work
+
+## Autonomy Policy
+
+This company is intended to be self-managing.
+
+That means it is allowed to:
+
+- monitor automatically
+- classify changes automatically
+- create issues automatically
+- create plans automatically
+- open draft pull requests automatically
+- run tests automatically
+- merge low-risk changes automatically
+
+It is not intended to wait for a human on routine work.
+
+## Safety Rules
+
+Autonomy is bounded by guardrails.
+
+Auto-merge is allowed only when:
+
+- the change is classified low-risk
+- tests pass
+- smoke checks pass
+- the change does not touch clearly sensitive areas
+
+Sensitive areas include:
+
+- authentication
+- permissions
+- deployment
+- database migrations
+- billing
+- uncertain or breaking behavior
+
+If a change touches one of those areas, the company should hold it for deeper internal triage and only escalate if a real decision is required.
+
+## Communication Policy
+
+The communication model is intentionally quiet.
+
+Normal work stays inside `The Monitor Agency`.
+
+You only get interrupted for major decisions such as:
+
+- high-risk upstream breakage
+- important failing validation
+- likely breaking provider changes
+- strategic actions with meaningful business consequences
+- changes involving money, permissions, or irreversible action
+
+This means you are not expected to monitor drafts, logs, releases, or technical severity yourself.
+
+## Why Separate Company Instead of Separate Server
+
+It should not be a separate Paperclip deployment.
+
+Using a separate company inside the existing Paperclip instance is better because:
+
+- it uses the same permissions and GitHub connections
+- it can create work in the same operating environment
+- it stays visible inside the same system
+- it avoids another server to maintain
+- it remains isolated enough through company boundaries
+
+## Success Criteria
+
+This design is successful when:
+
+- important upstream and market changes are detected without human checking
+- low-risk updates are handled automatically
+- risky changes are translated into plain-English decisions
+- you are interrupted rarely
+- the company reduces maintenance burden instead of creating a new one
+
+## Rollout Recommendation
+
+Start with a conservative first phase:
+
+- monitor everything
+- triage everything
+- open draft PRs automatically
+- run validation automatically
+- auto-merge only clearly low-risk changes
+- log all actions inside `The Monitor Agency`
+
+This provides real autonomy without giving the company unlimited power on day one.
+
+## Non-Goals
+
+This company should not:
+
+- silently make risky production changes
+- spam the main inbox with routine updates
+- require the user to interpret technical release notes
+- become a second full operational Paperclip environment
+
+## Next Step
+
+After design approval, the next artifact should be an implementation plan covering:
+
+- company bootstrap
+- project and agent creation
+- routine setup
+- GitHub and provider watch inputs
+- change-classification policy
+- branch and PR workflow
+- test and merge policy
+- escalation pipeline

--- a/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
+++ b/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
@@ -14,6 +14,7 @@ In simple terms:
 - It decides what changed and whether the change matters.
 - It prepares work automatically: issues, plans, draft pull requests, tests, and low-risk merges.
 - It actively looks for new tools, features, and opportunities that could make your products better or your team faster.
+- It actively looks for new AI capabilities you may not even know exist yet, so you do not have to rely on luck or random discovery.
 - It stays quiet unless a change is important enough that a human decision is actually needed.
 
 This is not a second Paperclip server. It is a new company living inside the same Paperclip you already use.
@@ -38,6 +39,8 @@ That creates two problems:
 `The Monitor Agency` solves that by making monitoring part of operations instead of a manual chore.
 
 It should also help you get ahead, not just avoid problems. That means it should look for useful new AI tools, feature ideas, and market openings before you ask for them.
+
+Part of the reason this matters is that modern AI moves too fast for a normal person to track comfortably. Good tools, new agent products, useful MCPs, and valuable workflows can appear at any time. If nobody is actively scouting, you only learn about them by accident.
 
 ## What It Is
 
@@ -94,6 +97,18 @@ This lane looks for things that could make your business faster, better, or more
 - new market openings created by technology shifts
 - new ways to package, automate, or sell what you already do
 
+### 4. Capability Discovery
+
+This lane is specifically about finding useful AI capabilities before they are widely known inside your business:
+
+- new AI tools
+- new skills worth installing
+- new MCPs and plugins
+- new agent frameworks
+- new specialist AI agents
+- new AI companies or services worth hiring or integrating
+- new workflows that give leverage without requiring a full rebuild
+
 ## How It Works In Plain English
 
 Think of it like a small operations team.
@@ -123,6 +138,7 @@ It asks:
 - Is this small, risky, urgent, or strategic?
 - Does it need code, planning, or no action at all?
 - Is this a threat, an opportunity, or both?
+- Is this something we should build, buy, integrate, hire, or ignore?
 
 ### Step 3. Act
 
@@ -136,6 +152,7 @@ Depending on the answer, it can:
 - merge low-risk updates automatically
 - create a major-decision escalation for you
 - create a proactive proposal when it finds something worth exploiting
+- recommend a build-versus-buy decision when a new capability appears
 
 ### Step 4. Escalate Only When Needed
 
@@ -161,6 +178,7 @@ Projects:
 - `Platform Monitoring`
 - `Strategic Monitoring`
 - `Opportunity Pipeline`
+- `Capability Discovery`
 - `Escalations`
 
 ## Agent Roles
@@ -188,6 +206,10 @@ Tracks competitor and industry changes and turns those into strategy work when u
 ### Opportunity Hunter
 
 Looks for new AI tools, product ideas, automation opportunities, and workflow improvements that could help you move faster or make more money.
+
+### Capability Scout
+
+Looks for new skills, MCPs, plugins, agents, services, and AI companies that could give you leverage, and recommends whether to test them, adopt them, integrate them, or hire them.
 
 ### Executive Escalation
 
@@ -221,6 +243,7 @@ That means it is allowed to:
 - run tests automatically
 - merge low-risk changes automatically
 - create proactive proposals automatically
+- recommend new capabilities automatically
 
 It is not intended to wait for a human on routine work.
 
@@ -259,6 +282,7 @@ You only get interrupted for major decisions such as:
 - likely breaking provider changes
 - strategic actions with meaningful business consequences
 - major opportunities worth funding, shipping, or prioritizing
+- major new capabilities worth adopting, integrating, or hiring
 - changes involving money, permissions, or irreversible action
 
 This means you are not expected to monitor drafts, logs, releases, or technical severity yourself.
@@ -282,6 +306,7 @@ This design is successful when:
 - important upstream and market changes are detected without human checking
 - low-risk updates are handled automatically
 - valuable new tools and feature opportunities are surfaced proactively
+- important new AI capabilities are discovered before you would normally hear about them
 - risky changes are translated into plain-English decisions
 - you are interrupted rarely
 - the company reduces maintenance burden instead of creating a new one
@@ -296,6 +321,7 @@ Start with a conservative first phase:
 - run validation automatically
 - auto-merge only clearly low-risk changes
 - create opportunity proposals when confidence is high
+- create capability recommendations when confidence is high
 - log all actions inside `The Monitor Agency`
 
 This provides real autonomy without giving the company unlimited power on day one.

--- a/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
+++ b/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
@@ -13,6 +13,7 @@ In simple terms:
 - It watches the tools, services, and competitors that could affect your business.
 - It decides what changed and whether the change matters.
 - It prepares work automatically: issues, plans, draft pull requests, tests, and low-risk merges.
+- It actively looks for new tools, features, and opportunities that could make your products better or your team faster.
 - It stays quiet unless a change is important enough that a human decision is actually needed.
 
 This is not a second Paperclip server. It is a new company living inside the same Paperclip you already use.
@@ -35,6 +36,8 @@ That creates two problems:
 2. Even when changes are noticed, someone still has to read them, interpret them, and decide what to do next.
 
 `The Monitor Agency` solves that by making monitoring part of operations instead of a manual chore.
+
+It should also help you get ahead, not just avoid problems. That means it should look for useful new AI tools, feature ideas, and market openings before you ask for them.
 
 ## What It Is
 
@@ -80,6 +83,17 @@ This lane watches business and market changes:
 - partnerships
 - other market signals that suggest a strategy change
 
+### 3. Opportunity Monitoring
+
+This lane looks for things that could make your business faster, better, or more profitable:
+
+- new AI tools that could save time
+- new products or services worth integrating
+- new workflows that reduce manual work
+- new feature ideas for your own products
+- new market openings created by technology shifts
+- new ways to package, automate, or sell what you already do
+
 ## How It Works In Plain English
 
 Think of it like a small operations team.
@@ -108,6 +122,7 @@ It asks:
 - Does this affect us?
 - Is this small, risky, urgent, or strategic?
 - Does it need code, planning, or no action at all?
+- Is this a threat, an opportunity, or both?
 
 ### Step 3. Act
 
@@ -120,6 +135,7 @@ Depending on the answer, it can:
 - run tests
 - merge low-risk updates automatically
 - create a major-decision escalation for you
+- create a proactive proposal when it finds something worth exploiting
 
 ### Step 4. Escalate Only When Needed
 
@@ -144,6 +160,7 @@ Projects:
 
 - `Platform Monitoring`
 - `Strategic Monitoring`
+- `Opportunity Pipeline`
 - `Escalations`
 
 ## Agent Roles
@@ -167,6 +184,10 @@ Monitors model providers, APIs, pricing, policy shifts, and platform changes.
 ### Market Intel
 
 Tracks competitor and industry changes and turns those into strategy work when useful.
+
+### Opportunity Hunter
+
+Looks for new AI tools, product ideas, automation opportunities, and workflow improvements that could help you move faster or make more money.
 
 ### Executive Escalation
 
@@ -199,6 +220,7 @@ That means it is allowed to:
 - open draft pull requests automatically
 - run tests automatically
 - merge low-risk changes automatically
+- create proactive proposals automatically
 
 It is not intended to wait for a human on routine work.
 
@@ -236,6 +258,7 @@ You only get interrupted for major decisions such as:
 - important failing validation
 - likely breaking provider changes
 - strategic actions with meaningful business consequences
+- major opportunities worth funding, shipping, or prioritizing
 - changes involving money, permissions, or irreversible action
 
 This means you are not expected to monitor drafts, logs, releases, or technical severity yourself.
@@ -258,6 +281,7 @@ This design is successful when:
 
 - important upstream and market changes are detected without human checking
 - low-risk updates are handled automatically
+- valuable new tools and feature opportunities are surfaced proactively
 - risky changes are translated into plain-English decisions
 - you are interrupted rarely
 - the company reduces maintenance burden instead of creating a new one
@@ -271,6 +295,7 @@ Start with a conservative first phase:
 - open draft PRs automatically
 - run validation automatically
 - auto-merge only clearly low-risk changes
+- create opportunity proposals when confidence is high
 - log all actions inside `The Monitor Agency`
 
 This provides real autonomy without giving the company unlimited power on day one.

--- a/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
+++ b/docs/superpowers/specs/2026-03-30-monitor-agency-design.md
@@ -57,7 +57,7 @@ It is separate from your other companies so its work does not clutter normal pro
 
 ## What It Watches
 
-The company has two major lanes of work.
+The company has four major lanes of work.
 
 ### 1. Platform Monitoring
 
@@ -109,6 +109,41 @@ This lane is specifically about finding useful AI capabilities before they are w
 - new AI companies or services worth hiring or integrating
 - new workflows that give leverage without requiring a full rebuild
 
+## Watch Registry
+
+The company should not operate on a vague idea of "everything."
+
+It needs a concrete watch registry that says exactly what is being monitored.
+
+Each registry entry should include:
+
+- source type
+- source identifier
+- why it is being watched
+- priority level
+- polling cadence
+- mute or disable status
+- owning project or lane
+- last checked time
+- last meaningful change seen
+
+Examples of source types:
+
+- GitHub repository
+- release feed
+- changelog page
+- pricing page
+- documentation page
+- provider status or policy page
+- competitor website
+- product announcement source
+- skill registry
+- MCP source
+- plugin source
+- AI company or service source
+
+This registry turns the mission into a concrete operating list.
+
 ## How It Works In Plain English
 
 Think of it like a small operations team.
@@ -153,6 +188,120 @@ Depending on the answer, it can:
 - create a major-decision escalation for you
 - create a proactive proposal when it finds something worth exploiting
 - recommend a build-versus-buy decision when a new capability appears
+
+## Decision Matrix
+
+The company needs explicit rules for what it is allowed to do.
+
+Every detected item should be scored on at least two dimensions:
+
+- risk
+- confidence
+
+Suggested risk levels:
+
+- `low`
+- `medium`
+- `high`
+- `critical`
+
+Suggested confidence levels:
+
+- `low`
+- `medium`
+- `high`
+
+Examples of how these combine:
+
+- low risk + high confidence: auto-handle if validation passes
+- medium risk + high confidence: create issue or draft PR and validate
+- high risk: never auto-merge, escalate internally
+- critical: immediate escalation path
+- low confidence: do not take irreversible action
+
+This is how words like `low-risk` become usable by the system.
+
+## Validation Matrix
+
+Different kinds of changes need different kinds of checks.
+
+The company should not use one generic "run tests" step for everything.
+
+Examples:
+
+- dependency update: relevant tests, lockfile integrity, smoke check
+- provider API change: integration check, auth check, pricing impact review
+- deployment change: environment validation, rollout safety checks
+- documentation or policy change: source verification and impact classification
+- new tool recommendation: usefulness score, integration difficulty, confidence score
+- strategic recommendation: evidence threshold and source corroboration
+
+If the required validation for a change type does not exist yet, the system should fail closed rather than silently treating the change as safe.
+
+## Memory and Deduplication
+
+The company needs memory of what it has already seen and decided.
+
+Without that, it will keep rediscovering the same things.
+
+It should record:
+
+- source item fingerprint
+- first seen time
+- last seen time
+- prior classification
+- prior recommendation
+- prior action taken
+- cooldown window before re-raising the same item
+
+Examples:
+
+- a tool already rejected should not be suggested every week
+- a previously accepted MCP should not be rediscovered as if it were new
+- a release already merged should not reopen the same work
+
+## Routing and Handoff
+
+`The Monitor Agency` should not own every downstream task forever.
+
+Recommended rule:
+
+- monitoring, triage, validation, and low-risk maintenance stay inside `The Monitor Agency`
+- product opportunities get routed into the relevant product company or project
+- strategic opportunities get routed as plans or decision items
+- technical maintenance that can be safely completed stays with the agency
+
+This makes the company the scout and operator for discovery and upkeep, while still allowing real business work to land in the right place.
+
+## Budget and Quotas
+
+Because this company watches many sources, it needs limits.
+
+It should have:
+
+- per-lane budget targets
+- polling limits
+- source count limits
+- backoff rules for low-value sources
+- caps on how many new items can be raised in a given period
+
+This keeps the system useful instead of noisy or expensive.
+
+## Source Reliability
+
+Not all sources deserve equal trust.
+
+The company should use explicit source weighting.
+
+Examples:
+
+- official docs and release notes: high trust
+- source code and commits: high trust
+- pricing or policy pages from providers: high trust
+- competitor marketing pages: medium trust
+- social posts, hype threads, and commentary: low trust unless corroborated
+
+For strategic or capability recommendations, major decisions should require multiple trustworthy signals rather than one exciting source.
 
 ### Step 4. Escalate Only When Needed
 
@@ -247,6 +396,12 @@ That means it is allowed to:
 
 It is not intended to wait for a human on routine work.
 
+Recommended operating rule:
+
+- the agency originates, triages, validates, and completes low-risk work
+- it routes product and strategic work to the appropriate destination once the opportunity is clear
+- it does not directly commit money, procurement, or hiring decisions without approval
+
 ## Safety Rules
 
 Autonomy is bounded by guardrails.
@@ -269,6 +424,10 @@ Sensitive areas include:
 
 If a change touches one of those areas, the company should hold it for deeper internal triage and only escalate if a real decision is required.
 
+Additional safety rule:
+
+- low confidence should block irreversible action, even when the apparent risk is low
+
 ## Communication Policy
 
 The communication model is intentionally quiet.
@@ -286,6 +445,78 @@ You only get interrupted for major decisions such as:
 - changes involving money, permissions, or irreversible action
 
 This means you are not expected to monitor drafts, logs, releases, or technical severity yourself.
+
+This also means the messages that do reach you should already answer:
+
+- what happened
+- why it matters
+- what the recommended action is
+- what happens if you do nothing
+
+## Delivery and Notifications
+
+The company should separate execution from reading and alerts.
+
+Recommended delivery architecture:
+
+- Paperclip: system of record
+- Notion: executive briefing surface
+- Telegram via Theo/OpenClaw: notification and escalation channel
+
+### Paperclip As The System Of Record
+
+Paperclip should keep the real operational state:
+
+- issues
+- plans
+- PRs
+- validation results
+- routing decisions
+- logs of what the agency did
+
+### Notion As The Reading Surface
+
+Notion should be used for polished human-readable briefings such as:
+
+- daily digest
+- weekly digest
+- opportunity memos
+- capability reports
+- strategy summaries
+- recommended actions in plain English
+
+Why:
+
+- easier to read
+- better for narrative summaries
+- better for reviewing multiple items at once
+- better than chat for longer executive briefings
+
+### Telegram As The Delivery Layer
+
+Telegram should be used for short messages that point you to what matters.
+
+Recommended Telegram message types:
+
+- urgent decision alert
+- new digest available
+- proactive suggestion
+- high-priority capability recommendation
+
+Each Telegram message should be short and include:
+
+- what happened
+- why it matters
+- the top recommended action
+- a Notion link for full reading when appropriate
+
+### Recommended Channel Rules
+
+- urgent items: Telegram immediately, with optional Notion detail
+- routine digest: write in Notion, then send Telegram summary plus link
+- proactive suggestions: short Telegram summary, with Notion page if the recommendation is substantial
+
+This keeps Telegram lightweight while making Notion the place where you actually read the full update.
 
 ## Why Separate Company Instead of Separate Server
 
@@ -310,6 +541,9 @@ This design is successful when:
 - risky changes are translated into plain-English decisions
 - you are interrupted rarely
 - the company reduces maintenance burden instead of creating a new one
+- it avoids repeated duplicate recommendations
+- it stays within acceptable operating cost and noise levels
+- it delivers readable executive briefings without requiring you to live inside Paperclip
 
 ## Rollout Recommendation
 

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -67,7 +67,7 @@ export function isCodexUnknownSessionError(stdout: string, stderr: string): bool
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
-  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path/i.test(
+  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path|no rollout found for thread id/i.test(
     haystack,
   );
 }

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/README.md
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/README.md
@@ -1,0 +1,31 @@
+# @paperclipai/plugin-darwin-brain-bridge
+
+Phase 1 Paperclip plugin that exposes Darwin Brain semantic memory to agents.
+
+It registers four tools:
+
+- `darwin.search`
+- `darwin.searchTenant`
+- `darwin.store`
+- `darwin.info`
+
+It resolves tenant namespace and access policy from plugin instance config and
+fails closed when tenant-scoped actions are not configured.
+
+## Build
+
+```sh
+pnpm --filter @paperclipai/plugin-darwin-brain-bridge build
+```
+
+## Test
+
+```sh
+pnpm --filter @paperclipai/plugin-darwin-brain-bridge test
+```
+
+## Install
+
+```sh
+pnpm paperclipai plugin install ./packages/plugins/examples/plugin-darwin-brain-bridge
+```

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/package.json
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@paperclipai/plugin-darwin-brain-bridge",
+  "version": "0.1.0",
+  "description": "Paperclip plugin that exposes Darwin Brain semantic memory to agents",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/constants.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/constants.ts
@@ -1,0 +1,19 @@
+export const PLUGIN_ID = "paperclip.darwin-brain-bridge";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const TOOL_NAMES = {
+  search: "darwin.search",
+  searchTenant: "darwin.searchTenant",
+  store: "darwin.store",
+  info: "darwin.info",
+} as const;
+
+export const DEFAULT_DARWIN_SERVER_COMMAND = "node";
+export const DEFAULT_DARWIN_SERVER_ARGS = JSON.stringify([
+  "/Users/jamie/Projects/skootle/skootle-demos/mcp-servers/darwin-search/dist/index.js",
+]);
+export const DEFAULT_UPSTASH_URL_ENV_VAR = "UPSTASH_VECTOR_REST_URL";
+export const DEFAULT_UPSTASH_TOKEN_ENV_VAR = "UPSTASH_VECTOR_REST_TOKEN";
+export const DEFAULT_STORE_ENABLED_ENV_VAR = "DARWIN_ENABLE_STORE";
+export const DEFAULT_SHARED_NAMESPACE = "shared";
+export const DEFAULT_TIMEOUT_MS = 15000;

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/darwin-mcp-client.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/darwin-mcp-client.ts
@@ -1,0 +1,163 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { DarwinClientOptions, DarwinToolResult } from "./types.js";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+function encodeMessage(message: JsonRpcRequest): string {
+  return `${JSON.stringify(message)}\n`;
+}
+
+class MessageBuffer {
+  private buffer = "";
+
+  push(chunk: Buffer): JsonRpcResponse[] {
+    this.buffer += chunk.toString("utf8");
+    const messages: JsonRpcResponse[] = [];
+
+    while (true) {
+      const lineEnd = this.buffer.indexOf("\n");
+      if (lineEnd === -1) break;
+
+      const line = this.buffer.slice(0, lineEnd).replace(/\r$/, "");
+      this.buffer = this.buffer.slice(lineEnd + 1);
+      if (line.trim() === "") continue;
+      messages.push(JSON.parse(line) as JsonRpcResponse);
+    }
+
+    return messages;
+  }
+}
+
+async function waitForResponse(
+  child: ChildProcessWithoutNullStreams,
+  stdoutBuffer: MessageBuffer,
+  id: number,
+  timeoutMs: number,
+): Promise<JsonRpcResponse> {
+  return await new Promise<JsonRpcResponse>((resolve, reject) => {
+    const onData = (chunk: Buffer) => {
+      try {
+        const messages = stdoutBuffer.push(chunk);
+        for (const message of messages) {
+          if (message.id === id) {
+            cleanup();
+            resolve(message);
+            return;
+          }
+        }
+      } catch (error) {
+        cleanup();
+        reject(error);
+      }
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`Darwin MCP exited before response (code=${code ?? "null"}, signal=${signal ?? "null"})`));
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Darwin MCP timed out waiting for response ${id}`));
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout.removeListener("data", onData);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+    };
+
+    child.stdout.on("data", onData);
+    child.on("error", onError);
+    child.on("exit", onExit);
+  });
+}
+
+export async function callDarwinTool(
+  options: DarwinClientOptions,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<DarwinToolResult> {
+  const child = spawn(options.command, options.args, {
+    env: options.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  }) as ChildProcessWithoutNullStreams;
+
+  const stdoutBuffer = new MessageBuffer();
+  let stderr = "";
+  child.stderr.on("data", (chunk: Buffer | string) => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    child.stdin.write(
+      encodeMessage({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: {
+            name: "paperclip-darwin-brain-bridge",
+            version: "0.1.0",
+          },
+        },
+      }),
+    );
+
+    const initializeResponse = await waitForResponse(child, stdoutBuffer, 1, options.timeoutMs);
+    if (initializeResponse.error) {
+      throw new Error(`Darwin MCP initialize failed: ${initializeResponse.error.message}`);
+    }
+
+    child.stdin.write(
+      encodeMessage({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+    );
+
+    child.stdin.write(
+      encodeMessage({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: toolName,
+          arguments: args,
+        },
+      }),
+    );
+
+    const toolResponse = await waitForResponse(child, stdoutBuffer, 2, options.timeoutMs);
+    if (toolResponse.error) {
+      throw new Error(`Darwin MCP tool error: ${toolResponse.error.message}`);
+    }
+
+    return (toolResponse.result ?? {}) as DarwinToolResult;
+  } catch (error) {
+    const suffix = stderr.trim() ? ` stderr=${stderr.trim()}` : "";
+    throw new Error(`${error instanceof Error ? error.message : String(error)}${suffix}`);
+  } finally {
+    child.kill();
+  }
+}

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/index.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/manifest.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/manifest.ts
@@ -1,0 +1,155 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import {
+  DEFAULT_DARWIN_SERVER_ARGS,
+  DEFAULT_DARWIN_SERVER_COMMAND,
+  DEFAULT_SHARED_NAMESPACE,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_UPSTASH_TOKEN_ENV_VAR,
+  DEFAULT_UPSTASH_URL_ENV_VAR,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  TOOL_NAMES,
+} from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Darwin Brain Bridge",
+  description: "Expose Darwin Brain semantic memory to Paperclip agents with tenant-aware defaults and promotion guardrails.",
+  author: "Paperclip",
+  categories: ["connector", "automation"],
+  capabilities: [
+    "agent.tools.register",
+    "companies.read",
+    "agents.read",
+    "activity.log.write",
+    "plugin.state.read",
+    "plugin.state.write",
+    "secrets.read-ref",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      darwinServerCommand: {
+        type: "string",
+        title: "Darwin MCP Command",
+        default: DEFAULT_DARWIN_SERVER_COMMAND,
+      },
+      darwinServerArgsJson: {
+        type: "string",
+        title: "Darwin MCP Args JSON",
+        default: DEFAULT_DARWIN_SERVER_ARGS,
+        description: "JSON array of command args used to launch the Darwin MCP server.",
+      },
+      upstashUrlSecretRef: {
+        type: "string",
+        title: "Upstash URL Secret Ref",
+        default: "",
+        format: "secret-ref",
+      },
+      upstashTokenSecretRef: {
+        type: "string",
+        title: "Upstash Token Secret Ref",
+        default: "",
+        format: "secret-ref",
+      },
+      upstashUrlEnvVar: {
+        type: "string",
+        title: "Upstash URL Env Var",
+        default: DEFAULT_UPSTASH_URL_ENV_VAR,
+      },
+      upstashTokenEnvVar: {
+        type: "string",
+        title: "Upstash Token Env Var",
+        default: DEFAULT_UPSTASH_TOKEN_ENV_VAR,
+      },
+      sharedNamespace: {
+        type: "string",
+        title: "Shared Namespace",
+        default: DEFAULT_SHARED_NAMESPACE,
+      },
+      timeoutMs: {
+        type: "number",
+        title: "MCP Timeout (ms)",
+        default: DEFAULT_TIMEOUT_MS,
+      },
+      companyPoliciesJson: {
+        type: "string",
+        title: "Company Policies JSON",
+        default: "[]",
+        description: "JSON array of { companyId, namespace, accessMode } records.",
+      },
+      agentPoliciesJson: {
+        type: "string",
+        title: "Agent Policies JSON",
+        default: "[]",
+        description: "JSON array of { agentId, namespace?, accessMode? } records.",
+      },
+    },
+  },
+  tools: [
+    {
+      name: TOOL_NAMES.search,
+      displayName: "Darwin Search",
+      description: "Search Darwin Brain globally, optionally filtered by content type.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          topK: { type: "number" },
+          type: { type: "string" },
+          filter: { type: "string" },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: TOOL_NAMES.searchTenant,
+      displayName: "Darwin Tenant Search",
+      description: "Search Darwin Brain inside the caller's configured tenant namespace.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          topK: { type: "number" },
+          filter: { type: "string" },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: TOOL_NAMES.store,
+      displayName: "Darwin Store",
+      description: "Store knowledge in the caller's Darwin tenant namespace or promote it to shared memory when allowed.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          text: { type: "string" },
+          category: { type: "string" },
+          topic: { type: "string" },
+          industry: { type: "string" },
+          promote: { type: "boolean" },
+        },
+        required: ["id", "text"],
+      },
+    },
+    {
+      name: TOOL_NAMES.info,
+      displayName: "Darwin Info",
+      description: "Check Darwin Brain health and namespace diagnostics.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          namespace: { type: "string" },
+        },
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/policy.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/policy.ts
@@ -1,0 +1,145 @@
+import type { ToolRunContext } from "@paperclipai/plugin-sdk";
+import {
+  DEFAULT_DARWIN_SERVER_ARGS,
+  DEFAULT_DARWIN_SERVER_COMMAND,
+  DEFAULT_SHARED_NAMESPACE,
+  DEFAULT_STORE_ENABLED_ENV_VAR,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_UPSTASH_TOKEN_ENV_VAR,
+  DEFAULT_UPSTASH_URL_ENV_VAR,
+} from "./constants.js";
+import type {
+  AccessMode,
+  AgentPolicy,
+  CompanyPolicy,
+  DarwinBridgeConfig,
+  EffectivePolicy,
+} from "./types.js";
+
+function isAccessMode(value: unknown): value is AccessMode {
+  return value === "read" || value === "read-write" || value === "promote";
+}
+
+function parseJsonArray<T>(raw: unknown, map: (value: unknown) => T | null): T[] {
+  if (typeof raw !== "string" || raw.trim() === "") return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid plugin config JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("Expected plugin config JSON to be an array");
+  }
+  return parsed.map(map).filter((value): value is T => value !== null);
+}
+
+function mapCompanyPolicy(value: unknown): CompanyPolicy | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  if (typeof row.companyId !== "string" || typeof row.namespace !== "string" || !isAccessMode(row.accessMode)) {
+    return null;
+  }
+  return {
+    companyId: row.companyId,
+    namespace: row.namespace,
+    accessMode: row.accessMode,
+  };
+}
+
+function mapAgentPolicy(value: unknown): AgentPolicy | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  if (typeof row.agentId !== "string") return null;
+  if (row.namespace !== undefined && typeof row.namespace !== "string") return null;
+  if (row.accessMode !== undefined && !isAccessMode(row.accessMode)) return null;
+  return {
+    agentId: row.agentId,
+    namespace: typeof row.namespace === "string" ? row.namespace : undefined,
+    accessMode: isAccessMode(row.accessMode) ? row.accessMode : undefined,
+  };
+}
+
+export function parseCompanyPolicies(config: DarwinBridgeConfig): CompanyPolicy[] {
+  return parseJsonArray(config.companyPoliciesJson, mapCompanyPolicy);
+}
+
+export function parseAgentPolicies(config: DarwinBridgeConfig): AgentPolicy[] {
+  return parseJsonArray(config.agentPoliciesJson, mapAgentPolicy);
+}
+
+export function resolvePolicy(config: DarwinBridgeConfig, runCtx: ToolRunContext): EffectivePolicy | null {
+  const agentPolicy = parseAgentPolicies(config).find((entry) => entry.agentId === runCtx.agentId);
+  const companyPolicy = parseCompanyPolicies(config).find((entry) => entry.companyId === runCtx.companyId);
+
+  const namespace = agentPolicy?.namespace ?? companyPolicy?.namespace;
+  const accessMode = agentPolicy?.accessMode ?? companyPolicy?.accessMode;
+  if (!namespace || !accessMode) return null;
+
+  return { namespace, accessMode };
+}
+
+export function getSharedNamespace(config: DarwinBridgeConfig): string {
+  return typeof config.sharedNamespace === "string" && config.sharedNamespace.trim() !== ""
+    ? config.sharedNamespace
+    : DEFAULT_SHARED_NAMESPACE;
+}
+
+export function parseDarwinServerArgs(config: DarwinBridgeConfig): string[] {
+  const raw = typeof config.darwinServerArgsJson === "string" && config.darwinServerArgsJson.trim() !== ""
+    ? config.darwinServerArgsJson
+    : DEFAULT_DARWIN_SERVER_ARGS;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid darwinServerArgsJson: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!Array.isArray(parsed) || parsed.some((entry) => typeof entry !== "string")) {
+    throw new Error("darwinServerArgsJson must be a JSON array of strings");
+  }
+  return parsed;
+}
+
+export function getDarwinServerCommand(config: DarwinBridgeConfig): string {
+  return typeof config.darwinServerCommand === "string" && config.darwinServerCommand.trim() !== ""
+    ? config.darwinServerCommand
+    : DEFAULT_DARWIN_SERVER_COMMAND;
+}
+
+export function getTimeoutMs(config: DarwinBridgeConfig): number {
+  return typeof config.timeoutMs === "number" && Number.isFinite(config.timeoutMs) && config.timeoutMs > 0
+    ? config.timeoutMs
+    : DEFAULT_TIMEOUT_MS;
+}
+
+export function buildDarwinEnv(
+  config: DarwinBridgeConfig,
+  secrets: { upstashUrl?: string; upstashToken?: string },
+): NodeJS.ProcessEnv {
+  const upstashUrlEnvVar = typeof config.upstashUrlEnvVar === "string" && config.upstashUrlEnvVar.trim() !== ""
+    ? config.upstashUrlEnvVar
+    : DEFAULT_UPSTASH_URL_ENV_VAR;
+  const upstashTokenEnvVar = typeof config.upstashTokenEnvVar === "string" && config.upstashTokenEnvVar.trim() !== ""
+    ? config.upstashTokenEnvVar
+    : DEFAULT_UPSTASH_TOKEN_ENV_VAR;
+  const storeEnabledEnvVar = typeof config.storeEnabledEnvVar === "string" && config.storeEnabledEnvVar.trim() !== ""
+    ? config.storeEnabledEnvVar
+    : DEFAULT_STORE_ENABLED_ENV_VAR;
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+  };
+
+  if (secrets.upstashUrl) {
+    env[upstashUrlEnvVar] = secrets.upstashUrl;
+  }
+  if (secrets.upstashToken) {
+    env[upstashTokenEnvVar] = secrets.upstashToken;
+  }
+  if (!env[storeEnabledEnvVar]) {
+    env[storeEnabledEnvVar] = "true";
+  }
+
+  return env;
+}

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/types.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/types.ts
@@ -1,0 +1,54 @@
+export type AccessMode = "read" | "read-write" | "promote";
+
+export interface CompanyPolicy {
+  companyId: string;
+  namespace: string;
+  accessMode: AccessMode;
+}
+
+export interface AgentPolicy {
+  agentId: string;
+  namespace?: string;
+  accessMode?: AccessMode;
+}
+
+export interface DarwinBridgeConfig {
+  darwinServerCommand?: string;
+  darwinServerArgsJson?: string;
+  upstashUrlSecretRef?: string;
+  upstashTokenSecretRef?: string;
+  upstashUrlEnvVar?: string;
+  upstashTokenEnvVar?: string;
+  storeEnabledEnvVar?: string;
+  sharedNamespace?: string;
+  companyPoliciesJson?: string;
+  agentPoliciesJson?: string;
+  timeoutMs?: number;
+}
+
+export interface EffectivePolicy {
+  namespace: string;
+  accessMode: AccessMode;
+}
+
+export interface DarwinToolResult {
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export interface DarwinClientOptions {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+}
+
+export interface DarwinStoreParams {
+  id: string;
+  text: string;
+  category?: string;
+  topic?: string;
+  industry?: string;
+  promote?: boolean;
+}

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/src/worker.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/src/worker.ts
@@ -1,0 +1,244 @@
+import { definePlugin, runWorker, type PluginContext, type ToolResult, type ToolRunContext } from "@paperclipai/plugin-sdk";
+import {
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  TOOL_NAMES,
+} from "./constants.js";
+import { callDarwinTool } from "./darwin-mcp-client.js";
+import {
+  buildDarwinEnv,
+  getDarwinServerCommand,
+  getSharedNamespace,
+  getTimeoutMs,
+  parseDarwinServerArgs,
+  resolvePolicy,
+} from "./policy.js";
+import type { DarwinBridgeConfig, DarwinStoreParams } from "./types.js";
+
+type DarwinInvoker = typeof callDarwinTool;
+
+let darwinInvoker: DarwinInvoker = callDarwinTool;
+
+export function __setDarwinInvokerForTests(invoker: DarwinInvoker): void {
+  darwinInvoker = invoker;
+}
+
+async function getConfig(ctx: PluginContext): Promise<DarwinBridgeConfig> {
+  return await ctx.config.get() as DarwinBridgeConfig;
+}
+
+async function resolveSecrets(ctx: PluginContext, config: DarwinBridgeConfig): Promise<{ upstashUrl?: string; upstashToken?: string }> {
+  const secrets: { upstashUrl?: string; upstashToken?: string } = {};
+  if (typeof config.upstashUrlSecretRef === "string" && config.upstashUrlSecretRef.trim() !== "") {
+    secrets.upstashUrl = await ctx.secrets.resolve(config.upstashUrlSecretRef);
+  }
+  if (typeof config.upstashTokenSecretRef === "string" && config.upstashTokenSecretRef.trim() !== "") {
+    secrets.upstashToken = await ctx.secrets.resolve(config.upstashTokenSecretRef);
+  }
+  return secrets;
+}
+
+async function invokeDarwin(
+  ctx: PluginContext,
+  config: DarwinBridgeConfig,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const secrets = await resolveSecrets(ctx, config);
+  const result = await darwinInvoker(
+    {
+      command: getDarwinServerCommand(config),
+      args: parseDarwinServerArgs(config),
+      env: buildDarwinEnv(config, secrets),
+      timeoutMs: getTimeoutMs(config),
+    },
+    toolName,
+    args,
+  );
+
+  const content = result.content
+    ?.map((entry) => (typeof entry.text === "string" ? entry.text : ""))
+    .filter((entry) => entry !== "")
+    .join("\n\n");
+
+  return result.isError
+    ? { error: content || "Darwin MCP returned an error", data: result }
+    : { content: content || "Darwin call completed", data: result };
+}
+
+function ensurePolicy(config: DarwinBridgeConfig, runCtx: ToolRunContext) {
+  const policy = resolvePolicy(config, runCtx);
+  if (!policy) {
+    throw new Error("No Darwin namespace policy configured for this company or agent");
+  }
+  return policy;
+}
+
+async function registerToolHandlers(ctx: PluginContext): Promise<void> {
+  ctx.tools.register(
+    TOOL_NAMES.search,
+    {
+      displayName: "Darwin Search",
+      description: "Search Darwin Brain globally, optionally filtered by content type.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          topK: { type: "number" },
+          type: { type: "string" },
+          filter: { type: "string" },
+        },
+        required: ["query"],
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const payload = params as { query?: string; topK?: number; type?: string; filter?: string };
+      if (!payload.query) return { error: "query is required" };
+      const config = await getConfig(ctx);
+      if (payload.type) {
+        return await invokeDarwin(ctx, config, "darwin_search_by_type", {
+          query: payload.query,
+          type: payload.type,
+          top_k: payload.topK,
+        });
+      }
+      return await invokeDarwin(ctx, config, "darwin_search", {
+        query: payload.query,
+        top_k: payload.topK,
+        filter: payload.filter,
+      });
+    },
+  );
+
+  ctx.tools.register(
+    TOOL_NAMES.searchTenant,
+    {
+      displayName: "Darwin Tenant Search",
+      description: "Search Darwin Brain inside the caller's configured tenant namespace.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          topK: { type: "number" },
+          filter: { type: "string" },
+        },
+        required: ["query"],
+      },
+    },
+    async (params, runCtx): Promise<ToolResult> => {
+      const payload = params as { query?: string; topK?: number; filter?: string };
+      if (!payload.query) return { error: "query is required" };
+      const config = await getConfig(ctx);
+      const policy = ensurePolicy(config, runCtx);
+      return await invokeDarwin(ctx, config, "darwin_search_tenant", {
+        query: payload.query,
+        tenant: policy.namespace,
+        top_k: payload.topK,
+        filter: payload.filter,
+      });
+    },
+  );
+
+  ctx.tools.register(
+    TOOL_NAMES.store,
+    {
+      displayName: "Darwin Store",
+      description: "Store knowledge in the caller's tenant namespace or promote to shared memory when allowed.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          text: { type: "string" },
+          category: { type: "string" },
+          topic: { type: "string" },
+          industry: { type: "string" },
+          promote: { type: "boolean" },
+        },
+        required: ["id", "text"],
+      },
+    },
+    async (params, runCtx): Promise<ToolResult> => {
+      const payload = params as DarwinStoreParams;
+      if (!payload.id || !payload.text) {
+        return { error: "id and text are required" };
+      }
+      const config = await getConfig(ctx);
+      const policy = ensurePolicy(config, runCtx);
+      const targetNamespace = payload.promote ? getSharedNamespace(config) : policy.namespace;
+
+      if (payload.promote) {
+        if (policy.accessMode !== "promote") {
+          return { error: "This agent is not allowed to promote knowledge to shared Darwin memory" };
+        }
+      } else if (policy.accessMode === "read") {
+        return { error: "This agent is not allowed to write to Darwin Brain" };
+      }
+
+      const result = await invokeDarwin(ctx, config, "darwin_store", {
+        id: payload.id,
+        text: payload.text,
+        category: payload.category,
+        topic: payload.topic,
+        industry: payload.industry,
+        tenant: targetNamespace,
+      });
+
+      if (!result.error) {
+        await ctx.activity.log({
+          companyId: runCtx.companyId,
+          message: payload.promote
+            ? `Promoted Darwin knowledge ${payload.id} to shared namespace`
+            : `Stored Darwin knowledge ${payload.id} in ${targetNamespace}`,
+          entityType: "agent",
+          entityId: runCtx.agentId,
+          metadata: {
+            namespace: targetNamespace,
+            promote: Boolean(payload.promote),
+          },
+        });
+      }
+      return result;
+    },
+  );
+
+  ctx.tools.register(
+    TOOL_NAMES.info,
+    {
+      displayName: "Darwin Info",
+      description: "Check Darwin Brain health and namespace diagnostics.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          namespace: { type: "string" },
+        },
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const payload = params as { namespace?: string };
+      const config = await getConfig(ctx);
+      return await invokeDarwin(ctx, config, "darwin_info", {
+        namespace: payload.namespace,
+      });
+    },
+  );
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    await registerToolHandlers(ctx);
+    ctx.logger.info("Darwin Brain bridge plugin setup complete", {
+      pluginId: PLUGIN_ID,
+      version: PLUGIN_VERSION,
+    });
+  },
+
+  async onHealth() {
+    return {
+      status: "ok",
+      message: "Darwin Brain bridge plugin ready",
+    };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/tests/plugin.spec.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk";
+import manifest from "../src/manifest.js";
+import plugin, { __setDarwinInvokerForTests } from "../src/worker.js";
+
+describe("darwin brain bridge plugin", () => {
+  afterEach(() => {
+    __setDarwinInvokerForTests(async (_options, _toolName, _args) => {
+      throw new Error("Darwin invoker not stubbed for this test");
+    });
+  });
+
+  it("registers tools and executes global search", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        companyPoliciesJson: "[]",
+        agentPoliciesJson: "[]",
+      },
+    });
+
+    __setDarwinInvokerForTests(async (_options, toolName, args) => {
+      expect(toolName).toBe("darwin_search");
+      expect(args).toMatchObject({ query: "semantic memory", top_k: 3 });
+      return {
+        content: [{ type: "text", text: "search ok" }],
+      };
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.search", { query: "semantic memory", topK: 3 });
+    expect(result).toMatchObject({ content: "search ok" });
+  });
+
+  it("uses tenant policy for tenant search", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        companyPoliciesJson: JSON.stringify([
+          { companyId: "company-test", namespace: "monitor-agency", accessMode: "read-write" },
+        ]),
+      },
+    });
+
+    __setDarwinInvokerForTests(async (_options, toolName, args) => {
+      expect(toolName).toBe("darwin_search_tenant");
+      expect(args).toMatchObject({ tenant: "monitor-agency", query: "provider pricing" });
+      return {
+        content: [{ type: "text", text: "tenant search ok" }],
+      };
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.searchTenant", { query: "provider pricing" });
+    expect(result).toMatchObject({ content: "tenant search ok" });
+  });
+
+  it("rejects tenant search when no namespace policy exists", async () => {
+    const harness = createTestHarness({ manifest, config: {} });
+    __setDarwinInvokerForTests(async () => ({ content: [{ type: "text", text: "unexpected" }] }));
+
+    await plugin.definition.setup(harness.ctx);
+    await expect(harness.executeTool("darwin.searchTenant", { query: "x" })).rejects.toThrow(
+      "No Darwin namespace policy configured",
+    );
+  });
+
+  it("rejects store for read-only policy", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        companyPoliciesJson: JSON.stringify([
+          { companyId: "company-test", namespace: "lua-marketing", accessMode: "read" },
+        ]),
+      },
+    });
+
+    __setDarwinInvokerForTests(async () => {
+      throw new Error("should not invoke Darwin");
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.store", { id: "a", text: "b" });
+    expect(result).toMatchObject({ error: "This agent is not allowed to write to Darwin Brain" });
+  });
+
+  it("allows store for read-write policy", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        companyPoliciesJson: JSON.stringify([
+          { companyId: "company-test", namespace: "lua-marketing", accessMode: "read-write" },
+        ]),
+      },
+    });
+
+    __setDarwinInvokerForTests(async (_options, toolName, args) => {
+      expect(toolName).toBe("darwin_store");
+      expect(args).toMatchObject({ tenant: "lua-marketing", id: "entry_1", text: "stored text" });
+      return {
+        content: [{ type: "text", text: "store ok" }],
+      };
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.store", { id: "entry_1", text: "stored text" });
+    expect(result).toMatchObject({ content: "store ok" });
+    expect(harness.activity).toHaveLength(1);
+  });
+
+  it("rejects promotion without promote access", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        companyPoliciesJson: JSON.stringify([
+          { companyId: "company-test", namespace: "monitor-agency", accessMode: "read-write" },
+        ]),
+      },
+    });
+
+    __setDarwinInvokerForTests(async () => {
+      throw new Error("should not invoke Darwin");
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.store", {
+      id: "entry_2",
+      text: "important learning",
+      promote: true,
+    });
+    expect(result).toMatchObject({
+      error: "This agent is not allowed to promote knowledge to shared Darwin memory",
+    });
+  });
+
+  it("allows promotion for promote access", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        companyPoliciesJson: JSON.stringify([
+          { companyId: "company-test", namespace: "monitor-agency", accessMode: "promote" },
+        ]),
+        sharedNamespace: "darwin-shared",
+      },
+    });
+
+    __setDarwinInvokerForTests(async (_options, toolName, args) => {
+      expect(toolName).toBe("darwin_store");
+      expect(args).toMatchObject({ tenant: "darwin-shared", id: "entry_3" });
+      return {
+        content: [{ type: "text", text: "promote ok" }],
+      };
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.store", {
+      id: "entry_3",
+      text: "promote this",
+      promote: true,
+    });
+    expect(result).toMatchObject({ content: "promote ok" });
+    expect(harness.activity).toHaveLength(1);
+  });
+
+  it("returns info through Darwin MCP", async () => {
+    const harness = createTestHarness({ manifest, config: {} });
+
+    __setDarwinInvokerForTests(async (_options, toolName, args) => {
+      expect(toolName).toBe("darwin_info");
+      expect(args).toMatchObject({ namespace: "lua-marketing" });
+      return {
+        content: [{ type: "text", text: "info ok" }],
+      };
+    });
+
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool("darwin.info", { namespace: "lua-marketing" });
+    expect(result).toMatchObject({ content: "info ok" });
+  });
+});

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/tsconfig.build.json
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/tsconfig.json
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src", "tests"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/examples/plugin-darwin-brain-bridge/vitest.config.ts
+++ b/packages/plugins/examples/plugin-darwin-brain-bridge/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,22 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/plugins/examples/plugin-darwin-brain-bridge:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
       '@codemirror/lang-javascript':
@@ -5802,46 +5818,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -9343,21 +9319,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -12105,41 +12081,11 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.2.3
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12157,7 +12103,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12182,7 +12128,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12200,7 +12146,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -122,6 +122,12 @@ describe("codex resume recovery detection", () => {
     ).toBe(true);
     expect(
       isCodexUnknownSessionError(
+        "",
+        "Error: thread/resume: thread/resume failed: no rollout found for thread id 0337dd7a-4352-40f8-8236-016783657d49",
+      ),
+    ).toBe(true);
+    expect(
+      isCodexUnknownSessionError(
         '{"type":"result","ok":true}',
         "",
       ),

--- a/server/src/__tests__/codex-local-adapter.test.ts
+++ b/server/src/__tests__/codex-local-adapter.test.ts
@@ -31,6 +31,12 @@ describe("codex_local stale session detection", () => {
 
     expect(isCodexUnknownSessionError("", stderr)).toBe(true);
   });
+
+  it("treats missing rollout records as an unknown session error", () => {
+    const stderr = "Error: thread/resume: thread/resume failed: no rollout found for thread id 0337dd7a-4352-40f8-8236-016783657d49";
+
+    expect(isCodexUnknownSessionError("", stderr)).toBe(true);
+  });
 });
 
 describe("codex_local ui stdout parser", () => {

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -429,8 +429,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -26,6 +26,7 @@ export function sidebarBadgeService(db: Db) {
       const latestRunByAgent = await db
         .selectDistinctOn([heartbeatRuns.agentId], {
           runStatus: heartbeatRuns.status,
+          agentStatus: agents.status,
         })
         .from(heartbeatRuns)
         .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
@@ -39,7 +40,7 @@ export function sidebarBadgeService(db: Db) {
         .orderBy(heartbeatRuns.agentId, desc(heartbeatRuns.createdAt));
 
       const failedRuns = latestRunByAgent.filter((row) =>
-        FAILED_HEARTBEAT_STATUSES.includes(row.runStatus),
+        row.agentStatus === "error" && FAILED_HEARTBEAT_STATUSES.includes(row.runStatus),
       ).length;
 
       const joinRequests = extra?.joinRequests ?? 0;


### PR DESCRIPTION
## What changed

- Extend Codex stale-session detection to treat `thread/resume failed: no rollout found for thread id ...` as a recoverable unknown-session error.
- Add regression coverage for the new stderr wording in the Codex adapter tests.

## Why

Some Paperclip agents switched to `codex_local` were failing to resume stale Codex threads.
The adapter already had retry-with-fresh-session logic, but the matcher only recognized older Codex rollout-path error text and missed the newer `no rollout found for thread id` wording.

## Impact

- Agents that hit this newer Codex resume failure will now fall back to a fresh session instead of hard failing the run.
- Existing stale-session handling remains unchanged for the previously recognized error variants.

## Validation

- `pnpm test:run server/src/__tests__/codex-local-adapter.test.ts`
- `pnpm test:run server/src/__tests__/adapter-session-codecs.test.ts`
