### PR TITLE
fix(ui): render documents with MarkdownBody in read-only view

### DIFF
--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -1055,9 +1055,16 @@ export function IssueDocumentsSection({
                     ) : (
                       <div
                         className="cursor-text"
+                        tabIndex={0}
+                        role="button"
                         onClick={(e) => {
                           if ((e.target as HTMLElement).closest("a")) return;
                           beginEdit(doc.key);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !(e.target as HTMLElement).closest("a")) {
+                            beginEdit(doc.key);
+                          }
                         }}
                       >
                         {displayedBody.trim()


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents generate documents (plans, specs, notes) attached to issues, rendered in the Documents section of the issue detail page
> - The Documents section uses MDXEditor for both display and editing of document content
> - MDXEditor parses content as MDX (a JSX superset of markdown), not standard markdown
> - When agent-generated documents contain bare angle brackets in prose (e.g. `Map<callId, CallState>`, `<Feature area>`), MDXEditor interprets them as JSX tags
> - MDXEditor's parser silently fails on invalid JSX and renders nothing — just the "Markdown body" placeholder
> - This PR separates read-only display (using MarkdownBody/react-markdown with GFM) from editing (MDXEditor), so documents always render correctly in read-only view
> - The benefit is that agent-generated documents with standard markdown now display properly instead of showing a blank body

## What Changed

- In `IssueDocumentsSection.tsx`, the document body rendering now has three states:
  1. **Historical preview** → `MarkdownBody` (unchanged)
  2. **Active draft (editing)** → `MarkdownEditor` (MDXEditor) — only mounted when user clicks to edit
  3. **Read-only view (new)** → `MarkdownBody` (react-markdown + GFM) with click-to-edit
- The click-to-edit handler delegates to `beginEdit()` to properly reset error banners and autosave state

## Why It Matters

- `MarkdownBody` uses react-markdown which treats `<callId>` as plain text, not JSX — so standard markdown always renders
- Copy and download already worked (they read the raw string), but the visual display was completely broken
- Documents generated by agents frequently contain code-like syntax with angle brackets in prose

## Before / After

**Before:** Document with bare angle brackets shows only the "Markdown body" placeholder — the entire document body is invisible:

<img width="724" height="425" alt="Screenshot 2026-03-31 072637" src="https://github.com/user-attachments/assets/86897b70-2f7a-48e3-b5bf-d4c66942071e" />

_The "before" state shows a document expanded with only the italic gray text "Markdown body" where the content should be. Copy and download buttons still work, confirming the data exists._

**After:** The same document renders correctly using MarkdownBody with full GFM support (tables, headings, inline code, etc.). Clicking the body enters edit mode via MDXEditor.

<img width="738" height="558" alt="image" src="https://github.com/user-attachments/assets/20aa3cbf-224b-48be-8733-3edf4f7356bb" />


## Risks

- When a user clicks to edit a document that contains MDX-unsafe content (bare angle brackets outside code blocks), MDXEditor may still fail to parse it in the editor. This is an existing limitation of MDXEditor and is unchanged by this PR — the read-only view is the fix.
- No risk to existing editing workflows: the `beginEdit()` path is identical to the existing `onFocusCapture` entry point.

## Verification

- [x] Open an issue with a document containing bare angle brackets (e.g. `Map<K, V>`) — renders correctly
- [x] Open an issue with a normal document — renders correctly
- [x] Click on a document body — enters edit mode via `beginEdit()`
- [x] Empty documents show italic "Markdown body" placeholder
- [x] Copy and download continue to work

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] Clear description of what & why
- [x] Proof it works (manual testing notes above)
- [x] I have considered and documented risks above
- [x] Before/after screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)