### PR TITLE
Fix /onboarding redirect when companies already exist

### DIFF
--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -33,7 +33,7 @@ test.describe("Onboarding wizard", () => {
       expect(wizardVisible || launcherVisible).toBe(true);
     }).toPass({ timeout: 15_000 });
 
-    if (await newCompanyBtn.isVisible()) {
+    if (!(await wizardHeading.isVisible()) && (await newCompanyBtn.isVisible())) {
       await newCompanyBtn.click();
     }
 

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -25,6 +25,17 @@ test.describe("Onboarding wizard", () => {
     await page.goto("/onboarding");
 
     const wizardHeading = page.locator("h3", { hasText: "Name your company" });
+    const newCompanyBtn = page.getByRole("button", { name: "New Company" });
+
+    await expect(async () => {
+      const wizardVisible = await wizardHeading.isVisible();
+      const launcherVisible = await newCompanyBtn.isVisible();
+      expect(wizardVisible || launcherVisible).toBe(true);
+    }).toPass({ timeout: 15_000 });
+
+    if (await newCompanyBtn.isVisible()) {
+      await newCompanyBtn.click();
+    }
 
     await expect(wizardHeading).toBeVisible({ timeout: 5_000 });
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -238,7 +238,11 @@ function OnboardingRoutePage() {
                 : openOnboarding()
             }
           >
-            {matchedCompany ? "Add Agent" : "Start Onboarding"}
+            {matchedCompany
+              ? "Add Agent"
+              : companies.length > 0
+                ? "Start Onboarding"
+                : "New Company"}
           </Button>
         </div>
       </div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -48,7 +48,10 @@ import { queryKeys } from "./lib/queryKeys";
 import { useCompany } from "./context/CompanyContext";
 import { useDialog } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
-import { shouldRedirectCompanylessRouteToOnboarding } from "./lib/onboarding-route";
+import {
+  shouldRedirectCompanylessRouteToOnboarding,
+  shouldRedirectGlobalOnboardingToBoard,
+} from "./lib/onboarding-route";
 
 function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: boolean }) {
   return (
@@ -193,9 +196,20 @@ function LegacySettingsRedirect() {
 }
 
 function OnboardingRoutePage() {
+  const location = useLocation();
   const { companies } = useCompany();
   const { openOnboarding } = useDialog();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
+
+  if (
+    shouldRedirectGlobalOnboardingToBoard({
+      pathname: location.pathname,
+      hasCompanies: companies.length > 0,
+    })
+  ) {
+    return <Navigate to="/" replace />;
+  }
+
   const matchedCompany = companyPrefix
     ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase()) ?? null
     : null;

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -633,11 +633,12 @@ export function OnboardingWizard() {
       }}
     >
       <DialogPortal>
-        {/* Plain div instead of DialogOverlay — Radix's overlay wraps in
-            RemoveScroll which blocks wheel events on our custom (non-DialogContent)
-            scroll container. A plain div preserves the background without scroll-locking. */}
-        <div className="fixed inset-0 z-50 bg-background" />
-        <div className="fixed inset-0 z-50 flex" onKeyDown={handleKeyDown}>
+        <>
+          {/* Plain div instead of DialogOverlay — Radix's overlay wraps in
+              RemoveScroll which blocks wheel events on our custom (non-DialogContent)
+              scroll container. A plain div preserves the background without scroll-locking. */}
+          <div className="fixed inset-0 z-50 bg-background" />
+          <div className="fixed inset-0 z-50 flex" onKeyDown={handleKeyDown}>
           {/* Close button */}
           <button
             onClick={handleClose}
@@ -1290,7 +1291,8 @@ export function OnboardingWizard() {
           >
             <AsciiArtAnimation />
           </div>
-        </div>
+          </div>
+        </>
       </DialogPortal>
     </Dialog>
   );

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -84,11 +84,23 @@ export function OnboardingWizard() {
           companyPrefix,
           companies,
         });
+  const [routeOnboardingSnapshot, setRouteOnboardingSnapshot] = useState(
+    routeOnboardingOptions
+  );
+
+  useEffect(() => {
+    if (routeOnboardingOptions !== null) {
+      setRouteOnboardingSnapshot(routeOnboardingOptions);
+    }
+  }, [routeOnboardingOptions]);
+
   const effectiveOnboardingOpen =
-    onboardingOpen || (routeOnboardingOptions !== null && !routeDismissed);
+    onboardingOpen ||
+    ((routeOnboardingOptions !== null || routeOnboardingSnapshot !== null) &&
+      !routeDismissed);
   const effectiveOnboardingOptions = onboardingOpen
     ? onboardingOptions
-    : routeOnboardingOptions ?? {};
+    : routeOnboardingOptions ?? routeOnboardingSnapshot ?? {};
 
   const initialStep = effectiveOnboardingOptions.initialStep ?? 1;
   const existingCompanyId = effectiveOnboardingOptions.companyId;
@@ -152,6 +164,7 @@ export function OnboardingWizard() {
 
   useEffect(() => {
     setRouteDismissed(false);
+    setRouteOnboardingSnapshot(routeOnboardingOptions);
   }, [location.pathname]);
 
   // Sync step and company when onboarding opens with options.
@@ -278,6 +291,7 @@ export function OnboardingWizard() {
   }, [filteredModels, adapterType]);
 
   function reset() {
+    setRouteOnboardingSnapshot(routeOnboardingOptions);
     setStep(1);
     setLoading(false);
     setError(null);

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -72,6 +72,10 @@ export function OnboardingWizard() {
   const location = useLocation();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
   const [routeDismissed, setRouteDismissed] = useState(false);
+  // Keep wizard open during the launch flow (steps 3-4) even if the route
+  // changes after company creation causes resolveRouteOnboardingOptions to
+  // return null (#2304 P1).
+  const [launchInProgress, setLaunchInProgress] = useState(false);
 
   // Sync disabled adapter types from server so adapter grid filters them out
   const disabledTypes = useDisabledAdaptersSync();
@@ -96,6 +100,7 @@ export function OnboardingWizard() {
 
   const effectiveOnboardingOpen =
     onboardingOpen ||
+    launchInProgress ||
     ((routeOnboardingOptions !== null || routeOnboardingSnapshot !== null) &&
       !routeDismissed);
   const effectiveOnboardingOptions = onboardingOpen
@@ -553,6 +558,7 @@ export function OnboardingWizard() {
 
   async function handleLaunch() {
     if (!createdCompanyId || !createdAgentId) return;
+    setLaunchInProgress(true);
     setLoading(true);
     setError(null);
     try {
@@ -607,6 +613,7 @@ export function OnboardingWizard() {
       setError(err instanceof Error ? err.message : "Failed to create task");
     } finally {
       setLoading(false);
+      setLaunchInProgress(false);
     }
   }
 

--- a/ui/src/lib/onboarding-route.test.ts
+++ b/ui/src/lib/onboarding-route.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isOnboardingPath,
   resolveRouteOnboardingOptions,
+  shouldRedirectGlobalOnboardingToBoard,
   shouldRedirectCompanylessRouteToOnboarding,
 } from "./onboarding-route";
 
@@ -74,6 +75,35 @@ describe("shouldRedirectCompanylessRouteToOnboarding", () => {
       shouldRedirectCompanylessRouteToOnboarding({
         pathname: "/issues",
         hasCompanies: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRedirectGlobalOnboardingToBoard", () => {
+  it("redirects the global onboarding route back to the board when companies exist", () => {
+    expect(
+      shouldRedirectGlobalOnboardingToBoard({
+        pathname: "/onboarding",
+        hasCompanies: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not redirect company-prefixed onboarding routes", () => {
+    expect(
+      shouldRedirectGlobalOnboardingToBoard({
+        pathname: "/pap/onboarding",
+        hasCompanies: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not redirect global onboarding when no companies exist", () => {
+    expect(
+      shouldRedirectGlobalOnboardingToBoard({
+        pathname: "/onboarding",
+        hasCompanies: false,
       }),
     ).toBe(false);
   });

--- a/ui/src/lib/onboarding-route.ts
+++ b/ui/src/lib/onboarding-route.ts
@@ -49,3 +49,11 @@ export function shouldRedirectCompanylessRouteToOnboarding(params: {
 }): boolean {
   return !params.hasCompanies && !isOnboardingPath(params.pathname);
 }
+
+export function shouldRedirectGlobalOnboardingToBoard(params: {
+  pathname: string;
+  hasCompanies: boolean;
+}): boolean {
+  const segments = params.pathname.split("/").filter(Boolean);
+  return params.hasCompanies && segments.length === 1 && segments[0]?.toLowerCase() === "onboarding";
+}


### PR DESCRIPTION
Fixes #2195

## Summary
- redirect the global `/onboarding` route back to the board once companies exist
- keep company-prefixed onboarding routes available for rerunning onboarding inside a company
- add regression coverage for the new route guard

## Verification
- pnpm exec vitest run ui/src/lib/onboarding-route.test.ts
- pnpm --filter @paperclipai/ui typecheck