### PR TITLE
fix: suppress HTML processing in MarkdownEditor to prevent invisible content

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -546,6 +546,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         ref={ref}
         markdown={value}
         placeholder={placeholder}
+        suppressHtmlProcessing
         onChange={(next) => {
           latestValueRef.current = next;
           onChange(next);

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -687,7 +687,7 @@ export function IssueDetail() {
   );
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="w-full space-y-6 px-4 sm:px-6 lg:px-8">
       {/* Parent chain breadcrumb */}
       {ancestors.length > 0 && (
         <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">


### PR DESCRIPTION
## Problem

MDXEditor's default HTML processing parses angle brackets in markdown content (e.g. `<=EUR60`, `<25%`) as unclosed HTML tags. This corrupts the Lexical editor tree and causes the **entire document body to render as invisible/empty**.

The content is still present in the component state (copy buttons work, API returns correct data), but the contenteditable div renders nothing visually.

This is sporadic — it only affects documents containing `<` characters that aren't valid HTML, which is common in financial/technical documents.

## Root Cause

`MDXEditor` processes HTML in markdown by default (`suppressHtmlProcessing: false`). When it encounters `<=EUR60` it interprets `<=EUR60**` as a malformed HTML tag, which breaks the Lexical AST and results in an empty render.

## Fix

Add `suppressHtmlProcessing` prop to the `MDXEditor` component in `MarkdownEditor.tsx`. This tells the editor to treat HTML-like content as plain text instead of attempting to parse it as HTML nodes.

This is a one-line, zero-risk change — Paperclip documents are markdown, not MDX with JSX components, so HTML processing is unnecessary.

## Also included

Minor: make issue detail page responsive (`w-full` with responsive padding) instead of fixed `max-w-2xl` width.

## Testing

- Verified on documents with 15K-32K chars containing markdown tables with `<=` operators
- Before: document body invisible, copy button still works
- After: document renders correctly, editing works