### PR TITLE
fix: handle Windows paths with spaces in resolveSpawnTarget

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -329,7 +329,7 @@ async function resolveSpawnTarget(
       try {
         const cmdContent = await fs.readFile(executable, "utf8");
         // npm-generated .cmd wrappers contain: "%dp0%\path\to\entry.js"
-        const jsMatch = cmdContent.match(/%dp0%\\([^\s"]+\.js)/);
+        const jsMatch = cmdContent.match(/%(?:~)?dp0%?\\([^\s"]+\.js)/i);
         if (jsMatch) {
           const jsFile = path.join(path.dirname(executable), jsMatch[1]!);
           if (await pathExists(jsFile)) {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -320,6 +320,31 @@ async function resolveSpawnTarget(
   }
 
   if (/\.(cmd|bat)$/i.test(executable)) {
+    // When the executable path contains spaces (e.g. C:\Users\Admin Backup\...),
+    // cmd.exe /d /s /c breaks because Node.js adds extra quotes around the
+    // command-line argument in CreateProcess, which interact badly with /s
+    // quote-stripping behaviour. Work around this by reading the .cmd wrapper
+    // to extract the underlying .js entrypoint and spawning node directly.
+    if (/\s/.test(executable)) {
+      try {
+        const cmdContent = await fs.readFile(executable, "utf8");
+        // npm-generated .cmd wrappers contain: "%dp0%\path\to\entry.js"
+        const jsMatch = cmdContent.match(/%dp0%\\([^\s"]+\.js)/);
+        if (jsMatch) {
+          const jsFile = path.join(path.dirname(executable), jsMatch[1]!);
+          if (await pathExists(jsFile)) {
+            const nodeExe = path.join(path.dirname(process.execPath), "node.exe");
+            return {
+              command: (await pathExists(nodeExe)) ? nodeExe : "node",
+              args: [jsFile, ...args],
+            };
+          }
+        }
+      } catch {
+        // Fall through to the cmd.exe approach below.
+      }
+    }
+
     const shell = env.ComSpec || process.env.ComSpec || "cmd.exe";
     const commandLine = [quoteForCmd(executable), ...args.map(quoteForCmd)].join(" ");
     return {


### PR DESCRIPTION
## Problem

On Windows, when the npm global directory sits inside a user profile whose name contains spaces (e.g. `C:\Users\Admin Backup\AppData\Roaming\npm\codex.CMD`), the Codex hello probe (and all agent spawning) fails with:

```
'"C:\Users\Admin Backup\AppData\Roaming\npm\codex.CMD"' is not recognized as an internal or external command
```

This affects **any Windows user whose username contains a space** (very common: `John Doe`, `Admin Backup`, etc.).

## Root Cause

`resolveSpawnTarget()` in `adapter-utils` wraps `.cmd/.bat` executables with `cmd.exe /d /s /c`. When the executable path contains spaces, `quoteForCmd()` correctly adds double quotes around it. However, Node.js `spawn()` on Windows builds the command line for `CreateProcess` and adds its **own** quotes around arguments containing spaces. The `/s` flag then strips the outermost quotes, leaving the path unquoted and broken into multiple tokens by `cmd.exe`.

## Fix

When the resolved `.cmd/.bat` path contains whitespace:
1. Read the `.cmd` wrapper file content
2. Extract the underlying `.js` entrypoint (npm-generated `.cmd` files always reference it via `%dp0%\...\entry.js`)
3. Spawn `node.exe` directly with the `.js` file, bypassing `cmd.exe` entirely

Falls back to the original `cmd.exe` approach for paths without spaces or when extraction fails.

## Testing

Verified on Windows 11 with path `C:\Users\Admin Backup\AppData\Roaming\npm\codex.CMD`:
- Before fix: `Codex hello probe failed`
- After fix: `codex-cli 0.117.0` responds correctly

The fix is backward-compatible: paths without spaces continue to use the existing `cmd.exe` approach unchanged.
