### PR TITLE
fix(adapter-utils): kill entire process tree on Windows when terminating runs

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1,10 +1,40 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import type {
   AdapterSkillEntry,
   AdapterSkillSnapshot,
 } from "./types.js";
+
+/**
+ * Kill a child process and its entire descendant tree.
+ *
+ * On Windows, `child.kill()` only terminates the direct child process.
+ * Grandchildren — such as MCP servers spawned by Claude CLI and the browser
+ * instances those servers launch — are left as orphaned background processes.
+ * These orphans accumulate across runs and cause "browser already in use"
+ * conflicts for agents that rely on browser automation (e.g. Playwright MCP).
+ *
+ * This function solves that by additionally running `taskkill /F /T /PID`
+ * on Windows, which traverses the entire process tree and force-terminates
+ * every descendant before they can be re-parented by the OS.
+ *
+ * `child.kill(signal)` is always called regardless of platform so that
+ * `child.killed` is set to `true` for downstream state-tracking checks.
+ */
+export function killChildProcess(child: ChildProcess, signal: "SIGTERM" | "SIGKILL"): void {
+  if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {
+    // Kill the entire process tree synchronously, while the children are
+    // still traceable via their parent PID. spawnSync ensures taskkill
+    // completes before child.kill() terminates the direct process — using
+    // async spawn().unref() here would race with child.kill() and lose,
+    // since TerminateProcess() is nearly instantaneous on Windows.
+    spawnSync("taskkill", ["/F", "/T", "/PID", String(child.pid)], {
+      stdio: "ignore",
+    });
+  }
+  child.kill(signal);
+}
 
 export interface RunProcessResult {
   exitCode: number | null;
@@ -814,10 +844,10 @@ export async function runChildProcess(
           opts.timeoutSec > 0
             ? setTimeout(() => {
                 timedOut = true;
-                child.kill("SIGTERM");
+                killChildProcess(child, "SIGTERM");
                 setTimeout(() => {
                   if (!child.killed) {
-                    child.kill("SIGKILL");
+                    killChildProcess(child, "SIGKILL");
                   }
                 }, Math.max(1, opts.graceSec) * 1000);
               }, opts.timeoutSec * 1000)

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -4,6 +4,7 @@
 import type { ChildProcess } from "node:child_process";
 import { logger } from "../middleware/logger.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 export type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 
 type BuildInvocationEnvForLogsOptions = {
@@ -33,6 +34,7 @@ export const ensurePathInEnv = serverUtils.ensurePathInEnv;
 export const ensureAbsoluteDirectory = serverUtils.ensureAbsoluteDirectory;
 export const ensureCommandResolvable = serverUtils.ensureCommandResolvable;
 export const resolveCommandForLogs = serverUtils.resolveCommandForLogs;
+export const killChildProcess = serverUtils.killChildProcess;
 
 export function buildInvocationEnvForLogs(
   env: Record<string, string>,
@@ -71,7 +73,6 @@ export function buildInvocationEnvForLogs(
 }
 
 // Re-export runChildProcess with the server's pino logger wired in.
-import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 const _runChildProcess = serverUtils.runChildProcess;
 
 export async function runChildProcess(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -23,7 +23,7 @@ import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
-import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES, killChildProcess } from "../adapters/utils.js";
 import { costService } from "./costs.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
@@ -3713,11 +3713,11 @@ export function heartbeatService(db: Db) {
 
     const running = runningProcesses.get(run.id);
     if (running) {
-      running.child.kill("SIGTERM");
+      killChildProcess(running.child, "SIGTERM");
       const graceMs = Math.max(1, running.graceSec) * 1000;
       setTimeout(() => {
         if (!running.child.killed) {
-          running.child.kill("SIGKILL");
+          killChildProcess(running.child, "SIGKILL");
         }
       }, graceMs);
     }
@@ -3769,7 +3769,7 @@ export function heartbeatService(db: Db) {
 
       const running = runningProcesses.get(run.id);
       if (running) {
-        running.child.kill("SIGTERM");
+        killChildProcess(running.child, "SIGTERM");
         runningProcesses.delete(run.id);
       }
       await releaseIssueExecutionAndPromote(run);


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents via local adapters that spawn child processes (Claude CLI, which in turn spawns MCP servers)
> - On Windows, Node.js `child.kill()` only terminates the direct child process — it does not traverse the process tree
> - MCP servers (e.g. `@playwright/mcp`) and their browser instances (Chrome/Chromium) are left as orphaned background processes
> - These orphans accumulate across runs and cause "browser already in use" conflicts for agents using browser automation
> - This PR uses `taskkill /F /T /PID` on Windows to kill the entire process tree when terminating runs
> - Prevents orphaned processes from accumulating during development and production use

## What

Add `killChildProcess(child, signal)` to `packages/adapter-utils/src/server-utils.ts` that:
- On **Windows**: runs `taskkill /F /T /PID <pid>` to force-kill all descendants, then calls `child.kill(signal)` to set `child.killed` for downstream state checks
- On **other platforms**: delegates directly to `child.kill(signal)` (existing behaviour)

Replace all `child.kill("SIGTERM")` / `child.kill("SIGKILL")` call sites in:
- `runChildProcess` timeout path (server-utils.ts)
- `cancelRunInternal` and `cancelActiveForAgentInternal` in heartbeat.ts

Export the helper via the `server/src/adapters/utils.ts` shim.

## Why

On Windows, `process.kill(pid)` only terminates the direct process, not its children. Long-running agent processes (MCP servers, compilers, bundlers, browser instances) become orphans that persist after the run ends. Users see accumulating `chrome.exe` / `node.exe` processes in Task Manager, and agents hit "browser already in use" errors on their next run.

## How to verify

1. Start a run on Windows that spawns child processes (e.g. an agent using `@playwright/mcp`)
2. Cancel or let the run complete naturally
3. Verify no orphaned child processes remain in Task Manager

## Risks

- `taskkill /F /T` is Windows-specific — gated behind `process.platform === "win32"` check
- Force-kill does not allow graceful shutdown for grandchildren — acceptable for run termination since MCP servers are ephemeral helpers with no important shutdown logic
- `child.kill(signal)` still runs after `taskkill`, which is redundant but harmless (signal to an already-dead process returns false silently)
- No change for non-Windows platforms

## Upstream Search Evidence

Searched `paperclipai/paperclip` open PRs before submitting:

- **Search terms:** `process tree kill windows`, `taskkill`, `win32 process`
- **Commands:**
  - `gh pr list --repo paperclipai/paperclip --state open --search "process tree kill windows"`
  - `gh pr list --repo paperclipai/paperclip --state open --search "taskkill"`
  - `gh pr list --repo paperclipai/paperclip --state open --search "win32 process"`
- **Found:** No matching upstream PRs addressing process tree cleanup
- **Conclusion:** No duplicate. Safe to submit.