### PR TITLE
fix(ui): error feedback for mark-read and update-issue in IssueDetail

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -540,12 +540,18 @@ export function IssueDetail() {
         queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(selectedCompanyId) });
       }
     },
+    onError: (err) => {
+      pushToast({ title: "Failed to mark as read", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
+    },
   });
 
   const updateIssue = useMutation({
     mutationFn: (data: Record<string, unknown>) => issuesApi.update(issueId!, data),
     onSuccess: () => {
       invalidateIssue();
+    },
+    onError: (err) => {
+      pushToast({ title: "Failed to update issue", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
   });
 


### PR DESCRIPTION
## Problem

After the recent big refactor of IssueDetail, two mutations are still missing error handlers:

### markIssueRead (line 533)
When the API call to mark an issue as read fail, nothing happen. The sidebar badge and issue lists don't update (because onSuccess don't run) but user get no explanation why.

### updateIssue (line 545)
When changing issue status, priority, assignee, or other properties fail, same problem - silent failure. User click a status dropdown, select "Done", and nothing change with no error message.

The \`addComment\` mutation right below these two already have excellent error handling with optimistic rollback (added in the recent refactor). But these two simpler mutations was not updated with error handlers.

## What I changed

Added \`onError\` callback to both mutations showing error toast via \`pushToast\` (already available in the component). Same pattern used throughout the app.

## How to test

1. Try changing issue status when network is disconnected - should see error toast
2. Try marking issue as read when API is down - should see error toast

1 file, 6 lines added.