### PR TITLE
Use junctions for Windows Paperclip skill links

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -664,11 +664,28 @@ export function writePaperclipSkillSyncPreference(
   return next;
 }
 
+export async function linkPaperclipSkill(
+  source: string,
+  target: string,
+  options: {
+    platform?: NodeJS.Platform;
+    fsImpl?: Pick<typeof fs, "lstat" | "symlink">;
+  } = {},
+): Promise<void> {
+  const platform = options.platform ?? process.platform;
+  const fsImpl = options.fsImpl ?? fs;
+  const sourceStats = await fsImpl.lstat(source);
+  if (platform === "win32" && sourceStats.isDirectory()) {
+    await fsImpl.symlink(path.resolve(source), target, "junction");
+    return;
+  }
+  await fsImpl.symlink(source, target);
+}
+
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
-  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+  linkSkill: (source: string, target: string) => Promise<void> = linkPaperclipSkill,
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -12,6 +12,7 @@ import {
   buildInvocationEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
+  linkPaperclipSkill,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
@@ -160,7 +161,7 @@ export async function ensureCodexSkillsInjected(
 
   const skillsHome = options.skillsHome ?? resolveCodexSkillsDir(resolveSharedCodexHomeDir());
   await fs.mkdir(skillsHome, { recursive: true });
-  const linkSkill = options.linkSkill;
+  const linkSkill = options.linkSkill ?? linkPaperclipSkill;
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.runtimeName);
 
@@ -177,11 +178,7 @@ export async function ensureCodexSkillsInjected(
           (await isLikelyPaperclipRuntimeSkillPath(resolvedLinkedPath, entry.runtimeName))
         ) {
           await fs.unlink(target);
-          if (linkSkill) {
-            await linkSkill(entry.source, target);
-          } else {
-            await fs.symlink(entry.source, target);
-          }
+          await linkSkill(entry.source, target);
           await onLog(
             "stdout",
             `[paperclip] Repaired Codex skill "${entry.runtimeName}" into ${skillsHome}\n`,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -12,6 +12,7 @@ import {
   buildInvocationEnvForLogs,
   ensureAbsoluteDirectory,
   ensureCommandResolvable,
+  linkPaperclipSkill,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
@@ -137,7 +138,7 @@ export async function ensureCursorSkillsInjected(
       `[paperclip] Removed maintainer-only Cursor skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target));
+  const linkSkill = options.linkSkill ?? linkPaperclipSkill;
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.runtimeName);
     try {

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  linkPaperclipSkill,
   listPaperclipSkillEntries,
   removeMaintainerOnlySkillSymlinks,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -58,5 +59,40 @@ describe("paperclip skill utils", () => {
     await expect(fs.lstat(path.join(skillsHome, "release"))).rejects.toThrow();
     expect((await fs.lstat(path.join(skillsHome, "paperclip"))).isSymbolicLink()).toBe(true);
     expect((await fs.lstat(path.join(skillsHome, "release-notes"))).isSymbolicLink()).toBe(true);
+  });
+
+  it("uses a junction for Windows directory-backed Paperclip skills", async () => {
+    const symlink = vi.fn(async () => {});
+
+    await linkPaperclipSkill("C:\\paperclip\\skills\\paperclip", "C:\\codex\\skills\\paperclip", {
+      platform: "win32",
+      fsImpl: {
+        lstat: vi.fn(async () => ({ isDirectory: () => true })) as unknown as typeof fs.lstat,
+        symlink: symlink as unknown as typeof fs.symlink,
+      },
+    });
+
+    expect(symlink).toHaveBeenCalledWith(
+      path.resolve("C:\\paperclip\\skills\\paperclip"),
+      "C:\\codex\\skills\\paperclip",
+      "junction",
+    );
+  });
+
+  it("keeps using a regular symlink for non-Windows Paperclip skills", async () => {
+    const symlink = vi.fn(async () => {});
+
+    await linkPaperclipSkill("/tmp/paperclip/skills/paperclip", "/tmp/codex/skills/paperclip", {
+      platform: "linux",
+      fsImpl: {
+        lstat: vi.fn(async () => ({ isDirectory: () => true })) as unknown as typeof fs.lstat,
+        symlink: symlink as unknown as typeof fs.symlink,
+      },
+    });
+
+    expect(symlink).toHaveBeenCalledWith(
+      "/tmp/paperclip/skills/paperclip",
+      "/tmp/codex/skills/paperclip",
+    );
   });
 });


### PR DESCRIPTION
## Thinking Path

Paperclip makes local agent skills available by linking runtime skill directories into each adapter's skills home instead of copying them into the user workspace. That keeps Paperclip-owned skills live, repairable, and separate from user files while still letting adapters like Codex and Cursor discover them at run time.

The problem on Windows is that these skill entries are directories, but the current injection path still uses plain `fs.symlink(...)`. Directory symlinks are much more permission-sensitive on Windows than they are on macOS or Linux, which means Paperclip can fail to inject required skills even though the desired behavior is just to link one directory tree into another. In practice, that shows up as noisy runtime failures when a local agent starts and Paperclip tries to inject skills like `paperclip` or `para-memory-files`.

For directory-backed Paperclip skills, Windows junctions preserve the intended linked behavior without requiring the same symlink privileges. This PR teaches the shared Paperclip skill-link helper to create a junction on Windows when the source is a directory, and then makes the Codex and Cursor execution paths consistently use that helper instead of bypassing it with raw `fs.symlink(...)` calls.

That keeps the existing model intact: Paperclip skills are still linked, still repairable, and still isolated from the project checkout. The difference is that Windows local agents can now materialize those links using the filesystem primitive that best matches how Paperclip already treats runtime skills.

## What Changed

- Added a shared `linkPaperclipSkill(...)` helper that uses a Windows junction for directory-backed skill entries.
- Updated `ensurePaperclipSkillSymlink(...)` to use that helper by default.
- Updated the Codex local adapter's repair path to use the shared helper instead of a raw `fs.symlink(...)` call.
- Updated the Cursor local adapter's default link function to use the same shared helper.
- Added tests that verify Windows directory-backed Paperclip skills use a junction while non-Windows environments keep using a regular symlink.

## Why This Matters

- Windows operators should not lose required Paperclip skills just because directory symlink privileges are stricter on their machine.
- Paperclip's local-skill model stays linked and repairable instead of degrading to copied snapshots.
- The fix reduces noisy startup/runtime failures for local adapters while preserving the intended skill-discovery behavior.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/paperclip-skill-utils.test.ts src/__tests__/codex-local-skill-injection.test.ts`
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/adapter-cursor-local typecheck`

## Risks

- This changes the link primitive for Windows directory-backed Paperclip skills, so any code that assumes those links are always created with the default symlink type now observes a junction instead.
- The change is intentionally limited to directory-backed Paperclip skills; it does not alter how regular files are linked elsewhere.

## Checklist

- [x] Keep the fix focused on Windows local skill-linking behavior
- [x] Preserve linked skill semantics instead of copying runtime skills
- [x] Add targeted verification for the new Windows behavior
- [x] Verify the affected adapter packages still typecheck