### PR TITLE
fix: suppress HTML processing in MarkdownEditor to prevent invisible content

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -546,6 +546,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         ref={ref}
         markdown={value}
         placeholder={placeholder}
+        suppressHtmlProcessing
         onChange={(next) => {
           latestValueRef.current = next;
           onChange(next);


### PR DESCRIPTION
## Problem

Document bodies render as invisible/empty when the markdown contains angle bracket characters like `<=EUR60` or `<25%`. The content is present in state (copy buttons work), but the contenteditable div shows nothing.

## Thinking Path

`IssueDetail` → `IssueDocumentsSection` → `MarkdownEditor` → `MDXEditor`

1. API returns full document body (`/api/issues/:id/documents` — confirmed 15K+ chars)
2. `MarkdownEditor` passes `value` to `MDXEditor` correctly
3. `MDXEditor` internally parses markdown → MDAST → Lexical AST
4. Default `suppressHtmlProcessing: false` means the parser tries to interpret `<` as HTML
5. `<=EUR60` is parsed as a malformed/unclosed HTML tag → corrupts the Lexical tree → empty render
6. Fix: `suppressHtmlProcessing` tells MDXEditor to skip HTML parsing entirely

## Fix

One-line change: add `suppressHtmlProcessing` prop to the `MDXEditor` component in `MarkdownEditor.tsx`.

This is safe because Paperclip documents are pure markdown — no JSX or HTML components are used in document bodies.

## Testing

- Verified on documents with 15K-32K chars containing markdown tables with `<=` operators
- Before: document body invisible, copy button still works
- After: document renders and edits correctly