### PR TITLE
feat(ui): add i18n support with Korean locale

### DIFF
--- a/ui/src/components/AgentProperties.tsx
+++ b/ui/src/components/AgentProperties.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "../lib/i18n";
 import { Link } from "@/lib/router";
 import { AGENT_ROLE_LABELS, type Agent, type AgentRuntimeState } from "@paperclipai/shared";
 import { agentsApi } from "../api/agents";
@@ -37,6 +38,7 @@ function PropertyRow({ label, children }: { label: string; children: React.React
 }
 
 export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
 
   const { data: agents } = useQuery({
@@ -50,18 +52,18 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
   return (
     <div className="space-y-4">
       <div className="space-y-1">
-        <PropertyRow label="Status">
+        <PropertyRow label={t("agentProperties.status")}>
           <StatusBadge status={agent.status} />
         </PropertyRow>
-        <PropertyRow label="Role">
+        <PropertyRow label={t("agentProperties.role")}>
           <span className="text-sm">{roleLabels[agent.role] ?? agent.role}</span>
         </PropertyRow>
         {agent.title && (
-          <PropertyRow label="Title">
+          <PropertyRow label={t("agentProperties.title")}>
             <span className="text-sm">{agent.title}</span>
           </PropertyRow>
         )}
-        <PropertyRow label="Adapter">
+        <PropertyRow label={t("agentProperties.adapter")}>
           <span className="text-sm font-mono">{adapterLabels[agent.adapterType] ?? agent.adapterType}</span>
         </PropertyRow>
       </div>
@@ -70,24 +72,24 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
 
       <div className="space-y-1">
         {(runtimeState?.sessionDisplayId ?? runtimeState?.sessionId) && (
-          <PropertyRow label="Session">
+          <PropertyRow label={t("agentProperties.session")}>
             <span className="text-xs font-mono">
               {String(runtimeState.sessionDisplayId ?? runtimeState.sessionId).slice(0, 12)}...
             </span>
           </PropertyRow>
         )}
         {runtimeState?.lastError && (
-          <PropertyRow label="Last error">
+          <PropertyRow label={t("agentProperties.lastError")}>
             <span className="text-xs text-red-600 dark:text-red-400 truncate max-w-[160px]">{runtimeState.lastError}</span>
           </PropertyRow>
         )}
         {agent.lastHeartbeatAt && (
-          <PropertyRow label="Last Heartbeat">
+          <PropertyRow label={t("agentProperties.lastHeartbeat")}>
             <span className="text-sm">{formatDate(agent.lastHeartbeatAt)}</span>
           </PropertyRow>
         )}
         {agent.reportsTo && (
-          <PropertyRow label="Reports To">
+          <PropertyRow label={t("agentProperties.reportsTo")}>
             {reportsToAgent ? (
               <Link to={agentUrl(reportsToAgent)} className="hover:underline">
                 <Identity name={reportsToAgent.name} size="sm" />
@@ -97,7 +99,7 @@ export function AgentProperties({ agent, runtimeState }: AgentPropertiesProps) {
             )}
           </PropertyRow>
         )}
-        <PropertyRow label="Created">
+        <PropertyRow label={t("agentProperties.created")}>
           <span className="text-sm">{formatDate(agent.createdAt)}</span>
         </PropertyRow>
       </div>

--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@/lib/router";
+import { useTranslation } from "../lib/i18n";
 import { Menu } from "lucide-react";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useSidebar } from "../context/SidebarContext";
@@ -31,6 +32,7 @@ function GlobalToolbarPlugins({ context }: { context: GlobalToolbarContext }) {
 }
 
 export function BreadcrumbBar() {
+  const { t } = useTranslation();
   const { breadcrumbs } = useBreadcrumbs();
   const { toggleSidebar, isMobile } = useSidebar();
   const { selectedCompanyId, selectedCompany } = useCompany();
@@ -59,7 +61,7 @@ export function BreadcrumbBar() {
       size="icon-sm"
       className="mr-2 shrink-0"
       onClick={toggleSidebar}
-      aria-label="Open sidebar"
+      aria-label={t("layout.openSidebar")}
     >
       <Menu className="h-5 w-5" />
     </Button>

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useNavigate } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import { useCompany } from "../context/CompanyContext";
@@ -33,6 +34,7 @@ import { Identity } from "./Identity";
 import { agentUrl, projectUrl } from "../lib/utils";
 
 export function CommandPalette() {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
@@ -106,7 +108,7 @@ export function CommandPalette() {
         if (v && isMobile) setSidebarOpen(false);
       }}>
       <CommandInput
-        placeholder="Search issues, agents, projects..."
+        placeholder={t("actions.searchIssues")}
         value={query}
         onValueChange={setQuery}
       />

--- a/ui/src/components/InstanceSidebar.tsx
+++ b/ui/src/components/InstanceSidebar.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "../lib/i18n";
 import { Clock3, FlaskConical, Puzzle, Settings, SlidersHorizontal } from "lucide-react";
 import { NavLink } from "@/lib/router";
 import { pluginsApi } from "@/api/plugins";
@@ -6,6 +7,7 @@ import { queryKeys } from "@/lib/queryKeys";
 import { SidebarNavItem } from "./SidebarNavItem";
 
 export function InstanceSidebar() {
+  const { t } = useTranslation();
   const { data: plugins } = useQuery({
     queryKey: queryKeys.plugins.all,
     queryFn: () => pluginsApi.list(),
@@ -16,16 +18,16 @@ export function InstanceSidebar() {
       <div className="flex items-center gap-2 px-3 h-12 shrink-0">
         <Settings className="h-4 w-4 text-muted-foreground shrink-0 ml-1" />
         <span className="flex-1 text-sm font-bold text-foreground truncate">
-          Instance Settings
+          {t("instanceSettings.title")}
         </span>
       </div>
 
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 px-3 py-2">
         <div className="flex flex-col gap-0.5">
-          <SidebarNavItem to="/instance/settings/general" label="General" icon={SlidersHorizontal} end />
-          <SidebarNavItem to="/instance/settings/heartbeats" label="Heartbeats" icon={Clock3} end />
-          <SidebarNavItem to="/instance/settings/experimental" label="Experimental" icon={FlaskConical} />
-          <SidebarNavItem to="/instance/settings/plugins" label="Plugins" icon={Puzzle} />
+          <SidebarNavItem to="/instance/settings/general" label={t("instanceSettings.general")} icon={SlidersHorizontal} end />
+          <SidebarNavItem to="/instance/settings/heartbeats" label={t("instanceSettings.heartbeats")} icon={Clock3} end />
+          <SidebarNavItem to="/instance/settings/experimental" label={t("instanceSettings.experimental")} icon={FlaskConical} />
+          <SidebarNavItem to="/instance/settings/plugins" label={t("instanceSettings.plugins")} icon={Puzzle} />
           {(plugins ?? []).length > 0 ? (
             <div className="ml-4 mt-1 flex flex-col gap-0.5 border-l border-border/70 pl-3">
               {(plugins ?? []).map((plugin) => (

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { Link } from "@/lib/router";
 import type { Issue } from "@paperclipai/shared";
@@ -118,6 +119,7 @@ function PropertyPicker({
 }
 
 export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProps) {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const queryClient = useQueryClient();
   const companyId = issue.companyId ?? selectedCompanyId;
@@ -491,7 +493,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
   return (
     <div className="space-y-4">
       <div className="space-y-1">
-        <PropertyRow label="Status">
+        <PropertyRow label={t("issueProperties.status")}>
           <StatusIcon
             status={issue.status}
             onChange={(status) => onUpdate({ status })}
@@ -499,7 +501,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
           />
         </PropertyRow>
 
-        <PropertyRow label="Priority">
+        <PropertyRow label={t("issueProperties.priority")}>
           <PriorityIcon
             priority={issue.priority}
             onChange={(priority) => onUpdate({ priority })}
@@ -509,7 +511,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
 
         <PropertyPicker
           inline={inline}
-          label="Labels"
+          label={t("issueProperties.labels")}
           open={labelsOpen}
           onOpenChange={(open) => { setLabelsOpen(open); if (!open) setLabelSearch(""); }}
           triggerContent={labelsTrigger}
@@ -521,7 +523,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
 
         <PropertyPicker
           inline={inline}
-          label="Assignee"
+          label={t("issueProperties.assignee")}
           open={assigneeOpen}
           onOpenChange={(open) => { setAssigneeOpen(open); if (!open) setAssigneeSearch(""); }}
           triggerContent={assigneeTrigger}
@@ -541,7 +543,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
 
         <PropertyPicker
           inline={inline}
-          label="Project"
+          label={t("issueProperties.project")}
           open={projectOpen}
           onOpenChange={(open) => { setProjectOpen(open); if (!open) setProjectSearch(""); }}
           triggerContent={projectTrigger}
@@ -561,7 +563,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
         </PropertyPicker>
 
         {issue.parentId && (
-          <PropertyRow label="Parent">
+          <PropertyRow label={t("issueProperties.parent")}>
             <Link
               to={`/issues/${issue.ancestors?.[0]?.identifier ?? issue.parentId}`}
               className="text-sm hover:underline"
@@ -572,7 +574,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
         )}
 
         {issue.requestDepth > 0 && (
-          <PropertyRow label="Depth">
+          <PropertyRow label={t("issueProperties.depth")}>
             <span className="text-sm font-mono">{issue.requestDepth}</span>
           </PropertyRow>
         )}
@@ -582,7 +584,7 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
 
       <div className="space-y-1">
         {(issue.createdByAgentId || issue.createdByUserId) && (
-          <PropertyRow label="Created by">
+          <PropertyRow label={t("issueProperties.createdBy")}>
             {issue.createdByAgentId ? (
               <Link
                 to={`/agents/${issue.createdByAgentId}`}
@@ -593,25 +595,25 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
             ) : (
               <>
                 <User className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-sm">{creatorUserLabel ?? "User"}</span>
+                <span className="text-sm">{creatorUserLabel ?? t("issueProperties.user")}</span>
               </>
             )}
           </PropertyRow>
         )}
         {issue.startedAt && (
-          <PropertyRow label="Started">
+          <PropertyRow label={t("issueProperties.started")}>
             <span className="text-sm">{formatDate(issue.startedAt)}</span>
           </PropertyRow>
         )}
         {issue.completedAt && (
-          <PropertyRow label="Completed">
+          <PropertyRow label={t("issueProperties.completed")}>
             <span className="text-sm">{formatDate(issue.completedAt)}</span>
           </PropertyRow>
         )}
-        <PropertyRow label="Created">
+        <PropertyRow label={t("issueProperties.created")}>
           <span className="text-sm">{formatDate(issue.createdAt)}</span>
         </PropertyRow>
-        <PropertyRow label="Updated">
+        <PropertyRow label={t("issueProperties.updated")}>
           <span className="text-sm">{timeAgo(issue.updatedAt)}</span>
         </PropertyRow>
       </div>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -1,4 +1,5 @@
 import { startTransition, useEffect, useMemo, useState, useCallback, useRef } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useQuery } from "@tanstack/react-query";
 import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { useDialog } from "../context/DialogContext";
@@ -30,8 +31,13 @@ import type { Issue } from "@paperclipai/shared";
 const statusOrder = ["in_progress", "todo", "backlog", "in_review", "blocked", "done", "cancelled"];
 const priorityOrder = ["critical", "high", "medium", "low"];
 
-function statusLabel(status: string): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+function useStatusLabel() {
+  const { t } = useTranslation();
+  return (status: string) => {
+    const key = `statuses.${status}`;
+    const translated = t(key);
+    return translated !== key ? translated : status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  };
 }
 
 /* ── View state ── */
@@ -236,6 +242,7 @@ export function IssuesList({
     queryFn: () => authApi.getSession(),
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  const statusLabel = useStatusLabel();
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { Link } from "@/lib/router";
 import {
   DndContext,
@@ -32,8 +33,13 @@ const boardStatuses = [
   "cancelled",
 ];
 
-function statusLabel(status: string): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+function useStatusLabel() {
+  const { t } = useTranslation();
+  return (status: string) => {
+    const key = `statuses.${status}`;
+    const translated = t(key);
+    return translated !== key ? translated : status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  };
 }
 
 interface Agent {
@@ -61,6 +67,7 @@ function KanbanColumn({
   agents?: Agent[];
   liveIssueIds?: Set<string>;
 }) {
+  const statusLabel = useStatusLabel();
   const { setNodeRef, isOver } = useDroppable({ id: status });
 
   return (

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { BookOpen, Moon, Settings, Sun } from "lucide-react";
+import { useTranslation, SUPPORTED_LANGUAGES, type SupportedLanguage } from "../lib/i18n";
+import { BookOpen, Globe, Moon, Settings, Sun } from "lucide-react";
 import { Link, Outlet, useLocation, useNavigate, useParams } from "@/lib/router";
 import { CompanyRail } from "./CompanyRail";
 import { Sidebar } from "./Sidebar";
@@ -46,7 +47,13 @@ function readRememberedInstanceSettingsPath(): string {
   }
 }
 
+const LANGUAGE_LABELS: Record<SupportedLanguage, string> = {
+  en: "English",
+  ko: "한국어",
+};
+
 export function Layout() {
+  const { t, language, setLanguage } = useTranslation();
   const { sidebarOpen, setSidebarOpen, toggleSidebar, isMobile } = useSidebar();
   const { openNewIssue, openOnboarding } = useDialog();
   const { togglePanelVisible } = usePanel();
@@ -68,6 +75,12 @@ export function Layout() {
   const [mobileNavVisible, setMobileNavVisible] = useState(true);
   const [instanceSettingsTarget, setInstanceSettingsTarget] = useState<string>(() => readRememberedInstanceSettingsPath());
   const nextTheme = theme === "dark" ? "light" : "dark";
+  const currentLang = language;
+  const cycleLanguage = useCallback(() => {
+    const currentIndex = SUPPORTED_LANGUAGES.indexOf(currentLang);
+    const nextIndex = (currentIndex + 1) % SUPPORTED_LANGUAGES.length;
+    setLanguage(SUPPORTED_LANGUAGES[nextIndex]);
+  }, [currentLang, setLanguage]);
   const matchedCompany = useMemo(() => {
     if (!companyPrefix) return null;
     const requestedPrefix = companyPrefix.toUpperCase();
@@ -269,7 +282,7 @@ export function Layout() {
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[200] focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        Skip to Main Content
+        {t("layout.skipToMain")}
       </a>
       <WorktreeBanner />
       <DevRestartBanner devServer={health?.devServer} />
@@ -279,7 +292,7 @@ export function Layout() {
             type="button"
             className="fixed inset-0 z-40 bg-black/50"
             onClick={() => setSidebarOpen(false)}
-            aria-label="Close sidebar"
+            aria-label={t("layout.closeSidebar")}
           />
         )}
 
@@ -303,7 +316,7 @@ export function Layout() {
                   className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
                 >
                   <BookOpen className="h-4 w-4 shrink-0" />
-                  <span className="truncate">Documentation</span>
+                  <span className="truncate">{t("layout.documentation")}</span>
                 </a>
                 {health?.version && (
                   <Tooltip>
@@ -316,8 +329,8 @@ export function Layout() {
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link
                     to={instanceSettingsTarget}
-                    aria-label="Instance settings"
-                    title="Instance settings"
+                    aria-label={t("layout.instanceSettings")}
+                    title={t("layout.instanceSettings")}
                     onClick={() => {
                       if (isMobile) setSidebarOpen(false);
                     }}
@@ -331,11 +344,27 @@ export function Layout() {
                   size="icon-sm"
                   className="text-muted-foreground shrink-0"
                   onClick={toggleTheme}
-                  aria-label={`Switch to ${nextTheme} mode`}
-                  title={`Switch to ${nextTheme} mode`}
+                  aria-label={t(nextTheme === "light" ? "layout.switchToLight" : "layout.switchToDark")}
+                  title={t(nextTheme === "light" ? "layout.switchToLight" : "layout.switchToDark")}
                 >
                   {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
                 </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground shrink-0"
+                      onClick={cycleLanguage}
+                      aria-label={t("language.label")}
+                      title={LANGUAGE_LABELS[currentLang]}
+                    >
+                      <Globe className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{LANGUAGE_LABELS[currentLang]}</TooltipContent>
+                </Tooltip>
               </div>
             </div>
           </div>
@@ -361,7 +390,7 @@ export function Layout() {
                   className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors text-foreground/80 hover:bg-accent/50 hover:text-foreground flex-1 min-w-0"
                 >
                   <BookOpen className="h-4 w-4 shrink-0" />
-                  <span className="truncate">Documentation</span>
+                  <span className="truncate">{t("layout.documentation")}</span>
                 </a>
                 {health?.version && (
                   <Tooltip>
@@ -374,8 +403,8 @@ export function Layout() {
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
                   <Link
                     to={instanceSettingsTarget}
-                    aria-label="Instance settings"
-                    title="Instance settings"
+                    aria-label={t("layout.instanceSettings")}
+                    title={t("layout.instanceSettings")}
                     onClick={() => {
                       if (isMobile) setSidebarOpen(false);
                     }}
@@ -389,11 +418,27 @@ export function Layout() {
                   size="icon-sm"
                   className="text-muted-foreground shrink-0"
                   onClick={toggleTheme}
-                  aria-label={`Switch to ${nextTheme} mode`}
-                  title={`Switch to ${nextTheme} mode`}
+                  aria-label={t(nextTheme === "light" ? "layout.switchToLight" : "layout.switchToDark")}
+                  title={t(nextTheme === "light" ? "layout.switchToLight" : "layout.switchToDark")}
                 >
                   {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
                 </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground shrink-0"
+                      onClick={cycleLanguage}
+                      aria-label={t("language.label")}
+                      title={LANGUAGE_LABELS[currentLang]}
+                    >
+                      <Globe className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{LANGUAGE_LABELS[currentLang]}</TooltipContent>
+                </Tooltip>
               </div>
             </div>
           </div>

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { NavLink, useLocation } from "@/lib/router";
+import { useTranslation } from "../lib/i18n";
 import {
   House,
   CircleDot,
@@ -34,6 +35,7 @@ interface MobileNavActionItem {
 type MobileNavItem = MobileNavLinkItem | MobileNavActionItem;
 
 export function MobileBottomNav({ visible }: MobileBottomNavProps) {
+  const { t } = useTranslation();
   const location = useLocation();
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialog();
@@ -41,19 +43,19 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
 
   const items = useMemo<MobileNavItem[]>(
     () => [
-      { type: "link", to: "/dashboard", label: "Home", icon: House },
-      { type: "link", to: "/issues", label: "Issues", icon: CircleDot },
-      { type: "action", label: "Create", icon: SquarePen, onClick: () => openNewIssue() },
-      { type: "link", to: "/agents/all", label: "Agents", icon: Users },
+      { type: "link", to: "/dashboard", label: t("mobileNav.dashboard"), icon: House },
+      { type: "link", to: "/issues", label: t("mobileNav.issues"), icon: CircleDot },
+      { type: "action", label: t("sidebar.newIssue"), icon: SquarePen, onClick: () => openNewIssue() },
+      { type: "link", to: "/agents/all", label: t("mobileNav.agents"), icon: Users },
       {
         type: "link",
         to: "/inbox",
-        label: "Inbox",
+        label: t("mobileNav.inbox"),
         icon: Inbox,
         badge: inboxBadge.inbox,
       },
     ],
-    [openNewIssue, inboxBadge.inbox],
+    [t, openNewIssue, inboxBadge.inbox],
   );
 
   return (

--- a/ui/src/components/PriorityIcon.tsx
+++ b/ui/src/components/PriorityIcon.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ArrowUp, ArrowDown, Minus, AlertTriangle } from "lucide-react";
 import { cn } from "../lib/utils";
+import { useTranslation } from "../lib/i18n";
 import { priorityColor, priorityColorDefault } from "../lib/status-colors";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,8 @@ interface PriorityIconProps {
 }
 
 export function PriorityIcon({ priority, onChange, className, showLabel }: PriorityIconProps) {
+  const { t } = useTranslation();
+  const priorityLabel = (key: string) => t(`priorities.${key}`) !== `priorities.${key}` ? t(`priorities.${key}`) : (priorityConfig[key]?.label ?? key);
   const [open, setOpen] = useState(false);
   const config = priorityConfig[priority] ?? priorityConfig.medium!;
   const Icon = config.icon;
@@ -39,12 +42,12 @@ export function PriorityIcon({ priority, onChange, className, showLabel }: Prior
     </span>
   );
 
-  if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{icon}<span className="text-sm">{config.label}</span></span> : icon;
+  if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{icon}<span className="text-sm">{priorityLabel(priority)}</span></span> : icon;
 
   const trigger = showLabel ? (
     <button className="inline-flex items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors">
       {icon}
-      <span className="text-sm">{config.label}</span>
+      <span className="text-sm">{priorityLabel(priority)}</span>
     </button>
   ) : icon;
 
@@ -67,7 +70,7 @@ export function PriorityIcon({ priority, onChange, className, showLabel }: Prior
               }}
             >
               <PIcon className={cn("h-3.5 w-3.5", c.color)} />
-              {c.label}
+              {priorityLabel(p)}
             </Button>
           );
         })}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Settings,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "../lib/i18n";
 import { SidebarSection } from "./SidebarSection";
 import { SidebarNavItem } from "./SidebarNavItem";
 import { SidebarProjects } from "./SidebarProjects";
@@ -26,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import { PluginSlotOutlet } from "@/plugins/slots";
 
 export function Sidebar() {
+  const { t } = useTranslation();
   const { openNewIssue } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
   const inboxBadge = useInboxBadge(selectedCompanyId);
@@ -57,7 +59,7 @@ export function Sidebar() {
           />
         )}
         <span className="flex-1 text-sm font-bold text-foreground truncate pl-1">
-          {selectedCompany?.name ?? "Select company"}
+          {selectedCompany?.name ?? t("sidebar.selectCompany")}
         </span>
         <Button
           variant="ghost"
@@ -77,12 +79,12 @@ export function Sidebar() {
             className="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
           >
             <SquarePen className="h-4 w-4 shrink-0" />
-            <span className="truncate">New Issue</span>
+            <span className="truncate">{t("sidebar.newIssue")}</span>
           </button>
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem to="/dashboard" label={t("sidebar.dashboard")} icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
-            label="Inbox"
+            label={t("sidebar.inbox")}
             icon={Inbox}
             badge={inboxBadge.inbox}
             badgeTone={inboxBadge.failedRuns > 0 ? "danger" : "default"}
@@ -97,22 +99,22 @@ export function Sidebar() {
           />
         </div>
 
-        <SidebarSection label="Work">
-          <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} textBadge="Beta" textBadgeTone="amber" />
-          <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+        <SidebarSection label={t("sidebar.work")}>
+          <SidebarNavItem to="/issues" label={t("sidebar.issues")} icon={CircleDot} />
+          <SidebarNavItem to="/routines" label={t("sidebar.routines")} icon={Repeat} textBadge={t("beta")} textBadgeTone="amber" />
+          <SidebarNavItem to="/goals" label={t("sidebar.goals")} icon={Target} />
         </SidebarSection>
 
         <SidebarProjects />
 
         <SidebarAgents />
 
-        <SidebarSection label="Company">
-          <SidebarNavItem to="/org" label="Org" icon={Network} />
-          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
-          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
-          <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+        <SidebarSection label={t("sidebar.company")}>
+          <SidebarNavItem to="/org" label={t("sidebar.org")} icon={Network} />
+          <SidebarNavItem to="/skills" label={t("sidebar.skills")} icon={Boxes} />
+          <SidebarNavItem to="/costs" label={t("sidebar.costs")} icon={DollarSign} />
+          <SidebarNavItem to="/activity" label={t("sidebar.activity")} icon={History} />
+          <SidebarNavItem to="/company/settings" label={t("sidebar.settings")} icon={Settings} />
         </SidebarSection>
 
         <PluginSlotOutlet

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -1,14 +1,11 @@
 import { useState } from "react";
 import { cn } from "../lib/utils";
+import { useTranslation } from "../lib/i18n";
 import { issueStatusIcon, issueStatusIconDefault } from "../lib/status-colors";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 
 const allStatuses = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "blocked"];
-
-function statusLabel(status: string): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
 
 interface StatusIconProps {
   status: string;
@@ -18,6 +15,8 @@ interface StatusIconProps {
 }
 
 export function StatusIcon({ status, onChange, className, showLabel }: StatusIconProps) {
+  const { t } = useTranslation();
+  const statusLabel = (s: string) => t(`statuses.${s}`) !== `statuses.${s}` ? t(`statuses.${s}`) : s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
   const [open, setOpen] = useState(false);
   const colorClass = issueStatusIcon[status] ?? issueStatusIconDefault;
   const isDone = status === "done";

--- a/ui/src/lib/i18n.ts
+++ b/ui/src/lib/i18n.ts
@@ -1,0 +1,109 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { createElement } from "react";
+import en from "../locales/en";
+import ko from "../locales/ko";
+
+const LANGUAGE_STORAGE_KEY = "paperclip.language";
+const SUPPORTED_LANGUAGES = ["en", "ko"] as const;
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+type TranslationMap = typeof en.translation;
+
+const resources: Record<SupportedLanguage, { translation: Record<string, unknown> }> = { en, ko };
+
+function getNestedValue(obj: unknown, path: string): string {
+  const keys = path.split(".");
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current == null || typeof current !== "object") return path;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === "string" ? current : path;
+}
+
+function detectLanguage(): SupportedLanguage {
+  try {
+    const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    if (stored && SUPPORTED_LANGUAGES.includes(stored as SupportedLanguage)) {
+      return stored as SupportedLanguage;
+    }
+  } catch {
+    // ignore
+  }
+  const nav = navigator.language ?? "";
+  const prefix = nav.split("-")[0]?.toLowerCase();
+  if (prefix && SUPPORTED_LANGUAGES.includes(prefix as SupportedLanguage)) {
+    return prefix as SupportedLanguage;
+  }
+  return "en";
+}
+
+interface I18nContextValue {
+  language: SupportedLanguage;
+  setLanguage: (lang: SupportedLanguage) => void;
+  t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+function I18nProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<SupportedLanguage>(detectLanguage);
+
+  const setLanguage = useCallback((lang: SupportedLanguage) => {
+    setLanguageState(lang);
+    try {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+    } catch {
+      // ignore
+    }
+  }, [language]);
+
+  const t = useCallback(
+    (key: string): string => {
+      const result = getNestedValue(resources[language]?.translation, key);
+      if (result !== key) return result;
+      return getNestedValue(resources.en.translation, key);
+    },
+    [language],
+  );
+
+  const value = useMemo(() => ({ language, setLanguage, t }), [language, setLanguage, t]);
+
+  return createElement(I18nContext.Provider, { value }, children);
+}
+
+const fallbackT = (key: string): string => getNestedValue(resources.en.translation, key);
+const fallbackValue: I18nContextValue = {
+  language: "en",
+  setLanguage: () => {},
+  t: fallbackT,
+};
+
+function useTranslation(): I18nContextValue {
+  const context = useContext(I18nContext);
+  return context ?? fallbackValue;
+}
+
+export {
+  I18nProvider,
+  useTranslation,
+  SUPPORTED_LANGUAGES,
+  LANGUAGE_STORAGE_KEY,
+  type SupportedLanguage,
+};

--- a/ui/src/lib/timeAgo.ts
+++ b/ui/src/lib/timeAgo.ts
@@ -1,31 +1,43 @@
+import { LANGUAGE_STORAGE_KEY } from "./i18n";
+
 const MINUTE = 60;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const MONTH = 30 * DAY;
 
+function getCurrentLanguage(): string {
+  try {
+    return localStorage.getItem(LANGUAGE_STORAGE_KEY) ?? "en";
+  } catch {
+    return "en";
+  }
+}
+
+function formatTimeAgoKo(seconds: number): string {
+  if (seconds < MINUTE) return "방금 전";
+  if (seconds < HOUR) return `${Math.floor(seconds / MINUTE)}분 전`;
+  if (seconds < DAY) return `${Math.floor(seconds / HOUR)}시간 전`;
+  if (seconds < WEEK) return `${Math.floor(seconds / DAY)}일 전`;
+  if (seconds < MONTH) return `${Math.floor(seconds / WEEK)}주 전`;
+  return `${Math.floor(seconds / MONTH)}개월 전`;
+}
+
+function formatTimeAgoEn(seconds: number): string {
+  if (seconds < MINUTE) return "just now";
+  if (seconds < HOUR) return `${Math.floor(seconds / MINUTE)}m ago`;
+  if (seconds < DAY) return `${Math.floor(seconds / HOUR)}h ago`;
+  if (seconds < WEEK) return `${Math.floor(seconds / DAY)}d ago`;
+  if (seconds < MONTH) return `${Math.floor(seconds / WEEK)}w ago`;
+  return `${Math.floor(seconds / MONTH)}mo ago`;
+}
+
 export function timeAgo(date: Date | string): string {
   const now = Date.now();
   const then = new Date(date).getTime();
   const seconds = Math.round((now - then) / 1000);
+  const lang = getCurrentLanguage();
 
-  if (seconds < MINUTE) return "just now";
-  if (seconds < HOUR) {
-    const m = Math.floor(seconds / MINUTE);
-    return `${m}m ago`;
-  }
-  if (seconds < DAY) {
-    const h = Math.floor(seconds / HOUR);
-    return `${h}h ago`;
-  }
-  if (seconds < WEEK) {
-    const d = Math.floor(seconds / DAY);
-    return `${d}d ago`;
-  }
-  if (seconds < MONTH) {
-    const w = Math.floor(seconds / WEEK);
-    return `${w}w ago`;
-  }
-  const mo = Math.floor(seconds / MONTH);
-  return `${mo}mo ago`;
+  if (lang === "ko") return formatTimeAgoKo(seconds);
+  return formatTimeAgoEn(seconds);
 }

--- a/ui/src/locales/en.ts
+++ b/ui/src/locales/en.ts
@@ -1,0 +1,278 @@
+const en = {
+  translation: {
+    // Sidebar navigation
+    sidebar: {
+      selectCompany: "Select company",
+      newIssue: "New Issue",
+      dashboard: "Dashboard",
+      inbox: "Inbox",
+      issues: "Issues",
+      routines: "Routines",
+      goals: "Goals",
+      work: "Work",
+      company: "Company",
+      org: "Org",
+      skills: "Skills",
+      costs: "Costs",
+      activity: "Activity",
+      settings: "Settings",
+      projects: "Projects",
+      agents: "Agents",
+    },
+
+    // Instance settings sidebar
+    instanceSettings: {
+      title: "Instance Settings",
+      general: "General",
+      heartbeats: "Heartbeats",
+      experimental: "Experimental",
+      plugins: "Plugins",
+    },
+
+    // Layout
+    layout: {
+      skipToMain: "Skip to Main Content",
+      closeSidebar: "Close sidebar",
+      openSidebar: "Open sidebar",
+      documentation: "Documentation",
+      instanceSettings: "Instance settings",
+      switchToLight: "Switch to light mode",
+      switchToDark: "Switch to dark mode",
+    },
+
+    // Issue properties
+    issueProperties: {
+      status: "Status",
+      priority: "Priority",
+      labels: "Labels",
+      assignee: "Assignee",
+      project: "Project",
+      parent: "Parent",
+      depth: "Depth",
+      createdBy: "Created by",
+      started: "Started",
+      completed: "Completed",
+      created: "Created",
+      updated: "Updated",
+      noLabels: "No labels",
+      noAssignee: "No assignee",
+      unassigned: "Unassigned",
+      assignToMe: "Assign to me",
+      noProject: "No project",
+      searchLabels: "Search labels...",
+      searchAssignees: "Search assignees...",
+      searchProjects: "Search projects...",
+      createLabel: "Create label",
+      user: "User",
+      billingCode: "Billing code",
+      goal: "Goal",
+    },
+
+    // Agent properties
+    agentProperties: {
+      status: "Status",
+      role: "Role",
+      title: "Title",
+      adapter: "Adapter",
+      session: "Session",
+      lastError: "Last error",
+      lastHeartbeat: "Last Heartbeat",
+      reportsTo: "Reports To",
+      created: "Created",
+      capabilities: "Capabilities",
+      model: "Model",
+    },
+
+    // Project properties
+    projectProperties: {
+      name: "Name",
+      description: "Description",
+      status: "Status",
+      lead: "Lead",
+      goals: "Goals",
+      created: "Created",
+      updated: "Updated",
+      targetDate: "Target Date",
+      clearRepo: "Clear repo",
+      clearLocalFolder: "Clear local folder",
+      codebaseHelp: "Codebase help",
+      executionWorkspacesHelp: "Execution workspaces help",
+    },
+
+    // Goal properties
+    goalProperties: {
+      status: "Status",
+      level: "Level",
+      owner: "Owner",
+      parentGoal: "Parent Goal",
+      created: "Created",
+      updated: "Updated",
+    },
+
+    // Pages
+    pages: {
+      issues: "Issues",
+      agents: "Agents",
+      projects: "Projects",
+      goals: "Goals",
+      routines: "Routines",
+      activity: "Activity",
+      inbox: "Inbox",
+      costs: "Costs",
+      org: "Org",
+      approvals: "Approvals",
+      skills: "Skills",
+      settings: "Settings",
+      dashboard: "Dashboard",
+    },
+
+    // Empty states
+    emptyStates: {
+      selectCompanyAgents: "Select a company to view agents.",
+      selectCompanyProjects: "Select a company to view projects.",
+      selectCompanyGoals: "Select a company to view goals.",
+      selectCompanyRoutines: "Select a company to view routines.",
+      selectCompanyActivity: "Select a company to view activity.",
+      selectCompanyInbox: "Select a company to view inbox.",
+      selectCompanyCosts: "Select a company to view costs.",
+      selectCompanyOrg: "Select a company to view the org chart.",
+      selectCompanySkills: "Select a company to manage skills.",
+      noProjects: "No projects yet.",
+      noGoals: "No goals yet.",
+      noRoutines: "No routines yet. Use Create routine to define the first recurring workflow.",
+      noActivity: "No activity yet.",
+      inboxZero: "Inbox zero.",
+      noInboxNew: "No new inbox items.",
+      noInboxRecent: "No recent inbox items.",
+      noInboxFilter: "No inbox items match these filters.",
+      noPendingApprovals: "No pending approvals.",
+      noApprovals: "No approvals yet.",
+      noOrgHierarchy: "No organizational hierarchy defined.",
+      selectSkill: "Select a skill to inspect its files.",
+      noMonthlyCap: "No monthly cap configured",
+      noFinanceEvents: "No finance events yet...",
+      noHeartbeats: "No scheduler heartbeats match the current criteria.",
+    },
+
+    // Dialogs
+    dialogs: {
+      issueTitle: "Issue title",
+      assignee: "Assignee",
+      project: "Project",
+      defaultModel: "Default model",
+      addDescription: "Add description...",
+      removeDocument: "Remove document",
+      removeAttachment: "Remove attachment",
+      projectName: "Project name",
+      goalTitle: "Goal title",
+      create: "Create",
+      cancel: "Cancel",
+      save: "Save",
+      delete: "Delete",
+      close: "Close",
+      upload: "Upload",
+    },
+
+    // Agent config form
+    agentConfig: {
+      name: "Name",
+      title: "Title",
+      reportsTo: "Reports to",
+      capabilities: "Capabilities",
+      promptTemplate: "Prompt Template",
+      adapterType: "Adapter type",
+      workingDirectory: "Working directory (deprecated)",
+      command: "Command",
+      bootstrapPrompt: "Bootstrap prompt (legacy)",
+      extraArgs: "Extra args (comma-separated)",
+      envVars: "Environment variables",
+      timeoutSec: "Timeout (sec)",
+      gracePeriod: "Interrupt grace period (sec)",
+      heartbeatInterval: "Heartbeat on interval",
+      wakeOnDemand: "Wake on demand",
+      cooldownSec: "Cooldown (sec)",
+      maxConcurrentRuns: "Max concurrent runs",
+      model: "Model",
+      thinkingEffort: "Thinking effort",
+    },
+
+    // Common actions
+    actions: {
+      search: "Search",
+      searchIssues: "Search issues, agents, projects...",
+      searchIssuesPlaceholder: "Search issues...",
+      leaveComment: "Leave a comment...",
+      copyAsMarkdown: "Copy as markdown",
+      attachImage: "Attach image",
+      markAsRead: "Mark as read",
+      dismissFromInbox: "Dismiss from inbox",
+      expandDocument: "Expand document",
+      collapseDocument: "Collapse document",
+      listView: "List view",
+      boardView: "Board view",
+    },
+
+    // Status labels
+    statuses: {
+      backlog: "Backlog",
+      todo: "To Do",
+      in_progress: "In Progress",
+      in_review: "In Review",
+      done: "Done",
+      blocked: "Blocked",
+      cancelled: "Cancelled",
+    },
+
+    // Priority labels
+    priorities: {
+      critical: "Critical",
+      high: "High",
+      medium: "Medium",
+      low: "Low",
+    },
+
+    // Agent roles
+    roles: {
+      ceo: "CEO",
+      cto: "CTO",
+      manager: "Manager",
+      engineer: "Engineer",
+      designer: "Designer",
+      qa: "QA",
+    },
+
+    // Onboarding / App
+    app: {
+      instanceSetupRequired: "Instance setup required",
+      noInstanceAdmin: "No instance admin exists yet...",
+      createFirstCompany: "Create your first company",
+      getStarted: "Get started by creating a company.",
+      addAgent: "Add Agent",
+      startOnboarding: "Start Onboarding",
+      createAnotherCompany: "Create another company",
+      createAnotherAgent: "Create another agent",
+      loading: "Loading...",
+    },
+
+    // Language
+    language: {
+      label: "Language",
+      en: "English",
+      ko: "한국어",
+    },
+
+    // Mobile bottom nav
+    mobileNav: {
+      dashboard: "Dashboard",
+      inbox: "Inbox",
+      issues: "Issues",
+      agents: "Agents",
+      more: "More",
+    },
+
+    // Breadcrumb & misc labels
+    beta: "Beta",
+  },
+} as const;
+
+export default en;

--- a/ui/src/locales/ko.ts
+++ b/ui/src/locales/ko.ts
@@ -1,0 +1,278 @@
+const ko = {
+  translation: {
+    // 사이드바 네비게이션
+    sidebar: {
+      selectCompany: "회사 선택",
+      newIssue: "새 이슈",
+      dashboard: "대시보드",
+      inbox: "수신함",
+      issues: "이슈",
+      routines: "루틴",
+      goals: "목표",
+      work: "업무",
+      company: "회사",
+      org: "조직도",
+      skills: "스킬",
+      costs: "비용",
+      activity: "활동",
+      settings: "설정",
+      projects: "프로젝트",
+      agents: "에이전트",
+    },
+
+    // 인스턴스 설정 사이드바
+    instanceSettings: {
+      title: "인스턴스 설정",
+      general: "일반",
+      heartbeats: "하트비트",
+      experimental: "실험적 기능",
+      plugins: "플러그인",
+    },
+
+    // 레이아웃
+    layout: {
+      skipToMain: "본문으로 건너뛰기",
+      closeSidebar: "사이드바 닫기",
+      openSidebar: "사이드바 열기",
+      documentation: "문서",
+      instanceSettings: "인스턴스 설정",
+      switchToLight: "라이트 모드로 전환",
+      switchToDark: "다크 모드로 전환",
+    },
+
+    // 이슈 속성
+    issueProperties: {
+      status: "상태",
+      priority: "우선순위",
+      labels: "라벨",
+      assignee: "담당자",
+      project: "프로젝트",
+      parent: "상위 이슈",
+      depth: "깊이",
+      createdBy: "생성자",
+      started: "시작일",
+      completed: "완료일",
+      created: "생성일",
+      updated: "수정일",
+      noLabels: "라벨 없음",
+      noAssignee: "담당자 없음",
+      unassigned: "미할당",
+      assignToMe: "나에게 할당",
+      noProject: "프로젝트 없음",
+      searchLabels: "라벨 검색...",
+      searchAssignees: "담당자 검색...",
+      searchProjects: "프로젝트 검색...",
+      createLabel: "라벨 생성",
+      user: "사용자",
+      billingCode: "청구 코드",
+      goal: "목표",
+    },
+
+    // 에이전트 속성
+    agentProperties: {
+      status: "상태",
+      role: "역할",
+      title: "직함",
+      adapter: "어댑터",
+      session: "세션",
+      lastError: "마지막 오류",
+      lastHeartbeat: "마지막 하트비트",
+      reportsTo: "보고 대상",
+      created: "생성일",
+      capabilities: "역량",
+      model: "모델",
+    },
+
+    // 프로젝트 속성
+    projectProperties: {
+      name: "이름",
+      description: "설명",
+      status: "상태",
+      lead: "담당자",
+      goals: "목표",
+      created: "생성일",
+      updated: "수정일",
+      targetDate: "목표 일자",
+      clearRepo: "레포 초기화",
+      clearLocalFolder: "로컬 폴더 초기화",
+      codebaseHelp: "코드베이스 도움말",
+      executionWorkspacesHelp: "실행 워크스페이스 도움말",
+    },
+
+    // 목표 속성
+    goalProperties: {
+      status: "상태",
+      level: "레벨",
+      owner: "소유자",
+      parentGoal: "상위 목표",
+      created: "생성일",
+      updated: "수정일",
+    },
+
+    // 페이지
+    pages: {
+      issues: "이슈",
+      agents: "에이전트",
+      projects: "프로젝트",
+      goals: "목표",
+      routines: "루틴",
+      activity: "활동",
+      inbox: "수신함",
+      costs: "비용",
+      org: "조직도",
+      approvals: "승인",
+      skills: "스킬",
+      settings: "설정",
+      dashboard: "대시보드",
+    },
+
+    // 빈 상태 메시지
+    emptyStates: {
+      selectCompanyAgents: "에이전트를 보려면 회사를 선택하세요.",
+      selectCompanyProjects: "프로젝트를 보려면 회사를 선택하세요.",
+      selectCompanyGoals: "목표를 보려면 회사를 선택하세요.",
+      selectCompanyRoutines: "루틴을 보려면 회사를 선택하세요.",
+      selectCompanyActivity: "활동을 보려면 회사를 선택하세요.",
+      selectCompanyInbox: "수신함을 보려면 회사를 선택하세요.",
+      selectCompanyCosts: "비용을 보려면 회사를 선택하세요.",
+      selectCompanyOrg: "조직도를 보려면 회사를 선택하세요.",
+      selectCompanySkills: "스킬을 관리하려면 회사를 선택하세요.",
+      noProjects: "아직 프로젝트가 없습니다.",
+      noGoals: "아직 목표가 없습니다.",
+      noRoutines: "아직 루틴이 없습니다. 루틴 생성을 사용하여 첫 번째 반복 워크플로를 정의하세요.",
+      noActivity: "아직 활동이 없습니다.",
+      inboxZero: "수신함이 비어 있습니다.",
+      noInboxNew: "새 수신 항목이 없습니다.",
+      noInboxRecent: "최근 수신 항목이 없습니다.",
+      noInboxFilter: "필터와 일치하는 수신 항목이 없습니다.",
+      noPendingApprovals: "대기 중인 승인이 없습니다.",
+      noApprovals: "아직 승인이 없습니다.",
+      noOrgHierarchy: "정의된 조직 체계가 없습니다.",
+      selectSkill: "파일을 확인하려면 스킬을 선택하세요.",
+      noMonthlyCap: "월간 한도가 설정되지 않았습니다",
+      noFinanceEvents: "아직 재무 이벤트가 없습니다...",
+      noHeartbeats: "현재 조건에 맞는 스케줄러 하트비트가 없습니다.",
+    },
+
+    // 다이얼로그
+    dialogs: {
+      issueTitle: "이슈 제목",
+      assignee: "담당자",
+      project: "프로젝트",
+      defaultModel: "기본 모델",
+      addDescription: "설명 추가...",
+      removeDocument: "문서 제거",
+      removeAttachment: "첨부파일 제거",
+      projectName: "프로젝트 이름",
+      goalTitle: "목표 제목",
+      create: "생성",
+      cancel: "취소",
+      save: "저장",
+      delete: "삭제",
+      close: "닫기",
+      upload: "업로드",
+    },
+
+    // 에이전트 설정 폼
+    agentConfig: {
+      name: "이름",
+      title: "직함",
+      reportsTo: "보고 대상",
+      capabilities: "역량",
+      promptTemplate: "프롬프트 템플릿",
+      adapterType: "어댑터 유형",
+      workingDirectory: "작업 디렉토리 (비추천)",
+      command: "명령어",
+      bootstrapPrompt: "부트스트랩 프롬프트 (레거시)",
+      extraArgs: "추가 인수 (쉼표 구분)",
+      envVars: "환경 변수",
+      timeoutSec: "타임아웃 (초)",
+      gracePeriod: "인터럽트 유예 시간 (초)",
+      heartbeatInterval: "하트비트 주기",
+      wakeOnDemand: "요청 시 실행",
+      cooldownSec: "쿨다운 (초)",
+      maxConcurrentRuns: "최대 동시 실행 수",
+      model: "모델",
+      thinkingEffort: "추론 수준",
+    },
+
+    // 공통 액션
+    actions: {
+      search: "검색",
+      searchIssues: "이슈, 에이전트, 프로젝트 검색...",
+      searchIssuesPlaceholder: "이슈 검색...",
+      leaveComment: "댓글 남기기...",
+      copyAsMarkdown: "마크다운으로 복사",
+      attachImage: "이미지 첨부",
+      markAsRead: "읽음으로 표시",
+      dismissFromInbox: "수신함에서 제거",
+      expandDocument: "문서 펼치기",
+      collapseDocument: "문서 접기",
+      listView: "목록 보기",
+      boardView: "보드 보기",
+    },
+
+    // 상태 라벨
+    statuses: {
+      backlog: "백로그",
+      todo: "할 일",
+      in_progress: "진행 중",
+      in_review: "검토 중",
+      done: "완료",
+      blocked: "차단됨",
+      cancelled: "취소됨",
+    },
+
+    // 우선순위 라벨
+    priorities: {
+      critical: "긴급",
+      high: "높음",
+      medium: "보통",
+      low: "낮음",
+    },
+
+    // 에이전트 역할
+    roles: {
+      ceo: "CEO",
+      cto: "CTO",
+      manager: "매니저",
+      engineer: "엔지니어",
+      designer: "디자이너",
+      qa: "QA",
+    },
+
+    // 온보딩 / 앱
+    app: {
+      instanceSetupRequired: "인스턴스 설정이 필요합니다",
+      noInstanceAdmin: "아직 인스턴스 관리자가 없습니다...",
+      createFirstCompany: "첫 번째 회사 만들기",
+      getStarted: "회사를 만들어 시작하세요.",
+      addAgent: "에이전트 추가",
+      startOnboarding: "온보딩 시작",
+      createAnotherCompany: "다른 회사 만들기",
+      createAnotherAgent: "다른 에이전트 추가",
+      loading: "로딩 중...",
+    },
+
+    // 언어
+    language: {
+      label: "언어",
+      en: "English",
+      ko: "한국어",
+    },
+
+    // 모바일 하단 네비게이션
+    mobileNav: {
+      dashboard: "대시보드",
+      inbox: "수신함",
+      issues: "이슈",
+      agents: "에이전트",
+      more: "더보기",
+    },
+
+    // 브레드크럼 & 기타
+    beta: "베타",
+  },
+} as const;
+
+export default ko;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -16,6 +16,7 @@ import { ThemeProvider } from "./context/ThemeContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { initPluginBridge } from "./plugins/bridge-init";
 import { PluginLauncherProvider } from "./plugins/launchers";
+import { I18nProvider } from "./lib/i18n";
 import "@mdxeditor/editor/style.css";
 import "./index.css";
 
@@ -39,6 +40,7 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
+      <I18nProvider>
       <ThemeProvider>
         <BrowserRouter>
           <CompanyProvider>
@@ -62,6 +64,7 @@ createRoot(document.getElementById("root")!).render(
           </CompanyProvider>
         </BrowserRouter>
       </ThemeProvider>
+      </I18nProvider>
     </QueryClientProvider>
   </StrictMode>
 );

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useQuery } from "@tanstack/react-query";
 import { activityApi } from "../api/activity";
 import { agentsApi } from "../api/agents";
@@ -22,6 +23,7 @@ import { History } from "lucide-react";
 import type { Agent } from "@paperclipai/shared";
 
 export function Activity() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const [filter, setFilter] = useState("all");
@@ -82,7 +84,7 @@ export function Activity() {
   }, [issues]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={History} message="Select a company to view activity." />;
+    return <EmptyState icon={History} message={t("emptyStates.selectCompanyActivity")} />;
   }
 
   if (isLoading) {
@@ -119,7 +121,7 @@ export function Activity() {
       {error && <p className="text-sm text-destructive">{error.message}</p>}
 
       {filtered && filtered.length === 0 && (
-        <EmptyState icon={History} message="No activity yet." />
+        <EmptyState icon={History} message={t("emptyStates.noActivity")} />
       )}
 
       {filtered && filtered.length > 0 && (

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { useTranslation } from "../lib/i18n";
 import { Link, useNavigate, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import { agentsApi, type OrgNode } from "../api/agents";
@@ -64,6 +65,7 @@ function filterOrgTree(nodes: OrgNode[], tab: FilterTab, showTerminated: boolean
 }
 
 export function Agents() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -123,7 +125,7 @@ export function Agents() {
   }, [setBreadcrumbs]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Bot} message="Select a company to view agents." />;
+    return <EmptyState icon={Bot} message={t("emptyStates.selectCompanyAgents")} />;
   }
 
   if (isLoading) {

--- a/ui/src/pages/Approvals.tsx
+++ b/ui/src/pages/Approvals.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useNavigate, useLocation } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { approvalsApi } from "../api/approvals";
@@ -16,6 +17,7 @@ import { PageSkeleton } from "../components/PageSkeleton";
 type StatusFilter = "pending" | "all";
 
 export function Approvals() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
@@ -107,7 +109,7 @@ export function Approvals() {
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <ShieldCheck className="h-8 w-8 text-muted-foreground/30 mb-3" />
           <p className="text-sm text-muted-foreground">
-            {statusFilter === "pending" ? "No pending approvals." : "No approvals yet."}
+            {statusFilter === "pending" ? t("emptyStates.noPendingApprovals") : t("emptyStates.noApprovals")}
           </p>
         </div>
       )}

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type SVGProps } from "react";
+import { useTranslation } from "../lib/i18n";
 import { Link, useNavigate, useParams } from "@/lib/router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
@@ -525,6 +526,7 @@ function SkillPane({
   onSave: () => void;
   savePending: boolean;
 }) {
+  const { t } = useTranslation();
   const { pushToast } = useToast();
 
   if (!detail) {
@@ -534,7 +536,7 @@ function SkillPane({
     return (
       <EmptyState
         icon={Boxes}
-        message="Select a skill to inspect its files."
+        message={t("emptyStates.selectSkill")}
       />
     );
   }
@@ -733,6 +735,7 @@ function SkillPane({
 }
 
 export function CompanySkills() {
+  const { t } = useTranslation();
   const { "*": routePath } = useParams<{ "*": string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -988,7 +991,7 @@ export function CompanySkills() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Boxes} message="Select a company to manage skills." />;
+    return <EmptyState icon={Boxes} message={t("emptyStates.selectCompanySkills")} />;
   }
 
   function handleAddSkillSource() {

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   BudgetPolicySummary,
@@ -147,6 +148,7 @@ function FinanceSummaryCard({
 }
 
 export function Costs() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
@@ -529,7 +531,7 @@ export function Costs() {
   }), [budgetPolicies]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={DollarSign} message="Select a company to view costs." />;
+    return <EmptyState icon={DollarSign} message={t("emptyStates.selectCompanyCosts")} />;
   }
 
   const showCustomPrompt = preset === "custom" && !customReady;
@@ -598,7 +600,7 @@ export function Costs() {
                   ? `${budgetData?.pausedAgentCount ?? 0} agents paused · ${budgetData?.pausedProjectCount ?? 0} projects paused`
                   : spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
                     ? `${formatCents(spendData.summary.spendCents)} of ${formatCents(spendData.summary.budgetCents)}`
-                    : "No monthly cap configured"
+                    : t("emptyStates.noMonthlyCap")
               }
               icon={Coins}
             />
@@ -1082,7 +1084,7 @@ export function Costs() {
                     </CardHeader>
                     <CardContent className="grid gap-4 px-5 pb-5 pt-2 md:grid-cols-2">
                       {(financeData?.byBiller.length ?? 0) === 0 ? (
-                        <p className="text-sm text-muted-foreground">No finance events yet.</p>
+                        <p className="text-sm text-muted-foreground">{t("emptyStates.noFinanceEvents")}</p>
                       ) : (
                         financeData?.byBiller.map((row) => <FinanceBillerCard key={row.biller} row={row} />)
                       )}

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useQuery } from "@tanstack/react-query";
 import { goalsApi } from "../api/goals";
 import { useCompany } from "../context/CompanyContext";
@@ -12,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Target, Plus } from "lucide-react";
 
 export function Goals() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { openNewGoal } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -27,7 +29,7 @@ export function Goals() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Target} message="Select a company to view goals." />;
+    return <EmptyState icon={Target} message={t("emptyStates.selectCompanyGoals")} />;
   }
 
   if (isLoading) {
@@ -41,7 +43,7 @@ export function Goals() {
       {goals && goals.length === 0 && (
         <EmptyState
           icon={Target}
-          message="No goals yet."
+          message={t("emptyStates.noGoals")}
           action="Add Goal"
           onAction={() => openNewGoal()}
         />

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { Link, useLocation, useNavigate } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { INBOX_MINE_ISSUE_STATUS_FILTER } from "@paperclipai/shared";
@@ -591,6 +592,7 @@ function JoinRequestInboxRow({
 }
 
 export function Inbox() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
@@ -1173,7 +1175,7 @@ export function Inbox() {
   }, [selectedIndex]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={InboxIcon} message="Select a company to view inbox." />;
+    return <EmptyState icon={InboxIcon} message={t("emptyStates.selectCompanyInbox")} />;
   }
 
   const hasRunFailures = failedRuns.length > 0;
@@ -1300,12 +1302,12 @@ export function Inbox() {
           icon={InboxIcon}
           message={
             tab === "mine"
-              ? "Inbox zero."
+              ? t("emptyStates.inboxZero")
               : tab === "unread"
-              ? "No new inbox items."
+              ? t("emptyStates.noInboxNew")
               : tab === "recent"
-                ? "No recent inbox items."
-                : "No inbox items match these filters."
+                ? t("emptyStates.noInboxRecent")
+                : t("emptyStates.noInboxFilter")
           }
         />
       )}

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Clock3, ExternalLink, Settings } from "lucide-react";
 import type { InstanceSchedulerHeartbeatAgent } from "@paperclipai/shared";
@@ -27,6 +28,7 @@ function buildAgentHref(agent: InstanceSchedulerHeartbeatAgent) {
 }
 
 export function InstanceSettings() {
+  const { t } = useTranslation();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
@@ -207,7 +209,7 @@ export function InstanceSettings() {
       {agents.length === 0 ? (
         <EmptyState
           icon={Clock3}
-          message="No scheduler heartbeats match the current criteria."
+          message={t("emptyStates.noHeartbeats")}
         />
       ) : (
         <div className="space-y-4">

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import { useTranslation } from "../lib/i18n";
 import { Link, useNavigate } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import { agentsApi, type OrgNode } from "../api/agents";
@@ -141,6 +142,7 @@ const defaultDotColor = "#a3a3a3";
 // ── Main component ──────────────────────────────────────────────────────
 
 export function OrgChart() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
@@ -257,7 +259,7 @@ export function OrgChart() {
   }, [zoom, pan]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Network} message="Select a company to view the org chart." />;
+    return <EmptyState icon={Network} message={t("emptyStates.selectCompanyOrg")} />;
   }
 
   if (isLoading) {
@@ -265,7 +267,7 @@ export function OrgChart() {
   }
 
   if (orgTree && orgTree.length === 0) {
-    return <EmptyState icon={Network} message="No organizational hierarchy defined." />;
+    return <EmptyState icon={Network} message={t("emptyStates.noOrgHierarchy")} />;
   }
 
   return (

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useQuery } from "@tanstack/react-query";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
@@ -14,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Hexagon, Plus } from "lucide-react";
 
 export function Projects() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { openNewProject } = useDialog();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -33,7 +35,7 @@ export function Projects() {
   );
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Hexagon} message="Select a company to view projects." />;
+    return <EmptyState icon={Hexagon} message={t("emptyStates.selectCompanyProjects")} />;
   }
 
   if (isLoading) {
@@ -54,7 +56,7 @@ export function Projects() {
       {!isLoading && projects.length === 0 && (
         <EmptyState
           icon={Hexagon}
-          message="No projects yet."
+          message={t("emptyStates.noProjects")}
           action="Add Project"
           onAction={openNewProject}
         />

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "../lib/i18n";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@/lib/router";
 import { ChevronDown, ChevronRight, MoreHorizontal, Play, Plus, Repeat } from "lucide-react";
@@ -63,6 +64,7 @@ function nextRoutineStatus(currentStatus: string, enabled: boolean) {
 }
 
 export function Routines() {
+  const { t } = useTranslation();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
@@ -218,7 +220,7 @@ export function Routines() {
   const currentProject = draft.projectId ? projectById.get(draft.projectId) ?? null : null;
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Repeat} message="Select a company to view routines." />;
+    return <EmptyState icon={Repeat} message={t("emptyStates.selectCompanyRoutines")} />;
   }
 
   if (isLoading) {
@@ -507,7 +509,7 @@ export function Routines() {
           <div className="py-12">
             <EmptyState
               icon={Repeat}
-              message="No routines yet. Use Create routine to define the first recurring workflow."
+              message={t("emptyStates.noRoutines")}
             />
           </div>
         ) : (


### PR DESCRIPTION
## Thinking Path

Paperclip serves users in multiple locales → Korean is a priority → existing ~20 i18n PRs all use i18next (adds deps, breaks CI lockfile policy) → we built a zero-dependency i18n system using React Context → then went deeper than surface-level by translating StatusIcon, PriorityIcon, timeAgo, and Kanban board labels.

## Summary

- **Zero external dependencies** — no i18next, no lockfile changes, CI-compatible
- Deep translation of core UI primitives (status/priority labels, relative time)
- Language toggle (Globe icon) in sidebar footer
- Browser language auto-detection + localStorage persistence

## Key Differentiators vs Other i18n PRs

| Feature | This PR | Most others |
|---------|---------|-------------|
| External deps | **None** | i18next + react-i18next |
| CI compatibility | **Full** (no lockfile change) | Breaks policy check |
| Status labels (StatusIcon) | **Translated** | Usually missed |
| Priority labels (PriorityIcon) | **Translated** | Usually missed |
| Relative time (timeAgo) | **Locale-aware** ("3시간 전") | English only |
| Kanban board column headers | **Translated** | Usually missed |
| IssuesList group headers | **Translated** | Usually missed |

## Changes (28 files)

### New files
- `ui/src/lib/i18n.ts` — React Context i18n system (90 lines, zero deps)
- `ui/src/locales/en.ts` — English translations (200+ keys)
- `ui/src/locales/ko.ts` — Korean translations (200+ keys)

### Core UI primitives (deep translation)
- `StatusIcon.tsx` — Status dropdown labels ("할 일", "진행 중", "완료", etc.)
- `PriorityIcon.tsx` — Priority dropdown labels ("긴급", "높음", "보통", "낮음")
- `timeAgo.ts` — Locale-aware relative time ("방금 전", "3분 전", "2일 전")
- `KanbanBoard.tsx` — Board column headers
- `IssuesList.tsx` — List group headers

### Navigation & Layout
- Sidebar, InstanceSidebar, MobileBottomNav, BreadcrumbBar, Layout, CommandPalette

### Property Panels
- IssueProperties, AgentProperties

### Pages (11 empty states)
- Issues, Agents, Projects, Goals, Routines, Activity, Inbox, Costs, OrgChart, Approvals, CompanySkills, InstanceSettings

## How to verify

1. `pnpm install && pnpm --filter @paperclipai/ui build` — passes (no new deps)
2. Open UI with browser set to Korean → all labels in Korean
3. Click Globe icon → cycles English ↔ Korean
4. Check issue detail → Status shows "진행 중" not "In Progress"
5. Check timeAgo → shows "3시간 전" not "3h ago"

## Adding more languages

1. Create `ui/src/locales/{lang}.ts`
2. Import in `ui/src/lib/i18n.ts` and add to `resources`
3. Add language code to `SUPPORTED_LANGUAGES` in `i18n.ts`
4. Add to `LANGUAGE_LABELS` in `Layout.tsx`

## Test plan

- [x] TypeScript type check passes
- [x] Vite production build succeeds
- [x] No lockfile changes (CI policy compatible)
- [ ] Manual: Korean labels in sidebar, properties, dropdowns
- [ ] Manual: Korean status/priority labels in StatusIcon/PriorityIcon
- [ ] Manual: Korean timeAgo format
- [ ] Manual: Language toggle persistence