### PR TITLE
fix(issues): treat never-started queued runs as stale on checkout

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -6,6 +6,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -676,5 +677,109 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     expect(followUp.executionWorkspaceSettings).toEqual({
       mode: "operator_branch",
     });
+  });
+});
+
+describeEmbeddedPostgres("issueService.checkout stale queued run lock", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-checkout-stale-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture(opts: { runCreatedAt: Date }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleRunId = randomUUID();
+    const newRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "running",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        status: "queued",
+        startedAt: null,
+        createdAt: opts.runCreatedAt,
+        updatedAt: opts.runCreatedAt,
+        invocationSource: "assignment",
+      },
+      {
+        id: newRunId,
+        companyId,
+        agentId,
+        status: "running",
+        invocationSource: "assignment",
+      },
+    ]);
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        id: randomUUID(),
+        companyId,
+        title: "Test issue",
+        status: "todo",
+        assigneeAgentId: agentId,
+        executionRunId: staleRunId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      })
+      .returning();
+    return { companyId, agentId, issueId: issue!.id, staleRunId, newRunId };
+  }
+
+  it("allows checkout when executionRunId points to a queued run older than 15 minutes", async () => {
+    const staleCreatedAt = new Date(Date.now() - 20 * 60 * 1000); // 20 minutes ago
+    const { agentId, issueId, newRunId } = await seedFixture({ runCreatedAt: staleCreatedAt });
+
+    const result = await svc.checkout(issueId, agentId, ["todo", "backlog", "blocked"], newRunId);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("in_progress");
+    expect(result?.executionRunId).toBe(newRunId);
+  });
+
+  it("blocks checkout when executionRunId points to a recently queued run (under 15 minutes)", async () => {
+    const freshCreatedAt = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+    const { agentId, issueId, newRunId } = await seedFixture({ runCreatedAt: freshCreatedAt });
+
+    await expect(
+      svc.checkout(issueId, agentId, ["todo", "backlog", "blocked"], newRunId),
+    ).rejects.toMatchObject({ status: 409 });
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -591,12 +591,20 @@ export function issueService(db: Db) {
 
   async function isTerminalOrMissingHeartbeatRun(runId: string) {
     const run = await db
-      .select({ status: heartbeatRuns.status })
+      .select({ status: heartbeatRuns.status, startedAt: heartbeatRuns.startedAt, createdAt: heartbeatRuns.createdAt })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
     if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+    // A queued run that never started and is older than 15 minutes is stale.
+    // This handles the case where a server restart or process failure left a
+    // "queued" run that will never be picked up by the original process.
+    if (run.status === "queued" && !run.startedAt) {
+      const ageMs = Date.now() - new Date(run.createdAt).getTime();
+      if (ageMs > 15 * 60 * 1000) return true;
+    }
+    return false;
   }
 
   async function adoptStaleCheckoutRun(input: {
@@ -1313,6 +1321,72 @@ export function issueService(db: Db) {
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
         const [enriched] = await withIssueLabels(db, [row]);
         return enriched;
+      }
+
+      // Handle stale executionRunId on non-in_progress issues (e.g. todo with orphaned queued run).
+      // The initial UPDATE above fails because executionLockCondition rejects a non-matching
+      // executionRunId. If that run is stale (terminal or never-started queued > 15min), clear
+      // the lock and retry the checkout.
+      if (
+        current.executionRunId &&
+        (!checkoutRunId || current.executionRunId !== checkoutRunId) &&
+        expectedStatuses.includes(current.status)
+      ) {
+        const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
+        if (stale) {
+          // Step 1: clear the stale lock atomically
+          await db
+            .update(issues)
+            .set({
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(issues.id, id),
+                eq(issues.executionRunId, current.executionRunId),
+                inArray(issues.status, expectedStatuses),
+              ),
+            );
+          // Step 2: retry the full checkout now that the lock is cleared
+          const retryPredicates = [
+            eq(issues.id, id),
+            inArray(issues.status, expectedStatuses),
+            isNull(issues.executionRunId),
+            or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
+          ];
+          if (checkoutRunId) {
+            retryPredicates.push(
+              or(
+                isNull(issues.checkoutRunId),
+                and(
+                  eq(issues.checkoutRunId, checkoutRunId),
+                  eq(issues.assigneeAgentId, agentId),
+                ),
+              ),
+            );
+          }
+          const retried = await db
+            .update(issues)
+            .set({
+              assigneeAgentId: agentId,
+              assigneeUserId: null,
+              checkoutRunId,
+              executionRunId: checkoutRunId,
+              status: "in_progress",
+              startedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(and(...retryPredicates))
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (retried) {
+            const [enriched] = await withIssueLabels(db, [retried]);
+            return enriched;
+          }
+        }
       }
 
       throw conflict("Issue checkout conflict", {


### PR DESCRIPTION
## Thinking Path
> - Paperclip uses execution locks on issues to ensure single-agent checkout semantics
> - Heartbeat runs progress: queued -> running -> succeeded/failed
> - When a server restarts or adapter crashes before a queued run starts, the run is left permanently orphaned with status "queued" and no startedAt
> - These orphaned runs hold executionRunId locks on issues, permanently blocking any agent from checking out the issue
> - `isTerminalOrMissingHeartbeatRun` only treated truly terminal statuses as stale, not never-started queued runs
> - This PR adds a 15-minute age threshold to also consider queued-but-never-started runs as stale, plus a two-step clear+retry bypass for non-in_progress issues with stale executionRunId locks

## What

1. **Extended `isTerminalOrMissingHeartbeatRun`** to return `true` for heartbeat runs that:
   - have `status = "queued"`
   - have no `startedAt` (never transitioned to "running")
   - were created more than 15 minutes ago

2. **Added stale executionRunId bypass** for issues in `expectedStatuses` (todo/backlog/blocked) whose `executionRunId` points to a stale run. Uses a two-step approach:
   - Step 1: Clear `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` using an optimistic lock on the old executionRunId value
   - Step 2: Retry the full checkout UPDATE with standard predicates

3. **Added regression tests** for the new staleness boundary (>15min stale vs <15min fresh).

## Why

After a server restart or adapter failure, "queued" runs with no `startedAt` will never progress. They permanently hold `executionRunId` locks, blocking checkout for assigned agents indefinitely. The existing `adoptStaleCheckoutRun` path only handles `in_progress` issues, so `todo`/`backlog`/`blocked` issues with orphaned executionRunId locks had no recovery path.

The 15-minute threshold is conservative — a healthy queued run should start within seconds on a properly running adapter.

## How to verify

1. Create an issue assigned to an agent with `executionRunId` pointing to a "queued" heartbeat run (no `startedAt`, created >15min ago)
2. Attempt to checkout the issue as the assignee
3. Confirm checkout succeeds and the stale lock is cleared

Or run the regression tests:
```sh
vitest run server/src/__tests__/issues-service.test.ts
```

## Risks

- Low: the 15-minute threshold is conservative enough to avoid false positives for slow-starting adapters
- A fresh "queued" run (<15min old) is correctly treated as non-stale, preserving the existing queueing behavior

## Upstream Search Evidence

Searched `paperclipai/paperclip` open PRs before submitting:

- **Search terms:** `stale queued run checkout`, `checkout lock`, `execution lock stale`
- **Commands:**
  - `gh pr list --repo paperclipai/paperclip --state open --search "stale queued run checkout"`
  - `gh pr list --repo paperclipai/paperclip --state open --search "checkout lock"`
  - `gh pr list --repo paperclipai/paperclip --state open --search "execution lock stale"`
- **Found:**
  - [#1971 — fix(issues): recover stale execution run lock on checkout](https://github.com/paperclipai/paperclip/pull/1971) — handles *in_progress* issues with stale terminal/missing execution run and no checkout lock. Different scenario.
  - [#1508 — fix: adopt stale execution lock on checkout](https://github.com/paperclipai/paperclip/pull/1508) — adds adoption path when `executionRunId` is stale but `checkoutRunId` is null. Addresses stale *terminal* runs; does not handle never-started *queued* runs.
  - [#2083 — fix: clear execution lock fields on issue release and auto-recover stale locks on checkout](https://github.com/paperclipai/paperclip/pull/2083) — focuses on release() cleanup and general stale lock recovery.
- **Conclusion:** No duplicate. The above PRs address stale *terminal/missing* execution runs. This PR specifically addresses the distinct scenario of heartbeat runs stuck in `queued` status that never had `startedAt` set (never-started queued runs). The fixes are complementary — this PR extends `isTerminalOrMissingHeartbeatRun` at the staleness-detection level, which the other PRs do not modify for the queued case.