### PR TITLE
feat(ui): explain why Run Heartbeat button is disabled

### DIFF
--- a/ui/src/components/AgentActionButtons.tsx
+++ b/ui/src/components/AgentActionButtons.tsx
@@ -4,16 +4,18 @@ import { Button } from "@/components/ui/button";
 export function RunButton({
   onClick,
   disabled,
+  disabledReason,
   label = "Run now",
   size = "sm",
 }: {
   onClick: () => void;
   disabled?: boolean;
+  disabledReason?: string;
   label?: string;
   size?: "sm" | "default";
 }) {
   return (
-    <Button variant="outline" size={size} onClick={onClick} disabled={disabled}>
+    <Button variant="outline" size={size} onClick={onClick} disabled={disabled} title={disabled ? disabledReason : undefined}>
       <Play className="h-3.5 w-3.5 sm:mr-1" />
       <span className="hidden sm:inline">{label}</span>
     </Button>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -836,6 +836,7 @@ export function AgentDetail() {
           <RunButton
             onClick={() => agentAction.mutate("invoke")}
             disabled={agentAction.isPending || isPendingApproval}
+            disabledReason={isPendingApproval ? "Agent is pending board approval" : "Action in progress"}
             label="Run Heartbeat"
           />
           <PauseResumeButton


### PR DESCRIPTION
## Problem

On the agent detail page, the "Run Heartbeat" button sometimes get disabled but there is no explanation why. User see a greyed out button and don't know what to do. There are two reasons it can be disabled:

1. **Action in progress** - another action (invoke, pause, resume) is already running
2. **Pending board approval** - the agent hire is pending and need to be approved first

Without any tooltip or explanation, user might think the button is broken or the agent is misconfigured. They have to figure out the reason by checking the status badge or looking at the approvals page.

## What I changed

Added optional \`disabledReason\` prop to the \`RunButton\` component. When the button is disabled AND a reason is provided, it show as a \`title\` tooltip on hover. When the button is enabled, no tooltip appear (clean UX).

In \`AgentDetail.tsx\`, passed the appropriate reason:
- "Agent is pending board approval" when \`isPendingApproval\` is true
- "Action in progress" when \`agentAction.isPending\` is true

## How to test

1. Go to an agent that is pending approval - hover over disabled Run Heartbeat button - should see "Agent is pending board approval"
2. Click Run Heartbeat on any agent - while it's processing, hover over the button - should see "Action in progress"

2 files, 4 lines added.