### PR TITLE
feat: inject PAPERCLIP_COMPANY_PREFIX env var into agent runs

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -228,7 +228,7 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
-export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+export function buildPaperclipEnv(agent: { id: string; companyId: string; companyIssuePrefix?: string | null }): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
@@ -239,6 +239,9 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     PAPERCLIP_AGENT_ID: agent.id,
     PAPERCLIP_COMPANY_ID: agent.companyId,
   };
+  if (agent.companyIssuePrefix) {
+    vars.PAPERCLIP_COMPANY_PREFIX = agent.companyIssuePrefix;
+  }
   const runtimeHost = resolveHostForUrl(
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -5,6 +5,7 @@
 export interface AdapterAgent {
   id: string;
   companyId: string;
+  companyIssuePrefix?: string | null;
   name: string;
   adapterType: string | null;
   adapterConfig: unknown;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { and, asc, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import type { BillingType, ExecutionWorkspace, ExecutionWorkspaceConfig } from "@paperclipai/shared";
 import {
@@ -899,18 +899,11 @@ export function heartbeatService(db: Db) {
 
   async function getAgent(agentId: string) {
     return db
-      .select()
+      .select({ ...getTableColumns(agents), companyIssuePrefix: companies.issuePrefix })
       .from(agents)
+      .leftJoin(companies, eq(companies.id, agents.companyId))
       .where(eq(agents.id, agentId))
       .then((rows) => rows[0] ?? null);
-  }
-
-  async function getCompanyIssuePrefix(companyId: string): Promise<string | null> {
-    return db
-      .select({ issuePrefix: companies.issuePrefix })
-      .from(companies)
-      .where(eq(companies.id, companyId))
-      .then((rows) => rows[0]?.issuePrefix ?? null);
   }
 
   async function getRun(runId: string) {
@@ -2663,10 +2656,9 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
-      const companyIssuePrefix = await getCompanyIssuePrefix(agent.companyId);
       const adapterResult = await adapter.execute({
         runId: run.id,
-        agent: { ...agent, companyIssuePrefix },
+        agent,
         runtime: runtimeForAdapter,
         config: runtimeConfig,
         context,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10,6 +10,7 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  companies,
   heartbeatRunEvents,
   heartbeatRuns,
   issues,
@@ -902,6 +903,14 @@ export function heartbeatService(db: Db) {
       .from(agents)
       .where(eq(agents.id, agentId))
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function getCompanyIssuePrefix(companyId: string): Promise<string | null> {
+    return db
+      .select({ issuePrefix: companies.issuePrefix })
+      .from(companies)
+      .where(eq(companies.id, companyId))
+      .then((rows) => rows[0]?.issuePrefix ?? null);
   }
 
   async function getRun(runId: string) {
@@ -2654,9 +2663,10 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+      const companyIssuePrefix = await getCompanyIssuePrefix(agent.companyId);
       const adapterResult = await adapter.execute({
         runId: run.id,
-        agent,
+        agent: { ...agent, companyIssuePrefix },
         runtime: runtimeForAdapter,
         config: runtimeConfig,
         context,

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -171,7 +171,7 @@ When posting issue comments or writing issue descriptions, use concise markdown 
 
 Never leave bare ticket ids in issue descriptions or comments when a clickable internal link can be provided.
 
-**Company-prefixed URLs (required):** All internal links MUST include the company prefix. Derive the prefix from any issue identifier you have (e.g., `PAP-315` → prefix is `PAP`). Use this prefix in all UI links:
+**Company-prefixed URLs (required):** All internal links MUST include the company prefix. Use `$PAPERCLIP_COMPANY_PREFIX` from your environment — this is always the correct current prefix. If that env var is unavailable, derive it from recently created issues (not legacy ones, which may have an old prefix from a rename). Use this prefix in all UI links:
 
 - Issues: `/<prefix>/issues/<issue-identifier>` (e.g., `/PAP/issues/PAP-224`)
 - Issue comments: `/<prefix>/issues/<issue-identifier>#comment-<comment-id>` (deep link to a specific comment)


### PR DESCRIPTION
## Summary

- Agents currently derive the Paperclip UI URL prefix from issue identifiers (e.g. `LIG-15` → prefix `LIG`). This breaks when a company renames its issue prefix — legacy issues keep the old prefix, so agents generate broken links like `/LIG/issues/LIG-15` instead of the correct `/LF/issues/LIG-15`.
- Adds `PAPERCLIP_COMPANY_PREFIX` to every agent's runtime environment, giving agents a reliable source of truth for building internal URLs regardless of what prefix legacy issues carry.
- Updates the `paperclip` skill's SKILL.md to reference `$PAPERCLIP_COMPANY_PREFIX` as the authoritative prefix source.

## Changes

- **`packages/adapter-utils/src/types.ts`**: Add optional `companyIssuePrefix` field to `AdapterAgent`
- **`packages/adapter-utils/src/server-utils.ts`**: Emit `PAPERCLIP_COMPANY_PREFIX` in `buildPaperclipEnv` when prefix is available
- **`server/src/services/heartbeat.ts`**: Look up company `issuePrefix` and attach to agent before calling `adapter.execute`
- **`skills/paperclip/SKILL.md`**: Update URL-prefix guidance to use `$PAPERCLIP_COMPANY_PREFIX` as the authoritative source

## Test plan

- [ ] Rename a company's issue prefix in settings
- [ ] Trigger an agent heartbeat and verify `PAPERCLIP_COMPANY_PREFIX` reflects the new prefix in the run environment
- [ ] Confirm agent-generated links to legacy issues use the new prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)