### PR TITLE
feat: add Model Used section to PR template and checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,9 +38,25 @@
 
 -
 
+## Model Used
+
+<!--
+  Required. Specify which AI model was used to produce or assist with
+  this change. Be as descriptive as possible — include:
+    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
+    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
+    • Context window size if relevant (e.g., 1M context)
+    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
+    • Any other relevant capability details (e.g., tool use, code execution)
+  If no AI model was used, write "None — human-authored".
+-->
+
+-
+
 ## Checklist
 
 - [ ] I have included a thinking path that traces from project context to this change
+- [ ] I have specified the model used (with version and capability details)
 - [ ] I have run tests locally and they pass
 - [ ] I have added or updated tests where applicable
 - [ ] If this change affects the UI, I have included before/after screenshots


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The PR template defines what contributors must include when submitting changes
> - We need traceability on which AI model (and version) produced each change
> - Without this, it's hard to audit quality, debug regressions, or compare model outputs
> - This pull request adds a required "Model Used" section to the PR template
> - Contributors must specify provider, model ID/version, context window, reasoning mode, and other relevant details
> - The benefit is full model provenance on every PR for auditing and quality tracking

## What Changed

- Added a new **Model Used** section to `.github/PULL_REQUEST_TEMPLATE.md` between Risks and Checklist
- The section includes an HTML comment guide explaining what to include: provider/model name, exact model ID or version, context window size, reasoning/thinking mode, and other capability details
- Added a fallback instruction for human-authored PRs ("None — human-authored")
- Added a new checklist item: "I have specified the model used (with version and capability details)"

## Verification

- Open a new PR on this repo and confirm the template now includes the "Model Used" section
- Verify the checklist includes the new model item
- Confirm the HTML comment provides clear guidance on what to fill in

## Risks

- Low risk — this only adds a new section to the PR template; no code changes

## Model Used

- Claude Opus 4.6 (1M context), model ID: `claude-opus-4-6`, with tool use

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge