### PR TITLE
fix: preserve skill file edits and support deleting skills

### DIFF
--- a/ui/src/api/companySkills.ts
+++ b/ui/src/api/companySkills.ts
@@ -31,6 +31,10 @@ export const companySkillsApi = {
       `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}/files`,
       { path, content },
     ),
+  delete: (companyId: string, skillId: string) =>
+    api.delete<CompanySkill>(
+      `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}`,
+    ),
   create: (companyId: string, payload: CompanySkillCreateRequest) =>
     api.post<CompanySkill>(
       `/companies/${encodeURIComponent(companyId)}/skills`,

--- a/ui/src/api/companySkills.ts
+++ b/ui/src/api/companySkills.ts
@@ -55,8 +55,4 @@ export const companySkillsApi = {
       `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}/install-update`,
       {},
     ),
-  delete: (companyId: string, skillId: string) =>
-    api.delete<CompanySkill>(
-      `/companies/${encodeURIComponent(companyId)}/skills/${encodeURIComponent(skillId)}`,
-    ),
 };

--- a/ui/src/lib/company-skill-editor.test.ts
+++ b/ui/src/lib/company-skill-editor.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCompanySkillSaveContent,
+  getCompanySkillEditorDraft,
+  mergeSkillFrontmatter,
+  splitSkillFrontmatter,
+} from "./company-skill-editor";
+
+describe("company skill editor helpers", () => {
+  const markdownFile = {
+    markdown: true,
+    content: [
+      "---",
+      "name: demo-skill",
+      "description: demo",
+      "---",
+      "",
+      "# Demo",
+      "",
+      "Body text",
+      "",
+    ].join("\n"),
+  };
+
+  it("splits frontmatter from markdown skill files", () => {
+    expect(splitSkillFrontmatter(markdownFile.content)).toEqual({
+      frontmatter: "name: demo-skill\ndescription: demo",
+      body: "# Demo\n\nBody text\n",
+    });
+  });
+
+  it("keeps frontmatter when saving preview-mode markdown edits", () => {
+    expect(mergeSkillFrontmatter(markdownFile.content, "# Demo\n\nUpdated body\n")).toContain("name: demo-skill");
+    expect(buildCompanySkillSaveContent(markdownFile, "# Demo\n\nUpdated body\n", "preview")).toContain("Updated body");
+  });
+
+  it("returns raw markdown in code mode so frontmatter can be edited", () => {
+    expect(getCompanySkillEditorDraft(markdownFile, "code")).toBe(markdownFile.content);
+    expect(buildCompanySkillSaveContent(markdownFile, "---\nname: renamed\n---\n\n# Demo\n", "code")).toBe(
+      "---\nname: renamed\n---\n\n# Demo\n",
+    );
+  });
+
+  it("treats non-markdown files as raw text", () => {
+    const file = { markdown: false, content: "echo hello\n" };
+    expect(getCompanySkillEditorDraft(file, "preview")).toBe("echo hello\n");
+    expect(buildCompanySkillSaveContent(file, "echo updated\n", "preview")).toBe("echo updated\n");
+  });
+});

--- a/ui/src/lib/company-skill-editor.ts
+++ b/ui/src/lib/company-skill-editor.ts
@@ -1,0 +1,41 @@
+import type { CompanySkillFileDetail } from "@paperclipai/shared";
+
+export function splitSkillFrontmatter(markdown: string): { frontmatter: string | null; body: string } {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return { frontmatter: null, body: normalized };
+  }
+  const closing = normalized.indexOf("\n---\n", 4);
+  if (closing < 0) {
+    return { frontmatter: null, body: normalized };
+  }
+  return {
+    frontmatter: normalized.slice(4, closing).trim(),
+    body: normalized.slice(closing + 5).trimStart(),
+  };
+}
+
+export function mergeSkillFrontmatter(markdown: string, body: string) {
+  const parsed = splitSkillFrontmatter(markdown);
+  if (!parsed.frontmatter) return body;
+  return ["---", parsed.frontmatter, "---", "", body].join("\n");
+}
+
+export function getCompanySkillEditorDraft(
+  file: Pick<CompanySkillFileDetail, "content" | "markdown"> | null | undefined,
+  viewMode: "preview" | "code",
+) {
+  if (!file) return "";
+  if (!file.markdown || viewMode === "code") return file.content;
+  return splitSkillFrontmatter(file.content).body;
+}
+
+export function buildCompanySkillSaveContent(
+  file: Pick<CompanySkillFileDetail, "content" | "markdown"> | null | undefined,
+  draft: string,
+  viewMode: "preview" | "code",
+) {
+  if (!file) return draft;
+  if (!file.markdown || viewMode === "code") return draft;
+  return mergeSkillFrontmatter(file.content, draft);
+}

