### PR TITLE
fix(adapters/claude-local): classify quota exhaustion as recoverable failure

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -28,6 +28,7 @@ import {
   detectClaudeLoginRequired,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
+  isClaudeQuotaExhausted,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
@@ -561,7 +562,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (proc.exitCode ?? 0) === 0
           ? null
           : describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`,
-      errorCode: loginMeta.requiresLogin ? "claude_auth_required" : null,
+      errorCode: loginMeta.requiresLogin
+        ? "claude_auth_required"
+        : isClaudeQuotaExhausted(parsed)
+          ? "provider_quota_exhausted"
+          : null,
       errorMeta,
       usage,
       sessionId: resolvedSessionId,

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -6,6 +6,7 @@ export {
   describeClaudeFailure,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
+  isClaudeQuotaExhausted,
 } from "./parse.js";
 export {
   getQuotaWindows,

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -167,6 +167,24 @@ export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | 
   return /max(?:imum)?\s+turns?/i.test(resultText);
 }
 
+/**
+ * Detect provider quota / extra-usage exhaustion from the Claude result.
+ *
+ * Known patterns:
+ *   "You're out of extra usage · resets 2am (Europe/Warsaw)"
+ *   "You've exceeded your usage limit"
+ *   "out of usage"
+ */
+export function isClaudeQuotaExhausted(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+  const resultText = asString(parsed.result, "").trim();
+  const errors = extractClaudeErrorMessages(parsed);
+  const allMessages = [resultText, ...errors].map((m) => m.trim()).filter(Boolean);
+  return allMessages.some((msg) =>
+    /out of (?:extra )?usage|exceeded your usage limit|usage limit reached/i.test(msg),
+  );
+}
+
 export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]

--- a/server/src/__tests__/claude-local-adapter.test.ts
+++ b/server/src/__tests__/claude-local-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isClaudeMaxTurnsResult } from "@paperclipai/adapter-claude-local/server";
+import { isClaudeMaxTurnsResult, isClaudeQuotaExhausted } from "@paperclipai/adapter-claude-local/server";
 import { parseClaudeStdoutLine } from "@paperclipai/adapter-claude-local/ui";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 
@@ -28,6 +28,47 @@ describe("claude_local max-turn detection", () => {
         stop_reason: "end_turn",
       }),
     ).toBe(false);
+  });
+});
+
+describe("claude_local quota exhaustion detection", () => {
+  it("detects 'out of extra usage' message", () => {
+    expect(
+      isClaudeQuotaExhausted({
+        subtype: "success",
+        result: "You're out of extra usage · resets 2am (Europe/Warsaw)",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects 'out of usage' without 'extra'", () => {
+    expect(
+      isClaudeQuotaExhausted({
+        result: "You're out of usage for today.",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects 'exceeded your usage limit'", () => {
+    expect(
+      isClaudeQuotaExhausted({
+        result: "You've exceeded your usage limit",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for normal success", () => {
+    expect(
+      isClaudeQuotaExhausted({
+        subtype: "success",
+        result: "Done. All tests pass.",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isClaudeQuotaExhausted(null)).toBe(false);
+    expect(isClaudeQuotaExhausted(undefined)).toBe(false);
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1799,6 +1799,7 @@ export function heartbeatService(db: Db) {
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+    opts?: { errorCode?: string | null },
   ) {
     const existing = await getAgent(agentId);
     if (!existing) return;
@@ -1808,10 +1809,13 @@ export function heartbeatService(db: Db) {
     }
 
     const runningCount = await countRunningRunsForAgent(agentId);
+    // Provider quota exhaustion is a transient, self-recovering condition —
+    // keep the agent idle so the dashboard doesn't show a spurious error.
+    const recoverable = opts?.errorCode === "provider_quota_exhausted";
     const nextStatus =
       runningCount > 0
         ? "running"
-        : outcome === "succeeded" || outcome === "cancelled"
+        : outcome === "succeeded" || outcome === "cancelled" || recoverable
           ? "idle"
           : "error";
 
@@ -2856,7 +2860,9 @@ export function heartbeatService(db: Db) {
           }
         }
       }
-      await finalizeAgentStatus(agent.id, outcome);
+      await finalizeAgentStatus(agent.id, outcome, {
+        errorCode: adapterResult.errorCode ?? null,
+      });
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents via local adapter processes
> - claude_local agents periodically hit Anthropic provider quota limits
> - When this happens, the run fails and the agent transitions to error status
> - Timer-triggered recovery runs cause the agent to oscillate between running and error
> - This PR classifies quota exhaustion as a recoverable failure so the agent stays idle instead of error

## What

1. **`packages/adapters/claude-local/src/server/parse.ts`** -- Added `isClaudeQuotaExhausted()` detector that matches known quota/usage-limit patterns in Claude CLI result text.

2. **`packages/adapters/claude-local/src/server/execute.ts`** -- When `isClaudeQuotaExhausted()` is true, the adapter returns `errorCode: "provider_quota_exhausted"` instead of null (which previously defaulted to `"adapter_failed"`).

3. **`packages/adapters/claude-local/src/server/index.ts`** -- Exported the new `isClaudeQuotaExhausted` function.

4. **`server/src/services/heartbeat.ts`** -- `finalizeAgentStatus()` now accepts an optional `errorCode` parameter. When the code is `"provider_quota_exhausted"`, the agent transitions to `idle` instead of `error`.

5. **`server/src/__tests__/claude-local-adapter.test.ts`** -- Added 5 test cases covering quota exhaustion detection (positive and negative).

## Why

Quota exhaustion is not an agent malfunction -- it is a transient provider-side limit that auto-resolves when the window resets. Treating it as `error` creates noise and false alarms, and causes agents to oscillate between `error` and `running` on each timer cycle.

## How to verify

```bash
npx tsc --noEmit
npx vitest run src/__tests__/claude-local-adapter.test.ts
```

All 10 tests pass (5 existing + 5 new).

## Risks

- **Low**: Narrowly scoped to a single error code. All other failure modes behave exactly as before.
- **Edge case**: If a quota-exhausted agent has queued work, the "idle" status could be briefly misleading -- but the run history still shows the failure.