### PR TITLE
docs: document local demo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,37 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 
 > **Requirements:** Node.js 20+, pnpm 9.15+
 
+## Demo / Agent Setup
+
+Paperclip has two materially different local demo paths:
+
+- `local_trusted`: fastest path, no browser login required
+- `authenticated`: browser-auth flow plus bootstrap CEO invite for the first
+  human admin
+
+Recommended local operator path:
+
+```bash
+pnpm paperclipai run
+```
+
+For authenticated-mode demos, use a real local signup and then mint the first
+admin invite with:
+
+```bash
+pnpm paperclipai auth bootstrap-ceo
+```
+
+Current conventions for later agents:
+
+- do not commit a fixed demo company or canned user into the repo
+- create demo companies and agents inside the local instance or an isolated
+  worktree instance
+- for parallel capture or automation work, prefer worktree-local Paperclip
+  instances over sharing one mutable local instance
+
+The detailed operator workflow lives in [doc/DEVELOPING.md](doc/DEVELOPING.md).
+
 <br/>
 
 ## FAQ

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -80,6 +80,48 @@ pnpm paperclipai run
 2. `paperclipai doctor` with repair enabled
 3. starts the server when checks pass
 
+## Demo / automation conventions
+
+Use these rules when preparing Paperclip for screenshots, videos, or later
+Codex automations.
+
+### 1. Choose the right deployment mode
+
+- `local_trusted`: fastest local demo path, no login ceremony
+- `authenticated`: use when you explicitly need the real browser auth and invite
+  flow
+
+### 2. Bootstrap authenticated mode correctly
+
+Authenticated mode does not rely on a committed fixed admin account. The
+canonical flow is:
+
+1. start the app in authenticated mode
+2. sign up a real local human user
+3. run `pnpm paperclipai auth bootstrap-ceo`
+4. accept the generated invite URL in the browser
+
+That keeps the bootstrap path aligned with the product instead of bypassing it
+with hidden fixture users.
+
+### 3. Keep demo state local and isolated
+
+- do not commit reusable demo companies, tasks, or secrets into the repo
+- prefer per-instance or per-worktree demo state
+- for parallel agent work, create a worktree-local instance instead of sharing a
+  mutable default instance
+
+Useful commands:
+
+```sh
+pnpm paperclipai worktree init
+pnpm paperclipai worktree:make my-demo-lane
+```
+
+By default, worktree instances can seed from an existing local Paperclip
+instance in `minimal` or `full` mode, which makes them suitable for safe demo
+or regression capture lanes without cross-contaminating the main local state.
+
 ## Docker Quickstart (No local Node install)
 
 Build and run Paperclip in Docker:


### PR DESCRIPTION
This updates the repo-local documentation for local demo setup, agent handoff, and capture readiness.