### PR TITLE
Add Telegram Relay example plugin

### DIFF
--- a/packages/plugins/examples/plugin-telegram-relay-example/README.md
+++ b/packages/plugins/examples/plugin-telegram-relay-example/README.md
@@ -1,0 +1,125 @@
+# Telegram Relay Plugin (Example)
+
+Bridge incoming Telegram messages to Paperclip issue comments in real time. When a message arrives, it's posted as a comment on a designated "Inbound" issue, triggering the assigned agent's heartbeat so it wakes up and processes the message immediately.
+
+## How it works
+
+```
+Telegram user → sends message → relay posts comment on "Inbound" issue
+                                       ↓
+                              agent heartbeat fires → agent wakes up and responds
+                                       ↓
+                              pulse reply sent back → "Got it — on it now."
+```
+
+The relay sends a quick acknowledgment ("pulse") back to Telegram so the user knows their message was received while the agent starts working.
+
+## Setup
+
+### 1. Create a Telegram bot
+
+Message [@BotFather](https://t.me/BotFather) on Telegram and run `/newbot`. Save the API token.
+
+### 2. Get your chat ID
+
+Send any message to your new bot, then run:
+
+```bash
+curl https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates
+```
+
+The `chat.id` field in the response is your chat ID.
+
+### 3. Create the "Inbound" relay issue
+
+Create a persistent issue in Paperclip that will receive all Telegram messages as comments. Assign it to the agent you want to wake (e.g. the CEO):
+
+```bash
+curl -X POST http://127.0.0.1:3100/api/companies/<COMPANY_ID>/issues \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Inbound — Telegram Messages",
+    "description": "Each incoming Telegram message is posted here as a comment to wake the assigned agent.",
+    "status": "in_progress",
+    "priority": "high",
+    "assigneeAgentId": "<AGENT_ID>"
+  }'
+```
+
+Save the issue `id` from the response.
+
+### 4. Run the real-time relay
+
+The `relay.mjs` script uses Telegram long-polling for instant delivery (no cron delay):
+
+```bash
+TELEGRAM_BOT_TOKEN=<your-bot-token>    \
+TELEGRAM_CHAT_ID=<your-chat-id>        \
+RELAY_ISSUE_ID=<issue-uuid>            \
+PAPERCLIP_API_KEY=<your-api-key>       \
+AGENT_MENTION=@CEO                     \
+node relay.mjs
+```
+
+> **Note:** `PAPERCLIP_API_KEY` is optional in local trusted mode (no auth required) but required for authenticated Paperclip deployments. See the [Authentication docs](https://docs.paperclip.dev/authentication) for details on creating agent API keys.
+
+The `AGENT_MENTION` variable is optional — when set, comments include an `@AgentName` mention which triggers a heartbeat for that specific agent.
+
+To run it in the background:
+
+```bash
+nohup node relay.mjs > relay.log 2>&1 &
+```
+
+### 5. (Optional) Install the plugin for cron-based fallback
+
+The plugin provides a cron job that polls Telegram every 2 minutes as a safety net in case the relay script goes down.
+
+Install the plugin from a local path:
+
+```bash
+curl -X POST http://127.0.0.1:3100/api/plugins/install \
+  -H "Content-Type: application/json" \
+  -d '{
+    "packageName": "/path/to/plugin-telegram-relay-example",
+    "isLocalPath": true
+  }'
+```
+
+Then configure it:
+
+```bash
+curl -X POST http://127.0.0.1:3100/api/plugins/<PLUGIN_ID>/config \
+  -H "Content-Type: application/json" \
+  -d '{
+    "configJson": {
+      "telegramBotToken": "<your-bot-token>",
+      "telegramChatId": "<your-chat-id>",
+      "relayIssueId": "<issue-uuid>",
+      "agentMention": "@CEO"
+    }
+  }'
+```
+
+## Environment variables (relay.mjs)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TELEGRAM_BOT_TOKEN` | Yes | — | Bot API token from @BotFather |
+| `TELEGRAM_CHAT_ID` | Yes | — | Telegram chat ID to monitor |
+| `RELAY_ISSUE_ID` | Yes | — | Paperclip issue UUID for the "Inbound" relay issue |
+| `PAPERCLIP_BASE` | No | `http://127.0.0.1:3100` | Paperclip API base URL |
+| `PAPERCLIP_API_KEY` | No | — | Bearer token for authenticated Paperclip deployments (not needed in local trusted mode) |
+| `AGENT_MENTION` | No | — | `@AgentName` to include in comments for heartbeat triggers |
+
+## Security notes
+
+- **Bot token in URLs:** The Telegram bot token is included in `getUpdates` API URLs. If an error is logged (e.g. via `console.error` or `ctx.logger.error`), the token may appear in log output. Keep your log files protected and avoid piping relay output to shared dashboards.
+- **Token storage:** The plugin stores the bot token in Paperclip's plugin config (plaintext). For production deployments, consider moving it to Paperclip's secrets store and referencing it via `ctx.secrets.resolve()`.
+
+## Architecture notes
+
+- **Long-polling vs webhooks:** This example uses Telegram long-polling (`getUpdates` with `timeout=30`) rather than webhooks. This avoids needing a public URL or TLS certificate, making it ideal for local Paperclip instances.
+- **Pulse acknowledgment:** The relay sends a random short confirmation message back to the Telegram user immediately, so they know the message was received before the agent starts processing.
+- **Cursor persistence:** Both the relay script (in-memory) and the plugin (via `ctx.state`) track a cursor so messages aren't double-posted across restarts.
+- **The "Inbound" pattern:** A single persistent issue assigned to a top-level agent (like the CEO) acts as a message bus. The agent sees each new comment and can triage, delegate, or respond directly.

--- a/packages/plugins/examples/plugin-telegram-relay-example/package.json
+++ b/packages/plugins/examples/plugin-telegram-relay-example/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@paperclipai/plugin-telegram-relay-example",
+  "version": "0.1.0",
+  "description": "Relay incoming Telegram messages to Paperclip issue comments in real time, waking agents instantly",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/plugins/examples/plugin-telegram-relay-example/relay.mjs
+++ b/packages/plugins/examples/plugin-telegram-relay-example/relay.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Telegram → Paperclip real-time relay.
+ *
+ * Uses Telegram long-polling (getUpdates with timeout=30) so comments
+ * are posted within seconds of a message arriving. Sends a quick
+ * acknowledgment ("pulse") back to the Telegram chat so the user
+ * knows the message was received before the agent starts working.
+ *
+ * Usage:
+ *   TELEGRAM_BOT_TOKEN=<token>            \
+ *   TELEGRAM_CHAT_ID=<chat_id>            \
+ *   PAPERCLIP_BASE=http://127.0.0.1:3100  \
+ *   PAPERCLIP_API_KEY=<bearer-token>      \
+ *   RELAY_ISSUE_ID=<issue-uuid>           \
+ *   AGENT_MENTION=@CEO                    \
+ *   node relay.mjs
+ *
+ * All values are read from environment variables. None are hard-coded.
+ */
+
+const {
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_CHAT_ID,
+  PAPERCLIP_BASE = "http://127.0.0.1:3100",
+  PAPERCLIP_API_KEY = "",
+  RELAY_ISSUE_ID,
+  AGENT_MENTION = "",
+} = process.env;
+
+if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID || !RELAY_ISSUE_ID) {
+  console.error(
+    "Missing required env vars: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, RELAY_ISSUE_ID",
+  );
+  process.exit(1);
+}
+
+const PULSE_MESSAGES = [
+  "Got it — on it now.",
+  "Received. Working on it.",
+  "Roger that, processing.",
+  "Message received — firing up the agents.",
+  "Heard you loud and clear. Working.",
+];
+
+let offset = 0;
+
+/** Send a quick acknowledgment back to the Telegram user. */
+async function sendPulse(chatId) {
+  const text =
+    PULSE_MESSAGES[Math.floor(Math.random() * PULSE_MESSAGES.length)];
+  try {
+    await fetch(
+      `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text }),
+      },
+    );
+  } catch (err) {
+    console.error("Failed to send pulse:", err.message);
+  }
+}
+
+async function poll() {
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates?offset=${offset}&timeout=30`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    console.error("Telegram HTTP error:", resp.status, await resp.text());
+    return;
+  }
+  const data = await resp.json();
+  if (!data.ok) {
+    console.error("Telegram error:", data);
+    return;
+  }
+
+  for (const update of data.result) {
+    offset = update.update_id + 1;
+    const msg = update.message;
+    if (!msg?.text) continue;
+    if (String(msg.chat?.id) !== TELEGRAM_CHAT_ID) continue;
+
+    const sender = [msg.from?.first_name, msg.from?.last_name]
+      .filter(Boolean)
+      .join(" ") || "Unknown";
+
+    const mention = AGENT_MENTION ? `${AGENT_MENTION} ` : "";
+    const body = `${mention}**Telegram from ${sender}:**\n\n${msg.text}`;
+
+    console.log(`[${new Date().toISOString()}] ${sender}: ${msg.text}`);
+
+    // Send pulse acknowledgment and post comment concurrently
+    const headers = { "Content-Type": "application/json" };
+    if (PAPERCLIP_API_KEY) {
+      headers["Authorization"] = `Bearer ${PAPERCLIP_API_KEY}`;
+    }
+
+    const commentPromise = fetch(
+      `${PAPERCLIP_BASE}/api/issues/${RELAY_ISSUE_ID}/comments`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ body }),
+      },
+    ).then(async (res) => {
+      if (!res.ok) {
+        console.error("Paperclip error:", res.status, await res.text());
+      } else {
+        console.log("  → Comment posted");
+      }
+    }).catch((err) => {
+      console.error("Failed to post comment:", err.message);
+    });
+
+    const pulsePromise = sendPulse(msg.chat.id);
+
+    await Promise.all([commentPromise, pulsePromise]);
+  }
+}
+
+let running = true;
+
+function shutdown() {
+  console.log("\nShutting down relay...");
+  running = false;
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+console.log("Telegram relay started — listening for messages...");
+
+while (running) {
+  try {
+    await poll();
+  } catch (err) {
+    console.error("Poll error:", err.message);
+    if (running) await new Promise((r) => setTimeout(r, 3000));
+  }
+}
+
+console.log("Relay stopped.");

--- a/packages/plugins/examples/plugin-telegram-relay-example/src/index.ts
+++ b/packages/plugins/examples/plugin-telegram-relay-example/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-telegram-relay-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-telegram-relay-example/src/manifest.ts
@@ -1,0 +1,76 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_ID = "paperclip.telegram-relay-example";
+const PLUGIN_VERSION = "0.1.0";
+
+/**
+ * Telegram Relay plugin manifest.
+ *
+ * This plugin polls Telegram for new messages on a 2-minute cron schedule
+ * and posts each message as a comment on a designated "Inbound" issue.
+ * The comment triggers an agent heartbeat, waking the assigned agent
+ * to process the message.
+ *
+ * For near-instant delivery, use the companion `relay.mjs` long-polling
+ * script instead of (or alongside) the cron job. See README.md for details.
+ */
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Telegram Relay (Example)",
+  description:
+    "Bridges incoming Telegram messages to Paperclip issue comments, waking agents in real time.",
+  author: "Paperclip",
+  categories: ["connector", "automation"],
+
+  capabilities: [
+    "jobs.schedule",
+    "http.outbound",
+    "issues.read",
+    "issue.comments.create",
+    "plugin.state.read",
+    "plugin.state.write",
+  ],
+
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      telegramBotToken: {
+        type: "string",
+        description: "Telegram Bot API token (from @BotFather)",
+      },
+      telegramChatId: {
+        type: "string",
+        description: "Telegram chat ID to monitor",
+      },
+      relayIssueId: {
+        type: "string",
+        description:
+          "Paperclip issue ID where incoming messages are posted as comments",
+      },
+      agentMention: {
+        type: "string",
+        description:
+          "Optional @AgentName to include in comments so the agent gets a heartbeat trigger",
+      },
+    },
+    required: ["telegramBotToken", "telegramChatId", "relayIssueId"],
+  },
+
+  jobs: [
+    {
+      jobKey: "poll-telegram",
+      displayName: "Poll Telegram",
+      description:
+        "Polls Telegram getUpdates every 2 minutes for new messages (fallback for the real-time relay script)",
+      schedule: "*/2 * * * *",
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-telegram-relay-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-telegram-relay-example/src/worker.ts
@@ -1,0 +1,173 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+
+interface TelegramConfig {
+  telegramBotToken: string;
+  telegramChatId: string;
+  relayIssueId: string;
+  agentMention?: string;
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: {
+    message_id: number;
+    from?: { first_name?: string; last_name?: string; username?: string };
+    chat?: { id: number };
+    date: number;
+    text?: string;
+  };
+}
+
+const CURSOR_KEY = "telegram-update-cursor";
+
+/**
+ * Build a Paperclip comment body from a Telegram message.
+ * Optionally prepends an @AgentName mention to trigger a heartbeat.
+ */
+function formatComment(
+  sender: string,
+  text: string,
+  agentMention?: string,
+): string {
+  const mention = agentMention ? `${agentMention} ` : "";
+  return `${mention}**Telegram from ${sender}:**\n\n${text}`;
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("Telegram Relay plugin starting");
+
+    ctx.jobs.register("poll-telegram", async (job) => {
+      ctx.logger.info("Polling Telegram for new messages", {
+        runId: job.runId,
+        trigger: job.trigger,
+      });
+
+      const config = (await ctx.config.get()) as TelegramConfig;
+
+      if (
+        !config.telegramBotToken ||
+        !config.telegramChatId ||
+        !config.relayIssueId
+      ) {
+        ctx.logger.error("Missing required config", {
+          hasToken: !!config.telegramBotToken,
+          hasChatId: !!config.telegramChatId,
+          hasRelayIssue: !!config.relayIssueId,
+        });
+        return;
+      }
+
+      // Read cursor from plugin state
+      const cursorState = await ctx.state.get({
+        scopeKind: "instance",
+        stateKey: CURSOR_KEY,
+      });
+      const cursor = cursorState ? Number(cursorState) : 0;
+
+      // Poll Telegram getUpdates.
+      // timeout=5 keeps the cron job short — relay.mjs uses timeout=30 for
+      // true long-polling since it runs continuously.
+      const url = `https://api.telegram.org/bot${config.telegramBotToken}/getUpdates?offset=${cursor}&timeout=5`;
+
+      let updates: TelegramUpdate[];
+      try {
+        const resp = await ctx.http.fetch(url);
+        const data = (await resp.json()) as {
+          ok: boolean;
+          result: TelegramUpdate[];
+        };
+        if (!data.ok) {
+          ctx.logger.error("Telegram API error", { data });
+          return;
+        }
+        updates = data.result;
+      } catch (err) {
+        ctx.logger.error("Failed to poll Telegram", {
+          error: String(err),
+        });
+        return;
+      }
+
+      if (!updates || updates.length === 0) {
+        ctx.logger.info("No new Telegram messages");
+        return;
+      }
+
+      // Process updates in order. Only advance the cursor past messages
+      // that were successfully posted — if a comment fails, stop so the
+      // next cron run retries from the first failure.
+      let lastSuccessId = cursor;
+
+      for (const update of updates) {
+        const msg = update.message;
+        if (!msg?.text) {
+          // Non-text updates (joins, edits, etc.) — skip but advance cursor
+          lastSuccessId = update.update_id;
+          continue;
+        }
+
+        // Only relay messages from the configured chat
+        if (String(msg.chat?.id) !== config.telegramChatId) {
+          lastSuccessId = update.update_id;
+          continue;
+        }
+
+        const sender = msg.from
+          ? [msg.from.first_name, msg.from.last_name]
+              .filter(Boolean)
+              .join(" ")
+          : "Unknown";
+
+        const commentBody = formatComment(
+          sender,
+          msg.text,
+          config.agentMention,
+        );
+
+        try {
+          await ctx.issues.createComment(config.relayIssueId, {
+            body: commentBody,
+          });
+          ctx.logger.info("Posted Telegram message as comment", {
+            messageId: msg.message_id,
+            sender,
+            relayIssueId: config.relayIssueId,
+          });
+          lastSuccessId = update.update_id;
+        } catch (err) {
+          ctx.logger.error("Failed to create comment — stopping batch so next run retries", {
+            error: String(err),
+            messageId: msg.message_id,
+          });
+          break;
+        }
+      }
+
+      // Save cursor past the last successfully handled update
+      if (lastSuccessId >= cursor) {
+        await ctx.state.set(
+          { scopeKind: "instance", stateKey: CURSOR_KEY },
+          String(lastSuccessId + 1),
+        );
+      }
+
+      ctx.logger.info("Telegram poll complete", {
+        processedUpdates: updates.length,
+        newCursor: lastSuccessId + 1,
+      });
+    });
+
+    ctx.data.register("health", async () => ({
+      status: "ok",
+      description: "Telegram Relay is running",
+    }));
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Telegram Relay healthy" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-telegram-relay-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-telegram-relay-example/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds a new example plugin that bridges Telegram messages to Paperclip issue comments in real time
- Includes a long-polling relay script (`relay.mjs`) for sub-second delivery with instant "pulse" acknowledgments back to the user
- Cron-based plugin fallback polls every 2 minutes as a safety net
- Uses the "Inbound issue" pattern: a persistent issue assigned to an agent (e.g. CEO) where each Telegram message becomes a comment, triggering a heartbeat

## What's included

| File | Purpose |
|------|---------|
| `relay.mjs` | Standalone long-polling script for real-time relay with pulse responses |
| `src/worker.ts` | Plugin worker with cron-based fallback polling |
| `src/manifest.ts` | Plugin manifest with config schema |
| `README.md` | Setup guide, env vars, architecture and security notes |

## Test plan

- [ ] Create a Telegram bot via @BotFather
- [ ] Create an "Inbound" issue assigned to an agent
- [ ] Run `relay.mjs` with env vars and send a Telegram message
- [ ] Verify comment appears on the issue and agent heartbeat fires
- [ ] Verify pulse acknowledgment is sent back to Telegram
- [ ] Install the plugin and verify cron fallback works independently