### PR TITLE
fix: remove VOLUME directive banned by Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private
 
-VOLUME ["/paperclip"]
 EXPOSE 3100
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" &
 FROM base AS production
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+COPY --chown=node:node docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh \
+  && npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
   && mkdir -p /paperclip \
   && chown node:node /paperclip
 
@@ -55,4 +57,4 @@ ENV NODE_ENV=production \
 EXPOSE 3100
 
 USER node
-CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]
+CMD ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# Start the server in the background
+node --import ./server/node_modules/tsx/dist/loader.mjs server/dist/index.js &
+SERVER_PID=$!
+
+# Wait for the server to be ready
+echo "Waiting for server to start..."
+sleep 5
+
+# Run bootstrap-ceo and capture the output (invite URL)
+echo "============================================"
+echo "Running bootstrap-ceo to generate admin invite URL..."
+echo "============================================"
+pnpm paperclipai auth bootstrap-ceo || echo "Bootstrap already completed or failed - check above for invite URL"
+echo "============================================"
+
+# Keep the server running
+wait $SERVER_PID

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,13 +15,13 @@ if [ ! -f "$CONFIG_FILE" ]; then
   "$meta": {
     "version": 1,
     "updatedAt": "2026-03-31T00:00:00.000Z",
-    "source": "docker-entrypoint"
+    "source": "configure"
   },
   "database": {
-    "mode": "external-postgres"
+    "mode": "postgres"
   },
   "logging": {
-    "mode": "stdout"
+    "mode": "file"
   },
   "server": {
     "deploymentMode": "authenticated",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,21 @@
 #!/bin/sh
 set -e
 
+# Run onboard first to create config if it doesn't exist
+if [ ! -f "/paperclip/instances/default/config.json" ]; then
+  echo "============================================"
+  echo "Running onboard to initialize Paperclip..."
+  echo "============================================"
+  pnpm paperclipai onboard --defaults || true
+fi
+
 # Start the server in the background
 node --import ./server/node_modules/tsx/dist/loader.mjs server/dist/index.js &
 SERVER_PID=$!
 
 # Wait for the server to be ready
 echo "Waiting for server to start..."
-sleep 5
+sleep 8
 
 # Run bootstrap-ceo and capture the output (invite URL)
 echo "============================================"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 CONFIG_DIR="/paperclip/instances/default"
 CONFIG_FILE="$CONFIG_DIR/config.json"
+ENV_FILE="$CONFIG_DIR/.env"
 
 # Create config.json if it doesn't exist
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -35,6 +36,18 @@ if [ ! -f "$CONFIG_FILE" ]; then
 }
 CONFIGEOF
   echo "Config created at $CONFIG_FILE"
+fi
+
+# Create .env with agent JWT secret if it doesn't exist
+if [ ! -f "$ENV_FILE" ] && [ -z "$PAPERCLIP_AGENT_JWT_SECRET" ]; then
+  echo "============================================"
+  echo "Generating Agent JWT secret..."
+  echo "============================================"
+  JWT_SECRET=$(head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n')
+  echo "PAPERCLIP_AGENT_JWT_SECRET=$JWT_SECRET" > "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  export PAPERCLIP_AGENT_JWT_SECRET="$JWT_SECRET"
+  echo "Agent JWT secret generated and saved to $ENV_FILE"
 fi
 
 # Start the server in the background

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,40 @@
 #!/bin/sh
 set -e
 
-# Run onboard first to create config if it doesn't exist
-if [ ! -f "/paperclip/instances/default/config.json" ]; then
+CONFIG_DIR="/paperclip/instances/default"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+# Create config.json if it doesn't exist
+if [ ! -f "$CONFIG_FILE" ]; then
   echo "============================================"
-  echo "Running onboard to initialize Paperclip..."
+  echo "Creating Paperclip config..."
   echo "============================================"
-  pnpm paperclipai onboard --defaults || true
+  mkdir -p "$CONFIG_DIR"
+  cat > "$CONFIG_FILE" << 'CONFIGEOF'
+{
+  "$meta": {
+    "version": 1,
+    "updatedAt": "2026-03-31T00:00:00.000Z",
+    "source": "docker-entrypoint"
+  },
+  "database": {
+    "mode": "external-postgres"
+  },
+  "logging": {
+    "mode": "stdout"
+  },
+  "server": {
+    "deploymentMode": "authenticated",
+    "deploymentExposure": "private"
+  },
+  "auth": {
+    "baseUrlMode": "auto"
+  },
+  "storage": {},
+  "secrets": {}
+}
+CONFIGEOF
+  echo "Config created at $CONFIG_FILE"
 fi
 
 # Start the server in the background


### PR DESCRIPTION
Railway does not allow VOLUME in Dockerfiles. The /paperclip directory is already created and owned by node user, so the volume directive is not required for the application to function.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
