### PR TITLE
fix(skill): use skill-relative reference docs

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -139,4 +139,4 @@ Before sending a hire request:
 - If board requests revision, update payload and resubmit through approval flow.
 
 For endpoint payload shapes and full examples, read:
-`skills/paperclip-create-agent/references/api-reference.md`
+`references/api-reference.md`

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -135,7 +135,7 @@ Authorized managers can install company skills independently of hiring, then ass
 - When hiring or creating an agent, include optional `desiredSkills` so the same assignment model is applied on day one.
 
 If you are asked to install a skill for the company or an agent you MUST read:
-`skills/paperclip/references/company-skills.md`
+`references/company-skills.md`
 
 ## Critical Rules
 
@@ -364,4 +364,4 @@ If you use direct `curl` during these tests, include `X-Paperclip-Run-Id` on all
 
 ## Full Reference
 
-For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `skills/paperclip/references/api-reference.md`
+For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `references/api-reference.md`


### PR DESCRIPTION
## Summary
- fix paperclip skill reference docs to use skill-relative paths
- fix the same reference pattern in paperclip-create-agent
- avoid file lookup failures when the skill is executed with the skill directory as cwd

## Problem
The skill docs referenced files like `skills/paperclip/references/...`, but in actual execution the cwd can already be the skill directory itself. In that case the runtime resolves a non-existent nested path and fails with a file-not-found error.

## Scope
This change only updates markdown references inside skill docs. There is no runtime or API behavior change beyond making the referenced docs resolvable from the expected skill working directory.

## Testing
- verified the referenced files exist under each skill
- verified the changed paths are now relative to the skill directory
- confirmed the compare view only includes the two affected skill docs
