### PR TITLE
fix(ui): inbox badge should only count unread mine issues

### DIFF
--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -319,6 +319,21 @@ describe("inbox helpers", () => {
     });
   });
 
+  it("excludes read mine issues from the inbox badge count", () => {
+    const result = computeInboxBadgeData({
+      approvals: [],
+      joinRequests: [],
+      dashboard,
+      heartbeatRuns: [],
+      mineIssues: [makeIssue("1", false), makeIssue("2", false), makeIssue("3", true)],
+      dismissed: new Set<string>(),
+    });
+
+    expect(result.mineIssues).toBe(1);
+    // inbox = mineIssues(1) + agent-error alert(1) + budget alert(1)
+    expect(result.inbox).toBe(3);
+  });
+
   it("keeps read issues in the touched list but excludes them from unread counts", () => {
     const issues = [makeIssue("1", true), makeIssue("2", false)];
 

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -362,7 +362,7 @@ export function computeInboxBadgeData({
   const visibleJoinRequests = joinRequests.filter(
     (jr) => !dismissed.has(`join:${jr.id}`),
   ).length;
-  const visibleMineIssues = mineIssues.length;
+  const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Human users oversee agents through the web UI, including a sidebar inbox
> - The inbox badge shows a count of items needing attention (unread issues, approvals, errors, etc.)
> - But the badge was counting **all** "mine" issues instead of only unread ones
> - This caused the badge to show e.g. 14 even when the Unread tab was empty
> - This PR filters `mineIssues` by `isUnreadForMe` in `computeInboxBadgeData`
> - The benefit is the badge now accurately reflects what the user sees in the Unread tab

## What Changed

- In `ui/src/lib/inbox.ts`: changed `mineIssues.length` to `mineIssues.filter((issue) => issue.isUnreadForMe).length`
- Added test case in `ui/src/lib/inbox.test.ts` verifying read mine issues are excluded from badge count

## Verification

- `pnpm test` — all 15 inbox tests pass
- API check: `sidebar-badges` returns `inbox: 0` when `mineIssues` has 14 items but `unreadIssues` has 0
- Before: badge shows 14 (all mine issues). After: badge shows 0 (only unread mine issues)

## Risks

- Low risk. Single-line logic change with test coverage. Only affects badge count display, not issue data.

## Model Used

- Anthropic Claude Opus 4.6 (`claude-opus-4-6`), with tool use via Claude Code CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge