### PR TITLE
fix: add meta description and Open Graph tags for social sharing

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,10 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Paperclip" />
+    <meta name="description" content="Open-source orchestration for AI agent teams. Manage goals, budgets, and agent coordination from one dashboard." />
+    <meta property="og:title" content="Paperclip" />
+    <meta property="og:description" content="Open-source orchestration for AI agent teams. Manage goals, budgets, and agent coordination from one dashboard." />
+    <meta property="og:type" content="website" />
     <title>Paperclip</title>
     <!-- PAPERCLIP_RUNTIME_BRANDING_START -->
     <!-- PAPERCLIP_RUNTIME_BRANDING_END -->


### PR DESCRIPTION
## Problem

The \`index.html\` was missing both \`<meta name="description">\` and Open Graph (\`og:\`) meta tags. When someone share a Paperclip URL on Slack, Discord, Twitter, or LinkedIn, the link preview show just "Paperclip" as title with blank description and no card content.

The page already had all the mobile web app meta tags (theme-color, apple-mobile-web-app, viewport) but the basic SEO and social sharing tags was not there.

## What I changed

Added 4 meta tags:
- \`<meta name="description">\` - for search engines and browser bookmarks
- \`<meta property="og:title">\` - title for social sharing cards
- \`<meta property="og:description">\` - description for social sharing cards
- \`<meta property="og:type">\` - "website" type identifier

All use a short description matching the project README: "Open-source orchestration for AI agent teams. Manage goals, budgets, and agent coordination from one dashboard."

## How to test

1. Deploy and share the URL on Slack or Discord
2. Link preview should now show title "Paperclip" with description text
3. Check page source to verify meta tags are present

1 file, 4 lines added.