### PR TITLE
fix(adapter-claude-local): clear stale session ID when retry also fails

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -592,6 +592,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
+      // If the retry also failed, suppress any session ID captured from the system/init
+      // event before the failure. Claude emits system/init (with a new session_id) before
+      // crashing, so parsedStream.sessionId is non-null even on a failed run. Without this
+      // guard, that ephemeral ID gets persisted as agent_runtime_state.session_id, the next
+      // run tries --resume <id> and fails again, and the loop repeats indefinitely.
+      const retrySucceeded = !retry.proc.timedOut && (retry.proc.exitCode ?? 0) === 0;
+      if (!retrySucceeded) {
+        retry.parsedStream.sessionId = null;
+      }
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 


### PR DESCRIPTION
## Problem

The SMM (Social Media Manager) agent entered a persistent error loop: every heartbeat failed with `Claude run failed: subtype=init` / `errorCode=adapter_failed`. Manual workaround required to clear `agent_runtime_state.session_id` directly in Postgres.

**Root cause:** When Claude gets `--resume <stale_id>`, it emits a `system/init` event containing a *new* `session_id` before crashing with the unknown-session error. `parseClaudeStreamJson` captures that ephemeral ID from the `system/init` line. After `isClaudeUnknownSessionError` fires and the retry runs (`runAttempt(null)`), the same thing happens: the retry also emits `system/init` (another ephemeral ID) before failing.

Because `clearSessionOnMissingSession` only clears the session when `!resolvedSessionId`, and `parsedStream.sessionId` is **non-null** (from the `system/init` event), the ephemeral ID gets persisted to `agent_runtime_state.session_id`. The next heartbeat tries `--resume <that_id>` → same cycle → loop repeats indefinitely.

## Fix

After the retry attempt, check whether it actually succeeded. If it failed, null out `parsedStream.sessionId` before passing to `toAdapterResult`. This ensures `clearSession=true` fires and `agent_runtime_state.session_id` is cleared, so the next heartbeat starts with a genuinely fresh session.

```ts
const retry = await runAttempt(null);
// If the retry also failed, suppress any session ID captured from the system/init
// event before the failure. Claude emits system/init (with a new session_id) before
// crashing, so parsedStream.sessionId is non-null even on a failed run. Without this
// guard, that ephemeral ID gets persisted as agent_runtime_state.session_id, the next
// run tries --resume <id> and fails again, and the loop repeats indefinitely.
const retrySucceeded = !retry.proc.timedOut && (retry.proc.exitCode ?? 0) === 0;
if (!retrySucceeded) {
  retry.parsedStream.sessionId = null;
}
return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
```

Happy path (retry succeeds) is completely unchanged — session ID is preserved normally.

## Test plan

- [ ] Agent with a stale session file recovers on the next heartbeat without manual DB intervention
- [ ] Agent with a valid resumable session continues to resume correctly (regression check)
- [ ] Agent that times out on retry does not persist the ephemeral session ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)