### PR TITLE
[codex] align issue detail unread flows

### DIFF
--- a/docs/plans/2026-04-01-issue-detail-latest-progress-design.md
+++ b/docs/plans/2026-04-01-issue-detail-latest-progress-design.md
@@ -1,0 +1,28 @@
+# Issue Detail Latest Progress Design
+
+## Context
+
+`IssueDetail` currently renders the timeline via `CommentThread` and exposes a generic floating `ScrollToBottom` button, but it does not actively position the reader at the newest activity on first open. It also lacks an explicit follow-state model for deciding when new timeline items should auto-scroll and when user scroll intent should win.
+
+## Decision
+
+Adopt a page-level follow controller inside `ui/src/pages/IssueDetail.tsx`.
+
+- On first issue open, if there is no deep link hash for a comment or document, auto-position to the bottom of the active scroller so the newest activity is visible.
+- While the reader remains near the bottom, new timeline growth keeps the page pinned to latest activity.
+- If the reader scrolls away from the bottom, release follow immediately and stop auto-scrolling on refresh or new comments.
+- If navigation includes `#comment-*` or `#document-*`, respect that explicit target and skip default bottom positioning.
+
+## Implementation Shape
+
+- Add a pure helper module for issue-detail scroll decisions so the follow rules are unit-testable.
+- Reuse the proven bottom-distance / growth-delta pattern already used in `AgentDetail`.
+- Keep the existing `ScrollToBottom` button as the explicit recovery action instead of introducing a second jump UI.
+
+## Testing
+
+- Unit-test the pure decision helpers for:
+  - initial auto-position enable/disable
+  - deep-link bypass
+  - bottom-tolerance detection
+  - follow release when the user moves away during content growth

