### PR TITLE
feat(ui): add collapsible org tree to sidebar agents

### DIFF
--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment node
+
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Agent } from "@paperclipai/shared";
+import { describe, expect, it, vi } from "vitest";
+import { SidebarAgents } from "./SidebarAgents";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(({ queryKey }: { queryKey: readonly unknown[] }) => {
+    if (queryKey[0] === "agents") {
+      return { data: [makeAgent("agent-1", "CEO"), makeAgent("agent-2", "Engineer", "agent-1")] };
+    }
+    if (queryKey[0] === "auth") {
+      return { data: { user: { id: "user-1" } } };
+    }
+    if (queryKey[0] === "live-runs") {
+      return { data: [] };
+    }
+    return { data: undefined };
+  }),
+}));
+
+vi.mock("@/lib/router", () => ({
+  NavLink: ({ children, to, className, style, onClick }: React.ComponentProps<"a"> & { to: string }) => (
+    <a href={to} className={className} style={style} onClick={onClick}>
+      {children}
+    </a>
+  ),
+  useLocation: () => ({ pathname: "/agents/ceo" }),
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => ({ openNewAgent: vi.fn() }),
+}));
+
+vi.mock("../context/SidebarContext", () => ({
+  useSidebar: () => ({ isMobile: false, setSidebarOpen: vi.fn() }),
+}));
+
+vi.mock("../hooks/useAgentOrder", () => ({
+  useAgentOrder: ({ agents }: { agents: Agent[] }) => ({ orderedAgents: agents }),
+}));
+
+vi.mock("./AgentIconPicker", () => ({
+  AgentIcon: ({ className }: { className?: string }) => <span className={className} data-agent-icon />,
+}));
+
+vi.mock("./BudgetSidebarMarker", () => ({
+  BudgetSidebarMarker: ({ title }: { title: string }) => <span title={title} />,
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <button type="button" className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+function makeAgent(id: string, name: string, reportsTo: string | null = null): Agent {
+  return {
+    id,
+    companyId: "company-1",
+    name,
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "idle",
+    reportsTo,
+    capabilities: null,
+    adapterType: "process",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    urlKey: name.toLowerCase(),
+  };
+}
+
+describe("SidebarAgents", () => {
+  it("renders expand controls outside the navigation link", () => {
+    const html = renderToStaticMarkup(<SidebarAgents />);
+
+    expect(html).toContain('aria-label="Expand CEO"');
+    expect(html).toContain('href="/agents/ceo"');
+    expect(html).toMatch(/<button[^>]*aria-label="Expand CEO"[\s\S]*<\/button><a href="\/agents\/ceo"/);
+    expect(html).not.toMatch(/<a href="\/agents\/ceo"[\s\S]*<button[^>]*aria-label="Expand CEO"/);
+    expect(html).toMatch(/<button[^>]*aria-label="Expand CEO"[^>]*class="[^"]*cursor-pointer[^"]*"/);
+  });
+});

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, useLocation } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Plus } from "lucide-react";
+import { ChevronRight, CornerDownRight, Plus } from "lucide-react";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
@@ -11,6 +11,12 @@ import { heartbeatsApi } from "../api/heartbeats";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, agentRouteRef, agentUrl } from "../lib/utils";
 import { useAgentOrder } from "../hooks/useAgentOrder";
