### PR TITLE
fix: allow agents to discover and execute plugin tools

### DIFF
--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -1,6 +1,12 @@
 import type { Request } from "express";
 import { forbidden, unauthorized } from "../errors.js";
 
+export function assertAuthenticated(req: Request) {
+  if (req.actor.type === "none") {
+    throw unauthorized();
+  }
+}
+
 export function assertBoard(req: Request) {
   if (req.actor.type !== "board") {
     throw forbidden("Board access required");

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -11,7 +11,8 @@
  * - Retrieving UI slot contributions for frontend rendering
  * - Discovering and executing plugin-contributed agent tools
  *
- * All routes require board-level authentication (assertBoard middleware).
+ * Most routes require board-level authentication (assertBoard middleware);
+ * tool discovery and execution routes accept any authenticated caller (assertAuthenticated).
  *
  * @module server/routes/plugins
  * @see doc/plugins/PLUGIN_SPEC.md for the full plugin specification
@@ -558,7 +559,7 @@ export function pluginRoutes(
         res.status(403).json({ error: "runContext.agentId must match authenticated agent" });
         return;
       }
-      if (req.actor.runId && runContext.runId !== req.actor.runId) {
+      if (req.actor.runId !== runContext.runId) {
         res.status(403).json({ error: "runContext.runId must match authenticated run" });
         return;
       }

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -47,7 +47,7 @@ import type { PluginStreamBus } from "../services/plugin-stream-bus.js";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 import type { ToolRunContext } from "@paperclipai/plugin-sdk";
 import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertAuthenticated, assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -483,7 +483,7 @@ export function pluginRoutes(
    * Errors: 501 if tool dispatcher is not configured
    */
   router.get("/plugins/tools", async (req, res) => {
-    assertBoard(req);
+    assertAuthenticated(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -517,7 +517,7 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoard(req);
+    assertAuthenticated(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -552,6 +552,18 @@ export function pluginRoutes(
 
     assertCompanyAccess(req, runContext.companyId);
 
+    // For agent callers, enforce that runContext matches authenticated identity
+    if (req.actor.type === "agent") {
+      if (req.actor.agentId && runContext.agentId !== req.actor.agentId) {
+        res.status(403).json({ error: "runContext.agentId must match authenticated agent" });
+        return;
+      }
+      if (req.actor.runId && runContext.runId !== req.actor.runId) {
+        res.status(403).json({ error: "runContext.runId must match authenticated run" });
+        return;
+      }
+    }
+
     // Verify the tool exists
     const registeredTool = toolDeps.toolDispatcher.getTool(tool);
     if (!registeredTool) {


### PR DESCRIPTION
## Summary

- Plugin tool endpoints (`GET /api/plugins/tools` and `POST /api/plugins/tools/execute`) are gated behind `assertBoard`, rejecting agent API keys with "Board access required"
- The JSDoc on the execute endpoint describes it as "the primary endpoint used by the agent service to invoke plugin tools during an agent run" — but agents can't actually call it
- Replace `assertBoard` with `assertAuthenticated` on these two endpoints so agents can discover and call plugin tools during heartbeats
- Add identity validation: when the caller is an agent, enforce that `runContext.agentId` and `runContext.runId` match the authenticated identity from `req.actor`, preventing spoofing

## Test plan

- [ ] Agent API key can call `GET /api/plugins/tools` and receive tool list
- [ ] Agent API key can call `POST /api/plugins/tools/execute` with matching runContext
- [ ] Agent API key is rejected if `runContext.agentId` doesn't match authenticated agent
- [ ] Agent API key is rejected if `runContext.companyId` doesn't match (existing `assertCompanyAccess`)
- [ ] Board users continue to work as before
- [ ] Unauthenticated callers get 401