### PR TITLE
fix: recover cleanly from stale codex resume sessions

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -9,13 +9,12 @@ import {
   asStringArray,
   parseObject,
   buildPaperclipEnv,
-  buildInvocationEnvForLogs,
+  redactEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
-  resolveCommandForLogs,
   resolvePaperclipDesiredSkillNames,
   renderTemplate,
   renderPaperclipWakePrompt,
@@ -390,12 +389,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveCodexBillingType(effectiveEnv);
   const runtimeEnv = ensurePathInEnv(effectiveEnv);
   await ensureCommandResolvable(command, cwd, runtimeEnv);
-  const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
-  const loggedEnv = buildInvocationEnvForLogs(env, {
-    runtimeEnv,
-    includeRuntimeKeys: ["HOME"],
-    resolvedCommand,
-  });
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
@@ -516,14 +509,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (onMeta) {
       await onMeta({
         adapterType: "codex_local",
-        command: resolvedCommand,
+        command,
         cwd,
         commandNotes,
         commandArgs: args.map((value, idx) => {
           if (idx === args.length - 1 && value !== "-") return `<prompt ${prompt.length} chars>`;
           return value;
         }),
-        env: loggedEnv,
+        env: redactEnvForLogs(env),
         prompt,
         promptMetrics,
         context,
@@ -572,7 +565,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       };
     }
 
-    const resolvedSessionId = attempt.parsed.sessionId ?? runtimeSessionId ?? runtime.sessionId ?? null;
+    const fallbackSessionId =
+      clearSessionOnMissingSession
+        ? null
+        : (runtimeSessionId || runtime.sessionId || null);
+    const resolvedSessionId = attempt.parsed.sessionId ?? fallbackSessionId;
     const resolvedSessionParams = resolvedSessionId
       ? ({
         sessionId: resolvedSessionId,

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -9,12 +9,14 @@ import {
   asStringArray,
   parseObject,
   buildPaperclipEnv,
+  buildInvocationEnvForLogs,
   redactEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
+  resolveCommandForLogs,
   resolvePaperclipDesiredSkillNames,
   renderTemplate,
   renderPaperclipWakePrompt,
@@ -389,6 +391,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveCodexBillingType(effectiveEnv);
   const runtimeEnv = ensurePathInEnv(effectiveEnv);
   await ensureCommandResolvable(command, cwd, runtimeEnv);
+  const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
+  const loggedEnv = buildInvocationEnvForLogs(env, {
+    runtimeEnv,
+    includeRuntimeKeys: ["HOME"],
+    resolvedCommand,
+  });
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
@@ -509,14 +517,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (onMeta) {
       await onMeta({
         adapterType: "codex_local",
-        command,
+        command: resolvedCommand,
         cwd,
         commandNotes,
         commandArgs: args.map((value, idx) => {
           if (idx === args.length - 1 && value !== "-") return `<prompt ${prompt.length} chars>`;
           return value;
         }),
-        env: redactEnvForLogs(env),
+        env: loggedEnv,
         prompt,
         promptMetrics,
         context,

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -67,7 +67,7 @@ export function isCodexUnknownSessionError(stdout: string, stderr: string): bool
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
-  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path|no rollout found for thread id/i.test(
+  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path|no rollout found for thread id|no rollout found for thread|this session was recorded with model .* but is resuming with/i.test(
     haystack,
   );
 }

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -122,6 +122,12 @@ describe("codex resume recovery detection", () => {
     ).toBe(true);
     expect(
       isCodexUnknownSessionError(
+        '{"type":"error","message":"thread/resume failed: no rollout found for thread id abc"}',
+        "",
+      ),
+    ).toBe(true);
+    expect(
+      isCodexUnknownSessionError(
         '{"type":"result","ok":true}',
         "",
       ),

--- a/server/src/__tests__/codex-local-adapter.test.ts
+++ b/server/src/__tests__/codex-local-adapter.test.ts
@@ -31,6 +31,18 @@ describe("codex_local stale session detection", () => {
 
     expect(isCodexUnknownSessionError("", stderr)).toBe(true);
   });
+
+  it("treats model-mismatch resume errors as an unknown session error", () => {
+    const stdout = JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "error",
+        message: "This session was recorded with model `claude-sonnet-4` but is resuming with `gpt-5-nano`.",
+      },
+    });
+
+    expect(isCodexUnknownSessionError(stdout, "")).toBe(true);
+  });
 });
 
 describe("codex_local ui stdout parser", () => {

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -29,6 +29,70 @@ console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, c
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeRetryingFakeCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const argv = process.argv.slice(2);
+const captures = capturePath && fs.existsSync(capturePath)
+  ? JSON.parse(fs.readFileSync(capturePath, "utf8"))
+  : [];
+captures.push(argv);
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(captures), "utf8");
+}
+
+const resumeIdx = argv.indexOf("resume");
+if (resumeIdx !== -1) {
+  const threadId = argv[resumeIdx + 1] || "unknown-thread";
+  console.log(JSON.stringify({
+    type: "error",
+    message: "thread/resume: thread/resume failed: no rollout found for thread id " + threadId,
+  }));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "fresh retry completed" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+async function writeRetryingModelMismatchCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const argv = process.argv.slice(2);
+const captures = capturePath && fs.existsSync(capturePath)
+  ? JSON.parse(fs.readFileSync(capturePath, "utf8"))
+  : [];
+captures.push(argv);
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(captures), "utf8");
+}
+
+const resumeIdx = argv.indexOf("resume");
+if (resumeIdx !== -1) {
+  console.log(JSON.stringify({
+    type: "item.completed",
+    item: {
+      type: "error",
+      message: "This session was recorded with model \`claude-sonnet-4\` but is resuming with \`gpt-5-nano\`.",
+    },
+  }));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "fresh retry after model swap" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 type CapturePayload = {
   argv: string[];
   prompt: string;
@@ -669,6 +733,151 @@ describe("codex execute", () => {
       else process.env.PAPERCLIP_IN_WORKTREE = previousPaperclipInWorktree;
       if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
       else process.env.CODEX_HOME = previousCodexHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("clears stale resume sessions when a fresh retry succeeds without a replacement session id", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-retry-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeRetryingFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const logs: LogEntry[] = [];
+      const result = await execute({
+        runId: "run-retry",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "stale-thread",
+          sessionParams: {
+            sessionId: "stale-thread",
+            cwd: workspace,
+          },
+          sessionDisplayId: "stale-thread",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => {
+          logs.push({ stream, chunk });
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(result.clearSession).toBe(true);
+      expect(result.sessionId).toBeNull();
+      expect(result.sessionParams).toBeNull();
+      expect(result.sessionDisplayId).toBeNull();
+      expect(result.summary).toBe("fresh retry completed");
+
+      const captures = JSON.parse(await fs.readFile(capturePath, "utf8")) as string[][];
+      expect(captures).toHaveLength(2);
+      expect(captures[0]).toEqual(expect.arrayContaining(["resume", "stale-thread", "-"]));
+      expect(captures[1]).toEqual(expect.arrayContaining(["exec", "--json", "-"]));
+      expect(captures[1]).not.toContain("resume");
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining('retrying with a fresh session'),
+        }),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries with a fresh session when Codex rejects resume after a model change", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-model-mismatch-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeRetryingModelMismatchCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const logs: LogEntry[] = [];
+      const result = await execute({
+        runId: "run-model-swap",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "old-thread",
+          sessionParams: {
+            sessionId: "old-thread",
+            cwd: workspace,
+          },
+          sessionDisplayId: "old-thread",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "gpt-5-nano",
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Continue after model swap.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => {
+          logs.push({ stream, chunk });
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(result.clearSession).toBe(true);
+      expect(result.sessionId).toBeNull();
+      expect(result.sessionParams).toBeNull();
+      expect(result.sessionDisplayId).toBeNull();
+      expect(result.summary).toBe("fresh retry after model swap");
+
+      const captures = JSON.parse(await fs.readFile(capturePath, "utf8")) as string[][];
+      expect(captures).toHaveLength(2);
+      expect(captures[0]).toEqual(expect.arrayContaining(["resume", "old-thread", "-"]));
+      expect(captures[1]).toEqual(expect.arrayContaining(["exec", "--json", "--model", "gpt-5-nano", "-"]));
+      expect(captures[1]).not.toContain("resume");
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining('retrying with a fresh session'),
+        }),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
       await fs.rm(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- clear stale Codex resume session ids when a retry needs to start fresh
- treat model-mismatch resume errors the same way as missing-rollout resume failures
- add regression coverage for both missing rollout and model-swap retry flows

## Testing
- pnpm exec vitest run server/src/__tests__/codex-local-adapter.test.ts server/src/__tests__/codex-local-execute.test.ts server/src/__tests__/adapter-session-codecs.test.ts
- pnpm --filter @paperclipai/server typecheck
- pnpm --filter @paperclipai/adapter-codex-local typecheck

Closes #2088
Closes #2159
