### PR TITLE
fix(skills): resolve 422 for root-level SKILL.md in GitHub imports

### DIFF
--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -91,7 +91,7 @@ describe("project workspace skill discovery", () => {
     expect(normalizeGitHubSkillDirectory("retro/.", "retro")).toBe("retro");
     expect(normalizeGitHubSkillDirectory("retro/SKILL.md", "retro")).toBe("retro");
     expect(normalizeGitHubSkillDirectory("SKILL.md", "root-skill")).toBe("");
-    expect(normalizeGitHubSkillDirectory("", "fallback-skill")).toBe("fallback-skill");
+    expect(normalizeGitHubSkillDirectory("", "fallback-skill")).toBe("");
   });
 
   it("finds bounded skill roots under supported workspace paths", async () => {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -194,8 +194,13 @@ export function normalizeGitHubSkillDirectory(
   value: string | null | undefined,
   fallback: string,
 ) {
-  const normalized = normalizePortablePath(value ?? "");
-  if (!normalized) return normalizePortablePath(fallback);
+  const raw = (value ?? "").trim();
+  // "." or "./" or empty means repo root — normalizePortablePath strips these
+  // to "", but empty should also mean root for stored metadata where root was
+  // correctly saved as "".
+  if (raw === "." || raw === "./" || raw === "") return "";
+  const normalized = normalizePortablePath(raw);
+  if (!normalized) return "";
   if (path.posix.basename(normalized).toLowerCase() === "skill.md") {
     return normalizePortablePath(path.posix.dirname(normalized));
   }


### PR DESCRIPTION
Fixes #1982

When a GitHub repo has SKILL.md at the root (not in a subdirectory), the file reading endpoint constructs an incorrect raw.githubusercontent.com URL that includes the skill slug as a directory prefix, resulting in 404/422.

Root cause: normalizeGitHubSkillDirectory() uses normalizePortablePath() which strips '.' segments. When skillDir is '.' (root), it becomes '' which triggers the fallback to the skill slug. The slug is then used as a directory in the GitHub raw URL.

Fix: detect '.', './', and empty string as root directory markers and return '' instead of falling back to the slug. Updated test to match.

Before: raw.githubusercontent.com/owner/repo/ref/my-skill/SKILL.md (404)
After: raw.githubusercontent.com/owner/repo/ref/SKILL.md (200)
