### PR TITLE
docs: fix silent npx install failure on macOS with Homebrew libvips

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ npx paperclipai onboard --yes
 
 If you already have Paperclip configured, rerunning `onboard` keeps the existing config in place. Use `paperclipai configure` to edit settings.
 
+> **macOS troubleshooting:** If `npx paperclipai onboard` silently exits with no output, you likely have `libvips` installed via Homebrew. This causes the `sharp` dependency to attempt a source build instead of using its prebuilt binary, which fails silently. Fix with:
+>
+> ```bash
+> SHARP_IGNORE_GLOBAL_LIBVIPS=1 npx paperclipai onboard --yes
+> ```
+
 Or manually:
 
 ```bash


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates ai-agents for zero-human companies
> - The quickstart path is `npx paperclipai onboard --yes`
> - But this silently fails on macOS when Homebrew libvips is installed
> - Because `sharp@0.34.5`'s install script detects global libvips via `pkg-config` and forces a source build
> - The source build fails (missing `node-addon-api`), and npx swallows the error — zero output shown
> - Any macOS dev who has ever run `brew install vips` (common for Ruby/Python image processing) hits this
> - This PR adds a troubleshooting note to the Quickstart section with the workaround
> - The benefit is users can self-diagnose instead of thinking the tool is broken

## Summary

- Adds a troubleshooting callout to the Quickstart section documenting the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` workaround
- References #2273 which has the full root cause analysis and debug logs

## Details

**Root cause chain:**
1. `sharp/install/check.js` calls `useGlobalLibvips()` → finds Homebrew vips via `pkg-config --modversion vips-cpp` → `process.exit(1)`
2. npm falls through to `npm run build` → `sharp/install/build.js`
3. Build fails: "Please add node-addon-api to your dependencies"
4. npm/npx exit code 1 with **no error shown to user**

**Environment:** macOS (Apple Silicon), Node.js 22, npm 11, Homebrew vips 8.18.0

## Test plan

- [ ] On a Mac with `brew install vips`, run `npx paperclipai onboard --yes` — fails silently (reproduces bug)
- [ ] Run `SHARP_IGNORE_GLOBAL_LIBVIPS=1 npx paperclipai onboard --yes` — onboarding UI appears (workaround works)
- [ ] README renders correctly on GitHub

Fixes #2273