+import {
+  buildSidebarAgentTree,
+  collectExpandableSidebarAgentIds,
+  normalizeExpandedSidebarAgentIds,
+  type SidebarAgentTreeNode,
+} from "../lib/sidebar-agent-tree";
 import { AgentIcon } from "./AgentIconPicker";
 import { BudgetSidebarMarker } from "./BudgetSidebarMarker";
 import {
@@ -19,6 +25,174 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import type { Agent } from "@paperclipai/shared";
+
+const SIDEBAR_AGENT_TREE_STORAGE_PREFIX = "paperclip.sidebarAgentTree";
+
+function getSidebarAgentTreeStorageKey(companyId: string) {
+  return `${SIDEBAR_AGENT_TREE_STORAGE_PREFIX}:${companyId}`;
+}
+
+function readExpandedSidebarAgentIds(storageKey: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string" && id.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function writeExpandedSidebarAgentIds(storageKey: string, expandedIds: string[]) {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(expandedIds));
+  } catch {
+    // Ignore storage failures in restricted browser contexts.
+  }
+}
+
+type SidebarAgentTreeListProps = {
+  nodes: SidebarAgentTreeNode[];
+  depth?: number;
+  activeAgentId: string | null;
+  activeTab: string | null;
+  isMobile: boolean;
+  onNavigate: () => void;
+  liveCountByAgent: Map<string, number>;
+  expandedAgentIds: Set<string>;
+  onToggleExpanded: (agentId: string) => void;
+};
+
+function SidebarAgentTreeList({
+  nodes,
+  depth = 0,
+  activeAgentId,
+  activeTab,
+  isMobile,
+  onNavigate,
+  liveCountByAgent,
+  expandedAgentIds,
+  onToggleExpanded,
+}: SidebarAgentTreeListProps) {
+  return (
+    <>
+      {nodes.map((node) => (
+        <SidebarAgentTreeItem
+          key={node.agent.id}
+          node={node}
+          depth={depth}
+          activeAgentId={activeAgentId}
+          activeTab={activeTab}
+          isMobile={isMobile}
+          onNavigate={onNavigate}
+          liveCountByAgent={liveCountByAgent}
+          expandedAgentIds={expandedAgentIds}
+          onToggleExpanded={onToggleExpanded}
+        />
+      ))}
+    </>
+  );
+}
+
+type SidebarAgentTreeItemProps = Omit<SidebarAgentTreeListProps, "nodes" | "depth"> & {
+  node: SidebarAgentTreeNode;
+  depth: number;
+};
+
+function SidebarAgentTreeItem({
+  node,
+  depth,
+  activeAgentId,
+  activeTab,
+  isMobile,
+  onNavigate,
+  liveCountByAgent,
+  expandedAgentIds,
+  onToggleExpanded,
+}: SidebarAgentTreeItemProps) {
+  const { agent, children } = node;
+  const hasChildren = children.length > 0;
+  const expanded = hasChildren && expandedAgentIds.has(agent.id);
+  const runCount = liveCountByAgent.get(agent.id) ?? 0;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex items-center gap-2.5 pl-3 text-[13px] font-medium transition-colors",
+          activeAgentId === agentRouteRef(agent)
+            ? "bg-accent text-foreground"
+            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground"
+        )}
+        style={{ paddingLeft: `${depth * 14 + 12}px` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={expanded ? `Collapse ${agent.name}` : `Expand ${agent.name}`}
+            aria-expanded={expanded}
+            className="flex h-3.5 w-3.5 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground/60 hover:bg-accent/60 hover:text-foreground"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleExpanded(agent.id);
+            }}
+          >
+            <ChevronRight className={cn("h-3 w-3 transition-transform", expanded && "rotate-90")} />
+          </button>
+        ) : depth > 0 ? (
+          <span className="flex h-3.5 w-3.5 items-center justify-center text-muted-foreground/35">
+            <CornerDownRight className="h-3 w-3" />
+          </span>
+        ) : (
+          <span className="h-3.5 w-3.5 shrink-0" />
+        )}
+        <NavLink
+          to={activeTab ? `${agentUrl(agent)}/${activeTab}` : agentUrl(agent)}
+          onClick={() => {
+            if (isMobile) onNavigate();
+          }}
+          className="flex min-w-0 flex-1 items-center gap-2.5 py-1.5 pr-3"
+        >
+          <AgentIcon icon={agent.icon} className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
+          <span className="flex-1 truncate">{agent.name}</span>
+          {(agent.pauseReason === "budget" || runCount > 0) && (
+            <span className="ml-auto flex items-center gap-1.5 shrink-0">
+              {agent.pauseReason === "budget" ? (
+                <BudgetSidebarMarker title="Agent paused by budget" />
+              ) : null}
+              {runCount > 0 ? (
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+                </span>
+              ) : null}
+              {runCount > 0 ? (
+                <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
+                  {runCount} live
+                </span>
+              ) : null}
+            </span>
+          )}
+        </NavLink>
+      </div>
+      {hasChildren && expanded ? (
+        <SidebarAgentTreeList
+          nodes={children}
+          depth={depth + 1}
+          activeAgentId={activeAgentId}
+          activeTab={activeTab}
+          isMobile={isMobile}
+          onNavigate={onNavigate}
+          liveCountByAgent={liveCountByAgent}
+          expandedAgentIds={expandedAgentIds}
+          onToggleExpanded={onToggleExpanded}
+        />
+      ) : null}
+    </>
+  );
+}
+
 export function SidebarAgents() {
   const [open, setOpen] = useState(true);
   const { selectedCompanyId } = useCompany();
@@ -63,11 +237,56 @@ export function SidebarAgents() {
     companyId: selectedCompanyId,
     userId: currentUserId,
   });
