### PR TITLE
Support enterprise-safe Claude onboarding without skip-permissions

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -10,6 +10,8 @@ description: >
 
 Use this skill when you are asked to hire/create an agent.
 
+If Bash is unavailable but an MCP shell tool is available (for example `mcp__shell__shell_exec`), use that tool for the `curl` examples below.
+
 ## Preconditions
 
 You need either:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -23,6 +23,8 @@ Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli
 
 **Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
 
+**Shell tool fallback:** If Bash is unavailable but an MCP shell tool is available (for example `mcp__shell__shell_exec`), use that tool for the command examples in this skill. Treat it as equivalent to Bash for `curl`, `git`, `gh`, and similar shell operations.
+
 ## The Heartbeat Procedure
 
 Follow these steps every time you wake up:

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -312,7 +312,7 @@ export function OnboardingWizard() {
 
   function buildAdapterConfig(): Record<string, unknown> {
     return buildOnboardingAdapterConfig({
-      adapterType,
+      adapterType: adapterType as import("../lib/onboarding-adapter-config").OnboardingAdapterType,
       model,
       command,
       extraArgs,

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -33,13 +33,11 @@ import {
   buildOnboardingProjectPayload,
   selectDefaultCompanyGoalId
 } from "../lib/onboarding-launch";
-import {
-  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
-  DEFAULT_CODEX_LOCAL_MODEL
-} from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CODEX_LOCAL_MODEL } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
+import { buildOnboardingAdapterConfig } from "../lib/onboarding-adapter-config";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import {
   Building2,
@@ -108,7 +106,9 @@ export function OnboardingWizard() {
   const [adapterType, setAdapterType] = useState<AdapterType>("claude_local");
   const [model, setModel] = useState("");
   const [command, setCommand] = useState("");
-  const [args, setArgs] = useState("");
+  const [extraArgs, setExtraArgs] = useState("");
+  const [dangerouslySkipPermissions, setDangerouslySkipPermissions] =
+    useState(true);
   const [url, setUrl] = useState("");
   const [adapterEnvResult, setAdapterEnvResult] =
     useState<AdapterEnvironmentTestResult | null>(null);
@@ -229,7 +229,7 @@ export function OnboardingWizard() {
     if (step !== 2) return;
     setAdapterEnvResult(null);
     setAdapterEnvError(null);
-  }, [step, adapterType, model, command, args, url]);
+  }, [step, adapterType, model, command, extraArgs, url, dangerouslySkipPermissions]);
 
   const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
   const hasAnthropicApiKeyOverrideCheck =
@@ -287,7 +287,8 @@ export function OnboardingWizard() {
     setAdapterType("claude_local");
     setModel("");
     setCommand("");
-    setArgs("");
+    setExtraArgs("");
+    setDangerouslySkipPermissions(true);
     setUrl("");
     setAdapterEnvResult(null);
     setAdapterEnvError(null);
@@ -310,39 +311,15 @@ export function OnboardingWizard() {
   }
 
   function buildAdapterConfig(): Record<string, unknown> {
-    const adapter = getUIAdapter(adapterType);
-    const config = adapter.buildAdapterConfig({
-      ...defaultCreateValues,
+    return buildOnboardingAdapterConfig({
       adapterType,
-      model:
-        adapterType === "codex_local"
-          ? model || DEFAULT_CODEX_LOCAL_MODEL
-          : adapterType === "gemini_local"
-            ? model || DEFAULT_GEMINI_LOCAL_MODEL
-          : adapterType === "cursor"
-          ? model || DEFAULT_CURSOR_LOCAL_MODEL
-          : model,
+      model,
       command,
-      args,
+      extraArgs,
       url,
-      dangerouslySkipPermissions:
-        adapterType === "claude_local" || adapterType === "opencode_local",
-      dangerouslyBypassSandbox:
-        adapterType === "codex_local"
-          ? DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX
-          : defaultCreateValues.dangerouslyBypassSandbox
+      dangerouslySkipPermissions,
+      forceUnsetAnthropicApiKey,
     });
-    if (adapterType === "claude_local" && forceUnsetAnthropicApiKey) {
-      const env =
-        typeof config.env === "object" &&
-        config.env !== null &&
-        !Array.isArray(config.env)
-          ? { ...(config.env as Record<string, unknown>) }
-          : {};
-      env.ANTHROPIC_API_KEY = { type: "plain", value: "" };
-      config.env = env;
-    }
-    return config;
   }
 
   async function runAdapterEnvironmentTest(
@@ -772,6 +749,9 @@ export function OnboardingWizard() {
                             if (nextType !== "codex_local") {
                               setModel("");
                             }
+                            setDangerouslySkipPermissions(
+                              nextType === "claude_local" || nextType === "opencode_local"
+                            );
                           }}
                         >
                           {opt.recommended && (
@@ -821,18 +801,24 @@ export function OnboardingWizard() {
                               setAdapterType(nextType);
                               if (nextType === "gemini_local" && !model) {
                                 setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+                                setDangerouslySkipPermissions(false);
                                 return;
                               }
                               if (nextType === "cursor" && !model) {
                                 setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+                                setDangerouslySkipPermissions(false);
                                 return;
                               }
                               if (nextType === "opencode_local") {
                                 if (!model.includes("/")) {
                                   setModel("");
                                 }
+                                setDangerouslySkipPermissions(true);
                                 return;
                               }
+                              setDangerouslySkipPermissions(
+                                nextType === "claude_local"
+                              );
                               setModel("");
                             }}
                           >
@@ -949,6 +935,59 @@ export function OnboardingWizard() {
                           </PopoverContent>
                         </Popover>
                       </div>
+
+                      {(adapterType === "claude_local" ||
+                        adapterType === "opencode_local") && (
+                        <label className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
+                          <div>
+                            <div className="text-xs font-medium">
+                              Skip permissions
+                            </div>
+                            <div className="text-[11px] text-muted-foreground">
+                              Auto-approve CLI permission prompts when the adapter supports it.
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            data-slot="toggle"
+                            className={cn(
+                              "relative inline-flex h-5 w-9 items-center rounded-full transition-colors shrink-0",
+                              dangerouslySkipPermissions ? "bg-green-600" : "bg-muted"
+                            )}
+                            onClick={() =>
+                              setDangerouslySkipPermissions((value) => !value)
+                            }
+                          >
+                            <span
+                              className={cn(
+                                "inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform",
+                                dangerouslySkipPermissions ? "translate-x-4.5" : "translate-x-0.5"
+                              )}
+                            />
+                          </button>
+                        </label>
+                      )}
+
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Extra args (optional)
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="e.g. --mcp-config, /path/to/shell.json, --allowedTools, mcp__shell__*"
+                          value={extraArgs}
+                          onChange={(e) => setExtraArgs(e.target.value)}
+                        />
+                      </div>
+
+                      {adapterType === "claude_local" &&
+                        !dangerouslySkipPermissions && (
+                          <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px] text-muted-foreground">
+                            For locked-down Claude environments, pair this with
+                            <span className="font-mono"> --mcp-config</span> and
+                            <span className="font-mono"> --allowedTools</span> so agents can use shell MCP tools instead of Bash.
+                          </div>
+                        )}
                     </div>
                   )}
 

--- a/ui/src/lib/onboarding-adapter-config.test.ts
+++ b/ui/src/lib/onboarding-adapter-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildOnboardingAdapterConfig } from "./onboarding-adapter-config";
+
+describe("buildOnboardingAdapterConfig", () => {
+  it("preserves claude_local extra args and skip-permissions override", () => {
+    const config = buildOnboardingAdapterConfig({
+      adapterType: "claude_local",
+      model: "",
+      command: "",
+      extraArgs: "--mcp-config, /tmp/shell.json, --allowedTools, mcp__shell__*",
+      url: "",
+      dangerouslySkipPermissions: false,
+    });
+
+    expect(config.dangerouslySkipPermissions).toBe(false);
+    expect(config.extraArgs).toEqual([
+      "--mcp-config",
+      "/tmp/shell.json",
+      "--allowedTools",
+      "mcp__shell__*",
+    ]);
+  });
+
+  it("can force-clear ANTHROPIC_API_KEY for claude_local onboarding retries", () => {
+    const config = buildOnboardingAdapterConfig({
+      adapterType: "claude_local",
+      model: "",
+      command: "",
+      extraArgs: "",
+      url: "",
+      dangerouslySkipPermissions: true,
+      forceUnsetAnthropicApiKey: true,
+    });
+
+    expect(config.env).toEqual({
+      ANTHROPIC_API_KEY: { type: "plain", value: "" },
+    });
+  });
+});

--- a/ui/src/lib/onboarding-adapter-config.test.ts
+++ b/ui/src/lib/onboarding-adapter-config.test.ts
@@ -21,6 +21,19 @@ describe("buildOnboardingAdapterConfig", () => {
     ]);
   });
 
+  it("preserves opencode_local skip-permissions override", () => {
+    const config = buildOnboardingAdapterConfig({
+      adapterType: "opencode_local",
+      model: "",
+      command: "",
+      extraArgs: "",
+      url: "",
+      dangerouslySkipPermissions: false,
+    });
+
+    expect(config.dangerouslySkipPermissions).toBe(false);
+  });
+
   it("can force-clear ANTHROPIC_API_KEY for claude_local onboarding retries", () => {
     const config = buildOnboardingAdapterConfig({
       adapterType: "claude_local",

--- a/ui/src/lib/onboarding-adapter-config.ts
+++ b/ui/src/lib/onboarding-adapter-config.ts
@@ -1,0 +1,64 @@
+import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX, DEFAULT_CODEX_LOCAL_MODEL } from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { getUIAdapter } from "../adapters";
+import { defaultCreateValues } from "../components/agent-config-defaults";
+
+type OnboardingAdapterType =
+  | "claude_local"
+  | "codex_local"
+  | "gemini_local"
+  | "hermes_local"
+  | "opencode_local"
+  | "pi_local"
+  | "cursor"
+  | "http"
+  | "openclaw_gateway";
+
+export function buildOnboardingAdapterConfig(input: {
+  adapterType: OnboardingAdapterType;
+  model: string;
+  command: string;
+  extraArgs: string;
+  url: string;
+  dangerouslySkipPermissions: boolean;
+  forceUnsetAnthropicApiKey?: boolean;
+}) {
+  const adapter = getUIAdapter(input.adapterType);
+  const config = adapter.buildAdapterConfig({
+    ...defaultCreateValues,
+    adapterType: input.adapterType,
+    model:
+      input.adapterType === "codex_local"
+        ? input.model || DEFAULT_CODEX_LOCAL_MODEL
+        : input.adapterType === "gemini_local"
+          ? input.model || DEFAULT_GEMINI_LOCAL_MODEL
+          : input.adapterType === "cursor"
+            ? input.model || DEFAULT_CURSOR_LOCAL_MODEL
+            : input.model,
+    command: input.command,
+    extraArgs: input.extraArgs,
+    url: input.url,
+    dangerouslySkipPermissions:
+      input.adapterType === "claude_local" || input.adapterType === "opencode_local"
+        ? input.dangerouslySkipPermissions
+        : defaultCreateValues.dangerouslySkipPermissions,
+    dangerouslyBypassSandbox:
+      input.adapterType === "codex_local"
+        ? DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX
+        : defaultCreateValues.dangerouslyBypassSandbox,
+  });
+
+  if (input.adapterType === "claude_local" && input.forceUnsetAnthropicApiKey) {
+    const env =
+      typeof config.env === "object" &&
+      config.env !== null &&
+      !Array.isArray(config.env)
+        ? { ...(config.env as Record<string, unknown>) }
+        : {};
+    env.ANTHROPIC_API_KEY = { type: "plain", value: "" };
+    config.env = env;
+  }
+
+  return config;
+}

--- a/ui/src/lib/onboarding-adapter-config.ts
+++ b/ui/src/lib/onboarding-adapter-config.ts
@@ -4,7 +4,7 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { getUIAdapter } from "../adapters";
 import { defaultCreateValues } from "../components/agent-config-defaults";
 
-type OnboardingAdapterType =
+export type OnboardingAdapterType =
   | "claude_local"
   | "codex_local"
   | "gemini_local"


### PR DESCRIPTION
## Thinking Path

Paperclip onboards agents by launching their CLI process. The Claude and OpenCode adapters accept `--dangerouslySkipPermissions` and extra CLI args, but these were hardcoded during onboarding and couldn't be customised up front. Enterprise setups that need MCP shell configs (`--mcp-config`) or want to keep permission prompts active had no way to set these during the onboarding wizard. This PR extracts a shared `buildOnboardingAdapterConfig` helper so both adapters can accept these settings at onboarding time.

Closes #2145

## Changes

- Extract `buildOnboardingAdapterConfig` helper for consistent adapter config during onboarding
- Expose extra args and skip-permissions controls for Claude and OpenCode in the onboarding wizard
- Document MCP shell fallback in the bundled Paperclip skills

## Verification

```bash
pnpm exec vitest run ui/src/lib/onboarding-adapter-config.test.ts
pnpm --filter @paperclipai/ui typecheck
```

## Risks

- **Low**: Only affects initial onboarding config generation. Existing agents are not modified.
- The `dangerouslySkipPermissions` flag is intentionally available for both `claude_local` and `opencode_local` — enterprise users need this for automated setups.

## Model Used

- Claude Opus 4.6 (Anthropic) — assisted with test additions and PR template

## Checklist

- [x] Thinking path documented
- [x] Model specified
- [x] Tests pass locally
- [x] Test coverage for both claude_local and opencode_local paths
- [x] No database changes
- [x] Risk analysis included