### PR TITLE
feat(ui): show Sending badge on optimistic comments while posting

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -164,7 +164,11 @@ function CommentCard({
           <Identity name="You" size="sm" />
         )}
         <span className="flex items-center gap-1.5">
-          {isQueued ? (
+          {isPending ? (
+            <span className="inline-flex items-center rounded-full border border-border bg-muted/50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground animate-pulse">
+              Sending
+            </span>
+          ) : isQueued ? (
             <span className="inline-flex items-center rounded-full border border-amber-400/60 bg-amber-100/70 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-amber-800 dark:border-amber-400/40 dark:bg-amber-500/20 dark:text-amber-200">
               Queued
             </span>


### PR DESCRIPTION
## Problem

The recent refactor added really nice optimistic comment rendering - when you post a comment it appear immediately in the thread before the server respond. There are two states:
- **pending**: comment is being sent to the server
- **queued**: comment is waiting to be delivered to a running agent

The "queued" state already have a beautiful amber "Queued" badge (line 168-170). But the "pending" state only had reduced opacity (\`opacity-80\`) with no text label. User see their comment appear slightly faded and don't know what that mean. Is it sending? Did it fail? Is it stuck?

## What I changed

Added a "Sending" badge that show during the pending state:
- Uses the same pill/badge styling as "Queued" (rounded-full, uppercase, tracking)
- Neutral muted colors instead of amber (since sending is a normal state, not a special queue)
- Pulse animation to indicate active progress
- Disappear as soon as the comment is accepted by the server

The comment lifecycle is now visually clear:
1. User submit -> comment appear with **"Sending"** badge (pulsing)
2. Server accept -> badge disappear, comment look normal
3. OR if agent is running -> **"Queued"** badge (amber, steady)

## How to test

1. Open any issue and post a comment
2. Should briefly see "Sending" badge pulsing next to the timestamp area
3. After server respond (usually <1 second), badge disappear
4. On slow network, the badge stay visible longer

1 file, 5 lines added / 1 removed.