### PR TITLE
fix: add gemini_local to AGENT_ADAPTER_TYPES validation enum

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -26,6 +26,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "gemini_local",
   "opencode_local",
   "pi_local",
   "cursor",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents are backed by adapter types (claude_local, codex_local, gemini_local, etc.) validated through a shared constants enum
> - The gemini_local adapter is fully implemented across the adapter package, server registry, and UI — but was never added to the `AGENT_ADAPTER_TYPES` validation enum in `packages/shared`
> - This means Zod validators reject any API request that sets `adapterType: "gemini_local"`, blocking agent creation and invite acceptance for Gemini users
> - This pull request adds `gemini_local` to the `AGENT_ADAPTER_TYPES` array in `packages/shared/src/constants.ts`
> - The benefit is that Gemini adapter users can now create and configure agents through the API without hitting a 400 validation error

## What Changed

Added `"gemini_local"` to the `AGENT_ADAPTER_TYPES` array in `packages/shared/src/constants.ts`

## Verification

- `pnpm -r typecheck` - passes
- `pnpm test:run` - 150 files, 762 tests passed
- Confirm the enum now includes `gemini_local`:
  ```sh
  grep -A 12 'AGENT_ADAPTER_TYPES' packages/shared/src/constants.ts
  ```

## Risks

- Low risk. This is an additive change to a string literal array. No migrations, no schema changes, no behavioral shifts for existing adapter types.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #2413
