### PR TITLE
feat(ui): improve file attachment UX in New Issue dialog

### DIFF
--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -680,6 +680,25 @@ export function NewIssueDialog() {
     }
   }
 
+  function handlePaste(e: React.ClipboardEvent) {
+    // Only intercept pastes that contain image files from the clipboard
+    // (e.g. screenshot paste via Cmd/Ctrl+V). If the paste originates from
+    // inside the MarkdownEditor description field the editor's own imagePlugin
+    // will handle it, so we check the event target to avoid double-processing.
+    const target = e.target as HTMLElement | null;
+    if (target?.closest?.(".paperclip-mdxeditor")) return;
+
+    const files = Array.from(e.clipboardData.items)
+      .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null);
+
+    if (files.length === 0) return;
+
+    e.preventDefault();
+    stageFiles(files);
+  }
+
   function stageFiles(files: File[]) {
     if (files.length === 0) return;
     setStagedFiles((current) => {
@@ -869,9 +888,15 @@ export function NewIssueDialog() {
           "p-0 gap-0 flex flex-col max-h-[calc(100dvh-2rem)]",
           expanded
             ? "sm:max-w-2xl h-[calc(100dvh-2rem)]"
-            : "sm:max-w-lg"
+            : "sm:max-w-lg",
+          isFileDragOver && "ring-2 ring-primary/60",
         )}
         onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onDragEnter={handleFileDragEnter}
+        onDragOver={handleFileDragOver}
+        onDragLeave={handleFileDragLeave}
+        onDrop={handleFileDrop}
         onEscapeKeyDown={(event) => {
           if (createIssue.isPending) {
             event.preventDefault();
@@ -1230,10 +1255,6 @@ export function NewIssueDialog() {
         {/* Description */}
         <div
           className={cn("px-4 pb-2 overflow-y-auto min-h-0 border-t border-border/60 pt-3", expanded ? "flex-1" : "")}
-          onDragEnter={handleFileDragEnter}
-          onDragOver={handleFileDragOver}
-          onDragLeave={handleFileDragLeave}
-          onDrop={handleFileDrop}
         >
           <div
             className={cn(
@@ -1467,6 +1488,16 @@ export function NewIssueDialog() {
             </Button>
           </div>
         </div>
+
+        {/* Full-dialog drop zone overlay */}
+        {isFileDragOver && (
+          <div className="pointer-events-none absolute inset-2 z-50 flex items-center justify-center rounded-lg border-2 border-dashed border-primary/60 bg-primary/5">
+            <div className="flex flex-col items-center gap-1.5 text-primary">
+              <Paperclip className="h-6 w-6" />
+              <span className="text-sm font-medium">Drop files to attach</span>
+            </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

Improves the attachment/screenshot UX in the New Issue creation dialog to make file attachment more discoverable and robust.

### Changes

1. **Clipboard paste support at dialog level** — Cmd/Ctrl+V with screenshot/image data from clipboard now stages the file as an attachment even when focus is on the title field (not just inside the markdown editor). The handler skips paste events originating from the MDXEditor to avoid double-processing.

2. **Dialog-wide drag-and-drop** — Moved drag-and-drop handlers from the description area to the entire `DialogContent`, so files can be dropped anywhere on the dialog.

3. **Drop zone overlay** — Added a full-dialog visual overlay ("Drop files to attach" with a paperclip icon) that appears when files are dragged over the dialog, plus a ring highlight on the dialog border.

### Context

The dialog already supported:
- File upload via the Upload button (paperclip chip in the property bar)
- Drag-and-drop on the description area
- Image paste/drop inside the MDXEditor via `imagePlugin`

These changes extend that support so attachments work from any interaction point in the dialog.

### Testing

- TypeScript typecheck passes
- Clipboard paste from title field stages image as attachment
- Drag-and-drop works from any area of the dialog
- MDXEditor image paste still works independently (no double-processing)