--- a/ui/src/lib/company-skill-editor.ts
+++ b/ui/src/lib/company-skill-editor.ts
@@ -5,13 +5,19 @@ export function splitSkillFrontmatter(markdown: string): { frontmatter: string |
   if (!normalized.startsWith("---\n")) {
     return { frontmatter: null, body: normalized };
   }
-  const closing = normalized.indexOf("\n---\n", 4);
+  let closing = normalized.indexOf("\n---\n", 4);
   if (closing < 0) {
-    return { frontmatter: null, body: normalized };
+    // Handle file ending with --- and no trailing newline
+    if (normalized.endsWith("\n---")) {
+      closing = normalized.length - 4;
+    } else {
+      return { frontmatter: null, body: normalized };
+    }
   }
+  const afterClosing = closing + 4 < normalized.length ? normalized.slice(closing + 5).trimStart() : "";
   return {
     frontmatter: normalized.slice(4, closing).trim(),
-    body: normalized.slice(closing + 5).trimStart(),
+    body: afterClosing,
   };
 }
 

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -21,6 +21,11 @@ import { MarkdownBody } from "../components/MarkdownBody";
 import { MarkdownEditor } from "../components/MarkdownEditor";
 import { PageSkeleton } from "../components/PageSkeleton";
 import {
+  buildCompanySkillSaveContent,
+  getCompanySkillEditorDraft,
+  splitSkillFrontmatter,
+} from "../lib/company-skill-editor";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -76,32 +81,7 @@ function VercelMark(props: SVGProps<SVGSVGElement>) {
 }
 
 function stripFrontmatter(markdown: string) {
-  const normalized = markdown.replace(/\r\n/g, "\n");
-  if (!normalized.startsWith("---\n")) return normalized.trim();
-  const closing = normalized.indexOf("\n---\n", 4);
-  if (closing < 0) return normalized.trim();
-  return normalized.slice(closing + 5).trim();
-}
-
-function splitFrontmatter(markdown: string): { frontmatter: string | null; body: string } {
-  const normalized = markdown.replace(/\r\n/g, "\n");
-  if (!normalized.startsWith("---\n")) {
-    return { frontmatter: null, body: normalized };
-  }
-  const closing = normalized.indexOf("\n---\n", 4);
-  if (closing < 0) {
-    return { frontmatter: null, body: normalized };
-  }
-  return {
-    frontmatter: normalized.slice(4, closing).trim(),
-    body: normalized.slice(closing + 5).trimStart(),
-  };
-}
-
-function mergeFrontmatter(markdown: string, body: string) {
-  const parsed = splitFrontmatter(markdown);
-  if (!parsed.frontmatter) return body;
-  return ["---", parsed.frontmatter, "---", "", body].join("\n");
+  return splitSkillFrontmatter(markdown).body.trim();
 }
 
 function buildTree(entries: CompanySkillFileInventoryEntry[]) {
@@ -727,7 +707,7 @@ function SkillPane({
         ) : !file ? (
           <div className="text-sm text-muted-foreground">Select a file to inspect.</div>
         ) : editMode && file.editable ? (
-          file.markdown ? (
+          file.markdown && viewMode === "preview" ? (
             <MarkdownEditor
               value={draft}
               onChange={setDraft}
@@ -859,14 +839,20 @@ export function CompanySkills() {
   useEffect(() => {
     if (fileQuery.data) {
       setDisplayedFile(fileQuery.data);
-      setDraft(fileQuery.data.markdown ? splitFrontmatter(fileQuery.data.content).body : fileQuery.data.content);
     }
   }, [fileQuery.data]);
+
+  useEffect(() => {
+    const nextFile = fileQuery.data ?? displayedFile;
+    if (!nextFile || editMode) return;
+    setDraft(getCompanySkillEditorDraft(nextFile, viewMode));
+  }, [displayedFile, editMode, fileQuery.data, viewMode]);
 
   useEffect(() => {
     if (selectedSkillId) return;
     setDisplayedDetail(null);
     setDisplayedFile(null);
+    setDraft("");
   }, [selectedSkillId]);
 
   const activeDetail = detailQuery.data ?? displayedDetail;
@@ -975,15 +961,16 @@ export function CompanySkills() {
       selectedCompanyId!,
       selectedSkillId!,
       selectedPath,
-      activeFile?.markdown ? mergeFrontmatter(activeFile.content, draft) : draft,
+      buildCompanySkillSaveContent(activeFile, draft, viewMode),
     ),
     onSuccess: async (result) => {
+      setDisplayedFile(result);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.detail(selectedCompanyId!, selectedSkillId!) }),
         queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.file(selectedCompanyId!, selectedSkillId!, selectedPath) }),
       ]);
-      setDraft(result.markdown ? splitFrontmatter(result.content).body : result.content);
+      setDraft(getCompanySkillEditorDraft(result, viewMode));
       setEditMode(false);
       pushToast({
         tone: "success",
@@ -996,6 +983,41 @@ export function CompanySkills() {
         tone: "error",
         title: "Save failed",
         body: error instanceof Error ? error.message : "Failed to save skill file.",
+      });
+    },
+  });
+
+  const deleteSkill = useMutation({
+    mutationFn: () => companySkillsApi.delete(selectedCompanyId!, selectedSkillId!),
+    onSuccess: async (deletedSkill) => {
+      const remainingSkills = (skillsQuery.data ?? []).filter((skill) => skill.id !== deletedSkill.id);
+      queryClient.setQueryData(queryKeys.companySkills.list(selectedCompanyId!), remainingSkills);
+      queryClient.removeQueries({
+        queryKey: queryKeys.companySkills.detail(selectedCompanyId!, deletedSkill.id),
+      });
+      queryClient.removeQueries({
+        queryKey: ["company-skills", selectedCompanyId!, deletedSkill.id, "file"],
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.companySkills.updateStatus(selectedCompanyId!, deletedSkill.id),
+      });
+      setDisplayedDetail(null);
+      setDisplayedFile(null);
+      setEditMode(false);
+      setDraft("");
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) });
+      navigate(remainingSkills[0] ? skillRoute(remainingSkills[0].id) : "/skills", { replace: true });
+      pushToast({
+        tone: "success",
+        title: "Skill deleted",
+        body: deletedSkill.name,
+      });
+    },
+    onError: (error) => {
+      pushToast({
+        tone: "error",
+        title: "Delete failed",
+        body: error instanceof Error ? error.message : "Failed to delete skill.",
       });
     },
   });

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -987,41 +987,6 @@ export function CompanySkills() {
     },
   });
 
