### PR TITLE
fix: handle missing codex binary during quota checks

### DIFF
--- a/packages/adapters/codex-local/src/server/quota.ts
+++ b/packages/adapters/codex-local/src/server/quota.ts
@@ -425,20 +425,20 @@ class CodexRpcClient {
     this.proc.stderr.on("data", (chunk: string) => {
       this.stderr += chunk;
     });
+    this.proc.on("error", (error) => {
+      this.failPending(error.message);
+    });
     this.proc.on("exit", () => {
-      for (const request of this.pending.values()) {
-        clearTimeout(request.timer);
-        request.reject(new Error(this.stderr.trim() || "codex app-server closed unexpectedly"));
-      }
-      this.pending.clear();
+      this.failPending(this.stderr.trim() || "codex app-server closed unexpectedly");
     });
-    this.proc.on("error", (err: Error) => {
-      for (const request of this.pending.values()) {
-        clearTimeout(request.timer);
-        request.reject(err);
-      }
-      this.pending.clear();
-    });
+  }
+
+  private failPending(message: string) {
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error(message));
+    }
+    this.pending.clear();
   }
 
   private onStdout(chunk: string) {

--- a/server/src/__tests__/quota-windows-codex-spawn.test.ts
+++ b/server/src/__tests__/quota-windows-codex-spawn.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const proc = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+      stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+      stdin: { write: (chunk: string) => boolean };
+      kill: (signal?: string) => boolean;
+    };
+    proc.stdout = Object.assign(new EventEmitter(), {
+      setEncoding: vi.fn(),
+    });
+    proc.stderr = Object.assign(new EventEmitter(), {
+      setEncoding: vi.fn(),
+    });
+    proc.stdin = {
+      write: vi.fn(() => true),
+    };
+    proc.kill = vi.fn(() => true);
+
+    queueMicrotask(() => {
+      proc.emit("error", new Error("spawn codex ENOENT"));
+    });
+
+    return proc;
+  }),
+}));
+
+describe("codex quota spawn failure", () => {
+  it("returns an error result instead of crashing when the codex binary is missing", async () => {
+    const savedCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = path.join(
+      os.tmpdir(),
+      `paperclip-missing-codex-auth-${Date.now()}`
+    );
+    const { getQuotaWindows } = await import("@paperclipai/adapter-codex-local/server");
+
+    try {
+      await expect(getQuotaWindows()).resolves.toEqual({
+        provider: "openai",
+        ok: false,
+        error: expect.stringContaining("spawn codex ENOENT"),
+        windows: [],
+      });
+    } finally {
+      if (savedCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = savedCodexHome;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- handle Codex child-process spawn failures inside the quota RPC client
- reject pending requests instead of crashing the server when the Codex binary is missing
- add regression coverage for the missing-binary quota path

## Testing
- pnpm exec vitest run server/src/__tests__/quota-windows-codex-spawn.test.ts server/src/__tests__/quota-windows.test.ts
- pnpm --filter @paperclipai/server typecheck
- pnpm --filter @paperclipai/adapter-codex-local typecheck

Closes #2140
