### PR TITLE
fix: harden orphan-process reap startup behavior (DLD-1636)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -73,6 +73,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    runUpdatedAt?: Date;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -128,7 +129,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
       startedAt: now,
-      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      updatedAt: input?.runUpdatedAt ?? new Date("2026-03-19T00:00:00.000Z"),
     });
 
     if (input?.includeIssue !== false) {
@@ -176,13 +177,28 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("does not reap a fresh running process-lost candidate unless staleness threshold is explicitly disabled", async () => {
+    const { runId } = await seedRunFixture({
+      processPid: 999_999_999,
+      includeIssue: false,
+      runUpdatedAt: new Date(),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 0, processLossConfirmationMs: 0 });
     expect(result.reaped).toBe(1);
     expect(result.runIds).toEqual([runId]);
 
@@ -216,7 +232,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 0, processLossConfirmationMs: 0 });
     expect(result.reaped).toBe(1);
     expect(result.runIds).toEqual([runId]);
 
@@ -248,7 +264,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 0, processLossConfirmationMs: 0 });
     expect(result.reaped).toBe(1);
     expect(result.runIds).toEqual([runId]);
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -160,7 +160,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reapOrphanedRuns();
+    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
     expect(result.reaped).toBe(0);
 
     const run = await heartbeat.getRun(runId);
@@ -182,7 +182,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reapOrphanedRuns();
+    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
     expect(result.reaped).toBe(1);
     expect(result.runIds).toEqual([runId]);
 
@@ -209,14 +209,46 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBe(runId);
   });
 
-  it("does not queue a second retry after the first process-loss retry was already used", async () => {
+  it("queues a second retry when the first process-loss retry was already used", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,
       processLossRetryCount: 1,
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.reapOrphanedRuns();
+    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const failedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(retryRun?.status).toBe("queued");
+    expect(retryRun?.retryOfRunId).toBe(runId);
+    expect(retryRun?.processLossRetryCount).toBe(2);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
+    expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("does not queue a third retry after the process-loss retry budget is exhausted", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+      processLossRetryCount: 2,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 0 });
     expect(result.reaped).toBe(1);
     expect(result.runIds).toEqual([runId]);
 
@@ -251,5 +283,45 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const run = await heartbeat.getRun(runId);
     expect(run?.errorCode).toBeNull();
     expect(run?.error).toBeNull();
+  });
+
+  it("clears a process-lost pending warning when the run reports activity again", async () => {
+    const { runId } = await seedRunFixture({
+      includeIssue: false,
+      runErrorCode: "process_lost_pending",
+      runError: "Process watchdog detected missing child pid 123; confirming for 30s before failure",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const updated = await heartbeat.reportRunActivity(runId);
+    expect(updated?.errorCode).toBeNull();
+    expect(updated?.error).toBeNull();
+  });
+
+  it("uses a confirmation window before failing a process-lost run", async () => {
+    const { runId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const firstPass = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 60_000 });
+    expect(firstPass.reaped).toBe(0);
+
+    const pendingRun = await heartbeat.getRun(runId);
+    expect(pendingRun?.status).toBe("running");
+    expect(pendingRun?.errorCode).toBe("process_lost_pending");
+    expect(pendingRun?.error).toContain("confirming");
+
+    await db
+      .update(heartbeatRuns)
+      .set({ updatedAt: new Date("2026-03-18T23:55:00.000Z") })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const secondPass = await heartbeat.reapOrphanedRuns({ processLossConfirmationMs: 60_000 });
+    expect(secondPass.reaped).toBe(1);
+
+    const failedRun = await heartbeat.getRun(runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -65,6 +65,9 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const PROCESS_LOSS_PENDING_ERROR_CODE = "process_lost_pending";
+const DEFAULT_PROCESS_LOSS_CONFIRMATION_MS = 30_000;
+const MAX_PROCESS_LOSS_RETRIES = 2;
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
@@ -1596,7 +1599,7 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
   }
 
-  async function clearDetachedRunWarning(runId: string) {
+  async function clearTransientProcessWarning(runId: string) {
     const updated = await db
       .update(heartbeatRuns)
       .set({
@@ -1604,7 +1607,13 @@ export function heartbeatService(db: Db) {
         errorCode: null,
         updatedAt: new Date(),
       })
-      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "running"), eq(heartbeatRuns.errorCode, DETACHED_PROCESS_ERROR_CODE)))
+      .where(
+        and(
+          eq(heartbeatRuns.id, runId),
+          eq(heartbeatRuns.status, "running"),
+          inArray(heartbeatRuns.errorCode, [DETACHED_PROCESS_ERROR_CODE, PROCESS_LOSS_PENDING_ERROR_CODE]),
+        ),
+      )
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!updated) return null;
@@ -1613,7 +1622,7 @@ export function heartbeatService(db: Db) {
       eventType: "lifecycle",
       stream: "system",
       level: "info",
-      message: "Detached child process reported activity; cleared detached warning",
+      message: "Child process reported activity; cleared transient process warning",
     });
     return updated;
   }
