### PR TITLE
Fix plugin entity scope filtering for company-scoped queries

### DIFF
--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -354,6 +354,10 @@ export interface PluginConfig {
 export interface PluginEntityQuery {
   /** Optional filter by entity type (e.g. 'project', 'issue'). */
   entityType?: string;
+  /** Optional filter by scope kind. */
+  scopeKind?: PluginStateScopeKind;
+  /** Optional filter by scope identifier. */
+  scopeId?: string;
   /** Optional filter by external system identifier. */
   externalId?: string;
   /** Maximum number of records to return. Defaults to 100. */

--- a/server/src/services/plugin-registry.ts
+++ b/server/src/services/plugin-registry.ts
@@ -399,6 +399,8 @@ export function pluginRegistryService(db: Db) {
     listEntities: (pluginId: string, query?: PluginEntityQuery) => {
       const conditions = [eq(pluginEntities.pluginId, pluginId)];
       if (query?.entityType) conditions.push(eq(pluginEntities.entityType, query.entityType));
+      if (query?.scopeKind) conditions.push(eq(pluginEntities.scopeKind, query.scopeKind));
+      if (query?.scopeId) conditions.push(eq(pluginEntities.scopeId, query.scopeId));
       if (query?.externalId) conditions.push(eq(pluginEntities.externalId, query.externalId));
 
       return db


### PR DESCRIPTION
## Thinking Path

A workflow-engine bug surfaced in production: newly started company-scoped workflow runs were not showing up in `activeRuns` / `recentRuns`, and duplicate human-readable run labels were being generated.

Tracing the flow from the workflow plugin down to core entity storage showed that plugins were correctly calling:

```ts
ctx.entities.list({
  entityType,
  scopeKind: "company",
  scopeId: companyId,
})
```

But the server-side plugin registry did not apply `scopeKind` / `scopeId` filters in `listEntities()`. In practice, that turned company-scoped reads into plugin-wide reads, ordered oldest-first and truncated by the default limit. The workflow plugin then operated on incomplete company history, which explains both the missing recent runs and the duplicated run labels.

## Problem

Plugins can query entities with company scope:

```ts
ctx.entities.list({
  entityType,
  scopeKind: "company",
  scopeId: companyId,
})
```

However, the server-side plugin registry currently ignores `scopeKind` and `scopeId` in `listEntities()`.

That means company-scoped entity reads are effectively plugin-wide reads, ordered by oldest rows first and truncated by the default limit.

This caused a real workflow-engine issue:

- latest workflow runs were missing from `activeRuns` / `recentRuns`
- run label generation used incomplete history
- duplicate human-readable run labels were generated

## Root Cause

`server/src/services/plugin-registry.ts`

`listEntities()` filtered by:

- `pluginId`
- `entityType`
- `externalId`

but not by:

- `scopeKind`
- `scopeId`

Also, the shared `PluginEntityQuery` type did not expose those fields even though the SDK side already expected them.

## Fix

1. Add `scopeKind` and `scopeId` to the shared `PluginEntityQuery` type.
2. Apply both filters in `pluginRegistry.listEntities()` when present.

## Why It Matters

This is a core bug, not a workflow-only bug. Any plugin that relies on company-scoped plugin entities can be affected by the same incorrect cross-company mixing.

## Verification

- Confirmed the workflow plugin was already passing `scopeKind: "company"` and `scopeId` correctly.
- Reproduced the bad behavior where company-specific workflow runs disappeared from recent/active views once enough plugin-wide entity rows existed.
- Verified the fix is limited to the shared query type plus the server-side registry filter.
- Verified the PR now contains only the intended two-file diff.

## Risk

Low.

- The change only applies additional filters when `scopeKind` / `scopeId` are explicitly provided.
- Existing unscoped entity queries continue to behave the same.

## Notes

I also added plugin-side pagination in workflow-engine/tool-registry in a separate deployment repo as a defensive mitigation, but the server-side scope filtering is the actual fix.
