### PR TITLE
feat(heartbeat): idle circuit breaker for timer wakeups

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -578,7 +578,7 @@ export async function startServer(): Promise<StartedServer> {
       void heartbeat
         .tickTimers(new Date())
         .then((result) => {
-          if (result.enqueued > 0) {
+          if (result.enqueued > 0 || result.idleSkipped > 0) {
             logger.info({ ...result }, "heartbeat timer tick enqueued runs");
           }
         })

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1730,6 +1730,7 @@ export function heartbeatService(db: Db) {
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      idleAutoPauseAfter: Math.max(0, asNumber(heartbeat.idleAutoPauseAfter, 0)),
     };
   }
 
@@ -1973,6 +1974,19 @@ export function heartbeatService(db: Db) {
     const biller = resolveLedgerBiller(result);
     const ledgerScope = await resolveLedgerScopeForRun(db, agent.companyId, run);
 
+    // Circuit breaker: track consecutive idle timer runs.
+    // A "timer idle" run = timer-triggered, succeeded, low output tokens.
+    const isTimerSource = run.invocationSource === "timer";
+    const isSucceeded = run.status === "succeeded";
+    const isLowOutput = outputTokens < 2000;
+    const isTimerIdle = isTimerSource && isSucceeded && isLowOutput;
+
+    const currentState = await getRuntimeState(agent.id);
+    const currentStateJson = parseObject(currentState?.stateJson);
+    const prevIdleCount = asNumber(currentStateJson.consecutiveTimerIdleRuns, 0);
+    const nextIdleCount = isTimerIdle ? prevIdleCount + 1 : 0;
+    const updatedStateJson = { ...currentStateJson, consecutiveTimerIdleRuns: nextIdleCount };
+
     await db
       .update(agentRuntimeState)
       .set({
@@ -1981,6 +1995,7 @@ export function heartbeatService(db: Db) {
         lastRunId: run.id,
         lastRunStatus: run.status,
         lastError: result.errorMessage ?? null,
+        stateJson: updatedStateJson,
         totalInputTokens: sql`${agentRuntimeState.totalInputTokens} + ${inputTokens}`,
         totalOutputTokens: sql`${agentRuntimeState.totalOutputTokens} + ${outputTokens}`,
         totalCachedInputTokens: sql`${agentRuntimeState.totalCachedInputTokens} + ${cachedInputTokens}`,
@@ -3950,6 +3965,7 @@ export function heartbeatService(db: Db) {
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
+      let idleSkipped = 0;
 
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
@@ -3960,6 +3976,23 @@ export function heartbeatService(db: Db) {
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        // Circuit breaker: skip timer wakeup if agent has been idle for N consecutive runs.
+        // Non-timer wakeups (assignments, mentions) still go through and reset the counter.
+        if (policy.idleAutoPauseAfter > 0) {
+          const runtimeState = await getRuntimeState(agent.id);
+          const stateJson = parseObject(runtimeState?.stateJson);
+          const consecutiveIdle = asNumber(stateJson.consecutiveTimerIdleRuns, 0);
+          if (consecutiveIdle >= policy.idleAutoPauseAfter) {
+            logger.info(
+              { agentId: agent.id, agentName: agent.name, consecutiveIdle, threshold: policy.idleAutoPauseAfter },
+              "idle circuit breaker: skipping timer wakeup",
+            );
+            idleSkipped += 1;
+            skipped += 1;
+            continue;
+          }
+        }
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",
@@ -3977,7 +4010,7 @@ export function heartbeatService(db: Db) {
         else skipped += 1;
       }
 
-      return { checked, enqueued, skipped };
+      return { checked, enqueued, skipped, idleSkipped };
     },
 
     cancelRun: (runId: string) => cancelRunInternal(runId),


### PR DESCRIPTION
## Summary

- Adds `idleAutoPauseAfter` to heartbeat policy — configurable per agent via `runtimeConfig.heartbeat.idleAutoPauseAfter` (default `0` = disabled)
- After N consecutive idle timer runs (succeeded + <2,000 output tokens), the scheduler skips further timer wakeups for that agent
- Event-based wakeups (assignments, mentions) are unaffected and reset the counter when the agent does productive work
- Counter stored in `agentRuntimeState.stateJson` — no schema migration needed

### Problem

Agents with timer-based heartbeats that find empty inboxes still consume API quota and rate limit capacity on every tick. With multiple idle agents polling simultaneously, they crowd out productive agents that actually have work.

### How it works

1. `updateRuntimeState` increments `consecutiveTimerIdleRuns` when a timer-triggered run succeeds with <2,000 output tokens (typical idle run: 200-500 tokens for inbox check). Any productive or non-timer run resets the counter to 0.
2. `tickTimers` checks the counter before enqueuing. If it meets the threshold, the wakeup is skipped with an info log.
3. `idleSkipped` is added to the tick result for observability.

### Configuration

```json
{
  "runtimeConfig": {
    "heartbeat": {
      "idleAutoPauseAfter": 3
    }
  }
}
```

## Test plan

- [ ] Agent with `idleAutoPauseAfter: 3` stops receiving timer wakeups after 3 consecutive idle runs
- [ ] Event-based wakeup (assignment/mention) still triggers normally while circuit breaker is active
- [ ] Productive run resets the counter and timer wakeups resume
- [ ] Agent with `idleAutoPauseAfter: 0` (default) behaves unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)