### PR TITLE
fix(server): support multi-word plain-text agent mentions

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -402,6 +402,51 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       resurfacedIssueId,
     ]));
   });
+
+  it("finds plain-text mentions for agents with multi-word names", async () => {
+    const companyId = randomUUID();
+    const qaEngineerId = randomUUID();
+    const singleWordAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaEngineerId,
+        companyId,
+        name: "QA Engineer",
+        role: "qa",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: singleWordAgentId,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const mentionedIds = await svc.findMentionedAgents(
+      companyId,
+      "Please sync with @QA Engineer and @CEO before shipping.",
+    );
+
+    expect(new Set(mentionedIds)).toEqual(new Set([qaEngineerId, singleWordAgentId]));
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -343,6 +343,25 @@ export function normalizeAgentMentionToken(raw: string): string {
   return s.trim();
 }
 
+function containsPlainTextAgentMention(bodyLower: string, agentNameLower: string): boolean {
+  const needle = `@${agentNameLower}`;
+  let index = bodyLower.indexOf(needle);
+
+  while (index !== -1) {
+    const before = index > 0 ? bodyLower[index - 1] : "";
+    const afterIndex = index + needle.length;
+    const after = afterIndex < bodyLower.length ? bodyLower[afterIndex] : "";
+
+    const startsMention = before === "" || /[^a-z0-9_]/.test(before);
+    const endsMention = after === "" || /[\s,!?;:.)\]}>"'`]/.test(after);
+    if (startsMention && endsMention) return true;
+
+    index = bodyLower.indexOf(needle, index + 1);
+  }
+
+  return false;
+}
+
 export function deriveIssueUserContext(
   issue: IssueUserContextInput,
   userId: string,
@@ -1745,8 +1764,13 @@ export function issueService(db: Db) {
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
       const resolved = new Set<string>(explicitAgentMentionIds);
+      const bodyLower = body.toLowerCase();
       for (const agent of rows) {
-        if (tokens.has(agent.name.toLowerCase())) {
+        const agentNameLower = agent.name.toLowerCase();
+        if (
+          tokens.has(agentNameLower) ||
+          (agentNameLower.includes(" ") && containsPlainTextAgentMention(bodyLower, agentNameLower))
+        ) {
           resolved.add(agent.id);
         }
       }


### PR DESCRIPTION
## Thinking Path

- Paperclip uses issues and comments as the core communication surface between humans and agents
- A key part of that flow is waking agents when they are mentioned in issue comments
- Many default or realistic agent names are multi-word titles like `QA Engineer` or `Technical Writer`
- But the current plain-text mention parsing only captures a single token after `@`
- That means comments like `@QA Engineer` only resolve `QA`, so the intended agent is never matched or woken
- This PR adds multi-word plain-text mention matching while preserving the existing single-word behavior and structured mention support
- The result is that issue comment mentions work for the multi-word agent names Paperclip already encourages people to use

## What Changed

- Added a plain-text multi-word mention fallback in `findMentionedAgents`
- Kept existing token-based handling for single-word mentions
- Added regression coverage for a mixed comment containing both `@QA Engineer` and `@CEO`

## Why This Matters

Without this fix, `wakeOnDemand` via issue comments is silently broken for agents whose names contain spaces.

That affects common role-based names such as:

- `QA Engineer`
- `Staff Engineer`
- `Release Engineer`
- `Technical Writer`

## Verification

Ran:

- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts server/src/__tests__/normalize-agent-mention-token.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Notes

This change is intentionally narrow:
- existing single-word mention parsing is preserved
- structured `[@Name](agent://...)` mentions still work as before
- multi-word fallback only applies when an agent name actually contains spaces

Closes #2360
