### PR TITLE
build: add agent-friendly runtime toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-trixie-slim AS base
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl git \
+  && apt-get install -y --no-install-recommends ca-certificates curl git openssh-client \
   && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,34 @@
 FROM node:lts-trixie-slim AS base
+ARG UV_VERSION=0.6.17
+ARG YQ_VERSION=v4.44.5
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl git openssh-client \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    fd-find \
+    file \
+    git \
+    jq \
+    less \
+    openssh-client \
+    procps \
+    python-is-python3 \
+    python3 \
+    python3-pip \
+    python3-venv \
+    ripgrep \
   && rm -rf /var/lib/apt/lists/*
+RUN ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+  && arch="$(dpkg --print-architecture)" \
+  && case "$arch" in \
+    amd64) yq_arch=amd64 ;; \
+    arm64) yq_arch=arm64 ;; \
+    *) echo "Unsupported arch: $arch" >&2; exit 1 ;; \
+  esac \
+  && curl -fsSL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${yq_arch}" \
+  && chmod +x /usr/local/bin/yq \
+  && curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | env UV_INSTALL_DIR=/usr/local/bin sh
 RUN corepack enable
 
 FROM base AS deps
@@ -38,6 +65,7 @@ FROM base AS production
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+  && ln -sf /app/scripts/agent-env-report.sh /usr/local/bin/agent-env-report \
   && mkdir -p /paperclip \
   && chown node:node /paperclip
 

--- a/scripts/agent-env-report.sh
+++ b/scripts/agent-env-report.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+workspace_root="${1:-/workspace/voyage}"
+
+print_header() {
+  printf "== %s ==\n" "$1"
+}
+
+print_version() {
+  tool="$1"
+  version_flag="${2:---version}"
+  if command -v "$tool" >/dev/null 2>&1; then
+    version_output="$($tool "$version_flag" 2>/dev/null | head -n 1 || true)"
+    if [ -n "$version_output" ]; then
+      printf "%-10s %s\n" "$tool" "$version_output"
+    else
+      tool_path="$(command -v "$tool")"
+      printf "%-10s available at %s\n" "$tool" "$tool_path"
+    fi
+  else
+    printf "%-10s missing\n" "$tool"
+  fi
+}
+
+print_path() {
+  path="$1"
+  if [ -e "$path" ]; then
+    printf "%-28s present\n" "$path"
+  else
+    printf "%-28s missing\n" "$path"
+  fi
+}
+
+print_header "Agent Environment"
+printf "timestamp    %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf "user         %s\n" "$(id -un)"
+printf "uid:gid      %s:%s\n" "$(id -u)" "$(id -g)"
+printf "cwd          %s\n" "$(pwd)"
+printf "home         %s\n" "${HOME:-<unset>}"
+printf "shell        %s\n" "${SHELL:-<unset>}"
+printf "arch         %s\n" "$(uname -m)"
+printf "kernel       %s\n" "$(uname -sr)"
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
+  printf "os           %s\n" "${PRETTY_NAME:-unknown}"
+fi
+
+print_header "Key Paths"
+print_path /workspace
+print_path "$workspace_root"
+print_path /paperclip
+print_path /paperclip/.ssh
+print_path /app
+
+print_header "Tool Versions"
+print_version node
+print_version npm
+print_version pnpm
+print_version git
+print_version rg
+print_version fd
+print_version jq
+print_version yq
+print_version python
+print_version python3
+print_version uv
+print_version codex version
+print_version opencode version
+print_version claude version
+
+print_header "Workspace Snapshot"
+if [ -d "$workspace_root" ]; then
+  printf "workspace    %s\n" "$workspace_root"
+  find "$workspace_root" -maxdepth 1 -mindepth 1 | sort | sed 's#^#- #'
+else
+  printf "workspace    missing\n"
+fi


### PR DESCRIPTION
## Summary
- install `openssh-client` so git-over-ssh workflows work in the runtime image
- add a small agent-friendly baseline toolchain: `rg`, `fd`, `jq`, `yq`, `python`, and `uv`
- add `scripts/agent-env-report.sh` as a lightweight runtime self-report helper

## Why
In the live Voyage rollout, execution agents were repeatedly falling back to slower or less predictable commands because the container image lacked common tools that agentic coding workflows expect. The missing SSH client also blocked GitHub SSH operations in the runtime image.

This patch makes the execution environment more predictable for agents without introducing host-specific repo mounts or credential wiring.

## Validation
- validated in a live Paperclip instance
- confirmed availability of `ssh`, `rg`, `fd`, `jq`, `yq`, `python`, and `uv`
- confirmed `agent-env-report` provides a compact runtime capability summary

## Notes
This PR is intentionally limited to image/tooling ergonomics. Read-only mounts, deploy-key mounts, and project-specific workspace/database configuration remain server-local.