### PR TITLE
fix(ui): revision date tooltip and restore confirmation in documents

### DIFF
--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -784,7 +784,7 @@ export function IssueDocumentsSection({
                                         </span>
                                       ) : null}
                                     </div>
-                                    <span className="text-xs text-muted-foreground">
+                                    <span className="text-xs text-muted-foreground" title={new Date(revision.createdAt).toLocaleString()}>
                                       {relativeTime(revision.createdAt)} • {getRevisionActorLabel(revision)}
                                     </span>
                                   </div>
@@ -902,10 +902,7 @@ export function IssueDocumentsSection({
                           </Button>
                           <Button
                             size="sm"
-                            onClick={() => restoreDocumentRevision.mutate({
-                              key: doc.key,
-                              revisionId: selectedHistoricalRevision.id,
-                            })}
+                            onClick={() => { if (window.confirm("Restore this revision? Current document content will be overwritten.")) restoreDocumentRevision.mutate({ key: doc.key, revisionId: selectedHistoricalRevision.id }); }}
                             disabled={restoreDocumentRevision.isPending}
                           >
                             {restoreDocumentRevision.isPending && restoreDocumentRevision.variables?.key === doc.key


### PR DESCRIPTION
## Problem

The new document revision feature (just merged) had two small UX gaps:

### 1. Revision dates missing hover tooltip
In the revision dropdown, each revision show a relative timestamp like "3h ago" using relativeTime(). But there was no title attribute so user cannot see the exact date and time without checking the API. We already add these tooltips to all other relative time displays in the app.

### 2. Restore revision has no confirmation
The "Restore this revision" button call restoreDocumentRevision.mutate() immediately with one click. This overwrite the current document content with a historical version. Same pattern we fix for agent config rollback - destructive actions should confirm first.

## What I changed

1. Added \`title={new Date(revision.createdAt).toLocaleString()}\` to the revision timestamp span
2. Added \`window.confirm("Restore this revision? Current document content will be overwritten.")\` before calling the restore mutation

## How to test

1. Open any issue with a document that has revision history
2. Click the revision dropdown - hover over timestamps, should see full date tooltip
3. Select an older revision, click "Restore this revision" - should see confirmation dialog

1 file, 2 lines changed.