### PR TITLE
Fix managed instruction bundle staging for local adapters

### DIFF
--- a/packages/adapter-utils/src/instructions-bundle.test.ts
+++ b/packages/adapter-utils/src/instructions-bundle.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareWorkspaceInstructionsBundle } from "./server-utils.js";
+
+const cleanupPaths = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all(
+    [...cleanupPaths].map(async (target) => {
+      await fs.rm(target, { recursive: true, force: true });
+      cleanupPaths.delete(target);
+    }),
+  );
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  cleanupPaths.add(root);
+  return root;
+}
+
+describe("prepareWorkspaceInstructionsBundle", () => {
+  it("stages external instruction bundles into the workspace", async () => {
+    const workspaceRoot = await makeTempDir("paperclip-workspace-");
+    const sourceRoot = await makeTempDir("paperclip-instructions-");
+    const sourceInstructions = path.join(sourceRoot, "AGENTS.md");
+    await fs.writeFile(sourceInstructions, "# AGENTS\n", "utf8");
+    await fs.writeFile(path.join(sourceRoot, "HEARTBEAT.md"), "# HEARTBEAT\n", "utf8");
+
+    const logLines: string[] = [];
+    const prepared = await prepareWorkspaceInstructionsBundle({
+      cwd: workspaceRoot,
+      instructionsFilePath: sourceInstructions,
+      agentId: "agent-123",
+      onLog: async (_stream, text) => {
+        logLines.push(text);
+      },
+    });
+
+    expect(prepared.sourceInstructionsFilePath).toBe(sourceInstructions);
+    expect(prepared.stagedBundleRoot).toBe(
+      path.join(workspaceRoot, ".agents", "instructions", "agent-123"),
+    );
+    expect(prepared.effectiveInstructionsFilePath).toBe(
+      path.join(workspaceRoot, ".agents", "instructions", "agent-123", "AGENTS.md"),
+    );
+    await expect(
+      fs.readFile(path.join(workspaceRoot, ".agents", "instructions", "agent-123", "HEARTBEAT.md"), "utf8"),
+    ).resolves.toBe("# HEARTBEAT\n");
+    expect(logLines.join("")).toContain("Staged agent instructions bundle");
+  });
+
+  it("keeps instruction bundles in place when they are already inside the workspace", async () => {
+    const workspaceRoot = await makeTempDir("paperclip-workspace-");
+    const instructionsRoot = path.join(workspaceRoot, "config", "instructions");
+    await fs.mkdir(instructionsRoot, { recursive: true });
+    const instructionsFilePath = path.join(instructionsRoot, "AGENTS.md");
+    await fs.writeFile(instructionsFilePath, "# AGENTS\n", "utf8");
+
+    const prepared = await prepareWorkspaceInstructionsBundle({
+      cwd: workspaceRoot,
+      instructionsFilePath: "config/instructions/AGENTS.md",
+      agentId: "agent-123",
+    });
+
+    expect(prepared.sourceInstructionsFilePath).toBe(instructionsFilePath);
+    expect(prepared.effectiveInstructionsFilePath).toBe(instructionsFilePath);
+    expect(prepared.effectiveInstructionsDir).toBe(`${instructionsRoot}/`);
+    expect(prepared.stagedBundleRoot).toBeNull();
+    await expect(
+      fs.access(path.join(workspaceRoot, ".agents", "instructions", "agent-123")),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -51,6 +51,14 @@ export interface PaperclipSkillEntry {
   requiredReason?: string | null;
 }
 
+export interface PreparedWorkspaceInstructionsBundle {
+  sourceInstructionsFilePath: string;
+  sourceInstructionsDir: string;
+  effectiveInstructionsFilePath: string;
+  effectiveInstructionsDir: string;
+  stagedBundleRoot: string | null;
+}
+
 export interface InstalledSkillTarget {
   targetPath: string | null;
   kind: "symlink" | "directory" | "file";
@@ -246,6 +254,75 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   const apiUrl = process.env.PAPERCLIP_API_URL ?? `http://${runtimeHost}:${runtimePort}`;
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
+}
+
+function pathIsInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export async function prepareWorkspaceInstructionsBundle(options: {
+  cwd: string;
+  instructionsFilePath: string;
+  agentId: string;
+  onLog?: (stream: "stdout" | "stderr", text: string) => Promise<void> | void;
+}): Promise<PreparedWorkspaceInstructionsBundle> {
+  const resolvedWorkspaceCwd = path.resolve(options.cwd);
+  const resolvedInstructionsFilePath = path.resolve(
+    resolvedWorkspaceCwd,
+    options.instructionsFilePath,
+  );
+  const sourceInstructionsDir = path.dirname(resolvedInstructionsFilePath);
+  const bundle: PreparedWorkspaceInstructionsBundle = {
+    sourceInstructionsFilePath: resolvedInstructionsFilePath,
+    sourceInstructionsDir,
+    effectiveInstructionsFilePath: resolvedInstructionsFilePath,
+    effectiveInstructionsDir: `${sourceInstructionsDir}/`,
+    stagedBundleRoot: null,
+  };
+
+  if (pathIsInside(resolvedWorkspaceCwd, resolvedInstructionsFilePath)) {
+    return bundle;
+  }
+
+  const stagedBundleRoot = path.join(
+    resolvedWorkspaceCwd,
+    ".agents",
+    "instructions",
+    options.agentId,
+  );
+
+  try {
+    await fs.mkdir(path.dirname(stagedBundleRoot), { recursive: true });
+    await fs.rm(stagedBundleRoot, { recursive: true, force: true });
+    await fs.cp(sourceInstructionsDir, stagedBundleRoot, {
+      recursive: true,
+      force: true,
+      dereference: true,
+    });
+    if (options.onLog) {
+      await options.onLog(
+        "stdout",
+        `[paperclip] Staged agent instructions bundle from "${sourceInstructionsDir}" to "${stagedBundleRoot}"\n`,
+      );
+    }
+    bundle.effectiveInstructionsFilePath = path.join(
+      stagedBundleRoot,
+      path.basename(resolvedInstructionsFilePath),
+    );
+    bundle.effectiveInstructionsDir = `${stagedBundleRoot}/`;
+    bundle.stagedBundleRoot = stagedBundleRoot;
+    return bundle;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (options.onLog) {
+      await options.onLog(
+        "stdout",
+        `[paperclip] Warning: failed to stage agent instructions bundle "${sourceInstructionsDir}" into "${stagedBundleRoot}": ${reason}\n`,
+      );
+    }
+    return bundle;
+  }
 }
 
 export function defaultPathForPlatform() {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -14,6 +14,7 @@ import {
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  prepareWorkspaceInstructionsBundle,
   readPaperclipRuntimeSkillEntries,
   resolveCommandForLogs,
   resolvePaperclipDesiredSkillNames,
@@ -413,40 +414,56 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
   }
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
-  const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  const preparedInstructions = instructionsFilePath
+    ? await prepareWorkspaceInstructionsBundle({
+        cwd,
+        instructionsFilePath,
+        agentId: agent.id,
+        onLog,
+      })
+    : null;
+  const effectiveInstructionsFilePath = preparedInstructions?.effectiveInstructionsFilePath ?? "";
+  const instructionsDir = preparedInstructions?.effectiveInstructionsDir ?? "";
   let instructionsPrefix = "";
   let instructionsChars = 0;
-  if (instructionsFilePath) {
+  if (effectiveInstructionsFilePath) {
     try {
-      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
+      const instructionsContents = await fs.readFile(effectiveInstructionsFilePath, "utf8");
       instructionsPrefix =
         `${instructionsContents}\n\n` +
-        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `The above agent instructions were loaded from ${effectiveInstructionsFilePath}. ` +
         `Resolve any relative file references from ${instructionsDir}.\n\n`;
       instructionsChars = instructionsPrefix.length;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
         "stdout",
-        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+        `[paperclip] Warning: could not read agent instructions file "${effectiveInstructionsFilePath}": ${reason}\n`,
       );
     }
   }
   const repoAgentsNote =
     "Codex exec automatically applies repo-scoped AGENTS.md instructions from the current workspace; Paperclip does not currently suppress that discovery.";
   const commandNotes = (() => {
-    if (!instructionsFilePath) {
+    if (!effectiveInstructionsFilePath) {
       return [repoAgentsNote];
     }
+    const stagedNotes = preparedInstructions?.stagedBundleRoot
+      ? [
+          `Staged agent instructions bundle into ${preparedInstructions.stagedBundleRoot} from ${preparedInstructions.sourceInstructionsDir}.`,
+        ]
+      : [];
     if (instructionsPrefix.length > 0) {
       return [
-        `Loaded agent instructions from ${instructionsFilePath}`,
+        ...stagedNotes,
+        `Loaded agent instructions from ${effectiveInstructionsFilePath}`,
         `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
         repoAgentsNote,
       ];
     }
     return [
-      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+      ...stagedNotes,
+      `Configured instructionsFilePath ${effectiveInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
       repoAgentsNote,
     ];
   })();

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -15,6 +15,7 @@ import {
   ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
+  prepareWorkspaceInstructionsBundle,
   resolveCommandForLogs,
   renderTemplate,
   runChildProcess,
@@ -224,39 +225,50 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
 
     const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
-    const resolvedInstructionsFilePath = instructionsFilePath
-      ? path.resolve(cwd, instructionsFilePath)
-      : "";
-    const instructionsDir = resolvedInstructionsFilePath ? `${path.dirname(resolvedInstructionsFilePath)}/` : "";
+    const preparedInstructions = instructionsFilePath
+      ? await prepareWorkspaceInstructionsBundle({
+          cwd,
+          instructionsFilePath,
+          agentId: agent.id,
+          onLog,
+        })
+      : null;
+    const effectiveInstructionsFilePath = preparedInstructions?.effectiveInstructionsFilePath ?? "";
+    const instructionsDir = preparedInstructions?.effectiveInstructionsDir ?? "";
     let instructionsPrefix = "";
-    if (resolvedInstructionsFilePath) {
+    if (effectiveInstructionsFilePath) {
       try {
-        const instructionsContents = await fs.readFile(resolvedInstructionsFilePath, "utf8");
+        const instructionsContents = await fs.readFile(effectiveInstructionsFilePath, "utf8");
         instructionsPrefix =
           `${instructionsContents}\n\n` +
-          `The above agent instructions were loaded from ${resolvedInstructionsFilePath}. ` +
+          `The above agent instructions were loaded from ${effectiveInstructionsFilePath}. ` +
           `Resolve any relative file references from ${instructionsDir}.\n\n`;
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         await onLog(
           "stdout",
-          `[paperclip] Warning: could not read agent instructions file "${resolvedInstructionsFilePath}": ${reason}\n`,
+          `[paperclip] Warning: could not read agent instructions file "${effectiveInstructionsFilePath}": ${reason}\n`,
         );
       }
     }
 
     const commandNotes = (() => {
       const notes = [...preparedRuntimeConfig.notes];
-      if (!resolvedInstructionsFilePath) return notes;
+      if (!effectiveInstructionsFilePath) return notes;
+      if (preparedInstructions?.stagedBundleRoot) {
+        notes.push(
+          `Staged agent instructions bundle into ${preparedInstructions.stagedBundleRoot} from ${preparedInstructions.sourceInstructionsDir}.`,
+        );
+      }
       if (instructionsPrefix.length > 0) {
-        notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
+        notes.push(`Loaded agent instructions from ${effectiveInstructionsFilePath}`);
         notes.push(
           `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
         );
         return notes;
       }
       notes.push(
-        `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+        `Configured instructionsFilePath ${effectiveInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
       );
       return notes;
     })();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: [
+      "packages/adapter-utils",
       "packages/db",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",


### PR DESCRIPTION
## Summary
- stage external instruction bundles into workspace-local `.agents/instructions/<agent-id>` directories before prompt injection
- update `codex_local` and `opencode_local` to read the staged copy and log the staged path for traceability
- add helper coverage for staged and already-in-workspace instruction bundles, and include `adapter-utils` in the root Vitest project list

## Verification
- `corepack pnpm exec vitest run packages/adapter-utils/src/instructions-bundle.test.ts packages/adapters/opencode-local/src/server/runtime-config.test.ts packages/adapters/codex-local/src/server/quota-spawn-error.test.ts`
- `corepack pnpm --filter @paperclipai/adapter-utils typecheck`
- `corepack pnpm --filter @paperclipai/adapter-opencode-local typecheck`
- `corepack pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `corepack pnpm --filter @paperclipai/adapter-utils build`
- `corepack pnpm --filter @paperclipai/adapter-opencode-local build`
- `corepack pnpm --filter @paperclipai/adapter-codex-local build`