### PR TITLE
feat: add hermes_gateway adapter

### DIFF
--- a/packages/adapters/hermes-gateway/package.json
+++ b/packages/adapters/hermes-gateway/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@paperclipai/adapter-hermes-gateway",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/hermes-gateway/src/index.ts
+++ b/packages/adapters/hermes-gateway/src/index.ts
@@ -1,0 +1,16 @@
+export const type = "hermes_gateway";
+export const label = "Hermes Gateway";
+
+export const models: { id: string; label: string }[] = [];
+
+export const agentConfigurationDoc = `# hermes_gateway agent configuration
+
+Adapter: hermes_gateway
+
+Use when:
+- You want Paperclip to connect to a standalone Hermes Agent running on the network (e.g. Railway)
+
+Core fields:
+- url (string, required): Hermes agent API URL (e.g., http://hermes-agent.railway.internal:8080/v1/chat/completions)
+- apiKey (string, optional): Auth key setup in Hermes
+`;

--- a/packages/adapters/hermes-gateway/src/server/execute.ts
+++ b/packages/adapters/hermes-gateway/src/server/execute.ts
@@ -1,0 +1,100 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { asString, asNumber } from "@paperclipai/adapter-utils/server-utils";
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, config, context, onLog, onMeta } = ctx;
+
+  const url = asString(config.url, "http://localhost:8080/v1/chat/completions");
+  const apiKey = asString(config.apiKey, "");
+  const model = asString(config.model, "anthropic/claude-3-5-sonnet-20241022");
+  
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work."
+  );
+
+  const prompt = promptTemplate
+    .replace("{{agent.id}}", ctx.agent.id)
+    .replace("{{agent.name}}", ctx.agent.name);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  }
+
+  // Record meta for debugging/UI
+  if (onMeta) {
+    await onMeta({
+      adapterType: "hermes_gateway",
+      command: `fetch ${url}`,
+      commandArgs: ["--model", model],
+      prompt,
+    });
+  }
+
+  try {
+    const startTime = Date.now();
+    await onLog("stdout", `[paperclip] Invoking Hermes Agent at ${url}\n`);
+
+    const requestBody = {
+      model,
+      messages: [
+        { role: "system", content: "You are an autonomous agent orchestrated by Paperclip." },
+        { role: "user", content: prompt }
+      ],
+      stream: false
+    };
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      await onLog("stderr", `[paperclip] Hermes API Error: ${response.status} - ${errorText}\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `Hermes API Error: ${response.status}`,
+        errorCode: "hermes_api_error",
+        clearSession: true,
+      };
+    }
+
+    const data = await response.json() as any;
+    const summary = data.choices?.[0]?.message?.content || "[No content returned]";
+    const costUsd = data.usage?.total_cost_usd ?? 0;
+
+    await onLog("stdout", `[paperclip] Hermes replied successfully in ${Date.now() - startTime}ms.\n`);
+
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      errorCode: null,
+      provider: "hermes",
+      model: data.model || model,
+      resultJson: data,
+      summary,
+      costUsd,
+      clearSession: false,
+    };
+  } catch (error: any) {
+    await onLog("stderr", `[paperclip] Failed to invoke Hermes: ${error.message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: `Failed to invoke Hermes: ${error.message}`,
+      errorCode: "hermes_invoke_failed",
+      clearSession: true,
+    };
+  }
+}

--- a/packages/adapters/hermes-gateway/src/server/index.ts
+++ b/packages/adapters/hermes-gateway/src/server/index.ts
@@ -1,0 +1,42 @@
+export { execute } from "./execute.js";
+
+import type { AdapterSessionCodec, AdapterEnvironmentTestResult, AdapterEnvironmentTestContext } from "@paperclipai/adapter-utils";
+
+export async function testEnvironment(ctx: AdapterEnvironmentTestContext): Promise<AdapterEnvironmentTestResult> {
+  return {
+    adapterType: ctx.adapterType,
+    status: "pass",
+    checks: [
+      {
+        code: "hermes_api_url",
+        level: "info",
+        message: "Hermes adapter is loaded.",
+      },
+    ],
+    testedAt: new Date().toISOString(),
+  };
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    return { sessionId };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    return { sessionId };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};

--- a/packages/adapters/hermes-gateway/tsconfig.json
+++ b/packages/adapters/hermes-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  }
+}

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -54,6 +54,15 @@ import {
   agentConfigurationDoc as openclawGatewayAgentConfigurationDoc,
   models as openclawGatewayModels,
 } from "@paperclipai/adapter-openclaw-gateway";
+import {
+  execute as hermesGatewayExecute,
+  testEnvironment as hermesGatewayTestEnvironment,
+  sessionCodec as hermesGatewaySessionCodec,
+} from "@paperclipai/adapter-hermes-gateway/server";
+import {
+  agentConfigurationDoc as hermesGatewayAgentConfigurationDoc,
+  models as hermesGatewayModels,
+} from "@paperclipai/adapter-hermes-gateway";
 import { listCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
@@ -147,6 +156,16 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,
 };
 
+const hermesGatewayAdapter: ServerAdapterModule = {
+  type: "hermes_gateway",
+  execute: hermesGatewayExecute,
+  testEnvironment: hermesGatewayTestEnvironment,
+  sessionCodec: hermesGatewaySessionCodec,
+  models: hermesGatewayModels,
+  supportsLocalAgentJwt: false,
+  agentConfigurationDoc: hermesGatewayAgentConfigurationDoc,
+};
+
 const openCodeLocalAdapter: ServerAdapterModule = {
   type: "opencode_local",
   execute: openCodeExecute,
@@ -198,6 +217,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
+    hermesGatewayAdapter,
     processAdapter,
     httpAdapter,
   ].map((a) => [a.type, a]),


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - There are many adapter types for connecting different agent providers
> - Hermes Agent (by Nous Research) is a powerful standalone agent with 70+ skills, browser automation, code execution, and Telegram integration
> - But there's no way to orchestrate a remote Hermes instance from Paperclip today
> - This PR adds a `hermes_gateway` adapter that calls Hermes over HTTP (OpenAI-compatible chat completions endpoint)
> - Configurable URL and API key per agent — works with Railway internal networking or any reachable endpoint
> - This lets Paperclip users add Hermes agents to their AI companies alongside Claude, Codex, Cursor, etc.

## Summary

- New adapter package `@paperclipai/adapter-hermes-gateway` with execute, testEnvironment, and sessionCodec
- Registers `hermes_gateway` type in the server adapter registry
- Targets OpenAI-compatible `/v1/chat/completions` endpoint (Hermes's native API)
- Supports configurable `url` and `apiKey` per agent
- No UI adapter needed — uses generic config form

## Test plan

- [ ] `pnpm -r typecheck` passes
- [ ] Create agent with `hermes_gateway` adapter type in Paperclip UI
- [ ] Configure URL pointing to a running Hermes instance
- [ ] Assign a task and verify heartbeat execution completes
- [ ] Verify run logs show Hermes response

🤖 Generated with [Claude Code](https://claude.com/claude-code)