### PR TITLE
fix(pi-local): harden model-discovery preflight for DLD-1538

### DIFF
--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -39,6 +39,10 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
+function classifyPiDiscoveryError(message: string): "runtime_availability" | "config_or_infra" {
+  return /timed out|timeout/i.test(message) ? "runtime_availability" : "config_or_infra";
+}
+
 function parseModelProvider(model: string | null): string | null {
   if (!model) return null;
   const trimmed = model.trim();
@@ -212,13 +216,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     resolvedCommand,
   });
 
-  // Validate model is available before execution
-  await ensurePiModelConfiguredAndAvailable({
-    model,
-    command,
-    cwd,
-    env: runtimeEnv,
-  });
+  // Validate model is available before execution.
+  // Keep failure classification explicit for monitor/RCA pipelines.
+  try {
+    await ensurePiModelConfiguredAndAvailable({
+      model,
+      command,
+      cwd,
+      env: runtimeEnv,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Pi model discovery failed.";
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: classifyPiDiscoveryError(message),
+      errorMessage: message,
+      resultJson: {
+        preflightStep: "ensurePiModelConfiguredAndAvailable",
+      },
+    };
+  }
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);

--- a/packages/adapters/pi-local/src/server/models.test.ts
+++ b/packages/adapters/pi-local/src/server/models.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
+  discoverPiModelsCached,
   ensurePiModelConfiguredAndAvailable,
   listPiModels,
   resetPiModelsCacheForTests,
 } from "./models.js";
+
+async function writeFakePi(pathToFile: string, body: string): Promise<void> {
+  await fs.writeFile(pathToFile, body, "utf8");
+  await fs.chmod(pathToFile, 0o755);
+}
 
 describe("pi models", () => {
   afterEach(() => {
@@ -29,5 +38,48 @@ describe("pi models", () => {
         model: "xai/grok-4",
       }),
     ).rejects.toThrow();
+  });
+
+  it("falls back to stale cached models when discovery later times out", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-models-"));
+    const piPath = path.join(root, "pi");
+
+    await writeFakePi(
+      piPath,
+      `#!/usr/bin/env node
+if (process.argv.includes("--list-models")) {
+  console.error("provider  model");
+  console.error("openai    gpt-4.1-mini");
+  process.exit(0);
+}
+process.exit(1);
+`,
+    );
+
+    const first = await discoverPiModelsCached({
+      command: piPath,
+      cwd: root,
+      env: {},
+    });
+    expect(first.some((m) => m.id === "openai/gpt-4.1-mini")).toBe(true);
+
+    await writeFakePi(
+      piPath,
+      `#!/usr/bin/env node
+if (process.argv.includes("--list-models")) {
+  // Keep process alive until timeout to simulate transient runtime slowness.
+  setTimeout(() => process.exit(0), 60_000);
+}
+`,
+    );
+
+    const second = await discoverPiModelsCached({
+      command: piPath,
+      cwd: root,
+      env: {},
+    });
+    expect(second.some((m) => m.id === "openai/gpt-4.1-mini")).toBe(true);
+
+    await fs.rm(root, { recursive: true, force: true });
   });
 });

--- a/packages/adapters/pi-local/src/server/models.ts
+++ b/packages/adapters/pi-local/src/server/models.ts
@@ -3,6 +3,8 @@ import type { AdapterModel } from "@paperclipai/adapter-utils";
 import { asString, runChildProcess } from "@paperclipai/adapter-utils/server-utils";
 
 const MODELS_CACHE_TTL_MS = 60_000;
