### PR TITLE
fix(adapter-utils): spawn child processes with detached mode for proper process group cleanup

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -788,8 +788,10 @@ export async function runChildProcess(
           cwd: opts.cwd,
           env: mergedEnv,
           shell: false,
+          detached: true,
           stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
         }) as ChildProcessWithEvents;
+        child.unref();
         const startedAt = new Date().toISOString();
 
         if (opts.stdin != null && child.stdin) {
@@ -814,10 +816,26 @@ export async function runChildProcess(
           opts.timeoutSec > 0
             ? setTimeout(() => {
                 timedOut = true;
-                child.kill("SIGTERM");
+                if (typeof child.pid === "number" && child.pid > 0 && process.platform !== "win32") {
+                  try {
+                    process.kill(-child.pid, "SIGTERM");
+                  } catch {
+                    child.kill("SIGTERM");
+                  }
+                } else {
+                  child.kill("SIGTERM");
+                }
                 setTimeout(() => {
-                  if (!child.killed) {
-                    child.kill("SIGKILL");
+                  if (!child.killed && typeof child.pid === "number" && child.pid > 0) {
+                    if (process.platform !== "win32") {
+                      try {
+                        process.kill(-child.pid, "SIGKILL");
+                      } catch {
+                        child.kill("SIGKILL");
+                      }
+                    } else {
+                      child.kill("SIGKILL");
+                    }
                   }
                 }, Math.max(1, opts.graceSec) * 1000);
               }, opts.timeoutSec * 1000)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3683,11 +3683,28 @@ export function heartbeatService(db: Db) {
 
     const running = runningProcesses.get(run.id);
     if (running) {
-      running.child.kill("SIGTERM");
+      const child = running.child;
+      if (typeof child.pid === "number" && child.pid > 0 && process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+        } catch {
+          child.kill("SIGTERM");
+        }
+      } else {
+        child.kill("SIGTERM");
+      }
       const graceMs = Math.max(1, running.graceSec) * 1000;
       setTimeout(() => {
-        if (!running.child.killed) {
-          running.child.kill("SIGKILL");
+        if (!child.killed && typeof child.pid === "number" && child.pid > 0) {
+          if (process.platform !== "win32") {
+            try {
+              process.kill(-child.pid, "SIGKILL");
+            } catch {
+              child.kill("SIGKILL");
+            }
+          } else {
+            child.kill("SIGKILL");
+          }
         }
       }, graceMs);
     }
@@ -3739,7 +3756,16 @@ export function heartbeatService(db: Db) {
 
       const running = runningProcesses.get(run.id);
       if (running) {
-        running.child.kill("SIGTERM");
+        const child = running.child;
+        if (typeof child.pid === "number" && child.pid > 0 && process.platform !== "win32") {
+          try {
+            process.kill(-child.pid, "SIGTERM");
+          } catch {
+            child.kill("SIGTERM");
+          }
+        } else {
+          child.kill("SIGTERM");
+        }
         runningProcesses.delete(run.id);
       }
       await releaseIssueExecutionAndPromote(run);


### PR DESCRIPTION
- Paperclip orchestrates AI agents that spawn child processes for execution
- When heartbeat runs time out, the adapter needs to clean up all spawned processes
- On Linux/macOS, the process tree has two layers: node wrapper → opencode native binary
- When only the wrapper is killed, the grandchild becomes orphaned and survives
- This leaves zombie processes running that consume resources and can cause issues
- The fix adds detached: true to spawn() making the wrapper a process group leader
- Adding child.unref() allows the parent to exit without waiting for the child
- Now process.kill(-child.pid, SIGTERM) kills the entire group including orphans
- This matches the approach in PR #2266 which fixed the same issue on Windows using taskkill

Closes #2297