--- a/docs/plans/2026-04-01-issue-detail-latest-progress.md
+++ b/docs/plans/2026-04-01-issue-detail-latest-progress.md
@@ -1,0 +1,73 @@
+# Issue Detail Latest Progress Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make issue detail open at the latest progress by default without stealing scroll back after the user leaves the bottom.
+
+**Architecture:** Keep scroll-follow state in `IssueDetail`, but move the actual follow/bypass decisions into a small pure helper module under `ui/src/lib`. Reuse the existing page scroller and current `ScrollToBottom` affordance instead of adding a second bottom-jump control.
+
+**Tech Stack:** React 19, Vite, Vitest, TypeScript
+
+---
+
+### Task 1: Add failing tests for scroll-follow decisions
+
+**Files:**
+- Create: `ui/src/lib/issue-detail-scroll.test.ts`
+
+**Step 1: Write the failing test**
+
+- Cover initial open auto-scroll, deep-link bypass, near-bottom detection, and follow release on growth.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test --run ui/src/lib/issue-detail-scroll.test.ts`
+
+Expected: FAIL because `ui/src/lib/issue-detail-scroll.ts` does not exist yet.
+
+### Task 2: Implement the pure scroll decision helpers
+
+**Files:**
+- Create: `ui/src/lib/issue-detail-scroll.ts`
+- Test: `ui/src/lib/issue-detail-scroll.test.ts`
+
+**Step 1: Write minimal implementation**
+
+- Add helpers for deep-link detection, initial auto-position eligibility, near-bottom detection, and growth-based follow release.
+
+**Step 2: Run test to verify it passes**
+
+Run: `pnpm test --run ui/src/lib/issue-detail-scroll.test.ts`
+
+Expected: PASS
+
+### Task 3: Wire follow state into issue detail
+
+**Files:**
+- Modify: `ui/src/pages/IssueDetail.tsx`
+
+**Step 1: Integrate helpers**
+
+- Track whether the page is currently following the bottom.
+- Auto-position once on initial open when allowed.
+- Stop auto-follow after the user scrolls away.
+- Preserve deep-link navigation targets.
+
+**Step 2: Run focused tests**
+
+Run: `pnpm test --run ui/src/lib/issue-detail-scroll.test.ts`
+
+Expected: PASS
+
+### Task 4: Verify broader UI safety
+
+**Files:**
+- Modify: `ui/src/pages/IssueDetail.tsx`
+
+**Step 1: Run targeted verification**
+
+Run:
+- `pnpm test --run ui/src/lib/issue-detail-scroll.test.ts`
+- `pnpm test --run ui/src/pages/Inbox.test.tsx`
+
+Expected: PASS

--- a/ui/src/components/CommentThread.test.tsx
+++ b/ui/src/components/CommentThread.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { IssueComment } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommentThread } from "./CommentThread";
+
+let mockHash = "";
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, className, ...props }: React.ComponentProps<"a">) => (
+    <a className={className} {...props}>{children}</a>
+  ),
+  useLocation: () => ({ hash: mockHash }),
+}));
+
+vi.mock("./MarkdownBody", () => ({
+  MarkdownBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("./MarkdownEditor", () => ({
+  MarkdownEditor: ({ value, onChange }: { value?: string; onChange?: (value: string) => void }) => (
+    <textarea value={value ?? ""} onChange={(event) => onChange?.(event.target.value)} />
+  ),
+}));
+
+vi.mock("./Identity", () => ({
+  Identity: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock("./InlineEntitySelector", () => ({
+  InlineEntitySelector: () => null,
+}));
+
+vi.mock("./StatusBadge", () => ({
+  StatusBadge: () => null,
+}));
+
+vi.mock("./AgentIconPicker", () => ({
+  AgentIcon: () => null,
+}));
+
+vi.mock("./button", () => ({}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/plugins/slots", () => ({
+  PluginSlotOutlet: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createComment(id: string, createdAt: string): IssueComment {
+  return {
+    id,
+    companyId: "company-1",
+    issueId: "issue-1",
+    authorAgentId: "agent-1",
+    authorUserId: null,
+    body: `comment ${id}`,
+    createdAt,
+    updatedAt: createdAt,
+    runId: null,
+    runAgentId: null,
+    interruptedRunId: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+  };
+}
+
+describe("CommentThread initial positioning", () => {
+  let container: HTMLDivElement;
+  let calledIds: string[];
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    calledIds = [];
+    mockHash = "";
+    HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+      calledIds.push(this.id);
+    };
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to the latest comment on first entry when there is no hash", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <CommentThread
+          comments={[
+            createComment("comment-1", "2026-03-31T00:00:00.000Z"),
+            createComment("comment-2", "2026-03-31T00:01:00.000Z"),
+          ]}
+          onAdd={async () => {}}
+        />,
+      );
+    });
+
+    expect(calledIds).toContain("comment-comment-2");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("respects a comment hash instead of overriding it with latest positioning", () => {
+    const root = createRoot(container);
+    mockHash = "#comment-comment-1";
+
+    act(() => {
+      root.render(
+        <CommentThread
+          comments={[
+            createComment("comment-1", "2026-03-31T00:00:00.000Z"),
+            createComment("comment-2", "2026-03-31T00:01:00.000Z"),
+          ]}
+          onAdd={async () => {}}
+        />,
+      );
+    });
+
+    expect(calledIds).toEqual(["comment-comment-1"]);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("does not force a comment scroll when a document hash is present", () => {
+    const root = createRoot(container);
+    mockHash = "#document-plan";
+
+    act(() => {
+      root.render(
+        <CommentThread
+          comments={[
+            createComment("comment-1", "2026-03-31T00:00:00.000Z"),
+            createComment("comment-2", "2026-03-31T00:01:00.000Z"),
+          ]}
+          onAdd={async () => {}}
+        />,
+      );
+    });
+
+    expect(calledIds).toEqual([]);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -35,6 +35,10 @@ interface CommentReassignment {
   assigneeUserId: string | null;
 }
 
+function timelineItemDomId(item: TimelineItem): string {
+  return item.kind === "comment" ? `comment-${item.comment.id}` : `run-${item.run.runId}`;
+}
+
 interface CommentThreadProps {
   comments: CommentWithRunMeta[];
   queuedComments?: CommentWithRunMeta[];
@@ -265,7 +269,11 @@ const TimelineList = memo(function TimelineList({
         if (item.kind === "run") {
           const run = item.run;
           return (
-            <div key={`run:${run.runId}`} className="border border-border bg-accent/20 p-3 overflow-hidden min-w-0 rounded-sm">
+            <div
+              key={`run:${run.runId}`}
+              id={`run-${run.runId}`}
+              className="border border-border bg-accent/20 p-3 overflow-hidden min-w-0 rounded-sm"
+            >
               <div className="flex items-center justify-between mb-2">
                 <Link to={`/agents/${run.agentId}`} className="hover:underline">
                   <Identity
@@ -339,6 +347,7 @@ export function CommentThread({
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const location = useLocation();
   const hasScrolledRef = useRef(false);
+  const hasAutoScrolledToLatestRef = useRef(false);
 
   const timeline = useMemo<TimelineItem[]>(() => {
     const commentItems: TimelineItem[] = comments.map((comment) => ({
@@ -415,6 +424,18 @@ export function CommentThread({
       return () => clearTimeout(timer);
     }
   }, [location.hash, comments, queuedComments]);
+
+  useEffect(() => {
+    if (hasAutoScrolledToLatestRef.current) return;
+    if (location.hash) return;
+    if (timeline.length === 0) return;
+
+    const latestElement = document.getElementById(timelineItemDomId(timeline[timeline.length - 1]!));
+    if (!latestElement) return;
+
+    hasAutoScrolledToLatestRef.current = true;
+    latestElement.scrollIntoView({ behavior: "auto", block: "end" });
+  }, [location.hash, timeline]);
 
   async function handleSubmit() {
     const trimmed = body.trim();

--- a/ui/src/components/IssueRow.test.tsx
+++ b/ui/src/components/IssueRow.test.tsx
@@ -113,4 +113,32 @@ describe("IssueRow", () => {
       root.unmount();
     });
   });
+
+  it("marks an unread issue as read when the row itself is opened", () => {
+    const root = createRoot(container);
+    const onMarkRead = vi.fn();
+
+    act(() => {
+      root.render(
+        <IssueRow
+          issue={createIssue({ isUnreadForMe: true })}
+          unreadState="visible"
+          onMarkRead={onMarkRead}
+        />,
+      );
+    });
+
+    const link = container.querySelector("[data-inbox-issue-link]") as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+
+    act(() => {
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(onMarkRead).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root.unmount();
+    });
+  });
 });

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -52,6 +52,11 @@ export function IssueRow({
       to={createIssueDetailPath(issuePathId, issueLinkState)}
       state={issueLinkState}
       data-inbox-issue-link
+      onClick={() => {
+        if (showUnreadDot) {
+          onMarkRead?.();
+        }
+      }}
       className={cn(
         "group flex items-start gap-2 border-b border-border py-2.5 pl-2 pr-3 text-sm no-underline text-inherit transition-colors last:border-b-0 sm:items-center sm:py-2 sm:pl-1",
         selected ? "hover:bg-transparent" : "hover:bg-accent/50",

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -247,6 +247,26 @@ describe("inbox helpers", () => {
     });
   });
 
+  it("counts only unread touched issues toward the inbox badge", () => {
+    const result = computeInboxBadgeData({
+      approvals: [],
+      joinRequests: [],
+      dashboard: undefined,
+      heartbeatRuns: [],
+      mineIssues: [makeIssue("1", true), makeIssue("2", false)],
+      dismissed: new Set<string>(),
+    });
+
+    expect(result).toEqual({
+      inbox: 1,
+      approvals: 0,
+      failedRuns: 0,
+      joinRequests: 0,
+      mineIssues: 1,
+      alerts: 0,
+    });
+  });
+
   it("keeps read issues in the touched list but excludes them from unread counts", () => {
     const issues = [makeIssue("1", true), makeIssue("2", false)];
 

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -291,7 +291,7 @@ export function computeInboxBadgeData({
   const visibleJoinRequests = joinRequests.filter(
     (jr) => !dismissed.has(`join:${jr.id}`),
   ).length;
-  const visibleMineIssues = mineIssues.length;
+  const visibleMineIssues = getUnreadTouchedIssues(mineIssues).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;

--- a/ui/src/lib/issue-detail-invalidation.test.ts
+++ b/ui/src/lib/issue-detail-invalidation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
+import { buildIssueDetailCompanyInvalidationKeys } from "./issue-detail-invalidation";
+
+describe("issue detail invalidation keys", () => {
+  it("uses the issue company id when the selected company is not ready", () => {
+    expect(
+      buildIssueDetailCompanyInvalidationKeys("company-from-issue", null),
+    ).toEqual([
+      queryKeys.issues.list("company-from-issue"),
+      queryKeys.issues.listMineByMe("company-from-issue"),
+      queryKeys.issues.listTouchedByMe("company-from-issue"),
+      queryKeys.issues.listUnreadTouchedByMe("company-from-issue"),
+      queryKeys.sidebarBadges("company-from-issue"),
+    ]);
+  });
+
+  it("falls back to the selected company id when the issue company is missing", () => {
+    expect(
+      buildIssueDetailCompanyInvalidationKeys(null, "company-selected"),
+    ).toEqual([
+      queryKeys.issues.list("company-selected"),
+      queryKeys.issues.listMineByMe("company-selected"),
+      queryKeys.issues.listTouchedByMe("company-selected"),
+      queryKeys.issues.listUnreadTouchedByMe("company-selected"),
+      queryKeys.sidebarBadges("company-selected"),
+    ]);
+  });
+
+  it("returns no invalidation keys when neither company id exists", () => {
+    expect(buildIssueDetailCompanyInvalidationKeys(null, null)).toEqual([]);
+  });
+});

--- a/ui/src/lib/issue-detail-invalidation.ts
+++ b/ui/src/lib/issue-detail-invalidation.ts
@@ -1,0 +1,17 @@
+import { queryKeys } from "./queryKeys";
+
+export function buildIssueDetailCompanyInvalidationKeys(
+  issueCompanyId: string | null | undefined,
+  selectedCompanyId: string | null | undefined,
+) {
+  const companyId = issueCompanyId ?? selectedCompanyId ?? null;
+  if (!companyId) return [];
+
+  return [
+    queryKeys.issues.list(companyId),
+    queryKeys.issues.listMineByMe(companyId),
+    queryKeys.issues.listTouchedByMe(companyId),
+    queryKeys.issues.listUnreadTouchedByMe(companyId),
+    queryKeys.sidebarBadges(companyId),
+  ] as const;
+}

--- a/ui/src/lib/issue-detail-scroll.test.ts
+++ b/ui/src/lib/issue-detail-scroll.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasIssueDetailDeepLink,
+  isIssueDetailNearBottom,
+  shouldAutoScrollIssueDetailOnOpen,
+  shouldContinueFollowingIssueDetail,
+} from "./issue-detail-scroll";
+
+describe("issue detail scroll follow helpers", () => {
+  it("auto-scrolls on first open when there is timeline activity and no deep link", () => {
+    expect(
+      shouldAutoScrollIssueDetailOnOpen({
+        hash: "",
+        activityCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips initial auto-scroll when opening a specific comment or document anchor", () => {
+    expect(
+      shouldAutoScrollIssueDetailOnOpen({
+        hash: "#comment-comment-1",
+        activityCount: 3,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldAutoScrollIssueDetailOnOpen({
+        hash: "#document-plan",
+        activityCount: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("detects deep links only for supported issue detail anchors", () => {
+    expect(hasIssueDetailDeepLink("#comment-123")).toBe(true);
+    expect(hasIssueDetailDeepLink("#document-plan")).toBe(true);
+    expect(hasIssueDetailDeepLink("#activity")).toBe(false);
+    expect(hasIssueDetailDeepLink("")).toBe(false);
+  });
+
+  it("treats short bottom distance as still following", () => {
+    expect(isIssueDetailNearBottom(12)).toBe(true);
+    expect(isIssueDetailNearBottom(48)).toBe(false);
+  });
+
+  it("keeps following when growth happens and the reader stays pinned to bottom", () => {
+    expect(
+      shouldContinueFollowingIssueDetail({
+        previousScrollHeight: 1000,
+        previousDistanceFromBottom: 0,
+        currentScrollHeight: 1200,
+        currentDistanceFromBottom: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("releases follow when the reader moves away from bottom during growth", () => {
+    expect(
+      shouldContinueFollowingIssueDetail({
+        previousScrollHeight: 1000,
+        previousDistanceFromBottom: 0,
+        currentScrollHeight: 1200,
+        currentDistanceFromBottom: 260,
+      }),
+    ).toBe(false);
+  });
+});

--- a/ui/src/lib/issue-detail-scroll.ts
+++ b/ui/src/lib/issue-detail-scroll.ts
@@ -1,0 +1,45 @@
+export const ISSUE_DETAIL_FOLLOW_TOLERANCE_PX = 32;
+
+const COMMENT_HASH_PREFIX = "#comment-";
+const DOCUMENT_HASH_PREFIX = "#document-";
+
+export function hasIssueDetailDeepLink(hash: string): boolean {
+  const normalized = hash.trim();
+  return normalized.startsWith(COMMENT_HASH_PREFIX) || normalized.startsWith(DOCUMENT_HASH_PREFIX);
+}
+
+export function shouldAutoScrollIssueDetailOnOpen({
+  hash,
+  activityCount,
+}: {
+  hash: string;
+  activityCount: number;
+}): boolean {
+  return activityCount > 0 && !hasIssueDetailDeepLink(hash);
+}
+
+export function isIssueDetailNearBottom(
+  distanceFromBottom: number,
+  tolerance = ISSUE_DETAIL_FOLLOW_TOLERANCE_PX,
+): boolean {
+  return distanceFromBottom <= tolerance;
+}
+
+export function shouldContinueFollowingIssueDetail({
+  previousScrollHeight,
+  previousDistanceFromBottom,
+  currentScrollHeight,
+  currentDistanceFromBottom,
+  tolerance = ISSUE_DETAIL_FOLLOW_TOLERANCE_PX,
+}: {
+  previousScrollHeight: number;
+  previousDistanceFromBottom: number;
+  currentScrollHeight: number;
+  currentDistanceFromBottom: number;
+  tolerance?: number;
+}): boolean {
+  const growth = Math.max(0, currentScrollHeight - previousScrollHeight);
+  const expectedDistance = previousDistanceFromBottom + growth;
+  const movedAwayBy = currentDistanceFromBottom - expectedDistance;
+  return movedAwayBy <= tolerance;
+}

--- a/ui/src/lib/issue-read-marker.test.ts
+++ b/ui/src/lib/issue-read-marker.test.ts
@@ -1,0 +1,100 @@
+import type { Issue } from "@paperclipai/shared";
+import { describe, expect, it } from "vitest";
+import { buildIssueReadMarker, shouldMarkIssueRead } from "./issue-read-marker";
+
+function createIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    identifier: "PAP-22",
+    companyId: "company-1",
+    projectId: null,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    title: "Issue",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: 22,
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    labels: [],
+    labelIds: [],
+    myLastTouchAt: null,
+    lastExternalCommentAt: null,
+    isUnreadForMe: false,
+    ...overrides,
+  };
+}
+
+describe("issue read marker", () => {
+  it("does not request mark-read for already-read issues", () => {
+    const issue = createIssue({ isUnreadForMe: false });
+
+    expect(buildIssueReadMarker(issue)).toBeNull();
+    expect(shouldMarkIssueRead(issue, null)).toBe(false);
+  });
+
+  it("marks an unread issue the first time it is opened", () => {
+    const issue = createIssue({
+      isUnreadForMe: true,
+      lastExternalCommentAt: new Date("2026-04-01T01:00:00.000Z"),
+    });
+
+    expect(shouldMarkIssueRead(issue, null)).toBe(true);
+  });
+
+  it("does not mark read again for the same unread marker", () => {
+    const issue = createIssue({
+      isUnreadForMe: true,
+      lastExternalCommentAt: new Date("2026-04-01T01:00:00.000Z"),
+    });
+
+    const marker = buildIssueReadMarker(issue);
+    expect(marker).not.toBeNull();
+    expect(shouldMarkIssueRead(issue, marker)).toBe(false);
+  });
+
+  it("marks read again when the same issue gets a newer external comment", () => {
+    const original = createIssue({
+      isUnreadForMe: true,
+      lastExternalCommentAt: new Date("2026-04-01T01:00:00.000Z"),
+    });
+    const next = createIssue({
+      isUnreadForMe: true,
+      lastExternalCommentAt: new Date("2026-04-01T02:00:00.000Z"),
+    });
+
+    const marker = buildIssueReadMarker(original);
+    expect(marker).not.toBeNull();
+    expect(shouldMarkIssueRead(next, marker)).toBe(true);
+  });
+
+  it("falls back to updatedAt when there is no external comment timestamp yet", () => {
+    const issue = createIssue({
+      isUnreadForMe: true,
+      lastExternalCommentAt: null,
+      updatedAt: new Date("2026-04-01T03:00:00.000Z"),
+    });
+
+    expect(buildIssueReadMarker(issue)).toContain("2026-04-01T03:00:00.000Z");
+  });
+});

--- a/ui/src/lib/issue-read-marker.ts
+++ b/ui/src/lib/issue-read-marker.ts
@@ -1,0 +1,18 @@
+import type { Issue } from "@paperclipai/shared";
+
+type IssueReadMarkerSource = Pick<Issue, "id" | "isUnreadForMe" | "lastExternalCommentAt" | "updatedAt">;
+
+function toMarkerTimestamp(value: Date | null | undefined): string | null {
+  return value instanceof Date ? value.toISOString() : null;
+}
+
+export function buildIssueReadMarker(issue: IssueReadMarkerSource): string | null {
+  if (!issue.isUnreadForMe) return null;
+  const timestamp = toMarkerTimestamp(issue.lastExternalCommentAt) ?? toMarkerTimestamp(issue.updatedAt);
+  return timestamp ? `${issue.id}:${timestamp}` : issue.id;
+}
+
+export function shouldMarkIssueRead(issue: IssueReadMarkerSource, lastReadMarker: string | null): boolean {
+  const marker = buildIssueReadMarker(issue);
+  return marker !== null && marker !== lastReadMarker;
+}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -25,6 +25,14 @@ import {
   type OptimisticIssueComment,
 } from "../lib/optimistic-issue-comments";
 import { useProjectOrder } from "../hooks/useProjectOrder";
+import {
+  hasIssueDetailDeepLink,
+  isIssueDetailNearBottom,
+  shouldAutoScrollIssueDetailOnOpen,
+  shouldContinueFollowingIssueDetail,
+} from "../lib/issue-detail-scroll";
+import { buildIssueDetailCompanyInvalidationKeys } from "../lib/issue-detail-invalidation";
+import { buildIssueReadMarker, shouldMarkIssueRead } from "../lib/issue-read-marker";
 import { relativeTime, cn, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { InlineEditor } from "../components/InlineEditor";
 import { CommentThread } from "../components/CommentThread";
@@ -73,6 +81,12 @@ type IssueDetailComment = (IssueComment | OptimisticIssueComment) & {
   interruptedRunId?: string | null;
   queueState?: "queued";
   queueTargetRunId?: string | null;
+};
+
+type IssueDetailScrollContainer = Window | HTMLElement;
+type IssueDetailScrollSnapshot = {
+  scrollHeight: number;
+  distanceFromBottom: number;
 };
 
 const ACTION_LABELS: Record<string, string> = {
@@ -208,6 +222,63 @@ function ActorIdentity({ evt, agentMap }: { evt: ActivityEvent; agentMap: Map<st
   return <Identity name={id || "Unknown"} size="sm" />;
 }
 
+function resolveIssueDetailScrollContainer(): IssueDetailScrollContainer {
+  const mainContent = document.getElementById("main-content");
+
+  if (mainContent instanceof HTMLElement) {
+    const overflowY = window.getComputedStyle(mainContent).overflowY;
+    const usesOwnScroll =
+      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay")
+      && mainContent.scrollHeight > mainContent.clientHeight + 1;
+
+    if (usesOwnScroll) {
+      return mainContent;
+    }
+  }
+
+  return window;
+}
+
+function isIssueDetailWindowContainer(container: IssueDetailScrollContainer): container is Window {
+  return container === window;
+}
+
+function readIssueDetailScrollSnapshot(container: IssueDetailScrollContainer): IssueDetailScrollSnapshot {
+  if (isIssueDetailWindowContainer(container)) {
+    const pageHeight = Math.max(
+      document.documentElement.scrollHeight,
+      document.body.scrollHeight,
+    );
+    const viewportBottom = window.scrollY + window.innerHeight;
+    return {
+      scrollHeight: pageHeight,
+      distanceFromBottom: Math.max(0, pageHeight - viewportBottom),
+    };
+  }
+
+  const viewportBottom = container.scrollTop + container.clientHeight;
+  return {
+    scrollHeight: container.scrollHeight,
+    distanceFromBottom: Math.max(0, container.scrollHeight - viewportBottom),
+  };
+}
+
+function scrollIssueDetailToBottom(
+  container: IssueDetailScrollContainer,
+  behavior: ScrollBehavior = "auto",
+) {
+  if (isIssueDetailWindowContainer(container)) {
+    const pageHeight = Math.max(
+      document.documentElement.scrollHeight,
+      document.body.scrollHeight,
+    );
+    window.scrollTo({ top: pageHeight, behavior });
+    return;
+  }
+
+  container.scrollTo({ top: container.scrollHeight, behavior });
+}
+
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
   const { selectedCompanyId } = useCompany();
@@ -228,7 +299,13 @@ export function IssueDetail() {
   const [attachmentDragActive, setAttachmentDragActive] = useState(false);
   const [optimisticComments, setOptimisticComments] = useState<OptimisticIssueComment[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const lastMarkedReadIssueIdRef = useRef<string | null>(null);
+  const lastMarkedReadMarkerRef = useRef<string | null>(null);
+  const hasAutoPositionedRef = useRef(false);
+  const isFollowingLatestRef = useRef(false);
+  const lastScrollSnapshotRef = useRef<IssueDetailScrollSnapshot>({
+    scrollHeight: 0,
+    distanceFromBottom: Number.POSITIVE_INFINITY,
+  });
 
   const { data: issue, isLoading, error } = useQuery({
     queryKey: queryKeys.issues.detail(issueId!),
@@ -473,6 +550,12 @@ export function IssueDetail() {
     [commentsWithRunMeta],
   );
 
+  const latestActivityCount = timelineComments.length + queuedComments.length + timelineRuns.length + (hasLiveRuns ? 1 : 0);
+  const companyInvalidationKeys = useMemo(
+    () => buildIssueDetailCompanyInvalidationKeys(issue?.companyId ?? null, selectedCompanyId),
+    [issue?.companyId, selectedCompanyId],
+  );
+
   const issueCostSummary = useMemo(() => {
     let input = 0;
     let output = 0;
@@ -521,23 +604,16 @@ export function IssueDetail() {
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.documents(issueId!) });
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.liveRuns(issueId!) });
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.activeRun(issueId!) });
-    if (selectedCompanyId) {
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(selectedCompanyId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listMineByMe(selectedCompanyId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(selectedCompanyId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.issues.listUnreadTouchedByMe(selectedCompanyId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(selectedCompanyId) });
+    for (const queryKey of companyInvalidationKeys) {
+      queryClient.invalidateQueries({ queryKey });
     }
   };
 
   const markIssueRead = useMutation({
     mutationFn: (id: string) => issuesApi.markRead(id),
     onSuccess: () => {
-      if (selectedCompanyId) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.issues.listMineByMe(selectedCompanyId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(selectedCompanyId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.issues.listUnreadTouchedByMe(selectedCompanyId) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.sidebarBadges(selectedCompanyId) });
+      for (const queryKey of companyInvalidationKeys) {
+        queryClient.invalidateQueries({ queryKey });
       }
     },
   });
@@ -794,10 +870,99 @@ export function IssueDetail() {
 
   useEffect(() => {
     if (!issue?.id) return;
-    if (lastMarkedReadIssueIdRef.current === issue.id) return;
-    lastMarkedReadIssueIdRef.current = issue.id;
+    if (!shouldMarkIssueRead(issue, lastMarkedReadMarkerRef.current)) return;
+    lastMarkedReadMarkerRef.current = buildIssueReadMarker(issue);
     markIssueRead.mutate(issue.id);
-  }, [issue?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [issue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    hasAutoPositionedRef.current = false;
+    isFollowingLatestRef.current = false;
+    lastScrollSnapshotRef.current = {
+      scrollHeight: 0,
+      distanceFromBottom: Number.POSITIVE_INFINITY,
+    };
+  }, [issueId]);
+
+  useEffect(() => {
+    if (detailTab !== "comments") return;
+
+    const updateFollowingState = () => {
+      const container = resolveIssueDetailScrollContainer();
+      const snapshot = readIssueDetailScrollSnapshot(container);
+      lastScrollSnapshotRef.current = snapshot;
+      isFollowingLatestRef.current = isIssueDetailNearBottom(snapshot.distanceFromBottom);
+    };
+
+    const container = resolveIssueDetailScrollContainer();
+    updateFollowingState();
+
+    if (isIssueDetailWindowContainer(container)) {
+      window.addEventListener("scroll", updateFollowingState, { passive: true });
+    } else {
+      container.addEventListener("scroll", updateFollowingState, { passive: true });
+    }
+    window.addEventListener("resize", updateFollowingState);
+
+    return () => {
+      if (isIssueDetailWindowContainer(container)) {
+        window.removeEventListener("scroll", updateFollowingState);
+      } else {
+        container.removeEventListener("scroll", updateFollowingState);
+      }
+      window.removeEventListener("resize", updateFollowingState);
+    };
+  }, [detailTab, issueId]);
+
+  useEffect(() => {
+    if (detailTab !== "comments") return;
+
+    const frame = window.requestAnimationFrame(() => {
+      if (!hasAutoPositionedRef.current) {
+        if (hasIssueDetailDeepLink(location.hash)) {
+          hasAutoPositionedRef.current = true;
+          const container = resolveIssueDetailScrollContainer();
+          lastScrollSnapshotRef.current = readIssueDetailScrollSnapshot(container);
+          isFollowingLatestRef.current = false;
+          return;
+        }
+
+        if (!shouldAutoScrollIssueDetailOnOpen({ hash: location.hash, activityCount: latestActivityCount })) {
+          return;
+        }
+
+        const container = resolveIssueDetailScrollContainer();
+        scrollIssueDetailToBottom(container, "auto");
+        lastScrollSnapshotRef.current = readIssueDetailScrollSnapshot(container);
+        hasAutoPositionedRef.current = true;
+        isFollowingLatestRef.current = true;
+        return;
+      }
+
+      if (!isFollowingLatestRef.current) return;
+
+      const container = resolveIssueDetailScrollContainer();
+      const current = readIssueDetailScrollSnapshot(container);
+      const previous = lastScrollSnapshotRef.current;
+
+      if (!shouldContinueFollowingIssueDetail({
+        previousScrollHeight: previous.scrollHeight,
+        previousDistanceFromBottom: previous.distanceFromBottom,
+        currentScrollHeight: current.scrollHeight,
+        currentDistanceFromBottom: current.distanceFromBottom,
+      })) {
+        lastScrollSnapshotRef.current = current;
+        isFollowingLatestRef.current = false;
+        return;
+      }
+
+      scrollIssueDetailToBottom(container, "auto");
+      lastScrollSnapshotRef.current = readIssueDetailScrollSnapshot(container);
+      isFollowingLatestRef.current = true;
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [detailTab, latestActivityCount, location.hash]);
 
   useEffect(() => {
     if (issue) {


### PR DESCRIPTION
## What changed

This PR tightens the unread/read experience around issue detail and inbox flows.

- default issue detail open now lands on the latest activity unless a `#comment-*` or `#document-*` deep link is present
- issue detail follow behavior no longer steals scroll back once the reader leaves the bottom
- repeated unread transitions on the same issue now re-trigger `markRead`
- issue detail cache invalidation now uses the issue company id when company selection state is not ready
- inbox badge now counts unread touched issues instead of all touched mine issues
- clicking an unread issue row from Inbox immediately marks it as read while still navigating into detail

## Why

The original user report started as a "open issue detail at the latest progress" request, but the work exposed a cluster of unread-state regressions around the same flow:

- issue detail only marked an issue as read once per issue id
- cache invalidation could miss when opening an issue directly before company selection resolved
- the sidebar Inbox badge was not aligned with unread semantics
- opening an unread row from Inbox did not mark it as read unless the explicit dot action was used

This PR fixes that full chain so the UI behavior matches user expectation end-to-end.

## User impact

- opening an unread issue is more predictable
- unread counts and row state align better with the actual interaction flow
- deep-link navigation remains respected
- first-open issue detail experience is improved without forcing scroll while reading history

## Validation

- `pnpm exec vitest run ui/src/components/IssueRow.test.tsx ui/src/lib/inbox.test.ts ui/src/pages/Inbox.test.tsx ui/src/lib/issue-detail-scroll.test.ts ui/src/lib/issue-read-marker.test.ts ui/src/lib/issue-detail-invalidation.test.ts`