+const DISCOVERY_MAX_ATTEMPTS = 2;
+const DISCOVERY_RETRY_DELAY_MS = 400;
 
 function firstNonEmptyLine(text: string): string {
   return (
@@ -11,6 +13,19 @@ function firstNonEmptyLine(text: string): string {
       .map((line) => line.trim())
       .find(Boolean) ?? ""
   );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function summarizeOutput(stdout: string, stderr: string): string {
+  const stderrLine = firstNonEmptyLine(stderr);
+  const stdoutLine = firstNonEmptyLine(stdout);
+  if (stderrLine && stdoutLine && stderrLine !== stdoutLine) {
+    return `stderr=${stderrLine}; stdout=${stdoutLine}`;
+  }
+  return stderrLine || stdoutLine || "";
 }
 
 function parseModelsOutput(stdout: string): AdapterModel[] {
@@ -110,30 +125,51 @@ export async function discoverPiModels(input: {
   const env = normalizeEnv(input.env);
   const runtimeEnv = normalizeEnv({ ...process.env, ...env });
 
-  const result = await runChildProcess(
-    `pi-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-    command,
-    ["--list-models"],
-    {
-      cwd,
-      env: runtimeEnv,
-      timeoutSec: 20,
-      graceSec: 3,
-      onLog: async () => {},
-    },
-  );
+  for (let attempt = 1; attempt <= DISCOVERY_MAX_ATTEMPTS; attempt++) {
+    const result = await runChildProcess(
+      `pi-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command,
+      ["--list-models"],
+      {
+        cwd,
+        env: runtimeEnv,
+        timeoutSec: 20,
+        graceSec: 3,
+        onLog: async () => {},
+      },
+    );
 
-  if (result.timedOut) {
-    throw new Error("`pi --list-models` timed out.");
-  }
-  if ((result.exitCode ?? 1) !== 0) {
-    const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
-    throw new Error(detail ? `\`pi --list-models\` failed: ${detail}` : "`pi --list-models` failed.");
+    if (!result.timedOut && (result.exitCode ?? 1) === 0) {
+      // Pi outputs model list to stderr, but fall back to stdout for older versions
+      const output = result.stderr || result.stdout;
+      return sortModels(dedupeModels(parseModelsOutput(output)));
+    }
+
+    const detail = summarizeOutput(result.stdout, result.stderr);
+    const lastAttempt = attempt >= DISCOVERY_MAX_ATTEMPTS;
+
+    if (result.timedOut) {
+      if (!lastAttempt) {
+        await sleep(DISCOVERY_RETRY_DELAY_MS);
+        continue;
+      }
+      throw new Error(
+        detail
+          ? `\`pi --list-models\` timed out after ${DISCOVERY_MAX_ATTEMPTS} attempts. ${detail}`
+          : `\`pi --list-models\` timed out after ${DISCOVERY_MAX_ATTEMPTS} attempts.`,
+      );
+    }
+
+    if ((result.exitCode ?? 1) !== 0) {
+      if (!lastAttempt) {
+        await sleep(DISCOVERY_RETRY_DELAY_MS);
+        continue;
+      }
+      throw new Error(detail ? `\`pi --list-models\` failed: ${detail}` : "`pi --list-models` failed.");
+    }
   }
 
-  // Pi outputs model list to stderr, but fall back to stdout for older versions
-  const output = result.stderr || result.stdout;
-  return sortModels(dedupeModels(parseModelsOutput(output)));
+  throw new Error("`pi --list-models` failed unexpectedly.");
 }
 
 function normalizeEnv(input: unknown): Record<string, string> {
@@ -160,10 +196,17 @@ export async function discoverPiModelsCached(input: {
   pruneExpiredDiscoveryCache(now);
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
-
-  const models = await discoverPiModels({ command, cwd, env });
-  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
-  return models;
+  try {
+    const models = await discoverPiModels({ command, cwd, env });
+    discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
+    return models;
+  } catch (err) {
+    if (cached && cached.models.length > 0) {
+      // Fail open to stale cache to keep transient discovery slowness from hard-failing every run.
+      return cached.models;
+    }
+    throw err;
+  }
 }
 
 export async function ensurePiModelConfiguredAndAvailable(input: {


### PR DESCRIPTION
## Summary
Harden pi_local model-discovery preflight to reduce false `adapter_failed` incidents during transient `pi --list-models` slowness.

Closes delivery scope for [DLD-1566](/DLD/issues/DLD-1566), related to [DLD-1538](/DLD/issues/DLD-1538).

## Changes
- Added bounded retry/backoff for `pi --list-models` discovery attempts.
- Added stale-cache fallback in discovery cache path when live discovery fails after cache exists.
- Added richer timeout/failure error detail using stderr/stdout excerpts for preflight visibility.
- Added explicit execute preflight error classification via `errorCode`:
  - `runtime_availability` for timeout-like failures
  - `config_or_infra` for non-timeout discovery failures
- Added/updated pi-local model tests to cover stale-cache fallback behavior.

## Verification
- `pnpm exec vitest run packages/adapters/pi-local/src/server/models.test.ts`
- `pnpm exec vitest run server/src/__tests__/pi-local-adapter-environment.test.ts`
- `pnpm --filter @paperclipai/adapter-pi-local typecheck`
