### PR TITLE
feat: add Slack stakeholder progress notifications

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -133,6 +133,19 @@ Configure storage provider/settings:
 pnpm paperclipai configure --section storage
 ```
 
+## Optional Slack stakeholder progress notifications
+
+To emit Slack notifications when issues move to `done`, `blocked`, or get handed back to the requesting user, set a Slack Incoming Webhook in local env/runtime config:
+
+```sh
+PAPERCLIP_STAKEHOLDER_PROGRESS_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+```
+
+Notes:
+
+- Do not commit webhook URLs to the repo.
+- Message links use `PAPERCLIP_PUBLIC_URL` when set; otherwise Paperclip falls back to the current request host / `PAPERCLIP_API_URL`.
+
 ## Default Agent Workspaces
 
 When a local agent run has no resolved project/session workspace, Paperclip falls back to an agent home workspace under the instance root:

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -29,6 +29,7 @@ const mockAgentService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockNotifyIssueStakeholderProgress = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
@@ -40,6 +41,7 @@ vi.mock("../services/index.js", () => ({
   issueApprovalService: () => ({}),
   issueService: () => mockIssueService,
   logActivity: mockLogActivity,
+  notifyIssueStakeholderProgress: mockNotifyIssueStakeholderProgress,
   projectService: () => ({}),
   routineService: () => ({
     syncRunStatusForIssue: vi.fn(async () => undefined),

--- a/server/src/__tests__/issue-document-restore-routes.test.ts
+++ b/server/src/__tests__/issue-document-restore-routes.test.ts
@@ -40,6 +40,7 @@ vi.mock("../services/index.js", () => ({
   issueApprovalService: () => ({}),
   issueService: () => mockIssueService,
   logActivity: mockLogActivity,
+  notifyIssueStakeholderProgress: vi.fn(async () => undefined),
   projectService: () => ({}),
   routineService: () => ({
     syncRunStatusForIssue: vi.fn(async () => undefined),

--- a/server/src/__tests__/issue-stakeholder-progress-routes.test.ts
+++ b/server/src/__tests__/issue-stakeholder-progress-routes.test.ts
@@ -1,0 +1,144 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const issueId = "11111111-1111-4111-8111-111111111111";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+}));
+
+const mockNotifyIssueStakeholderProgress = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+    getRun: vi.fn(async () => null),
+    getActiveRunForAgent: vi.fn(async () => null),
+    cancelRun: vi.fn(async () => null),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  notifyIssueStakeholderProgress: mockNotifyIssueStakeholderProgress,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: issueId,
+    companyId: "company-1",
+    identifier: "THEA-3",
+    title: "Implement Slack stakeholder progress notifications",
+    status: "in_progress",
+    priority: "high",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    ...overrides,
+  };
+}
+
+describe("issue stakeholder progress route integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PAPERCLIP_PUBLIC_URL;
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...patch,
+    }));
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-1",
+      issueId,
+      companyId: "company-1",
+      body: "Waiting on webhook access",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: null,
+      authorUserId: "local-board",
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+  });
+
+  it("passes before/after issue state, comment summary, and request base url to the notifier", async () => {
+    const res = await request(createApp())
+      .patch(`/api/issues/${issueId}`)
+      .set("Host", "paperclip.test")
+      .send({ status: "blocked", comment: "Waiting on webhook access" });
+
+    expect(res.status).toBe(200);
+    expect(mockNotifyIssueStakeholderProgress).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        existingIssue: expect.objectContaining({
+          id: issueId,
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+        }),
+        issue: expect.objectContaining({
+          id: issueId,
+          status: "blocked",
+          assigneeAgentId: "agent-1",
+        }),
+        comment: "Waiting on webhook access",
+        baseUrl: "http://paperclip.test",
+      }),
+    );
+  });
+
+  it("prefers PAPERCLIP_PUBLIC_URL over the request host when present", async () => {
+    process.env.PAPERCLIP_PUBLIC_URL = "https://paperclip.example.com/";
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issueId}`)
+      .set("Host", "localhost:3100")
+      .send({ status: "done", comment: "Ready for review" });
+
+    expect(res.status).toBe(200);
+    expect(mockNotifyIssueStakeholderProgress).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        baseUrl: "https://paperclip.example.com",
+      }),
+    );
+  });
+});

