### PR TITLE
docs(skills): document directory setup prerequisite for para-memory-files

### DIFF
--- a/skills/para-memory-files/SKILL.md
+++ b/skills/para-memory-files/SKILL.md
@@ -14,6 +14,18 @@ description: >
 
 Persistent, file-based memory organized by Tiago Forte's PARA method. Three layers: a knowledge graph, daily notes, and tacit knowledge. All paths are relative to `$AGENT_HOME`.
 
+## Directory Setup (required before first use)
+
+This skill is a prompt — it cannot create directories automatically. Before writing any memory files, ensure these directories exist under `$AGENT_HOME`:
+
+```bash
+mkdir -p "$AGENT_HOME/life/projects" "$AGENT_HOME/life/areas/people" \
+         "$AGENT_HOME/life/areas/companies" "$AGENT_HOME/life/resources" \
+         "$AGENT_HOME/life/archives" "$AGENT_HOME/memory"
+```
+
+If any path is missing on first write, create it. Do not assume lazy creation is handled elsewhere.
+
 ## Three Memory Layers
 
 ### Layer 1: Knowledge Graph (`$AGENT_HOME/life/` -- PARA)


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents for autonomous companies
> - Agents use the para-memory-files skill for persistent file-based memory (PARA method)
> - The skill is a prompt — it cannot create directories automatically
> - Agents that start with a clean $AGENT_HOME fail on first write because the PARA directory structure does not exist
> - This PR documents the required directory setup as a prerequisite in the SKILL.md
> - Prevents silent failures and ensures agents can write memory files from the first heartbeat

## What

Adds a "Directory Setup (required before first use)" section to `skills/para-memory-files/SKILL.md` with a `mkdir -p` command that creates all required PARA directories under `$AGENT_HOME`.

## Why

The skill references paths like `$AGENT_HOME/life/projects/`, `$AGENT_HOME/memory/`, etc., but these directories don't exist by default. Agents following the skill's instructions fail on first write. Making the prerequisite explicit prevents this.

## How to verify

1. Read `skills/para-memory-files/SKILL.md` — the new section should appear after the frontmatter and before the memory layers documentation.
2. Confirm the `mkdir -p` command creates all 6 required directories.

## Risks

None — documentation-only change, no code modifications.

## Upstream Search Evidence

Searched `paperclipai/paperclip` open PRs before submitting:

- **Search terms:** `para-memory`, `agent home directory`, `memory setup`
- **Command:** `gh pr list --repo paperclipai/paperclip --state open --search "para-memory"`
- **Found:** #461 (agent persistent memory store) — different scope (feature, not docs). #1779 (bootstrap agent home) — bootstraps PARA skeleton but doesn't document the prerequisite in the skill itself.
- **Conclusion:** No duplicate. #1779 is complementary (server-side bootstrap vs skill-side documentation). Safe to submit.