### PR TITLE
Fix Codex metered cost attribution

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -586,7 +586,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       biller: resolveCodexBiller(effectiveEnv, billingType),
       model,
       billingType,
-      costUsd: null,
+      costUsd: attempt.parsed.costUsd,
       resultJson: {
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
+
+describe("parseCodexJsonl", () => {
+  it("parses usage, cost, assistant text, and session id from JSONL output", () => {
+    const stdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "agent_message",
+          text: "Finished the task",
+        },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        total_cost_usd: 0.123456,
+        usage: {
+          input_tokens: 1200,
+          cached_input_tokens: 200,
+          output_tokens: 80,
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseCodexJsonl(stdout);
+    expect(parsed.sessionId).toBe("thread_123");
+    expect(parsed.summary).toBe("Finished the task");
+    expect(parsed.usage).toEqual({
+      inputTokens: 1200,
+      cachedInputTokens: 200,
+      outputTokens: 80,
+    });
+    expect(parsed.costUsd).toBeCloseTo(0.123456, 6);
+    expect(parsed.errorMessage).toBeNull();
+  });
+
+  it("detects missing-session failures", () => {
+    expect(isCodexUnknownSessionError("unknown session id", "")).toBe(true);
+    expect(isCodexUnknownSessionError("", "thread abc not found")).toBe(true);
+    expect(isCodexUnknownSessionError("all good", "")).toBe(false);
+  });
+});

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -4,6 +4,7 @@ export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
   const messages: string[] = [];
   let errorMessage: string | null = null;
+  let costUsd: number | null = null;
   const usage = {
     inputTokens: 0,
     cachedInputTokens: 0,
@@ -43,6 +44,8 @@ export function parseCodexJsonl(stdout: string) {
       usage.inputTokens = asNumber(usageObj.input_tokens, usage.inputTokens);
       usage.cachedInputTokens = asNumber(usageObj.cached_input_tokens, usage.cachedInputTokens);
       usage.outputTokens = asNumber(usageObj.output_tokens, usage.outputTokens);
+      const totalCostUsd = asNumber(event.total_cost_usd, Number.NaN);
+      if (Number.isFinite(totalCostUsd)) costUsd = totalCostUsd;
       continue;
     }
 
@@ -50,6 +53,8 @@ export function parseCodexJsonl(stdout: string) {
       const err = parseObject(event.error);
       const msg = asString(err.message, "").trim();
       if (msg) errorMessage = msg;
+      const totalCostUsd = asNumber(event.total_cost_usd, Number.NaN);
+      if (Number.isFinite(totalCostUsd)) costUsd = totalCostUsd;
     }
   }
 
@@ -57,6 +62,7 @@ export function parseCodexJsonl(stdout: string) {
     sessionId,
     summary: messages.join("\n\n").trim(),
     usage,
+    costUsd,
     errorMessage,
   };
 }

