### PR TITLE
fix(server): isolate worktree port writeback test from host DATABASE_URL/PORT env vars

### DIFF
--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -397,6 +397,8 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_HOME = isolatedHome;
     process.env.PAPERCLIP_INSTANCE_ID = "pap-878-create-a-mine-tab-in-inbox";
     process.env.PAPERCLIP_CONFIG = configPath;
+    delete process.env.DATABASE_URL;
+    delete process.env.PORT;
 
     maybePersistWorktreeRuntimePorts({
       serverPort: 3103,


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents for autonomous companies
> - The worktree-config module handles port allocation and persistence for isolated worktree instances
> - The maybePersistWorktreeRuntimePorts function guards database port writes behind !nonEmpty(process.env.DATABASE_URL)
> - The "persists runtime-selected worktree ports back into config" test fails on machines with DATABASE_URL set in the host environment because it does not clear that env var before testing
> - This fix deletes DATABASE_URL and PORT from process.env in the test, matching the pattern used by other tests for env isolation

## What

Delete `DATABASE_URL` and `PORT` from `process.env` in the "persists runtime-selected worktree ports back into config" test before calling `maybePersistWorktreeRuntimePorts`.

## Why

On machines where `DATABASE_URL` is set (e.g. `postgres://paperclip:paperclip@localhost:5432/paperclip`), the function's `allowDatabasePortWrite: !nonEmpty(process.env.DATABASE_URL)` evaluates to `false`, causing the database port to remain at `54331` instead of being updated to `54335`.

The bug is in the **test** (missing env isolation), not in the **logic** -- the production guard is correct.

## How to verify

```bash
pnpm exec vitest run server/src/__tests__/worktree-config.test.ts
```

All 5 tests pass after the fix. Previously, "persists runtime-selected worktree ports back into config" failed with `expected 54331 to be 54335` when `DATABASE_URL` was set in the host environment.

## Risks

- Minimal. Only deletes two env vars within a single test case, restored by the existing `afterEach` cleanup.