### PR TITLE
fix: use real cmd.exe for Windows .cmd/.bat adapter invocation

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -308,8 +308,7 @@ function quoteForCmd(arg: string) {
 
 function resolveWindowsCmdShell(env: NodeJS.ProcessEnv): string {
   const fallbackRoot = env.SystemRoot || process.env.SystemRoot || "C:\\Windows";
-  const candidate = path.join(fallbackRoot, "System32", "cmd.exe");
-  return candidate;
+  return path.join(fallbackRoot, "System32", "cmd.exe");
 }
 
 async function resolveSpawnTarget(


### PR DESCRIPTION
### Thinking Path
- Paperclip orchestrates AI agents through adapter processes for different local/provider CLIs.
- Adapter execution relies on a shared process launcher (`runChildProcess`) to run those CLIs consistently across platforms.
- On Windows, many CLIs are exposed through `.cmd` wrappers, so Paperclip uses a shell wrapper path for `.cmd/.bat` targets.
- The current implementation takes shell from `ComSpec`, but on some Win11 systems `ComSpec` is overridden to PowerShell.
- Paperclip still passes cmd-specific flags (`/d /s /c`) in that code path; those flags are not valid PowerShell script arguments.
- This causes adapter commands like `opencode models` to fail even though the CLI itself is correctly installed and works directly.
- Therefore the correct fix is to always execute `.cmd/.bat` wrappers via real `cmd.exe` (`%SystemRoot%\\System32\\cmd.exe`) instead of trusting `ComSpec`.
- Benefit: reliable Windows adapter command execution (including OpenCode model discovery) without changing non-Windows behavior or direct executable launches.

## Summary
- force `.cmd`/`.bat` invocations to use `%SystemRoot%\\System32\\cmd.exe` in `runChildProcess`
- stop relying on `ComSpec` for wrapper execution on Windows

## Why
On some Win11 setups, `ComSpec` is overridden to PowerShell. Paperclip passes cmd-specific flags (`/d /s /c`) for `.cmd` wrappers, which PowerShell misinterprets. This breaks OpenCode model discovery (`opencode models`) and adapter environment tests.

## Validation
- `npx --yes pnpm --filter @paperclipai/adapter-utils typecheck`
- runtime harness on Windows:
  - `runChildProcess('opencode', ['models'])` ✅
  - `runChildProcess('...\\opencode.cmd', ['models'])` ✅

## Risk
Low. Change is scoped to Windows `.cmd`/`.bat` wrapper launch path only. Non-Windows paths and direct executable launches are unchanged.
