### PR TITLE
fix: cascade-delete all company-scoped tables in correct FK order

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -6,25 +6,48 @@ import {
   assets,
   agents,
   agentApiKeys,
+  agentConfigRevisions,
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
   issues,
+  issueApprovals,
+  issueAttachments,
   issueComments,
+  issueDocuments,
+  issueInboxArchives,
+  issueLabels,
+  issueReadStates,
+  issueWorkProducts,
+  labels,
+  documents,
+  documentRevisions,
   projects,
+  projectGoals,
+  projectWorkspaces,
+  executionWorkspaces,
+  workspaceOperations,
+  workspaceRuntimeServices,
   goals,
   heartbeatRuns,
   heartbeatRunEvents,
   costEvents,
   financeEvents,
+  budgetIncidents,
+  budgetPolicies,
   approvalComments,
   approvals,
   activityLog,
   companySecrets,
+  companySkills,
+  routines,
+  routineTriggers,
+  routineRuns,
   joinRequests,
   invites,
   principalPermissionGrants,
   companyMemberships,
+  pluginCompanySettings,
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 
@@ -253,30 +276,69 @@ export function companyService(db: Db) {
 
     remove: (id: string) =>
       db.transaction(async (tx) => {
-        // Delete from child tables in dependency order
+        // Cascade-delete all company-scoped rows in FK-dependency order.
+        // Tables are grouped into phases: each phase only runs after
+        // all its blocking (non-CASCADE / non-SET-NULL) children are gone.
+
+        // Phase 1 — leaf tables (nothing has a blocking FK to these)
+        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
-        await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
-        await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
-        await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
-        await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
-        await tx.delete(issueComments).where(eq(issueComments.companyId, id));
-        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
-        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        await tx.delete(activityLog).where(eq(activityLog.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
-        await tx.delete(approvals).where(eq(approvals.companyId, id));
-        await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
+        await tx.delete(budgetIncidents).where(eq(budgetIncidents.companyId, id));
+        await tx.delete(issueComments).where(eq(issueComments.companyId, id));
+        await tx.delete(issueAttachments).where(eq(issueAttachments.companyId, id));
+        await tx.delete(issueApprovals).where(eq(issueApprovals.companyId, id));
+        await tx.delete(issueDocuments).where(eq(issueDocuments.companyId, id));
+        await tx.delete(issueLabels).where(eq(issueLabels.companyId, id));
+        await tx.delete(issueReadStates).where(eq(issueReadStates.companyId, id));
+        await tx.delete(issueInboxArchives).where(eq(issueInboxArchives.companyId, id));
+        await tx.delete(issueWorkProducts).where(eq(issueWorkProducts.companyId, id));
+        await tx.delete(workspaceOperations).where(eq(workspaceOperations.companyId, id));
+        await tx.delete(documentRevisions).where(eq(documentRevisions.companyId, id));
+        await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
+        await tx.delete(agentConfigRevisions).where(eq(agentConfigRevisions.companyId, id));
+        await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(joinRequests).where(eq(joinRequests.companyId, id));
-        await tx.delete(invites).where(eq(invites.companyId, id));
         await tx.delete(principalPermissionGrants).where(eq(principalPermissionGrants.companyId, id));
         await tx.delete(companyMemberships).where(eq(companyMemberships.companyId, id));
-        await tx.delete(issues).where(eq(issues.companyId, id));
+        await tx.delete(companySkills).where(eq(companySkills.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
+        await tx.delete(projectGoals).where(eq(projectGoals.companyId, id));
+        await tx.delete(pluginCompanySettings).where(eq(pluginCompanySettings.companyId, id));
+        await tx.delete(routineRuns).where(eq(routineRuns.companyId, id));
+
+        // Phase 2 — parents whose blocking children are now gone
+        await tx.delete(budgetPolicies).where(eq(budgetPolicies.companyId, id));
+        await tx.delete(approvals).where(eq(approvals.companyId, id));
+        await tx.delete(workspaceRuntimeServices).where(eq(workspaceRuntimeServices.companyId, id));
+        await tx.delete(labels).where(eq(labels.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
-        await tx.delete(goals).where(eq(goals.companyId, id));
+        await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
+
+        // Phase 3 — mid-level parents
+        await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
+        await tx.delete(documents).where(eq(documents.companyId, id));
+        await tx.delete(executionWorkspaces).where(eq(executionWorkspaces.companyId, id));
+        await tx.delete(invites).where(eq(invites.companyId, id));
+
+        // Phase 4 — issue & workspace parents
+        await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
+        await tx.delete(issues).where(eq(issues.companyId, id));
+        await tx.delete(projectWorkspaces).where(eq(projectWorkspaces.companyId, id));
+
+        // Phase 5 — routines
+        await tx.delete(routineTriggers).where(eq(routineTriggers.companyId, id));
+        await tx.delete(routines).where(eq(routines.companyId, id));
+
+        // Phase 6 — top-level domain (projects before goals: projects.goalId → goals)
         await tx.delete(projects).where(eq(projects.companyId, id));
+        await tx.delete(goals).where(eq(goals.companyId, id));
+
+        // Phase 7 — agents and company
         await tx.delete(agents).where(eq(agents.companyId, id));
-        await tx.delete(activityLog).where(eq(activityLog.companyId, id));
         const rows = await tx
           .delete(companies)
           .where(eq(companies.id, id))


### PR DESCRIPTION
## Problem

`DELETE /api/companies/:id` returns **500 Internal Server Error** due to PostgreSQL foreign key constraint violations.

### Root Causes

1. **Missing tables**: The `remove()` function in `server/src/services/companies.ts` was only deleting ~10 tables, but **~30+ tables** have `companyId` FK references that must be cleaned up first.

2. **Wrong deletion order**: Even with all tables present, inter-table FK constraints with `NO ACTION` behavior require a specific topological deletion order. For example:
   - `finance_events.costEventId → cost_events.id` — finance_events must go before cost_events
   - `cost_events.heartbeatRunId → heartbeat_runs.id` — cost_events must go before heartbeat_runs
   - `activity_log.runId → heartbeat_runs.id` — activity_log must go before heartbeat_runs
   - `budget_incidents.approvalId → approvals.id` — budget_incidents before approvals
   - `projects.goalId → goals.id` — projects before goals

### Error from server logs

```
PostgresError: update or delete on table "heartbeat_runs" violates foreign key constraint
"cost_events_heartbeat_run_id_heartbeat_runs_id_fk" on table "cost_events"
  code: "23503"
```

## Fix

- Added ~20 missing table imports
- Rewrote `remove()` with a **7-phase topological deletion order** that respects every inter-table FK dependency:
  1. **Phase 1** — Leaf tables (no other table has a blocking FK to these)
  2. **Phase 2** — Parents whose blocking children are now gone (budgetPolicies, approvals, labels, assets, etc.)
  3. **Phase 3** — Mid-level parents (heartbeatRuns, documents, executionWorkspaces, invites)
  4. **Phase 4** — Issue & workspace parents (issues, projectWorkspaces, agentWakeupRequests)
  5. **Phase 5** — Routines (routineTriggers, then routines)
  6. **Phase 6** — Top-level domain (projects before goals, since `projects.goalId → goals`)
  7. **Phase 7** — Agents, then the company row itself

The entire operation runs inside a single transaction.

## Testing

Verified against a PGlite dev instance:
- `DELETE /api/companies/:id` for two archived companies → both returned `{"ok":true}` (HTTP 200)
- `GET /api/companies` → `[]` (clean slate confirmed)
- `pnpm -r typecheck` passes across all packages