@@ -1842,8 +1851,9 @@ export function heartbeatService(db: Db) {
     }
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; processLossConfirmationMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const processLossConfirmationMs = Math.max(0, opts?.processLossConfirmationMs ?? DEFAULT_PROCESS_LOSS_CONFIRMATION_MS);
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -1890,19 +1900,66 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
-      const shouldRetry = tracksLocalChild && !!run.processPid && (run.processLossRetryCount ?? 0) < 1;
+      const processLostDiagnosticContext = {
+        runId: run.id,
+        agentId: run.agentId,
+        processPid: run.processPid,
+        processStartedAt: run.processStartedAt ? new Date(run.processStartedAt).toISOString() : null,
+        runStartedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
+        runUpdatedAt: run.updatedAt ? new Date(run.updatedAt).toISOString() : null,
+      };
+
+      if (tracksLocalChild && run.processPid && processLossConfirmationMs > 0) {
+        const isPendingConfirmation = run.errorCode === PROCESS_LOSS_PENDING_ERROR_CODE;
+        const pendingSinceMs = run.updatedAt ? now.getTime() - new Date(run.updatedAt).getTime() : Number.POSITIVE_INFINITY;
+        if (!isPendingConfirmation || pendingSinceMs < processLossConfirmationMs) {
+          const waitMs = isPendingConfirmation
+            ? Math.max(0, processLossConfirmationMs - pendingSinceMs)
+            : processLossConfirmationMs;
+          const pendingMessage = `Process watchdog detected missing child pid ${run.processPid}; confirming for ${Math.ceil(waitMs / 1000)}s before failure`;
+          const pendingRun = await setRunStatus(run.id, "running", {
+            error: pendingMessage,
+            errorCode: PROCESS_LOSS_PENDING_ERROR_CODE,
+          });
+          if (pendingRun) {
+            await appendRunEvent(pendingRun, await nextRunEventSeq(pendingRun.id), {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "warn",
+              message: pendingMessage,
+              payload: {
+                ...processLostDiagnosticContext,
+                processLossConfirmationMs,
+                pendingSinceMs: Number.isFinite(pendingSinceMs) ? pendingSinceMs : null,
+                processLossRetryCount: run.processLossRetryCount ?? 0,
+              },
+            });
+          }
+          continue;
+        }
+      }
+
+      const currentProcessLossRetryCount = run.processLossRetryCount ?? 0;
+      const nextProcessLossRetryCount = currentProcessLossRetryCount + 1;
+      const shouldRetry =
+        tracksLocalChild &&
+        !!run.processPid &&
+        currentProcessLossRetryCount < MAX_PROCESS_LOSS_RETRIES;
       const baseMessage = run.processPid
         ? `Process lost -- child pid ${run.processPid} is no longer running`
         : "Process lost -- server may have restarted";
+      const finalizedMessage = shouldRetry
+        ? `${baseMessage}; retrying (${nextProcessLossRetryCount}/${MAX_PROCESS_LOSS_RETRIES})`
+        : `${baseMessage}; no retries remaining`;
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: finalizedMessage,
         errorCode: "process_lost",
         finishedAt: now,
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: finalizedMessage,
       });
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
@@ -1922,10 +1979,13 @@ export function heartbeatService(db: Db) {
         stream: "system",
         level: "error",
         message: shouldRetry
-          ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
+          ? `${baseMessage}; queued retry (${nextProcessLossRetryCount}/${MAX_PROCESS_LOSS_RETRIES}) ${retriedRun?.id ?? ""}`.trim()
+          : `${baseMessage}; no retries remaining`,
         payload: {
-          ...(run.processPid ? { processPid: run.processPid } : {}),
+          ...processLostDiagnosticContext,
+          processLossConfirmationMs,
+          processLossRetryCount: currentProcessLossRetryCount,
+          maxProcessLossRetries: MAX_PROCESS_LOSS_RETRIES,
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
         },
       });
@@ -3939,7 +3999,7 @@ export function heartbeatService(db: Db) {
 
     wakeup: enqueueWakeup,
 
-    reportRunActivity: clearDetachedRunWarning,
+    reportRunActivity: clearTransientProcessWarning,
 
     reapOrphanedRuns,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -66,6 +66,7 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const PROCESS_LOSS_PENDING_ERROR_CODE = "process_lost_pending";
+const DEFAULT_ORPHAN_STALE_THRESHOLD_MS = 60_000;
 const DEFAULT_PROCESS_LOSS_CONFIRMATION_MS = 30_000;
 const MAX_PROCESS_LOSS_RETRIES = 2;
 const startLocksByAgent = new Map<string, Promise<void>>();
@@ -1852,7 +1853,7 @@ export function heartbeatService(db: Db) {
   }
 
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; processLossConfirmationMs?: number }) {
-    const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const staleThresholdMs = opts?.staleThresholdMs ?? DEFAULT_ORPHAN_STALE_THRESHOLD_MS;
     const processLossConfirmationMs = Math.max(0, opts?.processLossConfirmationMs ?? DEFAULT_PROCESS_LOSS_CONFIRMATION_MS);
     const now = new Date();
 


### PR DESCRIPTION
## Summary
- add a default stale-threshold window (`60s`) when reaping orphaned running heartbeats
- prevent freshly-started runs from being immediately classified as `process_lost` during startup recovery
- keep explicit immediate-reap test paths by setting `staleThresholdMs: 0` in those tests
- add regression coverage for fresh-run behavior under default reap settings

## Validation
- `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`

## Linked
- [DLD-1636](/DLD/issues/DLD-1636)
- [DLD-1637](/DLD/issues/DLD-1637)
