### PR TITLE
fix(claude-local): fall back to fs.cp on Windows when symlink fails with EPERM

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -51,10 +51,21 @@ async function buildSkillsDir(config: Record<string, unknown>): Promise<string> 
   );
   for (const entry of availableEntries) {
     if (!desiredNames.has(entry.key)) continue;
-    await fs.symlink(
-      entry.source,
-      path.join(target, entry.runtimeName),
-    );
+    try {
+      await fs.symlink(
+        entry.source,
+        path.join(target, entry.runtimeName),
+      );
+    } catch (err: unknown) {
+      // Windows without Developer Mode (or non-admin) blocks symlink creation with EPERM.
+      // Fall back to a recursive copy so Paperclip works out of the box on Windows.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") {
+        await fs.cp(entry.source, path.join(target, entry.runtimeName), { recursive: true });
+      } else {
+        throw err;
+      }
+    }
   }
   return tmp;
 }


### PR DESCRIPTION
## Problem

On Windows, creating symlinks requires either **Developer Mode** or elevated (admin) privileges. Without these, `fs.symlink()` throws `EPERM`, causing all agent runs to fail immediately with `adapter_failed`.

**Error seen by users:**
```
EPERM: operation not permitted, symlink '...\skills\paperclip' -> '...\paperclip-skills-xxx\.claude\skills\paperclip'
```

This affects any Windows user who hasn't enabled Developer Mode — the majority of non-developer Windows installs.

## Fix

Add a try/catch around the `fs.symlink()` call in `buildSkillsDir()` that falls back to `fs.cp({ recursive: true })` when the error code is `EPERM` or `EACCES`.

The skills directory is ephemeral — created per-run and cleaned up in the `finally` block — so a copy is functionally equivalent to a symlink here.

## Testing

Tested on Windows 11 without Developer Mode enabled. Before the fix: `adapter_failed` on every run. After the fix: agents run correctly.

---
*Found this while setting up Paperclip on Windows to run a marketing agency. Happy to add a test if there's a pattern for platform-specific adapter tests.*