### PR TITLE
fix: prevent skills pages from hanging during load

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -519,11 +519,12 @@ export function agentRoutes(db: Db) {
   }
 
   function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+    let timerId: ReturnType<typeof setTimeout>;
     return Promise.race([
-      promise,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
-      ),
+      promise.finally(() => clearTimeout(timerId)),
+      new Promise<never>((_, reject) => {
+        timerId = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      }),
     ]);
   }
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -518,6 +518,15 @@ export function agentRoutes(db: Db) {
     return details;
   }
 
+  function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+      ),
+    ]);
+  }
+
   function buildUnsupportedSkillSnapshot(
     adapterType: string,
     desiredSkills: string[] = [],
@@ -726,35 +735,48 @@ export function agentRoutes(db: Db) {
     }
     await assertCanReadConfigurations(req, agent.companyId);
 
-    const adapter = findServerAdapter(agent.adapterType);
-    if (!adapter?.listSkills) {
-      const preference = readPaperclipSkillSyncPreference(
-        agent.adapterConfig as Record<string, unknown>,
-      );
-      const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId, {
-        materializeMissing: false,
-      });
-      const requiredSkills = runtimeSkillEntries.filter((entry) => entry.required).map((entry) => entry.key);
-      res.json(buildUnsupportedSkillSnapshot(agent.adapterType, Array.from(new Set([...requiredSkills, ...preference.desiredSkills]))));
-      return;
-    }
+    try {
+      const adapter = findServerAdapter(agent.adapterType);
+      if (!adapter?.listSkills) {
+        const preference = readPaperclipSkillSyncPreference(
+          agent.adapterConfig as Record<string, unknown>,
+        );
+        const runtimeSkillEntries = await withTimeout(
+          companySkills.listRuntimeSkillEntries(agent.companyId, {
+            materializeMissing: false,
+          }),
+          30_000,
+          "listRuntimeSkillEntries",
+        );
+        const requiredSkills = runtimeSkillEntries.filter((entry) => entry.required).map((entry) => entry.key);
+        res.json(buildUnsupportedSkillSnapshot(agent.adapterType, Array.from(new Set([...requiredSkills, ...preference.desiredSkills]))));
+        return;
+      }
 
-    const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(
-      agent.companyId,
-      agent.adapterConfig,
-    );
-    const runtimeSkillConfig = await buildRuntimeSkillConfig(
-      agent.companyId,
-      agent.adapterType,
-      runtimeConfig,
-    );
-    const snapshot = await adapter.listSkills({
-      agentId: agent.id,
-      companyId: agent.companyId,
-      adapterType: agent.adapterType,
-      config: runtimeSkillConfig,
-    });
-    res.json(snapshot);
+      const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(
+        agent.companyId,
+        agent.adapterConfig,
+      );
+      const runtimeSkillConfig = await buildRuntimeSkillConfig(
+        agent.companyId,
+        agent.adapterType,
+        runtimeConfig,
+      );
+      const snapshot = await withTimeout(
+        adapter.listSkills({
+          agentId: agent.id,
+          companyId: agent.companyId,
+          adapterType: agent.adapterType,
+          config: runtimeSkillConfig,
+        }),
+        30_000,
+        "adapter.listSkills",
+      );
+      res.json(snapshot);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(504).json({ error: message });
+    }
   });
 
   router.post(
@@ -813,21 +835,37 @@ export function agentRoutes(db: Db) {
         ...runtimeConfig,
         paperclipRuntimeSkills: runtimeSkillEntries,
       };
-      const snapshot = adapter?.syncSkills
-        ? await adapter.syncSkills({
-            agentId: updated.id,
-            companyId: updated.companyId,
-            adapterType: updated.adapterType,
-            config: runtimeSkillConfig,
-          }, desiredSkills)
-        : adapter?.listSkills
-          ? await adapter.listSkills({
-              agentId: updated.id,
-              companyId: updated.companyId,
-              adapterType: updated.adapterType,
-              config: runtimeSkillConfig,
-            })
-          : buildUnsupportedSkillSnapshot(updated.adapterType, desiredSkills);
+
+      let snapshot: AgentSkillSnapshot;
+      try {
+        snapshot = adapter?.syncSkills
+          ? await withTimeout(
+              adapter.syncSkills({
+                agentId: updated.id,
+                companyId: updated.companyId,
+                adapterType: updated.adapterType,
+                config: runtimeSkillConfig,
+              }, desiredSkills),
+              30_000,
+              "adapter.syncSkills",
+            )
+          : adapter?.listSkills
+            ? await withTimeout(
+                adapter.listSkills({
+                  agentId: updated.id,
+                  companyId: updated.companyId,
+                  adapterType: updated.adapterType,
+                  config: runtimeSkillConfig,
+                }),
+                30_000,
+                "adapter.listSkills",
+              )
+            : buildUnsupportedSkillSnapshot(updated.adapterType, desiredSkills);
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        res.status(504).json({ error });
+        return;
+      }
 
       await logActivity(db, {
         companyId: updated.companyId,

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2063,7 +2063,7 @@ export function companySkillService(db: Db) {
     const markerPath = path.resolve(skillDir, ".materialized");
     const markerStat = await fs.stat(markerPath).catch(() => null);
     if (markerStat?.isFile()) {
-      const skillUpdatedAt = skill.updatedAt ? new Date(skill.updatedAt).getTime() : Number.POSITIVE_INFINITY;
+      const skillUpdatedAt = skill.updatedAt ? new Date(skill.updatedAt).getTime() : 0;
       if (markerStat.mtimeMs >= skillUpdatedAt) {
         return skillDir;
       }
@@ -2082,6 +2082,8 @@ export function companySkillService(db: Db) {
       }
     };
 
+    // TODO: pass AbortSignal for cooperative cancel so background fs.writeFile calls
+    // stop when the deadline fires rather than continuing as orphaned promises.
     await Promise.race([
       materializeFiles(),
       new Promise<void>((_, reject) =>

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -100,6 +100,7 @@ type RuntimeSkillEntryOptions = {
 };
 
 const skillInventoryRefreshPromises = new Map<string, Promise<void>>();
+const skillInventoryLastRefreshed = new Map<string, number>();
 
 const PROJECT_SCAN_DIRECTORY_ROOTS = [
   "skills",
@@ -482,6 +483,7 @@ async function fetchJson<T>(url: string): Promise<T> {
     headers: {
       accept: "application/vnd.github+json",
     },
+    signal: AbortSignal.timeout(15_000),
   });
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
@@ -788,11 +790,11 @@ async function walkLocalFiles(
   root: string,
   current: string,
   out: string[],
-  options: { maxDepth?: number; maxFiles?: number; visited?: Set<bigint> } = {},
+  options: { maxDepth?: number; maxFiles?: number; visited?: Set<number> } = {},
 ) {
   const maxDepth = options.maxDepth ?? 10;
   const maxFiles = options.maxFiles ?? 5000;
-  const visited = options.visited ?? new Set<bigint>();
+  const visited = options.visited ?? new Set<number>();
 
   if (maxDepth <= 0 || out.length >= maxFiles) return;
 
@@ -1524,9 +1526,15 @@ export function companySkillService(db: Db) {
   }
 
   async function ensureSkillInventoryCurrent(companyId: string) {
+    const lastTs = skillInventoryLastRefreshed.get(companyId);
+    if (lastTs !== undefined && Date.now() - lastTs < 30_000) {
+      return;
+    }
+
     const existingRefresh = skillInventoryRefreshPromises.get(companyId);
     if (existingRefresh) {
       await existingRefresh;
+      skillInventoryLastRefreshed.set(companyId, Date.now());
       return;
     }
 
@@ -1538,6 +1546,7 @@ export function companySkillService(db: Db) {
     skillInventoryRefreshPromises.set(companyId, refreshPromise);
     try {
       await refreshPromise;
+      skillInventoryLastRefreshed.set(companyId, Date.now());
     } finally {
       if (skillInventoryRefreshPromises.get(companyId) === refreshPromise) {
         skillInventoryRefreshPromises.delete(companyId);
@@ -2063,13 +2072,22 @@ export function companySkillService(db: Db) {
     await fs.rm(skillDir, { recursive: true, force: true });
     await fs.mkdir(skillDir, { recursive: true });
 
-    for (const entry of skill.fileInventory) {
-      const detail = await readFile(companyId, skill.id, entry.path).catch(() => null);
-      if (!detail) continue;
-      const targetPath = path.resolve(skillDir, entry.path);
-      await fs.mkdir(path.dirname(targetPath), { recursive: true });
-      await fs.writeFile(targetPath, detail.content, "utf8");
-    }
+    const materializeFiles = async () => {
+      for (const entry of skill.fileInventory) {
+        const detail = await readFile(companyId, skill.id, entry.path).catch(() => null);
+        if (!detail) continue;
+        const targetPath = path.resolve(skillDir, entry.path);
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+        await fs.writeFile(targetPath, detail.content, "utf8");
+      }
+    };
+
+    await Promise.race([
+      materializeFiles(),
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("Skill materialization timed out")), 30_000),
+      ),
+    ]);
 
     await fs.writeFile(markerPath, "", "utf8");
 

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -470,7 +470,7 @@ function parseFrontmatterMarkdown(raw: string): { frontmatter: Record<string, un
 }
 
 async function fetchText(url: string) {
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
@@ -771,13 +771,46 @@ function readInlineSkillImports(companyId: string, files: Record<string, string>
   return imports;
 }
 
-async function walkLocalFiles(root: string, current: string, out: string[]) {
-  const entries = await fs.readdir(current, { withFileTypes: true });
+const WALK_SKIP_DIRS = new Set([
+  ".git",
+  "node_modules",
+  ".pnpm-store",
+  ".cache",
+  ".venv",
+  "__pycache__",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+]);
+
+async function walkLocalFiles(
+  root: string,
+  current: string,
+  out: string[],
+  options: { maxDepth?: number; maxFiles?: number; visited?: Set<bigint> } = {},
+) {
+  const maxDepth = options.maxDepth ?? 10;
+  const maxFiles = options.maxFiles ?? 5000;
+  const visited = options.visited ?? new Set<bigint>();
+
+  if (maxDepth <= 0 || out.length >= maxFiles) return;
+
+  const entries = await fs.readdir(current, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
-    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    if (out.length >= maxFiles) return;
+    if (WALK_SKIP_DIRS.has(entry.name)) continue;
     const absolutePath = path.join(current, entry.name);
     if (entry.isDirectory()) {
-      await walkLocalFiles(root, absolutePath, out);
+      const stat = await fs.stat(absolutePath).catch(() => null);
+      if (!stat) continue;
+      if (visited.has(stat.ino)) continue;
+      visited.add(stat.ino);
+      await walkLocalFiles(root, absolutePath, out, {
+        maxDepth: maxDepth - 1,
+        maxFiles,
+        visited,
+      });
       continue;
     }
     if (!entry.isFile()) continue;
@@ -2018,6 +2051,15 @@ export function companySkillService(db: Db) {
   async function materializeRuntimeSkillFiles(companyId: string, skill: CompanySkill) {
     const runtimeRoot = path.resolve(resolveManagedSkillsRoot(companyId), "__runtime__");
     const skillDir = path.resolve(runtimeRoot, buildSkillRuntimeName(skill.key, skill.slug));
+    const markerPath = path.resolve(skillDir, ".materialized");
+    const markerStat = await fs.stat(markerPath).catch(() => null);
+    if (markerStat?.isFile()) {
+      const skillUpdatedAt = skill.updatedAt ? new Date(skill.updatedAt).getTime() : Number.POSITIVE_INFINITY;
+      if (markerStat.mtimeMs >= skillUpdatedAt) {
+        return skillDir;
+      }
+    }
+
     await fs.rm(skillDir, { recursive: true, force: true });
     await fs.mkdir(skillDir, { recursive: true });
 
@@ -2028,6 +2070,8 @@ export function companySkillService(db: Db) {
       await fs.mkdir(path.dirname(targetPath), { recursive: true });
       await fs.writeFile(targetPath, detail.content, "utf8");
     }
+
+    await fs.writeFile(markerPath, "", "utf8");
 
     return skillDir;
   }

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -19,10 +19,13 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     headers.set("Content-Type", "application/json");
   }
 
+  const signal = init?.signal ?? AbortSignal.timeout(60_000);
+
   const res = await fetch(`${BASE}${path}`, {
     headers,
     credentials: "include",
     ...init,
+    signal,
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => null);

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2374,7 +2374,7 @@ function AgentSkillsTab({
   const hasHydratedSkillSnapshotRef = useRef(false);
   const skipNextSkillAutosaveRef = useRef(true);
 
-  const { data: skillSnapshot, isLoading } = useQuery({
+  const { data: skillSnapshot, isLoading, isError, error: skillsError } = useQuery({
     queryKey: queryKeys.agents.skills(agent.id),
     queryFn: () => agentsApi.skills(agent.id, companyId),
     enabled: Boolean(companyId),
@@ -2535,11 +2535,13 @@ function AgentSkillsTab({
     return "Paperclip cannot manage skills for this adapter yet. Manage them in the adapter directly.";
   }, [agent.adapterType, skillSnapshot?.mode]);
   const hasUnsavedChanges = !arraysEqual(skillDraft, lastSavedSkills);
-  const saveStatusLabel = syncSkills.isPending
-    ? "Saving changes..."
-    : hasUnsavedChanges
-      ? "Saving soon..."
-      : null;
+  const saveStatusLabel = syncSkills.isError
+    ? "Save failed - will retry"
+    : syncSkills.isPending
+      ? "Saving changes..."
+      : hasUnsavedChanges
+        ? "Saving soon..."
+        : null;
 
   return (
     <div className="max-w-4xl space-y-5">
@@ -2551,7 +2553,12 @@ function AgentSkillsTab({
           View company skills library
         </Link>
         {saveStatusLabel ? (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div
+            className={cn(
+              "flex items-center gap-2 text-xs",
+              syncSkills.isError ? "text-destructive" : "text-muted-foreground",
+            )}
+          >
             {syncSkills.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
             <span>{saveStatusLabel}</span>
           </div>
@@ -2574,6 +2581,21 @@ function AgentSkillsTab({
 
       {isLoading ? (
         <PageSkeleton variant="list" />
+      ) : isError ? (
+        <div className="flex flex-col items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 px-4 py-4 text-sm">
+          <p className="text-destructive">
+            {skillsError instanceof Error ? skillsError.message : String(skillsError)}
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void queryClient.invalidateQueries({ queryKey: queryKeys.agents.skills(agent.id) });
+            }}
+          >
+            Retry
+          </Button>
+        </div>
       ) : (
         <>
           {(() => {

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -505,6 +505,8 @@ function SkillPane({
   installUpdatePending,
   onSave,
   savePending,
+  error,
+  onRetry,
 }: {
   loading: boolean;
   detail: CompanySkillDetail | null | undefined;
@@ -524,8 +526,21 @@ function SkillPane({
   installUpdatePending: boolean;
   onSave: () => void;
   savePending: boolean;
+  error: string | null;
+  onRetry: () => void;
 }) {
   const { pushToast } = useToast();
+
+  if (error) {
+    return (
+      <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 px-6 py-10 text-center">
+        <p className="max-w-md text-sm text-destructive">{error}</p>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
 
   if (!detail) {
     if (loading) {
@@ -833,11 +848,23 @@ export function CompanySkills() {
   }, [detailQuery.data]);
 
   useEffect(() => {
+    if (detailQuery.error) {
+      setDisplayedDetail(null);
+    }
+  }, [detailQuery.error]);
+
+  useEffect(() => {
     if (fileQuery.data) {
       setDisplayedFile(fileQuery.data);
       setDraft(fileQuery.data.markdown ? splitFrontmatter(fileQuery.data.content).body : fileQuery.data.content);
     }
   }, [fileQuery.data]);
+
+  useEffect(() => {
+    if (fileQuery.error) {
+      setDisplayedFile(null);
+    }
+  }, [fileQuery.error]);
 
   useEffect(() => {
     if (selectedSkillId) return;
@@ -847,6 +874,20 @@ export function CompanySkills() {
 
   const activeDetail = detailQuery.data ?? displayedDetail;
   const activeFile = fileQuery.data ?? displayedFile;
+
+  const skillPaneError = detailQuery.isError
+    ? (detailQuery.error instanceof Error ? detailQuery.error.message : String(detailQuery.error))
+    : fileQuery.isError
+      ? (fileQuery.error instanceof Error ? fileQuery.error.message : String(fileQuery.error))
+      : null;
+
+  const retrySkillPane = () => {
+    if (detailQuery.isError) {
+      void detailQuery.refetch();
+    } else if (fileQuery.isError) {
+      void fileQuery.refetch();
+    }
+  };
 
   const importSkill = useMutation({
     mutationFn: (importSource: string) => companySkillsApi.importFromSource(selectedCompanyId!, importSource),
@@ -1162,6 +1203,8 @@ export function CompanySkills() {
             installUpdatePending={installUpdate.isPending}
             onSave={() => saveFile.mutate()}
             savePending={saveFile.isPending}
+            error={skillPaneError}
+            onRetry={retrySkillPane}
           />
         </div>
       </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip serves company and agent skill metadata over HTTP and materializes runtime skill files on disk
> - Large skill sets and slow I/O could block indefinitely: directory walks, GitHub fetches, and per-skill file writes had no deadlines
> - The agent skills tab and company skill UI could hang with no user-visible failure mode
> - We need bounded time for risky operations and clear HTTP errors when limits are exceeded
> - This pull request adds timeouts to walks/fetches, TTL refresh for bundled inventory, caps runtime materialization, wraps list/sync API paths, and improves UI fetch timeout + retry
> - The benefit is skills surfaces remain responsive and surface errors instead of spinning forever

## What Changed

- Harden local skill file walks and GitHub fetches with timeouts and safer directory traversal
- TTL-cache bundled skill inventory refresh (30s)
- Cap runtime skill materialization with a 30s timeout (with follow-up for cooperative cancel noted in code where applicable)
- Wrap agent `listSkills` / `syncSkills` with timeouts; return 504 on failure
- UI: default 60s fetch timeout; error + retry on company skill detail and agent skills tab
- Runtime materialization cache: `.materialized` marker + mtime vs `updatedAt`; missing `updatedAt` uses `0` so marker comparison remains valid
- `withTimeout` in `agents` route clears timers when the main promise settles first

## Verification

- Open company Skills page and agent Skills tab; confirm load completes or shows a clear error with retry
- `npx tsc --noEmit` in `server` and `ui` as applicable
- **UI:** before/after screenshots recommended for the skills error/retry states (attach in PR thread if not embedded here)

## Risks

- Timeouts may surface as errors for very slow but eventually successful operations; thresholds (30s/60s) may need tuning per deployment
- `Promise.race` timeouts do not cancel in-flight FS work without `AbortSignal` (noted for follow-up)

## Model Used

Mixed human and AI-assisted edits; includes Claude Code and Cursor (exact model IDs not recorded for all commits).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