--- a/scripts/backfill-codex-metered-costs.ts
+++ b/scripts/backfill-codex-metered-costs.ts
@@ -1,0 +1,198 @@
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import {
+  agentRuntimeState,
+  costEvents,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import type { BillingType } from "@paperclipai/shared";
+import { resolveBilledCost, type CostUsageTotals } from "../server/src/services/cost-estimation.js";
+
+function parseArgs(argv: string[]) {
+  const companyId = argv.find((arg) => arg.startsWith("--company-id="))?.slice("--company-id=".length) ?? null;
+  const apply = argv.includes("--apply");
+  if (!companyId) {
+    throw new Error("Missing required --company-id=<uuid>");
+  }
+  return { companyId, apply };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function readRawUsageTotals(usageJson: unknown): CostUsageTotals | null {
+  const parsed = asRecord(usageJson);
+  if (!parsed) return null;
+
+  const inputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawInputTokens, asNumber(parsed.inputTokens, 0))),
+  );
+  const cachedInputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawCachedInputTokens, asNumber(parsed.cachedInputTokens, 0))),
+  );
+  const outputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawOutputTokens, asNumber(parsed.outputTokens, 0))),
+  );
+
+  if (inputTokens <= 0 && cachedInputTokens <= 0 && outputTokens <= 0) {
+    return null;
+  }
+
+  return {
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+  };
+}
+
+async function main() {
+  const { companyId, apply } = parseArgs(process.argv.slice(2));
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const db = createDb(databaseUrl);
+
+  const runs = await db
+    .select({
+      id: heartbeatRuns.id,
+      agentId: heartbeatRuns.agentId,
+      sessionIdAfter: heartbeatRuns.sessionIdAfter,
+      startedAt: heartbeatRuns.startedAt,
+      usageJson: heartbeatRuns.usageJson,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.companyId, companyId))
+    .orderBy(asc(heartbeatRuns.agentId), asc(heartbeatRuns.startedAt));
+
+  const previousRawUsageByRunId = new Map<string, CostUsageTotals | null>();
+  const latestRawUsageBySessionKey = new Map<string, CostUsageTotals>();
+
+  for (const run of runs) {
+    const sessionId = typeof run.sessionIdAfter === "string" && run.sessionIdAfter.trim().length > 0
+      ? run.sessionIdAfter.trim()
+      : null;
+    const sessionKey = sessionId ? `${run.agentId}:${sessionId}` : null;
+    previousRawUsageByRunId.set(run.id, sessionKey ? latestRawUsageBySessionKey.get(sessionKey) ?? null : null);
+
+    const rawUsage = readRawUsageTotals(run.usageJson);
+    if (sessionKey && rawUsage) {
+      latestRawUsageBySessionKey.set(sessionKey, rawUsage);
+    }
+  }
+
+  const runsById = new Map(runs.map((run) => [run.id, run]));
+
+  const events = await db
+    .select({
+      id: costEvents.id,
+      agentId: costEvents.agentId,
+      heartbeatRunId: costEvents.heartbeatRunId,
+      provider: costEvents.provider,
+      biller: costEvents.biller,
+      model: costEvents.model,
+      billingType: costEvents.billingType,
+      inputTokens: costEvents.inputTokens,
+      cachedInputTokens: costEvents.cachedInputTokens,
+      outputTokens: costEvents.outputTokens,
+      costCents: costEvents.costCents,
+    })
+    .from(costEvents)
+    .where(and(
+      eq(costEvents.companyId, companyId),
+      eq(costEvents.billingType, "metered_api"),
+      eq(costEvents.costCents, 0),
+    ))
+    .orderBy(desc(costEvents.occurredAt));
+
+  let estimatedEvents = 0;
+  let estimatedCents = 0;
+  const updates: Array<{ id: string; costCents: number }> = [];
+  const affectedAgentIds = new Set<string>();
+
+  for (const event of events) {
+    const usage: CostUsageTotals = {
+      inputTokens: event.inputTokens,
+      cachedInputTokens: event.cachedInputTokens,
+      outputTokens: event.outputTokens,
+    };
+    const run = event.heartbeatRunId ? runsById.get(event.heartbeatRunId) ?? null : null;
+    const rawUsage = run ? readRawUsageTotals(run.usageJson) : null;
+    const previousRawUsage = run ? previousRawUsageByRunId.get(run.id) ?? null : null;
+    const resolved = resolveBilledCost({
+      providerCostUsd: null,
+      provider: event.provider,
+      biller: event.biller,
+      model: event.model,
+      billingType: event.billingType as BillingType,
+      usage,
+      rawUsage,
+      previousRawUsage,
+    });
+
+    if (resolved.costCents <= 0) continue;
+    updates.push({ id: event.id, costCents: resolved.costCents });
+    affectedAgentIds.add(event.agentId);
+    estimatedEvents += 1;
+    estimatedCents += resolved.costCents;
+  }
+
+  console.log(JSON.stringify({
+    companyId,
+    apply,
+    scannedEvents: events.length,
+    estimatedEvents,
+    estimatedCents,
+  }, null, 2));
+
+  if (!apply || updates.length === 0) return;
+
+  for (const update of updates) {
+    await db
+      .update(costEvents)
+      .set({ costCents: update.costCents })
+      .where(eq(costEvents.id, update.id));
+  }
+
+  for (const agentId of affectedAgentIds) {
+    const sumRow = await db
+      .select({
+        totalCostCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
+      })
+      .from(costEvents)
+      .where(and(eq(costEvents.companyId, companyId), eq(costEvents.agentId, agentId)))
+      .then((rows) => rows[0] ?? { totalCostCents: 0 });
+
+    await db
+      .update(agentRuntimeState)
+      .set({
+        totalCostCents: sumRow.totalCostCents,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(agentRuntimeState.companyId, companyId),
+        eq(agentRuntimeState.agentId, agentId),
+      ));
+  }
+
+  console.log(JSON.stringify({
+    companyId,
+    updatedEvents: updates.length,
+    affectedAgents: affectedAgentIds.size,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/server/src/services/cost-estimation.test.ts
+++ b/server/src/services/cost-estimation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { estimateMeteredCostUsd, resolveBilledCost } from "./cost-estimation.js";
+
+describe("estimateMeteredCostUsd", () => {
+  it("estimates gpt-5.4 standard metered cost from token usage", () => {
+    const estimated = estimateMeteredCostUsd({
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 1_000_000,
+        cachedInputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      },
+      rawUsage: {
+        inputTokens: 200_000,
+        cachedInputTokens: 50_000,
+        outputTokens: 1_000_000,
+      },
+    });
+
+    expect(estimated).toBeCloseTo(17.75, 6);
+  });
+
+  it("applies the long-context uplift only to the portion above the threshold", () => {
+    const estimated = estimateMeteredCostUsd({
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 100_000,
+        cachedInputTokens: 20_000,
+        outputTokens: 10_000,
+      },
+      rawUsage: {
+        inputTokens: 260_000,
+        cachedInputTokens: 90_000,
+        outputTokens: 25_000,
+      },
+      previousRawUsage: {
+        inputTokens: 180_000,
+        cachedInputTokens: 50_000,
+        outputTokens: 15_000,
+      },
+    });
+
+    expect(estimated).toBeCloseTo(0.6195, 6);
+  });
+});
+
+describe("resolveBilledCost", () => {
+  it("prefers provider-reported cost when available", () => {
+    const resolved = resolveBilledCost({
+      providerCostUsd: 1.234,
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 10,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+    });
+
+    expect(resolved).toEqual({
+      costUsd: 1.234,
+      costCents: 123,
+      estimated: false,
+      source: "provider_reported",
+    });
+  });
+
+  it("returns an estimated metered cost when the provider does not report dollars", () => {
+    const resolved = resolveBilledCost({
+      providerCostUsd: null,
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 1_000_000,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      rawUsage: {
+        inputTokens: 1_000_000,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+    });
+
+    expect(resolved.costUsd).toBeCloseTo(4.32, 6);
+    expect(resolved.costCents).toBe(432);
+    expect(resolved.estimated).toBe(true);
+    expect(resolved.source).toBe("openai_model_pricing");
+  });
+});

--- a/server/src/services/cost-estimation.test.ts
+++ b/server/src/services/cost-estimation.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { estimateMeteredCostUsd, resolveBilledCost } from "./cost-estimation.js";
 
 describe("estimateMeteredCostUsd", () => {
-  it("estimates gpt-5.4 standard metered cost from token usage", () => {
+  it("treats cached input as a subset of total input tokens", () => {
     const estimated = estimateMeteredCostUsd({
       provider: "openai",
       biller: "openai",
       model: "gpt-5.4",
       billingType: "metered_api",
       usage: {
-        inputTokens: 1_000_000,
-        cachedInputTokens: 1_000_000,
+        inputTokens: 200_000,
+        cachedInputTokens: 50_000,
         outputTokens: 1_000_000,
       },
       rawUsage: {
@@ -20,10 +20,10 @@ describe("estimateMeteredCostUsd", () => {
       },
     });
 
-    expect(estimated).toBeCloseTo(17.75, 6);
+    expect(estimated).toBeCloseTo(15.3875, 6);
   });
 
-  it("applies the long-context uplift only to the portion above the threshold", () => {
+  it("applies the long-context uplift to uncached input and output only", () => {
     const estimated = estimateMeteredCostUsd({
       provider: "openai",
       biller: "openai",
@@ -35,18 +35,18 @@ describe("estimateMeteredCostUsd", () => {
         outputTokens: 10_000,
       },
       rawUsage: {
-        inputTokens: 260_000,
+        inputTokens: 350_000,
         cachedInputTokens: 90_000,
         outputTokens: 25_000,
       },
       previousRawUsage: {
-        inputTokens: 180_000,
+        inputTokens: 230_000,
         cachedInputTokens: 50_000,
         outputTokens: 15_000,
       },
     });
 
-    expect(estimated).toBeCloseTo(0.6195, 6);
+    expect(estimated).toBeCloseTo(0.5695, 6);
   });
 });
 
@@ -82,18 +82,18 @@ describe("resolveBilledCost", () => {
       billingType: "metered_api",
       usage: {
         inputTokens: 1_000_000,
-        cachedInputTokens: 0,
+        cachedInputTokens: 400_000,
         outputTokens: 0,
       },
       rawUsage: {
         inputTokens: 1_000_000,
-        cachedInputTokens: 0,
+        cachedInputTokens: 400_000,
         outputTokens: 0,
       },
     });
 
-    expect(resolved.costUsd).toBeCloseTo(4.32, 6);
-    expect(resolved.costCents).toBe(432);
+    expect(resolved.costUsd).toBeCloseTo(2.692, 6);
+    expect(resolved.costCents).toBe(269);
     expect(resolved.estimated).toBe(true);
     expect(resolved.source).toBe("openai_model_pricing");
   });

--- a/server/src/services/cost-estimation.ts
+++ b/server/src/services/cost-estimation.ts
@@ -19,7 +19,6 @@ type ModelPricing = {
   outputUsdPerMillion: number;
   longContextThresholdPromptTokens?: number;
   longContextInputMultiplier?: number;
-  longContextCachedInputMultiplier?: number;
   longContextOutputMultiplier?: number;
 };
 
@@ -35,13 +34,17 @@ const OPENAI_MODEL_PRICING: Array<{ match: (model: string) => boolean; pricing: 
       longContextThresholdPromptTokens: 272_000,
       longContextInputMultiplier: 2,
       // OpenAI documents the long-context uplift for input/output on GPT-5.4.
-      // We apply the same input uplift to cached input because cached prompt
-      // tokens still consume the long-context window and are billed as discounted input.
-      longContextCachedInputMultiplier: 2,
+      // We do not apply an extra uplift to cached input because the cached-token
+      // pricing is documented separately and the long-context docs do not state
+      // an additional cached-input multiplier.
       longContextOutputMultiplier: 1.5,
     },
   },
 ];
+
+function resolveUncachedInputTokens(usage: CostUsageTotals): number {
+  return Math.max(0, usage.inputTokens - usage.cachedInputTokens);
+}
 
 function normalizeKnownParty(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
@@ -78,17 +81,13 @@ function resolveLongContextShare(input: {
   const threshold = input.pricing.longContextThresholdPromptTokens ?? 0;
   if (threshold <= 0) return 0;
 
-  const deltaPromptTokens = Math.max(0, input.usage.inputTokens + input.usage.cachedInputTokens);
+  const deltaPromptTokens = Math.max(0, input.usage.inputTokens);
   if (deltaPromptTokens <= 0) return 0;
 
-  const currentPromptTokens = Math.max(
-    0,
-    (input.rawUsage?.inputTokens ?? input.usage.inputTokens) +
-      (input.rawUsage?.cachedInputTokens ?? input.usage.cachedInputTokens),
-  );
+  const currentPromptTokens = Math.max(0, input.rawUsage?.inputTokens ?? input.usage.inputTokens);
   const previousPromptTokens =
     input.previousRawUsage
-      ? Math.max(0, input.previousRawUsage.inputTokens + input.previousRawUsage.cachedInputTokens)
+      ? Math.max(0, input.previousRawUsage.inputTokens)
       : Math.max(0, currentPromptTokens - deltaPromptTokens);
 
   if (previousPromptTokens >= threshold) return 1;
@@ -122,19 +121,17 @@ export function estimateMeteredCostUsd(input: {
     pricing,
   });
   const standardShare = 1 - longContextShare;
+  const uncachedInputTokens = resolveUncachedInputTokens(input.usage);
   const inputMultiplier = standardShare + longContextShare * (pricing.longContextInputMultiplier ?? 1);
-  const cachedInputMultiplier =
-    standardShare + longContextShare * (pricing.longContextCachedInputMultiplier ?? pricing.longContextInputMultiplier ?? 1);
   const outputMultiplier = standardShare + longContextShare * (pricing.longContextOutputMultiplier ?? 1);
 
   const inputCostUsd =
-    (input.usage.inputTokens / TOKENS_PER_MILLION) *
+    (uncachedInputTokens / TOKENS_PER_MILLION) *
     pricing.inputUsdPerMillion *
     inputMultiplier;
   const cachedInputCostUsd =
     (input.usage.cachedInputTokens / TOKENS_PER_MILLION) *
-    pricing.cachedInputUsdPerMillion *
-    cachedInputMultiplier;
+    pricing.cachedInputUsdPerMillion;
   const outputCostUsd =
     (input.usage.outputTokens / TOKENS_PER_MILLION) *
     pricing.outputUsdPerMillion *

--- a/server/src/services/cost-estimation.ts
+++ b/server/src/services/cost-estimation.ts
@@ -1,0 +1,199 @@
+import type { BillingType } from "@paperclipai/shared";
+
+export interface CostUsageTotals {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+}
+
+export interface BilledCostResolution {
+  costUsd: number | null;
+  costCents: number;
+  estimated: boolean;
+  source: "provider_reported" | "openai_model_pricing" | "unknown";
+}
+
+type ModelPricing = {
+  inputUsdPerMillion: number;
+  cachedInputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  longContextThresholdPromptTokens?: number;
+  longContextInputMultiplier?: number;
+  longContextCachedInputMultiplier?: number;
+  longContextOutputMultiplier?: number;
+};
+
+const TOKENS_PER_MILLION = 1_000_000;
+
+const OPENAI_MODEL_PRICING: Array<{ match: (model: string) => boolean; pricing: ModelPricing }> = [
+  {
+    match: (model) => model === "gpt-5.4" || model.startsWith("gpt-5.4-"),
+    pricing: {
+      inputUsdPerMillion: 2.5,
+      cachedInputUsdPerMillion: 0.25,
+      outputUsdPerMillion: 15,
+      longContextThresholdPromptTokens: 272_000,
+      longContextInputMultiplier: 2,
+      // OpenAI documents the long-context uplift for input/output on GPT-5.4.
+      // We apply the same input uplift to cached input because cached prompt
+      // tokens still consume the long-context window and are billed as discounted input.
+      longContextCachedInputMultiplier: 2,
+      longContextOutputMultiplier: 1.5,
+    },
+  },
+];
+
+function normalizeKnownParty(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeModel(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function roundUsdToCents(costUsd: number | null | undefined): number {
+  if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
+  return Math.max(0, Math.round(costUsd * 100));
+}
+
+function resolveOpenAiPricing(model: string | null | undefined): ModelPricing | null {
+  const normalizedModel = normalizeModel(model);
+  if (!normalizedModel) return null;
+  for (const entry of OPENAI_MODEL_PRICING) {
+    if (entry.match(normalizedModel)) return entry.pricing;
+  }
+  return null;
+}
+
+function resolveLongContextShare(input: {
+  usage: CostUsageTotals;
+  rawUsage: CostUsageTotals | null | undefined;
+  previousRawUsage: CostUsageTotals | null | undefined;
+  pricing: ModelPricing;
+}): number {
+  const threshold = input.pricing.longContextThresholdPromptTokens ?? 0;
+  if (threshold <= 0) return 0;
+
+  const deltaPromptTokens = Math.max(0, input.usage.inputTokens + input.usage.cachedInputTokens);
+  if (deltaPromptTokens <= 0) return 0;
+
+  const currentPromptTokens = Math.max(
+    0,
+    (input.rawUsage?.inputTokens ?? input.usage.inputTokens) +
+      (input.rawUsage?.cachedInputTokens ?? input.usage.cachedInputTokens),
+  );
+  const previousPromptTokens =
+    input.previousRawUsage
+      ? Math.max(0, input.previousRawUsage.inputTokens + input.previousRawUsage.cachedInputTokens)
+      : Math.max(0, currentPromptTokens - deltaPromptTokens);
+
+  if (previousPromptTokens >= threshold) return 1;
+  if (currentPromptTokens <= threshold) return 0;
+
+  return Math.max(0, Math.min(1, (currentPromptTokens - threshold) / deltaPromptTokens));
+}
+
+export function estimateMeteredCostUsd(input: {
+  provider: string | null | undefined;
+  biller: string | null | undefined;
+  model: string | null | undefined;
+  billingType: BillingType;
+  usage: CostUsageTotals | null | undefined;
+  rawUsage?: CostUsageTotals | null | undefined;
+  previousRawUsage?: CostUsageTotals | null | undefined;
+}): number | null {
+  if (input.billingType !== "metered_api" || !input.usage) return null;
+
+  const provider = normalizeKnownParty(input.provider);
+  const biller = normalizeKnownParty(input.biller);
+  if (provider !== "openai" && biller !== "openai") return null;
+
+  const pricing = resolveOpenAiPricing(input.model);
+  if (!pricing) return null;
+
+  const longContextShare = resolveLongContextShare({
+    usage: input.usage,
+    rawUsage: input.rawUsage,
+    previousRawUsage: input.previousRawUsage,
+    pricing,
+  });
+  const standardShare = 1 - longContextShare;
+  const inputMultiplier = standardShare + longContextShare * (pricing.longContextInputMultiplier ?? 1);
+  const cachedInputMultiplier =
+    standardShare + longContextShare * (pricing.longContextCachedInputMultiplier ?? pricing.longContextInputMultiplier ?? 1);
+  const outputMultiplier = standardShare + longContextShare * (pricing.longContextOutputMultiplier ?? 1);
+
+  const inputCostUsd =
+    (input.usage.inputTokens / TOKENS_PER_MILLION) *
+    pricing.inputUsdPerMillion *
+    inputMultiplier;
+  const cachedInputCostUsd =
+    (input.usage.cachedInputTokens / TOKENS_PER_MILLION) *
+    pricing.cachedInputUsdPerMillion *
+    cachedInputMultiplier;
+  const outputCostUsd =
+    (input.usage.outputTokens / TOKENS_PER_MILLION) *
+    pricing.outputUsdPerMillion *
+    outputMultiplier;
+
+  const total = inputCostUsd + cachedInputCostUsd + outputCostUsd;
+  return Number.isFinite(total) ? total : null;
+}
+
+export function resolveBilledCost(input: {
+  providerCostUsd: number | null | undefined;
+  provider: string | null | undefined;
+  biller: string | null | undefined;
+  model: string | null | undefined;
+  billingType: BillingType;
+  usage: CostUsageTotals | null | undefined;
+  rawUsage?: CostUsageTotals | null | undefined;
+  previousRawUsage?: CostUsageTotals | null | undefined;
+}): BilledCostResolution {
+  if (input.billingType === "subscription_included") {
+    return {
+      costUsd: 0,
+      costCents: 0,
+      estimated: false,
+      source: "provider_reported",
+    };
+  }
+
+  if (typeof input.providerCostUsd === "number" && Number.isFinite(input.providerCostUsd)) {
+    return {
+      costUsd: input.providerCostUsd,
+      costCents: roundUsdToCents(input.providerCostUsd),
+      estimated: false,
+      source: "provider_reported",
+    };
+  }
+
+  const estimatedUsd = estimateMeteredCostUsd({
+    provider: input.provider,
+    biller: input.biller,
+    model: input.model,
+    billingType: input.billingType,
+    usage: input.usage,
+    rawUsage: input.rawUsage,
+    previousRawUsage: input.previousRawUsage,
+  });
+  if (estimatedUsd !== null) {
+    return {
+      costUsd: estimatedUsd,
+      costCents: roundUsdToCents(estimatedUsd),
+      estimated: true,
+      source: "openai_model_pricing",
+    };
+  }
+
+  return {
+    costUsd: null,
+    costCents: 0,
+    estimated: false,
+    source: "unknown",
+  };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -30,6 +30,7 @@ import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
+import { resolveBilledCost, type BilledCostResolution } from "./cost-estimation.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -370,12 +371,6 @@ function normalizeLedgerBillingType(value: unknown): BillingType {
 
 function resolveLedgerBiller(result: AdapterExecutionResult): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
-}
-
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
-  if (billingType === "subscription_included") return 0;
-  if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
-  return Math.max(0, Math.round(costUsd * 100));
 }
 
 async function resolveLedgerScopeForRun(
@@ -1960,6 +1955,7 @@ export function heartbeatService(db: Db) {
     result: AdapterExecutionResult,
     session: { legacySessionId: string | null },
     normalizedUsage?: UsageTotals | null,
+    costResolution?: BilledCostResolution | null,
   ) {
     await ensureRuntimeState(agent);
     const usage = normalizedUsage ?? normalizeUsageTotals(result.usage);
@@ -1967,7 +1963,15 @@ export function heartbeatService(db: Db) {
     const outputTokens = usage?.outputTokens ?? 0;
     const cachedInputTokens = usage?.cachedInputTokens ?? 0;
     const billingType = normalizeLedgerBillingType(result.billingType);
-    const additionalCostCents = normalizeBilledCostCents(result.costUsd, billingType);
+    const resolvedCost = costResolution ?? resolveBilledCost({
+      providerCostUsd: result.costUsd,
+      provider: result.provider,
+      biller: result.biller,
+      model: result.model,
+      billingType,
+      usage,
+    });
+    const additionalCostCents = resolvedCost.costCents;
     const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
@@ -2730,6 +2734,18 @@ export function heartbeatService(db: Db) {
         rawUsage,
       });
       const normalizedUsage = sessionUsageResolution.normalizedUsage;
+      const resolvedBiller = resolveLedgerBiller(adapterResult);
+      const resolvedBillingType = normalizeLedgerBillingType(adapterResult.billingType);
+      const costResolution = resolveBilledCost({
+        providerCostUsd: adapterResult.costUsd,
+        provider: adapterResult.provider,
+        biller: resolvedBiller,
+        model: adapterResult.model,
+        billingType: resolvedBillingType,
+        usage: normalizedUsage,
+        rawUsage,
+        previousRawUsage: sessionUsageResolution.previousRawUsage,
+      });
 
       let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
@@ -2776,10 +2792,16 @@ export function heartbeatService(db: Db) {
               sessionRotated: sessionCompaction.rotate,
               sessionRotationReason: sessionCompaction.reason,
               provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
-              biller: resolveLedgerBiller(adapterResult),
+              biller: resolvedBiller,
               model: readNonEmptyString(adapterResult.model) ?? "unknown",
               ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
-              billingType: normalizeLedgerBillingType(adapterResult.billingType),
+              ...(costResolution.estimated && costResolution.costUsd != null
+                ? {
+                    estimatedCostUsd: costResolution.costUsd,
+                    estimatedCostSource: costResolution.source,
+                  }
+                : {}),
+              billingType: resolvedBillingType,
             } as Record<string, unknown>)
           : null;
 
@@ -2835,7 +2857,7 @@ export function heartbeatService(db: Db) {
       if (finalizedRun) {
         await updateRuntimeState(agent, finalizedRun, adapterResult, {
           legacySessionId: nextSessionState.legacySessionId,
-        }, normalizedUsage);
+        }, normalizedUsage, costResolution);
         if (taskKey) {
           if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
             await clearTaskSessions(agent.companyId, agent.id, {


### PR DESCRIPTION
## Summary
- propagate provider-reported Codex cost when the local adapter emits 	otal_cost_usd
- estimate OpenAI GPT-5.4 metered cost from token usage when the provider does not return billed dollars
- add regression tests plus a backfill script for historical metered Codex runs

## Validation
- corepack pnpm --dir /app exec vitest run /app/packages/adapters/codex-local/src/server/parse.test.ts /app/server/src/services/cost-estimation.test.ts
- built and deployed a Docker image from the patched repo on the live Hostinger instance
- backfilled historical cost_events and verified non-zero cost_cents in production for the affected company