### PR TITLE
fix: address semgrep security findings

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -62,11 +62,14 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Launch Docker smoke harness
+        env:
+          INPUT_HOST_PORT: ${{ inputs.host_port }}
+          INPUT_PAPERCLIP_VERSION: ${{ inputs.paperclip_version }}
         run: |
           metadata_file="$RUNNER_TEMP/release-smoke.env"
-          HOST_PORT="${{ inputs.host_port }}" \
+          HOST_PORT="$INPUT_HOST_PORT" \
           DATA_DIR="$RUNNER_TEMP/release-smoke-data" \
-          PAPERCLIPAI_VERSION="${{ inputs.paperclip_version }}" \
+          PAPERCLIPAI_VERSION="$INPUT_PAPERCLIP_VERSION" \
           SMOKE_DETACH=true \
           SMOKE_METADATA_FILE="$metadata_file" \
           ./scripts/docker-onboard-smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,10 +183,11 @@ jobs:
       - name: Dry-run stable release
         env:
           GITHUB_ACTIONS: "true"
+          INPUT_STABLE_DATE: ${{ inputs.stable_date }}
         run: |
           args=(stable --skip-verify --dry-run)
-          if [ -n "${{ inputs.stable_date }}" ]; then
-            args+=(--date "${{ inputs.stable_date }}")
+          if [ -n "$INPUT_STABLE_DATE" ]; then
+            args+=(--date "$INPUT_STABLE_DATE")
           fi
           ./scripts/release.sh "${args[@]}"
 
@@ -232,10 +233,11 @@ jobs:
       - name: Publish stable
         env:
           GITHUB_ACTIONS: "true"
+          INPUT_STABLE_DATE: ${{ inputs.stable_date }}
         run: |
           args=(stable --skip-verify)
-          if [ -n "${{ inputs.stable_date }}" ]; then
-            args+=(--date "${{ inputs.stable_date }}")
+          if [ -n "$INPUT_STABLE_DATE" ]; then
+            args+=(--date "$INPUT_STABLE_DATE")
           fi
           ./scripts/release.sh "${args[@]}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,7 @@ ENV NODE_ENV=production \
 VOLUME ["/paperclip"]
 EXPOSE 3100
 
+USER node
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]

--- a/docker/openclaw-smoke/Dockerfile
+++ b/docker/openclaw-smoke/Dockerfile
@@ -5,4 +5,6 @@ COPY server.mjs /app/server.mjs
 
 EXPOSE 8787
 
+USER node
+
 CMD ["node", "/app/server.mjs"]

--- a/server/src/routes/llms.ts
+++ b/server/src/routes/llms.ts
@@ -70,14 +70,14 @@ export function llmRoutes(db: Db) {
     const adapterType = req.params.adapterType as string;
     const adapter = listServerAdapters().find((entry) => entry.type === adapterType);
     if (!adapter) {
-      res.status(404).type("text/plain").send(`Unknown adapter type: ${adapterType}`);
+      res.status(404).type("text/plain").send(`Unknown adapter type: ${adapterType.replace(/[<>&"']/g, "")}`);
       return;
     }
     res
       .type("text/plain")
       .send(
         adapter.agentConfigurationDoc ??
-          `# ${adapterType} agent configuration\n\nNo adapter-specific documentation registered.`,
+          `# ${adapterType.replace(/[<>&"']/g, "")} agent configuration\n\nNo adapter-specific documentation registered.`,
       );
   });
 

--- a/server/src/secrets/local-encrypted-provider.ts
+++ b/server/src/secrets/local-encrypted-provider.ts
@@ -93,7 +93,7 @@ function decryptValue(masterKey: Buffer, material: LocalEncryptedMaterial): stri
   const iv = Buffer.from(material.iv, "base64");
   const tag = Buffer.from(material.tag, "base64");
   const ciphertext = Buffer.from(material.ciphertext, "base64");
-  const decipher = createDecipheriv("aes-256-gcm", masterKey, iv);
+  const decipher = createDecipheriv("aes-256-gcm", masterKey, iv, { authTagLength: 16 });
   decipher.setAuthTag(tag);
   const plain = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
   return plain.toString("utf8");


### PR DESCRIPTION
## Summary

Fixes 4 security findings detected via Semgrep static analysis (10 rulesets including Trail of Bits and elttam).

## Changes

### 1. Docker: Add `USER node` before ENTRYPOINT (fixes #2415)
- `Dockerfile`: Add `USER node` before ENTRYPOINT so the container doesn't run as root
- `docker/openclaw-smoke/Dockerfile`: Same fix — the `node:22-alpine` base image includes a `node` user

### 2. GitHub Actions: Prevent shell injection (fixes #2416)
- `.github/workflows/release-smoke.yml`: Move `${{ inputs.host_port }}` and `${{ inputs.paperclip_version }}` to `env:` block
- `.github/workflows/release.yml`: Move `${{ inputs.stable_date }}` to `env:` block (2 instances)
- Pattern: `${{ }}` in `run:` → `env:` + `$VAR` reference

### 3. Express: Sanitize user input in text responses (fixes #2417)
- `server/src/routes/llms.ts`: Strip `<>&"'` from `req.params.adapterType` before including in `text/plain` responses

### 4. Crypto: Explicit GCM auth tag length (fixes #2418)
- `server/src/secrets/local-encrypted-provider.ts`: Add `{ authTagLength: 16 }` to `createDecipheriv` call

## Testing

All changes are minimal and defensive — no functional behavior changes. The Docker USER change may require verifying that file permissions are correct for the `node` user in production volumes.