### PR TITLE
fix: fall back to fresh session when API fails before emitting JSON

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -27,7 +27,7 @@ import {
   describeClaudeFailure,
   detectClaudeLoginRequired,
   isClaudeMaxTurnsResult,
-  isClaudeUnknownSessionError,
+  shouldFallbackToFreshSession,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
@@ -580,13 +580,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
-    if (
-      sessionId &&
-      !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
-      initial.parsed &&
-      isClaudeUnknownSessionError(initial.parsed)
-    ) {
+    if (shouldFallbackToFreshSession(sessionId, initial.proc, initial.parsed)) {
       await onLog(
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseClaudeStreamJson,
+  isClaudeUnknownSessionError,
+  shouldFallbackToFreshSession,
+} from "./parse.js";
+
+describe("parseClaudeStreamJson", () => {
+  it("extracts session id, model, summary, and usage from a complete stream", () => {
+    const stdout = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "sess_abc", model: "claude-sonnet-4-5" }),
+      JSON.stringify({ type: "assistant", session_id: "sess_abc", message: { content: [{ type: "text", text: "Hello!" }] } }),
+      JSON.stringify({ type: "result", session_id: "sess_abc", result: "Hello!", usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 2 }, total_cost_usd: 0.001 }),
+    ].join("\n");
+
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.sessionId).toBe("sess_abc");
+    expect(parsed.model).toBe("claude-sonnet-4-5");
+    expect(parsed.summary).toBe("Hello!");
+    expect(parsed.usage).toEqual({ inputTokens: 10, outputTokens: 5, cachedInputTokens: 2 });
+    expect(parsed.costUsd).toBeCloseTo(0.001, 6);
+  });
+
+  it("returns null resultJson when no result event is present", () => {
+    const stdout = JSON.stringify({ type: "system", subtype: "init", session_id: "sess_xyz", model: "claude-sonnet-4-5" });
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.resultJson).toBeNull();
+    expect(parsed.sessionId).toBe("sess_xyz");
+  });
+});
+
+describe("isClaudeUnknownSessionError", () => {
+  it("detects 'no conversation found with session id' message", () => {
+    expect(isClaudeUnknownSessionError({ result: "No conversation found with session ID: abc-123" })).toBe(true);
+  });
+
+  it("detects 'unknown session' message in errors array", () => {
+    expect(isClaudeUnknownSessionError({ errors: ["Unknown session encountered"] })).toBe(true);
+  });
+
+  it("detects 'session * not found' pattern", () => {
+    expect(isClaudeUnknownSessionError({ result: "session abc-123 not found" })).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isClaudeUnknownSessionError({ result: "Something went wrong" })).toBe(false);
+  });
+});
+
+describe("shouldFallbackToFreshSession", () => {
+  const failedProc = { exitCode: 1, timedOut: false };
+  const timedOutProc = { exitCode: null, timedOut: true };
+  const successProc = { exitCode: 0, timedOut: false };
+
+  it("falls back when session resume fails and parsed is null (API-level failure)", () => {
+    // This is the core bug: API returns 500 before emitting any JSON → parsed is null
+    expect(shouldFallbackToFreshSession("sess-dead", failedProc, null)).toBe(true);
+  });
+
+  it("falls back when parsed contains an unknown session error", () => {
+    const parsed = { result: "No conversation found with session ID: sess-dead" };
+    expect(shouldFallbackToFreshSession("sess-dead", failedProc, parsed)).toBe(true);
+  });
+
+  it("does NOT fall back when there is no session to resume (fresh start)", () => {
+    expect(shouldFallbackToFreshSession(null, failedProc, null)).toBe(false);
+  });
+
+  it("does NOT fall back when the process timed out", () => {
+    expect(shouldFallbackToFreshSession("sess-abc", timedOutProc, null)).toBe(false);
+  });
+
+  it("does NOT fall back when the process succeeded", () => {
+    expect(shouldFallbackToFreshSession("sess-abc", successProc, null)).toBe(false);
+  });
+
+  it("does NOT fall back when failure is unrelated to session (not a session error)", () => {
+    const parsed = { result: "Internal server error" };
+    expect(shouldFallbackToFreshSession("sess-abc", failedProc, parsed)).toBe(false);
+  });
+});

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -177,3 +177,29 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
     /no conversation found with session id|unknown session|session .* not found/i.test(msg),
   );
 }
+
+/**
+ * Returns true when a session-resume attempt should be retried as a fresh session.
+ *
+ * This handles two failure modes:
+ * 1. API-level failure before any JSON is emitted (parsed === null) — e.g. a proxy
+ *    returning HTTP 500 for an invalid/expired model before Claude processes anything.
+ * 2. Claude returning a structured "unknown session" error in the result JSON.
+ *
+ * Timed-out runs and successful runs are never retried as fresh sessions.
+ */
+export function shouldFallbackToFreshSession(
+  sessionId: string | null,
+  proc: { exitCode?: number | null; timedOut: boolean },
+  parsed: Record<string, unknown> | null,
+): boolean {
+  if (!sessionId) return false;
+  if (proc.timedOut) return false;
+  if ((proc.exitCode ?? 0) === 0) return false;
+
+  // API-level failure: no JSON was emitted at all
+  if (parsed === null) return true;
+
+  // Claude returned a structured unknown-session error
+  return isClaudeUnknownSessionError(parsed);
+}

--- a/packages/adapters/claude-local/vitest.config.ts
+++ b/packages/adapters/claude-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
+      "packages/adapters/claude-local",
       "server",
       "ui",
       "cli",


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                               
  When an agent uses an unsupported model, the first run fails with HTTP 500                                                                                                                                                                                                                     
  before Claude emits any JSON. The session ID is stored and every subsequent                                                                                                                                                                                                                    
  run passes --resume <dead-session-id>, but the existing fallback was gated 
  on `initial.parsed` being non-null — which it never is for API-level failures.                                                                                                                                                                                                                 
  The agent gets stuck in an infinite retry loop.                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                 
  ## Fix                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                 
  Extract `shouldFallbackToFreshSession()` into parse.ts, handling both:                                                                                                                                                                                                                         
  1. API-level failure (parsed === null) — proxy 500 before any output                                                                                                                                                                                                                           
  2. Structured "unknown session" error in Claude's result JSON       
                                                                                                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                                                                                                     
  - parse.ts: add shouldFallbackToFreshSession()                                                                                                                                                                                                                                                 
  - execute.ts: replace inline guard with the new function                                                                                                                                                                                                                                       
  - parse.test.ts: 12 new tests covering the full decision matrix (new file)                                                                                                                                                                                                                   
  - vitest.config.ts: enable vitest for claude-local package (new file)
  - root vitest.config.ts: add claude-local to workspace test projects