### PR TITLE
Sync managed instructions into agent home

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -447,6 +447,17 @@ describe("materializeAgentHomeInstructions", () => {
     await expect(fs.readFile(path.join(agentHome, "SOUL.md"), "utf8")).resolves.toBe("# Soul\n");
     await expect(fs.readFile(path.join(agentHome, "docs", "TOOLS.md"), "utf8")).resolves.toBe("# Tools\n");
   });
+
+  it("rejects instruction bundle paths that escape AGENT_HOME", async () => {
+    const agentHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-"));
+    cleanupPaths.add(agentHome);
+
+    await expect(
+      materializeAgentHomeInstructions(buildAgent("codex_local"), agentHome, {
+        "../escaped.md": "# nope\n",
+      }),
+    ).rejects.toThrow("Instruction file path must stay within AGENT_HOME");
+  });
 });
 
 describe("prioritizeProjectWorkspaceCandidatesForRun", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
@@ -8,6 +11,7 @@ import {
   buildExplicitResumeSessionOverride,
   deriveTaskKeyWithHeartbeatFallback,
   formatRuntimeWorkspaceWarningLog,
+  materializeAgentHomeInstructions,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
   resolveRuntimeSessionParamsForWorkspace,
@@ -55,6 +59,17 @@ function buildAgent(adapterType: string, runtimeConfig: Record<string, unknown> 
     updatedAt: new Date(),
   } as unknown as typeof agents.$inferSelect;
 }
+
+const cleanupPaths = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all(
+    [...cleanupPaths].map(async (candidate) => {
+      await fs.rm(candidate, { recursive: true, force: true });
+      cleanupPaths.delete(candidate);
+    }),
+  );
+});
 
 describe("resolveRuntimeSessionParamsForWorkspace", () => {
   it("migrates fallback workspace sessions to project workspace when project cwd becomes available", () => {
@@ -414,6 +429,23 @@ describe("formatRuntimeWorkspaceWarningLog", () => {
       stream: "stdout",
       chunk: "[paperclip] Using fallback workspace\n",
     });
+  });
+});
+
+describe("materializeAgentHomeInstructions", () => {
+  it("writes exported instruction bundle files into AGENT_HOME", async () => {
+    const agentHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-"));
+    cleanupPaths.add(agentHome);
+
+    await materializeAgentHomeInstructions(buildAgent("codex_local"), agentHome, {
+      "AGENTS.md": "# Agent\n",
+      "SOUL.md": "# Soul\n",
+      "docs/TOOLS.md": "# Tools\n",
+    });
+
+    await expect(fs.readFile(path.join(agentHome, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+    await expect(fs.readFile(path.join(agentHome, "SOUL.md"), "utf8")).resolves.toBe("# Soul\n");
+    await expect(fs.readFile(path.join(agentHome, "docs", "TOOLS.md"), "utf8")).resolves.toBe("# Tools\n");
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2445,7 +2445,15 @@ export function heartbeatService(db: Db) {
       worktreePath: executionWorkspace.worktreePath,
       agentHome: await (async () => {
         const home = resolveDefaultAgentWorkspaceDir(agent.id);
-        await materializeAgentHomeInstructions(agent, home);
+        try {
+          await materializeAgentHomeInstructions(agent, home);
+        } catch (err) {
+          logger.warn(
+            { err, agentId: agent.id, runId: run.id, agentHome: home },
+            "failed to sync managed instruction bundle into AGENT_HOME; continuing with workspace only",
+          );
+          await fs.mkdir(home, { recursive: true });
+        }
         return home;
       })(),
     };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -32,6 +32,7 @@ import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
+import { agentInstructionsService } from "./agent-instructions.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -111,6 +112,27 @@ export function stripWorkspaceRuntimeFromExecutionRunConfig(config: Record<strin
   const nextConfig = { ...config };
   delete nextConfig.workspaceRuntime;
   return nextConfig;
+}
+
+export async function materializeAgentHomeInstructions(
+  agent: typeof agents.$inferSelect,
+  agentHome: string,
+  filesOverride?: Record<string, string>,
+) {
+  await fs.mkdir(agentHome, { recursive: true });
+  const files = filesOverride ?? (await agentInstructionsService().exportFiles(agent)).files;
+  const absoluteAgentHome = path.resolve(agentHome);
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.resolve(absoluteAgentHome, relativePath);
+    const relativeToHome = path.relative(absoluteAgentHome, absolutePath);
+    if (relativeToHome === ".." || relativeToHome.startsWith(`..${path.sep}`)) {
+      throw new Error(`Instruction file path must stay within AGENT_HOME: ${relativePath}`);
+    }
+
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, "utf8");
+  }
 }
 
 export function buildRealizedExecutionWorkspaceFromPersisted(input: {
@@ -2423,7 +2445,7 @@ export function heartbeatService(db: Db) {
       worktreePath: executionWorkspace.worktreePath,
       agentHome: await (async () => {
         const home = resolveDefaultAgentWorkspaceDir(agent.id);
-        await fs.mkdir(home, { recursive: true });
+        await materializeAgentHomeInstructions(agent, home);
         return home;
       })(),
     };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local adapters rely on a runtime AGENT_HOME directory that holds each agent's personal state and any instruction files referenced by onboarding assets
> - The managed instructions bundle system stores AGENTS.md, SOUL.md, HEARTBEAT.md, and TOOLS.md under a per-agent instructions/ directory in the company data area
> - But the heartbeat runtime currently points AGENT_HOME at the agent workspace root without copying those managed instruction files into it
> - The built-in onboarding assets explicitly tell agents to read $AGENT_HOME/SOUL.md, $AGENT_HOME/HEARTBEAT.md, and $AGENT_HOME/TOOLS.md
> - That mismatch causes local runs to emit file-not-found errors even when the managed instruction bundle exists on disk
> - This pull request syncs the managed instruction bundle into AGENT_HOME during heartbeat setup so the runtime home matches what the instructions expect
> - The benefit is smoother local agent execution with fewer noisy failures and a consistent contract between managed instructions and adapter runtime state

## What Changed

- Added materializeAgentHomeInstructions(...) in the heartbeat service to copy exported instruction bundle files into AGENT_HOME
- Called that helper when preparing context.paperclipWorkspace.agentHome for a run
- Added a heartbeat workspace/session regression test covering instruction bundle materialization into AGENT_HOME

## Why This Matters

- Fixes a real local runtime mismatch where Paperclip stores managed instruction files in one place but tells agents to read them from another
- Reduces noisy Get-Content failures for SOUL.md, HEARTBEAT.md, and TOOLS.md during local agent runs
- Keeps the AGENT_HOME contract aligned with the onboarding assets without changing adapter-specific prompt behavior

## Verification

- pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-workspace-session.test.ts
- pnpm --filter @paperclipai/server typecheck

## Risks

- Low risk: this only adds managed instruction bundle files into AGENT_HOME during heartbeat setup
- If a managed instruction bundle contains nested files, they will now also be mirrored under AGENT_HOME with the same relative paths
- The helper intentionally refuses paths that would escape AGENT_HOME

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge