### PR TITLE
fix codex command resolution fallback on macOS

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -842,8 +842,14 @@ export async function runChildProcess(
         const startedAt = new Date().toISOString();
 
         if (opts.stdin != null && child.stdin) {
-          child.stdin.write(opts.stdin);
-          child.stdin.end();
+          const stdin = child.stdin;
+          stdin.on("error", (err: NodeJS.ErrnoException) => {
+            // Short-lived probes can exit before consuming stdin.
+            if (err.code === "EPIPE" || err.code === "ECONNRESET") return;
+            onLogError(err, runId, "stdin stream error");
+          });
+          stdin.write(opts.stdin);
+          stdin.end();
         }
 
         if (typeof child.pid === "number" && child.pid > 0 && opts.onSpawn) {

--- a/server/src/__tests__/codex-local-adapter-environment.test.ts
+++ b/server/src/__tests__/codex-local-adapter-environment.test.ts
@@ -107,7 +107,6 @@ describe("codex_local environment diagnostics", () => {
     const binDir = path.join(root, "extra-bin");
     const cwd = path.join(root, "workspace");
     const fakeCodex = path.join(binDir, "codex");
-
     try {
       await fs.mkdir(binDir, { recursive: true });
       await fs.writeFile(fakeCodex, "#!/bin/sh\nexit 0\n", "utf8");


### PR DESCRIPTION
## Thinking Path
The command-resolution fallback itself was already correct, but the follow-up CI run exposed a stability issue in the Codex environment probe: short-lived child processes can exit before consuming stdin, which surfaces as an unhandled `EPIPE` during the test run. I also aligned the new env-var test with the existing `vi.stubEnv` pattern used elsewhere in the file.

## What Changed
- Ignore `EPIPE` and `ECONNRESET` on child stdin in `runChildProcess`, while still logging unexpected stdin errors.
- Keep the `PAPERCLIP_EXTRA_COMMAND_PATHS` regression test on `vi.stubEnv` for consistent env cleanup.

## Why It Matters
This keeps short-lived probe commands from failing verification due to a broken pipe after the child has already exited successfully.

## Benefits
- Fixes the flaky/unhandled-error path in CI.
- Keeps environment setup consistent across the Codex local adapter diagnostics tests.

## How To Verify
- `pnpm exec vitest run server/src/__tests__/codex-local-adapter-environment.test.ts`

## Risks
The change intentionally swallows only broken-pipe style stdin shutdown errors (`EPIPE` / `ECONNRESET`) for child stdin writes. Other stdin errors are still surfaced via the existing logger.