+  const treeAgents = useMemo(() => buildSidebarAgentTree(orderedAgents), [orderedAgents]);
+  const expandableAgentIds = useMemo(
+    () => collectExpandableSidebarAgentIds(treeAgents),
+    [treeAgents],
+  );
 
   const agentMatch = location.pathname.match(/^\/(?:[^/]+\/)?agents\/([^/]+)(?:\/([^/]+))?/);
   const activeAgentId = agentMatch?.[1] ?? null;
   const activeTab = agentMatch?.[2] ?? null;
+  const storageKey = selectedCompanyId ? getSidebarAgentTreeStorageKey(selectedCompanyId) : null;
+  const [expandedAgentIds, setExpandedAgentIds] = useState<string[]>([]);
 
+  useEffect(() => {
+    const baseExpandedIds = storageKey
+      ? readExpandedSidebarAgentIds(storageKey)
+      : expandableAgentIds;
+    const seededExpandedIds = baseExpandedIds.length > 0 ? baseExpandedIds : expandableAgentIds;
+    const nextExpandedIds = normalizeExpandedSidebarAgentIds(
+      treeAgents,
+      seededExpandedIds,
+      activeAgentId,
+    );
+
+    setExpandedAgentIds((current) => {
+      if (
+        current.length === nextExpandedIds.length &&
+        current.every((id, index) => id === nextExpandedIds[index])
+      ) {
+        return current;
+      }
+      return nextExpandedIds;
+    });
+  }, [activeAgentId, expandableAgentIds, storageKey, treeAgents]);
+
+  const expandedAgentIdSet = useMemo(() => new Set(expandedAgentIds), [expandedAgentIds]);
+
+  const toggleExpandedAgent = useCallback((agentId: string) => {
+    const nextExpandedIds = normalizeExpandedSidebarAgentIds(
+      treeAgents,
+      expandedAgentIds.includes(agentId)
+        ? expandedAgentIds.filter((id) => id !== agentId)
+        : [...expandedAgentIds, agentId],
+      activeAgentId,
+    );
+
+    setExpandedAgentIds(nextExpandedIds);
+    if (storageKey) {
+      writeExpandedSidebarAgentIds(storageKey, nextExpandedIds);
+    }
+  }, [activeAgentId, expandedAgentIds, storageKey, treeAgents]);
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -99,45 +318,16 @@ export function SidebarAgents() {
 
       <CollapsibleContent>
         <div className="flex flex-col gap-0.5 mt-0.5">
-          {orderedAgents.map((agent: Agent) => {
-            const runCount = liveCountByAgent.get(agent.id) ?? 0;
-            return (
-              <NavLink
-                key={agent.id}
-                to={activeTab ? `${agentUrl(agent)}/${activeTab}` : agentUrl(agent)}
-                onClick={() => {
-                  if (isMobile) setSidebarOpen(false);
-                }}
-                className={cn(
-                  "flex items-center gap-2.5 px-3 py-1.5 text-[13px] font-medium transition-colors",
-                  activeAgentId === agentRouteRef(agent)
-                    ? "bg-accent text-foreground"
-                    : "text-foreground/80 hover:bg-accent/50 hover:text-foreground"
-                )}
-              >
-                <AgentIcon icon={agent.icon} className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
-                <span className="flex-1 truncate">{agent.name}</span>
-                {(agent.pauseReason === "budget" || runCount > 0) && (
-                  <span className="ml-auto flex items-center gap-1.5 shrink-0">
-                    {agent.pauseReason === "budget" ? (
-                      <BudgetSidebarMarker title="Agent paused by budget" />
-                    ) : null}
-                    {runCount > 0 ? (
-                      <span className="relative flex h-2 w-2">
-                        <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
-                        <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
-                      </span>
-                    ) : null}
-                    {runCount > 0 ? (
-                      <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
-                        {runCount} live
-                      </span>
-                    ) : null}
-                  </span>
-                )}
-              </NavLink>
-            );
-          })}
+          <SidebarAgentTreeList
+            nodes={treeAgents}
+            activeAgentId={activeAgentId}
+            activeTab={activeTab}
+            isMobile={isMobile}
+            onNavigate={() => setSidebarOpen(false)}
+            liveCountByAgent={liveCountByAgent}
+            expandedAgentIds={expandedAgentIdSet}
+            onToggleExpanded={toggleExpandedAgent}
+          />
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/ui/src/lib/sidebar-agent-tree.test.ts
+++ b/ui/src/lib/sidebar-agent-tree.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { Agent } from "@paperclipai/shared";
+import {
+  buildSidebarAgentTree,
+  collectExpandableSidebarAgentIds,
+  normalizeExpandedSidebarAgentIds,
+} from "./sidebar-agent-tree";
+
+function makeAgent(id: string, name: string, reportsTo: string | null = null): Agent {
+  return {
+    id,
+    companyId: "company-1",
+    name,
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "idle",
+    reportsTo,
+    capabilities: null,
+    adapterType: "process",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    urlKey: name.toLowerCase(),
+  };
+}
+
+describe("buildSidebarAgentTree", () => {
+  it("nests reports under their manager while preserving sibling order", () => {
+    const ceo = makeAgent("agent-1", "CEO");
+    const cto = makeAgent("agent-2", "CTO", ceo.id);
+    const cmo = makeAgent("agent-3", "CMO", ceo.id);
+    const engineer = makeAgent("agent-4", "Engineer", cto.id);
+
+    const tree = buildSidebarAgentTree([ceo, cmo, cto, engineer]);
+
+    expect(tree.map((node) => node.agent.name)).toEqual(["CEO"]);
+    expect(tree[0]?.children.map((node) => node.agent.name)).toEqual(["CMO", "CTO"]);
+    expect(tree[0]?.children[1]?.children.map((node) => node.agent.name)).toEqual(["Engineer"]);
+  });
+
+  it("keeps agents with missing managers visible at the root", () => {
+    const orphan = makeAgent("agent-1", "Orphan", "missing-manager");
+    const root = makeAgent("agent-2", "Root");
+
+    const tree = buildSidebarAgentTree([orphan, root]);
+
+    expect(tree.map((node) => node.agent.name)).toEqual(["Orphan", "Root"]);
+  });
+});
+
+describe("sidebar agent tree expansion helpers", () => {
+  it("returns only managers as expandable ids", () => {
+    const ceo = makeAgent("agent-1", "CEO");
+    const cto = makeAgent("agent-2", "CTO", ceo.id);
+    const engineer = makeAgent("agent-3", "Engineer", cto.id);
+    const tree = buildSidebarAgentTree([ceo, cto, engineer]);
+
+    expect(collectExpandableSidebarAgentIds(tree)).toEqual([ceo.id, cto.id]);
+  });
+
+  it("forces the active agent ancestor chain to stay expanded", () => {
+    const ceo = makeAgent("agent-1", "CEO");
+    const cto = makeAgent("agent-2", "CTO", ceo.id);
+    const engineer = makeAgent("agent-3", "Engineer", cto.id);
+    const tree = buildSidebarAgentTree([ceo, cto, engineer]);
+
+    expect(normalizeExpandedSidebarAgentIds(tree, [], engineer.id)).toEqual([ceo.id, cto.id]);
+  });
+
+  it("filters out ids that are not expandable managers", () => {
+    const ceo = makeAgent("agent-1", "CEO");
+    const cto = makeAgent("agent-2", "CTO", ceo.id);
+    const engineer = makeAgent("agent-3", "Engineer", cto.id);
+    const tree = buildSidebarAgentTree([ceo, cto, engineer]);
+
+    expect(normalizeExpandedSidebarAgentIds(tree, [engineer.id, "missing", ceo.id], null)).toEqual([ceo.id]);
+  });
+});

--- a/ui/src/lib/sidebar-agent-tree.ts
+++ b/ui/src/lib/sidebar-agent-tree.ts
@@ -1,0 +1,90 @@
+import type { Agent } from "@paperclipai/shared";
+
+export interface SidebarAgentTreeNode {
+  agent: Agent;
+  children: SidebarAgentTreeNode[];
+}
+
+export function buildSidebarAgentTree(agents: Agent[]): SidebarAgentTreeNode[] {
+  if (agents.length === 0) return [];
+
+  const nodes = new Map<string, SidebarAgentTreeNode>();
+  for (const agent of agents) {
+    nodes.set(agent.id, { agent, children: [] });
+  }
+
+  const roots: SidebarAgentTreeNode[] = [];
+  for (const agent of agents) {
+    const node = nodes.get(agent.id);
+    if (!node) continue;
+
+    const parent = agent.reportsTo ? nodes.get(agent.reportsTo) : null;
+    if (!parent || parent === node) {
+      roots.push(node);
+      continue;
+    }
+
+    parent.children.push(node);
+  }
+
+  return roots;
+}
+
+export function collectExpandableSidebarAgentIds(nodes: SidebarAgentTreeNode[]): string[] {
+  const ids: string[] = [];
+
+  const walk = (node: SidebarAgentTreeNode) => {
+    if (node.children.length > 0) {
+      ids.push(node.agent.id);
+      node.children.forEach(walk);
+    }
+  };
+
+  nodes.forEach(walk);
+  return ids;
+}
+
+export function findSidebarAgentAncestorIds(
+  nodes: SidebarAgentTreeNode[],
+  targetAgentId: string | null,
+): string[] {
+  if (!targetAgentId) return [];
+
+  const visit = (node: SidebarAgentTreeNode, ancestors: string[]): string[] | null => {
+    if (node.agent.id === targetAgentId) {
+      return ancestors;
+    }
+
+    for (const child of node.children) {
+      const result = visit(child, [...ancestors, node.agent.id]);
+      if (result) return result;
+    }
+
+    return null;
+  };
+
+  for (const node of nodes) {
+    const result = visit(node, []);
+    if (result) return result;
+  }
+
+  return [];
+}
+
+export function normalizeExpandedSidebarAgentIds(
+  nodes: SidebarAgentTreeNode[],
+  expandedIds: string[],
+  activeAgentId: string | null,
+): string[] {
+  const expandableIds = new Set(collectExpandableSidebarAgentIds(nodes));
+  const normalized = expandedIds.filter((id) => expandableIds.has(id));
+  const normalizedSet = new Set(normalized);
+
+  for (const id of findSidebarAgentAncestorIds(nodes, activeAgentId)) {
+    if (!expandableIds.has(id) || normalizedSet.has(id)) continue;
+    normalized.push(id);
+    normalizedSet.add(id);
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
  ## Thinking Path

  > - Paperclip is the control plane that orchestrates AI agents operating inside zero-human companies.
  > - In the board UI, the sidebar is one of the primary navigation surfaces for understanding and moving through a company’s
  structure.
  > - Agents already have a reporting hierarchy in the data model, and the org pages already expose that hierarchy as a tree.
  > - The sidebar agent list, however, was still rendered as a flat list, which made larger orgs harder to scan and disconnected
  the primary navigation from the actual org structure.
  > - That gap becomes more noticeable as companies add more managers and direct reports, because the sidebar stops reflecting
  who owns whom.
  > - This pull request updates the sidebar to render agents as a nested org tree with per-manager expand/collapse controls.
  > - It also keeps the active agent’s ancestor chain expanded and persists expansion state per company so navigation remains
  stable across reloads.
  > - The benefit is a sidebar that matches the real org model, scales better for larger teams, and remains practical to use
  during day-to-day navigation.

  ## What Changed

  - Rendered the sidebar agent list as a nested org tree instead of a flat list.
  - Added a tree-building utility for sidebar agents based on `reportsTo`.
  - Added per-manager expand/collapse controls for agent subtrees.
  - Kept the active agent’s ancestor chain expanded so the current page never disappears from view.
  - Persisted expanded sidebar tree state in local storage on a per-company basis.
  - Preserved existing sidebar behaviors, including active tab routing, mobile sidebar closing, live run indicators, and budget
  markers.
  - Added focused tests for sidebar tree construction and expansion-state normalization.

  ## Verification

  - Ran:
    - `pnpm test:run ui/src/lib/sidebar-agent-tree.test.ts`
    - `pnpm --filter @paperclipai/ui typecheck`
    - `pnpm --filter @paperclipai/ui build`
  - Manual verification:
    - Open the board UI and confirm the `Agents` sidebar section now renders parent/child relationships.
    - Verify managers with direct reports show expand/collapse controls.
    - Verify clicking the expand/collapse control does not navigate away.
    - Verify navigating to a nested agent automatically expands that agent’s ancestor chain.
    - Verify expansion state is preserved after a page reload for the same company.
  - Before/after screenshots:
      - Before
        <img width="418" height="908" alt="image" src="https://github.com/user-attachments/assets/6539d648-c8a2-4410-8537-086bddc2a741" />

      - After
        <img width="470" height="908" alt="image" src="https://github.com/user-attachments/assets/85281def-e04c-46fc-a100-af3138dee519" />

  ## Risks

  - Low risk overall because the change is isolated to sidebar presentation logic and local UI state.
  - The main behavioral shift is that nested subtrees can now be collapsed, so any regression would most likely affect
  discoverability of agents in the sidebar.
  - To reduce that risk, the active agent’s ancestor chain is forced open and expansion state is normalized against the current
  tree.
  - No schema, API contract, or migration changes are involved.

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [ ] I have run tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [x] If this change affects the UI, I have included before/after screenshots
  - [ ] I have updated relevant documentation to reflect my changes
  - [x] I have considered and documented any risks above
  - [x] I will address all Greptile and reviewer comments before requesting merge
