### PR TITLE
docs: add manual @paperclipai/ui publishing prerequisites

### DIFF
--- a/doc/PUBLISHING.md
+++ b/doc/PUBLISHING.md
@@ -108,6 +108,13 @@ Notes:
 - `prepack` automatically rewrites `ui/package.json` to the lean publish manifest, and `postpack` restores the dev manifest after the command finishes.
 - If `npm view @paperclipai/ui version` already returns the same version that is in [`ui/package.json`](../ui/package.json), do not republish. Bump the version or use the normal repo-wide release flow in [`scripts/release.sh`](../scripts/release.sh).
 
+If the first real publish returns npm `E404`, check npm-side prerequisites before retrying:
+
+- `npm whoami` must succeed first. An expired or missing npm login will block the publish.
+- For an organization-scoped package like `@paperclipai/ui`, the `paperclipai` npm organization must exist and the publisher must be a member with permission to publish to that scope.
+- The initial publish must include `--access public` for a public scoped package.
+- npm also requires either account 2FA for publishing or a granular token that is allowed to bypass 2FA.
+
 ## Version formats
 
 Paperclip uses calendar versions:


### PR DESCRIPTION
### Thinking Path

- Paperclip ships reusable packages as part of the control plane, not just the app itself.
- When release automation is not enough, maintainers still need a safe manual path for publishing those packages.
- The `@paperclipai/ui` publishing docs were missing first-time npm prerequisites and the concrete manual steps.
- This pull request fills in that release documentation gap.
- The benefit is a more reproducible manual publish flow for maintainers.

## What changed

- Documented the manual `@paperclipai/ui` publish steps in `doc/PUBLISHING.md`.
- Added the npm prerequisite notes needed before a first manual UI package publish.

## Verification

- Docs-only change; reviewed rendered markdown in `doc/PUBLISHING.md`.

## Risks

- Low risk; no runtime code changes.
