### PR TITLE
fix: load the configured instructions entry file reliably

### DIFF
--- a/ui/src/lib/agent-instructions.test.ts
+++ b/ui/src/lib/agent-instructions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { instructionsBundleHasFile } from "./agent-instructions";
+
+describe("instructionsBundleHasFile", () => {
+  it("treats the configured entry file as existing even when it is missing from file metadata", () => {
+    expect(instructionsBundleHasFile({
+      bundleMatchesDraft: true,
+      currentEntryFile: "AGENTS.md",
+      selectedFile: "AGENTS.md",
+      fileOptions: ["HEARTBEAT.md"],
+    })).toBe(true);
+  });
+
+  it("does not treat unrelated missing files as existing", () => {
+    expect(instructionsBundleHasFile({
+      bundleMatchesDraft: true,
+      currentEntryFile: "AGENTS.md",
+      selectedFile: "TOOLS.md",
+      fileOptions: ["HEARTBEAT.md"],
+    })).toBe(false);
+  });
+
+  it("returns false while the visible bundle no longer matches the persisted draft", () => {
+    expect(instructionsBundleHasFile({
+      bundleMatchesDraft: false,
+      currentEntryFile: "AGENTS.md",
+      selectedFile: "AGENTS.md",
+      fileOptions: ["AGENTS.md"],
+    })).toBe(false);
+  });
+});

--- a/ui/src/lib/agent-instructions.test.ts
+++ b/ui/src/lib/agent-instructions.test.ts
@@ -11,6 +11,15 @@ describe("instructionsBundleHasFile", () => {
     })).toBe(true);
   });
 
+  it("returns true when the file is already present in fileOptions", () => {
+    expect(instructionsBundleHasFile({
+      bundleMatchesDraft: true,
+      currentEntryFile: "AGENTS.md",
+      selectedFile: "AGENTS.md",
+      fileOptions: ["AGENTS.md", "HEARTBEAT.md"],
+    })).toBe(true);
+  });
+
   it("does not treat unrelated missing files as existing", () => {
     expect(instructionsBundleHasFile({
       bundleMatchesDraft: true,

--- a/ui/src/lib/agent-instructions.ts
+++ b/ui/src/lib/agent-instructions.ts
@@ -1,0 +1,10 @@
+export function instructionsBundleHasFile(input: {
+  bundleMatchesDraft: boolean;
+  currentEntryFile: string;
+  selectedFile: string;
+  fileOptions: string[];
+}): boolean {
+  if (!input.bundleMatchesDraft) return false;
+  if (input.selectedFile === input.currentEntryFile) return true;
+  return input.fileOptions.includes(input.selectedFile);
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -91,6 +91,7 @@ import {
 } from "@paperclipai/shared";
 import { redactHomePathUserSegments, redactHomePathUserSegmentsInValue } from "@paperclipai/adapter-utils";
 import { agentRouteRef } from "../lib/utils";
+import { instructionsBundleHasFile } from "../lib/agent-instructions";
 import {
   applyAgentSkillSnapshot,
   arraysEqual,
@@ -1691,7 +1692,12 @@ function PromptsTab({
     [visibleFilePaths],
   );
   const selectedOrEntryFile = selectedFile || currentEntryFile;
-  const selectedFileExists = bundleMatchesDraft && fileOptions.includes(selectedOrEntryFile);
+  const selectedFileExists = instructionsBundleHasFile({
+    bundleMatchesDraft,
+    currentEntryFile,
+    selectedFile: selectedOrEntryFile,
+    fileOptions,
+  });
   const selectedFileSummary = bundle?.files.find((file) => file.path === selectedOrEntryFile) ?? null;
 
   const { data: selectedFileDetail, isLoading: fileLoading } = useQuery({
@@ -2176,7 +2182,14 @@ function PromptsTab({
             })}
             onSelectFile={(filePath) => {
               setSelectedFile(filePath);
-              if (!fileOptions.includes(filePath)) setDraft("");
+              if (!instructionsBundleHasFile({
+                bundleMatchesDraft,
+                currentEntryFile,
+                selectedFile: filePath,
+                fileOptions,
+              })) {
+                setDraft("");
+              }
               if (isMobile) setShowFilePanel(false);
             }}
             onToggleCheck={() => {}}


### PR DESCRIPTION
## Summary
- treat the configured instructions entry file as present even when bundle metadata omits it
- restore loading and editing for entry files like AGENTS.md instead of creating empty drafts
- add focused coverage for the bundle-file detection helper

## Testing
- pnpm exec vitest run ui/src/lib/agent-instructions.test.ts
- pnpm --filter @paperclipai/ui typecheck

Closes #2068
