### PR TITLE
fix: cache materialised GitHub skills to avoid re-fetch on every heartbeat run

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2048,9 +2048,15 @@ export function companySkillService(db: Db) {
       const sourceKind = asString(getSkillMeta(skill).sourceKind);
       let source = normalizeSkillDirectory(skill);
       if (!source) {
-        source = options.materializeMissing === false
-          ? resolveRuntimeSkillMaterializedPath(companyId, skill)
-          : await materializeRuntimeSkillFiles(companyId, skill).catch(() => null);
+        const cachedPath = resolveRuntimeSkillMaterializedPath(companyId, skill);
+        const cachedStat = await fs.stat(cachedPath).catch(() => null);
+        if (cachedStat?.isDirectory()) {
+          source = cachedPath;
+        } else if (options.materializeMissing === false) {
+          source = cachedPath;
+        } else {
+          source = await materializeRuntimeSkillFiles(companyId, skill).catch(() => null);
+        }
       }
       if (!source) continue;
 


### PR DESCRIPTION
## Summary

- Cache materialised GitHub skill directories on disk so they're only fetched once from `raw.githubusercontent.com`, not on every heartbeat run
- Subsequent runs use the existing `__runtime__` directory via `fs.stat` check, bypassing the expensive `materializeRuntimeSkillFiles` → `readFile` → HTTP fetch chain
- Cache is naturally invalidated when skills are updated/re-imported (which deletes the runtime directory)

Closes #2507

## Problem

`listRuntimeSkillEntries()` called `materializeRuntimeSkillFiles()` for every GitHub-sourced skill on every heartbeat run. Each materialisation fetched files individually from GitHub over HTTP. With 60+ GitHub skills, this added 3-5 minutes of blocking I/O to the `executeRun` setup phase — before the adapter could even spawn a process. Runs appeared permanently stuck (`processPid: null`, no logs) and were often killed by the orphan reaper.

## Change

In `listRuntimeSkillEntries`, before calling `materializeRuntimeSkillFiles`, check if the `__runtime__` cache directory already exists:

```ts
const cachedPath = resolveRuntimeSkillMaterializedPath(companyId, skill);
const cachedStat = await fs.stat(cachedPath).catch(() => null);
if (cachedStat?.isDirectory()) {
  source = cachedPath;
} else {
  source = await materializeRuntimeSkillFiles(...);
}
```

## Test plan

- [ ] Install 50+ GitHub-sourced skills via Skills Manager
- [ ] Trigger a heartbeat run — first run materialises skills (slow, expected)
- [ ] Trigger a second run — should start within seconds (cache hit)
- [ ] Update a GitHub skill via the UI — verify the updated content is used on the next run (cache invalidated by re-import)
- [ ] Verify `pnpm -r typecheck` passes

Made with [Cursor](https://cursor.com)