### PR TITLE
feat: make issue detail page responsive instead of fixed width

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -687,7 +687,7 @@ export function IssueDetail() {
   );
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="w-full space-y-6 px-4 sm:px-6 lg:px-8">
       {/* Parent chain breadcrumb */}
       {ancestors.length > 0 && (
         <nav className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">


### PR DESCRIPTION
## Problem

The issue detail page uses a fixed `max-w-2xl` (672px) container, which wastes screen space on wider viewports. Documents, tables, and long content get unnecessarily squeezed.

## Thinking Path

`IssueDetail` → root container `<div className="max-w-2xl space-y-6">`

1. `max-w-2xl` caps the content at 672px regardless of viewport
2. On 1440px+ screens, over half the page is empty whitespace
3. Issue documents with tables are particularly affected — columns get compressed
4. Fix: `w-full` with responsive padding (`px-4 sm:px-6 lg:px-8`) lets content breathe

## Fix

One-line change: replace `max-w-2xl` with `w-full px-4 sm:px-6 lg:px-8`.

No screenshots available for before/after, but the change is a single CSS class swap on the root container.