### PR TITLE
fix(shared): include gemini_local in AGENT_ADAPTER_TYPES

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -26,6 +26,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "gemini_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/packages/shared/src/validators/agent.test.ts
+++ b/packages/shared/src/validators/agent.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createAgentSchema, updateAgentSchema } from "./agent.js";
+
+describe("agent schemas", () => {
+  it("accepts gemini_local as an adapter type", () => {
+    const createResult = createAgentSchema.safeParse({
+      name: "Gemini Agent",
+      adapterType: "gemini_local",
+    });
+    const updateResult = updateAgentSchema.safeParse({
+      adapterType: "gemini_local",
+    });
+
+    expect(createResult.success).toBe(true);
+    expect(updateResult.success).toBe(true);
+  });
+});

--- a/packages/shared/src/validators/agent.test.ts
+++ b/packages/shared/src/validators/agent.test.ts
@@ -14,4 +14,17 @@ describe("agent schemas", () => {
     expect(createResult.success).toBe(true);
     expect(updateResult.success).toBe(true);
   });
+
+  it("rejects unknown adapter types", () => {
+    const createResult = createAgentSchema.safeParse({
+      name: "Unknown Adapter Agent",
+      adapterType: "not_a_real_adapter",
+    });
+    const updateResult = updateAgentSchema.safeParse({
+      adapterType: "not_a_real_adapter",
+    });
+
+    expect(createResult.success).toBe(false);
+    expect(updateResult.success).toBe(false);
+  });
 });

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     projects: [
       "packages/db",
+      "packages/shared",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
       "server",


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates many agent adapters through shared contracts
- Those shared contracts flow into API validation and UI adapter selection
- The Gemini local adapter exists in runtime/server code and is already supported by the product
- But the shared adapter type constant did not include `gemini_local`
- That caused validation to reject a valid adapter type before the request could reach the working runtime path
- This PR adds `gemini_local` back to the shared adapter type list and adds regression coverage
- It also ensures `@paperclipai/shared` tests are included in the root Vitest workspace so this contract stays protected

## What Changed

- Added `gemini_local` to `AGENT_ADAPTER_TYPES` in `@paperclipai/shared`
- Added a regression test covering `createAgentSchema` and `updateAgentSchema`
- Added a `packages/shared` Vitest config and included it in the root Vitest workspace so shared package tests run in normal CI/test flows

## Why This Matters

Requests that set an agent adapter to `gemini_local` were being rejected by shared schema validation even though the adapter exists and is implemented elsewhere in the repo.

This keeps the shared contract aligned with the runtime adapter surface.

## Verification

Ran:

- `pnpm -r typecheck`
- `pnpm build`

Also verified the relevant shared tests pass:

- `packages/shared/src/project-mentions.test.ts`
- `packages/shared/src/validators/agent.test.ts`

## Notes

`pnpm test:run` is currently not fully green in this workspace due to an existing unrelated failure in:

- `server/src/__tests__/workspace-runtime.test.ts`

The failure is about expected `.env` quoting/formatting and is not caused by this change.

Closes #2365
