### PR TITLE
fix: increment processLossRetryCount on original run when enqueuing process loss retry

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1683,6 +1683,14 @@ export function heartbeatService(db: Db) {
         })
         .where(eq(agentWakeupRequests.id, wakeupRequest.id));
 
+      await tx
+        .update(heartbeatRuns)
+        .set({
+          processLossRetryCount: (run.processLossRetryCount ?? 0) + 1,
+          updatedAt: now,
+        })
+        .where(eq(heartbeatRuns.id, run.id));
+
       if (issueId) {
         await tx
           .update(issues)


### PR DESCRIPTION
## Thinking Path
- Paperclip orchestrates AI-agents for zero-human companies
- When an agent process is lost, the heartbeat service detects orphaned runs via `reapOrphanedRuns`
- It checks `processLossRetryCount < 1` to determine if a retry should be attempted
- When retrying, `enqueueProcessLossRetry` creates a new run with an incremented counter
- But the original (now failed) run's counter was never updated
- **The bug:** If the original run's `processLossRetryCount` stays at 0, any future code that queries failed runs (for analytics, debugging, or retry logic) would incorrectly see this as a run that never had a retry attempted, causing confusion or incorrect decisions
- This PR adds an update within the transaction to increment the original run's counter, ensuring data consistency

## Changes
- Added database update in `enqueueProcessLossRetry` to increment `processLossRetryCount` on the original run

## Verification
- All 5 heartbeat-process-recovery tests pass
- Full test suite passes (800 tests)
- Typecheck passes across all packages

## Risks
- **None expected:** The change is inside an existing transaction, so it's atomically committed with the retry run creation
- The original run is already in `failed` status, so it won't be picked up again by `reapOrphanedRuns` (which only queries `status = 'running'`)
- This is a pure data-consistency fix with no behavioral changes to the retry logic

Closes #2487