### PR TITLE
fix(db): handle stale postmaster.pid with recycled PID on Windows

### DIFF
--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -126,12 +126,25 @@ async function ensureEmbeddedPostgresConnection(
   if (runningPid) {
     const port = runningPort ?? preferredPort;
     const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
-    await ensurePostgresDatabase(adminConnectionString, "paperclip");
-    return {
-      connectionString: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
-      source: `embedded-postgres@${port}`,
-      stop: async () => {},
-    };
+    try {
+      await ensurePostgresDatabase(adminConnectionString, "paperclip");
+      return {
+        connectionString: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
+        source: `embedded-postgres@${port}`,
+        stop: async () => {},
+      };
+    } catch (err: unknown) {
+      // On Windows, process.kill(pid, 0) does not throw for recycled PIDs, so a
+      // connection error here means the PID is stale — remove postmaster.pid and
+      // fall through to start a fresh cluster.
+      // On POSIX the liveness check is reliable, so any non-connection error is
+      // unexpected and should propagate.
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (typeof code !== "string" || !["ECONNREFUSED", "ECONNRESET", "ENOTFOUND", "ETIMEDOUT"].includes(code)) {
+        throw err;
+      }
+      rmSync(postmasterPidFile, { force: true });
+    }
   }
 
   const instance = new EmbeddedPostgres({


### PR DESCRIPTION
## Summary

Fixes #2333

On Windows, `process.kill(pid, 0)` does not throw for non-existent or recycled PIDs (unlike POSIX). This means `readRunningPostmasterPid` can return a non-null value even when postgres has exited and some unrelated process has claimed the old PID. The `runningPid` branch in `ensureEmbeddedPostgresConnection` then calls `ensurePostgresDatabase` with no error handling, crashing with `ECONNREFUSED` instead of gracefully falling back to starting a fresh cluster.

**Change:** wrap the `runningPid` connection attempt in a try-catch. On failure, delete `postmaster.pid` and fall through to start a fresh embedded postgres — the same recovery path that already exists for the `!runningPid` adopt block.

```diff
 if (runningPid) {
   const port = runningPort ?? preferredPort;
   const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
-  await ensurePostgresDatabase(adminConnectionString, "paperclip");
-  return {
-    connectionString: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
-    source: `embedded-postgres@${port}`,
-    stop: async () => {},
-  };
+  try {
+    await ensurePostgresDatabase(adminConnectionString, "paperclip");
+    return {
+      connectionString: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
+      source: `embedded-postgres@${port}`,
+      stop: async () => {},
+    };
+  } catch {
+    // postmaster.pid pointed to a stale or recycled PID (common on Windows).
+    // Remove the stale file and fall through to start a fresh embedded cluster.
+    rmSync(postmasterPidFile, { force: true });
+  }
 }
```

## Test plan

- [ ] Start Paperclip, let embedded postgres initialise
- [ ] Force-kill `postgres.exe` processes (`taskkill /F /IM postgres.exe` on Windows)
- [ ] Run `pnpm dev` again — should start cleanly without `ECONNREFUSED` crash
- [ ] Normal startup (no stale pid file) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)