### PR TITLE
Fix: resolve company project for timer heartbeats without issue context

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2092,6 +2092,10 @@ export function heartbeatService(db: Db) {
         .limit(1)
         .then((rows) => rows[0] ?? null);
       executionProjectId = companyProject?.id ?? null;
+      // Inject into context so resolveWorkspaceForRun can find the project workspace.
+      if (executionProjectId) {
+        context.projectId = executionProjectId;
+      }
     }
     const projectExecutionWorkspacePolicy = executionProjectId
       ? await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2082,7 +2082,17 @@ export function heartbeatService(db: Db) {
       ? parseIssueExecutionWorkspaceSettings(issueContext?.executionWorkspaceSettings)
       : null;
     const contextProjectId = readNonEmptyString(context.projectId);
-    const executionProjectId = issueContext?.projectId ?? contextProjectId;
+    let executionProjectId = issueContext?.projectId ?? contextProjectId;
+    // Fallback: when timer heartbeats have no issue/project context, resolve via the company's active project.
+    if (!executionProjectId) {
+      const companyProject = await db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.companyId, agent.companyId), sql`${projects.archivedAt} IS NULL`))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      executionProjectId = companyProject?.id ?? null;
+    }
     const projectExecutionWorkspacePolicy = executionProjectId
       ? await db
           .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType, ExecutionWorkspace, ExecutionWorkspaceConfig } from "@paperclipai/shared";
 import {
@@ -1161,7 +1161,7 @@ export function heartbeatService(db: Db) {
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null },
+    opts?: { useProjectWorkspace?: boolean | null; overrideProjectId?: string | null },
   ): Promise<ResolvedWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId);
     const contextProjectId = readNonEmptyString(context.projectId);
@@ -1179,7 +1179,7 @@ export function heartbeatService(db: Db) {
     const issueProjectId = issueProjectRef?.projectId ?? null;
     const preferredProjectWorkspaceId =
       issueProjectRef?.projectWorkspaceId ?? contextProjectWorkspaceId ?? null;
-    const resolvedProjectId = issueProjectId ?? contextProjectId;
+    const resolvedProjectId = issueProjectId ?? contextProjectId ?? opts?.overrideProjectId ?? null;
     const useProjectWorkspace = opts?.useProjectWorkspace !== false;
     const workspaceProjectId = useProjectWorkspace ? resolvedProjectId : null;
 
@@ -2088,14 +2088,11 @@ export function heartbeatService(db: Db) {
       const companyProject = await db
         .select({ id: projects.id })
         .from(projects)
-        .where(and(eq(projects.companyId, agent.companyId), sql`${projects.archivedAt} IS NULL`))
+        .where(and(eq(projects.companyId, agent.companyId), isNull(projects.archivedAt)))
+        .orderBy(asc(projects.createdAt), asc(projects.id))
         .limit(1)
         .then((rows) => rows[0] ?? null);
       executionProjectId = companyProject?.id ?? null;
-      // Inject into context so resolveWorkspaceForRun can find the project workspace.
-      if (executionProjectId) {
-        context.projectId = executionProjectId;
-      }
     }
     const projectExecutionWorkspacePolicy = executionProjectId
       ? await db
@@ -2136,7 +2133,10 @@ export function heartbeatService(db: Db) {
       agent,
       context,
       previousSessionParams,
-      { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
+      {
+        useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default",
+        overrideProjectId: executionProjectId,
+      },
     );
     const issueRef = issueContext
       ? {


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Agents run on heartbeats — some triggered by issues, some by timers
- Managed project workspaces keep agents working in a consistent cloned repo directory per project
- Issue-triggered heartbeats carry a `projectId` in context, so `resolveWorkspaceForRun` can find the project workspace and clone it via `ensureManagedProjectWorkspace`
- But timer-triggered heartbeats (`tickTimers`) build a context snapshot with only `{source, reason, now}` — no `projectId` and no `issueId`
- So for timer runs, `resolveWorkspaceForRun` computes `resolvedProjectId = null`, the project-workspace query returns empty, and the agent silently falls back to a per-agent home directory
- This PR resolves the company's single active project as a fallback when context has no project/issue and threads that ID into both the execution-workspace record and the workspace-directory lookup, so timer heartbeats land in the correct managed project workspace

## Summary

- **Bug:** Timer-triggered heartbeats have no `projectId`/`issueId` in context, so `resolveWorkspaceForRun` can't find the managed project workspace and agents fall back to per-agent home directories. Workspace clones are never triggered for these runs.
- **Fix:**
  1. When neither issue context nor heartbeat context supplies a `projectId`, query the company's first active (non-archived) project, ordered by `createdAt, id` for determinism.
  2. Thread that resolved ID into `resolveWorkspaceForRun` via a new `overrideProjectId` option so the workspace-directory lookup actually sees it (not just the execution-workspace DB record).

## Why it matters

Without this, timer-scheduled agents silently diverge from their managed workspace, doing work in an unrelated per-agent directory. Clones, repo state, and any cwd-dependent tooling are wrong for every timer-driven run.

## Verification

- [ ] Timer-triggered heartbeat runs resolve a project workspace instead of per-agent directories
- [ ] Heartbeats with explicit issue/project context are unchanged (fallback only hits when both are null)
- [ ] Companies with no active projects still get `executionProjectId = null` gracefully
- [ ] Companies with multiple active projects get a stable choice (oldest by `createdAt`, tiebreak on `id`)
- [ ] `pnpm --filter @paperclipai/server typecheck` passes

## Risks

- Companies with multiple active projects will have timer heartbeats pinned to the oldest one. For single-project companies (the common case) this is a no-op; for multi-project companies this is still an improvement over "random per-agent directory" but is not project-aware. A follow-up could let timer configs carry their own `projectId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)