### PR TITLE
fix(ui): add loading spinners to Restart and Stop runtime service buttons

### DIFF
--- a/ui/src/pages/ProjectWorkspaceDetail.tsx
+++ b/ui/src/pages/ProjectWorkspaceDetail.tsx
@@ -618,6 +618,7 @@ export function ProjectWorkspaceDetail() {
                   disabled={controlRuntimeServices.isPending || !workspace.cwd}
                   onClick={() => controlRuntimeServices.mutate("restart")}
                 >
+                  {controlRuntimeServices.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
                   Restart
                 </Button>
                 <Button
@@ -627,6 +628,7 @@ export function ProjectWorkspaceDetail() {
                   disabled={controlRuntimeServices.isPending || (workspace.runtimeServices?.length ?? 0) === 0}
                   onClick={() => controlRuntimeServices.mutate("stop")}
                 >
+                  {controlRuntimeServices.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
                   Stop
                 </Button>
               </div>


### PR DESCRIPTION
## Problem

In ProjectWorkspaceDetail, the runtime service control section have three buttons: Start, Restart, Stop. But only the Start button show a loading spinner while the mutation is pending. Restart and Stop just get disabled with no visual feedback.

This is inconsistent - all three buttons share the same mutation (\`controlRuntimeServices\`) and the same pending state, but only one show the spinner. User click Restart and the button just go gray, they don't know if something is happening or if it's broken.

## What I changed

Added the same \`Loader2\` spinner pattern to Restart and Stop buttons:
\`\`\`tsx
{controlRuntimeServices.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
\`\`\`

Exact same code that the Start button already use at line 611. Now all three buttons show consistent loading feedback.

## How to test

1. Go to any project workspace detail page with runtime services
2. Click Restart or Stop
3. Should see spinning loader icon appear in the button while operation is processing
4. Compare with Start button - all three should look the same during loading

1 file, 2 lines added.