### PR TITLE
fix(ui): show error toast when workspace runtime control fails

### DIFF
--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -221,6 +221,7 @@ function ProjectWorkspacesContent({
   summaries: ReturnType<typeof buildProjectWorkspaceSummaries>;
 }) {
   const queryClient = useQueryClient();
+  const { pushToast } = useToast();
   const [runtimeActionKey, setRuntimeActionKey] = useState<string | null>(null);
   const [closingWorkspace, setClosingWorkspace] = useState<{
     id: string;
@@ -239,6 +240,9 @@ function ProjectWorkspacesContent({
         return await projectsApi.controlWorkspaceRuntimeServices(projectId, input.workspaceId, input.action, companyId);
       }
       return await executionWorkspacesApi.controlRuntimeServices(input.workspaceId, input.action);
+    },
+    onError: (err) => {
+      pushToast({ title: "Runtime action failed", body: err instanceof Error ? err.message : "Something went wrong.", tone: "error" });
     },
     onSettled: () => {
       setRuntimeActionKey(null);


### PR DESCRIPTION
## Problem

The \`controlWorkspaceRuntime\` mutation in ProjectDetail's workspaces tab handle start/stop/restart of runtime services. But it had no \`onError\` handler - only \`onSettled\` which clean up loading state for both success and error cases.

If a runtime service fail to start (wrong config, port conflict, service crash), the loading spinner disappear via onSettled and user see nothing explaining what went wrong. They just think "maybe it worked?" and have to check manually.

Compare to \`ExecutionWorkspaceCloseDialog\` (line 68-74 in same codebase) which properly show error toast - that's the correct pattern.

## What I changed

- Added \`onError\` callback with \`pushToast\` showing the error message
- Added \`useToast()\` hook to the \`ProjectWorkspacesContent\` sub-component (it was only in the parent \`ProjectDetail\` function)

## How to test

1. Go to any project > Workspaces tab
2. Try to start/stop/restart runtime service when something go wrong
3. Should see red error toast with the error message

1 file, 4 lines added.