### PR TITLE
fix(inbox): filter resolved approvals from Mine tab to match badge count

### DIFF
--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -265,9 +265,9 @@ describe("inbox helpers", () => {
       ),
     ];
 
+    // "mine" tab only shows actionable approvals (pending + revision_requested)
     expect(getApprovalsForTab(approvals, "mine", "all").map((approval) => approval.id)).toEqual([
       "approval-revision",
-      "approval-approved",
       "approval-pending",
     ]);
     expect(getApprovalsForTab(approvals, "recent", "all").map((approval) => approval.id)).toEqual([

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -178,7 +178,12 @@ export function getApprovalsForTab(
     (a, b) => normalizeTimestamp(b.updatedAt) - normalizeTimestamp(a.updatedAt),
   );
 
-  if (tab === "mine" || tab === "recent") return sortedApprovals;
+  // "mine" shows only actionable approvals (matching badge count logic).
+  // Resolved (approved/rejected) approvals don't need user attention.
+  if (tab === "mine") {
+    return sortedApprovals.filter((approval) => ACTIONABLE_APPROVAL_STATUSES.has(approval.status));
+  }
+  if (tab === "recent") return sortedApprovals;
   if (tab === "unread") {
     return sortedApprovals.filter((approval) => ACTIONABLE_APPROVAL_STATUSES.has(approval.status));
   }


### PR DESCRIPTION
## Problem

The Inbox "Mine" tab displayed **all** approvals regardless of status, while the sidebar badge correctly only counted actionable ones (`pending`, `revision_requested`). With HAT generating ~30 JIT SSH token approvals/day (all auto-approved), the inbox became a wall of 365+ identical resolved approval rows that could not be bulk-dismissed.

## Root Cause

In `ui/src/lib/inbox.ts`, `getApprovalsForTab()` returned all approvals for the `mine` tab without filtering by status — only the `unread` tab filtered to actionable approvals.

## Fix

Filter the `mine` tab to only show actionable approvals (`pending`, `revision_requested`), matching the existing badge count logic. Resolved approvals remain accessible on the "Recent" and "All" tabs.

### Changed files
- `ui/src/lib/inbox.ts` — `getApprovalsForTab()` now filters `mine` tab to actionable only
- `ui/src/lib/inbox.test.ts` — updated test expectation

## Testing
- Existing inbox test suite passes (13/13 after rebase onto master)
- Badge count and Mine tab now show consistent numbers

Fixes HOL-550