### PR TITLE
Fix plugin tool dispatcher registration to keep worker routing

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,14 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (namespace prefix)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - Optional plugin database UUID used for worker routing
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +431,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Summary

Fixes plugin tool registration so tool execution keeps routing to the plugin's database UUID worker handle.

## Problem

`plugin-loader` registered manifest tools via `toolDispatcher.registerPluginTools(pluginKey, manifest)`
without passing the plugin DB id.

`PluginToolRegistry.executeTool()` checks worker liveness by DB id (`workerManager.isRunning(dbId)`),
so tools could be listed but fail at runtime with:

> Cannot execute tool "<pluginKey>:<tool>" — worker for plugin "<pluginKey>" is not running.

## Change

- Extend `PluginToolDispatcher.registerPluginTools(...)` with optional `pluginDbId`
- Pass that through to `registry.registerPlugin(...)`
- Update plugin activation path in `plugin-loader` to call
  `registerPluginTools(pluginKey, manifest, pluginId)`

## Validation

- `pnpm --filter @paperclipai/server typecheck`
- Local runtime verification: tools list + `POST /api/plugins/tools/execute` succeeded after restart (no false "worker not running")