-  const deleteSkill = useMutation({
-    mutationFn: () => companySkillsApi.delete(selectedCompanyId!, selectedSkillId!),
-    onSuccess: async (deletedSkill) => {
-      const remainingSkills = (skillsQuery.data ?? []).filter((skill) => skill.id !== deletedSkill.id);
-      queryClient.setQueryData(queryKeys.companySkills.list(selectedCompanyId!), remainingSkills);
-      queryClient.removeQueries({
-        queryKey: queryKeys.companySkills.detail(selectedCompanyId!, deletedSkill.id),
-      });
-      queryClient.removeQueries({
-        queryKey: ["company-skills", selectedCompanyId!, deletedSkill.id, "file"],
-      });
-      queryClient.removeQueries({
-        queryKey: queryKeys.companySkills.updateStatus(selectedCompanyId!, deletedSkill.id),
-      });
-      setDisplayedDetail(null);
-      setDisplayedFile(null);
-      setEditMode(false);
-      setDraft("");
-      await queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) });
-      navigate(remainingSkills[0] ? skillRoute(remainingSkills[0].id) : "/skills", { replace: true });
-      pushToast({
-        tone: "success",
-        title: "Skill deleted",
-        body: deletedSkill.name,
-      });
-    },
-    onError: (error) => {
-      pushToast({
-        tone: "error",
-        title: "Delete failed",
-        body: error instanceof Error ? error.message : "Failed to delete skill.",
-      });
-    },
-  });
-
   const installUpdate = useMutation({
     mutationFn: () => companySkillsApi.installUpdate(selectedCompanyId!, selectedSkillId!),
     onSuccess: async (skill) => {


### PR DESCRIPTION
## Summary
- keep Code mode edits attached to the full raw SKILL.md file so frontmatter changes persist
- refresh the visible skill file state immediately after save
- add delete support and focused helper coverage for the editor logic

## Testing
- pnpm exec vitest run ui/src/lib/company-skill-editor.test.ts
- pnpm --filter @paperclipai/ui typecheck

Closes #2121
