### PR TITLE
Add explicit agent stop and cancel runs when heartbeats are disabled

### DIFF
--- a/server/src/__tests__/agent-stop-routes.test.ts
+++ b/server/src/__tests__/agent-stop-routes.test.ts
@@ -1,0 +1,167 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelActiveForAgent: vi.fn(async () => 0),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(async (_companyId: string, config: Record<string, unknown>) => config),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => ({
+    getBundle: vi.fn(),
+    readFile: vi.fn(),
+    updateBundle: vi.fn(),
+    writeFile: vi.fn(),
+    deleteFile: vi.fn(),
+    exportFiles: vi.fn(),
+    ensureManagedBundle: vi.fn(),
+    materializeManagedBundle: vi.fn(),
+  }),
+  accessService: () => mockAccessService,
+  approvalService: () => ({}),
+  companySkillService: () => ({
+    listRuntimeSkillEntries: vi.fn(),
+    resolveRequestedSkillKeys: vi.fn(async (_companyId: string, requested: string[]) => requested),
+  }),
+  budgetService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => ({}),
+  issueService: () => ({}),
+  logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+  workspaceOperationService: () => ({}),
+}));
+
+vi.mock("../adapters/index.js", () => ({
+  findServerAdapter: vi.fn(() => null),
+  listAdapterModels: vi.fn(),
+  detectAdapterModel: vi.fn(),
+}));
+
+function createDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [
+          {
+            id: "company-1",
+            requireBoardApprovalForNewAgents: false,
+          },
+        ]),
+      })),
+    })),
+  };
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(createDb() as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeAgent(runtimeConfig: Record<string, unknown>) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    name: "Agent",
+    role: "engineer",
+    title: "Engineer",
+    status: "running",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig,
+    permissions: null,
+    updatedAt: new Date(),
+  };
+}
+
+describe("agent stop routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(
+      async (_companyId: string, config: Record<string, unknown>) => config,
+    );
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("cancels active runs when a patch disables heartbeats", async () => {
+    mockAgentService.getById.mockResolvedValue(
+      makeAgent({ heartbeat: { enabled: true, intervalSec: 3600 } }),
+    );
+    mockAgentService.update.mockResolvedValue(
+      makeAgent({ heartbeat: { enabled: false, intervalSec: 3600 } }),
+    );
+
+    const res = await request(createApp())
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({ runtimeConfig: { heartbeat: { enabled: false, intervalSec: 3600 } } });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "Cancelled because heartbeat was disabled",
+    );
+  });
+
+  it("exposes an explicit stop endpoint for operators", async () => {
+    mockAgentService.getById.mockResolvedValue(makeAgent({ heartbeat: { enabled: true } }));
+    mockHeartbeatService.cancelActiveForAgent.mockResolvedValue(2);
+
+    const res = await request(createApp())
+      .post("/api/agents/11111111-1111-4111-8111-111111111111/stop")
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.cancelledRuns).toBe(2);
+    expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "Cancelled by operator",
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "heartbeat.cancelled",
+        entityType: "agent",
+        entityId: "11111111-1111-4111-8111-111111111111",
+        details: expect.objectContaining({
+          cancelledRuns: 2,
+          source: "agent_stop",
+        }),
+      }),
+    );
+  });
+});

