### PR TITLE
Use per-agent OpenClaw Paperclip key paths

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -99,6 +99,17 @@ function nonEmpty(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function sanitizeOpenClawAgentPathSegment(value: unknown): string {
+  const raw = nonEmpty(value) ?? "agent";
+  const sanitized = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return sanitized.length > 0 ? sanitized : "agent";
+}
+
+function buildClaimedApiKeyPath(agentName: unknown): string {
+  const segment = sanitizeOpenClawAgentPathSegment(agentName);
+  return `~/.openclaw/agents/${segment}/paperclip/claimed-api-key.json`;
+}
+
 function parseOptionalPositiveInteger(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return Math.max(1, Math.floor(value));
@@ -335,8 +346,12 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+function buildWakeText(
+  payload: WakePayload,
+  paperclipEnv: Record<string, string>,
+  agentName: string | null,
+): string {
+  const claimedApiKeyPath = buildClaimedApiKeyPath(agentName);
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1053,7 +1068,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
-  const wakeText = buildWakeText(wakePayload, paperclipEnv);
+  const wakeText = buildWakeText(wakePayload, paperclipEnv, ctx.agent.name);
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -49,7 +49,7 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("headers.x-openclaw-token");
     expect(text).toContain("Do NOT use /v1/responses or /hooks/*");
     expect(text).toContain("set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl");
-    expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+    expect(text).toContain("~/.openclaw/agents/<agent-name>/paperclip/claimed-api-key.json");
     expect(text).toContain("PAPERCLIP_API_KEY");
     expect(text).toContain("saved token field");
     expect(text).toContain("Gateway token unexpectedly short");

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -77,6 +77,20 @@ function createClaimSecret() {
   return `pcp_claim_${randomBytes(24).toString("hex")}`;
 }
 
+function sanitizeOpenClawAgentPathSegment(value: unknown): string {
+  const raw =
+    typeof value === "string" && value.trim().length > 0
+      ? value.trim()
+      : "<agent-name>";
+  if (raw === "<agent-name>") return raw;
+  const sanitized = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return sanitized.length > 0 ? sanitized : "<agent-name>";
+}
+
+function buildOpenClawClaimedApiKeyPath(agentName?: string | null): string {
+  return `~/.openclaw/agents/${sanitizeOpenClawAgentPathSegment(agentName)}/paperclip/claimed-api-key.json`;
+}
+
 export function companyInviteExpiresAt(nowMs: number = Date.now()) {
   return new Date(nowMs + COMPANY_INVITE_TTL_MS);
 }
@@ -1036,7 +1050,7 @@ function buildInviteOnboardingManifest(
     ),
     onboarding: {
       instructions:
-        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
+        `Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ${buildOpenClawClaimedApiKeyPath()} and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. The <agent-name> segment must match the OpenClaw agent name/id you submit in agentName. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).`,
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: "openclaw_gateway",
       requiredFields: {
@@ -1244,8 +1258,10 @@ export function buildInviteOnboardingTextDocument(
 
     On successful claim, save the full JSON response to:
 
-    - ~/.openclaw/workspace/paperclip-claimed-api-key.json
-    chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+    - ${buildOpenClawClaimedApiKeyPath()}
+    chmod 600 ${buildOpenClawClaimedApiKeyPath()}
+
+    The <agent-name> segment must match the OpenClaw agent name/id you submitted in agentName.
 
     And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
     https://docs.openclaw.ai/help/environment
@@ -2864,6 +2880,9 @@ export function accessRoutes(
         keyId: created.id,
         token: created.token,
         agentId: joinRequest.createdAgentId,
+        recommendedOpenClawFilePath: buildOpenClawClaimedApiKeyPath(
+          joinRequest.agentName
+        ),
         createdAt: created.createdAt
       });
     }


### PR DESCRIPTION
## Summary
- change OpenClaw gateway wake text to use a per-agent claimed API key path
- update onboarding instructions to point at ~/.openclaw/agents/<agent-name>/paperclip/claimed-api-key.json
- include the recommended OpenClaw file path in claim responses

## Testing
- pnpm test:run server/src/__tests__/invite-onboarding-text.test.ts