### PR TITLE
fix: copy migrations into CLI dist to fix worktree init ENOENT

### DIFF
--- a/cli/esbuild.config.mjs
+++ b/cli/esbuild.config.mjs
@@ -5,7 +5,7 @@
  * External npm packages remain as regular dependencies.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, cpSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -50,6 +50,19 @@ for (const name of externalWorkspacePackages) {
   externals.add(name);
 }
 
+// Post-build plugin: copy DB migrations into dist/ so that
+// import.meta.url-based resolution works from the bundled CLI.
+const copyMigrationsPlugin = {
+  name: "copy-migrations",
+  setup(build) {
+    build.onEnd(() => {
+      const src = resolve(repoRoot, "packages/db/src/migrations");
+      const dest = resolve(__dirname, "dist/migrations");
+      cpSync(src, dest, { recursive: true });
+    });
+  },
+};
+
 /** @type {import('esbuild').BuildOptions} */
 export default {
   entryPoints: ["src/index.ts"],
@@ -62,4 +75,5 @@ export default {
   external: [...externals].sort(),
   treeShaking: true,
   sourcemap: true,
+  plugins: [copyMigrationsPlugin],
 };

--- a/cli/esbuild.config.mjs
+++ b/cli/esbuild.config.mjs
@@ -55,10 +55,19 @@ for (const name of externalWorkspacePackages) {
 const copyMigrationsPlugin = {
   name: "copy-migrations",
   setup(build) {
-    build.onEnd(() => {
-      const src = resolve(repoRoot, "packages/db/src/migrations");
-      const dest = resolve(__dirname, "dist/migrations");
-      cpSync(src, dest, { recursive: true });
+    build.onEnd((result) => {
+      try {
+        const src = resolve(repoRoot, "packages/db/src/migrations");
+        const dest = resolve(__dirname, "dist/migrations");
+        cpSync(src, dest, { recursive: true });
+      } catch (err) {
+        result.errors.push({
+          text: `copy-migrations: ${err instanceof Error ? err.message : String(err)}`,
+          location: null,
+          notes: [],
+          detail: err,
+        });
+      }
     });
   },
 };


### PR DESCRIPTION
## Thinking path
**Project level:** Paperclip CLI (`paperclipai` npm package) is the main entry point for users. It must work out of the box via `npx`.

**Package level:** The CLI bundles `@paperclipai/db` into a single `dist/index.js` via esbuild. The `@paperclipai/db` package uses `import.meta.url` to locate its `migrations/` directory relative to `client.ts`.

**Problem:** After esbuild bundling, `import.meta.url` resolves to the CLI's `dist/index.js` — not the original `@paperclipai/db/dist/client.js`. The relative `./migrations` path then resolves to `paperclipai/dist/migrations`, which doesn't exist in the published package.

**Why it matters:** Every user hitting `npx paperclipai worktree init` or any command that triggers `applyPendingMigrations()` gets an unrecoverable ENOENT crash.

**Fix:** An esbuild `onEnd` plugin copies `packages/db/src/migrations` into `cli/dist/migrations` after every build, placing the files exactly where the bundled `import.meta.url` resolution expects them.

**Benefits:** Zero runtime changes to `@paperclipai/db`. The fix lives entirely in the CLI build pipeline.

**Verification:** Run `npx paperclipai worktree init` and confirm it completes without ENOENT. Inspect `cli/dist/migrations/` to confirm files are present after build.

**Risks:** If migration files in `packages/db/src/migrations` are renamed or restructured, the copy still works (recursive copy). If the directory is removed entirely, the `onEnd` plugin surfaces a clean esbuild error.

## Summary
- Copies `packages/db/src/migrations` into `cli/dist/migrations` after the esbuild bundle step
- Fixes `worktree init` (and any CLI command that calls `applyPendingMigrations`) failing with `ENOENT: no such file or directory, scandir '.../paperclipai/dist/migrations'`

## Root Cause
The CLI bundles `@paperclipai/db` into `dist/index.js` via esbuild. The migration path resolution uses `import.meta.url`, which after bundling resolves to the CLI's `dist/index.js` instead of `@paperclipai/db/dist/client.js`. The relative `./migrations` path then points to a non-existent directory.

## Test plan
- [ ] `npx paperclipai worktree init` completes successfully
- [ ] `npx paperclipai onboard --yes` completes successfully
- [ ] Migrations are applied correctly to the worktree database

Closes #2470