### PR TITLE
fix(ui): add pointer-events:auto to mention dropdown portal

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -566,6 +566,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           <div
             className="fixed z-[9999] min-w-[180px] max-w-[calc(100vw-16px)] max-h-[200px] overflow-y-auto rounded-md border border-border bg-popover shadow-md"
             style={{
+              pointerEvents: "auto",
               top: Math.min(mentionState.viewportTop + 4, window.innerHeight - 208),
               left: Math.max(8, Math.min(mentionState.viewportLeft, window.innerWidth - 188)),
             }}


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Humans oversee agents by viewing issues and leaving comments with @mentions
- The comment editor uses a mention dropdown that appears when typing `@`
- The dropdown is rendered via `createPortal` to `document.body` to avoid overflow clipping in modals
- But when the editor is inside a Radix Dialog, Radix sets `pointer-events: none` on `<body>`
- CSS `pointer-events` is inherited, so the portal div inherits `none` from `<body>`
- This makes the mention dropdown completely unresponsive to mouse hover and click
- This PR adds `pointerEvents: "auto"` to the portal container's inline style
- This breaks the inheritance chain so mouse events reach the dropdown buttons
- Keyboard navigation was never affected (pointer-events only blocks mouse/touch)

## What Changed

**One file, one line:** `ui/src/components/MarkdownEditor.tsx`

Added `pointerEvents: "auto"` to the mention dropdown portal container's inline style object.

## Why It Matters

Without this fix, users cannot click mention suggestions with their mouse when the editor is inside a dialog — they must use keyboard navigation only. This is a regression from the portal rendering change (which moved the dropdown from relative positioning inside the editor to a `createPortal` to `document.body`).

## How to Verify

1. Open an issue that renders inside a modal/dialog
2. Start a comment and type `@`
3. Hover over suggestions — they should highlight
4. Click a suggestion — it should insert as a mention link

## Diagnosis Method

Injected DOM event instrumentation that revealed:
- `document.body` had `pointer-events: none` (set by Radix Dialog at runtime)
- The mention portal div inherited `pointer-events: none`
- Zero native `mousedown`/`mouseenter` events reached the portal buttons
- `document.elementFromPoint()` confirmed the dropdown was visually present but event-invisible

## Risk

Minimal. The change only affects the mention dropdown portal and explicitly sets a property that was already the default before Radix Dialog interference. No impact on modal overlay behavior or other UI elements.

Fixes #2258