### PR TITLE
feat(adapter): add poll adapter for self-driving agents

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "poll",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/server/src/adapters/poll/execute.ts
+++ b/server/src/adapters/poll/execute.ts
@@ -1,0 +1,10 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
+
+export async function execute(_ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    summary: "Poll-only agent — execution is agent-initiated via API",
+  };
+}

--- a/server/src/adapters/poll/index.ts
+++ b/server/src/adapters/poll/index.ts
@@ -1,0 +1,18 @@
+import type { ServerAdapterModule } from "../types.js";
+import { execute } from "./execute.js";
+import { testEnvironment } from "./test.js";
+
+export const pollAdapter: ServerAdapterModule = {
+  type: "poll",
+  execute,
+  testEnvironment,
+  models: [],
+  agentConfigurationDoc: `# poll agent configuration
+
+Adapter: poll
+
+No configuration required. The agent manages its own execution lifecycle
+by polling the Paperclip API for tasks, checking out issues, and reporting
+results back via API calls.
+`,
+};

--- a/server/src/adapters/poll/test.ts
+++ b/server/src/adapters/poll/test.ts
@@ -1,0 +1,22 @@
+import type {
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "../types.js";
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  return {
+    adapterType: ctx.adapterType,
+    status: "pass",
+    checks: [
+      {
+        code: "poll_no_config_needed",
+        level: "info",
+        message:
+          "Poll adapter requires no configuration — the agent drives its own execution via the API.",
+      },
+    ],
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -81,6 +81,7 @@ import {
 } from "hermes-paperclip-adapter";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
+import { pollAdapter } from "./poll/index.js";
 
 const claudeLocalAdapter: ServerAdapterModule = {
   type: "claude_local",
@@ -200,6 +201,7 @@ const adaptersByType = new Map<string, ServerAdapterModule>(
     hermesLocalAdapter,
     processAdapter,
     httpAdapter,
+    pollAdapter,
   ].map((a) => [a.type, a]),
 );
 

--- a/ui/src/adapters/poll/build-config.ts
+++ b/ui/src/adapters/poll/build-config.ts
@@ -1,0 +1,5 @@
+import type { CreateConfigValues } from "../../components/AgentConfigForm";
+
+export function buildPollConfig(_v: CreateConfigValues): Record<string, unknown> {
+  return {};
+}

--- a/ui/src/adapters/poll/config-fields.tsx
+++ b/ui/src/adapters/poll/config-fields.tsx
@@ -1,0 +1,10 @@
+import type { AdapterConfigFieldsProps } from "../types";
+
+export function PollConfigFields(_props: AdapterConfigFieldsProps) {
+  return (
+    <p className="text-xs text-muted-foreground">
+      No configuration needed. This agent polls the Paperclip API for tasks and
+      manages its own execution lifecycle.
+    </p>
+  );
+}

--- a/ui/src/adapters/poll/index.ts
+++ b/ui/src/adapters/poll/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parsePollStdoutLine } from "./parse-stdout";
+import { PollConfigFields } from "./config-fields";
+import { buildPollConfig } from "./build-config";
+
+export const pollUIAdapter: UIAdapterModule = {
+  type: "poll",
+  label: "Poll (API)",
+  parseStdoutLine: parsePollStdoutLine,
+  ConfigFields: PollConfigFields,
+  buildAdapterConfig: buildPollConfig,
+};

--- a/ui/src/adapters/poll/parse-stdout.ts
+++ b/ui/src/adapters/poll/parse-stdout.ts
@@ -1,0 +1,5 @@
+import type { TranscriptEntry } from "../types";
+
+export function parsePollStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -9,6 +9,7 @@ import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
+import { pollUIAdapter } from "./poll";
 
 const uiAdapters: UIAdapterModule[] = [
   claudeLocalUIAdapter,
@@ -21,6 +22,7 @@ const uiAdapters: UIAdapterModule[] = [
   openClawGatewayUIAdapter,
   processUIAdapter,
   httpUIAdapter,
+  pollUIAdapter,
 ];
 
 const adaptersByType = new Map<string, UIAdapterModule>(


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Agents are invoked via adapters (process, HTTP, local CLI tools)
- But some agents manage their own execution — they poll Paperclip's API for tasks, checkout, execute locally, and report results back
- These agents handle invocation themselves via API polling
- Currently they must use the HTTP adapter without a URL, which generates "HTTP adapter missing url" errors on every heartbeat
- This PR adds a "poll" adapter type — a no-op adapter for agents that drive their own lifecycle via the API
- The benefit: clean support for poll-based agents without error noise, and a third invocation model alongside "run a command" and "fire a webhook"

## What & Why

Adds a new "poll" adapter type for agents that poll the Paperclip API for work rather than being invoked by Paperclip. The execute function is a no-op — the agent handles wakeup, checkout, execution, and status updates itself via the API.

Use case: agents running as daemons or cron jobs that call GET /issues, POST /wakeup, POST /checkout, and PATCH /issues on their own schedule.

## Changes

- `packages/shared/src/constants.ts` — Add "poll" to AGENT_ADAPTER_TYPES
- `server/src/adapters/poll/` — Server adapter (no-op execute, always-pass test)
- `server/src/adapters/registry.ts` — Register poll adapter
- `ui/src/adapters/poll/` — UI adapter (info message, empty config)
- `ui/src/adapters/registry.ts` — Register poll UI adapter

## Verification

- `pnpm -r typecheck` passes
- No existing files modified beyond registry imports and constants array

## Risks

None — purely additive. No changes to existing adapter behavior or the heartbeat service.