### PR TITLE
fix(ui): detect and warn about duplicate env var keys in agent config

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1236,6 +1236,15 @@ function EnvVarEditor({
     }
   }
 
+  const duplicateKeys = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const row of rows) {
+      const k = row.key.trim().toUpperCase();
+      if (k) seen.set(k, (seen.get(k) ?? 0) + 1);
+    }
+    return new Set([...seen.entries()].filter(([, c]) => c > 1).map(([k]) => k));
+  }, [rows]);
+
   return (
     <div className="space-y-1.5">
       {rows.map((row, i) => {
@@ -1244,13 +1253,15 @@ function EnvVarEditor({
           !row.key &&
           !row.plainValue &&
           !row.secretId;
+        const isDuplicate = duplicateKeys.has(row.key.trim().toUpperCase());
         return (
           <div key={i} className="flex items-center gap-1.5">
             <input
-              className={cn(inputClass, "flex-[2]")}
+              className={cn(inputClass, "flex-[2]", isDuplicate && "border-amber-500")}
               placeholder="KEY"
               value={row.key}
               onChange={(e) => updateRow(i, { key: e.target.value })}
+              title={isDuplicate ? "Duplicate key - only the last value will be used" : undefined}
             />
             <select
               className={cn(inputClass, "flex-[1] bg-background")}
@@ -1322,6 +1333,7 @@ function EnvVarEditor({
           </div>
         );
       })}
+      {duplicateKeys.size > 0 && <p className="text-[11px] text-amber-600">Duplicate keys detected: {[...duplicateKeys].join(", ")}. Only the last value for each key will be used.</p>}
       {sealError && <p className="text-[11px] text-destructive">{sealError}</p>}
       <p className="text-[11px] text-muted-foreground/60">
         PAPERCLIP_* variables are injected automatically at runtime.


### PR DESCRIPTION
## Problem

The environment variables editor in agent configuration allow user to add the same key multiple times. For example you can have two rows both named "DATABASE_URL" with different values. When the config save, JavaScript object overwrite duplicate keys so only the LAST value is kept. The first one silently disappear.

I spent time debugging why my agent was not using the correct database URL - turns out I had the key defined twice and the wrong one was winning.

## What I changed

Added duplicate key detection using useMemo:
- Compute set of duplicate keys (case-insensitive, so DB_URL and db_url count as same)
- Amber border on duplicate key inputs so they stand out visually
- Tooltip on hover: "Duplicate key - only the last value will be used"
- Warning text below the env var list: "Duplicate keys detected: DB_URL, API_KEY. Only the last value for each key will be used."

The detection is case-insensitive because environment variables are typically case-sensitive but having DB_URL and db_url is almost always a mistake.

## How to test

1. Go to any agent > Config tab > Environment variables section
2. Add two rows with the same key name (like "TEST")
3. Both inputs should get amber border
4. Warning message should appear below the list
5. Fix by removing one duplicate - warning disappear

1 file, 13 lines added.