### PR TITLE
fix: prevent blank screen when clearing Capabilities field

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -515,7 +515,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             </Field>
             <Field label="Capabilities" hint={help.capabilities}>
               <MarkdownEditor
-                value={eff("identity", "capabilities", props.agent.capabilities ?? "")}
+                value={eff("identity", "capabilities", props.agent.capabilities ?? "") ?? ""}
                 onChange={(v) => mark("identity", "capabilities", v || null)}
                 placeholder="Describe what this agent can do..."
                 contentClassName="min-h-[44px] text-sm font-mono"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans oversee agents through the board UI, including configuring agent identity and capabilities
> - The agent Configuration tab has a Capabilities field powered by a MarkdownEditor (MDXEditor)
> - But clearing the Capabilities field completely causes a blank screen crash
> - The `onChange` handler converts empty strings to `null` via `(v || null)`, and the overlay system returns that `null` to MDXEditor which expects a `string`
> - This PR adds a null-coalescing fallback (`?? ""`) so MDXEditor always receives a string
> - The benefit is that users can clear the Capabilities field without crashing the page

## What changed

One-line fix in `ui/src/components/AgentConfigForm.tsx` (line 518):

```diff
- value={eff("identity", "capabilities", props.agent.capabilities ?? "")}
+ value={eff("identity", "capabilities", props.agent.capabilities ?? "") ?? ""}
```

## Why

The `eff()` function reads from a dirty-overlay map. When the user clears the field, `onChange` stores `null` (via `"" || null`). On re-render, `eff()` finds `null` in the overlay and returns it — but `MDXEditor` requires a `string` for its `markdown` prop. This causes an unhandled React error and a blank screen.

## Before / After

**Before:** Deleting the last character in the Capabilities field crashes the page to a blank white screen.

**After:** Clearing the field works normally — the placeholder text appears and the page remains functional.

## How to verify

1. Navigate to any agent → Configuration tab
2. Click into the Capabilities field
3. Delete all text until the field is empty
4. Confirm the page does not crash and the placeholder "Describe what this agent can do..." appears

## Risks

Minimal — single null-coalescing operator added at the call site. No changes to shared logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
