### PR TITLE
fix(openclaw-gateway): harden Paperclip runtime auth delivery for issue-bound runs

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -54,6 +54,15 @@ The agent request is built as:
 - optional additions:
   - all `payloadTemplate` fields merged in
   - `agentId` from config if set and not already in template
+  - `paperclip` structured context, including `paperclip.auth` for runtime-delivered Paperclip auth metadata
+
+## Paperclip Auth Delivery
+
+This adapter does **not** treat wake text as the steady-state source of Paperclip credentials.
+
+- Do not inject `PAPERCLIP_API_KEY` instructions via `payloadTemplate.message`.
+- Do not rely on shared claimed-key files as the steady-state runtime source.
+- Paperclip auth should be delivered via structured runtime context (`paperclip.auth`) and/or adapter config env bindings such as `secret_ref`.
 
 ## Timeouts
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -433,21 +433,11 @@ function appendWakeText(baseText: string, wakeText: string): string {
 
 function buildStandardPaperclipPayload(
   ctx: AdapterExecutionContext,
-  wakePayload: WakePayload,
+  _wakePayload: WakePayload,
   paperclipEnv: Record<string, string>,
   payloadTemplate: Record<string, unknown>,
 ): Record<string, unknown> {
   const templatePaperclip = parseObject(payloadTemplate.paperclip);
-  const workspace = asRecord(ctx.context.paperclipWorkspace);
-  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
-    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
-    : [];
-  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
-  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
-    ? ctx.context.paperclipRuntimeServiceIntents.filter(
-        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
-      )
-    : [];
 
   const standardPaperclip: Record<string, unknown> = {
     auth: {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -336,7 +336,6 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
 }
 
 function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -358,6 +357,14 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
   }
 
   const issueIdHint = payload.taskId ?? payload.issueId ?? "";
+  const structuredPaperclipPreview = JSON.stringify({
+    taskId: payload.taskId ?? null,
+    issueId: payload.issueId ?? null,
+    issueIds: payload.issueIds,
+    companyId: paperclipEnv.PAPERCLIP_COMPANY_ID ?? null,
+    agentId: paperclipEnv.PAPERCLIP_AGENT_ID ?? null,
+    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
+  });
   const apiBaseHint = paperclipEnv.PAPERCLIP_API_URL ?? "<set PAPERCLIP_API_URL>";
 
   const lines = [
@@ -365,11 +372,19 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     "",
     "Run this procedure now. Do not guess undocumented endpoints and do not ask for additional heartbeat docs.",
     "",
-    "Set these values in your run context:",
+    "Paperclip runtime context available for this run:",
     ...envLines,
-    `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
     "",
-    `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    "Auth rule:",
+    "- Use the runtime-provided agent auth context for this run.",
+    "- Runtime auth is provided structurally in the OpenClaw request and is guaranteed on exec/tool command paths, not as a model-visible environment variable.",
+    "- For every Paperclip API call in this workflow, use exec/curl (or an equivalent command tool path) so PAPERCLIP_API_KEY / PAPERCLIP_AUTH_HEADER are available from the tool environment.",
+    "- Do not assume PAPERCLIP_API_KEY is directly visible in the model prompt/runtime unless an exec/tool command is reading it.",
+    "- Every /api request must send Authorization using PAPERCLIP_AUTH_HEADER when set, otherwise Bearer $PAPERCLIP_API_KEY.",
+    "- Every mutating /api request must also send X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID.",
+    "- If exec/tool env does not provide PAPERCLIP_API_KEY, do not attempt issue checkout/comment/update calls.",
+    "- Do not rely on a shared claimed-key file as the steady-state source of Paperclip auth.",
+    "- Do not treat wake text or payloadTemplate.message as the source of PAPERCLIP_API_KEY.",
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,
@@ -379,25 +394,26 @@ function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string
     `approval_id=${payload.approvalId ?? ""}`,
     `approval_status=${payload.approvalStatus ?? ""}`,
     `linked_issue_ids=${payload.issueIds.join(",")}`,
+    `paperclip_json=${structuredPaperclipPreview}`,
     "",
     "HTTP rules:",
-    "- Use Authorization: Bearer $PAPERCLIP_API_KEY on every API call.",
+    "- Use Authorization derived from the runtime-provided Paperclip auth context on every API call.",
     "- Use X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID on every mutating API call.",
     "- Use only /api endpoints listed below.",
     "- Do NOT call guessed endpoints like /api/cloud-adapter/*, /api/cloud-adapters/*, /api/adapters/cloud/*, or /api/heartbeat.",
     "",
     "Workflow:",
-    "1) GET /api/agents/me",
+    "1) Use exec/curl to GET /api/agents/me.",
     `2) Determine issueId: PAPERCLIP_TASK_ID if present, otherwise issue_id (${issueIdHint}).`,
     "3) If issueId exists:",
-    "   - POST /api/issues/{issueId}/checkout with {\"agentId\":\"$PAPERCLIP_AGENT_ID\",\"expectedStatuses\":[\"todo\",\"backlog\",\"blocked\"]}",
-    "   - GET /api/issues/{issueId}",
-    "   - GET /api/issues/{issueId}/comments",
+    "   - Use exec/curl to POST /api/issues/{issueId}/checkout with {\"agentId\":\"$PAPERCLIP_AGENT_ID\",\"expectedStatuses\":[\"todo\",\"backlog\",\"blocked\"]}.",
+    "   - Use exec/curl to GET /api/issues/{issueId}.",
+    "   - Use exec/curl to GET /api/issues/{issueId}/comments.",
     "   - Execute the issue instructions exactly.",
-    "   - If instructions require a comment, POST /api/issues/{issueId}/comments with {\"body\":\"...\"}.",
-    "   - PATCH /api/issues/{issueId} with {\"status\":\"done\",\"comment\":\"what changed and why\"}.",
+    "   - If instructions require a comment, use exec/curl to POST /api/issues/{issueId}/comments with {\"body\":\"...\"}.",
+    "   - Use exec/curl to PATCH /api/issues/{issueId} with {\"status\":\"done\",\"comment\":\"what changed and why\"}.",
     "4) If issueId does not exist:",
-    "   - GET /api/companies/$PAPERCLIP_COMPANY_ID/issues?assigneeAgentId=$PAPERCLIP_AGENT_ID&status=todo,in_progress,blocked",
+    "   - Use exec/curl to GET /api/companies/$PAPERCLIP_COMPANY_ID/issues?assigneeAgentId=$PAPERCLIP_AGENT_ID&status=todo,in_progress,blocked.",
     "   - Pick in_progress first, then todo, then blocked, then execute step 3.",
     "",
     "Useful endpoints for issue work:",
@@ -434,32 +450,15 @@ function buildStandardPaperclipPayload(
     : [];
 
   const standardPaperclip: Record<string, unknown> = {
-    runId: ctx.runId,
-    companyId: ctx.agent.companyId,
-    agentId: ctx.agent.id,
-    agentName: ctx.agent.name,
-    taskId: wakePayload.taskId,
-    issueId: wakePayload.issueId,
-    issueIds: wakePayload.issueIds,
-    wakeReason: wakePayload.wakeReason,
-    wakeCommentId: wakePayload.wakeCommentId,
-    approvalId: wakePayload.approvalId,
-    approvalStatus: wakePayload.approvalStatus,
-    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
+    auth: {
+      apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
+      runId: ctx.runId,
+      agentId: ctx.agent.id,
+      companyId: ctx.agent.companyId,
+      authToken: ctx.authToken ?? null,
+      authScheme: ctx.authToken ? "bearer" : null,
+    },
   };
-
-  if (workspace) {
-    standardPaperclip.workspace = workspace;
-  }
-  if (workspaces.length > 0) {
-    standardPaperclip.workspaces = workspaces;
-  }
-  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
-    standardPaperclip.workspaceRuntime = {
-      ...configuredWorkspaceRuntime,
-      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
-    };
-  }
 
   return {
     ...templatePaperclip,
@@ -1067,13 +1066,33 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
   const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const issueBoundRun = Boolean(wakePayload.issueId || wakePayload.taskId || wakePayload.issueIds.length > 0);
+  if (issueBoundRun && !ctx.authToken) {
+    await ctx.onLog(
+      "stderr",
+      "[openclaw-gateway] issue-bound run missing runtime auth token; refusing to start because issue mutations would fall back to unauthenticated local requests\n",
+    );
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: "Issue-bound OpenClaw Gateway run missing runtime auth token",
+      errorCode: "openclaw_gateway_missing_runtime_auth",
+    };
+  }
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
     message,
     sessionKey,
     idempotencyKey: ctx.runId,
+    paperclip: paperclipPayload,
   };
+
+  const configuredModel = nonEmpty(ctx.config.model);
+  if (configuredModel && !nonEmpty(agentParams.model)) {
+    agentParams.model = configuredModel;
+  }
   delete agentParams.text;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);

--- a/scripts/smoke/openclaw-gateway-e2e.sh
+++ b/scripts/smoke/openclaw-gateway-e2e.sh
@@ -454,14 +454,13 @@ create_and_approve_gateway_join() {
   [[ -n "$AGENT_API_KEY" ]] || fail "claim response missing token"
 
   persist_claimed_key_artifacts "$RESPONSE_BODY"
-  inject_agent_api_key_payload_template
+  install_agent_api_key_secret_ref
 }
 
 persist_claimed_key_artifacts() {
   local claim_json="$1"
   local workspace_dir="${OPENCLAW_CONFIG_DIR%/}/workspace"
   local skill_dir="${OPENCLAW_CONFIG_DIR%/}/skills/paperclip"
-  local claimed_file="${workspace_dir}/paperclip-claimed-api-key.json"
   local claimed_raw_file="${workspace_dir}/paperclip-claimed-api-key.raw.json"
 
   mkdir -p "$workspace_dir" "$skill_dir"
@@ -471,18 +470,6 @@ persist_claimed_key_artifacts() {
 
   printf "%s\n" "$claim_json" > "$claimed_raw_file"
   chmod 600 "$claimed_raw_file"
-
-  jq -nc --arg token "$token" '{ token: $token, apiKey: $token }' > "$claimed_file"
-  # Keep this readable for OpenClaw runtime users across sandbox/container contexts.
-  chmod 644 "$claimed_file"
-
-  local container
-  container="$(detect_openclaw_container || true)"
-  if [[ -n "$container" ]]; then
-    docker exec "$container" sh -lc "mkdir -p /home/node/.openclaw/workspace" >/dev/null 2>&1 || true
-    docker cp "$claimed_file" "${container}:/home/node/.openclaw/workspace/paperclip-claimed-api-key.json" >/dev/null 2>&1 || true
-    docker exec "$container" sh -lc "chmod 644 /home/node/.openclaw/workspace/paperclip-claimed-api-key.json" >/dev/null 2>&1 || true
-  fi
 
   if [[ "$AUTO_INSTALL_SKILL" == "1" ]]; then
     api_request "GET" "/skills/paperclip"
@@ -495,33 +482,60 @@ persist_claimed_key_artifacts() {
     chmod 600 "${skill_dir}/SKILL.md"
   fi
 
-  log "wrote claimed key artifacts to ${claimed_file} and ${claimed_raw_file}"
+  log "wrote raw claim artifact to ${claimed_raw_file} for diagnostics only; steady-state runtime auth is installed via adapterConfig.env secret_ref, not payloadTemplate injection"
 }
 
-inject_agent_api_key_payload_template() {
-  [[ -n "$AGENT_ID" ]] || fail "inject_agent_api_key_payload_template requires AGENT_ID"
-  [[ -n "$AGENT_API_KEY" ]] || fail "inject_agent_api_key_payload_template requires AGENT_API_KEY"
+install_agent_api_key_secret_ref() {
+  [[ -n "$AGENT_ID" ]] || fail "install_agent_api_key_secret_ref requires AGENT_ID"
+  [[ -n "$AGENT_API_KEY" ]] || fail "install_agent_api_key_secret_ref requires AGENT_API_KEY"
+  [[ -n "$COMPANY_ID" ]] || fail "install_agent_api_key_secret_ref requires COMPANY_ID"
+
+  local secret_name secret_description create_secret_payload rotate_secret_payload secret_id
+  secret_name="paperclip-api-key-${AGENT_ID}"
+  secret_description="Agent-specific Paperclip API key claimed during openclaw_gateway smoke onboarding"
+  create_secret_payload="$(jq -nc \
+    --arg name "$secret_name" \
+    --arg value "$AGENT_API_KEY" \
+    --arg description "$secret_description" \
+    '{name:$name, value:$value, description:$description}'
+  )"
+
+  api_request "POST" "/companies/${COMPANY_ID}/secrets" "$create_secret_payload"
+  if [[ "$RESPONSE_CODE" == "201" ]]; then
+    secret_id="$(jq -r '.id // empty' <<<"$RESPONSE_BODY")"
+    [[ -n "$secret_id" ]] || fail "secret create response missing id"
+  elif [[ "$RESPONSE_CODE" == "409" ]]; then
+    api_request "GET" "/companies/${COMPANY_ID}/secrets"
+    assert_status "200"
+    secret_id="$(jq -r --arg name "$secret_name" 'map(select(.name == $name)) | first | .id // empty' <<<"$RESPONSE_BODY")"
+    [[ -n "$secret_id" ]] || fail "secret conflict for ${secret_name} but existing secret id not found"
+
+    rotate_secret_payload="$(jq -nc --arg value "$AGENT_API_KEY" '{value:$value}')"
+    api_request "POST" "/secrets/${secret_id}/rotate" "$rotate_secret_payload"
+    assert_status "200"
+  else
+    assert_status "201"
+  fi
 
   api_request "GET" "/agents/${AGENT_ID}"
   assert_status "200"
 
-  local base_message
-  base_message="Set PAPERCLIP_API_KEY=${AGENT_API_KEY} in your run context before running Paperclip heartbeat steps."
-  if [[ -n "$PAYLOAD_TEMPLATE_MESSAGE_APPEND" ]]; then
-    base_message="${base_message}\n\n${PAYLOAD_TEMPLATE_MESSAGE_APPEND}"
-  fi
-
   local patch_payload
-  patch_payload="$(jq -c --arg message "$base_message" '
+  patch_payload="$(jq -c \
+    --arg secretId "$secret_id" \
+    --arg apiUrl "$PAPERCLIP_API_URL_FOR_OPENCLAW" '
     {adapterConfig: ((.adapterConfig // {}) + {
-      payloadTemplate: (((.adapterConfig // {}).payloadTemplate // {}) + {
-        message: $message
+      env: (((.adapterConfig // {}).env // {}) + {
+        PAPERCLIP_API_KEY: {type: "secret_ref", secretId: $secretId, version: "latest"},
+        PAPERCLIP_API_URL: {type: "plain", value: $apiUrl}
       })
     })}
   ' <<<"$RESPONSE_BODY")"
 
   api_request "PATCH" "/agents/${AGENT_ID}" "$patch_payload"
   assert_status "200"
+
+  log "installed agent-specific PAPERCLIP_API_KEY via secret_ref on adapterConfig.env for ${AGENT_ID} (secret ${secret_id})"
 }
 
 validate_joined_gateway_agent() {
@@ -530,12 +544,16 @@ validate_joined_gateway_agent() {
   api_request "GET" "/agents/${AGENT_ID}"
   assert_status "200"
 
-  local adapter_type gateway_url configured_token disable_device_auth device_key_len
+  local adapter_type gateway_url configured_token disable_device_auth device_key_len env_api_key_type env_api_key_secret_id env_api_url payload_template_message
   adapter_type="$(jq -r '.adapterType // empty' <<<"$RESPONSE_BODY")"
   gateway_url="$(jq -r '.adapterConfig.url // empty' <<<"$RESPONSE_BODY")"
   configured_token="$(jq -r '.adapterConfig.headers["x-openclaw-token"] // .adapterConfig.headers["x-openclaw-auth"] // empty' <<<"$RESPONSE_BODY")"
   disable_device_auth="$(jq -r 'if .adapterConfig.disableDeviceAuth == true then "true" else "false" end' <<<"$RESPONSE_BODY")"
   device_key_len="$(jq -r '(.adapterConfig.devicePrivateKeyPem // "" | length)' <<<"$RESPONSE_BODY")"
+  env_api_key_type="$(jq -r '.adapterConfig.env.PAPERCLIP_API_KEY.type // empty' <<<"$RESPONSE_BODY")"
+  env_api_key_secret_id="$(jq -r '.adapterConfig.env.PAPERCLIP_API_KEY.secretId // empty' <<<"$RESPONSE_BODY")"
+  env_api_url="$(jq -r '.adapterConfig.env.PAPERCLIP_API_URL.value // empty' <<<"$RESPONSE_BODY")"
+  payload_template_message="$(jq -r '.adapterConfig.payloadTemplate.message // empty' <<<"$RESPONSE_BODY")"
 
   [[ "$adapter_type" == "openclaw_gateway" ]] || fail "joined agent adapterType is '${adapter_type}', expected 'openclaw_gateway'"
   [[ "$gateway_url" =~ ^wss?:// ]] || fail "joined agent gateway url is invalid: '${gateway_url}'"
@@ -555,8 +573,14 @@ validate_joined_gateway_agent() {
   if (( device_key_len < 32 )); then
     fail "joined agent missing persistent devicePrivateKeyPem (length=${device_key_len})"
   fi
+  [[ "$env_api_key_type" == "secret_ref" ]] || fail "joined agent missing adapterConfig.env.PAPERCLIP_API_KEY secret_ref"
+  [[ -n "$env_api_key_secret_id" ]] || fail "joined agent PAPERCLIP_API_KEY secret_ref missing secretId"
+  [[ "$env_api_url" == "$PAPERCLIP_API_URL_FOR_OPENCLAW" ]] || fail "joined agent PAPERCLIP_API_URL env mismatch (expected '${PAPERCLIP_API_URL_FOR_OPENCLAW}', got '${env_api_url}')"
+  if grep -q "Set PAPERCLIP_API_KEY=" <<<"$payload_template_message"; then
+    fail "joined agent still relies on payloadTemplate message injection for PAPERCLIP_API_KEY"
+  fi
 
-  log "validated joined gateway agent config (token sha256 prefix ${configured_hash})"
+  log "validated joined gateway agent config (token sha256 prefix ${configured_hash}; auth env installed via secret_ref ${env_api_key_secret_id})"
 }
 
 run_log_contains_pairing_required() {

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -49,9 +49,12 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("headers.x-openclaw-token");
     expect(text).toContain("Do NOT use /v1/responses or /hooks/*");
     expect(text).toContain("set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl");
-    expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
     expect(text).toContain("PAPERCLIP_API_KEY");
-    expect(text).toContain("saved token field");
+    expect(text).toContain("agent-specific PAPERCLIP_API_KEY");
+    expect(text).toContain("Do not treat any shared file or ad-hoc local artifact as the steady-state runtime source");
+    expect(text).toContain("Do not rely on payloadTemplate.message");
+    expect(text).toContain("secret_ref");
+    expect(text).toContain("PAPERCLIP_API_URL: { type: \"plain\"");
     expect(text).toContain("Gateway token unexpectedly short");
   });
 

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -35,6 +35,7 @@ function buildContext(
       issueIds: ["issue-123"],
     },
     onLog: async () => {},
+    authToken: "test-auth-token",
     ...overrides,
   };
 }
@@ -411,6 +412,8 @@ describe("openclaw gateway adapter execute", () => {
             payloadTemplate: {
               message: "wake now",
             },
+            model: "claude-sonnet-4-6",
+            authProfileOverride: "anthropic:default",
             waitTimeoutMs: 2000,
           },
           {
@@ -456,6 +459,20 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("wake now");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
+      expect(String(payload?.message ?? "")).not.toContain("PAPERCLIP_API_KEY=<agent-specific token for this agent>");
+      expect(payload?.paperclip).toEqual({
+        auth: {
+          apiUrl: "http://localhost:3100",
+          runId: "run-123",
+          agentId: "agent-123",
+          companyId: "company-123",
+          authToken: "test-auth-token",
+          authScheme: "bearer",
+        },
+      });
+      expect(payload?.paperclipAuth).toBeUndefined();
+      expect(payload?.model).toBe("claude-sonnet-4-6");
+      expect(payload?.authProfileOverride).toBeUndefined();
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {
@@ -549,6 +566,30 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(logs.some((entry) => entry.includes("auto-approved pairing request"))).toBe(true);
       expect(gateway.getAgentPayload()).toBeTruthy();
+    } finally {
+      await gateway.close();
+    }
+  });
+  it("fails fast for issue-bound runs when runtime auth token is missing", async () => {
+    const gateway = await createMockGatewayServer();
+    try {
+      const logs: string[] = [];
+      const result = await execute(
+        buildContext(
+          { url: gateway.url },
+          {
+            authToken: undefined,
+            onLog: async (_stream, chunk) => {
+              logs.push(String(chunk));
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("openclaw_gateway_missing_runtime_auth");
+      expect(logs.some((entry) => entry.includes("issue-bound run missing runtime auth token"))).toBe(true);
+      expect(gateway.getAgentPayload()).toBeNull();
     } finally {
       await gateway.close();
     }

--- a/server/src/__tests__/openclaw-gateway-wake-auth-contract.test.ts
+++ b/server/src/__tests__/openclaw-gateway-wake-auth-contract.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("openclaw-gateway wake auth contract", () => {
+  it("describes exec-scoped runtime auth instead of model-visible env auth", () => {
+    const filePath = path.resolve(
+      process.cwd(),
+      "packages/adapters/openclaw-gateway/src/server/execute.ts",
+    );
+    const text = fs.readFileSync(filePath, "utf8");
+
+    expect(text).toContain(
+      'Runtime auth is provided structurally in the OpenClaw request and is guaranteed on exec/tool command paths, not as a model-visible environment variable.',
+    );
+    expect(text).toContain(
+      'For every Paperclip API call in this workflow, use exec/curl (or an equivalent command tool path) so PAPERCLIP_API_KEY / PAPERCLIP_AUTH_HEADER are available from the tool environment.',
+    );
+    expect(text).not.toContain(
+      'When runtime auth is present, it is installed into the runtime environment as PAPERCLIP_API_KEY and PAPERCLIP_AUTH_HEADER.',
+    );
+    expect(text).toContain('Use exec/curl to GET /api/agents/me.');
+    expect(text).toContain('Use exec/curl to POST /api/issues/{issueId}/checkout');
+  });
+});

--- a/server/src/__tests__/paperclip-skill-auth-contract.test.ts
+++ b/server/src/__tests__/paperclip-skill-auth-contract.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("paperclip skill auth contract", () => {
+  it("documents structured runtime auth for non-local adapters", () => {
+    const skillPath = path.resolve(process.cwd(), "skills/paperclip/SKILL.md");
+    const text = fs.readFileSync(skillPath, "utf8");
+
+    expect(text).toContain("structured runtime auth for cloud/non-local adapters: `paperclip.auth` metadata in the wake payload");
+    expect(text).toContain("Do not scrape `PAPERCLIP_API_KEY` from `payloadTemplate.message` or other prompt text.");
+    expect(text).toContain("Do not use shared claimed-key files or ad-hoc local artifacts as the steady-state auth source.");
+    expect(text).toContain("Authorization: Bearer <Paperclip runtime auth token>");
+  });
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -142,7 +142,7 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   execute: openclawGatewayExecute,
   testEnvironment: openclawGatewayTestEnvironment,
   models: openclawGatewayModels,
-  supportsLocalAgentJwt: false,
+  supportsLocalAgentJwt: true,
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,
 };
 

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1027,7 +1027,7 @@ function buildInviteOnboardingManifest(
     invite: toInviteSummaryResponse(req, token, invite),
     onboarding: {
       instructions:
-        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
+        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Persist the claimed API key into this agent's own secret/env setup and run heartbeats with that agent-specific PAPERCLIP_API_KEY as structured runtime auth and/or adapter env bindings. Do not use any shared claimed-key file as the steady-state source. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: "openclaw_gateway",
       requiredFields: {
@@ -1228,24 +1228,29 @@ export function buildInviteOnboardingTextDocument(
       "claimSecret": "<one-time-claim-secret>"
     }
 
-    On successful claim, save the full JSON response to:
+    On successful claim, extract the claimed API key and PAPERCLIP_API_URL from the response and persist them into this agent's own environment/secret configuration.
 
-    - ~/.openclaw/workspace/paperclip-claimed-api-key.json
-    chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+    Preferred steady-state installation:
+    - store the claimed PAPERCLIP_API_KEY as an agent-specific Paperclip secret
+    - bind adapterConfig.env.PAPERCLIP_API_KEY to that secret via {"type":"secret_ref","secretId":"...","version":"latest"}
+    - set adapterConfig.env.PAPERCLIP_API_URL to the reachable Paperclip base URL
 
-    And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
+    Do not treat any shared file or ad-hoc local artifact as the steady-state runtime source for multiple agents.
+    Do not rely on payloadTemplate.message or other wake-text injection as the steady-state source of PAPERCLIP_API_KEY.
+
+    Set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
     https://docs.openclaw.ai/help/environment
 
     e.g. 
 
     {
       env: {
-        PAPERCLIP_API_KEY: "...",
-        PAPERCLIP_API_URL: "...",
+        PAPERCLIP_API_KEY: { type: "secret_ref", secretId: "...", version: "latest" },
+        PAPERCLIP_API_URL: { type: "plain", value: "http://host.docker.internal:3100" },
       },
     }
 
-    Then set PAPERCLIP_API_KEY and PAPERCLIP_API_URL from the saved token field for every heartbeat run.
+    Then run every heartbeat with that agent-specific PAPERCLIP_API_KEY and PAPERCLIP_API_URL.
 
     Important:
     - claim secrets expire

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -14,7 +14,25 @@ You run in **heartbeats** — short execution windows triggered by Paperclip. Ea
 
 ## Authentication
 
-Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
+Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated).
+
+Paperclip auth may arrive through either of these steady-state paths:
+- env-based auth: `PAPERCLIP_API_KEY` and `PAPERCLIP_API_URL`
+- structured runtime auth for cloud/non-local adapters: `paperclip.auth` metadata in the wake payload
+
+For local adapters, `PAPERCLIP_API_KEY` is commonly auto-injected as a short-lived run JWT. For non-local adapters, operators should prefer structured runtime auth and/or adapter-config env bindings such as `secret_ref` instead of wake-text instructions.
+
+OpenClaw Gateway auth delivery best practices:
+- For `openclaw_gateway`, send runtime auth only as `paperclip.auth`. Do not flatten run/task/workspace/auth fields into the top-level `paperclip` object unless the protocol explicitly supports them.
+- If structured runtime auth is present, the runtime should use `PAPERCLIP_AUTH_HEADER` when set, otherwise `Bearer $PAPERCLIP_API_KEY`.
+
+Auth rules:
+- Treat wake text as instructions, not as the source of secrets.
+- Do not scrape `PAPERCLIP_API_KEY` from `payloadTemplate.message` or other prompt text.
+- Do not use shared claimed-key files or ad-hoc local artifacts as the steady-state auth source.
+- If both env and structured runtime auth are present, use the structured runtime auth as authoritative for credential provenance and use whichever delivery path exposes the actual bearer token to the runtime.
+
+All requests use `Authorization: Bearer <Paperclip runtime auth token>`. All endpoints are under `/api`, all JSON. Never hard-code the API URL.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
@@ -50,7 +68,7 @@ If nothing is assigned and there is no valid mention-based ownership handoff, ex
 
 ```
 POST /api/issues/{issueId}/checkout
-Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers: Authorization: Bearer <Paperclip runtime auth token>, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked"] }
 ```
 


### PR DESCRIPTION
This PR hardens the auth contract between Paperclip and `openclaw_gateway`.

It changes the documented and tested steady-state auth path from shared claimed-key / prompt-injected guidance to structured runtime auth (`paperclip.auth`) and agent-specific env/secret bindings.

For issue-bound runs, the adapter now fails fast when runtime auth is missing, instead of proceeding into unauthenticated issue mutations.

## What this PR does
- enables runtime auth token delivery into `openclaw_gateway` execute context via the existing adapter auth capability flag
- passes Paperclip runtime auth as structured `paperclip.auth` context for gateway runs
- fails fast for issue-bound runs that lack runtime auth
- updates wake/auth contract wording to describe exec/tool-scoped auth delivery
- updates onboarding guidance away from shared claimed-key files
- updates smoke coverage to install claimed Paperclip auth as agent-specific `secret_ref` env

## What this PR does not do
- does **not** fix issue-scoped multi-agent session routing
- does **not** resolve stream/transcript mismatch behavior
- does **not** change broader manager/delegation policy behavior

Refs #930
Refs #1371
Refs #337
Refs #1177

## Test plan
- `pnpm -s vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts server/src/__tests__/invite-onboarding-text.test.ts server/src/__tests__/openclaw-gateway-wake-auth-contract.test.ts server/src/__tests__/paperclip-skill-auth-contract.test.ts`
- adapter unit test verifies structured auth payload and fail-fast behavior
- onboarding text test verifies agent-specific env/secret guidance
- wake auth contract test verifies exec/tool-scoped auth wording
- skill auth contract test verifies runtime auth guidance
- smoke script installs claimed key as `secret_ref` instead of payload-template injection

## Notes for reviewer
This PR intentionally stays scoped to auth delivery and documentation contract changes for OpenClaw gateway runs.
