### PR TITLE
docs(openclaw_gateway): document required session-key gateway config

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -43,6 +43,31 @@ The adapter supports the same session routing model as HTTP OpenClaw mode:
 
 Resolved session key is sent as `agent.sessionKey`.
 
+## Required OpenClaw Gateway Config (for custom session keys)
+
+If you use this adapter with per-issue/per-run session keys, your OpenClaw gateway must allow request-provided session keys.
+
+In `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "hooks": {
+    "allowRequestSessionKey": true,
+    "allowedSessionKeyPrefixes": ["agent:", "hook:"]
+  }
+}
+```
+
+Why this is required:
+
+- `allowRequestSessionKey` defaults to `false`; when false, gateway ignores adapter-provided `sessionKey` and falls back to `defaultSessionKey`.
+- `allowedSessionKeyPrefixes` is the allowlist applied when `allowRequestSessionKey=true`.
+- If `defaultSessionKey` is set, its prefix must also be present in `allowedSessionKeyPrefixes` (for example `hook:`), or gateway startup validation can fail.
+
+Without this configuration, routing can appear to work while session isolation is broken because all runs share the default session key.
+
+See also: issue #2293.
+
 ## Payload Mapping
 
 The agent request is built as:
@@ -70,3 +95,14 @@ Structured gateway event logs use:
 - `[openclaw-gateway:event] run=<id> stream=<stream> data=<json>` for `event agent` frames
 
 UI/CLI parsers consume these lines to render transcript updates.
+
+
+## Common Misconfiguration Signals
+
+Symptoms of missing gateway session-key config include:
+
+- runs always land in the same default session
+- cross-task context bleeding between otherwise unrelated issues
+- errors like `agent "X" does not match session key agent "main"` when agent/session prefixes diverge
+
+When this happens, verify the `hooks.allowRequestSessionKey` and `hooks.allowedSessionKeyPrefixes` values first.


### PR DESCRIPTION
## Summary
Documented required OpenClaw gateway hook config for custom session-key routing in:

- `packages/adapters/openclaw-gateway/README.md`

Added:
- required `~/.openclaw/openclaw.json` snippet (`allowRequestSessionKey` + `allowedSessionKeyPrefixes`)
- explanation of why these fields matter
- warning about `defaultSessionKey` prefix validation
- troubleshooting section (`Common Misconfiguration Signals`)

Closes #2293.

## Thinking path
- **Why this fix:** The issue is primarily a docs gap that causes confusing routing behavior in real deployments; the adapter README is the most direct source of truth for operator setup.
- **Alternatives considered:**
  1. Add validation logic in adapter runtime (larger behavioral/code change).
  2. Update only top-level docs (less discoverable for adapter-specific setup).
- **Why chosen approach:** A focused README update is smallest-scope, lowest-risk, and immediately actionable for users currently blocked by undocumented gateway requirements.

## Verification
### Steps
1. Confirmed issue details and absence of existing PR linked to #2293.
2. Updated `packages/adapters/openclaw-gateway/README.md` with required config and troubleshooting notes.
3. Captured before/after screenshots from upstream vs branch.
4. Uploaded evidence images and verified all raw links return HTTP 200.

### Evidence
- Before: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/paperclip/issue-2293/2026-04-02/before.png
- After: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/paperclip/issue-2293/2026-04-02/after.png
- Verification: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/paperclip/issue-2293/2026-04-02/verification.png

### Result
OpenClaw gateway session-key requirements are now explicitly documented where operators configure the adapter, reducing silent misconfiguration and session-isolation failures.
