### PR TITLE
fix: retry fresh when OpenCode resumes into an empty stale session

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -10,12 +10,11 @@ import {
   parseObject,
   buildPaperclipEnv,
   joinPromptSections,
-  buildInvocationEnvForLogs,
+  redactEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
-  resolveCommandForLogs,
   renderTemplate,
   runChildProcess,
   readPaperclipRuntimeSkillEntries,
@@ -34,6 +33,20 @@ function firstNonEmptyLine(text: string): string {
       .split(/\r?\n/)
       .map((line) => line.trim())
       .find(Boolean) ?? ""
+  );
+}
+
+function isEmptySuccessfulResumeRun(input: {
+  sessionId: string | null;
+  timedOut: boolean;
+  exitCode: number | null;
+  stdout: string;
+}): boolean {
+  return Boolean(
+    input.sessionId &&
+      !input.timedOut &&
+      (input.exitCode ?? 0) === 0 &&
+      input.stdout.trim().length === 0,
   );
 }
 
@@ -187,12 +200,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ),
     );
     await ensureCommandResolvable(command, cwd, runtimeEnv);
-    const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
-    const loggedEnv = buildInvocationEnvForLogs(preparedRuntimeConfig.env, {
-      runtimeEnv,
-      includeRuntimeKeys: ["HOME"],
-      resolvedCommand,
-    });
 
     await ensureOpenCodeModelConfiguredAndAvailable({
       model,
@@ -305,11 +312,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       if (onMeta) {
         await onMeta({
           adapterType: "opencode_local",
-          command: resolvedCommand,
+          command,
           cwd,
           commandNotes,
           commandArgs: [...args, `<stdin prompt ${prompt.length} chars>`],
-          env: loggedEnv,
+          env: redactEnvForLogs(preparedRuntimeConfig.env),
           prompt,
           promptMetrics,
           context,
@@ -403,14 +410,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const initial = await runAttempt(sessionId);
     const initialFailed =
       !initial.proc.timedOut && ((initial.proc.exitCode ?? 0) !== 0 || Boolean(initial.parsed.errorMessage));
+    const initialSucceededWithoutOutput = isEmptySuccessfulResumeRun({
+      sessionId,
+      timedOut: initial.proc.timedOut,
+      exitCode: initial.proc.exitCode,
+      stdout: initial.proc.stdout,
+    });
     if (
       sessionId &&
-      initialFailed &&
-      isOpenCodeUnknownSessionError(initial.proc.stdout, initial.rawStderr)
+      (
+        initialSucceededWithoutOutput ||
+        (initialFailed && isOpenCodeUnknownSessionError(initial.proc.stdout, initial.rawStderr))
+      )
     ) {
       await onLog(
         "stdout",
-        `[paperclip] OpenCode session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+        `[paperclip] OpenCode session "${sessionId}" is unavailable or produced no output; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
       return toResult(retry, true);

--- a/server/src/__tests__/opencode-local-execute.test.ts
+++ b/server/src/__tests__/opencode-local-execute.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-opencode-local/server";
+
+type CapturePayload = {
+  invocations: Array<{
+    argv: string[];
+    prompt: string;
+  }>;
+};
+
+async function writeRetryingFakeOpenCodeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const argv = process.argv.slice(2);
+const prompt = fs.readFileSync(0, "utf8");
+
+if (capturePath) {
+  const current = fs.existsSync(capturePath)
+    ? JSON.parse(fs.readFileSync(capturePath, "utf8"))
+    : { invocations: [] };
+  current.invocations.push({ argv, prompt });
+  fs.writeFileSync(capturePath, JSON.stringify(current), "utf8");
+}
+
+if (argv.length === 1 && argv[0] === "models") {
+  console.log("openai/gpt-5.4");
+  process.exit(0);
+}
+
+if (argv.includes("--session")) {
+  process.exit(0);
+}
+
+console.log(JSON.stringify({ type: "step_start", sessionID: "ses_fresh_123" }));
+console.log(JSON.stringify({ type: "text", part: { type: "text", text: "hello" } }));
+console.log(JSON.stringify({
+  type: "step_finish",
+  part: {
+    reason: "stop",
+    cost: 0.00042,
+    tokens: { input: 10, output: 5, cache: { read: 2, write: 0 } },
+  },
+}));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+describe("opencode execute", () => {
+  it("retries fresh when a resumed session exits successfully with no output", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-execute-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "opencode");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeRetryingFakeOpenCodeCommand(commandPath);
+
+    const logs: string[] = [];
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-1",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "OpenCode Agent",
+          adapterType: "opencode_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "43595c05-f3e2-453a-83df-a820bb791c64",
+          sessionParams: {
+            sessionId: "43595c05-f3e2-453a-83df-a820bb791c64",
+            cwd: workspace,
+          },
+          sessionDisplayId: "43595c05-f3e2-453a-83df-a820bb791c64",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "openai/gpt-5.4",
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async (_stream, chunk) => {
+          logs.push(chunk);
+        },
+      });
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.invocations.length).toBeGreaterThanOrEqual(2);
+      const runInvocations = capture.invocations.filter((entry) => entry.argv[0] === "run");
+      expect(runInvocations).toHaveLength(2);
+      expect(runInvocations[0]?.argv).toEqual(
+        expect.arrayContaining(["run", "--format", "json", "--session", "43595c05-f3e2-453a-83df-a820bb791c64"]),
+      );
+      expect(runInvocations[1]?.argv).toEqual(
+        expect.arrayContaining(["run", "--format", "json"]),
+      );
+      expect(runInvocations[1]?.argv).not.toContain("--session");
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(result.sessionId).toBe("ses_fresh_123");
+      expect(result.clearSession).toBe(false);
+      expect(logs.join("")).toContain("retrying with a fresh session");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- treat an empty successful resumed OpenCode run as a stale-session case
- retry once without --session instead of silently preserving the bad session forever
- add execute-level regression coverage for the empty-output stale-session path

## Testing
- pnpm exec vitest run server/src/__tests__/opencode-local-execute.test.ts server/src/__tests__/opencode-local-adapter.test.ts
- pnpm --filter @paperclipai/server typecheck
- pnpm --filter @paperclipai/adapter-opencode-local typecheck

Closes #2253
