### PR TITLE
fix(ui): use router Link in CompanySettings to apply company prefix

### DIFF
--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@/lib/router";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { DEFAULT_FEEDBACK_DATA_SHARING_TERMS_VERSION } from "@paperclipai/shared";
@@ -544,20 +545,20 @@ export function CompanySettings() {
         <div className="rounded-md border border-border px-4 py-4">
           <p className="text-sm text-muted-foreground">
             Import and export have moved to dedicated pages accessible from the{" "}
-            <a href="/org" className="underline hover:text-foreground">Org Chart</a> header.
+            <Link to="/org" className="underline hover:text-foreground">Org Chart</Link> header.
           </p>
           <div className="mt-3 flex items-center gap-2">
             <Button size="sm" variant="outline" asChild>
-              <a href="/company/export">
+              <Link to="/company/export">
                 <Download className="mr-1.5 h-3.5 w-3.5" />
                 Export
-              </a>
+              </Link>
             </Button>
             <Button size="sm" variant="outline" asChild>
-              <a href="/company/import">
+              <Link to="/company/import">
                 <Upload className="mr-1.5 h-3.5 w-3.5" />
                 Import
-              </a>
+              </Link>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Thinking path

CompanySettings page lives under a company-prefixed route (e.g. `/CLA/company/settings`). The project uses a custom `<Link>` wrapper (`@/lib/router`) that intercepts navigation and prepends the active company prefix via `applyCompanyPrefix()`. However, the Export, Import, and Org Chart links in CompanySettings used raw `<a href>` tags, which bypass the router entirely and navigate to unprefixed paths like `/company/export` — resulting in a 404 or wrong context.

## What was fixed

Replaced three bare `<a href>` tags with `<Link to>` from `@/lib/router` so the company prefix is automatically applied.

## Why it matters

Without the fix, clicking Export/Import/Org Chart from company settings navigates to a path missing the company prefix, breaking navigation for any multi-company or prefixed deployment.

## Risks

Minimal — the change is a direct substitution of HTML anchors with the existing router-aware Link component. All three target paths (`/org`, `/company/export`, `/company/import`) are listed in `BOARD_ROUTE_ROOTS`, so `applyCompanyPrefix` handles them correctly. No new dependencies or logic changes.

## Test plan

- [ ] Navigate to `/<PREFIX>/company/settings`
- [ ] Click Export — should go to `/<PREFIX>/company/export`
- [ ] Click Import — should go to `/<PREFIX>/company/import`
- [ ] Click Org Chart link — should go to `/<PREFIX>/org`