### PR TITLE
fix(routines): include routine execution issues in agent inbox

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -274,6 +274,54 @@ describe("agent permission routes", () => {
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
   });
 
+  it("includes routine executions in the agent inbox-lite view", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: "issue-1",
+        identifier: "PAP-911",
+        title: "Routine heartbeat",
+        status: "in_progress",
+        priority: "critical",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: "2026-04-02T02:22:06.418Z",
+        activeRun: null,
+      },
+    ]);
+
+    const app = createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+      source: "agent_key",
+    });
+
+    const res = await request(app).get("/api/agents/me/inbox-lite");
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(companyId, {
+      assigneeAgentId: agentId,
+      status: "todo,in_progress,blocked",
+      includeRoutineExecutions: true,
+    });
+    expect(res.body).toEqual([
+      {
+        id: "issue-1",
+        identifier: "PAP-911",
+        title: "Routine heartbeat",
+        status: "in_progress",
+        priority: "critical",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: "2026-04-02T02:22:06.418Z",
+        activeRun: null,
+      },
+    ]);
+  });
+
   it("exposes a dedicated agent route for the inbox mine view", async () => {
     mockIssueService.list.mockResolvedValue([
       {
@@ -301,6 +349,7 @@ describe("agent permission routes", () => {
       touchedByUserId: "board-user",
       inboxArchivedByUserId: "board-user",
       status: INBOX_MINE_ISSUE_STATUS_FILTER,
+      includeRoutineExecutions: true,
     });
     expect(res.body).toEqual([
       {

--- a/server/src/__tests__/issue-list-routine-executions-routes.test.ts
+++ b/server/src/__tests__/issue-list-routine-executions-routes.test.ts
@@ -1,0 +1,98 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(),
+  }),
+  goalService: () => ({
+    getById: vi.fn(),
+    getDefaultCompanyGoal: vi.fn(),
+  }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "run-1",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue list route routine-execution visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.list.mockResolvedValue([]);
+  });
+
+  it("includes routine executions by default when an agent requests their own assigned issues", async () => {
+    const app = createApp();
+
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ assigneeAgentId: "agent-1", status: "todo,in_progress,blocked" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith("company-1", {
+      status: "todo,in_progress,blocked",
+      assigneeAgentId: "agent-1",
+      participantAgentId: undefined,
+      assigneeUserId: undefined,
+      touchedByUserId: undefined,
+      inboxArchivedByUserId: undefined,
+      unreadForUserId: undefined,
+      projectId: undefined,
+      executionWorkspaceId: undefined,
+      parentId: undefined,
+      labelId: undefined,
+      originKind: undefined,
+      originId: undefined,
+      includeRoutineExecutions: true,
+      q: undefined,
+    });
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -989,6 +989,7 @@ export function agentRoutes(db: Db) {
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
       status: "todo,in_progress,blocked",
+      includeRoutineExecutions: true,
     });
 
     res.json(
@@ -1019,6 +1020,7 @@ export function agentRoutes(db: Db) {
       touchedByUserId: query.userId,
       inboxArchivedByUserId: query.userId,
       status: query.status,
+      includeRoutineExecutions: true,
     });
 
     res.json(rows);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -295,9 +295,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
 
+    const assigneeAgentId = req.query.assigneeAgentId as string | undefined;
+    const includeRoutineExecutionsExplicit =
+      req.query.includeRoutineExecutions === "true" || req.query.includeRoutineExecutions === "1";
+    const includeRoutineExecutionsImplicit =
+      req.query.includeRoutineExecutions === undefined &&
+      req.actor.type === "agent" &&
+      !!req.actor.agentId &&
+      assigneeAgentId === req.actor.agentId;
+
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
+      assigneeAgentId,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId,
       touchedByUserId,
@@ -309,8 +318,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originId: req.query.originId as string | undefined,
-      includeRoutineExecutions:
-        req.query.includeRoutineExecutions === "true" || req.query.includeRoutineExecutions === "1",
+      includeRoutineExecutions: includeRoutineExecutionsExplicit || includeRoutineExecutionsImplicit,
       q: req.query.q as string | undefined,
     });
     res.json(result);


### PR DESCRIPTION
## Summary
Routine-generated assignments were not visible to agents through the standard inbox/assigned-issue paths unless callers remembered to pass a special include flag. That caused routine execution issues like finance/reporting heartbeats to appear as if the assignee had no work.

## Changes
- include routine execution issues in `/api/agents/me/inbox-lite`
- include routine execution issues in `/api/agents/me/inbox/mine`
- default `/api/companies/:companyId/issues` to include routine executions when an agent is requesting their own assigned issues
- add regression coverage for both routes

## Why
Agents should not need route-specific knowledge to see routine-generated assignments in their normal working queue.
