### PR TITLE
fix: await clipboard write and show toast feedback for Copy Agent ID

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -528,6 +528,7 @@ export function AgentDetail() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { pushToast } = useToast();
   const [actionError, setActionError] = useState<string | null>(null);
   const [moreOpen, setMoreOpen] = useState(false);
   const activeView = urlRunId ? "runs" as AgentDetailView : parseAgentDetailView(urlTab ?? null);
@@ -868,8 +869,13 @@ export function AgentDetail() {
             <PopoverContent className="w-44 p-1" align="end">
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
-                onClick={() => {
-                  navigator.clipboard.writeText(agent.id);
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(agent.id);
+                    pushToast({ title: "Agent ID copied", body: agent.id, tone: "success" });
+                  } catch {
+                    pushToast({ title: "Copy failed", body: "Could not copy agent ID to clipboard.", tone: "error" });
+                  }
                   setMoreOpen(false);
                 }}
               >


### PR DESCRIPTION
## Thinking Path

- Paperclip is a control plane for AI-agent companies — users create and manage agents that autonomously execute tasks
- Users need to reference specific agents (e.g. in API calls, support tickets, or when sharing with teammates), so each agent has a unique ID
- The agent dashboard's overflow menu (⋯) exposes a **Copy Agent ID** button for this purpose
- However, `navigator.clipboard.writeText()` returns a Promise that was never awaited — any failure (no clipboard permission, document not focused, non-HTTPS context) was silently dropped and the user saw nothing happen
- Even on success, there was no feedback — so users couldn't tell if the copy worked
- This PR awaits the Promise, wraps it in `try/catch`, and surfaces the result via `pushToast` — the same toast system already used throughout `AgentDetail`
- The benefit: users now get reliable confirmation that their agent ID was copied, or a clear error message if something went wrong

---

## What changed

**`ui/src/pages/AgentDetail.tsx`**

- Added `const { pushToast } = useToast()` to the `AgentDetail` component (`useToast` was already imported at the top of the file, just not used in this component)
- Made the `Copy Agent ID` click handler `async` and `await`ed the clipboard write
- Wrapped in `try/catch` — success shows a `"success"` toast with the agent ID as the body; failure shows an `"error"` toast

```tsx
// Before
onClick={() => {
  navigator.clipboard.writeText(agent.id);
  setMoreOpen(false);
}}

// After
onClick={async () => {
  try {
    await navigator.clipboard.writeText(agent.id);
    pushToast({ title: "Agent ID copied", body: agent.id, tone: "success" });
  } catch {
    pushToast({ title: "Copy failed", body: "Could not copy agent ID to clipboard.", tone: "error" });
  }
  setMoreOpen(false);
}}
```

---

## Risks

- **Clipboard API availability:** `navigator.clipboard` is only available in secure contexts (HTTPS or localhost). In non-HTTPS deployments the catch block will fire and show the error toast — this is correct behavior (fail loudly rather than silently)
- **Document focus:** Some browsers deny clipboard writes when the document isn't focused. The `try/catch` handles this the same way
- **No behavior change on success path:** `setMoreOpen(false)` still runs regardless, so the menu closes as before

---

## Screenshots

> ⚠️ Screenshots below should be added by running the app locally and clicking **Copy Agent ID** before and after this change. The before state shows nothing happening; the after state shows a success toast with the agent ID.

**Before:** Clicking "Copy Agent ID" closes the menu with no visible feedback — users cannot confirm the copy worked.

**After:** A toast notification appears confirming the agent ID was copied (or showing an error if clipboard access failed).

_(Please replace this section with actual before/after screenshots from local testing)_

---

## Test plan

- [ ] Open an agent's dashboard
- [ ] Click the ⋯ overflow menu
- [ ] Click **Copy Agent ID**
- [ ] Verify a success toast appears with the agent ID in the body
- [ ] Paste into a text field and confirm the correct agent ID was copied
- [ ] Verify the overflow menu closes after clicking (unchanged behavior)
- [ ] (Optional) Block clipboard permissions in browser devtools and verify the error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)