### PR TITLE
fix: stabilize OpenClaw Gateway and Codex auth

### DIFF
--- a/doc/plans/2026-04-03-atlas-bridge-hardening-action-plan.md
+++ b/doc/plans/2026-04-03-atlas-bridge-hardening-action-plan.md
@@ -1,0 +1,727 @@
+# Atlas Bridge Hardening Action Plan
+
+## Context
+
+Atlas execution has been iterated on for months, but the current feedback loop is still too expensive and too opaque.
+
+Observed failure patterns keep repeating:
+
+- wrong stand or wrong branch bound to the task
+- stand bootstrap fails or returns `504`
+- changes are deployed but not visible where the operator expects them
+- task pickup / status / verify progress is unclear from Telegram alone
+- `Execution Failed` collapses many distinct failure classes into one operator-visible error
+- drift between task state, slot state, runtime state, and user-visible status is hard to inspect quickly
+
+The goal of this plan is not to replace Atlas.
+
+The goal is to introduce a hardening and transparency layer through Paperclip so the system becomes cheaper to debug, safer to operate, and easier for Codex and humans to reason about.
+
+## What We Know Today
+
+### Repository and workspace reality
+
+- `/Users/s1z0v/kd-projects/Paperclip` is an operational control-plane workspace, not a git repository.
+- The versioned upstream Paperclip checkout lives at `/Users/s1z0v/kd-projects/Paperclip/state/upstream/paperclip`.
+- The upstream Paperclip checkout is currently dirty on branch `codex/openclaw-gateway-auth-fix`.
+- Atlas lives at `/Users/s1z0v/kd-projects/Homio/atlas` and is currently dirty on branch `codex/atlas-openclaw-delivery-green-20260401`.
+
+This means bridge work must not be spread across those already-dirty branches without a separate canonical development lane.
+
+### Paperclip plugin capabilities already exist
+
+Paperclip already has the primitives needed for an `atlas-bridge` plugin:
+
+- plugin install and upgrade lifecycle
+- local-path plugin installs
+- plugin worker restart watcher for local development
+- plugin state storage
+- plugin jobs, webhooks, tools, UI bridge routes, and activity logging
+
+Relevant implementation surfaces:
+
+- `server/src/routes/plugins.ts`
+- `server/src/services/plugin-lifecycle.ts`
+- `server/src/services/plugin-loader.ts`
+- `server/src/services/plugin-dev-watcher.ts`
+- `server/src/services/plugin-state-store.ts`
+- `server/src/services/plugin-host-services.ts`
+
+### Atlas observe surfaces already exist
+
+Atlas already exposes most of the raw state the bridge needs:
+
+- A2A task status updates
+- A2A events
+- A2A artifacts
+- runtime verify runs
+- slot board and slot lock surfaces
+
+Relevant implementation surfaces:
+
+- `scripts/mini-app/server.ts`
+- `scripts/runtime/a2a-task-registry.ts`
+- `scripts/runtime/task-runtime-registry.ts`
+
+The key design opportunity is to normalize and reconcile these existing surfaces, not rebuild them.
+
+## Goals
+
+1. Give operators and Codex one canonical execution picture per issue.
+2. Reduce the debugging loop from "change, deploy, wait 5-10 minutes, discover almost nothing" to "change locally, observe live state immediately, classify failure quickly".
+3. Separate infrastructure failures, slot drift, preview lag, verify failures, and transport/handoff failures into explicit classes.
+4. Make the Paperclip bridge safe to iterate locally without repeated full live deploy cycles.
+5. Preserve work reliably by introducing a canonical repo and release path for the bridge itself.
+
+## Non-Goals
+
+- Replacing Atlas branch/worktree/slot/HMR/verify runtime.
+- Re-implementing full execution orchestration inside Paperclip.
+- Moving all Atlas services local before the bridge proves value.
+- Building tunnel-based remote plugin hosting as a first step.
+
+## Recommendation In One Sentence
+
+Build a versioned `atlas-bridge` plugin and supporting contracts locally, run it against live Atlas in `observe-only` mode first, use Paperclip as the canonical control and transparency plane, and only enable control actions after reconcile/debug surfaces are stable.
+
+## Core Decisions
+
+### 1. Use a hybrid live-local model, not full local and not full online
+
+The bridge should be developed locally with a short feedback loop while reading live Atlas state.
+
+Recommended topology:
+
+- local Paperclip dev host
+- local `atlas-bridge` plugin installed from local path
+- live Atlas mini-app / A2A / slot-board as the observed execution plane
+- live Paperclip untouched until the bridge is stable enough for canary rollout
+
+Why:
+
+- full local does not reproduce real slot drift, live deploy lag, auth edges, or infra failures cheaply
+- full online keeps the feedback loop too slow and too costly
+- hybrid gives fast plugin iteration while preserving real Atlas conditions
+
+### 2. Do not start with a tunnel into the live Paperclip runtime
+
+Phase 1 should not attempt to make the live Paperclip host execute a local plugin worker over a custom tunnel.
+
+That adds a second transport problem before the bridge itself exists.
+
+Instead:
+
+- run a local Paperclip dev instance
+- install the bridge from a local path
+- point it at live Atlas using observe-only credentials
+- use a tunnel only if the local UI must be shared externally for review
+
+### 3. Keep Atlas as the execution plane
+
+Atlas remains responsible for:
+
+- branch/worktree/workspace binding
+- slot allocation and release
+- HMR/deploy/sync
+- runtime sessions
+- verify execution and raw evidence
+
+Paperclip becomes responsible for:
+
+- issue-scoped execution envelope
+- state machine
+- failure classification
+- debug pack generation
+- human-readable status and audit trail
+- controlled rollout of retry/release/start operations
+
+### 4. Create a separate canonical bridge repository
+
+Because the current Paperclip and Atlas working trees are already dirty and on unrelated branches, the bridge itself should live in a separate repo from the beginning.
+
+Recommended local path:
+
+- `/Users/s1z0v/kd-projects/paperclip-atlas-bridge`
+
+Recommended remote:
+
+- GitLab project such as `homio/paperclip-atlas-bridge`
+
+Recommended contents:
+
+- `packages/atlas-bridge-plugin`
+- `packages/atlas-bridge-contracts`
+- `docs/`
+- `scripts/`
+- optional `examples/`
+
+Host changes that must land in Paperclip or Atlas should still be patched in their native repos. The bridge repo is the canonical home for bridge logic and shared contracts.
+
+### 5. Use `observe-only` as the first production mode
+
+The first successful milestone is not "the bridge can start tasks".
+
+The first successful milestone is:
+
+- the bridge can observe live Atlas
+- bind issue to task to slot to branch to commit
+- collect evidence
+- classify failures
+- show the operator what is happening without changing execution
+
+Only after that should the bridge gain control actions.
+
+## Product Requirements
+
+### Primary operator outcomes
+
+The operator must be able to:
+
+1. Open a Paperclip issue and immediately see the latest execution envelope.
+2. See whether a task was accepted, bound to a slot, deployed, verified, or stalled.
+3. Understand the difference between:
+   - infra failure
+   - binding drift
+   - preview visibility lag
+   - verify failure
+   - transport/handoff failure
+4. Open one debug pack and see all evidence needed for a first-pass diagnosis.
+5. See live slot occupancy and stale/unhealthy states directly in Paperclip.
+
+### Codex outcomes
+
+Codex must be able to call one stable surface instead of inspecting Atlas manually each time.
+
+Minimum bridge tools:
+
+- `atlas.get_issue_execution_context(issueId)`
+- `atlas.get_debug_pack(issueId)`
+- `atlas.list_live_slots()`
+- `atlas.reconcile_execution(issueId)`
+- `atlas.classify_failure(issueId)`
+- `atlas.request_verify(issueId)`
+- `atlas.release_slot(issueId, action)`
+
+## System Model
+
+### Canonical entities
+
+#### Paperclip issue execution envelope
+
+This is the bridge-owned issue-scoped state machine.
+
+Fields:
+
+- `paperclipIssueId`
+- `atlasTaskId`
+- `atlasSessionId`
+- `slotName`
+- `envName`
+- `branch`
+- `commitSha`
+- `executionState`
+- `failureClass`
+- `lastHeartbeatAt`
+- `latestPreviewUrl`
+- `latestVerifyVerdict`
+- `artifacts`
+- `timeline`
+
+#### Atlas raw execution facts
+
+These remain Atlas-owned:
+
+- A2A task
+- A2A events
+- A2A artifacts
+- slot board / slot lock state
+- runtime verify runs
+
+### State machine
+
+Recommended bridge states:
+
+- `requested`
+- `accepted`
+- `slot_bound`
+- `deploying`
+- `preview_declared`
+- `preview_healthy`
+- `verify_running`
+- `verify_passed`
+- `verify_failed`
+- `review_pending`
+- `done`
+- `drift_detected`
+- `infra_failed`
+- `transport_failed`
+
+No state change should happen without evidence.
+
+Examples:
+
+- `slot_bound` requires task binding plus slot name plus branch
+- `preview_declared` requires preview URL and slot binding
+- `preview_healthy` requires a successful probe plus a consistent slot/branch binding
+- `verify_passed` requires a recorded verify result, not just the absence of errors
+
+## Failure Taxonomy
+
+The bridge should classify failures into explicit buckets.
+
+### 1. `infra_bootstrap_failure`
+
+Examples:
+
+- `504` from stand
+- deploy timeout
+- registry pull too slow
+- runtime startup/OOM
+- auth probe or login bootstrap failure
+
+### 2. `slot_binding_drift`
+
+Examples:
+
+- task bound to one slot in task state but another slot in live board
+- branch mismatch between task metadata and slot metadata
+- duplicate slot occupancy for the same branch/task
+
+### 3. `preview_visibility_lag`
+
+Examples:
+
+- deploy completed but preview not yet healthy
+- preview artifact not published yet
+- operator-facing preview appears later than the underlying task state
+
+### 4. `verify_pipeline_failure`
+
+Examples:
+
+- verify run failed
+- screenshots missing
+- acceptance checks failed
+
+### 5. `transport_handoff_failure`
+
+Examples:
+
+- task created but not claimed
+- status not propagated back
+- callback lost
+- Telegram shows final error without intermediate execution picture
+
+### 6. `unknown_execution_failure`
+
+Used only when the bridge cannot classify confidently.
+
+## Debug Pack
+
+Every issue must be able to produce one machine-readable debug pack.
+
+Required sections:
+
+- issue binding
+- latest A2A task snapshot
+- ordered A2A event timeline
+- latest A2A artifacts by kind
+- live slot-board snapshot for the bound slot
+- slot drift analysis
+- preview URL and probe result
+- verify runs and latest verdict
+- failure classification
+- recommended operator next steps
+
+Minimum bindings to include:
+
+- `paperclipIssueId`
+- `atlasTaskId`
+- `atlasSessionId`
+- `slotName`
+- `envName`
+- `branch`
+- `commitSha`
+
+## Repository Strategy
+
+### 1. Paperclip control-plane workspace
+
+Path:
+
+- `/Users/s1z0v/kd-projects/Paperclip`
+
+Role:
+
+- operational notes
+- scripts
+- backups
+- high-level runbooks
+
+Important constraint:
+
+- this workspace is not git
+
+### 2. Paperclip upstream checkout
+
+Path:
+
+- `/Users/s1z0v/kd-projects/Paperclip/state/upstream/paperclip`
+
+Role:
+
+- actual Paperclip host code changes
+- Paperclip plugin platform changes
+- versioned documentation like this plan
+
+### 3. Atlas repo
+
+Path:
+
+- `/Users/s1z0v/kd-projects/Homio/atlas`
+
+Role:
+
+- Atlas mini-app / A2A / runtime changes
+
+### 4. New bridge repo
+
+Path:
+
+- `/Users/s1z0v/kd-projects/paperclip-atlas-bridge`
+
+Role:
+
+- canonical bridge logic
+- shared bridge contracts
+- plugin source
+- local dev harness
+- bridge release automation
+
+## Development Topology
+
+### Phase-1 topology
+
+- local Paperclip dev host
+- local bridge plugin from local path
+- live Atlas mini-app
+- live Atlas slots
+- live Atlas verify pipeline
+- Paperclip plugin in `observe-only`
+
+### Optional tunnel usage
+
+Tunnel is optional and should be used only for:
+
+- sharing the local Paperclip bridge UI externally
+- allowing remote browser access to a local Paperclip dev page
+
+Tunnel is not the primary plugin runtime model.
+
+## Paperclip Plugin Design
+
+### Required capabilities
+
+Minimum expected plugin capabilities:
+
+- `issues.read`
+- `issues.update`
+- `issue-comments.create`
+- `activity.log.write`
+- `plugin.state.read`
+- `plugin.state.write`
+- `events.subscribe`
+- `jobs.schedule`
+- `webhooks.receive`
+- `http.outbound`
+- relevant UI capabilities for issue and dashboard surfaces
+
+### Storage model
+
+Machine state:
+
+- keep in plugin state storage
+
+Human-readable projection:
+
+- issue document or work product summary
+
+Operational timeline:
+
+- activity log
+
+Why:
+
+- issue documents are not the right primary hot state surface for rapidly changing machine state
+- plugin state gives a better canonical store for reconcile and resumption
+
+### UI surfaces
+
+Minimum UI surfaces:
+
+- issue execution panel
+- issue debug pack panel
+- slot board widget
+- optional bridge admin/settings page
+
+## Atlas Integration Design
+
+### Observe surfaces to use first
+
+- `GET /api/slot-board`
+- `GET /api/slots`
+- `GET /api/a2a/tasks/:id`
+- `GET /api/a2a/tasks/:id/events`
+- `GET /api/a2a/tasks/:id/artifacts`
+- `POST /api/runtime/verify-runs` consumption on Atlas side, read via runtime/registry surfaces as needed
+
+### Control surfaces to enable later
+
+- task creation / start
+- verify trigger
+- slot release
+- retry execution
+
+These should remain feature-flagged until observe and reconcile are stable.
+
+## Reconcile Model
+
+The bridge must be dual-path:
+
+- push from Atlas callbacks/webhooks
+- pull from scheduled reconcile jobs
+
+Rules:
+
+1. Webhook delivery must not be assumed reliable.
+2. Reconcile must be able to reconstruct the issue execution envelope from Atlas facts.
+3. Any inconsistency between Atlas task and Atlas slot-board surfaces must be surfaced as drift, not hidden.
+4. Any execution state older than its SLA window must be reclassified as stale and revisited by reconcile.
+
+## Release Strategy
+
+### Local development
+
+Use:
+
+- local-path plugin install
+- plugin dev watcher
+- local Paperclip dev instance
+
+This gives the shortest loop for bridge worker/UI logic.
+
+### Live canary
+
+Only after local observe mode is stable:
+
+- install bridge in live Paperclip
+- keep it in `observe-only`
+- scope it to one repo and one slot pool subset
+
+### Production rollout
+
+Roll out in this order:
+
+1. observe-only
+2. reconcile-only
+3. verify trigger
+4. slot release
+5. start/retry execution
+
+## Workstreams
+
+### Workstream A: Repo and branch hygiene
+
+Deliverables:
+
+- canonical bridge repo created
+- branch policy documented
+- release path documented
+- no bridge logic living only in dirty ad hoc branches
+
+### Workstream B: Shared contracts
+
+Deliverables:
+
+- failure taxonomy
+- debug-pack schema
+- issue execution envelope schema
+- Atlas callback payload schema
+
+### Workstream C: Atlas observer facade
+
+Deliverables:
+
+- normalized Atlas client
+- slot-board reader
+- A2A reader
+- evidence assembler
+- canary scope configuration
+
+### Workstream D: Paperclip bridge plugin skeleton
+
+Deliverables:
+
+- plugin manifest
+- plugin state store model
+- scheduled reconcile job
+- webhook receiver
+- issue tool surface
+
+### Workstream E: UI and operator surfaces
+
+Deliverables:
+
+- issue execution panel
+- debug pack view
+- slot board widget
+- failure badges
+
+### Workstream F: Canary rollout and controls
+
+Deliverables:
+
+- observe-only deployment
+- canary repo/slot allowlists
+- feature flags for control actions
+- first controlled retry/release actions
+
+## Implementation Phases
+
+## Phase 0: Baseline and safety
+
+1. Create the canonical bridge repo.
+2. Snapshot current Paperclip and Atlas dirty working trees so nothing is lost.
+3. Document which changes belong in:
+   - bridge repo
+   - Paperclip upstream repo
+   - Atlas repo
+4. Do not start implementation until ownership boundaries are explicit.
+
+## Phase 1: Observe-only bridge
+
+1. Implement shared contracts.
+2. Implement Atlas observer client.
+3. Implement Paperclip plugin skeleton.
+4. Render issue execution envelope from live Atlas.
+5. Render slot board in Paperclip.
+6. Generate debug packs.
+
+Success criteria:
+
+- zero execution control actions
+- issue execution view works against live Atlas
+- major failure classes are distinguishable
+
+## Phase 2: Reconcile and classification
+
+1. Add scheduled reconcile job.
+2. Add stale execution detection.
+3. Add drift detection.
+4. Add failure classification rules.
+5. Add recommended next actions to debug packs.
+
+Success criteria:
+
+- webhook loss does not break the operator picture
+- stale issues are surfaced explicitly
+- drift is visible without manual DB inspection
+
+## Phase 3: Canary control
+
+1. Add verify trigger action.
+2. Add slot release action.
+3. Restrict by feature flags:
+   - allowed repos
+   - allowed slots
+   - allowed actions
+4. Canary on one repo and one slot pool subset.
+
+Success criteria:
+
+- control actions are safe and auditable
+- no accidental global rollout
+
+## Phase 4: Execution control
+
+1. Add start/retry execution paths.
+2. Keep Atlas as the execution runtime.
+3. Use the bridge as the orchestration and transparency layer.
+
+Success criteria:
+
+- issue-driven control loop runs through Paperclip
+- operator still has full debug visibility
+
+## Checklists
+
+### Baseline checklist
+
+- [ ] confirm canonical bridge repo location
+- [ ] snapshot current dirty branches in Paperclip upstream and Atlas
+- [ ] record remotes and active branches
+- [ ] agree on feature-flag names for canary rollout
+
+### Observe-only checklist
+
+- [ ] shared contracts package exists
+- [ ] Atlas observer client can read slot board
+- [ ] Atlas observer client can read A2A status/events/artifacts
+- [ ] Paperclip plugin can store issue execution envelope
+- [ ] issue execution panel renders
+- [ ] debug pack renders
+- [ ] no write/control actions enabled
+
+### Reconcile checklist
+
+- [ ] scheduled reconcile job exists
+- [ ] lost webhook scenario is recoverable
+- [ ] stale execution SLA is enforced
+- [ ] drift detection is visible in UI and debug pack
+- [ ] failure classification populates consistently
+
+### Canary control checklist
+
+- [ ] allowlist for repo scope exists
+- [ ] allowlist for slot scope exists
+- [ ] verify trigger is feature-flagged
+- [ ] slot release is feature-flagged
+- [ ] operator audit trail is recorded
+
+### Production readiness checklist
+
+- [ ] bridge can survive Paperclip restart
+- [ ] bridge can survive lost Atlas callback
+- [ ] bridge does not require tunnel for normal operation
+- [ ] bridge release path is documented and repeatable
+- [ ] Codex tools return enough context for first-pass diagnosis
+
+## Immediate Next Actions
+
+1. Create the canonical `paperclip-atlas-bridge` repo locally and remotely.
+2. Move bridge-specific logic out of ad hoc Paperclip and Atlas working branches.
+3. Scaffold:
+   - `packages/atlas-bridge-contracts`
+   - `packages/atlas-bridge-plugin`
+4. Implement read-only Atlas client against:
+   - slot board
+   - A2A task status
+   - A2A events
+   - A2A artifacts
+5. Install the plugin locally into a Paperclip dev instance from local path.
+6. Keep the live Paperclip host untouched until observe-only mode is proven.
+
+## Open Questions
+
+1. Which exact Paperclip dev environment should be used as the primary local bridge host?
+2. Which repo and slot should be the first canary target?
+3. Which credentials source should be used for the bridge in local observe-only mode?
+4. Do we want the shared contracts package to be fully separate, or colocated inside the bridge repo as a workspace package?
+
+## Acceptance Criteria
+
+1. A human or Codex can open a single Paperclip issue and immediately understand the current execution state without digging through Telegram and Atlas manually.
+2. The bridge can distinguish infra, drift, preview, verify, and transport failures.
+3. The first rollout path works with a short local feedback loop and without repeated full live deploy cycles for every bridge change.
+4. Bridge code has a canonical repo and release path, so work is not lost across dirty branches and parallel agents.
+5. Control actions are enabled only after observe and reconcile are already stable.

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -353,4 +353,7 @@ export interface CreateConfigValues {
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;
   intervalSec: number;
+  authToken?: string;
+  agentId?: string;
+  paperclipApiUrl?: string;
 }

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -20,6 +20,7 @@ import {
   renderTemplate,
   joinPromptSections,
   runChildProcess,
+  type RunProcessResult,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
@@ -28,6 +29,10 @@ import { resolveCodexDesiredSkillNames } from "./skills.js";
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
   /^\d{4}-\d{2}-\d{2}T[^\s]+\s+ERROR\s+codex_core::rollout::list:\s+state db missing rollout path for thread\s+[a-z0-9-]+$/i;
+const CODEX_AUTH_REQUIRED_RE =
+  /(?:not\s+logged\s+in|login\s+required|authentication\s+required|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|openai[_\s-]?api[_\s-]?key|api[_\s-]?key.*required|please\s+run\s+`?codex\s+login`?)/i;
+const ANSI_ESCAPE_RE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+const CODEX_DEVICE_CODE_RE = /\b[A-Z0-9]{4}-[A-Z0-9]{4,8}\b/;
 
 function stripCodexRolloutNoise(text: string): string {
   const parts = text.split(/\r?\n/);
@@ -53,6 +58,40 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function detectCodexLoginRequired(text: string): boolean {
+  return CODEX_AUTH_REQUIRED_RE.test(stripAnsi(text));
+}
+
+function extractCodexDeviceAuthUrl(text: string): string | null {
+  const match = stripAnsi(text).match(/https:\/\/[^\s]+/);
+  return match?.[0] ?? null;
+}
+
+function extractCodexDeviceCode(text: string): string | null {
+  const match = stripAnsi(text).match(CODEX_DEVICE_CODE_RE);
+  return match?.[0] ?? null;
+}
+
+function buildCodexLoginResult(input: {
+  proc: RunProcessResult;
+  loginUrl: string | null;
+  verificationCode: string | null;
+}) {
+  return {
+    exitCode: input.proc.exitCode,
+    signal: input.proc.signal,
+    timedOut: input.proc.timedOut,
+    stdout: input.proc.stdout,
+    stderr: input.proc.stderr,
+    loginUrl: input.loginUrl,
+    verificationCode: input.verificationCode,
+  };
+}
+
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
@@ -67,6 +106,13 @@ function resolveCodexBiller(env: Record<string, string>, billingType: "api" | "s
   const openAiCompatibleBiller = inferOpenAiCompatibleBiller(env, "openai");
   if (openAiCompatibleBiller === "openrouter") return "openrouter";
   return billingType === "subscription" ? "chatgpt" : openAiCompatibleBiller ?? "openai";
+}
+
+function resolveConfiguredCodexHome(config: Record<string, unknown>): string | null {
+  const envConfig = parseObject(config.env);
+  return typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
+    ? path.resolve(envConfig.CODEX_HOME.trim())
+    : null;
 }
 
 async function isLikelyPaperclipRepoRoot(candidate: string): Promise<boolean> {
@@ -212,6 +258,64 @@ export async function ensureCodexSkillsInjected(
   );
 }
 
+export async function runCodexLogin(input: {
+  runId: string;
+  agent: AdapterExecutionContext["agent"];
+  config: Record<string, unknown>;
+  authToken?: string;
+  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}) {
+  const onLog = input.onLog ?? (async () => {});
+  const command = asString(input.config.command, "codex");
+  const cwd = asString(input.config.cwd, process.cwd());
+  const envConfig = parseObject(input.config.env);
+  const configuredCodexHome = resolveConfiguredCodexHome(input.config);
+  const loginCodexHome = configuredCodexHome ?? resolveSharedCodexHomeDir(process.env);
+  const timeoutSec = asNumber(input.config.timeoutSec, 0);
+  const graceSec = asNumber(input.config.graceSec, 20);
+
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+  await fs.mkdir(loginCodexHome, { recursive: true });
+
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = {
+    ...buildPaperclipEnv(input.agent),
+    CODEX_HOME: loginCodexHome,
+    PAPERCLIP_RUN_ID: input.runId,
+  };
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  if (!hasExplicitApiKey && input.authToken) {
+    env.PAPERCLIP_API_KEY = input.authToken;
+  }
+
+  const runtimeEnv = ensurePathInEnv(
+    Object.fromEntries(
+      Object.entries({ ...process.env, ...env }).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    ),
+  );
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  const proc = await runChildProcess(input.runId, command, ["login", "--device-auth"], {
+    cwd,
+    env,
+    timeoutSec,
+    graceSec,
+    onLog,
+  });
+  const combinedOutput = [proc.stdout, proc.stderr].filter(Boolean).join("\n");
+
+  return buildCodexLoginResult({
+    proc,
+    loginUrl: extractCodexDeviceAuthUrl(combinedOutput),
+    verificationCode: extractCodexDeviceCode(combinedOutput),
+  });
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
 
@@ -262,10 +366,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   const envConfig = parseObject(config.env);
-  const configuredCodexHome =
-    typeof envConfig.CODEX_HOME === "string" && envConfig.CODEX_HOME.trim().length > 0
-      ? path.resolve(envConfig.CODEX_HOME.trim())
-      : null;
+  const configuredCodexHome = resolveConfiguredCodexHome(config);
   const codexSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = resolveCodexDesiredSkillNames(config, codexSkillEntries);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
@@ -569,6 +670,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       parsedError ||
       stderrLine ||
       `Codex exited with code ${attempt.proc.exitCode ?? -1}`;
+    const authEvidence = [attempt.parsed.errorMessage, attempt.proc.stderr, attempt.proc.stdout]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .join("\n");
+    const authRequired = detectCodexLoginRequired(authEvidence);
 
     return {
       exitCode: attempt.proc.exitCode,
@@ -578,6 +683,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (attempt.proc.exitCode ?? 0) === 0
           ? null
           : fallbackErrorMessage,
+      errorCode:
+        (attempt.proc.exitCode ?? 0) === 0
+          ? undefined
+          : authRequired
+            ? "codex_auth_required"
+            : undefined,
       usage: attempt.parsed.usage,
       sessionId: resolvedSessionId,
       sessionParams: resolvedSessionParams,

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,4 +1,4 @@
-export { execute, ensureCodexSkillsInjected } from "./execute.js";
+export { execute, ensureCodexSkillsInjected, runCodexLogin } from "./execute.js";
 export { listCodexSkills, syncCodexSkills } from "./skills.js";
 export { testEnvironment } from "./test.js";
 export { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -26,7 +26,7 @@ Gateway connect identity fields:
 - clientMode (string, optional): gateway client mode (default backend)
 - clientVersion (string, optional): client version string
 - role (string, optional): gateway role (default operator)
-- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin"])
+- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin", "operator.pairing", "operator.read", "operator.write"])
 - disableDeviceAuth (boolean, optional): disable signed device payload in connect params (default false)
 
 Request behavior fields:

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -79,7 +79,7 @@ type GatewayClientRequestOptions = {
 };
 
 const PROTOCOL_VERSION = 3;
-const DEFAULT_SCOPES = ["operator.admin"];
+const DEFAULT_SCOPES = ["operator.admin", "operator.pairing", "operator.read", "operator.write"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";
@@ -126,16 +126,49 @@ function normalizeSessionKeyStrategy(value: unknown): SessionKeyStrategy {
   return "issue";
 }
 
+function normalizeOpenClawAgentId(value: string | null | undefined): string {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) return "main";
+  const normalized = trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+/g, "")
+    .replace(/-+$/g, "");
+  return normalized || "main";
+}
+
+function scopeOpenClawSessionKey(agentId: string | null | undefined, sessionKey: string): string {
+  const trimmed = sessionKey.trim();
+  const normalizedAgentId = normalizeOpenClawAgentId(agentId);
+  if (!trimmed) return `agent:${normalizedAgentId}:main`;
+  if (trimmed.toLowerCase().startsWith("agent:")) return trimmed;
+  return `agent:${normalizedAgentId}:${trimmed}`;
+}
+
+function resolveClaimedApiKeyPath(agentId: string | null | undefined): string {
+  const normalizedAgentId = normalizeOpenClawAgentId(agentId);
+  const workspaceDir =
+    normalizedAgentId === "main"
+      ? "~/.openclaw/workspace"
+      : `~/.openclaw/workspace-${normalizedAgentId}`;
+  return `${workspaceDir}/paperclip-claimed-api-key.json`;
+}
+
 function resolveSessionKey(input: {
   strategy: SessionKeyStrategy;
   configuredSessionKey: string | null;
   runId: string;
   issueId: string | null;
+  agentId: string | null | undefined;
 }): string {
   const fallback = input.configuredSessionKey ?? "paperclip";
-  if (input.strategy === "run") return `paperclip:run:${input.runId}`;
-  if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
-  return fallback;
+  if (input.strategy === "run") {
+    return scopeOpenClawSessionKey(input.agentId, `paperclip:run:${input.runId}`);
+  }
+  if (input.strategy === "issue" && input.issueId) {
+    return scopeOpenClawSessionKey(input.agentId, `paperclip:issue:${input.issueId}`);
+  }
+  return scopeOpenClawSessionKey(input.agentId, fallback);
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -225,7 +258,9 @@ function resolveAuthToken(config: Record<string, unknown>, headers: Record<strin
   const authHeader =
     headerMapGetIgnoreCase(headers, "x-openclaw-auth") ??
     headerMapGetIgnoreCase(headers, "authorization");
-  return tokenFromAuthHeader(authHeader);
+  const fromHeader = tokenFromAuthHeader(authHeader);
+  if (fromHeader) return fromHeader;
+  return nonEmpty(process.env.OPENCLAW_TOKEN);
 }
 
 function isSensitiveLogKey(key: string): boolean {
@@ -335,8 +370,12 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+function buildWakeText(
+  payload: WakePayload,
+  paperclipEnv: Record<string, string>,
+  openClawAgentId: string | null | undefined,
+): string {
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(openClawAgentId);
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -599,6 +638,8 @@ class GatewayWsClient {
   private challengePromise: Promise<string>;
   private resolveChallenge!: (nonce: string) => void;
   private rejectChallenge!: (err: Error) => void;
+  private challengeState: "pending" | "resolved" | "rejected" = "pending";
+  private intentionalClose = false;
 
   constructor(private readonly opts: GatewayClientOptions) {
     this.challengePromise = new Promise<string>((resolve, reject) => {
@@ -612,6 +653,8 @@ class GatewayWsClient {
     buildConnectParams: (nonce: string) => Record<string, unknown>,
     timeoutMs: number,
   ): Promise<Record<string, unknown> | null> {
+    this.intentionalClose = false;
+    this.challengeState = "pending";
     this.ws = new WebSocket(this.opts.url, {
       headers: this.opts.headers,
       maxPayload: 25 * 1024 * 1024,
@@ -624,10 +667,12 @@ class GatewayWsClient {
     });
 
     ws.on("close", (code, reason) => {
+      this.ws = null;
+      if (this.intentionalClose) return;
       const reasonText = rawDataToString(reason);
       const err = new Error(`gateway closed (${code}): ${reasonText}`);
       this.failPending(err);
-      this.rejectChallenge(err);
+      this.rejectChallengeOnce(err);
     });
 
     ws.on("error", (err) => {
@@ -713,8 +758,12 @@ class GatewayWsClient {
 
   close() {
     if (!this.ws) return;
-    this.ws.close(1000, "paperclip-complete");
+    const ws = this.ws;
+    this.intentionalClose = true;
     this.ws = null;
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close(1000, "paperclip-complete");
+    }
   }
 
   private failPending(err: Error) {
@@ -738,7 +787,7 @@ class GatewayWsClient {
         const payload = asRecord(parsed.payload);
         const nonce = nonEmpty(payload?.nonce);
         if (nonce) {
-          this.resolveChallenge(nonce);
+          this.resolveChallengeOnce(nonce);
           return;
         }
       }
@@ -778,6 +827,18 @@ class GatewayWsClient {
     if (code) err.gatewayCode = code;
     if (details) err.gatewayDetails = details;
     pending.reject(err);
+  }
+
+  private resolveChallengeOnce(nonce: string) {
+    if (this.challengeState !== "pending") return;
+    this.challengeState = "resolved";
+    this.resolveChallenge(nonce);
+  }
+
+  private rejectChallengeOnce(err: Error) {
+    if (this.challengeState !== "pending") return;
+    this.challengeState = "rejected";
+    this.rejectChallenge(err);
   }
 }
 
@@ -874,8 +935,8 @@ function parseUsage(value: unknown): AdapterExecutionResult["usage"] | undefined
   const record = asRecord(value);
   if (!record) return undefined;
 
-  const inputTokens = asNumber(record.inputTokens ?? record.input, 0);
-  const outputTokens = asNumber(record.outputTokens ?? record.output, 0);
+  const inputTokens = asNumber(record.inputTokens ?? record.input_tokens ?? record.input, 0);
+  const outputTokens = asNumber(record.outputTokens ?? record.output_tokens ?? record.output, 0);
   const cachedInputTokens = asNumber(
     record.cachedInputTokens ?? record.cached_input_tokens ?? record.cacheRead ?? record.cache_read,
     0,
@@ -1033,6 +1094,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const payloadTemplate = parseObject(ctx.config.payloadTemplate);
   const transportHint = nonEmpty(ctx.config.streamTransport) ?? nonEmpty(ctx.config.transport);
+  const templateAgentId = nonEmpty(payloadTemplate.agentId);
+  const configuredAgentId = nonEmpty(ctx.config.agentId);
+  const effectiveGatewayAgentId = templateAgentId ?? configuredAgentId ?? null;
 
   const headers = toStringRecord(ctx.config.headers);
   const authToken = resolveAuthToken(parseObject(ctx.config), headers);
@@ -1053,7 +1117,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
-  const wakeText = buildWakeText(wakePayload, paperclipEnv);
+  const wakeText = buildWakeText(wakePayload, paperclipEnv, effectiveGatewayAgentId);
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
@@ -1062,6 +1126,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     configuredSessionKey,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
+    agentId: effectiveGatewayAgentId,
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
@@ -1076,7 +1141,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
   delete agentParams.text;
 
-  const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;
   }
@@ -1120,6 +1184,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const autoPairOnFirstConnect = parseBoolean(ctx.config.autoPairOnFirstConnect, true);
   let autoPairAttempted = false;
   let latestResultPayload: unknown = null;
+  let retryCount = 0;
+  const maxRetries = 2;
 
   while (true) {
     const trackedRunIds = new Set<string>([ctx.runId]);
@@ -1323,6 +1389,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         }
       }
 
+      let sessionUsageResult: Record<string, unknown> | null = null;
+      try {
+        sessionUsageResult = await client.request<Record<string, unknown>>(
+          "sessions.usage",
+          { key: sessionKey },
+          { timeoutMs: 10_000 },
+        );
+      } catch (usageErr) {
+        await ctx.onLog(
+          "stderr",
+          `[openclaw-gateway] sessions.usage failed (non-fatal): ${usageErr instanceof Error ? usageErr.message : String(usageErr)}\n`,
+        );
+      }
+
       const summaryFromEvents = assistantChunks.join("").trim();
       const summaryFromPayload =
         extractResultText(asRecord(acceptedPayload?.result)) ??
@@ -1344,11 +1424,40 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         asRecord(mergedMeta.agentMeta) ??
         asRecord(acceptedMeta?.agentMeta) ??
         asRecord(latestMeta?.agentMeta);
-      const usage = parseUsage(agentMeta?.usage ?? mergedMeta.usage);
+      const sessionUsage = asRecord(sessionUsageResult);
+      const sessionTotals = asRecord(sessionUsage?.totals);
+      const sessionAggregates = asRecord(sessionUsage?.aggregates);
+      const sessionByModel = Array.isArray(sessionAggregates?.byModel)
+        ? sessionAggregates.byModel
+        : [];
+      const primaryModelEntry =
+        sessionByModel.length > 0 ? asRecord(sessionByModel[0]) : null;
+      const usage =
+        parseUsage(agentMeta?.usage ?? mergedMeta.usage) ??
+        parseUsage(sessionTotals);
       const runtimeServices = extractRuntimeServicesFromMeta(agentMeta ?? mergedMeta);
-      const provider = nonEmpty(agentMeta?.provider) ?? nonEmpty(mergedMeta.provider) ?? "openclaw";
-      const model = nonEmpty(agentMeta?.model) ?? nonEmpty(mergedMeta.model) ?? null;
-      const costUsd = asNumber(agentMeta?.costUsd ?? mergedMeta.costUsd, 0);
+      const provider =
+        nonEmpty(agentMeta?.provider) ??
+        nonEmpty(mergedMeta.provider) ??
+        nonEmpty(primaryModelEntry?.provider) ??
+        "openclaw";
+      const model =
+        nonEmpty(agentMeta?.model) ??
+        nonEmpty(mergedMeta.model) ??
+        nonEmpty(primaryModelEntry?.model) ??
+        null;
+      const primaryCostSource = agentMeta?.costUsd ?? mergedMeta.costUsd;
+      const costUsd =
+        primaryCostSource == null
+          ? asNumber(sessionTotals?.totalCost, 0)
+          : asNumber(primaryCostSource, 0);
+
+      if (sessionUsageResult) {
+        await ctx.onLog(
+          "stdout",
+          `[openclaw-gateway] sessions.usage: input=${usage?.inputTokens ?? 0} output=${usage?.outputTokens ?? 0} cached=${usage?.cachedInputTokens ?? 0} model=${model ?? "unknown"} cost=$${costUsd.toFixed(4)}\n`,
+        );
+      }
 
       await ctx.onLog(
         "stdout",
@@ -1407,6 +1516,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           "stderr",
           `[openclaw-gateway] auto-pairing failed: ${pairResult.reason}\n`,
         );
+      }
+
+      const isTransient =
+        !pairingRequired &&
+        (lower.includes("econnrefused") ||
+          lower.includes("econnreset") ||
+          lower.includes("socket hang up") ||
+          (timedOut && !lower.includes("agent.wait")));
+      if (isTransient && retryCount < maxRetries) {
+        retryCount += 1;
+        const backoffMs = retryCount * 2000;
+        await ctx.onLog(
+          "stdout",
+          `[openclaw-gateway] transient error, retry ${retryCount}/${maxRetries} after ${backoffMs}ms: ${message}\n`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        continue;
       }
 
       const detailedMessage = pairingRequired

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -422,8 +422,14 @@ function buildWakeText(
     "HTTP rules:",
     "- Use Authorization: Bearer $PAPERCLIP_API_KEY on every API call.",
     "- Use X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID on every mutating API call.",
+    '- Shell safety: do NOT use unquoted array expansion for curl headers (for example `curl ... ${AUTH_HEADER[@]}`), because it splits `Bearer` and the token into separate arguments.',
+    '- Safe header pattern: `AUTH_HEADER="Authorization: Bearer $PAPERCLIP_API_KEY"` and then `curl -fsS -H "$AUTH_HEADER" ...`.',
     "- Use only /api endpoints listed below.",
     "- Do NOT call guessed endpoints like /api/cloud-adapter/*, /api/cloud-adapters/*, /api/adapters/cloud/*, or /api/heartbeat.",
+    "",
+    "Safe curl examples:",
+    '- GET identity: `curl -fsS -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/agents/me"`',
+    '- Checkout: `curl -fsS -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -H \'Content-Type: application/json\' -d \'{"agentId":"$PAPERCLIP_AGENT_ID","expectedStatuses":["todo","backlog","blocked"]}\' "$PAPERCLIP_API_URL/api/issues/{issueId}/checkout"`',
     "",
     "Workflow:",
     "1) GET /api/agents/me",
@@ -1054,6 +1060,30 @@ function extractResultText(value: unknown): string | null {
   return nonEmpty(record.text) ?? nonEmpty(record.summary) ?? null;
 }
 
+function classifyReportedRunFailure(summary: string | null): { errorCode: string; errorMessage: string } | null {
+  if (!summary) return null;
+
+  const normalized = summary.trim().toLowerCase();
+  const failureSignals = [
+    "failed to authenticate",
+    "authentication error",
+    "could not resolve host",
+    "unauthorized",
+    "permission denied",
+    "run completed but failed",
+    "request failed",
+  ];
+
+  if (!failureSignals.some((signal) => normalized.includes(signal))) {
+    return null;
+  }
+
+  return {
+    errorCode: "openclaw_gateway_run_reported_failure",
+    errorMessage: summary.trim(),
+  };
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const urlValue = asString(ctx.config.url, "").trim();
   if (!urlValue) {
@@ -1410,6 +1440,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         extractResultText(asRecord(latestResultPayload)) ??
         null;
       const summary = summaryFromEvents || summaryFromPayload || null;
+      const reportedFailure = classifyReportedRunFailure(summary);
+
+      if (reportedFailure) {
+        await ctx.onLog(
+          "stderr",
+          `[openclaw-gateway] run reported failure: ${reportedFailure.errorMessage}\n`,
+        );
+        return {
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage: reportedFailure.errorMessage,
+          errorCode: reportedFailure.errorCode,
+          provider: "openclaw",
+          resultJson: asRecord(latestResultPayload),
+          ...(summary ? { summary } : {}),
+        };
+      }
 
       const acceptedResult = asRecord(acceptedPayload?.result);
       const latestPayload = asRecord(latestResultPayload);

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.ts
@@ -15,11 +15,19 @@ function parseJsonObject(text: string): Record<string, unknown> | null {
 export function buildOpenClawGatewayConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
   if (v.url) ac.url = v.url;
+  if (v.authToken) {
+    ac.authToken = v.authToken;
+    ac.headers = {
+      "x-openclaw-token": v.authToken,
+    };
+  }
+  if (v.agentId) ac.agentId = v.agentId;
+  if (v.paperclipApiUrl) ac.paperclipApiUrl = v.paperclipApiUrl;
   ac.timeoutSec = 120;
   ac.waitTimeoutMs = 120000;
   ac.sessionKeyStrategy = "issue";
   ac.role = "operator";
-  ac.scopes = ["operator.admin"];
+  ac.scopes = ["operator.admin", "operator.pairing", "operator.read", "operator.write"];
   const payloadTemplate = parseJsonObject(v.payloadTemplateJson ?? "");
   if (payloadTemplate) ac.payloadTemplate = payloadTemplate;
   const runtimeServices = parseJsonObject(v.runtimeServicesJson ?? "");

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -255,6 +255,7 @@ export type {
   DashboardSummary,
   ActivityEvent,
   SidebarBadges,
+  CompanyAssignableUser,
   CompanyMembership,
   PrincipalPermissionGrant,
   Invite,

--- a/packages/shared/src/types/access.ts
+++ b/packages/shared/src/types/access.ts
@@ -21,6 +21,15 @@ export interface CompanyMembership {
   updatedAt: Date;
 }
 
+export interface CompanyAssignableUser {
+  membershipId: string;
+  companyId: string;
+  userId: string;
+  name: string;
+  email: string;
+  membershipRole: string | null;
+}
+
 export interface PrincipalPermissionGrant {
   id: string;
   companyId: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -141,6 +141,7 @@ export type { DashboardSummary } from "./dashboard.js";
 export type { ActivityEvent } from "./activity.js";
 export type { SidebarBadges } from "./sidebar-badges.js";
 export type {
+  CompanyAssignableUser,
   CompanyMembership,
   PrincipalPermissionGrant,
   Invite,

--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -3,12 +3,14 @@ import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 
 describe("agent local JWT", () => {
   const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
+  const betterAuthSecretEnv = "BETTER_AUTH_SECRET";
   const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
   const issuerEnv = "PAPERCLIP_AGENT_JWT_ISSUER";
   const audienceEnv = "PAPERCLIP_AGENT_JWT_AUDIENCE";
 
   const originalEnv = {
     secret: process.env[secretEnv],
+    betterAuthSecret: process.env[betterAuthSecretEnv],
     ttl: process.env[ttlEnv],
     issuer: process.env[issuerEnv],
     audience: process.env[audienceEnv],
@@ -16,6 +18,7 @@ describe("agent local JWT", () => {
 
   beforeEach(() => {
     process.env[secretEnv] = "test-secret";
+    delete process.env[betterAuthSecretEnv];
     process.env[ttlEnv] = "3600";
     delete process.env[issuerEnv];
     delete process.env[audienceEnv];
@@ -26,6 +29,8 @@ describe("agent local JWT", () => {
     vi.useRealTimers();
     if (originalEnv.secret === undefined) delete process.env[secretEnv];
     else process.env[secretEnv] = originalEnv.secret;
+    if (originalEnv.betterAuthSecret === undefined) delete process.env[betterAuthSecretEnv];
+    else process.env[betterAuthSecretEnv] = originalEnv.betterAuthSecret;
     if (originalEnv.ttl === undefined) delete process.env[ttlEnv];
     else process.env[ttlEnv] = originalEnv.ttl;
     if (originalEnv.issuer === undefined) delete process.env[issuerEnv];
@@ -50,11 +55,27 @@ describe("agent local JWT", () => {
     });
   });
 
-  it("returns null when secret is missing", () => {
+  it("falls back to BETTER_AUTH_SECRET when PAPERCLIP_AGENT_JWT_SECRET is missing", () => {
     process.env[secretEnv] = "";
+    process.env[betterAuthSecretEnv] = "better-auth-secret";
     const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
-    expect(token).toBeNull();
-    expect(verifyLocalAgentJwt("abc.def.ghi")).toBeNull();
+    expect(typeof token).toBe("string");
+    expect(verifyLocalAgentJwt(token!)).toMatchObject({
+      sub: "agent-1",
+      company_id: "company-1",
+    });
+  });
+
+  it("falls back to the local trusted dev secret when no explicit secret is configured", () => {
+    process.env[secretEnv] = "";
+    delete process.env[betterAuthSecretEnv];
+    const token = createLocalAgentJwt("agent-1", "company-1", "codex_local", "run-1");
+    expect(typeof token).toBe("string");
+    expect(verifyLocalAgentJwt(token!)).toMatchObject({
+      sub: "agent-1",
+      company_id: "company-1",
+      adapter_type: "codex_local",
+    });
   });
 
   it("rejects expired tokens", () => {

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { execute } from "@paperclipai/adapter-codex-local/server";
+import { execute, runCodexLogin } from "@paperclipai/adapter-codex-local/server";
 
 async function writeFakeCodexCommand(commandPath: string): Promise<void> {
   const script = `#!/usr/bin/env node
@@ -23,6 +23,39 @@ if (capturePath) {
 console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-1" }));
 console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "hello" } }));
 console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+async function writeFakeCodexLoginCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  argv: process.argv.slice(2),
+  codexHome: process.env.CODEX_HOME || null,
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+if (process.argv[2] === "login" && process.argv[3] === "--device-auth") {
+  console.log("Open this URL in your browser:");
+  console.log("https://auth.openai.com/codex/device");
+  console.log("Code: AB12-3CD45");
+  process.exit(0);
+}
+process.exit(1);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+async function writeFakeCodexAuthFailureCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.error("Authentication required. Please run \`codex login\`.");
+process.exit(1);
 `;
   await fs.writeFile(commandPath, script, "utf8");
   await fs.chmod(commandPath, 0o755);
@@ -448,6 +481,92 @@ describe("codex execute", () => {
       else process.env.PAPERCLIP_IN_WORKTREE = previousPaperclipInWorktree;
       if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
       else process.env.CODEX_HOME = previousCodexHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the device-auth login URL and verification code", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-login-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const sharedCodexHome = path.join(root, "shared-codex-home");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(sharedCodexHome, { recursive: true });
+    await writeFakeCodexLoginCommand(commandPath);
+
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = sharedCodexHome;
+
+    try {
+      const result = await runCodexLogin({
+        runId: "run-login",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.loginUrl).toBe("https://auth.openai.com/codex/device");
+      expect(result.verificationCode).toBe("AB12-3CD45");
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.argv).toEqual(["login", "--device-auth"]);
+      expect(capture.codexHome).toBe(sharedCodexHome);
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies login-required failures as codex_auth_required", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-auth-required-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexAuthFailureCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-auth-required",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("codex_auth_required");
+    } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -293,26 +293,26 @@ describe("shouldResetTaskSessionForWake", () => {
     ).toBe(true);
   });
 
-  it("does not reset session context on mention wake comment", () => {
+  it("resets session context on mention wake comment", () => {
     expect(
       shouldResetTaskSessionForWake({
         wakeReason: "issue_comment_mentioned",
         wakeCommentId: "comment-1",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("does not reset session context when commentId is present", () => {
+  it("resets session context when commentId is present", () => {
     expect(
       shouldResetTaskSessionForWake({
         wakeReason: "issue_commented",
         commentId: "comment-2",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("does not reset for comment wakes", () => {
-    expect(shouldResetTaskSessionForWake({ wakeReason: "issue_commented" })).toBe(false);
+  it("resets for comment wakes", () => {
+    expect(shouldResetTaskSessionForWake({ wakeReason: "issue_commented" })).toBe(true);
   });
 
   it("does not reset when wake reason is missing", () => {

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -49,9 +49,11 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("headers.x-openclaw-token");
     expect(text).toContain("Do NOT use /v1/responses or /hooks/*");
     expect(text).toContain("set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl");
+    expect(text).toContain("~/.openclaw/workspace-<openclaw-agent-id>/paperclip-claimed-api-key.json");
     expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
     expect(text).toContain("PAPERCLIP_API_KEY");
     expect(text).toContain("saved token field");
+    expect(text).toContain("Do not reuse another agent's claimed key file");
     expect(text).toContain("Gateway token unexpectedly short");
   });
 

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -42,6 +42,7 @@ function buildContext(
 async function createMockGatewayServer(options?: {
   waitPayload?: Record<string, unknown>;
   sessionUsagePayload?: Record<string, unknown>;
+  assistantChunks?: string[];
 }) {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -116,7 +117,7 @@ async function createMockGatewayServer(options?: {
               seq: 1,
               stream: "assistant",
               ts: Date.now(),
-              data: { delta: "cha" },
+              data: { delta: options?.assistantChunks?.[0] ?? "cha" },
             },
           }),
         );
@@ -129,10 +130,25 @@ async function createMockGatewayServer(options?: {
               seq: 2,
               stream: "assistant",
               ts: Date.now(),
-              data: { delta: "chacha" },
+              data: { delta: options?.assistantChunks?.[1] ?? "chacha" },
             },
           }),
         );
+        for (const [index, chunk] of (options?.assistantChunks ?? []).slice(2).entries()) {
+          socket.send(
+            JSON.stringify({
+              type: "event",
+              event: "agent",
+              payload: {
+                runId,
+                seq: index + 3,
+                stream: "assistant",
+                ts: Date.now(),
+                data: { delta: chunk },
+              },
+            }),
+          );
+        }
         return;
       }
 
@@ -482,6 +498,8 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
       expect(String(payload?.message ?? "")).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+      expect(String(payload?.message ?? "")).toContain("Shell safety:");
+      expect(String(payload?.message ?? "")).toContain('AUTH_HEADER="Authorization: Bearer $PAPERCLIP_API_KEY"');
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {
@@ -747,6 +765,49 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(logs.some((entry) => entry.includes("auto-approved pairing request"))).toBe(true);
       expect(gateway.getAgentPayload()).toBeTruthy();
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("marks the run failed when the final summary reports authentication failure", async () => {
+    const gateway = await createMockGatewayServer({
+      assistantChunks: [
+        "Run completed but failed to authenticate and mutate the issue.",
+        "\n\nWhat happened (summary)\n- GET /api/agents/me returned an authentication error.\n",
+      ],
+      waitPayload: {
+        runId: "run-123",
+        status: "ok",
+        startedAt: 1,
+        endedAt: 2,
+      },
+    });
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            waitTimeoutMs: 2000,
+          },
+          {
+            context: {
+              taskId: "task-123",
+              issueId: "issue-123",
+              wakeReason: "issue_assigned",
+              issueIds: ["issue-123"],
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("openclaw_gateway_run_reported_failure");
+      expect(result.errorMessage).toContain("failed to authenticate");
     } finally {
       await gateway.close();
     }

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -41,6 +41,7 @@ function buildContext(
 
 async function createMockGatewayServer(options?: {
   waitPayload?: Record<string, unknown>;
+  sessionUsagePayload?: Record<string, unknown>;
 }) {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -77,7 +78,7 @@ async function createMockGatewayServer(options?: {
               type: "hello-ok",
               protocol: 3,
               server: { version: "test", connId: "conn-1" },
-              features: { methods: ["connect", "agent", "agent.wait"], events: ["agent"] },
+              features: { methods: ["connect", "agent", "agent.wait", "sessions.usage"], events: ["agent"] },
               snapshot: { version: 1, ts: Date.now() },
               policy: { maxPayload: 1_000_000, maxBufferedBytes: 1_000_000, tickIntervalMs: 30_000 },
             },
@@ -147,6 +148,18 @@ async function createMockGatewayServer(options?: {
               startedAt: 1,
               endedAt: 2,
             },
+          }),
+        );
+        return;
+      }
+
+      if (frame.method === "sessions.usage") {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: options?.sessionUsagePayload ?? {},
           }),
         );
       }
@@ -239,7 +252,7 @@ async function createMockGatewayServerWithPairing() {
               protocol: 3,
               server: { version: "test", connId: "conn-1" },
               features: {
-                methods: ["connect", "agent", "agent.wait", "device.pair.list", "device.pair.approve"],
+                methods: ["connect", "agent", "agent.wait", "sessions.usage", "device.pair.list", "device.pair.approve"],
                 events: ["agent"],
               },
               snapshot: { version: 1, ts: Date.now() },
@@ -351,6 +364,18 @@ async function createMockGatewayServerWithPairing() {
             },
           }),
         );
+        return;
+      }
+
+      if (frame.method === "sessions.usage") {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: true,
+            payload: {},
+          }),
+        );
       }
     });
   });
@@ -452,12 +477,107 @@ describe("openclaw gateway adapter execute", () => {
       const payload = gateway.getAgentPayload();
       expect(payload).toBeTruthy();
       expect(payload?.idempotencyKey).toBe("run-123");
-      expect(payload?.sessionKey).toBe("paperclip:issue:issue-123");
+      expect(payload?.sessionKey).toBe("agent:main:paperclip:issue:issue-123");
       expect(String(payload?.message ?? "")).toContain("wake now");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
+      expect(String(payload?.message ?? "")).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("falls back to a per-agent session key when issue strategy has no issue id", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            agentId: "dot",
+            waitTimeoutMs: 2000,
+          },
+          {
+            context: {
+              taskId: null,
+              issueId: null,
+              wakeReason: "manual",
+              issueIds: [],
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload?.sessionKey).toBe("agent:dot:paperclip");
+      expect(payload?.agentId).toBe("dot");
+      expect(String(payload?.message ?? "")).toContain("~/.openclaw/workspace-dot/paperclip-claimed-api-key.json");
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("falls back to the main OpenClaw agent when no agent id is configured", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            waitTimeoutMs: 2000,
+          },
+          {
+            context: {
+              taskId: null,
+              issueId: null,
+              wakeReason: "manual",
+              issueIds: [],
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload?.sessionKey).toBe("agent:main:paperclip");
+      expect(payload?.agentId).toBeUndefined();
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("scopes a fixed session key to the configured OpenClaw agent", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          agentId: "dot",
+          sessionKeyStrategy: "fixed",
+          sessionKey: "paperclip",
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload?.sessionKey).toBe("agent:dot:paperclip");
+      expect(payload?.agentId).toBe("dot");
     } finally {
       await gateway.close();
     }
@@ -467,6 +587,36 @@ describe("openclaw gateway adapter execute", () => {
     const result = await execute(buildContext({}));
     expect(result.exitCode).toBe(1);
     expect(result.errorCode).toBe("openclaw_gateway_url_missing");
+  });
+
+  it("prefixes session keys when an explicit OpenClaw agent id is configured", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          agentId: "worker-42",
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const payload = gateway.getAgentPayload();
+      expect(payload?.sessionKey).toBe("agent:worker-42:paperclip:issue:issue-123");
+      expect(String(payload?.message ?? "")).toContain(
+        "~/.openclaw/workspace-worker-42/paperclip-claimed-api-key.json",
+      );
+    } finally {
+      await gateway.close();
+    }
   });
 
   it("returns adapter-managed runtime services from gateway result meta", async () => {
@@ -512,6 +662,54 @@ describe("openclaw gateway adapter execute", () => {
           status: "running",
         }),
       ]);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("uses sessions.usage to populate usage, model, and cost when agent.wait omits them", async () => {
+    const gateway = await createMockGatewayServer({
+      sessionUsagePayload: {
+        totals: {
+          inputTokens: 11,
+          input_tokens: 11,
+          outputTokens: 7,
+          output_tokens: 7,
+          cachedInputTokens: 3,
+          cached_input_tokens: 3,
+          totalCost: 0.42,
+        },
+        aggregates: {
+          byModel: [
+            {
+              provider: "openai",
+              model: "gpt-5-codex",
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.provider).toBe("openai");
+      expect(result.model).toBe("gpt-5-codex");
+      expect(result.usage).toEqual({
+        inputTokens: 11,
+        outputTokens: 7,
+        cachedInputTokens: 3,
+      });
+      expect(result.costUsd).toBe(0.42);
     } finally {
       await gateway.close();
     }
@@ -573,6 +771,9 @@ describe("openclaw gateway ui build config", () => {
       envVars: "",
       envBindings: {},
       url: "wss://gateway.example/ws",
+      authToken: "gateway-token",
+      agentId: "worker-42",
+      paperclipApiUrl: "https://paperclip.example",
       payloadTemplateJson: JSON.stringify({
         agentId: "remote-agent-123",
         metadata: { team: "platform" },
@@ -594,6 +795,12 @@ describe("openclaw gateway ui build config", () => {
     expect(config).toEqual(
       expect.objectContaining({
         url: "wss://gateway.example/ws",
+        authToken: "gateway-token",
+        agentId: "worker-42",
+        paperclipApiUrl: "https://paperclip.example",
+        headers: {
+          "x-openclaw-token": "gateway-token",
+        },
         payloadTemplate: {
           agentId: "remote-agent-123",
           metadata: { team: "platform" },

--- a/server/src/__tests__/plugin-bridge-agent-routes.test.ts
+++ b/server/src/__tests__/plugin-bridge-agent-routes.test.ts
@@ -1,0 +1,153 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { pluginRoutes } from "../routes/plugins.js";
+import { errorHandler } from "../middleware/index.js";
+
+const pluginId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const mockRegistry = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByKey: vi.fn(),
+}));
+
+const mockLifecycle = vi.hoisted(() => ({}));
+
+const mockWorkerManager = vi.hoisted(() => ({
+  call: vi.fn(),
+}));
+
+vi.mock("../services/plugin-registry.js", () => ({
+  pluginRegistryService: () => mockRegistry,
+}));
+
+vi.mock("../services/plugin-lifecycle.js", () => ({
+  pluginLifecycleManager: () => mockLifecycle,
+}));
+
+vi.mock("../services/plugin-loader.js", () => ({
+  getPluginUiContributionMetadata: vi.fn(),
+  pluginLoader: vi.fn(),
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: vi.fn(),
+}));
+
+vi.mock("../services/live-events.js", () => ({
+  publishGlobalLiveEvent: vi.fn(),
+}));
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", pluginRoutes(
+    {} as any,
+    {} as any,
+    undefined,
+    undefined,
+    undefined,
+    { workerManager: mockWorkerManager as any },
+  ));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("plugin bridge agent action routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistry.getById.mockResolvedValue({
+      id: pluginId,
+      pluginKey: "homio.atlas-bridge",
+      displayName: "Atlas Bridge",
+      status: "ready",
+    });
+    mockRegistry.getByKey.mockResolvedValue(null);
+    mockWorkerManager.call.mockResolvedValue({ ok: true });
+  });
+
+  it("allows agent-authenticated action calls when companyId is nested in params", async () => {
+    const app = createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/actions/atlas-bridge-sync-issue-projection`)
+      .send({
+        params: {
+          companyId,
+          issueId: "issue-1",
+          reason: "test",
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      data: { ok: true },
+    });
+    expect(mockWorkerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "performAction",
+      {
+        key: "atlas-bridge-sync-issue-projection",
+        params: {
+          companyId,
+          issueId: "issue-1",
+          reason: "test",
+        },
+        renderEnvironment: null,
+      },
+    );
+  });
+
+  it("rejects agent-authenticated action calls without company scope", async () => {
+    const app = createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/actions/atlas-bridge-sync-issue-projection`)
+      .send({
+        params: {
+          issueId: "issue-1",
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("companyId is required for agent plugin bridge access");
+  });
+
+  it("keeps board-authenticated action calls working without company scope", async () => {
+    const app = createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/actions/atlas-bridge-sync-issue-projection`)
+      .send({
+        params: {
+          issueId: "issue-1",
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      data: { ok: true },
+    });
+  });
+});

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -12,16 +12,65 @@ import {
 } from "../utils.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, context, onLog, onMeta, authToken } = ctx;
   const command = asString(config.command, "");
   if (!command) throw new Error("Process adapter missing command");
 
   const args = asStringArray(config.args);
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" &&
+    envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = {
+    ...buildPaperclipEnv(agent),
+    PAPERCLIP_RUN_ID: runId,
+  };
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" &&
+      context.wakeCommentId.trim().length > 0 &&
+      context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+  const workspaceCwd =
+    context.paperclipWorkspace &&
+    typeof context.paperclipWorkspace === "object" &&
+    typeof (context.paperclipWorkspace as { cwd?: unknown }).cwd === "string"
+      ? String((context.paperclipWorkspace as { cwd?: string }).cwd).trim()
+      : "";
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
+  }
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
   }
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);

--- a/server/src/adapters/process/index.ts
+++ b/server/src/adapters/process/index.ts
@@ -7,6 +7,7 @@ export const processAdapter: ServerAdapterModule = {
   execute,
   testEnvironment,
   models: [],
+  supportsLocalAgentJwt: true,
   agentConfigurationDoc: `# process agent configuration
 
 Adapter: process

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -26,7 +26,10 @@ function parseNumber(value: string | undefined, fallback: number) {
 }
 
 function jwtConfig() {
-  const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  const secret =
+    process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() ||
+    process.env.BETTER_AUTH_SECRET?.trim() ||
+    "paperclip-dev-secret";
   if (!secret) return null;
 
   return {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -9,12 +9,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Router } from "express";
 import type { Request } from "express";
-import { and, eq, isNull, desc } from "drizzle-orm";
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agentApiKeys,
   authUsers,
   companies,
+  companyMemberships,
   invites,
   joinRequests
 } from "@paperclipai/db";
@@ -2875,6 +2876,31 @@ export function accessRoutes(
     await assertCompanyPermission(req, companyId, "users:manage_permissions");
     const members = await access.listMembers(companyId);
     res.json(members);
+  });
+
+  router.get("/companies/:companyId/assignable-users", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const users = await db
+      .select({
+        membershipId: companyMemberships.id,
+        companyId: companyMemberships.companyId,
+        userId: authUsers.id,
+        name: authUsers.name,
+        email: authUsers.email,
+        membershipRole: companyMemberships.membershipRole,
+      })
+      .from(companyMemberships)
+      .innerJoin(authUsers, eq(companyMemberships.principalId, authUsers.id))
+      .where(
+        and(
+          eq(companyMemberships.companyId, companyId),
+          eq(companyMemberships.principalType, "user"),
+          eq(companyMemberships.status, "active"),
+        ),
+      )
+      .orderBy(asc(authUsers.name), asc(authUsers.email));
+    res.json(users);
   });
 
   router.patch(

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1036,7 +1036,7 @@ function buildInviteOnboardingManifest(
     ),
     onboarding: {
       instructions:
-        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
+        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to your own OpenClaw workspace: ~/.openclaw/workspace-<openclaw-agent-id>/paperclip-claimed-api-key.json for non-main agents, or ~/.openclaw/workspace/paperclip-claimed-api-key.json for main. Load PAPERCLIP_API_KEY from that per-agent file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: "openclaw_gateway",
       requiredFields: {
@@ -1242,10 +1242,11 @@ export function buildInviteOnboardingTextDocument(
       "claimSecret": "<one-time-claim-secret>"
     }
 
-    On successful claim, save the full JSON response to:
+    On successful claim, save the full JSON response to your own OpenClaw workspace:
 
-    - ~/.openclaw/workspace/paperclip-claimed-api-key.json
-    chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+    - non-main agents: ~/.openclaw/workspace-<openclaw-agent-id>/paperclip-claimed-api-key.json
+    - main agent: ~/.openclaw/workspace/paperclip-claimed-api-key.json
+    chmod 600 <that per-agent paperclip-claimed-api-key.json file>
 
     And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
     https://docs.openclaw.ai/help/environment
@@ -1259,7 +1260,7 @@ export function buildInviteOnboardingTextDocument(
       },
     }
 
-    Then set PAPERCLIP_API_KEY and PAPERCLIP_API_URL from the saved token field for every heartbeat run.
+    Then set PAPERCLIP_API_KEY and PAPERCLIP_API_URL from the saved token field for every heartbeat run. Do not reuse another agent's claimed key file.
 
     Important:
     - claim secrets expire

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -51,6 +51,7 @@ import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { runClaudeLogin } from "@paperclipai/adapter-claude-local/server";
+import { runCodexLogin } from "@paperclipai/adapter-codex-local/server";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
@@ -2081,6 +2082,37 @@ export function agentRoutes(db: Db) {
     const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(agent.companyId, config);
     const result = await runClaudeLogin({
       runId: `claude-login-${randomUUID()}`,
+      agent: {
+        id: agent.id,
+        companyId: agent.companyId,
+        name: agent.name,
+        adapterType: agent.adapterType,
+        adapterConfig: agent.adapterConfig,
+      },
+      config: runtimeConfig,
+    });
+
+    res.json(result);
+  });
+
+  router.post("/agents/:id/codex-login", async (req, res) => {
+    assertBoard(req);
+    const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+    if (agent.adapterType !== "codex_local") {
+      res.status(400).json({ error: "Login is only supported for codex_local agents" });
+      return;
+    }
+
+    const config = asRecord(agent.adapterConfig) ?? {};
+    const { config: runtimeConfig } = await secretsSvc.resolveAdapterConfigForRuntime(agent.companyId, config);
+    const result = await runCodexLogin({
+      runId: `codex-login-${randomUUID()}`,
       agent: {
         id: agent.id,
         companyId: agent.companyId,

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -11,7 +11,8 @@
  * - Retrieving UI slot contributions for frontend rendering
  * - Discovering and executing plugin-contributed agent tools
  *
- * All routes require board-level authentication (assertBoard middleware).
+ * Most routes require board-level authentication. Plugin bridge routes also
+ * accept agent-authenticated calls when a company scope is provided.
  *
  * @module server/routes/plugins
  * @see doc/plugins/PLUGIN_SPEC.md for the full plugin specification
@@ -40,6 +41,7 @@ import { pluginLifecycleManager } from "../services/plugin-lifecycle.js";
 import { getPluginUiContributionMetadata, pluginLoader } from "../services/plugin-loader.js";
 import { logActivity } from "../services/activity-log.js";
 import { publishGlobalLiveEvent } from "../services/live-events.js";
+import { forbidden, unauthorized } from "../errors.js";
 import type { PluginJobScheduler } from "../services/plugin-job-scheduler.js";
 import type { PluginJobStore } from "../services/plugin-job-store.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
@@ -704,6 +706,39 @@ export function pluginRoutes(
     details?: unknown;
   }
 
+  function resolveBridgeCompanyId(
+    body:
+      | {
+          companyId?: string;
+          params?: Record<string, unknown>;
+        }
+      | undefined,
+  ): string | null {
+    if (typeof body?.companyId === "string" && body.companyId.trim().length > 0) {
+      return body.companyId.trim();
+    }
+    const nestedCompanyId = body?.params?.companyId;
+    if (typeof nestedCompanyId === "string" && nestedCompanyId.trim().length > 0) {
+      return nestedCompanyId.trim();
+    }
+    return null;
+  }
+
+  function assertPluginBridgeAccess(
+    req: Request,
+    companyId: string | null,
+  ): void {
+    if (req.actor.type === "none") {
+      throw unauthorized();
+    }
+    if (req.actor.type === "agent" && !companyId) {
+      throw forbidden("companyId is required for agent plugin bridge access");
+    }
+    if (companyId) {
+      assertCompanyAccess(req, companyId);
+    }
+  }
+
   /**
    * Map a worker RPC error to a bridge-level error code.
    *
@@ -793,8 +828,6 @@ export function pluginRoutes(
    * @see PLUGIN_SPEC.md §19.7 — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/bridge/data", async (req, res) => {
-    assertBoard(req);
-
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
@@ -826,9 +859,7 @@ export function pluginRoutes(
       return;
     }
 
-    if (body.companyId) {
-      assertCompanyAccess(req, body.companyId);
-    }
+    assertPluginBridgeAccess(req, resolveBridgeCompanyId(body));
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -876,8 +907,6 @@ export function pluginRoutes(
    * @see PLUGIN_SPEC.md §19.7 — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/bridge/action", async (req, res) => {
-    assertBoard(req);
-
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
@@ -909,9 +938,7 @@ export function pluginRoutes(
       return;
     }
 
-    if (body.companyId) {
-      assertCompanyAccess(req, body.companyId);
-    }
+    assertPluginBridgeAccess(req, resolveBridgeCompanyId(body));
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -960,8 +987,6 @@ export function pluginRoutes(
    * @see PLUGIN_SPEC.md §19.7 — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/data/:key", async (req, res) => {
-    assertBoard(req);
-
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
@@ -992,9 +1017,7 @@ export function pluginRoutes(
       renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
     } | undefined;
 
-    if (body?.companyId) {
-      assertCompanyAccess(req, body.companyId);
-    }
+    assertPluginBridgeAccess(req, resolveBridgeCompanyId(body));
 
     try {
       const result = await bridgeDeps.workerManager.call(
@@ -1039,8 +1062,6 @@ export function pluginRoutes(
    * @see PLUGIN_SPEC.md §19.7 — Error Propagation Through The Bridge
    */
   router.post("/plugins/:pluginId/actions/:key", async (req, res) => {
-    assertBoard(req);
-
     if (!bridgeDeps) {
       res.status(501).json({ error: "Plugin bridge is not enabled" });
       return;
@@ -1071,9 +1092,7 @@ export function pluginRoutes(
       renderEnvironment?: PluginLauncherRenderContextSnapshot | null;
     } | undefined;
 
-    if (body?.companyId) {
-      assertCompanyAccess(req, body.companyId);
-    }
+    assertPluginBridgeAccess(req, resolveBridgeCompanyId(body));
 
     try {
       const result = await bridgeDeps.workerManager.call(

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -527,10 +527,9 @@ const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; valu
   openclaw_gateway: [
     { path: ["timeoutSec"], value: 120 },
     { path: ["waitTimeoutMs"], value: 120000 },
-    { path: ["sessionKeyStrategy"], value: "fixed" },
-    { path: ["sessionKey"], value: "paperclip" },
+    { path: ["sessionKeyStrategy"], value: "issue" },
     { path: ["role"], value: "operator" },
-    { path: ["scopes"], value: ["operator.admin"] },
+    { path: ["scopes"], value: ["operator.admin", "operator.pairing", "operator.read", "operator.write"] },
   ],
 };
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -30,6 +30,7 @@ import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
+import { logActivity } from "./activity-log.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -659,6 +660,8 @@ export function shouldResetTaskSessionForWake(
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (wakeReason === "issue_assigned") return true;
+  if (wakeReason === "issue_commented") return true;
+  if (wakeReason === "issue_comment_mentioned") return true;
   return false;
 }
 
@@ -676,6 +679,8 @@ function describeSessionResetReason(
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
+  if (wakeReason === "issue_commented") return "wake reason is issue_commented";
+  if (wakeReason === "issue_comment_mentioned") return "wake reason is issue_comment_mentioned";
   return null;
 }
 
@@ -910,6 +915,39 @@ export function heartbeatService(db: Db) {
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function logIssueExecutionActivity(
+    run: typeof heartbeatRuns.$inferSelect,
+    input: {
+      action: string;
+      status: string;
+      details?: Record<string, unknown> | null;
+    },
+  ) {
+    const context = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(context.issueId);
+    if (!issueId) return;
+
+    await logActivity(db, {
+      companyId: run.companyId,
+      actorType: "agent",
+      actorId: run.agentId,
+      agentId: run.agentId,
+      runId: run.id,
+      action: input.action,
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        heartbeatRunId: run.id,
+        status: input.status,
+        invocationSource: run.invocationSource,
+        triggerDetail: run.triggerDetail,
+        error: run.error ?? null,
+        errorCode: run.errorCode ?? null,
+        ...input.details,
+      },
+    });
   }
 
   async function getRuntimeState(agentId: string) {
@@ -1504,6 +1542,17 @@ export function heartbeatService(db: Db) {
           finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
         },
       });
+      if (status === "succeeded" || status === "failed" || status === "cancelled" || status === "timed_out") {
+        await logIssueExecutionActivity(updated, {
+          action: "issue.execution_finished",
+          status: updated.status,
+          details: {
+            finishedAt: updated.finishedAt ? new Date(updated.finishedAt).toISOString() : null,
+          },
+        }).catch((err) => {
+          logger.warn({ err, runId: updated.id, status }, "failed to log issue execution final activity");
+        });
+      }
     }
 
     return updated;
@@ -1793,6 +1842,15 @@ export function heartbeatService(db: Db) {
     });
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
+    await logIssueExecutionActivity(claimed, {
+      action: "issue.execution_started",
+      status: claimed.status,
+      details: {
+        startedAt: claimed.startedAt ? new Date(claimed.startedAt).toISOString() : null,
+      },
+    }).catch((err) => {
+      logger.warn({ err, runId: claimed.id }, "failed to log issue execution start activity");
+    });
     return claimed;
   }
 
@@ -3494,6 +3552,12 @@ export function heartbeatService(db: Db) {
         },
       });
 
+      await logIssueExecutionActivity(newRun, {
+        action: "issue.execution_queued",
+        status: newRun.status,
+      }).catch((err) => {
+        logger.warn({ err, runId: newRun.id }, "failed to log issue execution queued activity");
+      });
       await startNextQueuedRunForAgent(agent.id);
       return newRun;
     }
@@ -3602,6 +3666,12 @@ export function heartbeatService(db: Db) {
       },
     });
 
+    await logIssueExecutionActivity(newRun, {
+      action: "issue.execution_queued",
+      status: newRun.status,
+    }).catch((err) => {
+      logger.warn({ err, runId: newRun.id }, "failed to log issue execution queued activity");
+    });
     await startNextQueuedRunForAgent(agent.id);
 
     return newRun;

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -87,13 +87,14 @@ export function OpenClawGatewayConfigFields({
       delete nextHeaders["x-openclaw-token"];
       delete nextHeaders["x-openclaw-auth"];
     }
+    mark("adapterConfig", "authToken", nextValue || undefined);
     mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
   };
 
   const sessionStrategy = eff(
     "adapterConfig",
     "sessionKeyStrategy",
-    String(config.sessionKeyStrategy ?? "fixed"),
+    String(config.sessionKeyStrategy ?? "issue"),
   );
 
   return (
@@ -124,6 +125,39 @@ export function OpenClawGatewayConfigFields({
         mark={mark}
       />
 
+      <SecretField
+        label="Gateway auth token (x-openclaw-token)"
+        value={
+          isCreate
+            ? values!.authToken ?? ""
+            : effectiveGatewayToken
+        }
+        onCommit={(v) =>
+          isCreate
+            ? set!({ authToken: v })
+            : commitGatewayToken(v)
+        }
+        placeholder="OpenClaw gateway token"
+      />
+
+      <Field label="OpenClaw agent ID">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.agentId ?? ""
+              : eff("adapterConfig", "agentId", String(config.agentId ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ agentId: v })
+              : mark("adapterConfig", "agentId", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="main"
+        />
+      </Field>
+
       <RuntimeServicesJsonField
         isCreate={isCreate}
         values={values}
@@ -132,24 +166,30 @@ export function OpenClawGatewayConfigFields({
         mark={mark}
       />
 
-      {!isCreate && (
-        <>
-          <Field label="Paperclip API URL override">
-            <DraftInput
-              value={
-                eff(
+      <Field label="Paperclip API URL override">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.paperclipApiUrl ?? ""
+              : eff(
                   "adapterConfig",
                   "paperclipApiUrl",
                   String(config.paperclipApiUrl ?? ""),
                 )
-              }
-              onCommit={(v) => mark("adapterConfig", "paperclipApiUrl", v || undefined)}
-              immediate
-              className={inputClass}
-              placeholder="https://paperclip.example"
-            />
-          </Field>
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ paperclipApiUrl: v })
+              : mark("adapterConfig", "paperclipApiUrl", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="https://paperclip.example"
+        />
+      </Field>
 
+      {!isCreate && (
+        <>
           <Field label="Session strategy">
             <select
               value={sessionStrategy}
@@ -174,13 +214,6 @@ export function OpenClawGatewayConfigFields({
             </Field>
           )}
 
-          <SecretField
-            label="Gateway auth token (x-openclaw-token)"
-            value={effectiveGatewayToken}
-            onCommit={commitGatewayToken}
-            placeholder="OpenClaw gateway token"
-          />
-
           <Field label="Role">
             <DraftInput
               value={eff("adapterConfig", "role", String(config.role ?? "operator"))}
@@ -193,7 +226,11 @@ export function OpenClawGatewayConfigFields({
 
           <Field label="Scopes (comma-separated)">
             <DraftInput
-              value={eff("adapterConfig", "scopes", parseScopes(config.scopes ?? ["operator.admin"]))}
+              value={eff(
+                "adapterConfig",
+                "scopes",
+                parseScopes(config.scopes ?? ["operator.admin", "operator.pairing", "operator.read", "operator.write"]),
+              )}
               onCommit={(v) => {
                 const parsed = v
                   .split(",")
@@ -203,7 +240,7 @@ export function OpenClawGatewayConfigFields({
               }}
               immediate
               className={inputClass}
-              placeholder="operator.admin"
+              placeholder="operator.admin, operator.pairing, operator.read, operator.write"
             />
           </Field>
 

--- a/ui/src/api/access.ts
+++ b/ui/src/api/access.ts
@@ -1,4 +1,4 @@
-import type { AgentAdapterType, JoinRequest } from "@paperclipai/shared";
+import type { AgentAdapterType, CompanyAssignableUser, JoinRequest } from "@paperclipai/shared";
 import { api } from "./client";
 
 type InviteSummary = {
@@ -128,6 +128,9 @@ export const accessApi = {
 
   listJoinRequests: (companyId: string, status: "pending_approval" | "approved" | "rejected" = "pending_approval") =>
     api.get<JoinRequest[]>(`/companies/${companyId}/join-requests?status=${status}`),
+
+  listAssignableUsers: (companyId: string) =>
+    api.get<CompanyAssignableUser[]>(`/companies/${companyId}/assignable-users`),
 
   approveJoinRequest: (companyId: string, requestId: string) =>
     api.post<JoinRequest>(`/companies/${companyId}/join-requests/${requestId}/approve`, {}),

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -42,6 +42,16 @@ export interface ClaudeLoginResult {
   stderr: string;
 }
 
+export interface CodexLoginResult {
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  loginUrl: string | null;
+  verificationCode: string | null;
+  stdout: string;
+  stderr: string;
+}
+
 export interface OrgNode {
   id: string;
   name: string;
@@ -192,6 +202,8 @@ export const agentsApi = {
   ) => api.post<HeartbeatRun | { status: "skipped" }>(agentPath(id, companyId, "/wakeup"), data),
   loginWithClaude: (id: string, companyId?: string) =>
     api.post<ClaudeLoginResult>(agentPath(id, companyId, "/claude-login"), {}),
+  loginWithCodex: (id: string, companyId?: string) =>
+    api.post<CodexLoginResult>(agentPath(id, companyId, "/codex-login"), {}),
   availableSkills: () =>
     api.get<{ skills: AvailableSkill[] }>("/skills/available"),
 };

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1024,7 +1024,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local", "cursor", "hermes_local", "openclaw_gateway"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -88,6 +88,42 @@ function clearDraft(draftKey: string) {
   }
 }
 
+const DISPLAY_AUTHOR_MARKER_RE = /<!--\s*paperclip-display-author:\s*([^>]+?)\s*-->/i;
+
+function parseDisplayAuthorMarker(body: string): { label: string | null; sanitizedBody: string } {
+  const match = body.match(DISPLAY_AUTHOR_MARKER_RE);
+  const sanitizedBody = body.replace(DISPLAY_AUTHOR_MARKER_RE, "").replace(/^\s+/, "");
+  return {
+    label: match?.[1]?.trim() || null,
+    sanitizedBody,
+  };
+}
+
+function extractLegacyAtlasBridgeField(body: string, label: string): string | null {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = body.match(new RegExp(`(?:^|\\n)[-*]\\s+\\*\\*${escapedLabel}\\*\\*:\\s+(.+)$`, "m"));
+  return match?.[1]?.trim() || null;
+}
+
+function parseLegacyAtlasBridgeSync(body: string): {
+  execution: string | null;
+  slot: string | null;
+  action: string | null;
+  reason: string | null;
+} | null {
+  if (!body.startsWith("# Atlas Bridge sync")) {
+    return null;
+  }
+
+  const reasonMatch = body.match(/(?:^|\n)[-*]\s+Reason:\s+(.+)$/m);
+  return {
+    execution: extractLegacyAtlasBridgeField(body, "Execution"),
+    slot: extractLegacyAtlasBridgeField(body, "Slot"),
+    action: extractLegacyAtlasBridgeField(body, "Action"),
+    reason: reasonMatch?.[1]?.trim() || null,
+  };
+}
+
 function parseReassignment(target: string): CommentReassignment | null {
   if (!target || target === "__none__") {
     return { assigneeAgentId: null, assigneeUserId: null };
@@ -140,6 +176,11 @@ function CommentCard({
   const isHighlighted = highlightCommentId === comment.id;
   const isPending = comment.clientStatus === "pending";
   const isQueued = queued || comment.queueState === "queued" || comment.clientStatus === "queued";
+  const { label: displayAuthorLabel, sanitizedBody } = parseDisplayAuthorMarker(comment.body);
+  const fallbackAutomationLabel = comment.body.startsWith("# Atlas Bridge sync")
+    ? "Atlas Bridge · Reporter"
+    : "Automation";
+  const legacyAtlasBridgeSync = parseLegacyAtlasBridgeSync(sanitizedBody);
 
   return (
     <div
@@ -161,8 +202,12 @@ function CommentCard({
               size="sm"
             />
           </Link>
-        ) : (
+        ) : displayAuthorLabel ? (
+          <Identity name={displayAuthorLabel} size="sm" />
+        ) : comment.authorUserId ? (
           <Identity name="You" size="sm" />
+        ) : (
+          <Identity name={fallbackAutomationLabel} size="sm" />
         )}
         <span className="flex items-center gap-1.5">
           {isQueued ? (
@@ -196,10 +241,42 @@ function CommentCard({
               {formatDateTime(comment.createdAt)}
             </a>
           )}
-          <CopyMarkdownButton text={comment.body} />
+          <CopyMarkdownButton text={sanitizedBody} />
         </span>
       </div>
-      <MarkdownBody className="text-sm">{comment.body}</MarkdownBody>
+      {legacyAtlasBridgeSync ? (
+        <div className="space-y-3 text-sm">
+          <div className="font-medium">Служебный sync snapshot</div>
+          <div className="grid gap-2 md:grid-cols-2">
+            <div className="rounded-md border border-border/70 bg-accent/20 px-3 py-2">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">Execution</div>
+              <div className="mt-1">{legacyAtlasBridgeSync.execution ?? "n/a"}</div>
+            </div>
+            <div className="rounded-md border border-border/70 bg-accent/20 px-3 py-2">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">Слот</div>
+              <div className="mt-1">{legacyAtlasBridgeSync.slot ?? "n/a"}</div>
+            </div>
+            <div className="rounded-md border border-border/70 bg-accent/20 px-3 py-2">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">Причина</div>
+              <div className="mt-1">{legacyAtlasBridgeSync.reason ?? "n/a"}</div>
+            </div>
+            <div className="rounded-md border border-border/70 bg-accent/20 px-3 py-2">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">Действие</div>
+              <div className="mt-1">{legacyAtlasBridgeSync.action ?? "n/a"}</div>
+            </div>
+          </div>
+          <details className="rounded-md border border-border/70 bg-accent/10 px-3 py-2">
+            <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Raw sync payload
+            </summary>
+            <div className="mt-3">
+              <MarkdownBody className="text-sm">{sanitizedBody}</MarkdownBody>
+            </div>
+          </details>
+        </div>
+      ) : (
+        <MarkdownBody className="text-sm">{sanitizedBody}</MarkdownBody>
+      )}
       {companyId && !isPending ? (
         <div className="mt-2 space-y-2">
           <PluginSlotOutlet
@@ -242,6 +319,84 @@ type TimelineItem =
   | { kind: "comment"; id: string; createdAtMs: number; comment: CommentWithRunMeta }
   | { kind: "run"; id: string; createdAtMs: number; run: LinkedRunItem };
 
+type DisplayTimelineItem =
+  | TimelineItem
+  | {
+    kind: "atlasSyncGroup";
+    id: string;
+    createdAtMs: number;
+    items: Array<Extract<TimelineItem, { kind: "comment" }>>;
+  }
+  | {
+    kind: "atlasServiceGroup";
+    id: string;
+    createdAtMs: number;
+    items: Array<Extract<TimelineItem, { kind: "comment" }>>;
+  };
+
+function isLegacyAtlasBridgeSyncComment(body: string): boolean {
+  const { sanitizedBody } = parseDisplayAuthorMarker(body);
+  return parseLegacyAtlasBridgeSync(sanitizedBody) !== null;
+}
+
+function isAtlasBridgeServiceComment(comment: CommentWithRunMeta): boolean {
+  if (comment.authorAgentId || comment.authorUserId) return false;
+  const { label } = parseDisplayAuthorMarker(comment.body);
+  return Boolean(label?.startsWith("Atlas Bridge ·"));
+}
+
+function compactTimelineItems(timeline: TimelineItem[]): DisplayTimelineItem[] {
+  const compacted: DisplayTimelineItem[] = [];
+  let pendingSyncItems: Array<Extract<TimelineItem, { kind: "comment" }>> = [];
+  let pendingServiceItems: Array<Extract<TimelineItem, { kind: "comment" }>> = [];
+
+  const flushSyncItems = () => {
+    if (pendingSyncItems.length === 0) return;
+    if (pendingSyncItems.length === 1) {
+      compacted.push(pendingSyncItems[0]);
+    } else {
+      compacted.push({
+        kind: "atlasSyncGroup",
+        id: `atlas-sync-group:${pendingSyncItems[0]!.id}:${pendingSyncItems[pendingSyncItems.length - 1]!.id}`,
+        createdAtMs: pendingSyncItems[pendingSyncItems.length - 1]!.createdAtMs,
+        items: pendingSyncItems,
+      });
+    }
+    pendingSyncItems = [];
+  };
+
+  const flushServiceItems = () => {
+    if (pendingServiceItems.length === 0) return;
+    compacted.push({
+      kind: "atlasServiceGroup",
+      id: `atlas-service-group:${pendingServiceItems[0]!.id}:${pendingServiceItems[pendingServiceItems.length - 1]!.id}`,
+      createdAtMs: pendingServiceItems[pendingServiceItems.length - 1]!.createdAtMs,
+      items: pendingServiceItems,
+    });
+    pendingServiceItems = [];
+  };
+
+  for (const item of timeline) {
+    if (item.kind === "comment" && isLegacyAtlasBridgeSyncComment(item.comment.body)) {
+      flushServiceItems();
+      pendingSyncItems.push(item);
+      continue;
+    }
+    if (item.kind === "comment" && isAtlasBridgeServiceComment(item.comment)) {
+      flushSyncItems();
+      pendingServiceItems.push(item);
+      continue;
+    }
+    flushSyncItems();
+    flushServiceItems();
+    compacted.push(item);
+  }
+
+  flushSyncItems();
+  flushServiceItems();
+  return compacted;
+}
+
 const TimelineList = memo(function TimelineList({
   timeline,
   agentMap,
@@ -255,13 +410,121 @@ const TimelineList = memo(function TimelineList({
   projectId?: string | null;
   highlightCommentId?: string | null;
 }) {
-  if (timeline.length === 0) {
+  const displayTimeline = useMemo(() => compactTimelineItems(timeline), [timeline]);
+
+  if (displayTimeline.length === 0) {
     return <p className="text-sm text-muted-foreground">No comments or runs yet.</p>;
   }
 
   return (
     <div className="space-y-3">
-      {timeline.map((item) => {
+      {displayTimeline.map((item) => {
+        if (item.kind === "atlasSyncGroup") {
+          const latest = item.items[item.items.length - 1]!;
+          const latestSync = parseLegacyAtlasBridgeSync(parseDisplayAuthorMarker(latest.comment.body).sanitizedBody);
+          return (
+            <div
+              key={item.id}
+              className="rounded-sm border border-border bg-accent/10 p-3 text-sm"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Identity name="Atlas Bridge · Reporter" size="sm" />
+                    <span className="font-medium">Служебные sync snapshots</span>
+                  </div>
+                  <p className="mt-1 text-muted-foreground">
+                    Свернул {item.items.length} технических sync-комментариев Atlas Bridge.
+                    Последний snapshot: {latestSync?.execution ?? "n/a"} на {latestSync?.slot ?? "n/a"}.
+                  </p>
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDateTime(latest.comment.createdAt)}
+                </span>
+              </div>
+
+              <details className="mt-3 rounded-md border border-border/70 bg-background/60 px-3 py-2">
+                <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Развернуть техническую историю
+                </summary>
+                <div className="mt-3 space-y-2">
+                  {item.items.map((entry) => {
+                    const parsed = parseLegacyAtlasBridgeSync(
+                      parseDisplayAuthorMarker(entry.comment.body).sanitizedBody,
+                    );
+                    return (
+                      <div
+                        key={entry.id}
+                        className="grid gap-2 rounded-md border border-border/60 bg-accent/10 px-3 py-2 md:grid-cols-[140px_1fr]"
+                      >
+                        <div className="text-xs text-muted-foreground">
+                          {formatDateTime(entry.comment.createdAt)}
+                        </div>
+                        <div className="grid gap-1 text-xs">
+                          <div><strong>Execution:</strong> {parsed?.execution ?? "n/a"}</div>
+                          <div><strong>Слот:</strong> {parsed?.slot ?? "n/a"}</div>
+                          <div><strong>Причина:</strong> {parsed?.reason ?? "n/a"}</div>
+                          <div><strong>Действие:</strong> {parsed?.action ?? "n/a"}</div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </details>
+            </div>
+          );
+        }
+
+        if (item.kind === "atlasServiceGroup") {
+          const latest = item.items[item.items.length - 1]!;
+          return (
+            <div
+              key={item.id}
+              className="rounded-sm border border-border bg-accent/10 p-3 text-sm"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Identity name="Atlas Bridge · Service Log" size="sm" />
+                    <span className="font-medium">Служебные сообщения Atlas Bridge</span>
+                  </div>
+                  <p className="mt-1 text-muted-foreground">
+                    Свернул {item.items.length} технических bridge-сообщений. Смысловые комментарии ролей остаются в ленте отдельно.
+                  </p>
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDateTime(latest.comment.createdAt)}
+                </span>
+              </div>
+
+              <details className="mt-3 rounded-md border border-border/70 bg-background/60 px-3 py-2">
+                <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Развернуть техническую историю
+                </summary>
+                <div className="mt-3 space-y-2">
+                  {item.items.map((entry) => {
+                    const parsed = parseDisplayAuthorMarker(entry.comment.body);
+                    return (
+                      <div
+                        key={entry.id}
+                        className="grid gap-2 rounded-md border border-border/60 bg-accent/10 px-3 py-2 md:grid-cols-[180px_1fr]"
+                      >
+                        <div className="text-xs text-muted-foreground">
+                          <div>{formatDateTime(entry.comment.createdAt)}</div>
+                          <div className="mt-1 font-medium text-foreground/80">{parsed.label ?? "Atlas Bridge"}</div>
+                        </div>
+                        <div className="text-sm">
+                          <MarkdownBody className="text-sm">{parsed.sanitizedBody}</MarkdownBody>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </details>
+            </div>
+          );
+        }
+
         if (item.kind === "run") {
           const run = item.run;
           return (
@@ -464,10 +727,11 @@ export function CommentThread({
   }
 
   const canSubmit = !submitting && !!body.trim();
+  const displayTimeline = useMemo(() => compactTimelineItems(timeline), [timeline]);
 
   return (
     <div className="space-y-4">
-      <h3 className="text-sm font-semibold">Comments &amp; Runs ({timeline.length + queuedComments.length})</h3>
+      <h3 className="text-sm font-semibold">Comments &amp; Runs ({displayTimeline.length + queuedComments.length})</h3>
 
       {timeline.length > 0 ? (
         <TimelineList

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -3,6 +3,7 @@ import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { Link } from "@/lib/router";
 import type { Issue } from "@paperclipai/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { accessApi } from "../api/access";
 import { agentsApi } from "../api/agents";
 import { authApi } from "../api/auth";
 import { issuesApi } from "../api/issues";
@@ -11,7 +12,7 @@ import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
 import { useProjectOrder } from "../hooks/useProjectOrder";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
-import { formatAssigneeUserLabel } from "../lib/assignees";
+import { companyUserAssigneeOptions, createAssigneeUserDirectory, formatAssigneeUserLabel } from "../lib/assignees";
 import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
@@ -141,6 +142,11 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
     queryFn: () => agentsApi.list(companyId!),
     enabled: !!companyId,
   });
+  const { data: assignableUsers } = useQuery({
+    queryKey: queryKeys.access.assignableUsers(companyId!),
+    queryFn: () => accessApi.listAssignableUsers(companyId!),
+    enabled: !!companyId,
+  });
 
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(companyId!),
@@ -214,11 +220,20 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
     () => sortAgentsByRecency((agents ?? []).filter((a) => a.status !== "terminated"), recentAssigneeIds),
     [agents, recentAssigneeIds],
   );
+  const assignableUsersById = useMemo(
+    () => createAssigneeUserDirectory(assignableUsers ?? []),
+    [assignableUsers],
+  );
+  const otherUserOptions = useMemo(
+    () => companyUserAssigneeOptions(assignableUsers ?? [], currentUserId),
+    [assignableUsers, currentUserId],
+  );
 
   const assignee = issue.assigneeAgentId
     ? agents?.find((a) => a.id === issue.assigneeAgentId)
     : null;
-  const userLabel = (userId: string | null | undefined) => formatAssigneeUserLabel(userId, currentUserId);
+  const userLabel = (userId: string | null | undefined) =>
+    formatAssigneeUserLabel(userId, currentUserId, assignableUsersById);
   const assigneeUserLabel = userLabel(issue.assigneeUserId);
   const creatorUserLabel = userLabel(issue.createdByUserId);
 
@@ -403,6 +418,30 @@ export function IssueProperties({ issue, onUpdate, inline }: IssuePropertiesProp
             {a.name}
           </button>
         ))}
+        {otherUserOptions
+          .filter((user) => {
+            if (!assigneeSearch.trim()) return true;
+            return (user.searchText ?? user.label).toLowerCase().includes(assigneeSearch.toLowerCase());
+          })
+          .map((user) => {
+            const userId = user.id.slice("user:".length);
+            return (
+              <button
+                key={user.id}
+                className={cn(
+                  "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50",
+                  issue.assigneeUserId === userId && "bg-accent"
+                )}
+                onClick={() => {
+                  onUpdate({ assigneeAgentId: null, assigneeUserId: userId });
+                  setAssigneeOpen(false);
+                }}
+              >
+                <User className="h-3 w-3 shrink-0 text-muted-foreground" />
+                {user.label}
+              </button>
+            );
+          })}
       </div>
     </>
   );

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -3,10 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { accessApi } from "../api/access";
 import { issuesApi } from "../api/issues";
 import { authApi } from "../api/auth";
 import { queryKeys } from "../lib/queryKeys";
-import { formatAssigneeUserLabel } from "../lib/assignees";
+import { companyUserAssigneeOptions, createAssigneeUserDirectory, formatAssigneeUserLabel } from "../lib/assignees";
 import { groupBy } from "../lib/groupBy";
 import { formatDate, cn } from "../lib/utils";
 import { timeAgo } from "../lib/timeAgo";
@@ -102,6 +103,7 @@ function applyFilters(issues: Issue[], state: IssueViewState, currentUserId?: st
       for (const assignee of state.assignees) {
         if (assignee === "__unassigned" && !issue.assigneeAgentId && !issue.assigneeUserId) return true;
         if (assignee === "__me" && currentUserId && issue.assigneeUserId === currentUserId) return true;
+        if (assignee.startsWith("__user:") && issue.assigneeUserId === assignee.slice("__user:".length)) return true;
         if (issue.assigneeAgentId === assignee) return true;
       }
       return false;
@@ -236,6 +238,19 @@ export function IssuesList({
     queryFn: () => authApi.getSession(),
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  const { data: assignableUsers } = useQuery({
+    queryKey: queryKeys.access.assignableUsers(selectedCompanyId!),
+    queryFn: () => accessApi.listAssignableUsers(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+  const assignableUsersById = useMemo(
+    () => createAssigneeUserDirectory(assignableUsers ?? []),
+    [assignableUsers],
+  );
+  const userAssigneeOptions = useMemo(
+    () => companyUserAssigneeOptions(assignableUsers ?? [], currentUserId),
+    [assignableUsers, currentUserId],
+  );
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;
@@ -337,11 +352,11 @@ export function IssuesList({
         key === "__unassigned"
           ? "Unassigned"
           : key.startsWith("__user:")
-            ? (formatAssigneeUserLabel(key.slice("__user:".length), currentUserId) ?? "User")
+            ? (formatAssigneeUserLabel(key.slice("__user:".length), currentUserId, assignableUsersById) ?? "User")
             : (agentName(key) ?? key.slice(0, 8)),
       items: groups[key]!,
     }));
-  }, [filtered, viewState.groupBy, agents, agentName, currentUserId]);
+  }, [filtered, viewState.groupBy, agents, agentName, currentUserId, assignableUsersById]);
 
   const newIssueDefaults = (groupKey?: string) => {
     const defaults: Record<string, string> = {};
@@ -515,6 +530,19 @@ export function IssuesList({
                             <span className="text-sm">Me</span>
                           </label>
                         )}
+                        {userAssigneeOptions.map((user) => {
+                          const userFilterKey = `__user:${user.id.slice("user:".length)}`;
+                          return (
+                            <label key={user.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
+                              <Checkbox
+                                checked={viewState.assignees.includes(userFilterKey)}
+                                onCheckedChange={() => updateView({ assignees: toggleInArray(viewState.assignees, userFilterKey) })}
+                              />
+                              <User className="h-3.5 w-3.5 text-muted-foreground" />
+                              <span className="text-sm">{user.label}</span>
+                            </label>
+                          );
+                        })}
                         {(agents ?? []).map((agent) => (
                           <label key={agent.id} className="flex items-center gap-2 px-2 py-1 rounded-sm hover:bg-accent/50 cursor-pointer">
                             <Checkbox
@@ -793,7 +821,7 @@ export function IssuesList({
                                 <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-dashed border-muted-foreground/35 bg-muted/30">
                                   <User className="h-3 w-3" />
                                 </span>
-                                {formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? "User"}
+                                {formatAssigneeUserLabel(issue.assigneeUserId, currentUserId, assignableUsersById) ?? "User"}
                               </span>
                             ) : (
                               <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -848,6 +876,33 @@ export function IssuesList({
                                 <span>Me</span>
                               </button>
                             )}
+                            {userAssigneeOptions
+                              .filter((user) => {
+                                if (!assigneeSearch.trim()) return true;
+                                return (user.searchText ?? user.label)
+                                  .toLowerCase()
+                                  .includes(assigneeSearch.toLowerCase());
+                              })
+                              .map((user) => {
+                                const userId = user.id.slice("user:".length);
+                                return (
+                                  <button
+                                    key={user.id}
+                                    className={cn(
+                                      "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent/50",
+                                      issue.assigneeUserId === userId && "bg-accent",
+                                    )}
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      assignIssue(issue.id, null, userId);
+                                    }}
+                                  >
+                                    <User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                                    <span>{user.label}</span>
+                                  </button>
+                                );
+                              })}
                             {(agents ?? [])
                               .filter((agent) => {
                                 if (!assigneeSearch.trim()) return true;

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { pickTextColorForSolidBg } from "@/lib/color-contrast";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
+import { accessApi } from "../api/access";
 import { executionWorkspacesApi } from "../api/execution-workspaces";
 import { issuesApi } from "../api/issues";
 import { instanceSettingsApi } from "../api/instanceSettings";
@@ -16,6 +17,7 @@ import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "
 import { useToast } from "../context/ToastContext";
 import {
   assigneeValueFromSelection,
+  companyUserAssigneeOptions,
   currentUserAssigneeOption,
   parseAssigneeValue,
 } from "../lib/assignees";
@@ -310,6 +312,11 @@ export function NewIssueDialog() {
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(effectiveCompanyId!),
     queryFn: () => agentsApi.list(effectiveCompanyId!),
+    enabled: !!effectiveCompanyId && newIssueOpen,
+  });
+  const { data: assignableUsers } = useQuery({
+    queryKey: queryKeys.access.assignableUsers(effectiveCompanyId!),
+    queryFn: () => accessApi.listAssignableUsers(effectiveCompanyId!),
     enabled: !!effectiveCompanyId && newIssueOpen,
   });
 
@@ -790,6 +797,7 @@ export function NewIssueDialog() {
   const assigneeOptions = useMemo<InlineEntityOption[]>(
     () => [
       ...currentUserAssigneeOption(currentUserId),
+      ...companyUserAssigneeOptions(assignableUsers ?? [], currentUserId),
       ...sortAgentsByRecency(
         (agents ?? []).filter((agent) => agent.status !== "terminated"),
         recentAssigneeIds,
@@ -799,7 +807,7 @@ export function NewIssueDialog() {
         searchText: `${agent.name} ${agent.role} ${agent.title ?? ""}`,
       })),
     ],
-    [agents, currentUserId, recentAssigneeIds],
+    [agents, assignableUsers, currentUserId, recentAssigneeIds],
   );
   const projectOptions = useMemo<InlineEntityOption[]>(
     () =>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -119,6 +119,9 @@ export function OnboardingWizard() {
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [url, setUrl] = useState("");
+  const [gatewayToken, setGatewayToken] = useState("");
+  const [gatewayAgentId, setGatewayAgentId] = useState("");
+  const [gatewayPaperclipApiUrl, setGatewayPaperclipApiUrl] = useState("");
   const [adapterEnvResult, setAdapterEnvResult] =
     useState<AdapterEnvironmentTestResult | null>(null);
   const [adapterEnvError, setAdapterEnvError] = useState<string | null>(null);
@@ -294,6 +297,9 @@ export function OnboardingWizard() {
     setCommand("");
     setArgs("");
     setUrl("");
+    setGatewayToken("");
+    setGatewayAgentId("");
+    setGatewayPaperclipApiUrl("");
     setAdapterEnvResult(null);
     setAdapterEnvError(null);
     setAdapterEnvLoading(false);
@@ -330,6 +336,9 @@ export function OnboardingWizard() {
       command,
       args,
       url,
+      authToken: gatewayToken,
+      agentId: gatewayAgentId,
+      paperclipApiUrl: gatewayPaperclipApiUrl,
       dangerouslySkipPermissions:
         adapterType === "claude_local" || adapterType === "opencode_local",
       dangerouslyBypassSandbox:
@@ -828,41 +837,52 @@ export function OnboardingWizard() {
                             value: "gemini_local" as const,
                             label: "Gemini CLI",
                             icon: Gem,
-                            desc: "Local Gemini agent"
+                            desc: "Local Gemini agent",
+                            comingSoon: false,
                           },
                           {
                             value: "opencode_local" as const,
                             label: "OpenCode",
                             icon: OpenCodeLogoIcon,
-                            desc: "Local multi-provider agent"
+                            desc: "Local multi-provider agent",
+                            comingSoon: false,
                           },
                           {
                             value: "pi_local" as const,
                             label: "Pi",
                             icon: Terminal,
-                            desc: "Local Pi agent"
+                            desc: "Local Pi agent",
+                            comingSoon: false,
                           },
                           {
                             value: "cursor" as const,
                             label: "Cursor",
                             icon: MousePointer2,
-                            desc: "Local Cursor agent"
+                            desc: "Local Cursor agent",
+                            comingSoon: false,
                           },
                           {
                             value: "hermes_local" as const,
                             label: "Hermes Agent",
                             icon: HermesIcon,
-                            desc: "Local multi-provider agent"
+                            desc: "Local multi-provider agent",
+                            comingSoon: false,
                           },
                           {
                             value: "openclaw_gateway" as const,
                             label: "OpenClaw Gateway",
                             icon: Bot,
                             desc: "Invoke OpenClaw via gateway protocol",
-                            comingSoon: true,
-                            disabledLabel: "Configure OpenClaw within the App"
+                            comingSoon: false,
                           }
-                        ].map((opt) => (
+                        ].map((opt: {
+                          value: AdapterType;
+                          label: string;
+                          icon: any;
+                          desc: string;
+                          comingSoon?: boolean;
+                          disabledLabel?: string;
+                        }) => (
                           <button
                             key={opt.value}
                             disabled={!!opt.comingSoon}
@@ -1155,6 +1175,45 @@ export function OnboardingWizard() {
                         onChange={(e) => setUrl(e.target.value)}
                       />
                     </div>
+                  )}
+
+                  {adapterType === "openclaw_gateway" && (
+                    <>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Gateway auth token
+                        </label>
+                        <input
+                          type="password"
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="OpenClaw gateway token"
+                          value={gatewayToken}
+                          onChange={(e) => setGatewayToken(e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          OpenClaw agent ID
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="main"
+                          value={gatewayAgentId}
+                          onChange={(e) => setGatewayAgentId(e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Paperclip API URL override
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="https://paperclip.example"
+                          value={gatewayPaperclipApiUrl}
+                          onChange={(e) => setGatewayPaperclipApiUrl(e.target.value)}
+                        />
+                      </div>
+                    </>
                   )}
                 </div>
               )}

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -27,4 +27,7 @@ export const defaultCreateValues: CreateConfigValues = {
   maxTurnsPerRun: 300,
   heartbeatEnabled: false,
   intervalSec: 300,
+  authToken: "",
+  agentId: "",
+  paperclipApiUrl: "",
 };

--- a/ui/src/lib/assignees.test.ts
+++ b/ui/src/lib/assignees.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   assigneeValueFromSelection,
+  companyUserAssigneeOptions,
+  createAssigneeUserDirectory,
   currentUserAssigneeOption,
   formatAssigneeUserLabel,
   parseAssigneeValue,
@@ -50,6 +52,32 @@ describe("assignee selection helpers", () => {
     expect(formatAssigneeUserLabel("user-1", "user-1")).toBe("Me");
     expect(formatAssigneeUserLabel("local-board", "someone-else")).toBe("Board");
     expect(formatAssigneeUserLabel("user-abcdef", "someone-else")).toBe("user-");
+  });
+
+  it("uses assignable user identity data when available", () => {
+    const usersById = createAssigneeUserDirectory([
+      { userId: "user-2", name: "Stanislav", email: "stan@homio.pro" },
+    ]);
+
+    expect(formatAssigneeUserLabel("user-2", "someone-else", usersById)).toBe("Stanislav");
+  });
+
+  it("builds assignee options for other active company users", () => {
+    expect(
+      companyUserAssigneeOptions(
+        [
+          { userId: "user-1", name: "Current User", email: "me@homio.pro" },
+          { userId: "user-2", name: "Stanislav", email: "stan@homio.pro" },
+        ],
+        "user-1",
+      ),
+    ).toEqual([
+      {
+        id: "user:user-2",
+        label: "Stanislav (stan@homio.pro)",
+        searchText: "Stanislav stan@homio.pro human user-2",
+      },
+    ]);
   });
 
   it("suggests the last non-me commenter without changing the actual assignee encoding", () => {

--- a/ui/src/lib/assignees.ts
+++ b/ui/src/lib/assignees.ts
@@ -1,3 +1,5 @@
+import type { CompanyAssignableUser } from "@paperclipai/shared";
+
 export interface AssigneeSelection {
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
@@ -18,6 +20,9 @@ interface CommentAssigneeSuggestionComment {
   authorAgentId?: string | null;
   authorUserId?: string | null;
 }
+
+type AssigneeUserIdentity = Pick<CompanyAssignableUser, "userId" | "name" | "email">;
+export type AssigneeUserDirectory = Map<string, Pick<CompanyAssignableUser, "name" | "email">>;
 
 export function assigneeValueFromSelection(selection: Partial<AssigneeSelection>): string {
   if (selection.assigneeAgentId) return `agent:${selection.assigneeAgentId}`;
@@ -71,12 +76,56 @@ export function currentUserAssigneeOption(currentUserId: string | null | undefin
   }];
 }
 
+function conciseAssignableUserLabel(user: Pick<CompanyAssignableUser, "name" | "email">): string {
+  const name = user.name.trim();
+  const email = user.email.trim();
+  if (name && email && name.toLowerCase() !== email.toLowerCase()) {
+    return `${name} (${email})`;
+  }
+  return name || email;
+}
+
+function displayAssignableUserLabel(user: Pick<CompanyAssignableUser, "name" | "email">): string | null {
+  const name = user.name.trim();
+  const email = user.email.trim();
+  return name || email || null;
+}
+
+export function createAssigneeUserDirectory(users: AssigneeUserIdentity[]): AssigneeUserDirectory {
+  return new Map(
+    users.map((user) => [
+      user.userId,
+      {
+        name: user.name,
+        email: user.email,
+      },
+    ]),
+  );
+}
+
+export function companyUserAssigneeOptions(
+  users: AssigneeUserIdentity[],
+  currentUserId: string | null | undefined,
+): AssigneeOption[] {
+  return users
+    .filter((user) => user.userId !== currentUserId)
+    .map((user) => ({
+      id: assigneeValueFromSelection({ assigneeUserId: user.userId }),
+      label: conciseAssignableUserLabel(user),
+      searchText: `${user.name} ${user.email} human ${user.userId}`.trim(),
+    }));
+}
+
 export function formatAssigneeUserLabel(
   userId: string | null | undefined,
   currentUserId: string | null | undefined,
+  usersById?: AssigneeUserDirectory | null,
 ): string | null {
   if (!userId) return null;
   if (currentUserId && userId === currentUserId) return "Me";
   if (userId === "local-board") return "Board";
+  const knownUser = usersById?.get(userId);
+  const knownLabel = knownUser ? displayAssignableUserLabel(knownUser) : null;
+  if (knownLabel) return knownLabel;
   return userId.slice(0, 5);
 }

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -87,6 +87,8 @@ export const queryKeys = {
   access: {
     joinRequests: (companyId: string, status: string = "pending_approval") =>
       ["access", "join-requests", companyId, status] as const,
+    assignableUsers: (companyId: string) =>
+      ["access", "assignable-users", companyId] as const,
     invite: (token: string) => ["access", "invite", token] as const,
   },
   auth: {

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -5,6 +5,7 @@ import {
   agentsApi,
   type AgentKey,
   type ClaudeLoginResult,
+  type CodexLoginResult,
   type AgentPermissionUpdate,
 } from "../api/agents";
 import { companySkillsApi } from "../api/companySkills";
@@ -2900,9 +2901,11 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
   const metrics = runMetrics(run);
   const [sessionOpen, setSessionOpen] = useState(false);
   const [claudeLoginResult, setClaudeLoginResult] = useState<ClaudeLoginResult | null>(null);
+  const [codexLoginResult, setCodexLoginResult] = useState<CodexLoginResult | null>(null);
 
   useEffect(() => {
     setClaudeLoginResult(null);
+    setCodexLoginResult(null);
   }, [run.id]);
 
   const cancelRun = useMutation({
@@ -3005,6 +3008,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
     mutationFn: () => agentsApi.loginWithClaude(run.agentId, run.companyId),
     onSuccess: (data) => {
       setClaudeLoginResult(data);
+    },
+  });
+  const runCodexLogin = useMutation({
+    mutationFn: () => agentsApi.loginWithCodex(run.agentId, run.companyId),
+    onSuccess: (data) => {
+      setCodexLoginResult(data);
     },
   });
 
@@ -3246,6 +3255,58 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
                       </p>
                     )}
                   </div>
+                )}
+              </div>
+            )}
+            {run.errorCode === "codex_auth_required" && adapterType === "codex_local" && (
+              <div className="space-y-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => runCodexLogin.mutate()}
+                  disabled={runCodexLogin.isPending}
+                >
+                  {runCodexLogin.isPending ? "Running codex login..." : "Login to Codex"}
+                </Button>
+                {runCodexLogin.isError && (
+                  <p className="text-xs text-destructive">
+                    {runCodexLogin.error instanceof Error
+                      ? runCodexLogin.error.message
+                      : "Failed to run Codex login"}
+                  </p>
+                )}
+                {codexLoginResult?.loginUrl && (
+                  <p className="text-xs">
+                    Login URL:
+                    <a
+                      href={codexLoginResult.loginUrl}
+                      className="text-blue-600 underline underline-offset-2 ml-1 break-all dark:text-blue-400"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {codexLoginResult.loginUrl}
+                    </a>
+                  </p>
+                )}
+                {codexLoginResult?.verificationCode && (
+                  <p className="text-xs font-mono text-foreground">
+                    Code: {codexLoginResult.verificationCode}
+                  </p>
+                )}
+                {codexLoginResult && (
+                  <>
+                    {!!codexLoginResult.stdout && (
+                      <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap">
+                        {codexLoginResult.stdout}
+                      </pre>
+                    )}
+                    {!!codexLoginResult.stderr && (
+                      <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-red-700 dark:text-red-300 overflow-x-auto whitespace-pre-wrap">
+                        {codexLoginResult.stderr}
+                      </pre>
+                    )}
+                  </>
                 )}
               </div>
             )}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -208,6 +208,340 @@ function ActorIdentity({ evt, agentMap }: { evt: ActivityEvent; agentMap: Map<st
   return <Identity name={id || "Unknown"} size="sm" />;
 }
 
+type IssueActivityDisplayItem =
+  | {
+    kind: "event";
+    id: string;
+    actorLabel: string;
+    title: string;
+    body: string | null;
+    tone: "default" | "success" | "warning" | "error" | "info";
+    createdAt: string | Date;
+  }
+  | {
+    kind: "group";
+    id: string;
+    actorLabel: string;
+    title: string;
+    body: string;
+    tone: "default" | "success" | "warning" | "error" | "info";
+    createdAt: string | Date;
+    events: ActivityEvent[];
+  };
+
+type IssueActivityEventSummary = Omit<Extract<IssueActivityDisplayItem, { kind: "event" }>, "id" | "createdAt" | "kind">;
+
+function detailString(details: Record<string, unknown> | null, key: string): string | null {
+  const value = details?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function issueCommentSnippet(evt: ActivityEvent): string | null {
+  return detailString(asRecord(evt.details), "bodySnippet");
+}
+
+function isAtlasBridgeSyncCommentEvent(evt: ActivityEvent): boolean {
+  return evt.action === "issue.comment_added" && (issueCommentSnippet(evt)?.startsWith("# Atlas Bridge sync") ?? false);
+}
+
+function isAtlasBridgeDocumentNoise(evt: ActivityEvent): boolean {
+  if (!evt.action.startsWith("issue.document_")) return false;
+  const key = detailString(asRecord(evt.details), "key");
+  return key === "atlas-execution" || key === "atlas-debug-pack";
+}
+
+function technicalAtlasGroupKind(evt: ActivityEvent): "read" | "sync-comment" | "doc" | "reconcile" | "timeline" | "artifact" | null {
+  if (evt.action === "issue.read_marked") return "read";
+  if (isAtlasBridgeSyncCommentEvent(evt)) return "sync-comment";
+  if (isAtlasBridgeDocumentNoise(evt)) return "doc";
+  if (evt.action.startsWith("Atlas sync (reconcile:schedule)")) return "reconcile";
+  if (evt.action.startsWith("Atlas timeline #")) return "timeline";
+  if (evt.action.startsWith("Atlas artifact:")) return "artifact";
+  return null;
+}
+
+function summarizeTechnicalGroup(
+  kind: NonNullable<ReturnType<typeof technicalAtlasGroupKind>>,
+  events: ActivityEvent[],
+): IssueActivityDisplayItem | null {
+  if (events.length === 0) return null;
+  if (kind === "read" || kind === "doc") return null;
+
+  const latest = events[0]!;
+  const latestDetails = asRecord(latest.details);
+  const latestExecution = detailString(latestDetails, "executionState");
+  const latestSlot = detailString(latestDetails, "slotEnv");
+  const latestEventType = detailString(latestDetails, "eventType");
+  const artifactKinds = Array.from(
+    new Set(
+      events
+        .map((evt) => {
+          const actionMatch = evt.action.match(/^Atlas artifact:\s+([^/]+)/);
+          return actionMatch?.[1]?.trim() ?? null;
+        })
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  const config: Record<Exclude<typeof kind, "read" | "doc">, { title: string; body: string; tone: IssueActivityDisplayItem["tone"] }> = {
+    "sync-comment": {
+      title: "Свернуты служебные sync-комментарии",
+      body: `Скрыто ${events.length} технических snapshot-комментариев Atlas Bridge. Их детальная история доступна во вкладке Comments в свернутом блоке.`,
+      tone: "info",
+    },
+    reconcile: {
+      title: "Bridge периодически синхронизировал состояние",
+      body: `Свернуто ${events.length} reconcile-обновлений. Последнее состояние: ${latestExecution ?? "n/a"} на ${latestSlot ?? "n/a"}.`,
+      tone: "info",
+    },
+    timeline: {
+      title: "Свернута техническая timeline из Atlas",
+      body: `Скрыто ${events.length} низкоуровневых timeline-событий${latestEventType ? `, последнее: ${latestEventType}` : ""}.`,
+      tone: "default",
+    },
+    artifact: {
+      title: "Свернуты публикации artifacts",
+      body: `Скрыто ${events.length} технических artifact-событий${artifactKinds.length ? `: ${artifactKinds.join(", ")}` : ""}.`,
+      tone: "success",
+    },
+  };
+
+  const summary = config[kind];
+  return {
+    kind: "group",
+    id: `activity-group:${kind}:${latest.id}`,
+    actorLabel: "Atlas Bridge · Service Log",
+    title: summary.title,
+    body: summary.body,
+    tone: summary.tone,
+    createdAt: latest.createdAt,
+    events,
+  };
+}
+
+function describeAtlasActivityEvent(evt: ActivityEvent): IssueActivityEventSummary | null {
+  const details = asRecord(evt.details);
+  const slotEnv = detailString(details, "slotEnv");
+  const branch = detailString(details, "branch") ?? detailString(details, "slotBranch");
+  const repo = detailString(details, "repo");
+  const turnLabel = detailString(details, "turnLabel");
+  const verifyKind = evt.action.startsWith("Atlas artifact: VerifyReport");
+
+  if (evt.action === "Atlas Bridge requested Atlas cloud execution launch") {
+    return {
+      actorLabel: "Delivery Orchestrator",
+      title: "Оркестратор отправил задачу в Atlas",
+      body: [repo ? `Репозиторий ${repo}` : null, slotEnv ? `слот ${slotEnv}` : null, branch ? `ветка ${branch}` : null].filter(Boolean).join(", "),
+      tone: "info",
+    };
+  }
+
+  if (evt.action === "Atlas Bridge launch accepted by Atlas") {
+    return {
+      actorLabel: "Atlas Executor",
+      title: "Atlas принял execution-turn",
+      body: [slotEnv ? `Слот ${slotEnv}` : null, branch ? `ветка ${branch}` : null, detailString(details, "runtimeSessionId") ? `runtime session создан` : null].filter(Boolean).join(", "),
+      tone: "info",
+    };
+  }
+
+  if (evt.action === "Atlas Bridge requested Atlas follow-up execution turn") {
+    return {
+      actorLabel: "Atlas Executor",
+      title: turnLabel ? `${turnLabel} отправлен в текущий execution` : "Следующий turn отправлен в текущий execution",
+      body: [repo ? `Репозиторий ${repo}` : null, slotEnv ? `слот ${slotEnv}` : null, branch ? `ветка ${branch}` : null].filter(Boolean).join(", "),
+      tone: "info",
+    };
+  }
+
+  if (evt.action === "Atlas Bridge follow-up accepted by Atlas") {
+    return {
+      actorLabel: "Atlas Executor",
+      title: turnLabel ? `${turnLabel} принят Atlas` : "Follow-up turn принят Atlas",
+      body: [repo ? `Репозиторий ${repo}` : null, slotEnv ? `слот ${slotEnv}` : null, branch ? `ветка ${branch}` : null].filter(Boolean).join(", "),
+      tone: "info",
+    };
+  }
+
+  if (evt.action === "Atlas Bridge advanced issue to in_review after healthy stand sync") {
+    return {
+      actorLabel: "Reporter",
+      title: "Задача переведена в In Review",
+      body: slotEnv ? `Стенд ${slotEnv} успешно синхронизирован и готов к ручной проверке.` : "Стенд успешно синхронизирован и готов к ручной проверке.",
+      tone: "success",
+    };
+  }
+
+  if (evt.action.startsWith("Atlas stand transition")) {
+    const previousState = detailString(details, "previousAttachmentState") ?? "none";
+    const nextState = detailString(details, "nextAttachmentState") ?? "unknown";
+    return {
+      actorLabel: "Stand Controller",
+      title: "Состояние стенда изменилось",
+      body: `${slotEnv ?? "n/a"}: ${previousState} -> ${nextState}${branch ? `, ветка ${branch}` : ""}.`,
+      tone: nextState === "attached" ? "success" : nextState === "drifted" ? "warning" : "info",
+    };
+  }
+
+  if (verifyKind) {
+    return {
+      actorLabel: "Technical Verifier",
+      title: "Опубликован VerifyReport",
+      body: detailString(details, "artifactCreatedAt") ?? "Результат проверки опубликован.",
+      tone: "success",
+    };
+  }
+
+  if (evt.action === "issue.comment_added") {
+    const snippet = issueCommentSnippet(evt);
+    if (snippet?.includes("### Reporter")) {
+      return {
+        actorLabel: "Reporter",
+        title: "Опубликована человекочитаемая сводка",
+        body: "Новый комментарий содержит краткий итог и ссылки для ревью.",
+        tone: "success",
+      };
+    }
+  }
+
+  if (evt.action.startsWith("Atlas sync (")) {
+    const executionState = detailString(details, "executionState");
+    const attachmentState = detailString(details, "attachmentState");
+    return {
+      actorLabel: "Atlas Bridge",
+      title: "Bridge обновил состояние задачи",
+      body: [executionState ? `execution ${executionState}` : null, slotEnv ? `слот ${slotEnv}` : null, attachmentState ? `стенд ${attachmentState}` : null].filter(Boolean).join(", "),
+      tone: "default",
+    };
+  }
+
+  return null;
+}
+
+function buildIssueActivityItems(activity: ActivityEvent[]): IssueActivityDisplayItem[] {
+  const items: IssueActivityDisplayItem[] = [];
+  let pendingKind: NonNullable<ReturnType<typeof technicalAtlasGroupKind>> | null = null;
+  let pendingEvents: ActivityEvent[] = [];
+
+  const flushPending = () => {
+    if (!pendingKind || pendingEvents.length === 0) {
+      pendingKind = null;
+      pendingEvents = [];
+      return;
+    }
+    const summary = summarizeTechnicalGroup(pendingKind, pendingEvents);
+    if (summary) items.push(summary);
+    pendingKind = null;
+    pendingEvents = [];
+  };
+
+  for (const evt of activity) {
+    const groupKind = technicalAtlasGroupKind(evt);
+    if (groupKind) {
+      if (groupKind === "read") {
+        continue;
+      }
+      if (pendingKind === groupKind) {
+        pendingEvents.push(evt);
+      } else {
+        flushPending();
+        pendingKind = groupKind;
+        pendingEvents = [evt];
+      }
+      continue;
+    }
+
+    flushPending();
+
+    const atlasDescription = describeAtlasActivityEvent(evt);
+    if (atlasDescription) {
+      items.push({
+        kind: "event",
+        id: evt.id,
+        createdAt: evt.createdAt,
+        ...atlasDescription,
+      });
+      continue;
+    }
+
+    items.push({
+      kind: "event",
+      id: evt.id,
+      actorLabel: evt.actorType === "system" ? "System" : evt.actorType === "user" ? "Board" : evt.actorId || "Unknown",
+      title: formatAction(evt.action, asRecord(evt.details)),
+      body: null,
+      tone: "default",
+      createdAt: evt.createdAt,
+    });
+  }
+
+  flushPending();
+  return items;
+}
+
+function IssueActivityFeed({ activity }: { activity: ActivityEvent[] }) {
+  const items = useMemo(() => buildIssueActivityItems(activity), [activity]);
+
+  if (items.length === 0) {
+    return <p className="text-xs text-muted-foreground">Нет значимой activity по задаче.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.slice(0, 24).map((item) => {
+        const toneClasses =
+          item.tone === "success"
+            ? "border-emerald-200 bg-emerald-50/60 dark:border-emerald-500/30 dark:bg-emerald-500/10"
+            : item.tone === "warning"
+              ? "border-amber-200 bg-amber-50/60 dark:border-amber-500/30 dark:bg-amber-500/10"
+              : item.tone === "error"
+                ? "border-red-200 bg-red-50/60 dark:border-red-500/30 dark:bg-red-500/10"
+                : item.tone === "info"
+                  ? "border-sky-200 bg-sky-50/60 dark:border-sky-500/30 dark:bg-sky-500/10"
+                  : "border-border bg-background";
+
+        if (item.kind === "group") {
+          return (
+            <details key={item.id} className={`rounded-lg border px-3 py-3 ${toneClasses}`}>
+              <summary className="cursor-pointer list-none">
+                <div className="flex items-start gap-3">
+                  <Identity name={item.actorLabel} size="sm" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium">{item.title}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">{item.body}</div>
+                  </div>
+                  <span className="shrink-0 text-[11px] text-muted-foreground">{relativeTime(item.createdAt)}</span>
+                </div>
+              </summary>
+              <div className="mt-3 space-y-2 border-t border-border/60 pt-3">
+                {item.events.map((evt) => (
+                  <div key={evt.id} className="grid gap-1 rounded-md border border-border/60 bg-background/70 px-3 py-2 text-xs">
+                    <div className="font-medium">{evt.action}</div>
+                    <div className="text-muted-foreground">{relativeTime(evt.createdAt)}</div>
+                  </div>
+                ))}
+              </div>
+            </details>
+          );
+        }
+
+        return (
+          <div key={item.id} className={`rounded-lg border px-3 py-3 ${toneClasses}`}>
+            <div className="flex items-start gap-3">
+              <Identity name={item.actorLabel} size="sm" />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium">{item.title}</div>
+                {item.body ? <div className="mt-1 text-xs text-muted-foreground">{item.body}</div> : null}
+              </div>
+              <span className="shrink-0 text-[11px] text-muted-foreground">{relativeTime(item.createdAt)}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
   const { selectedCompanyId } = useCompany();
@@ -1327,15 +1661,7 @@ export function IssueDetail() {
           {!activity || activity.length === 0 ? (
             <p className="text-xs text-muted-foreground">No activity yet.</p>
           ) : (
-            <div className="space-y-1.5">
-              {activity.slice(0, 20).map((evt) => (
-                <div key={evt.id} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <ActorIdentity evt={evt} agentMap={agentMap} />
-                  <span>{formatAction(evt.action, evt.details)}</span>
-                  <span className="ml-auto shrink-0">{relativeTime(evt.createdAt)}</span>
-                </div>
-              ))}
-            </div>
+            <IssueActivityFeed activity={activity} />
           )}
         </TabsContent>
 


### PR DESCRIPTION
## Summary
- enable OpenClaw Gateway in the relevant Paperclip UI flows and persist required create-time auth fields
- harden OpenClaw Gateway runtime auth/session behavior and websocket handling
- add a Codex device-auth login flow to Paperclip server + UI when runs fail with `codex_auth_required`

## Validation
- pnpm exec vitest run server/src/__tests__/codex-local-execute.test.ts server/src/__tests__/openclaw-gateway-adapter.test.ts
- pnpm --filter @paperclipai/ui typecheck
- pnpm --filter @paperclipai/server typecheck
- pnpm build

## Notes
- this intentionally keeps invite-landing join disabled for OpenClaw Gateway because that flow still does not collect the required `agentDefaultsPayload` fields
- session keys are only agent-prefixed when an explicit OpenClaw agent id is configured, which avoids breaking default/main agents while fixing non-main routing
- related upstream PRs reviewed while shaping this patch: #2322, #2309, #2469, #1265, #2198, #2207