### PR TITLE
feat(SUD-1891): board-only force release for stale execution locks

### DIFF
--- a/server/src/__tests__/issue-force-release.test.ts
+++ b/server/src/__tests__/issue-force-release.test.ts
@@ -1,0 +1,182 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  release: vi.fn(),
+  forceRelease: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({ canUser: vi.fn(), hasPermission: vi.fn() }),
+  agentService: () => ({}),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+    getRun: vi.fn(async () => null),
+    getActiveRunForAgent: vi.fn(async () => null),
+    cancelRun: vi.fn(async () => null),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+const COMPANY_ID = "company-1";
+
+function makeLockedIssue() {
+  return {
+    id: ISSUE_ID,
+    companyId: COMPANY_ID,
+    status: "in_progress",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    checkoutRunId: "stale-run-id",
+    executionRunId: "stale-run-id",
+    executionLockedAt: new Date("2026-04-01T06:00:00Z"),
+    executionAgentNameKey: "sudoku ceo",
+  };
+}
+
+function makeReleasedIssue() {
+  return {
+    id: ISSUE_ID,
+    companyId: COMPANY_ID,
+    status: "todo",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionLockedAt: null,
+    executionAgentNameKey: null,
+  };
+}
+
+function createBoardApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "board-user-1",
+      companyId: COMPANY_ID,
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function createAgentApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: "agent-1",
+      runId: "run-abc",
+      companyId: COMPANY_ID,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("POST /issues/:id/release — force flag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("board user with force:true calls forceRelease and returns 200", async () => {
+    mockIssueService.getById.mockResolvedValue(makeLockedIssue());
+    mockIssueService.forceRelease.mockResolvedValue(makeReleasedIssue());
+
+    const res = await request(createBoardApp())
+      .post(`/api/issues/${ISSUE_ID}/release`)
+      .send({ force: true });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.forceRelease).toHaveBeenCalledWith(ISSUE_ID);
+    expect(mockIssueService.release).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.force_released", entityId: ISSUE_ID }),
+    );
+  });
+
+  it("agent with force:true is rejected with 403", async () => {
+    mockIssueService.getById.mockResolvedValue(makeLockedIssue());
+
+    const res = await request(createAgentApp())
+      .post(`/api/issues/${ISSUE_ID}/release`)
+      .send({ force: true, agentId: "agent-1" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Only board users can force-release a locked issue" });
+    expect(mockIssueService.forceRelease).not.toHaveBeenCalled();
+    expect(mockIssueService.release).not.toHaveBeenCalled();
+  });
+
+  it("board user without force calls normal release path", async () => {
+    mockIssueService.getById.mockResolvedValue(makeLockedIssue());
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.release.mockResolvedValue({
+      ...makeReleasedIssue(),
+      assigneeAgentId: null,
+    });
+
+    const res = await request(createBoardApp())
+      .post(`/api/issues/${ISSUE_ID}/release`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalled();
+    expect(mockIssueService.forceRelease).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.released", entityId: ISSUE_ID }),
+    );
+  });
+
+  it("returns 404 when force-releasing a non-existent issue", async () => {
+    mockIssueService.getById.mockResolvedValue(null);
+
+    const res = await request(createBoardApp())
+      .post(`/api/issues/${ISSUE_ID}/release`)
+      .send({ force: true });
+
+    expect(res.status).toBe(404);
+    expect(mockIssueService.forceRelease).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when forceRelease service returns null", async () => {
+    mockIssueService.getById.mockResolvedValue(makeLockedIssue());
+    mockIssueService.forceRelease.mockResolvedValue(null);
+
+    const res = await request(createBoardApp())
+      .post(`/api/issues/${ISSUE_ID}/release`)
+      .send({ force: true });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1382,6 +1382,34 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+
+    const forceRequested = req.body?.force === true;
+
+    if (forceRequested) {
+      if (req.actor.type !== "board") {
+        res.status(403).json({ error: "Only board users can force-release a locked issue" });
+        return;
+      }
+      const released = await svc.forceRelease(id);
+      if (!released) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: released.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.force_released",
+        entityType: "issue",
+        entityId: released.id,
+      });
+      res.json(released);
+      return;
+    }
+
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1420,6 +1420,37 @@ export function issueService(db: Db) {
       return enriched;
     },
 
+    forceRelease: async (id: string) => {
+      const existing = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, id))
+        .then((rows) => rows[0] ?? null);
+
+      if (!existing) return null;
+
+      const patch: Partial<typeof issues.$inferInsert> = {
+        checkoutRunId: null,
+        executionRunId: null,
+        executionLockedAt: null,
+        executionAgentNameKey: null,
+        updatedAt: new Date(),
+      };
+      if (existing.status === "in_progress") {
+        patch.status = "todo";
+      }
+
+      const updated = await db
+        .update(issues)
+        .set(patch)
+        .where(eq(issues.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!updated) return null;
+      const [enriched] = await withIssueLabels(db, [updated]);
+      return enriched;
+    },
+
     listLabels: (companyId: string) =>
       db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),
 


### PR DESCRIPTION
## Summary

- Extends `POST /api/issues/:id/release` with a `{ force: true }` path for board users to recover stale `executionRunId` locks without manual DB intervention
- Force path clears `executionRunId`, `checkoutRunId`, `executionLockedAt`, `executionAgentNameKey`; resets status to `todo` only when `in_progress`; preserves `assigneeAgentId`
- Agents calling with `force: true` receive 403; normal release behavior is unchanged
- Audit logged as `issue.force_released`

## Design

Implements the recovery path specified in [SUD-1882](/SUD/issues/SUD-1882). Affected incidents: [SUD-1878](/SUD/issues/SUD-1878), [SUD-1491](/SUD/issues/SUD-1491).

## Test plan

- [x] 5 new unit tests: board success, agent 403 rejection, no-regression on normal release, 404 on missing issue, 404 on null service return
- [x] All new tests pass
- [x] Pre-existing test failures confirmed pre-existing (unrelated to this change)

## Operator Recovery Runbook

Once merged, PM/CEO can unblock a stale-locked issue with:

```
POST /api/issues/{issueId}/release
Authorization: Bearer <board-user-token>
Content-Type: application/json

{ "force": true, "reason": "Stale executionRunId — run terminated without releasing" }
```

This clears the execution lock and resets the issue to `todo` so the next heartbeat can check it out normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)