### PR TITLE
fix(skill): use skill-relative reference paths in paperclip SKILL

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -135,7 +135,7 @@ Authorized managers can install company skills independently of hiring, then ass
 - When hiring or creating an agent, include optional `desiredSkills` so the same assignment model is applied on day one.
 
 If you are asked to install a skill for the company or an agent you MUST read:
-`skills/paperclip/references/company-skills.md`
+`references/company-skills.md`
 
 ## Critical Rules
 
@@ -364,4 +364,4 @@ If you use direct `curl` during these tests, include `X-Paperclip-Run-Id` on all
 
 ## Full Reference
 
-For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `skills/paperclip/references/api-reference.md`
+For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `references/api-reference.md`


### PR DESCRIPTION
## Thinking path
Paperclip skill files are resolved relative to the skill directory. Repo-relative paths (`skills/paperclip/references/...`) break when the agent CWD is not the repository root. Switching to skill-relative paths (`references/...`) ensures references resolve correctly across mount/symlink contexts.

## Summary
Fixes broken reference paths in `skills/paperclip/SKILL.md` by switching from repo-relative paths to skill-relative paths.

- `skills/paperclip/references/company-skills.md` → `references/company-skills.md`
- `skills/paperclip/references/api-reference.md` → `references/api-reference.md`

This aligns with how skills are mounted/symlinked for agents running outside the Paperclip repo root.

Closes #2461.

## Verification
### Steps
1. Opened upstream skill file and confirmed current references are repo-relative.
2. Updated both references to skill-relative paths.
3. Captured before/after screenshots and published evidence images.
4. Verified evidence links return HTTP 200.

### Evidence
- Before: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/paperclip/issue-2461/2026-04-02/before.png
- After: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/paperclip/issue-2461/2026-04-02/after.png
- Verification: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/paperclip/issue-2461/2026-04-02/verification.png

### Result
The Paperclip skill now uses skill-relative reference paths, so linked docs resolve when agent CWD is not the repository root.
