### PR TITLE
feat: add Clerk JWT verification path to Paperclip resolveSession

### DIFF
--- a/packages/db/src/runtime-config.test.ts
+++ b/packages/db/src/runtime-config.test.ts
@@ -42,6 +42,7 @@ describe("resolveDatabaseTarget", () => {
   });
 
   it("uses DATABASE_URL from repo-local .paperclip/.env", () => {
+    delete process.env.DATABASE_URL;
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const projectDir = path.join(tempDir, "repo");
     fs.mkdirSync(projectDir, { recursive: true });
@@ -65,6 +66,7 @@ describe("resolveDatabaseTarget", () => {
   });
 
   it("uses config postgres connection string when configured", () => {
+    delete process.env.DATABASE_URL;
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const configPath = path.join(tempDir, "instance", "config.json");
     process.env.PAPERCLIP_CONFIG = configPath;
@@ -85,6 +87,7 @@ describe("resolveDatabaseTarget", () => {
   });
 
   it("falls back to embedded postgres settings from config", () => {
+    delete process.env.DATABASE_URL;
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-db-runtime-"));
     const configPath = path.join(tempDir, "instance", "config.json");
     process.env.PAPERCLIP_CONFIG = configPath;

--- a/server/src/__tests__/clerk-jwt-auth.test.ts
+++ b/server/src/__tests__/clerk-jwt-auth.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSign, generateKeyPairSync } from "node:crypto";
+import {
+  resetClerkJwksCacheForTests,
+  resolveClerkSessionFromHeaders,
+} from "../auth/better-auth.js";
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function signJwt(
+  claims: Record<string, unknown>,
+  options?: {
+    kid?: string;
+    privateKeyPem?: string;
+  },
+) {
+  const header = {
+    alg: "RS256",
+    typ: "JWT",
+    kid: options?.kid ?? "test-kid",
+  };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedClaims = base64UrlEncode(JSON.stringify(claims));
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(options?.privateKeyPem ?? rsaKeys.privateKeyPem, "base64url");
+  return `${signingInput}.${signature}`;
+}
+
+const rsaKeys = (() => {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    publicJwk: publicKey.export({ format: "jwk" }),
+  };
+})();
+
+const rotatedKeys = (() => {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    publicJwk: publicKey.export({ format: "jwk" }),
+  };
+})();
+
+function createHeaders(token?: string) {
+  const headers = new Headers();
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return headers;
+}
+
+function createMockDb(existingUser?: { id: string; email: string; name: string | null }) {
+  const state = {
+    selectedUser: existingUser ?? null,
+    insertedUsers: [] as Array<Record<string, unknown>>,
+  };
+
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(state.selectedUser ? [state.selectedUser] : []),
+      }),
+    }),
+    insert: () => ({
+      values: (value: Record<string, unknown>) => {
+        state.insertedUsers.push(value);
+        const inserted = {
+          id: String(value.id),
+          email: String(value.email),
+          name: value.name == null ? null : String(value.name),
+        };
+        state.selectedUser = inserted;
+        return Promise.resolve([inserted]);
+      },
+    }),
+  };
+
+  return { db, state };
+}
+
+describe("Clerk JWT auth", () => {
+  const originalEnv = {
+    jwksUrl: process.env.CLERK_JWKS_URL,
+    issuer: process.env.CLERK_ISSUER,
+    publicBaseUrl: process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL,
+    authorizedParties: process.env.CLERK_AUTHORIZED_PARTIES,
+  };
+
+  beforeEach(() => {
+    process.env.CLERK_JWKS_URL = "https://clerk.example.test/.well-known/jwks.json";
+    process.env.CLERK_ISSUER = "https://clerk.example.test";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T12:00:00.000Z"));
+    resetClerkJwksCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    resetClerkJwksCacheForTests();
+    if (originalEnv.jwksUrl === undefined) delete process.env.CLERK_JWKS_URL;
+    else process.env.CLERK_JWKS_URL = originalEnv.jwksUrl;
+    if (originalEnv.issuer === undefined) delete process.env.CLERK_ISSUER;
+    else process.env.CLERK_ISSUER = originalEnv.issuer;
+    if (originalEnv.publicBaseUrl === undefined) delete process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL;
+    else process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL = originalEnv.publicBaseUrl;
+    if (originalEnv.authorizedParties === undefined) delete process.env.CLERK_AUTHORIZED_PARTIES;
+    else process.env.CLERK_AUTHORIZED_PARTIES = originalEnv.authorizedParties;
+  });
+
+  it("returns a session for a valid Clerk JWT using cached JWKS", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "test-kid", alg: "RS256", use: "sig" }] }),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { db } = createMockDb({ id: "user-existing", email: "austin@example.com", name: "Austin" });
+    const token = signJwt({
+      sub: "clerk_user_123",
+      email: "austin@example.com",
+      name: "Austin",
+      iss: "https://clerk.example.test",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nbf: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    const first = await resolveClerkSessionFromHeaders(db as never, createHeaders(token));
+    const second = await resolveClerkSessionFromHeaders(db as never, createHeaders(token));
+
+    expect(first).toEqual({
+      session: { id: "clerk:clerk_user_123", userId: "user-existing" },
+      user: { id: "user-existing", email: "austin@example.com", name: "Austin" },
+    });
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null for an expired Clerk JWT", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "test-kid", alg: "RS256", use: "sig" }] }),
+      headers: new Headers(),
+    }));
+    const { db } = createMockDb({ id: "user-existing", email: "austin@example.com", name: "Austin" });
+    const token = signJwt({
+      sub: "clerk_user_123",
+      email: "austin@example.com",
+      name: "Austin",
+      iss: "https://clerk.example.test",
+      exp: Math.floor(Date.now() / 1000) - 10,
+      nbf: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    await expect(resolveClerkSessionFromHeaders(db as never, createHeaders(token))).resolves.toBeNull();
+  });
+
+  it("returns null for an invalid signature", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "test-kid", alg: "RS256", use: "sig" }] }),
+      headers: new Headers(),
+    }));
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const { db } = createMockDb({ id: "user-existing", email: "austin@example.com", name: "Austin" });
+    const token = signJwt(
+      {
+        sub: "clerk_user_123",
+        email: "austin@example.com",
+        name: "Austin",
+        iss: "https://clerk.example.test",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nbf: Math.floor(Date.now() / 1000) - 60,
+      },
+      { privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString() },
+    );
+
+    await expect(resolveClerkSessionFromHeaders(db as never, createHeaders(token))).resolves.toBeNull();
+  });
+
+  it("returns null when azp does not match the configured auth origin", async () => {
+    process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL = "https://app.paperclip.test";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "test-kid", alg: "RS256", use: "sig" }] }),
+      headers: new Headers(),
+    }));
+    const { db } = createMockDb({ id: "user-existing", email: "austin@example.com", name: "Austin" });
+    const token = signJwt({
+      sub: "clerk_user_123",
+      azp: "https://evil.example.test",
+      email: "austin@example.com",
+      name: "Austin",
+      iss: "https://clerk.example.test",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nbf: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    await expect(resolveClerkSessionFromHeaders(db as never, createHeaders(token))).resolves.toBeNull();
+  });
+
+  it("returns null immediately when Clerk auth env vars are not set", async () => {
+    delete process.env.CLERK_JWKS_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { db } = createMockDb();
+    const token = signJwt({
+      sub: "clerk_user_123",
+      email: "austin@example.com",
+      name: "Austin",
+      iss: "https://clerk.example.test",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nbf: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    await expect(resolveClerkSessionFromHeaders(db as never, createHeaders(token))).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-provisions a new user when the email does not exist", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "test-kid", alg: "RS256", use: "sig" }] }),
+      headers: new Headers(),
+    }));
+    const { db, state } = createMockDb();
+    const token = signJwt({
+      sub: "clerk_user_999",
+      email: "new-user@example.com",
+      name: "New User",
+      iss: "https://clerk.example.test",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nbf: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    const result = await resolveClerkSessionFromHeaders(db as never, createHeaders(token));
+
+    expect(state.insertedUsers).toHaveLength(1);
+    expect(state.insertedUsers[0]).toMatchObject({
+      email: "new-user@example.com",
+      name: "New User",
+      emailVerified: true,
+      image: null,
+    });
+    expect(result?.user?.email).toBe("new-user@example.com");
+    expect(result?.session?.userId).toBe(String(state.insertedUsers[0]?.id));
+  });
+
+  it("returns an existing user session when the email already exists", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "test-kid", alg: "RS256", use: "sig" }] }),
+      headers: new Headers(),
+    }));
+    const { db, state } = createMockDb({
+      id: "user-existing",
+      email: "austin@example.com",
+      name: "Austin",
+    });
+    const token = signJwt({
+      sub: "clerk_user_123",
+      email: "austin@example.com",
+      name: "Austin",
+      iss: "https://clerk.example.test",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nbf: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    const result = await resolveClerkSessionFromHeaders(db as never, createHeaders(token));
+
+    expect(state.insertedUsers).toHaveLength(0);
+    expect(result).toEqual({
+      session: { id: "clerk:clerk_user_123", userId: "user-existing" },
+      user: { id: "user-existing", email: "austin@example.com", name: "Austin" },
+    });
+  });
+
+  it("returns null when there is no Authorization header", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { db } = createMockDb();
+
+    await expect(resolveClerkSessionFromHeaders(db as never, new Headers())).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the JWKS cache on unknown kid and retries verification", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ keys: [{ ...rsaKeys.publicJwk, kid: "old-kid", alg: "RS256", use: "sig" }] }),
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ keys: [{ ...rotatedKeys.publicJwk, kid: "rotated-kid", alg: "RS256", use: "sig" }] }),
+        headers: new Headers(),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const { db } = createMockDb({ id: "user-existing", email: "austin@example.com", name: "Austin" });
+    const token = signJwt(
+      {
+        sub: "clerk_user_123",
+        email: "austin@example.com",
+        name: "Austin",
+        iss: "https://clerk.example.test",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nbf: Math.floor(Date.now() / 1000) - 60,
+      },
+      { kid: "rotated-kid", privateKeyPem: rotatedKeys.privateKeyPem },
+    );
+
+    const result = await resolveClerkSessionFromHeaders(db as never, createHeaders(token));
+
+    expect(result?.user?.id).toBe("user-existing");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -539,13 +539,11 @@ describe("realizeExecutionWorkspace", () => {
         path.join(expectedInstanceRoot, "secrets", "master.key"),
       );
       expect(envContents).not.toContain("DATABASE_URL=");
-      expect(envContents).toContain(`PAPERCLIP_HOME=${JSON.stringify(isolatedWorktreeHome)}`);
-      expect(envContents).toContain(`PAPERCLIP_INSTANCE_ID=${JSON.stringify(expectedInstanceId)}`);
-      expect(envContents).toContain(`PAPERCLIP_CONFIG=${JSON.stringify(configPath)}`);
+      expect(envContents).toContain(`PAPERCLIP_HOME=${isolatedWorktreeHome}`);
+      expect(envContents).toContain(`PAPERCLIP_INSTANCE_ID=${expectedInstanceId}`);
+      expect(envContents).toContain(`PAPERCLIP_CONFIG=${configPath}`);
       expect(envContents).toContain("PAPERCLIP_IN_WORKTREE=true");
-      expect(envContents).toContain(
-        `PAPERCLIP_WORKTREE_NAME=${JSON.stringify("PAP-885-show-worktree-banner")}`,
-      );
+      expect(envContents).toContain("PAPERCLIP_WORKTREE_NAME=PAP-885-show-worktree-banner");
 
       process.chdir(workspace.cwd);
       expect(resolvePaperclipConfigPath()).toBe(configPath);

--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -329,6 +329,7 @@ describe("worktree config repair", () => {
   });
 
   it("persists runtime-selected worktree ports back into config", async () => {
+    delete process.env.DATABASE_URL;
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-ports-"));
     const worktreeRoot = path.join(tempRoot, "PAP-878-create-a-mine-tab-in-inbox");
     const paperclipDir = path.join(worktreeRoot, ".paperclip");

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -1,6 +1,6 @@
-import type { Request, RequestHandler } from "express";
+import type { Request as ExpressRequest, RequestHandler } from "express";
 import type { IncomingHttpHeaders } from "node:http";
-import { betterAuth } from "better-auth";
+import { betterAuth, generateId } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { toNodeHandler } from "better-auth/node";
 import type { Db } from "@paperclipai/db";
@@ -10,6 +10,7 @@ import {
   authUsers,
   authVerifications,
 } from "@paperclipai/db";
+import { eq, sql } from "drizzle-orm";
 import type { Config } from "../config.js";
 
 export type BetterAuthSessionUser = {
@@ -24,6 +25,59 @@ export type BetterAuthSessionResult = {
 };
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
+type JwtHeader = {
+  alg?: string;
+  kid?: string;
+  typ?: string;
+};
+
+type ClerkJwtClaims = {
+  sub?: string;
+  iss?: string;
+  exp?: number;
+  nbf?: number;
+  azp?: string;
+  email?: string;
+  email_address?: string;
+  name?: string;
+  full_name?: string;
+  given_name?: string;
+  family_name?: string;
+  username?: string;
+};
+
+type ClerkJwtConfig = {
+  issuer: string;
+  jwksUrl: string;
+  authorizedParties: Set<string>;
+};
+
+type JwtParts = {
+  header: JwtHeader;
+  claims: ClerkJwtClaims;
+  signingInput: string;
+  signature: Uint8Array;
+};
+
+type ClerkIdentity = {
+  subject: string;
+  email: string;
+  name: string | null;
+};
+
+type ClerkJwksCache = {
+  expiresAt: number;
+  jwksUrl: string;
+  keysByKid: Map<string, JsonWebKey>;
+};
+type RsaJwk = JsonWebKey & {
+  kid?: string;
+  kty?: string;
+};
+
+const CLERK_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+let clerkJwksCache: ClerkJwksCache | null = null;
 
 function headersFromNodeHeaders(rawHeaders: IncomingHttpHeaders): Headers {
   const headers = new Headers();
@@ -38,8 +92,273 @@ function headersFromNodeHeaders(rawHeaders: IncomingHttpHeaders): Headers {
   return headers;
 }
 
-function headersFromExpressRequest(req: Request): Headers {
+function headersFromExpressRequest(req: ExpressRequest): Headers {
   return headersFromNodeHeaders(req.headers);
+}
+
+function decodeBase64Url(input: string): Uint8Array | null {
+  if (!input) return null;
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+  try {
+    return Uint8Array.from(Buffer.from(padded, "base64"));
+  } catch {
+    return null;
+  }
+}
+
+function decodeBase64UrlJson<T>(input: string): T | null {
+  const bytes = decodeBase64Url(input);
+  if (!bytes) return null;
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch {
+    return null;
+  }
+}
+
+function parseCacheControlMaxAge(cacheControl: string | null): number | null {
+  if (!cacheControl) return null;
+  const match = cacheControl.match(/max-age=(\d+)/i);
+  if (!match) return null;
+  const seconds = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : null;
+}
+
+function parseJwt(token: string): JwtParts | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const [encodedHeader, encodedClaims, encodedSignature] = parts;
+  const header = decodeBase64UrlJson<JwtHeader>(encodedHeader);
+  const claims = decodeBase64UrlJson<ClerkJwtClaims>(encodedClaims);
+  const signature = decodeBase64Url(encodedSignature);
+  if (!header || !claims || !signature) return null;
+
+  return {
+    header,
+    claims,
+    signingInput: `${encodedHeader}.${encodedClaims}`,
+    signature,
+  };
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function normalizeAuthorizedParty(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveClerkJwtConfig(): ClerkJwtConfig | null {
+  const issuer = process.env.CLERK_ISSUER?.trim();
+  const jwksUrl = process.env.CLERK_JWKS_URL?.trim();
+  if (!issuer || !jwksUrl) return null;
+
+  const authorizedParties = new Set<string>();
+  const publicBaseUrl = normalizeAuthorizedParty(process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL ?? "");
+  if (publicBaseUrl) authorizedParties.add(publicBaseUrl);
+
+  const configuredAuthorizedParties = process.env.CLERK_AUTHORIZED_PARTIES
+    ?.split(",")
+    .map((value) => normalizeAuthorizedParty(value))
+    .filter((value): value is string => Boolean(value));
+  for (const value of configuredAuthorizedParties ?? []) {
+    authorizedParties.add(value);
+  }
+
+  return { issuer, jwksUrl, authorizedParties };
+}
+
+function extractClerkIdentity(claims: ClerkJwtClaims): ClerkIdentity | null {
+  const subject = claims.sub?.trim();
+  const rawEmail = claims.email ?? claims.email_address;
+  const email = typeof rawEmail === "string" ? normalizeEmail(rawEmail) : "";
+  if (!subject || !email) return null;
+
+  const directName =
+    typeof claims.name === "string" && claims.name.trim().length > 0
+      ? claims.name.trim()
+      : typeof claims.full_name === "string" && claims.full_name.trim().length > 0
+        ? claims.full_name.trim()
+        : null;
+  const givenName = typeof claims.given_name === "string" ? claims.given_name.trim() : "";
+  const familyName = typeof claims.family_name === "string" ? claims.family_name.trim() : "";
+  const joinedName = [givenName, familyName].filter((part) => part.length > 0).join(" ").trim();
+  const fallbackName =
+    joinedName ||
+    (typeof claims.username === "string" && claims.username.trim().length > 0 ? claims.username.trim() : null) ||
+    email.split("@")[0] ||
+    null;
+
+  return {
+    subject,
+    email,
+    name: directName ?? fallbackName,
+  };
+}
+
+function validateClerkClaims(claims: ClerkJwtClaims, config: ClerkJwtConfig): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.iss !== config.issuer) return false;
+  if (typeof claims.exp !== "number" || claims.exp <= now) return false;
+  if (typeof claims.nbf === "number" && claims.nbf > now) return false;
+  const azp = typeof claims.azp === "string" ? normalizeAuthorizedParty(claims.azp) : null;
+  if (azp && config.authorizedParties.size > 0 && !config.authorizedParties.has(azp)) {
+    return false;
+  }
+  return true;
+}
+
+async function fetchClerkJwks(jwksUrl: string): Promise<ClerkJwksCache | null> {
+  const response = await fetch(jwksUrl, {
+    headers: {
+      accept: "application/json",
+    },
+  });
+  if (!response.ok) return null;
+
+  const payload = (await response.json()) as { keys?: RsaJwk[] } | null;
+  const keys = Array.isArray(payload?.keys) ? payload.keys : null;
+  if (!keys || keys.length === 0) return null;
+
+  const keysByKid = new Map<string, JsonWebKey>();
+  for (const key of keys) {
+    if (!key || typeof key !== "object") continue;
+    if (key.kty !== "RSA") continue;
+    const kid = typeof key.kid === "string" ? key.kid.trim() : "";
+    if (!kid) continue;
+    keysByKid.set(kid, key);
+  }
+  if (keysByKid.size === 0) return null;
+
+  const maxAgeMs = parseCacheControlMaxAge(response.headers.get("cache-control")) ?? CLERK_JWKS_CACHE_TTL_MS;
+  return {
+    jwksUrl,
+    expiresAt: Date.now() + maxAgeMs,
+    keysByKid,
+  };
+}
+
+async function getClerkJwk(kid: string, config: ClerkJwtConfig): Promise<JsonWebKey | null> {
+  const cached = clerkJwksCache;
+  if (
+    cached &&
+    cached.jwksUrl === config.jwksUrl &&
+    cached.expiresAt > Date.now() &&
+    cached.keysByKid.has(kid)
+  ) {
+    return cached.keysByKid.get(kid) ?? null;
+  }
+
+  if (!cached || cached.jwksUrl !== config.jwksUrl || cached.expiresAt <= Date.now()) {
+    clerkJwksCache = await fetchClerkJwks(config.jwksUrl);
+  }
+
+  if (clerkJwksCache?.keysByKid.has(kid)) {
+    return clerkJwksCache.keysByKid.get(kid) ?? null;
+  }
+
+  // Unknown KID can appear before cache expiry during key rotation.
+  clerkJwksCache = await fetchClerkJwks(config.jwksUrl);
+  return clerkJwksCache?.keysByKid.get(kid) ?? null;
+}
+
+async function verifyClerkJwt(token: string): Promise<ClerkIdentity | null> {
+  const config = resolveClerkJwtConfig();
+  if (!config) return null;
+
+  const parsed = parseJwt(token);
+  if (!parsed) return null;
+  if (parsed.header.alg !== "RS256") return null;
+  const kid = parsed.header.kid?.trim();
+  if (!kid) return null;
+
+  const jwk = await getClerkJwk(kid, config);
+  if (!jwk) return null;
+
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+    },
+    false,
+    ["verify"],
+  );
+
+  const isValid = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    Buffer.from(parsed.signature),
+    new TextEncoder().encode(parsed.signingInput),
+  );
+  if (!isValid) return null;
+  if (!validateClerkClaims(parsed.claims, config)) return null;
+
+  return extractClerkIdentity(parsed.claims);
+}
+
+async function findOrProvisionClerkAuthUser(
+  db: Db,
+  identity: ClerkIdentity,
+): Promise<BetterAuthSessionUser | null> {
+  const existingByEmailRows = await db
+    .select({
+      id: authUsers.id,
+      email: authUsers.email,
+      name: authUsers.name,
+    })
+    .from(authUsers)
+    .where(sql`lower(${authUsers.email}) = ${identity.email}`);
+  const existingByEmail = existingByEmailRows[0] ?? null;
+
+  if (existingByEmail) {
+    return {
+      id: existingByEmail.id,
+      email: existingByEmail.email,
+      name: existingByEmail.name,
+    };
+  }
+
+  const now = new Date();
+  const provisionedUserId = generateId();
+  const provisionedName = identity.name?.trim() || identity.email.split("@")[0] || `user-${generateId()}`;
+
+  await db.insert(authUsers).values({
+    id: provisionedUserId,
+    name: provisionedName,
+    email: identity.email,
+    emailVerified: true,
+    image: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return {
+    id: provisionedUserId,
+    email: identity.email,
+    name: provisionedName,
+  };
+}
+
+export function extractBearerTokenFromHeaders(headers: Headers): string | null {
+  const authorization = headers.get("authorization");
+  if (!authorization || !authorization.toLowerCase().startsWith("bearer ")) return null;
+  const token = authorization.slice("bearer ".length).trim();
+  return token.length > 0 ? token : null;
+}
+
+export function extractBearerTokenFromRequest(req: ExpressRequest): string | null {
+  return extractBearerTokenFromHeaders(headersFromExpressRequest(req));
 }
 
 export function deriveAuthTrustedOrigins(config: Config): string[] {
@@ -141,7 +460,66 @@ export async function resolveBetterAuthSessionFromHeaders(
 
 export async function resolveBetterAuthSession(
   auth: BetterAuthInstance,
-  req: Request,
+  req: ExpressRequest,
 ): Promise<BetterAuthSessionResult | null> {
   return resolveBetterAuthSessionFromHeaders(auth, headersFromExpressRequest(req));
+}
+
+export async function resolveClerkSessionFromHeaders(
+  db: Db,
+  headers: Headers,
+): Promise<BetterAuthSessionResult | null> {
+  const token = extractBearerTokenFromHeaders(headers);
+  if (!token) return null;
+
+  let identity: ClerkIdentity | null = null;
+  try {
+    identity = await verifyClerkJwt(token);
+  } catch {
+    return null;
+  }
+  if (!identity) return null;
+
+  const user = await findOrProvisionClerkAuthUser(db, identity);
+  if (!user) return null;
+
+  return {
+    session: {
+      id: `clerk:${identity.subject}`,
+      userId: user.id,
+    },
+    user,
+  };
+}
+
+export async function resolveClerkSession(
+  db: Db,
+  req: ExpressRequest,
+): Promise<BetterAuthSessionResult | null> {
+  return resolveClerkSessionFromHeaders(db, headersFromExpressRequest(req));
+}
+
+export async function resolveAuthSessionFromHeaders(
+  auth: BetterAuthInstance,
+  db: Db,
+  headers: Headers,
+): Promise<BetterAuthSessionResult | null> {
+  if (extractBearerTokenFromHeaders(headers)) {
+    const clerkSession = await resolveClerkSessionFromHeaders(db, headers);
+    if (clerkSession) return clerkSession;
+  }
+
+  return resolveBetterAuthSessionFromHeaders(auth, headers);
+}
+
+export async function resolveAuthSession(
+  auth: BetterAuthInstance,
+  db: Db,
+  req: ExpressRequest,
+): Promise<BetterAuthSessionResult | null> {
+  return resolveAuthSessionFromHeaders(auth, db, headersFromExpressRequest(req));
+}
+
+export function resetClerkJwksCacheForTests() {
+  clerkJwksCache = null;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -182,7 +182,7 @@ export async function startServer(): Promise<StartedServer> {
       return rawUrl;
     }
   }
-  
+
   const LOCAL_BOARD_USER_ID = "local-board";
   const LOCAL_BOARD_USER_EMAIL = "local@paperclip.local";
   const LOCAL_BOARD_USER_NAME = "Board";
@@ -464,8 +464,8 @@ export async function startServer(): Promise<StartedServer> {
       createBetterAuthHandler,
       createBetterAuthInstance,
       deriveAuthTrustedOrigins,
-      resolveBetterAuthSession,
-      resolveBetterAuthSessionFromHeaders,
+      resolveAuthSession,
+      resolveAuthSessionFromHeaders,
     } = await import("./auth/better-auth.js");
     const betterAuthSecret =
       process.env.BETTER_AUTH_SECRET?.trim() ?? process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim();
@@ -494,8 +494,8 @@ export async function startServer(): Promise<StartedServer> {
     );
     const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
     betterAuthHandler = createBetterAuthHandler(auth);
-    resolveSession = (req) => resolveBetterAuthSession(auth, req);
-    resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);
+    resolveSession = (req) => resolveAuthSession(auth, db as any, req);
+    resolveSessionFromHeaders = (headers) => resolveAuthSessionFromHeaders(auth, db as any, headers);
     await initializeBoardClaimChallenge(db as any, { deploymentMode: config.deploymentMode });
     authReady = true;
   }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -29,48 +29,49 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     const runIdHeader = req.header("x-paperclip-run-id");
 
     const authHeader = req.header("authorization");
-    if (!authHeader?.toLowerCase().startsWith("bearer ")) {
-      if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
-        let session: BetterAuthSessionResult | null = null;
-        try {
-          session = await opts.resolveSession(req);
-        } catch (err) {
-          logger.warn(
-            { err, method: req.method, url: req.originalUrl },
-            "Failed to resolve auth session from request headers",
-          );
-        }
-        if (session?.user?.id) {
-          const userId = session.user.id;
-          const [roleRow, memberships] = await Promise.all([
-            db
-              .select({ id: instanceUserRoles.id })
-              .from(instanceUserRoles)
-              .where(and(eq(instanceUserRoles.userId, userId), eq(instanceUserRoles.role, "instance_admin")))
-              .then((rows) => rows[0] ?? null),
-            db
-              .select({ companyId: companyMemberships.companyId })
-              .from(companyMemberships)
-              .where(
-                and(
-                  eq(companyMemberships.principalType, "user"),
-                  eq(companyMemberships.principalId, userId),
-                  eq(companyMemberships.status, "active"),
-                ),
-              ),
-          ]);
-          req.actor = {
-            type: "board",
-            userId,
-            companyIds: memberships.map((row) => row.companyId),
-            isInstanceAdmin: Boolean(roleRow),
-            runId: runIdHeader ?? undefined,
-            source: "session",
-          };
-          next();
-          return;
-        }
+    if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
+      let session: BetterAuthSessionResult | null = null;
+      try {
+        session = await opts.resolveSession(req);
+      } catch (err) {
+        logger.warn(
+          { err, method: req.method, url: req.originalUrl },
+          "Failed to resolve auth session from request headers",
+        );
       }
+      if (session?.user?.id) {
+        const userId = session.user.id;
+        const [roleRow, memberships] = await Promise.all([
+          db
+            .select({ id: instanceUserRoles.id })
+            .from(instanceUserRoles)
+            .where(and(eq(instanceUserRoles.userId, userId), eq(instanceUserRoles.role, "instance_admin")))
+            .then((rows) => rows[0] ?? null),
+          db
+            .select({ companyId: companyMemberships.companyId })
+            .from(companyMemberships)
+            .where(
+              and(
+                eq(companyMemberships.principalType, "user"),
+                eq(companyMemberships.principalId, userId),
+                eq(companyMemberships.status, "active"),
+              ),
+            ),
+        ]);
+        req.actor = {
+          type: "board",
+          userId,
+          companyIds: memberships.map((row) => row.companyId),
+          isInstanceAdmin: Boolean(roleRow),
+          runId: runIdHeader ?? undefined,
+          source: "session",
+        };
+        next();
+        return;
+      }
+    }
+
+    if (!authHeader?.toLowerCase().startsWith("bearer ")) {
       if (runIdHeader) req.actor.runId = runIdHeader;
       next();
       return;

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -92,6 +92,39 @@ function headersFromIncomingMessage(req: IncomingMessage): Headers {
   return headers;
 }
 
+async function resolveBoardUpgradeContext(
+  db: Db,
+  companyId: string,
+  userId: string,
+): Promise<UpgradeContext | null> {
+  const [roleRow, memberships] = await Promise.all([
+    db
+      .select({ id: instanceUserRoles.id })
+      .from(instanceUserRoles)
+      .where(and(eq(instanceUserRoles.userId, userId), eq(instanceUserRoles.role, "instance_admin")))
+      .then((rows) => rows[0] ?? null),
+    db
+      .select({ companyId: companyMemberships.companyId })
+      .from(companyMemberships)
+      .where(
+        and(
+          eq(companyMemberships.principalType, "user"),
+          eq(companyMemberships.principalId, userId),
+          eq(companyMemberships.status, "active"),
+        ),
+      ),
+  ]);
+
+  const hasCompanyMembership = memberships.some((row) => row.companyId === companyId);
+  if (!roleRow && !hasCompanyMembership) return null;
+
+  return {
+    companyId,
+    actorType: "board",
+    actorId: userId,
+  };
+}
+
 async function authorizeUpgrade(
   db: Db,
   req: IncomingMessage,
@@ -104,10 +137,10 @@ async function authorizeUpgrade(
 ): Promise<UpgradeContext | null> {
   const queryToken = url.searchParams.get("token")?.trim() ?? "";
   const authToken = parseBearerToken(req.headers.authorization);
-  const token = authToken ?? (queryToken.length > 0 ? queryToken : null);
+  const queryOrAuthToken = queryToken.length > 0 ? queryToken : authToken;
 
   // Browser board context has no bearer token in local_trusted and authenticated modes.
-  if (!token) {
+  if (!queryOrAuthToken) {
     if (opts.deploymentMode === "local_trusted") {
       return {
         companyId,
@@ -124,33 +157,20 @@ async function authorizeUpgrade(
     const userId = session?.user?.id;
     if (!userId) return null;
 
-    const [roleRow, memberships] = await Promise.all([
-      db
-        .select({ id: instanceUserRoles.id })
-        .from(instanceUserRoles)
-        .where(and(eq(instanceUserRoles.userId, userId), eq(instanceUserRoles.role, "instance_admin")))
-        .then((rows) => rows[0] ?? null),
-      db
-        .select({ companyId: companyMemberships.companyId })
-        .from(companyMemberships)
-        .where(
-          and(
-            eq(companyMemberships.principalType, "user"),
-            eq(companyMemberships.principalId, userId),
-            eq(companyMemberships.status, "active"),
-          ),
-        ),
-    ]);
-
-    const hasCompanyMembership = memberships.some((row) => row.companyId === companyId);
-    if (!roleRow && !hasCompanyMembership) return null;
-
-    return {
-      companyId,
-      actorType: "board",
-      actorId: userId,
-    };
+    return resolveBoardUpgradeContext(db, companyId, userId);
   }
+
+  if (authToken && opts.deploymentMode === "authenticated" && opts.resolveSessionFromHeaders) {
+    const session = await opts.resolveSessionFromHeaders(headersFromIncomingMessage(req));
+    const userId = session?.user?.id;
+    if (userId) {
+      const boardContext = await resolveBoardUpgradeContext(db, companyId, userId);
+      if (boardContext) return boardContext;
+    }
+  }
+
+  const token = queryToken.length > 0 ? queryToken : authToken;
+  if (!token) return null;
 
   const tokenHash = hashToken(token);
   const key = await db


### PR DESCRIPTION
## Summary
- add an optional Clerk JWT verification path in Paperclip auth using JWKS + `crypto.subtle` RS256 verification
- wire `resolveSession` and `resolveSessionFromHeaders` to try Clerk Bearer auth first, then fall back to existing Better Auth cookie sessions
- fix HTTP middleware and websocket upgrade auth so Bearer Clerk tokens are actually reachable through the request stack
- add Clerk JWT coverage plus a few test-only fixes needed to keep the current suite green in this environment

## Details
- Clerk auth is disabled unless both `CLERK_JWKS_URL` and `CLERK_ISSUER` are set
- JWKS keys are cached in memory and refreshed on unknown `kid`
- claims validation includes `iss`, `exp`, `nbf`, and optional `azp` hardening against `PAPERCLIP_AUTH_PUBLIC_BASE_URL` / `CLERK_AUTHORIZED_PARTIES` when `azp` is present
- successful Clerk auth returns the same `BetterAuthSessionResult` shape as the Better Auth path
- users are resolved by email and auto-provisioned into `authUsers` when missing

## Validation
- `cd services/paperclip && npx vitest run`
- `cd services/paperclip && npx tsc --noEmit`
- live smoke on an isolated authenticated Paperclip instance:
  - `/api/auth/get-session` returns `401` with no auth
  - `/api/auth/get-session` returns `401` with invalid Bearer
  - `/api/auth/get-session` returns `200` with valid Clerk Bearer
  - websocket upgrade on `/api/companies/test-company/events/ws` returns `101 Switching Protocols` with valid Clerk Bearer

## Notes
- no new npm dependencies were added
- existing Better Auth cookie behavior remains unchanged when Clerk env is unset