--- a/server/src/__tests__/issue-stakeholder-progress.test.ts
+++ b/server/src/__tests__/issue-stakeholder-progress.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIssueStakeholderProgressSlackMessage,
+  selectIssueStakeholderProgressEvent,
+  type IssueStakeholderProgressIssueSnapshot,
+} from "../services/issue-stakeholder-progress.js";
+
+function makeIssue(
+  overrides: Partial<IssueStakeholderProgressIssueSnapshot> = {},
+): IssueStakeholderProgressIssueSnapshot {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    identifier: "THEA-3",
+    title: "Implement Slack stakeholder progress notifications",
+    status: "in_progress",
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    ...overrides,
+  };
+}
+
+describe("issue stakeholder progress notifications", () => {
+  it("selects done when an issue transitions to done", () => {
+    expect(
+      selectIssueStakeholderProgressEvent(
+        makeIssue({ status: "in_progress" }),
+        makeIssue({ status: "done" }),
+      ),
+    ).toBe("done");
+  });
+
+  it("selects blocked when an issue transitions to blocked", () => {
+    expect(
+      selectIssueStakeholderProgressEvent(
+        makeIssue({ status: "todo" }),
+        makeIssue({ status: "blocked" }),
+      ),
+    ).toBe("blocked");
+  });
+
+  it("selects returned_to_requester when the issue is handed back to the creator", () => {
+    expect(
+      selectIssueStakeholderProgressEvent(
+        makeIssue({ assigneeAgentId: "agent-1", assigneeUserId: null, createdByUserId: "local-board" }),
+        makeIssue({ status: "in_review", assigneeAgentId: null, assigneeUserId: "local-board", createdByUserId: "local-board" }),
+      ),
+    ).toBe("returned_to_requester");
+  });
+
+  it("ignores non-signal updates", () => {
+    expect(
+      selectIssueStakeholderProgressEvent(
+        makeIssue({ title: "Old title" }),
+        makeIssue({ title: "New title" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("builds a Slack payload with a cleaned summary and deep link", () => {
+    const payload = buildIssueStakeholderProgressSlackMessage({
+      event: "blocked",
+      issue: makeIssue({ status: "blocked" }),
+      comment: "## Blocked\n\n- Waiting on [THEA-1](/THEA/issues/THEA-1)\n- Need webhook access",
+      assigneeLabel: "Engineering Manager",
+      baseUrl: "http://paperclip.test",
+    });
+
+    expect(payload.text).toContain("THEA-3");
+    expect(payload.text).toContain("http://paperclip.test/THEA/issues/THEA-3");
+    expect(payload.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          text: expect.objectContaining({
+            text: expect.stringContaining("<http://paperclip.test/THEA/issues/THEA-3|THEA-3>"),
+          }),
+        }),
+        expect.objectContaining({
+          type: "section",
+          text: expect.objectContaining({
+            text: expect.stringContaining("Waiting on THEA-1 Need webhook access"),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("omits the Slack issue link when no absolute base url is available", () => {
+    const previousPublicUrl = process.env.PAPERCLIP_PUBLIC_URL;
+    const previousApiUrl = process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_PUBLIC_URL;
+    delete process.env.PAPERCLIP_API_URL;
+
+    try {
+      const payload = buildIssueStakeholderProgressSlackMessage({
+        event: "done",
+        issue: makeIssue({ status: "done" }),
+        assigneeLabel: "Engineering Manager",
+      });
+
+      expect(payload.text).not.toContain("/THEA/issues/THEA-3");
+      expect(payload.blocks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "section",
+            text: expect.objectContaining({
+              text: expect.not.stringContaining("</THEA/issues/THEA-3|THEA-3>"),
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      if (previousPublicUrl === undefined) {
+        delete process.env.PAPERCLIP_PUBLIC_URL;
+      } else {
+        process.env.PAPERCLIP_PUBLIC_URL = previousPublicUrl;
+      }
+      if (previousApiUrl === undefined) {
+        delete process.env.PAPERCLIP_API_URL;
+      } else {
+        process.env.PAPERCLIP_API_URL = previousApiUrl;
+      }
+    }
+  });
+});

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -44,6 +44,7 @@ vi.mock("../services/index.js", () => ({
   issueApprovalService: () => ({}),
   issueService: () => mockIssueService,
   logActivity: vi.fn(async () => undefined),
+  notifyIssueStakeholderProgress: vi.fn(async () => undefined),
   projectService: () => mockProjectService,
   routineService: () => ({
     syncRunStatusForIssue: vi.fn(async () => undefined),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -28,6 +28,7 @@ import {
   issueService,
   documentService,
   logActivity,
+  notifyIssueStakeholderProgress,
   projectService,
   routineService,
   workProductService,
@@ -198,6 +199,21 @@ export function issueRoutes(db: Db, storage: StorageService) {
       }
     }
     return rawId;
+  }
+
+  function requestBaseUrl(req: Request) {
+    const publicUrl = process.env.PAPERCLIP_PUBLIC_URL?.trim();
+    if (publicUrl) return publicUrl.replace(/\/+$/, "");
+
+    const forwardedProto = req.header("x-forwarded-proto");
+    const proto = forwardedProto?.split(",")[0]?.trim() || req.protocol || "http";
+    const host =
+      req.header("x-forwarded-host")?.split(",")[0]?.trim() ||
+      req.header("host") ||
+      process.env.PAPERCLIP_API_URL?.trim();
+    if (!host) return "";
+    if (host.startsWith("http://") || host.startsWith("https://")) return host.replace(/\/+$/, "");
+    return `${proto}://${host}`;
   }
 
   async function resolveIssueProjectAndGoal(issue: {
@@ -1176,6 +1192,31 @@ export function issueRoutes(db: Db, storage: StorageService) {
       });
 
     }
+
+    await notifyIssueStakeholderProgress(db, {
+      existingIssue: {
+        id: existing.id,
+        companyId: existing.companyId,
+        identifier: existing.identifier ?? null,
+        title: existing.title,
+        status: existing.status,
+        assigneeAgentId: existing.assigneeAgentId,
+        assigneeUserId: existing.assigneeUserId,
+        createdByUserId: existing.createdByUserId ?? null,
+      },
+      issue: {
+        id: issue.id,
+        companyId: issue.companyId,
+        identifier: issue.identifier ?? null,
+        title: issue.title,
+        status: issue.status,
+        assigneeAgentId: issue.assigneeAgentId,
+        assigneeUserId: issue.assigneeUserId,
+        createdByUserId: issue.createdByUserId ?? null,
+      },
+      comment: commentBody ?? null,
+      baseUrl: requestBaseUrl(req),
+    });
 
     const assigneeChanged = assigneeWillChange;
     const statusChangedFromBacklog =

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -27,6 +27,14 @@ export { workspaceOperationService } from "./workspace-operations.js";
 export { workProductService } from "./work-products.js";
 export { logActivity, type LogActivityInput } from "./activity-log.js";
 export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
+export {
+  notifyIssueStakeholderProgress,
+  selectIssueStakeholderProgressEvent,
+  buildIssueStakeholderProgressSlackMessage,
+  type NotifyIssueStakeholderProgressInput,
+  type IssueStakeholderProgressIssueSnapshot,
+  type IssueStakeholderProgressEvent,
+} from "./issue-stakeholder-progress.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
 export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
 export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";

--- a/server/src/services/issue-stakeholder-progress.ts
+++ b/server/src/services/issue-stakeholder-progress.ts
@@ -1,0 +1,305 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, authUsers } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+const PRIMARY_WEBHOOK_ENV = "PAPERCLIP_STAKEHOLDER_PROGRESS_SLACK_WEBHOOK_URL";
+const FALLBACK_WEBHOOK_ENV = "PAPERCLIP_STAKEHOLDER_SLACK_WEBHOOK_URL";
+const REQUEST_TIMEOUT_MS = 5000;
+
+export type IssueStakeholderProgressEvent = "done" | "blocked" | "returned_to_requester";
+
+export interface IssueStakeholderProgressIssueSnapshot {
+  id: string;
+  companyId: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+  createdByUserId: string | null;
+}
+
+export interface NotifyIssueStakeholderProgressInput {
+  existingIssue: IssueStakeholderProgressIssueSnapshot;
+  issue: IssueStakeholderProgressIssueSnapshot;
+  comment?: string | null;
+  baseUrl?: string | null;
+}
+
+interface BuildIssueStakeholderProgressSlackMessageInput {
+  event: IssueStakeholderProgressEvent;
+  issue: IssueStakeholderProgressIssueSnapshot;
+  comment?: string | null;
+  assigneeLabel: string;
+  baseUrl?: string | null;
+}
+
+function normalizeBaseUrl(baseUrl?: string | null): string {
+  const resolved =
+    baseUrl?.trim() ||
+    process.env.PAPERCLIP_PUBLIC_URL?.trim() ||
+    process.env.PAPERCLIP_API_URL?.trim() ||
+    "";
+  return resolved.replace(/\/+$/, "");
+}
+
+function slackEscape(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+function summarizeComment(comment?: string | null): string | null {
+  if (!comment) return null;
+  const normalized = comment
+    .replace(/```[\s\S]*?```/g, "[code]")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized ? truncate(normalized, 280) : null;
+}
+
+function fallbackSummary(event: IssueStakeholderProgressEvent): string {
+  switch (event) {
+    case "done":
+      return "Work finished and is ready for the next step.";
+    case "blocked":
+      return "Work is blocked and needs attention.";
+    case "returned_to_requester":
+      return "Work was handed back to the requesting user for review.";
+  }
+}
+
+function issuePath(issue: IssueStakeholderProgressIssueSnapshot): string | null {
+  if (issue.identifier) {
+    const prefix = issue.identifier.split("-")[0]?.trim();
+    if (prefix) return `/${prefix}/issues/${issue.identifier}`;
+  }
+  return null;
+}
+
+function statusHeadline(event: IssueStakeholderProgressEvent): string {
+  switch (event) {
+    case "done":
+      return "Issue completed";
+    case "blocked":
+      return "Issue blocked";
+    case "returned_to_requester":
+      return "Issue returned to requester";
+  }
+}
+
+function fallbackTextHeadline(event: IssueStakeholderProgressEvent): string {
+  switch (event) {
+    case "done":
+      return "completed";
+    case "blocked":
+      return "blocked";
+    case "returned_to_requester":
+      return "returned to requester";
+  }
+}
+
+function assigneeFallbackLabel(userId: string | null, agentId: string | null): string {
+  if (userId) {
+    if (userId === "local-board") return "Board";
+    return userId.slice(0, 5);
+  }
+  if (agentId) return agentId.slice(0, 8);
+  return "Unassigned";
+}
+
+export function selectIssueStakeholderProgressEvent(
+  existingIssue: IssueStakeholderProgressIssueSnapshot,
+  issue: IssueStakeholderProgressIssueSnapshot,
+): IssueStakeholderProgressEvent | null {
+  const returnedToRequester =
+    issue.assigneeAgentId === null &&
+    !!issue.assigneeUserId &&
+    !!existingIssue.createdByUserId &&
+    issue.assigneeUserId === existingIssue.createdByUserId &&
+    (issue.assigneeAgentId !== existingIssue.assigneeAgentId ||
+      issue.assigneeUserId !== existingIssue.assigneeUserId);
+
+  if (returnedToRequester) return "returned_to_requester";
+  if (existingIssue.status !== issue.status && issue.status === "blocked") return "blocked";
+  if (existingIssue.status !== issue.status && issue.status === "done") return "done";
+  return null;
+}
+
+export function buildIssueStakeholderProgressSlackMessage(
+  input: BuildIssueStakeholderProgressSlackMessageInput,
+): { text: string; blocks: Array<Record<string, unknown>> } {
+  const summary = summarizeComment(input.comment) ?? fallbackSummary(input.event);
+  const escapedTitle = slackEscape(input.issue.title);
+  const escapedSummary = slackEscape(summary);
+  const escapedAssignee = slackEscape(input.assigneeLabel);
+  const resolvedBaseUrl = normalizeBaseUrl(input.baseUrl);
+  const path = issuePath(input.issue);
+  const issueLabel = input.issue.identifier ?? input.issue.id;
+  const escapedIssueLabel = slackEscape(issueLabel);
+  const issueLink = resolvedBaseUrl && path ? `${resolvedBaseUrl}${path}` : "";
+  const issueLine =
+    issueLink && path
+      ? `<${issueLink}|${escapedIssueLabel}> ${escapedTitle}`
+      : `*${escapedIssueLabel}* ${escapedTitle}`;
+
+  const text =
+    `Stakeholder progress update: ${issueLabel} ${input.issue.title} ` +
+    `is ${fallbackTextHeadline(input.event)} (status: ${input.issue.status}, assignee: ${input.assigneeLabel}). ` +
+    `Summary: ${summary}` +
+    (issueLink ? ` ${issueLink}` : "");
+
+  return {
+    text,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Stakeholder progress update*\n${issueLine}`,
+        },
+      },
+      {
+        type: "section",
+        fields: [
+          {
+            type: "mrkdwn",
+            text: `*Event*\n${slackEscape(statusHeadline(input.event))}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Status*\n${slackEscape(input.issue.status)}`,
+          },
+          {
+            type: "mrkdwn",
+            text: `*Assignee*\n${escapedAssignee}`,
+          },
+        ],
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Summary*\n${escapedSummary}`,
+        },
+      },
+    ],
+  };
+}
+
+async function resolveAssigneeLabel(
+  db: Db,
+  issue: IssueStakeholderProgressIssueSnapshot,
+): Promise<string> {
+  if (issue.assigneeAgentId) {
+    const agent = await db
+      .select({ name: agents.name })
+      .from(agents)
+      .where(and(eq(agents.id, issue.assigneeAgentId), eq(agents.companyId, issue.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (agent?.name) return agent.name;
+  }
+
+  if (issue.assigneeUserId) {
+    const user = await db
+      .select({ name: authUsers.name })
+      .from(authUsers)
+      .where(eq(authUsers.id, issue.assigneeUserId))
+      .then((rows) => rows[0] ?? null);
+    if (user?.name) return user.name;
+  }
+
+  return assigneeFallbackLabel(issue.assigneeUserId, issue.assigneeAgentId);
+}
+
+function resolveWebhookUrl(): string {
+  return (
+    process.env[PRIMARY_WEBHOOK_ENV]?.trim() ||
+    process.env[FALLBACK_WEBHOOK_ENV]?.trim() ||
+    ""
+  );
+}
+
+async function readResponseText(response: Response): Promise<string | null> {
+  try {
+    const text = await response.text();
+    return text ? truncate(text, 500) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function notifyIssueStakeholderProgress(
+  db: Db,
+  input: NotifyIssueStakeholderProgressInput,
+): Promise<void> {
+  const event = selectIssueStakeholderProgressEvent(input.existingIssue, input.issue);
+  if (!event) return;
+
+  const webhookUrl = resolveWebhookUrl();
+  if (!webhookUrl) {
+    logger.info(
+      {
+        issueId: input.issue.id,
+        identifier: input.issue.identifier,
+        event,
+        env: PRIMARY_WEBHOOK_ENV,
+      },
+      "stakeholder progress slack webhook is not configured; skipping notification",
+    );
+    return;
+  }
+
+  const assigneeLabel = await resolveAssigneeLabel(db, input.issue);
+  const payload = buildIssueStakeholderProgressSlackMessage({
+    event,
+    issue: input.issue,
+    comment: input.comment,
+    assigneeLabel,
+    baseUrl: input.baseUrl,
+  });
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        {
+          issueId: input.issue.id,
+          identifier: input.issue.identifier,
+          event,
+          status: response.status,
+          body: await readResponseText(response),
+        },
+        "stakeholder progress slack notification failed",
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      {
+        err,
+        issueId: input.issue.id,
+        identifier: input.issue.identifier,
+        event,
+      },
+      "stakeholder progress slack notification errored",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Summary
- add a server-side Slack webhook notifier for issue transitions to `done`, `blocked`, and returned-to-requester handoff events
- wire issue update routes to emit stakeholder progress notifications with stable absolute links, preferring `PAPERCLIP_PUBLIC_URL` when configured
- document the optional webhook env var and add focused unit/route coverage for the new notification path

## Verification
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm vitest run server/src/__tests__/issue-stakeholder-progress.test.ts server/src/__tests__/issue-stakeholder-progress-routes.test.ts`
- `pnpm test:run` currently still reports unrelated existing failures in `server/src/__tests__/worktree-config.test.ts`, `server/src/__tests__/opencode-local-adapter-environment.test.ts`, and `server/src/__tests__/routines-e2e.test.ts`