### PR TITLE
fix: keep issue-comment wakes in the task session

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -15,6 +15,7 @@ import {
   resolveRuntimeSessionParamsForWorkspace,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
+  shouldUseAgentRuntimeSessionForTaskScope,
   type ResolvedWorkspaceForRun,
 } from "../services/heartbeat.ts";
 
@@ -331,6 +332,7 @@ describe("shouldResetTaskSessionForWake", () => {
   });
 });
 
+<<<<<<< HEAD
 describe("deriveTaskKeyWithHeartbeatFallback", () => {
   it("returns explicit taskKey when present", () => {
     expect(deriveTaskKeyWithHeartbeatFallback({ taskKey: "issue-123" }, null)).toBe("issue-123");
@@ -382,6 +384,35 @@ describe("comment wake batching", () => {
     expect(merged.commentId).toBe("comment-2");
     expect(merged.wakeCommentId).toBe("comment-2");
     expect(merged.paperclipWake).toBeUndefined();
+  });
+});
+
+describe("shouldUseAgentRuntimeSessionForTaskScope", () => {
+  it("does not reuse agent runtime sessions when a task key is present", () => {
+    expect(
+      shouldUseAgentRuntimeSessionForTaskScope({
+        taskKey: "issue-123",
+        resetTaskSession: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reuse agent runtime sessions when a fresh task session is required", () => {
+    expect(
+      shouldUseAgentRuntimeSessionForTaskScope({
+        taskKey: null,
+        resetTaskSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("reuses agent runtime sessions for unscoped heartbeats", () => {
+    expect(
+      shouldUseAgentRuntimeSessionForTaskScope({
+        taskKey: null,
+        resetTaskSession: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -332,7 +332,6 @@ describe("shouldResetTaskSessionForWake", () => {
   });
 });
 
-<<<<<<< HEAD
 describe("deriveTaskKeyWithHeartbeatFallback", () => {
   it("returns explicit taskKey when present", () => {
     expect(deriveTaskKeyWithHeartbeatFallback({ taskKey: "issue-123" }, null)).toBe("issue-123");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -700,6 +700,13 @@ export function shouldResetTaskSessionForWake(
   return false;
 }
 
+export function shouldUseAgentRuntimeSessionForTaskScope(input: {
+  taskKey: string | null | undefined;
+  resetTaskSession: boolean;
+}) {
+  return !readNonEmptyString(input.taskKey) && !input.resetTaskSession;
+}
+
 export function formatRuntimeWorkspaceWarningLog(warning: string) {
   return {
     stream: "stdout" as const,
@@ -2914,17 +2921,22 @@ export function heartbeatService(db: Db) {
     if (executionWorkspace.projectId && !readNonEmptyString(context.projectId)) {
       context.projectId = executionWorkspace.projectId;
     }
-    const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
+    const allowAgentRuntimeSessionFallback = shouldUseAgentRuntimeSessionForTaskScope({
+      taskKey,
+      resetTaskSession,
+    });
+    const runtimeSessionParamsForFallback = allowAgentRuntimeSessionFallback ? runtimeSessionParams : null;
+    const runtimeSessionFallback = allowAgentRuntimeSessionFallback ? runtime.sessionId : null;
     let previousSessionDisplayId = truncateDisplayId(
       explicitResumeSessionDisplayId ??
         taskSessionForRun?.sessionDisplayId ??
-        (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(runtimeSessionParams) : null) ??
-        readNonEmptyString(runtimeSessionParams?.sessionId) ??
+        (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(runtimeSessionParamsForFallback) : null) ??
+        readNonEmptyString(runtimeSessionParamsForFallback?.sessionId) ??
         runtimeSessionFallback,
     );
     let runtimeSessionIdForAdapter =
-      readNonEmptyString(runtimeSessionParams?.sessionId) ?? runtimeSessionFallback;
-    let runtimeSessionParamsForAdapter = runtimeSessionParams;
+      readNonEmptyString(runtimeSessionParamsForFallback?.sessionId) ?? runtimeSessionFallback;
+    let runtimeSessionParamsForAdapter = runtimeSessionParamsForFallback;
 
     const sessionCompaction = await evaluateSessionCompaction({
       agent,


### PR DESCRIPTION
## Summary
- stop task-scoped wakes from falling back to the agent-wide runtime session id
- keep comment-driven issue execution inside the saved task session when one exists
- add focused coverage for the runtime-session fallback gate

## Testing
- pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts
- pnpm --filter @paperclipai/server typecheck

Closes #2054
