### PR TITLE
fix(server): clear persisted sessions on adapter change

### DIFF
--- a/server/src/__tests__/agent-adapter-session-reset.test.ts
+++ b/server/src/__tests__/agent-adapter-session-reset.test.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentTaskSessions,
+  companies,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent adapter session reset tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agentService adapter session reset", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof agentService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-adapter-reset-");
+    db = createDb(tempDb.connectionString);
+    svc = agentService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agentTaskSessions);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("clears persisted runtime and task sessions when adapterType changes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "LightKeeper",
+      role: "general",
+      status: "idle",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentRuntimeState).values({
+      agentId,
+      companyId,
+      adapterType: "claude_local",
+      sessionId: "claude-session-1",
+      stateJson: { cwd: "/tmp/claude" },
+      lastError: "old runtime error",
+    });
+
+    await db.insert(agentTaskSessions).values([
+      {
+        companyId,
+        agentId,
+        adapterType: "claude_local",
+        taskKey: "task-1",
+        sessionDisplayId: "claude-task-session",
+        sessionParamsJson: { sessionId: "claude-task-session" },
+        lastError: "old claude task error",
+      },
+      {
+        companyId,
+        agentId,
+        adapterType: "codex_local",
+        taskKey: "task-2",
+        sessionDisplayId: "codex-task-session",
+        sessionParamsJson: { sessionId: "codex-task-session" },
+        lastError: "old codex task error",
+      },
+    ]);
+
+    const updated = await svc.update(agentId, { adapterType: "codex_local" });
+
+    expect(updated?.adapterType).toBe("codex_local");
+
+    const runtimeState = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(runtimeState?.adapterType).toBe("codex_local");
+    expect(runtimeState?.sessionId).toBeNull();
+    expect(runtimeState?.stateJson).toEqual({});
+    expect(runtimeState?.lastError).toBeNull();
+
+    const taskSessions = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(eq(agentTaskSessions.agentId, agentId));
+
+    expect(taskSessions).toHaveLength(0);
+  });
+
+  it("preserves persisted sessions when adapterType does not change", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodeForge",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: { model: "gpt-5.4" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentRuntimeState).values({
+      agentId,
+      companyId,
+      adapterType: "codex_local",
+      sessionId: "codex-session-1",
+      stateJson: { cwd: "/tmp/codex" },
+    });
+
+    await db.insert(agentTaskSessions).values({
+      companyId,
+      agentId,
+      adapterType: "codex_local",
+      taskKey: "task-1",
+      sessionDisplayId: "codex-task-session",
+      sessionParamsJson: { sessionId: "codex-task-session" },
+    });
+
+    const updated = await svc.update(agentId, {
+      adapterConfig: { model: "gpt-5.5" },
+    });
+
+    expect(updated?.adapterType).toBe("codex_local");
+
+    const runtimeState = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(runtimeState?.sessionId).toBe("codex-session-1");
+    expect(runtimeState?.stateJson).toEqual({ cwd: "/tmp/codex" });
+
+    const taskSessions = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(eq(agentTaskSessions.agentId, agentId));
+
+    expect(taskSessions).toHaveLength(1);
+    expect(taskSessions[0]?.sessionDisplayId).toBe("codex-task-session");
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -335,35 +335,63 @@ export function agentService(db: Db) {
       const role = (data.role ?? existing.role) as string;
       normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
     }
+    const nextAdapterType =
+      typeof normalizedPatch.adapterType === "string" && normalizedPatch.adapterType.length > 0
+        ? normalizedPatch.adapterType
+        : existing.adapterType;
+    const adapterTypeChanged = nextAdapterType !== existing.adapterType;
 
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
     const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
 