--- a/server/src/__tests__/heartbeat-agent-stop.test.ts
+++ b/server/src/__tests__/heartbeat-agent-stop.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { runningProcesses } from "../adapters/index.ts";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent stop tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+function spawnAliveProcess() {
+  return spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    stdio: "ignore",
+  });
+}
+
+async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs = 5_000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await Promise.race([
+    once(child, "exit"),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("Timed out waiting for child exit")), timeoutMs)),
+  ]);
+}
+
+describeEmbeddedPostgres("heartbeat agent stop", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-agent-stop-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    runningProcesses.clear();
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    runningProcesses.clear();
+    await tempDb?.cleanup();
+  });
+
+  async function seedRunningRun(processPid: number | null) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const now = new Date("2026-03-31T00:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Claude Operator",
+      role: "engineer",
+      status: "running",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {},
+      status: "claimed",
+      runId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId,
+      contextSnapshot: {},
+      processPid,
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    return { agentId, runId, wakeupRequestId };
+  }
+
+  it("cancels active local runs using the persisted pid when the in-memory handle is gone", async () => {
+    const child = spawnAliveProcess();
+    expect(child.pid).toBeTypeOf("number");
+
+    const { agentId, runId, wakeupRequestId } = await seedRunningRun(child.pid ?? null);
+    const heartbeat = heartbeatService(db);
+
+    const cancelledRuns = await heartbeat.cancelActiveForAgent(agentId, "Cancelled by operator");
+    expect(cancelledRuns).toBe(1);
+
+    await waitForExit(child);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("cancelled");
+    expect(run?.error).toBe("Cancelled by operator");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
+
+    const events = await heartbeat.listEvents(runId, 0, 20);
+    expect(events.some((event) => event.message === "run cancelled")).toBe(true);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1798,6 +1798,7 @@ export function agentRoutes(db: Db) {
     }
 
     const actor = getActorInfo(req);
+    const previousHeartbeatPolicy = parseSchedulerHeartbeatPolicy(existing.runtimeConfig);
     const agent = await svc.update(id, patchData, {
       recordRevision: {
         createdByAgentId: actor.agentId,
@@ -1808,6 +1809,11 @@ export function agentRoutes(db: Db) {
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
       return;
+    }
+
+    const nextHeartbeatPolicy = parseSchedulerHeartbeatPolicy(agent.runtimeConfig);
+    if (previousHeartbeatPolicy.enabled && !nextHeartbeatPolicy.enabled) {
+      await heartbeat.cancelActiveForAgent(id, "Cancelled because heartbeat was disabled");
     }
 
     await logActivity(db, {
@@ -1846,6 +1852,33 @@ export function agentRoutes(db: Db) {
     });
 
     res.json(agent);
+  });
+
+  router.post("/agents/:id/stop", async (req, res) => {
+    assertBoard(req);
+    const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+
+    const cancelledRuns = await heartbeat.cancelActiveForAgent(
+      id,
+      "Cancelled by operator",
+    );
+
+    await logActivity(db, {
+      companyId: agent.companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "heartbeat.cancelled",
+      entityType: "agent",
+      entityId: agent.id,
+      details: { cancelledRuns, source: "agent_stop" },
+    });
+
+    res.json({ agent, cancelledRuns });
   });
 
   router.post("/agents/:id/resume", async (req, res) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -753,6 +753,18 @@ function isProcessAlive(pid: number | null | undefined) {
   }
 }
 
+function killProcessByPid(pid: number, signal: NodeJS.Signals) {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ESRCH") return false;
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
 function truncateDisplayId(value: string | null | undefined, max = 128) {
   if (!value) return null;
   return value.length > max ? value.slice(0, max) : value;
@@ -3682,12 +3694,27 @@ export function heartbeatService(db: Db) {
     if (run.status !== "running" && run.status !== "queued") return run;
 
     const running = runningProcesses.get(run.id);
+    const agent = await getAgent(run.agentId);
     if (running) {
       running.child.kill("SIGTERM");
       const graceMs = Math.max(1, running.graceSec) * 1000;
       setTimeout(() => {
         if (!running.child.killed) {
           running.child.kill("SIGKILL");
+        }
+      }, graceMs);
+    } else if (
+      agent &&
+      isTrackedLocalChildProcessAdapter(agent.adapterType) &&
+      run.processPid &&
+      isProcessAlive(run.processPid)
+    ) {
+      const pid = run.processPid;
+      killProcessByPid(pid, "SIGTERM");
+      const graceMs = 15_000;
+      setTimeout(() => {
+        if (isProcessAlive(pid)) {
+          killProcessByPid(pid, "SIGKILL");
         }
       }, graceMs);
     }
@@ -3704,7 +3731,7 @@ export function heartbeatService(db: Db) {
     });
 
     if (cancelled) {
-      await appendRunEvent(cancelled, 1, {
+      await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
         eventType: "lifecycle",
         stream: "system",
         level: "warn",
@@ -3726,23 +3753,7 @@ export function heartbeatService(db: Db) {
       .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, ["queued", "running"])));
 
     for (const run of runs) {
-      await setRunStatus(run.id, "cancelled", {
-        finishedAt: new Date(),
-        error: reason,
-        errorCode: "cancelled",
-      });
-
-      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
-        finishedAt: new Date(),
-        error: reason,
-      });
-
-      const running = runningProcesses.get(run.id);
-      if (running) {
-        running.child.kill("SIGTERM");
-        runningProcesses.delete(run.id);
-      }
-      await releaseIssueExecutionAndPromote(run);
+      await cancelRunInternal(run.id, reason);
     }
 
     return runs.length;
@@ -3952,7 +3963,7 @@ export function heartbeatService(db: Db) {
 
     cancelRun: (runId: string) => cancelRunInternal(runId),
 
-    cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
+    cancelActiveForAgent: (agentId: string, reason?: string) => cancelActiveForAgentInternal(agentId, reason),
 
     cancelBudgetScopeWork,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3756,6 +3756,31 @@ export function heartbeatService(db: Db) {
       await cancelRunInternal(run.id, reason);
     }
 
+    const now = new Date();
+    const pendingWakeups = await db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.runId} is null`,
+        ),
+      )
+      .then((rows) => rows.map((row) => row.id));
+
+    if (pendingWakeups.length > 0) {
+      await db
+        .update(agentWakeupRequests)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: reason,
+          updatedAt: now,
+        })
+        .where(inArray(agentWakeupRequests.id, pendingWakeups));
+    }
+
     return runs.length;
   }
 


### PR DESCRIPTION
## Thinking Path

Paperclip allows operators to pause and resume agents, but the stop endpoint only cancels heartbeat runs that are already in `queued` or `running` status. Any `agentWakeupRequests` that haven't been promoted to a run yet (status `queued` or `deferred_issue_execution` with no `runId`) survive the stop and get promoted on the next heartbeat cycle, effectively restarting the agent. This PR adds an explicit stop lifecycle that also drains pending wakeup requests.

Closes #2224

## Changes

- Add `POST /agents/:id/stop` endpoint that cancels active runs AND drains pending wakeup requests
- Drain pending `agentWakeupRequests` (queued/deferred without a runId) inside `cancelActiveForAgentInternal`
- Log the cancellation with `agent_stop` source for audit trail

## Verification

```bash
pnpm vitest run agent-stop
pnpm --filter @paperclipai/server typecheck
```

## Risks

- **Low**: The wakeup drain only targets requests with no `runId` (not yet promoted), so it cannot interfere with in-flight runs
- Budget-scoped cancellation already uses the same pattern (`cancelPendingWakeupsForBudgetScope`)

## Model Used

- Claude Opus 4.6 (Anthropic) — assisted with wakeup drain fix and PR template

## Checklist

- [x] Thinking path documented
- [x] Model specified
- [x] Addresses P1 review feedback (pending wakeup drain)
- [x] Follows existing pattern from budget scope cancellation
- [x] Risk analysis included