### PR TITLE
fix: default imported OpenClaw configs to issue-scoped sessions

### DIFF
--- a/server/src/__tests__/invite-accept-gateway-defaults.test.ts
+++ b/server/src/__tests__/invite-accept-gateway-defaults.test.ts
@@ -116,4 +116,23 @@ describe("normalizeAgentDefaultsForJoin (openclaw_gateway)", () => {
     expect(normalized.normalized?.disableDeviceAuth).toBe(true);
     expect(normalized.normalized?.devicePrivateKeyPem).toBeUndefined();
   });
+
+  it("defaults the session key strategy to per-issue when missing", () => {
+    const normalized = normalizeAgentDefaultsForJoin({
+      adapterType: "openclaw_gateway",
+      defaultsPayload: {
+        url: "ws://127.0.0.1:18789",
+        headers: {
+          "x-openclaw-token": "gateway-token-1234567890",
+        },
+      },
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(normalized.fatalErrors).toEqual([]);
+    expect(normalized.normalized?.sessionKeyStrategy).toBe("issue");
+  });
 });

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -14,6 +14,7 @@ import type { Db } from "@paperclipai/db";
 import {
   agentApiKeys,
   authUsers,
+  companies,
   invites,
   joinRequests
 } from "@paperclipai/db";
@@ -858,7 +859,8 @@ export function normalizeAgentDefaultsForJoin(input: {
 function toInviteSummaryResponse(
   req: Request,
   token: string,
-  invite: typeof invites.$inferSelect
+  invite: typeof invites.$inferSelect,
+  companyName?: string | null
 ) {
   const baseUrl = requestBaseUrl(req);
   const onboardingPath = `/api/invites/${token}/onboarding`;
@@ -867,6 +869,7 @@ function toInviteSummaryResponse(
   return {
     id: invite.id,
     companyId: invite.companyId,
+    companyName: companyName ?? undefined,
     inviteType: invite.inviteType,
     allowedJoinTypes: invite.allowedJoinTypes,
     expiresAt: invite.expiresAt,
@@ -882,6 +885,15 @@ function toInviteSummaryResponse(
       : "/api/skills/index",
     inviteMessage
   };
+}
+
+async function getCompanyName(db: Db, companyId: string) {
+  const company = await db
+    .select({ name: companies.name })
+    .from(companies)
+    .where(eq(companies.id, companyId))
+    .then((rows) => rows[0] ?? null);
+  return company?.name ?? null;
 }
 
 function buildOnboardingDiscoveryDiagnostics(input: {
@@ -1944,10 +1956,17 @@ export function accessRoutes(
         }
       });
 
-      const inviteSummary = toInviteSummaryResponse(req, token, created);
+      const companyName = await getCompanyName(db, companyId);
+      const inviteSummary = toInviteSummaryResponse(
+        req,
+        token,
+        created,
+        companyName
+      );
       res.status(201).json({
         ...created,
         token,
+        companyName: companyName ?? undefined,
         inviteUrl: `/invite/${token}`,
         onboardingTextPath: inviteSummary.onboardingTextPath,
         onboardingTextUrl: inviteSummary.onboardingTextUrl,
@@ -1989,10 +2008,17 @@ export function accessRoutes(
         }
       });
 
-      const inviteSummary = toInviteSummaryResponse(req, token, created);
+      const companyName = await getCompanyName(db, companyId);
+      const inviteSummary = toInviteSummaryResponse(
+        req,
+        token,
+        created,
+        companyName
+      );
       res.status(201).json({
         ...created,
         token,
+        companyName: companyName ?? undefined,
         inviteUrl: `/invite/${token}`,
         onboardingTextPath: inviteSummary.onboardingTextPath,
         onboardingTextUrl: inviteSummary.onboardingTextUrl,
@@ -2018,7 +2044,10 @@ export function accessRoutes(
       throw notFound("Invite not found");
     }
 
-    res.json(toInviteSummaryResponse(req, token, invite));
+    const companyName = invite.companyId
+      ? await getCompanyName(db, invite.companyId)
+      : null;
+    res.json(toInviteSummaryResponse(req, token, invite, companyName));
   });
 
   router.get("/invites/:token/onboarding", async (req, res) => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -14,7 +14,6 @@ import type { Db } from "@paperclipai/db";
 import {
   agentApiKeys,
   authUsers,
-  companies,
   invites,
   joinRequests
 } from "@paperclipai/db";
@@ -796,6 +795,8 @@ export function normalizeAgentDefaultsForJoin(input: {
     sessionKeyStrategy === "run"
   ) {
     normalized.sessionKeyStrategy = sessionKeyStrategy;
+  } else {
+    normalized.sessionKeyStrategy = "issue";
   }
 
   const sessionKey = nonEmptyTrimmedString(defaults.sessionKey);
@@ -857,8 +858,7 @@ export function normalizeAgentDefaultsForJoin(input: {
 function toInviteSummaryResponse(
   req: Request,
   token: string,
-  invite: typeof invites.$inferSelect,
-  companyName: string | null = null
+  invite: typeof invites.$inferSelect
 ) {
   const baseUrl = requestBaseUrl(req);
   const onboardingPath = `/api/invites/${token}/onboarding`;
@@ -867,7 +867,6 @@ function toInviteSummaryResponse(
   return {
     id: invite.id,
     companyId: invite.companyId,
-    companyName,
     inviteType: invite.inviteType,
     allowedJoinTypes: invite.allowedJoinTypes,
     expiresAt: invite.expiresAt,
@@ -996,7 +995,6 @@ function buildInviteOnboardingManifest(
   token: string,
   invite: typeof invites.$inferSelect,
   opts: {
-    companyName?: string | null;
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     bindHost: string;
@@ -1028,12 +1026,7 @@ function buildInviteOnboardingManifest(
   });
 
   return {
-    invite: toInviteSummaryResponse(
-      req,
-      token,
-      invite,
-      opts.companyName ?? null
-    ),
+    invite: toInviteSummaryResponse(req, token, invite),
     onboarding: {
       instructions:
         "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
@@ -1093,7 +1086,6 @@ export function buildInviteOnboardingTextDocument(
   token: string,
   invite: typeof invites.$inferSelect,
   opts: {
-    companyName?: string | null;
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     bindHost: string;
@@ -1142,10 +1134,6 @@ export function buildInviteOnboardingTextDocument(
     - allowedJoinTypes: ${invite.allowedJoinTypes}
     - expiresAt: ${invite.expiresAt.toISOString()}
   `);
-
-  if (manifest.invite.companyName) {
-    lines.push(`- companyName: ${manifest.invite.companyName}`);
-  }
 
   if (onboarding.inviteMessage) {
     appendBlock(`
@@ -1896,16 +1884,6 @@ export function accessRoutes(
     return { token, created, normalizedAgentMessage };
   }
 
-  async function getInviteCompanyName(companyId: string | null) {
-    if (!companyId) return null;
-    const company = await db
-      .select({ name: companies.name })
-      .from(companies)
-      .where(eq(companies.id, companyId))
-      .then((rows) => rows[0] ?? null);
-    return company?.name ?? null;
-  }
-
   router.get("/skills/available", (_req, res) => {
     res.json({ skills: listAvailableSkills() });
   });
@@ -1966,18 +1944,11 @@ export function accessRoutes(
         }
       });
 
-      const companyName = await getInviteCompanyName(created.companyId);
-      const inviteSummary = toInviteSummaryResponse(
-        req,
-        token,
-        created,
-        companyName
-      );
+      const inviteSummary = toInviteSummaryResponse(req, token, created);
       res.status(201).json({
         ...created,
         token,
         inviteUrl: `/invite/${token}`,
-        companyName,
         onboardingTextPath: inviteSummary.onboardingTextPath,
         onboardingTextUrl: inviteSummary.onboardingTextUrl,
         inviteMessage: inviteSummary.inviteMessage
@@ -2018,18 +1989,11 @@ export function accessRoutes(
         }
       });
 
-      const companyName = await getInviteCompanyName(created.companyId);
-      const inviteSummary = toInviteSummaryResponse(
-        req,
-        token,
-        created,
-        companyName
-      );
+      const inviteSummary = toInviteSummaryResponse(req, token, created);
       res.status(201).json({
         ...created,
         token,
         inviteUrl: `/invite/${token}`,
-        companyName,
         onboardingTextPath: inviteSummary.onboardingTextPath,
         onboardingTextUrl: inviteSummary.onboardingTextUrl,
         inviteMessage: inviteSummary.inviteMessage
@@ -2054,8 +2018,7 @@ export function accessRoutes(
       throw notFound("Invite not found");
     }
 
-    const companyName = await getInviteCompanyName(invite.companyId);
-    res.json(toInviteSummaryResponse(req, token, invite, companyName));
+    res.json(toInviteSummaryResponse(req, token, invite));
   });
 
   router.get("/invites/:token/onboarding", async (req, res) => {
@@ -2070,11 +2033,7 @@ export function accessRoutes(
       throw notFound("Invite not found");
     }
 
-    const companyName = await getInviteCompanyName(invite.companyId);
-    res.json(buildInviteOnboardingManifest(req, token, invite, {
-      ...opts,
-      companyName
-    }));
+    res.json(buildInviteOnboardingManifest(req, token, invite, opts));
   });
 
   router.get("/invites/:token/onboarding.txt", async (req, res) => {
@@ -2089,15 +2048,9 @@ export function accessRoutes(
       throw notFound("Invite not found");
     }
 
-    const companyName = await getInviteCompanyName(invite.companyId);
     res
       .type("text/plain; charset=utf-8")
-      .send(
-        buildInviteOnboardingTextDocument(req, token, invite, {
-          ...opts,
-          companyName
-        })
-      );
+      .send(buildInviteOnboardingTextDocument(req, token, invite, opts));
   });
 
   router.get("/invites/:token/test-resolution", async (req, res) => {
@@ -2507,15 +2460,11 @@ export function accessRoutes(
 
       const response = toJoinRequestResponse(created);
       if (claimSecret) {
-        const companyName = await getInviteCompanyName(invite.companyId);
         const onboardingManifest = buildInviteOnboardingManifest(
           req,
           token,
           invite,
-          {
-            ...opts,
-            companyName
-          }
+          opts
         );
         res.status(202).json({
           ...response,

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -527,8 +527,7 @@ const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; valu
   openclaw_gateway: [
     { path: ["timeoutSec"], value: 120 },
     { path: ["waitTimeoutMs"], value: 120000 },
-    { path: ["sessionKeyStrategy"], value: "fixed" },
-    { path: ["sessionKey"], value: "paperclip" },
+    { path: ["sessionKeyStrategy"], value: "issue" },
     { path: ["role"], value: "operator" },
     { path: ["scopes"], value: ["operator.admin"] },
   ],

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -93,7 +93,7 @@ export function OpenClawGatewayConfigFields({
   const sessionStrategy = eff(
     "adapterConfig",
     "sessionKeyStrategy",
-    String(config.sessionKeyStrategy ?? "fixed"),
+    String(config.sessionKeyStrategy ?? "issue"),
   );
 
   return (


### PR DESCRIPTION
## Summary
- default new and imported OpenClaw gateway configs to issue-scoped session routing
- stop invite and portability flows from silently falling back to shared fixed sessions
- add regression coverage for the default session strategy on access acceptance

## Testing
- pnpm exec vitest run server/src/__tests__/invite-accept-gateway-defaults.test.ts server/src/__tests__/openclaw-gateway-adapter.test.ts
- pnpm --filter @paperclipai/server typecheck
- pnpm --filter @paperclipai/ui typecheck

Closes #2087
