### PR TITLE
fix(server): use node cpSync for onboarding-assets build on Windows

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "dev": "pnpm run preflight:workspace-links && tsx src/index.ts",
     "dev:watch": "pnpm run preflight:workspace-links && cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
-    "build": "pnpm run preflight:workspace-links && tsc && mkdir -p dist/onboarding-assets && cp -R src/onboarding-assets/. dist/onboarding-assets/",
+    "build": "pnpm run preflight:workspace-links && tsc && node -e \"require('fs').cpSync('src/onboarding-assets', 'dist/onboarding-assets', {recursive: true})\"",
     "prepack": "pnpm run prepare:ui-dist",
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents for autonomous companies
> - The server build step copies onboarding-assets using Unix shell commands (mkdir -p, cp -R)
> - On Windows, npm scripts run under CMD by default, where cp and mkdir -p are not recognized
> - This PR replaces the shell commands with Node.js fs.cpSync, which works cross-platform
> - Enables building Paperclip on Windows without requiring Git Bash or WSL in PATH

## What

Replace `mkdir -p dist/onboarding-assets && cp -R src/onboarding-assets/. dist/onboarding-assets/` with `node -e "require('fs').cpSync('src/onboarding-assets', 'dist/onboarding-assets', {recursive: true})"` in the server build script.

## Why

The current build script uses Unix-only shell utilities (`cp -R`, `mkdir -p`) that fail on Windows when npm/pnpm runs scripts via CMD.exe. `fs.cpSync` (available since Node 16.7.0) is cross-platform and eliminates the shell dependency.

## How to Verify

```bash
pnpm build   # Should succeed on both Windows and Unix
ls dist/onboarding-assets/   # Should contain the copied assets
```

## Risks

- **Low.** `fs.cpSync` with `{recursive: true}` mirrors `cp -R` behavior. Node 16+ is already a project requirement.

## Upstream Search Evidence

Searched `paperclipai/paperclip` open PRs before submitting:

- **Search terms:** `windows build cp cpSync onboarding`
- **Command:** `gh pr list --repo paperclipai/paperclip --state open --search "windows build cp cpSync onboarding"`
- **Found:** No matching upstream PRs
- **Conclusion:** No duplicate. Safe to submit.