### PR TITLE
feat(cursor-local): ensure ~/.local/bin on PATH for Cursor CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 DATABASE_URL=postgres://paperclip:paperclip@localhost:5432/paperclip
 PORT=3100
 SERVE_UI=false
+
+# Optional: Cursor Agent CLI auth for agents with adapter type `cursor` (otherwise use `agent login` on the host).
+# CURSOR_API_KEY=

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -23,6 +23,7 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
+import { ensureUserLocalBinOnPath } from "./local-bin-path.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
@@ -270,7 +271,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ),
   );
   const billingType = resolveCursorBillingType(effectiveEnv);
-  const runtimeEnv = ensurePathInEnv(effectiveEnv);
+  const runtimeEnv = ensureUserLocalBinOnPath(ensurePathInEnv(effectiveEnv));
   await ensureCommandResolvable(command, cwd, runtimeEnv);
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
   const loggedEnv = buildInvocationEnvForLogs(env, {

--- a/packages/adapters/cursor-local/src/server/local-bin-path.ts
+++ b/packages/adapters/cursor-local/src/server/local-bin-path.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Ensures `~/.local/bin` is on PATH (default install for `curl https://cursor.com/install | bash`).
+ * Appended when missing so explicit adapter `env.PATH` entries (e.g. tests or custom bins) keep priority.
+ */
+export function ensureUserLocalBinOnPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const localBin = path.join(os.homedir(), ".local", "bin");
+  try {
+    if (!fs.existsSync(localBin) || !fs.statSync(localBin).isDirectory()) return env;
+  } catch {
+    return env;
+  }
+  const sep = path.delimiter;
+  const absLocal = path.resolve(localBin);
+  const key: "PATH" | "Path" | null =
+    typeof env.PATH === "string" ? "PATH" : typeof env.Path === "string" ? "Path" : null;
+  if (!key) {
+    return { ...env, PATH: localBin };
+  }
+  const val = env[key]!;
+  if (val.length === 0) {
+    return { ...env, [key]: localBin };
+  }
+  for (const part of val.split(sep)) {
+    if (part && path.resolve(part) === absLocal) return env;
+  }
+  return { ...env, [key]: `${val}${sep}${localBin}` };
+}

--- a/packages/adapters/cursor-local/src/server/test.ts
+++ b/packages/adapters/cursor-local/src/server/test.ts
@@ -17,6 +17,7 @@ import os from "node:os";
 import path from "node:path";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl } from "./parse.js";
+import { ensureUserLocalBinOnPath } from "./local-bin-path.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
@@ -118,7 +119,7 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensureUserLocalBinOnPath(ensurePathInEnv({ ...process.env, ...env }));
   try {
     await ensureCommandResolvable(command, cwd, runtimeEnv);
     checks.push({
@@ -192,13 +193,18 @@ export async function testEnvironment(
       if (extraArgs.length > 0) args.push(...extraArgs);
       args.push("Respond with hello.");
 
+      const probeEnv = Object.fromEntries(
+        Object.entries(runtimeEnv).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
+      );
       const probe = await runChildProcess(
         `cursor-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
         command,
         args,
         {
           cwd,
-          env,
+          env: probeEnv,
           timeoutSec: 45,
           graceSec: 5,
           onLog: async () => {},


### PR DESCRIPTION
## Summary

The official Cursor install (`curl … | bash`) places the `agent` binary under `~/.local/bin`. The Paperclip API process often does not inherit a login shell `PATH`, so `ensureCommandResolvable` fails even when the CLI is installed.

This PR appends `~/.local/bin` to `PATH` (after `ensurePathInEnv`) when that directory exists, for both **execute** and **testEnvironment**, using a small helper `ensureUserLocalBinOnPath`.

Also documents optional `CURSOR_API_KEY` in `.env.example`.

## Testing

- `pnpm --filter @paperclipai/adapter-cursor-local typecheck`
- `vitest run server/src/__tests__/cursor-local-adapter-environment.test.ts`

## Related

Complements the merged `cursor_local` adapter; similar to issues where the CLI is installed but not found by the server process.

Made with [Cursor](https://cursor.com)