### PR TITLE
fix(ui): restore comment order + action area UX after upstream merge

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -353,9 +353,13 @@ export function CommentThread({
       createdAtMs: new Date(run.startedAt ?? run.createdAt).getTime(),
       run,
     }));
+    // Sort newest-first; timestamp and same-kind tie-breakers are reversed.
+    // The cross-kind tie-breaker is intentionally NOT reversed: comments
+    // always sort above runs at the same instant regardless of direction,
+    // keeping the visual grouping stable when toggling sort order.
     return [...commentItems, ...runItems].sort((a, b) => {
-      if (a.createdAtMs !== b.createdAtMs) return a.createdAtMs - b.createdAtMs;
-      if (a.kind === b.kind) return a.id.localeCompare(b.id);
+      if (a.createdAtMs !== b.createdAtMs) return b.createdAtMs - a.createdAtMs;
+      if (a.kind === b.kind) return b.id.localeCompare(a.id);
       return a.kind === "comment" ? -1 : 1;
     });
   }, [comments, linkedRuns]);
@@ -469,52 +473,6 @@ export function CommentThread({
     <div className="space-y-4">
       <h3 className="text-sm font-semibold">Comments &amp; Runs ({timeline.length + queuedComments.length})</h3>
 
-      {timeline.length > 0 ? (
-        <TimelineList
-          timeline={timeline}
-          agentMap={agentMap}
-          companyId={companyId}
-          projectId={projectId}
-          highlightCommentId={highlightCommentId}
-        />
-      ) : null}
-
-      {liveRunSlot}
-
-      {queuedComments.length > 0 && (
-        <div className="space-y-3">
-          <div className="flex items-center justify-between gap-2">
-            <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
-              Queued Comments ({queuedComments.length})
-            </h4>
-            {onInterruptQueued && queuedComments[0]?.queueTargetRunId ? (
-              <Button
-                size="sm"
-                variant="outline"
-                className="border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800 dark:border-red-500/40 dark:text-red-300 dark:hover:bg-red-500/10"
-                disabled={interruptingQueuedRunId === queuedComments[0].queueTargetRunId}
-                onClick={() => void onInterruptQueued(queuedComments[0]!.queueTargetRunId!)}
-              >
-                {interruptingQueuedRunId === queuedComments[0].queueTargetRunId ? "Interrupting..." : "Interrupt"}
-              </Button>
-            ) : null}
-          </div>
-          <div className="space-y-3">
-            {queuedComments.map((comment) => (
-              <CommentCard
-                key={comment.id}
-                comment={comment}
-                agentMap={agentMap}
-                companyId={companyId}
-                projectId={projectId}
-                highlightCommentId={highlightCommentId}
-                queued
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
       <div className="space-y-2">
         <MarkdownEditor
           ref={editorRef}
@@ -599,6 +557,52 @@ export function CommentThread({
           </Button>
         </div>
       </div>
+
+      {liveRunSlot}
+
+      {queuedComments.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
+              Queued Comments ({queuedComments.length})
+            </h4>
+            {onInterruptQueued && queuedComments[0]?.queueTargetRunId ? (
+              <Button
+                size="sm"
+                variant="outline"
+                className="border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800 dark:border-red-500/40 dark:text-red-300 dark:hover:bg-red-500/10"
+                disabled={interruptingQueuedRunId === queuedComments[0].queueTargetRunId}
+                onClick={() => void onInterruptQueued(queuedComments[0]!.queueTargetRunId!)}
+              >
+                {interruptingQueuedRunId === queuedComments[0].queueTargetRunId ? "Interrupting..." : "Interrupt"}
+              </Button>
+            ) : null}
+          </div>
+          <div className="space-y-3">
+            {queuedComments.map((comment) => (
+              <CommentCard
+                key={comment.id}
+                comment={comment}
+                agentMap={agentMap}
+                companyId={companyId}
+                projectId={projectId}
+                highlightCommentId={highlightCommentId}
+                queued
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {timeline.length > 0 ? (
+        <TimelineList
+          timeline={timeline}
+          agentMap={agentMap}
+          companyId={companyId}
+          projectId={projectId}
+          highlightCommentId={highlightCommentId}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents for autonomous companies
> - The board UI (CommentThread) shows issue comments and run history
> - The pap-979-board-ux branch rewrote CommentThread.tsx, clobbering two UX improvements
> - This PR restores both: newest-first sort order and composer at top of thread
> - Day-to-day board workflow is significantly better with both changes

## What

Restores two UX changes to `CommentThread.tsx` that were overwritten by the `pap-979-board-ux` merge:

1. **Comment sort order:** Comments and runs sort newest-first again. The merge reverted the comparison from `b - a` back to `a - b`.

2. **Action area at top:** The comment composer (MarkdownEditor + submit buttons) is placed at the top of the thread, above the live run slot, queued comments, and timeline. Avoids scrolling past full comment history to write a new comment.

## Why

Both changes improve the day-to-day board workflow. Newest-first makes it immediately obvious what's happening on a task without scrolling. Composer at top reduces friction for leaving follow-up comments.

## How to verify

1. Open an issue with multiple comments → newest comment appears first
2. The comment composer is the first thing visible (no scrolling needed to write a comment)
3. Live run slot, queued comments, and history appear below the composer

## Risks

Low — UI-only change, no backend impact. Only `CommentThread.tsx` is modified.

## Upstream Search Evidence

Searched `paperclipai/paperclip` open PRs before submitting:

- **Search terms:** `comment order newest first sort`, `comment action area composer UX`
- **Commands:**
  - `gh pr list --repo paperclipai/paperclip --state open --search "comment order newest first sort"`
  - `gh pr list --repo paperclipai/paperclip --state open --search "comment action area composer UX"`
- **Found:** [#2029 — fix(ui): sort comments newest-first in issue timeline](https://github.com/paperclipai/paperclip/pull/2029) (open, covers sort order only)
- **Conclusion:** Partial overlap with #2029 (sort order). This PR additionally restores the action-area-at-top UX, which has no upstream equivalent. If #2029 merges first, this PR can be rebased to only include the action area change.