### PR TITLE
[codex] self-heal stale heartbeat runs

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -20,7 +20,11 @@ import {
   joinPromptSections,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
-import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
+import {
+  parseCodexJsonl,
+  isCodexContextWindowExceededError,
+  isCodexUnknownSessionError,
+} from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir } from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 
@@ -137,6 +141,25 @@ async function pruneBrokenUnavailablePaperclipSkillSymlinks(
 
 function resolveCodexWorkspaceSkillsDir(cwd: string): string {
   return path.join(cwd, ".agents", "skills");
+}
+
+function buildFreshSessionHandoffNote(input: {
+  previousSessionId: string;
+  taskId: string | null;
+  reason: string;
+  lastErrorMessage: string | null;
+}) {
+  const { previousSessionId, taskId, reason, lastErrorMessage } = input;
+  return [
+    "Paperclip session handoff:",
+    `- Previous session: ${previousSessionId}`,
+    taskId ? `- Task: ${taskId}` : "",
+    `- Rotation reason: ${reason}`,
+    lastErrorMessage ? `- Last run summary: ${lastErrorMessage}` : "",
+    "Continue from the current task state. Rebuild only the minimum context you need.",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 type EnsureCodexSkillsInjectedOptions = {
@@ -452,24 +475,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     context,
   };
   const renderedPrompt = renderTemplate(promptTemplate, templateData);
-  const renderedBootstrapPrompt =
-    !sessionId && bootstrapPromptTemplate.trim().length > 0
-      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
-      : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
-  const prompt = joinPromptSections([
-    instructionsPrefix,
-    renderedBootstrapPrompt,
-    sessionHandoffNote,
-    renderedPrompt,
-  ]);
-  const promptMetrics = {
-    promptChars: prompt.length,
-    instructionsChars,
-    bootstrapPromptChars: renderedBootstrapPrompt.length,
-    sessionHandoffChars: sessionHandoffNote.length,
-    heartbeatPromptChars: renderedPrompt.length,
-  };
 
   const buildArgs = (resumeSessionId: string | null) => {
     const args = ["exec", "--json"];
@@ -483,8 +489,43 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     return args;
   };
 
-  const runAttempt = async (resumeSessionId: string | null) => {
+  const buildPromptForAttempt = (
+    resumeSessionId: string | null,
+    extraHandoffNote: string | null = null,
+  ) => {
+    const renderedBootstrapPrompt =
+      !resumeSessionId && bootstrapPromptTemplate.trim().length > 0
+        ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+        : "";
+    const mergedHandoffNote = joinPromptSections([
+      sessionHandoffNote,
+      extraHandoffNote?.trim() ?? "",
+    ]);
+    const prompt = joinPromptSections([
+      instructionsPrefix,
+      renderedBootstrapPrompt,
+      mergedHandoffNote,
+      renderedPrompt,
+    ]);
+
+    return {
+      prompt,
+      promptMetrics: {
+        promptChars: prompt.length,
+        instructionsChars,
+        bootstrapPromptChars: renderedBootstrapPrompt.length,
+        sessionHandoffChars: mergedHandoffNote.length,
+        heartbeatPromptChars: renderedPrompt.length,
+      },
+    };
+  };
+
+  const runAttempt = async (
+    resumeSessionId: string | null,
+    extraHandoffNote: string | null = null,
+  ) => {
     const args = buildArgs(resumeSessionId);
+    const { prompt, promptMetrics } = buildPromptForAttempt(resumeSessionId, extraHandoffNote);
     if (onMeta) {
       await onMeta({
         adapterType: "codex_local",
@@ -599,6 +640,26 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
     );
     const retry = await runAttempt(null);
+    return toResult(retry, true);
+  }
+
+  if (
+    sessionId &&
+    !initial.proc.timedOut &&
+    (initial.proc.exitCode ?? 0) !== 0 &&
+    isCodexContextWindowExceededError(initial.proc.stdout, initial.rawStderr)
+  ) {
+    const retryHandoffNote = buildFreshSessionHandoffNote({
+      previousSessionId: sessionId,
+      taskId: wakeTaskId,
+      reason: "Codex reported that the previous thread ran out of room in the model's context window",
+      lastErrorMessage: initial.parsed.errorMessage,
+    });
+    await onLog(
+      "stdout",
+      `[paperclip] Codex session "${sessionId}" exceeded the context window; retrying with a fresh session.\n`,
+    );
+    const retry = await runAttempt(null, retryHandoffNote);
     return toResult(retry, true);
   }
 

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -71,3 +71,14 @@ export function isCodexUnknownSessionError(stdout: string, stderr: string): bool
     haystack,
   );
 }
+
+export function isCodexContextWindowExceededError(stdout: string, stderr: string): boolean {
+  const haystack = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  return /ran out of room in the model's context window|context window.*(?:start a new thread|clear earlier history)/i.test(
+    haystack,
+  );
+}

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -28,6 +28,35 @@ console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, c
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeContextWindowRetryCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const argv = process.argv.slice(2);
+const payload = {
+  argv,
+  prompt: fs.readFileSync(0, "utf8"),
+};
+if (capturePath) {
+  fs.appendFileSync(capturePath, JSON.stringify(payload) + "\\n", "utf8");
+}
+
+const errorMessage = "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.";
+if (argv.includes("resume")) {
+  console.log(JSON.stringify({ type: "error", message: errorMessage }));
+  console.log(JSON.stringify({ type: "turn.failed", error: { message: errorMessage } }));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-fresh" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "recovered" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 2, cached_input_tokens: 0, output_tokens: 3 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 type CapturePayload = {
   argv: string[];
   prompt: string;
@@ -384,6 +413,91 @@ describe("codex execute", () => {
       else process.env.PAPERCLIP_IN_WORKTREE = previousPaperclipInWorktree;
       if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
       else process.env.CODEX_HOME = previousCodexHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries with a fresh session when Codex reports the resumed thread exceeded the context window", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-context-window-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeContextWindowRetryCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const logs: LogEntry[] = [];
+      const result = await execute({
+        runId: "run-context-window",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "codex-session-old",
+          sessionParams: { sessionId: "codex-session-old", cwd: workspace },
+          sessionDisplayId: "codex-session-old",
+          taskKey: "issue-123",
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Continue handling the assigned task.",
+          bootstrapPromptTemplate: "Bootstrap the fresh Codex session for {{agent.name}}.",
+        },
+        context: {
+          issueId: "issue-123",
+        },
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => {
+          logs.push({ stream, chunk });
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(result.sessionId).toBe("codex-session-fresh");
+
+      const captures = (await fs.readFile(capturePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Pick<CapturePayload, "argv" | "prompt">);
+      expect(captures).toHaveLength(2);
+      expect(captures[0]?.argv).toEqual([
+        "exec",
+        "--json",
+        "resume",
+        "codex-session-old",
+        "-",
+      ]);
+      expect(captures[1]?.argv).toEqual([
+        "exec",
+        "--json",
+        "-",
+      ]);
+      expect(captures[0]?.prompt).toContain("Continue handling the assigned task.");
+      expect(captures[0]?.prompt).not.toContain("Bootstrap the fresh Codex session");
+      expect(captures[1]?.prompt).toContain("Bootstrap the fresh Codex session for Codex Coder.");
+      expect(captures[1]?.prompt).toContain("Previous session: codex-session-old");
+      expect(captures[1]?.prompt).toContain("context window");
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("exceeded the context window; retrying with a fresh session"),
+        }),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -133,19 +133,26 @@ describe("heartbeat orphaned process recovery", () => {
 
   async function seedRunFixture(input?: {
     adapterType?: string;
+    agentStatus?: "idle" | "running" | "paused" | "error" | "terminated" | "pending_approval";
     runStatus?: "running" | "queued" | "failed";
     processPid?: number | null;
     processLossRetryCount?: number;
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    createdAt?: Date;
+    startedAt?: Date;
+    updatedAt?: Date;
+    processStartedAt?: Date | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const runId = randomUUID();
     const wakeupRequestId = randomUUID();
     const issueId = randomUUID();
-    const now = new Date("2026-03-19T00:00:00.000Z");
+    const now = input?.startedAt ?? new Date("2026-03-19T00:00:00.000Z");
+    const createdAt = input?.createdAt ?? now;
+    const updatedAt = input?.updatedAt ?? now;
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
 
     await db.insert(companies).values({
@@ -160,7 +167,7 @@ describe("heartbeat orphaned process recovery", () => {
       companyId,
       name: "CodexCoder",
       role: "engineer",
-      status: "paused",
+      status: input?.agentStatus ?? "paused",
       adapterType: input?.adapterType ?? "codex_local",
       adapterConfig: {},
       runtimeConfig: {},
@@ -190,11 +197,13 @@ describe("heartbeat orphaned process recovery", () => {
       wakeupRequestId,
       contextSnapshot: input?.includeIssue === false ? {} : { issueId },
       processPid: input?.processPid ?? null,
+      processStartedAt: input?.processStartedAt ?? null,
       processLossRetryCount: input?.processLossRetryCount ?? 0,
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
+      createdAt,
       startedAt: now,
-      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      updatedAt,
     });
 
     if (input?.includeIssue !== false) {
@@ -219,10 +228,14 @@ describe("heartbeat orphaned process recovery", () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);
     expect(child.pid).toBeTypeOf("number");
+    const activeAt = new Date();
 
     const { runId, wakeupRequestId } = await seedRunFixture({
       processPid: child.pid ?? null,
       includeIssue: false,
+      startedAt: activeAt,
+      updatedAt: activeAt,
+      processStartedAt: activeAt,
     });
     const heartbeat = heartbeatService(db);
 
@@ -240,6 +253,35 @@ describe("heartbeat orphaned process recovery", () => {
       .where(eq(agentWakeupRequests.id, wakeupRequestId))
       .then((rows) => rows[0] ?? null);
     expect(wakeup?.status).toBe("claimed");
+  });
+
+  it("cancels a stale local run even if the child process is still being tracked", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      includeIssue: false,
+    });
+    runningProcesses.set(runId, { child, graceSec: 1 });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("cancelled");
+    expect(run?.error).toContain("Cancelled stale run after 30 minutes without reported activity");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
   });
 
   it("queues exactly one retry when the recorded local pid is dead", async () => {
@@ -317,5 +359,190 @@ describe("heartbeat orphaned process recovery", () => {
     const run = await heartbeat.getRun(runId);
     expect(run?.errorCode).toBeNull();
     expect(run?.error).toBeNull();
+  });
+
+  it("promotes deferred issue execution for the current assignee before older deferred wakes", async () => {
+    const companyId = randomUUID();
+    const currentAgentId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const issueId = randomUUID();
+    const currentRunId = randomUUID();
+    const currentWakeupId = randomUUID();
+    const assigneeBlockingRunId = randomUUID();
+    const assigneeBlockingWakeupId = randomUUID();
+    const olderDeferredWakeupId = randomUUID();
+    const assigneeDeferredWakeupId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: currentAgentId,
+        companyId,
+        name: "CurrentAgent",
+        role: "engineer",
+        status: "paused",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "AssigneeAgent",
+        role: "engineer",
+        status: "running",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            maxConcurrentRuns: 1,
+          },
+        },
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "OtherAgent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(agentWakeupRequests).values([
+      {
+        id: currentWakeupId,
+        companyId,
+        agentId: currentAgentId,
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        status: "claimed",
+        runId: currentRunId,
+        claimedAt: now,
+      },
+      {
+        id: assigneeBlockingWakeupId,
+        companyId,
+        agentId: assigneeAgentId,
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "other_issue",
+        payload: { issueId: randomUUID() },
+        status: "claimed",
+        runId: assigneeBlockingRunId,
+        claimedAt: now,
+      },
+      {
+        id: olderDeferredWakeupId,
+        companyId,
+        agentId: otherAgentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_waiting",
+        payload: { issueId },
+        status: "deferred_issue_execution",
+        requestedAt: new Date("2026-03-19T00:01:00.000Z"),
+      },
+      {
+        id: assigneeDeferredWakeupId,
+        companyId,
+        agentId: assigneeAgentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_waiting",
+        payload: { issueId },
+        status: "deferred_issue_execution",
+        requestedAt: new Date("2026-03-19T00:02:00.000Z"),
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: currentRunId,
+        companyId,
+        agentId: currentAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: currentWakeupId,
+        contextSnapshot: { issueId },
+        startedAt: now,
+        updatedAt: now,
+      },
+      {
+        id: assigneeBlockingRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: assigneeBlockingWakeupId,
+        contextSnapshot: { issueId: randomUUID() },
+        startedAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Prefer assignee for deferred promotion",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.cancelRun(currentRunId);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).not.toBeNull();
+    expect(issue?.executionRunId).not.toBe(currentRunId);
+
+    const promotedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, issue?.executionRunId ?? ""))
+      .then((rows) => rows[0] ?? null);
+    expect(promotedRun?.agentId).toBe(assigneeAgentId);
+    expect(promotedRun?.wakeupRequestId).toBe(assigneeDeferredWakeupId);
+    expect(promotedRun?.status).toBe("queued");
+
+    const deferredWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    const olderDeferred = deferredWakeups.find((row) => row.id === olderDeferredWakeupId);
+    const assigneeDeferred = deferredWakeups.find((row) => row.id === assigneeDeferredWakeupId);
+
+    expect(olderDeferred?.status).toBe("failed");
+    expect(olderDeferred?.error).toBe("Deferred wake superseded by current issue assignee");
+    expect(assigneeDeferred?.status).toBe("queued");
+    expect(assigneeDeferred?.runId).toBe(promotedRun?.id ?? null);
+    expect(assigneeDeferred?.reason).toBe("issue_execution_promoted");
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -63,7 +63,10 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const RUN_ACTIVITY_PERSIST_INTERVAL_MS = 30 * 1000;
+const STALE_LOCAL_RUN_ACTIVITY_THRESHOLD_MS = 30 * 60 * 1000;
 const startLocksByAgent = new Map<string, Promise<void>>();
+const runActivityTimestamps = new Map<string, { lastObservedAt: number; lastPersistedAt: number }>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const execFile = promisify(execFileCallback);
@@ -75,6 +78,13 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+
+function readTimeMs(value: unknown) {
+  if (!value) return 0;
+  const date = value instanceof Date ? value : new Date(value as string | number);
+  const time = date.getTime();
+  return Number.isFinite(time) ? time : 0;
+}
 
 function deriveRepoNameFromRepoUrl(repoUrl: string | null): string | null {
   const trimmed = repoUrl?.trim() ?? "";
@@ -799,6 +809,62 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
   }
 
+  function recordRunActivity(runId: string, at = new Date()) {
+    const activityMs = readTimeMs(at);
+    if (activityMs <= 0) return;
+    const existing = runActivityTimestamps.get(runId);
+    runActivityTimestamps.set(runId, {
+      lastObservedAt: Math.max(activityMs, existing?.lastObservedAt ?? 0),
+      lastPersistedAt: existing?.lastPersistedAt ?? 0,
+    });
+  }
+
+  async function touchRunActivity(
+    runId: string,
+    opts?: { at?: Date; forcePersist?: boolean },
+  ) {
+    const activityAt = opts?.at instanceof Date ? opts.at : new Date();
+    const activityMs = readTimeMs(activityAt);
+    if (activityMs <= 0) return;
+
+    const existing = runActivityTimestamps.get(runId);
+    const next = {
+      lastObservedAt: Math.max(activityMs, existing?.lastObservedAt ?? 0),
+      lastPersistedAt: existing?.lastPersistedAt ?? 0,
+    };
+    const shouldPersist =
+      opts?.forcePersist === true ||
+      next.lastPersistedAt <= 0 ||
+      activityMs - next.lastPersistedAt >= RUN_ACTIVITY_PERSIST_INTERVAL_MS;
+
+    if (shouldPersist) {
+      await db
+        .update(heartbeatRuns)
+        .set({ updatedAt: activityAt })
+        .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "running")));
+      next.lastPersistedAt = activityMs;
+    }
+
+    runActivityTimestamps.set(runId, next);
+  }
+
+  function clearRunActivity(runId: string) {
+    runActivityTimestamps.delete(runId);
+  }
+
+  function getLastObservedRunActivity(run: typeof heartbeatRuns.$inferSelect) {
+    const trackedLastObservedAt = runActivityTimestamps.get(run.id)?.lastObservedAt ?? 0;
+    if (trackedLastObservedAt > 0) {
+      return trackedLastObservedAt;
+    }
+    return Math.max(
+      readTimeMs(run.updatedAt),
+      readTimeMs(run.processStartedAt),
+      readTimeMs(run.startedAt),
+      readTimeMs(run.createdAt),
+    );
+  }
+
   async function getRuntimeState(agentId: string) {
     return db
       .select()
@@ -1376,6 +1442,11 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
 
     if (updated) {
+      if (updated.status === "running") {
+        recordRunActivity(updated.id);
+      } else if (updated.status !== "queued") {
+        clearRunActivity(updated.id);
+      }
       publishLiveEvent({
         companyId: updated.companyId,
         type: "heartbeat.run.status",
@@ -1456,6 +1527,12 @@ export function heartbeatService(db: Db) {
         payload: sanitizedPayload ?? null,
       },
     });
+
+    if (run.status === "queued" || run.status === "running") {
+      recordRunActivity(run.id);
+    } else {
+      clearRunActivity(run.id);
+    }
   }
 
   async function nextRunEventSeq(runId: string) {
@@ -1471,7 +1548,7 @@ export function heartbeatService(db: Db) {
     meta: { pid: number; startedAt: string },
   ) {
     const startedAt = new Date(meta.startedAt);
-    return db
+    const persisted = await db
       .update(heartbeatRuns)
       .set({
         processPid: meta.pid,
@@ -1481,6 +1558,8 @@ export function heartbeatService(db: Db) {
       .where(eq(heartbeatRuns.id, runId))
       .returning()
       .then((rows) => rows[0] ?? null);
+    recordRunActivity(runId, Number.isNaN(startedAt.getTime()) ? new Date() : startedAt);
+    return persisted;
   }
 
   async function clearDetachedRunWarning(runId: string) {
@@ -1495,6 +1574,7 @@ export function heartbeatService(db: Db) {
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!updated) return null;
+    recordRunActivity(runId);
 
     await appendRunEvent(updated, await nextRunEventSeq(updated.id), {
       eventType: "lifecycle",
@@ -1662,6 +1742,7 @@ export function heartbeatService(db: Db) {
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!claimed) return null;
+    recordRunActivity(claimed.id, claimedAt);
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -1731,6 +1812,10 @@ export function heartbeatService(db: Db) {
 
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const localActivityStaleThresholdMs = Math.max(
+      staleThresholdMs > 0 ? staleThresholdMs * 6 : 0,
+      STALE_LOCAL_RUN_ACTIVITY_THRESHOLD_MS,
+    );
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -1746,7 +1831,34 @@ export function heartbeatService(db: Db) {
     const reaped: string[] = [];
 
     for (const { run, adapterType } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+      const hasTrackedExecution = runningProcesses.has(run.id) || activeRunExecutions.has(run.id);
+      const hasLiveDetachedPid = !!run.processPid && isProcessAlive(run.processPid);
+      const lastObservedActivityAt = getLastObservedRunActivity(run);
+      const isLocalRunActivityStale =
+        tracksLocalChild &&
+        localActivityStaleThresholdMs > 0 &&
+        lastObservedActivityAt > 0 &&
+        now.getTime() - lastObservedActivityAt >= localActivityStaleThresholdMs;
+      if (isLocalRunActivityStale && (hasTrackedExecution || hasLiveDetachedPid)) {
+        if (!hasTrackedExecution && hasLiveDetachedPid && run.processPid) {
+          try {
+            process.kill(run.processPid, "SIGTERM");
+          } catch {
+            // Best-effort kill for detached local children before marking the run stale.
+          }
+        }
+        const cancelled = await cancelRunInternal(
+          run.id,
+          `Cancelled stale run after ${Math.max(1, Math.round(localActivityStaleThresholdMs / 60000))} minutes without reported activity`,
+        );
+        if (cancelled) {
+          reaped.push(run.id);
+          continue;
+        }
+      }
+
+      if (hasTrackedExecution) continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
@@ -1754,7 +1866,6 @@ export function heartbeatService(db: Db) {
         if (now.getTime() - refTime < staleThresholdMs) continue;
       }
 
-      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       if (tracksLocalChild && run.processPid && isProcessAlive(run.processPid)) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -2428,6 +2539,7 @@ export function heartbeatService(db: Db) {
             truncated: payloadChunk.length !== sanitizedChunk.length,
           },
         });
+        await touchRunActivity(run.id);
       };
       for (const warning of runtimeWorkspaceWarnings) {
         const logEntry = formatRuntimeWorkspaceWarningLog(warning);
@@ -2483,6 +2595,7 @@ export function heartbeatService(db: Db) {
         }
       }
       const onAdapterMeta = async (meta: AdapterInvocationMeta) => {
+        await touchRunActivity(currentRun.id);
         if (meta.env && secretKeys.size > 0) {
           for (const key of secretKeys) {
             if (key in meta.env) meta.env[key] = "***REDACTED***";
@@ -2826,6 +2939,7 @@ export function heartbeatService(db: Db) {
         .select({
           id: issues.id,
           companyId: issues.companyId,
+          assigneeAgentId: issues.assigneeAgentId,
         })
         .from(issues)
         .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
@@ -2844,7 +2958,7 @@ export function heartbeatService(db: Db) {
         .where(eq(issues.id, issue.id));
 
       while (true) {
-        const deferred = await tx
+        const deferredCandidates = await tx
           .select()
           .from(agentWakeupRequests)
           .where(
@@ -2854,11 +2968,31 @@ export function heartbeatService(db: Db) {
               sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
             ),
           )
-          .orderBy(asc(agentWakeupRequests.requestedAt))
-          .limit(1)
-          .then((rows) => rows[0] ?? null);
+          .orderBy(asc(agentWakeupRequests.requestedAt));
 
-        if (!deferred) return null;
+        if (deferredCandidates.length === 0) return null;
+
+        const deferred = issue.assigneeAgentId
+          ? deferredCandidates.find((row) => row.agentId === issue.assigneeAgentId) ?? deferredCandidates[0]
+          : deferredCandidates[0];
+
+        if (issue.assigneeAgentId) {
+          const supersededDeferredIds = deferredCandidates
+            .filter((row) => row.id !== deferred.id && row.agentId !== issue.assigneeAgentId)
+            .map((row) => row.id);
+          if (supersededDeferredIds.length > 0) {
+            const finishedAt = new Date();
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                status: "failed",
+                finishedAt,
+                error: "Deferred wake superseded by current issue assignee",
+                updatedAt: finishedAt,
+              })
+              .where(inArray(agentWakeupRequests.id, supersededDeferredIds));
+          }
+        }
 
         const deferredAgent = await tx
           .select()
@@ -3797,7 +3931,13 @@ export function heartbeatService(db: Db) {
 
     wakeup: enqueueWakeup,
 
-    reportRunActivity: clearDetachedRunWarning,
+    reportRunActivity: async (runId: string) => {
+      const cleared = await clearDetachedRunWarning(runId);
+      if (!cleared) {
+        await touchRunActivity(runId, { forcePersist: true });
+      }
+      return cleared;
+    },
 
     reapOrphanedRuns,
 


### PR DESCRIPTION
## Summary

This change makes Paperclip self-heal a class of stuck heartbeat executions that previously required board intervention and manual scheduler recovery.

In the failing production case, local adapter runs could remain marked `running` indefinitely even after they stopped emitting logs or adapter metadata. Those runs held issue execution locks, blocked follow-on work, and left the scheduler relying on a board operator to cancel stale executions before QA or redeploy work could continue. On top of that, when an issue execution lock was released, deferred wake promotion could select the oldest deferred wakeup instead of the issue's current assignee, which let stale historical wakeups steal execution from the intended agent.

## Root Cause

The heartbeat service had process-loss recovery for runs whose child process had already disappeared, and it also had detached-process handling for runs whose child PID was still alive after the in-memory handle was lost. What it did not have was a notion of activity freshness for local runs that were still technically alive but had stopped making meaningful progress. In that state, the scheduler had no signal to distinguish a healthy long-running task from a hung process that had silently stopped advancing.

The deferred-promotion path had a related orchestration problem: once an execution lock was released, it promoted the oldest deferred wake for the issue. That favored historical wakeups over the current assignee and could reintroduce the wrong agent onto the issue after manual recovery or reassignment.

## Fix

The heartbeat service now tracks observed run activity in memory and periodically persists it to `heartbeat_runs.updated_at` while local runs are producing logs or adapter metadata. During orphan recovery, local runs that remain alive or tracked but have reported no activity for a sustained window are cancelled automatically with a stale-run reason instead of waiting forever for board cleanup. The older process-loss retry path is still preserved when the child process is already gone.

The release-and-promote flow also now prefers deferred issue execution wakeups for the issue's current assignee before falling back to the oldest deferred wakeup. Superseded deferred wakeups for non-assignee agents are marked failed so they do not continue to re-contend for the same issue.

Finally, `reportRunActivity` now behaves as a true activity refresh for active runs rather than only clearing detached-process warnings, which gives routes that report agent progress a direct way to keep healthy runs fresh.

## Validation

I added regression coverage in the existing heartbeat process recovery suite to verify:

- healthy detached local runs remain active when the child PID is still alive and activity is recent
- stale local runs are cancelled when they remain tracked without progress long enough to meet the stale threshold
- dead local processes still follow the existing process-loss retry behavior
- deferred issue execution promotion prefers the current assignee over older deferred wakeups

Checks run:

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`

## Notes

`pnpm --filter @paperclipai/server build` still fails on this release tag because of pre-existing `@paperclipai/plugin-sdk` workspace/type issues in unrelated plugin files. The heartbeat recovery test suite added here passes, and the new heartbeat changes are not present in the remaining build errors.
