### PR TITLE
fix(a11y): add scope=col to routines table headers after refactor

### DIFF
--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -515,12 +515,12 @@ export function Routines() {
             <table className="min-w-full text-sm">
               <thead>
                 <tr className="text-left text-xs text-muted-foreground border-b border-border">
-                  <th className="px-3 py-2 font-medium">Name</th>
-                  <th className="px-3 py-2 font-medium">Project</th>
-                  <th className="px-3 py-2 font-medium">Agent</th>
-                  <th className="px-3 py-2 font-medium">Last run</th>
-                  <th className="px-3 py-2 font-medium">Enabled</th>
-                  <th className="w-12 px-3 py-2" />
+                  <th scope="col" className="px-3 py-2 font-medium">Name</th>
+                  <th scope="col" className="px-3 py-2 font-medium">Project</th>
+                  <th scope="col" className="px-3 py-2 font-medium">Agent</th>
+                  <th scope="col" className="px-3 py-2 font-medium">Last run</th>
+                  <th scope="col" className="px-3 py-2 font-medium">Enabled</th>
+                  <th scope="col" className="w-12 px-3 py-2" />
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
## Problem

The Routines page table headers (\`<th>\` elements) are missing \`scope="col"\` attribute. Screen readers need this to properly associate data cells with their column headers. Without it, navigating the table with assistive technology is confusing - the screen reader cannot announce which column a cell belong to.

The Routines page was recently refactored (355 lines changed) which reset the table structure. The AgentDetail cost table already have scope=col from an earlier fix.

## What I changed

Added \`scope="col"\` to all 6 table header cells: Name, Project, Agent, Last run, Enabled, and the empty actions column.

## How to test

1. Go to Routines page with routines listed
2. Use screen reader (VoiceOver Cmd+F5 on Mac)
3. Navigate the table - each cell should announce its column header

1 file, 6 lines changed (attribute additions only).