### PR TITLE
feat: add Related Issues picker to New Issue dialog

### DIFF
--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -306,7 +306,7 @@ export function NewIssueDialog() {
   // Related issues search (debounced)
   useEffect(() => {
     if (relatedDebounceRef.current) clearTimeout(relatedDebounceRef.current);
-    relatedDebounceRef.current = setTimeout(() => setDebouncedRelatedSearch(relatedSearch), 300);
+    relatedDebounceRef.current = setTimeout(() => setDebouncedRelatedSearch(relatedSearch), DEBOUNCE_MS);
     return () => { if (relatedDebounceRef.current) clearTimeout(relatedDebounceRef.current); };
   }, [relatedSearch]);
   const { data: relatedSearchResults, isFetching: relatedFetching } = useQuery({
@@ -652,6 +652,8 @@ export function NewIssueDialog() {
     setAssigneeChrome(false);
     setExecutionWorkspaceMode("shared_workspace");
     setSelectedExecutionWorkspaceId("");
+    setRelatedIssues([]);
+    setRelatedSearch("");
   }
 
   function discardDraft() {
@@ -1468,7 +1470,7 @@ export function NewIssueDialog() {
                 </div>
               )}
               {/* Search results */}
-              {relatedSearch.length >= 2 && (
+              {debouncedRelatedSearch.length >= 2 && (
                 <div className="max-h-48 overflow-y-auto">
                   {relatedFetching ? (
                     <p className="text-xs text-muted-foreground px-1 py-2">Searching…</p>


### PR DESCRIPTION
## Summary

Adds a "Related" button to the property chips bar in the New Issue dialog that lets users search and link up to 5 related issues for context.

- Searchable popover using the existing issues search API (`q` parameter)
- Type-ahead filtering with 2-character minimum
- Selected issues shown as removable tags with identifiers
- Maximum 5 related issues enforced
- On submit, appends `Related: PREFIX-100, PREFIX-131` to the issue description

This convention enables adapters to auto-fetch referenced issues and inject their content into the agent's task context, giving agents background without copy-pasting descriptions.

![Related Issues picker is added as a chip in the property bar, between Labels and Upload]

## Test plan

- [ ] Open New Issue dialog
- [ ] Click "Related" chip in the property bar
- [ ] Type an issue identifier or title (minimum 2 characters)
- [ ] Verify search results appear from the issues API
- [ ] Click a result to add it (appears as a tag)
- [ ] Add up to 5 issues, verify the limit is enforced
- [ ] Remove a related issue via the X button
- [ ] Create the issue and verify `Related: ...` is appended to the description
- [ ] Close and reopen the dialog — verify related issues state is reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)