-    const updated = await db
-      .update(agents)
-      .set({ ...normalizedPatch, updatedAt: new Date() })
-      .where(eq(agents.id, id))
-      .returning()
-      .then((rows) => rows[0] ?? null);
-    const normalizedUpdated = updated ? normalizeAgentRow(updated) : null;
+    const updated = await db.transaction(async (tx) => {
+      const next = await tx
+        .update(agents)
+        .set({ ...normalizedPatch, updatedAt: new Date() })
+        .where(eq(agents.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
 
-    if (normalizedUpdated && shouldRecordRevision && beforeConfig) {
-      const afterConfig = buildConfigSnapshot(normalizedUpdated);
-      const changedKeys = diffConfigSnapshot(beforeConfig, afterConfig);
-      if (changedKeys.length > 0) {
-        await db.insert(agentConfigRevisions).values({
-          companyId: normalizedUpdated.companyId,
-          agentId: normalizedUpdated.id,
-          createdByAgentId: options?.recordRevision?.createdByAgentId ?? null,
-          createdByUserId: options?.recordRevision?.createdByUserId ?? null,
-          source: options?.recordRevision?.source ?? "patch",
-          rolledBackFromRevisionId: options?.recordRevision?.rolledBackFromRevisionId ?? null,
-          changedKeys,
-          beforeConfig: beforeConfig as unknown as Record<string, unknown>,
-          afterConfig: afterConfig as unknown as Record<string, unknown>,
-        });
+      if (!next) return null;
+
+      if (adapterTypeChanged) {
+        await tx
+          .delete(agentTaskSessions)
+          .where(eq(agentTaskSessions.agentId, id));
+
+        await tx
+          .update(agentRuntimeState)
+          .set({
+            adapterType: nextAdapterType,
+            sessionId: null,
+            stateJson: {},
+            lastError: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(agentRuntimeState.agentId, id));
       }
-    }
+
+      if (shouldRecordRevision && beforeConfig) {
+        const afterConfig = buildConfigSnapshot(normalizeAgentRow(next));
+        const changedKeys = diffConfigSnapshot(beforeConfig, afterConfig);
+        if (changedKeys.length > 0) {
+          await tx.insert(agentConfigRevisions).values({
+            companyId: next.companyId,
+            agentId: next.id,
+            createdByAgentId: options?.recordRevision?.createdByAgentId ?? null,
+            createdByUserId: options?.recordRevision?.createdByUserId ?? null,
+            source: options?.recordRevision?.source ?? "patch",
+            rolledBackFromRevisionId: options?.recordRevision?.rolledBackFromRevisionId ?? null,
+            changedKeys,
+            beforeConfig: beforeConfig as unknown as Record<string, unknown>,
+            afterConfig: afterConfig as unknown as Record<string, unknown>,
+          });
+        }
+      }
+
+      return next;
+    });
+    const normalizedUpdated = updated ? normalizeAgentRow(updated) : null;
 
     return normalizedUpdated;
   }


### PR DESCRIPTION
Title: fix(server): clear persisted sessions on adapter change

## Summary

This clears persisted runtime/task session state when an agent's `adapterType` changes.

Without this, Paperclip can carry a session ID created by one adapter into a different adapter after an agent migration, which causes the new adapter to attempt to resume an incompatible session.

## Problem

Paperclip persists session continuity in:

- `agent_runtime_state.session_id`
- `agent_task_sessions.session_display_id`
- `agent_task_sessions.session_params_json`

Those persisted values are adapter-specific, but they were not being cleared when an agent changed adapters.

That meant a migration like:

- `claude_local` -> `codex_local`

could leave behind a stale session ID from the previous adapter.

On the next heartbeat, Paperclip would feed that stale session into the new adapter's resume path.

## User-facing failure

In production this surfaced as a `codex_local` heartbeat repeatedly trying to resume an old thread:

```bash
codex exec --json --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 resume 789ad670-11d4-4fd3-a5a6-af74e50af5a3 -
```

Codex then failed with:

```text
Error: thread/resume: thread/resume failed: no rollout found for thread id 789ad670-11d4-4fd3-a5a6-af74e50af5a3
```

The immediate operational fix was to manually clear:

- `agent_runtime_state.session_id`
- `agent_task_sessions.session_display_id`
- `agent_task_sessions.session_params_json`

across affected agents.

## Root cause

Session continuity was preserved across adapter migrations even though session IDs are not portable across adapters.

The persisted session state belonged to the previous adapter, but Paperclip treated it as resumable state for the newly selected adapter.

This is especially problematic for local adapters (`claude_local`, `codex_local`, `cursor`, `gemini_local`, etc.) because each adapter owns its own session format and resume mechanism.

## Fix

The fix lives in `agentService.update()`, which is the correct central place because adapter changes can happen through multiple flows:

- direct agent PATCH updates
- rollback/config revision flows
- company portability/import/update flows
- any other service-layer caller using `agents.update(...)`

When `adapterType` changes, we now do all of the following in the same transaction as the agent update:

1. Update the agent record.
2. Delete persisted task sessions for that agent from `agent_task_sessions`.
3. Clear runtime session state in `agent_runtime_state`:
   - `sessionId = null`
   - `stateJson = {}`
   - `lastError = null`
   - `adapterType = <new adapter>`
4. Preserve the existing config revision behavior.

This ensures the next heartbeat starts a fresh session under the new adapter instead of trying to resume stale state from the previous one.

## Why this approach

- It fixes the real source of the bug rather than adding adapter-specific recovery hacks.
- It is adapter-agnostic and safe for all future adapter migrations.
- It keeps session cleanup consistent for every update path, not just the HTTP route.
- It avoids partial state by doing the cleanup transactionally with the adapter change.

## Tests

Added DB-backed regression coverage in:

- `server/src/__tests__/agent-adapter-session-reset.test.ts`

The new tests verify:

1. Changing `adapterType` clears both persisted runtime and task sessions.
2. Updating agent config without changing `adapterType` preserves valid sessions.

Also re-ran adjacent session logic coverage:

- `server/src/__tests__/heartbeat-workspace-session.test.ts`

## Verification

Executed:

```bash
npx vitest run server/src/__tests__/agent-adapter-session-reset.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts
```

Result:

- 2 test files passed
- 28 tests passed

## Notes

This intentionally resets session continuity on adapter migration. That is the correct behavior because adapter sessions are not portable.
