### PR TITLE
Skip Codex git repo check for fallback workspaces

### DIFF
--- a/packages/adapters/codex-local/src/server/cli-args.test.ts
+++ b/packages/adapters/codex-local/src/server/cli-args.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildCodexExecArgs } from "./cli-args.js";
+
+describe("buildCodexExecArgs", () => {
+  it("adds --skip-git-repo-check for non-repo fallback workspaces", () => {
+    expect(
+      buildCodexExecArgs({
+        search: false,
+        bypass: false,
+        skipGitRepoCheck: true,
+        extraArgs: [],
+        model: "",
+        modelReasoningEffort: "",
+        resumeSessionId: null,
+      }),
+    ).toEqual(["exec", "--json", "--skip-git-repo-check", "-"]);
+  });
+
+  it("does not duplicate --skip-git-repo-check when already provided in extra args", () => {
+    expect(
+      buildCodexExecArgs({
+        search: false,
+        bypass: false,
+        skipGitRepoCheck: true,
+        extraArgs: ["--skip-git-repo-check", "--color", "never"],
+        model: "",
+        modelReasoningEffort: "",
+        resumeSessionId: null,
+      }),
+    ).toEqual(["exec", "--json", "--skip-git-repo-check", "--color", "never", "-"]);
+  });
+
+  it("keeps normal repo-backed runs unchanged", () => {
+    expect(
+      buildCodexExecArgs({
+        search: true,
+        bypass: false,
+        skipGitRepoCheck: false,
+        extraArgs: [],
+        model: "gpt-5.4",
+        modelReasoningEffort: "medium",
+        resumeSessionId: null,
+      }),
+    ).toEqual([
+      "--search",
+      "exec",
+      "--json",
+      "--model",
+      "gpt-5.4",
+      "-c",
+      'model_reasoning_effort="medium"',
+      "-",
+    ]);
+  });
+});

--- a/packages/adapters/codex-local/src/server/cli-args.ts
+++ b/packages/adapters/codex-local/src/server/cli-args.ts
@@ -1,0 +1,26 @@
+type BuildCodexExecArgsOptions = {
+  search: boolean;
+  bypass: boolean;
+  skipGitRepoCheck: boolean;
+  extraArgs: string[];
+  model: string;
+  modelReasoningEffort: string;
+  resumeSessionId: string | null;
+};
+
+export function buildCodexExecArgs(options: BuildCodexExecArgsOptions): string[] {
+  const args = ["exec", "--json"];
+  if (options.search) args.unshift("--search");
+  if (options.bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
+  if (options.skipGitRepoCheck && !options.extraArgs.includes("--skip-git-repo-check")) {
+    args.push("--skip-git-repo-check");
+  }
+  if (options.model) args.push("--model", options.model);
+  if (options.modelReasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${JSON.stringify(options.modelReasoningEffort)}`);
+  }
+  if (options.extraArgs.length > 0) args.push(...options.extraArgs);
+  if (options.resumeSessionId) args.push("resume", options.resumeSessionId, "-");
+  else args.push("-");
+  return args;
+}

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -23,6 +23,8 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
+import { buildCodexExecArgs } from "./cli-args.js";
+import { isInsideGitRepo } from "./git-repo.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -434,21 +436,31 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   const repoAgentsNote =
     "Codex exec automatically applies repo-scoped AGENTS.md instructions from the current workspace; Paperclip does not currently suppress that discovery.";
+  const skipGitRepoCheck = !(await isInsideGitRepo(cwd));
   const commandNotes = (() => {
+    const notes: string[] = [];
+    if (skipGitRepoCheck) {
+      notes.push(
+        `Added --skip-git-repo-check because cwd "${cwd}" is not inside a Git repository.`,
+      );
+    }
     if (!instructionsFilePath) {
-      return [repoAgentsNote];
+      notes.push(repoAgentsNote);
+      return notes;
     }
     if (instructionsPrefix.length > 0) {
-      return [
+      notes.push(
         `Loaded agent instructions from ${instructionsFilePath}`,
         `Prepended instructions + path directive to stdin prompt (relative references from ${instructionsDir}).`,
         repoAgentsNote,
-      ];
+      );
+      return notes;
     }
-    return [
+    notes.push(
       `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
       repoAgentsNote,
-    ];
+    );
+    return notes;
   })();
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
   const templateData = {
@@ -481,15 +493,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const buildArgs = (resumeSessionId: string | null) => {
-    const args = ["exec", "--json"];
-    if (search) args.unshift("--search");
-    if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
-    if (model) args.push("--model", model);
-    if (modelReasoningEffort) args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
-    if (extraArgs.length > 0) args.push(...extraArgs);
-    if (resumeSessionId) args.push("resume", resumeSessionId, "-");
-    else args.push("-");
-    return args;
+    return buildCodexExecArgs({
+      search,
+      bypass,
+      skipGitRepoCheck,
+      extraArgs,
+      model,
+      modelReasoningEffort,
+      resumeSessionId,
+    });
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {

--- a/packages/adapters/codex-local/src/server/git-repo.test.ts
+++ b/packages/adapters/codex-local/src/server/git-repo.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isInsideGitRepo } from "./git-repo.js";
+
+describe("isInsideGitRepo", () => {
+  const cleanupDirs = new Set<string>();
+
+  afterEach(async () => {
+    await Promise.all(Array.from(cleanupDirs).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+    cleanupDirs.clear();
+  });
+
+  it("returns false for fallback workspaces outside git repos", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-fallback-"));
+    const workspace = path.join(root, "workspace");
+    cleanupDirs.add(root);
+    await fs.mkdir(workspace, { recursive: true });
+
+    await expect(isInsideGitRepo(workspace)).resolves.toBe(false);
+  });
+
+  it("returns true for directories inside a git repository", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-repo-"));
+    const workspace = path.join(root, "workspace", "nested");
+    cleanupDirs.add(root);
+    await fs.mkdir(path.join(root, ".git"), { recursive: true });
+    await fs.mkdir(workspace, { recursive: true });
+
+    await expect(isInsideGitRepo(workspace)).resolves.toBe(true);
+  });
+
+  it("treats worktree-style .git files as git repositories", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-worktree-"));
+    const workspace = path.join(root, "workspace");
+    cleanupDirs.add(root);
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.writeFile(path.join(root, ".git"), "gitdir: /tmp/worktrees/demo\n", "utf8");
+
+    await expect(isInsideGitRepo(workspace)).resolves.toBe(true);
+  });
+});

--- a/packages/adapters/codex-local/src/server/git-repo.ts
+++ b/packages/adapters/codex-local/src/server/git-repo.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { pathExists } from "./codex-home.js";
+
+export async function isInsideGitRepo(candidate: string): Promise<boolean> {
+  let current = path.resolve(candidate);
+
+  while (true) {
+    if (await pathExists(path.join(current, ".git"))) {
+      return true;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return false;
+    }
+    current = parent;
+  }
+}

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -14,8 +14,10 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import path from "node:path";
+import { buildCodexExecArgs } from "./cli-args.js";
 import { parseCodexJsonl } from "./parse.js";
 import { codexHomeDir, readCodexAuthInfo } from "./quota.js";
+import { isInsideGitRepo } from "./git-repo.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -155,16 +157,16 @@ export async function testEnvironment(
         if (fromExtraArgs.length > 0) return fromExtraArgs;
         return asStringArray(config.args);
       })();
-
-      const args = ["exec", "--json"];
-      if (search) args.unshift("--search");
-      if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
-      if (model) args.push("--model", model);
-      if (modelReasoningEffort) {
-        args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
-      }
-      if (extraArgs.length > 0) args.push(...extraArgs);
-      args.push("-");
+      const skipGitRepoCheck = !(await isInsideGitRepo(cwd));
+      const args = buildCodexExecArgs({
+        search,
+        bypass,
+        skipGitRepoCheck,
+        extraArgs,
+        model,
+        modelReasoningEffort,
+        resumeSessionId: null,
+      });
 
       const probe = await runChildProcess(
         `codex-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,


### PR DESCRIPTION
﻿## Thinking Path

Paperclip supports Codex agents in both real project workspaces and Paperclip-managed fallback workspaces. Real project workspaces are usually Git-backed, but fallback workspaces under `.paperclip/instances/.../workspaces/...` are intentionally plain directories so the agent still has somewhere to run when no project checkout or resumable session workspace exists.

The current Codex local adapter builds a normal `codex exec` invocation for both cases. That works in Git-backed repos, but fallback workspaces are not trusted Git directories, so Codex fails early with `Not inside a trusted directory and --skip-git-repo-check was not specified.` Operators can get past that today by turning on `--dangerously-bypass-approvals-and-sandbox`, but that removes the safety rails we actually want to keep.

This PR narrows the fix to the real problem: if Paperclip is launching Codex from a directory that is not inside any Git repository, Paperclip now adds Codex's narrower `--skip-git-repo-check` flag automatically. Repo-backed runs stay unchanged, and the existing sandbox / approval behavior remains intact.

## What Changed

- added a small `isInsideGitRepo()` helper that detects both `.git/` directories and worktree-style `.git` files while walking up from the configured cwd
- extracted Codex CLI argument assembly into `buildCodexExecArgs()` so both execution and the environment hello probe share the same flag logic
- updated the Codex local adapter runtime path to add `--skip-git-repo-check` only when the cwd is outside a Git repo
- updated the Codex local adapter environment probe to mirror that same behavior
- added focused unit tests for repo detection and CLI arg assembly
- added a command note so operators can see when Paperclip auto-added the git-check skip

## Why This Matters

Without this change, agents that fall back to a Paperclip-managed workspace can fail unless the operator disables Codex's sandbox protections entirely. This keeps fallback runs working while preserving the safer default execution model.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/cli-args.test.ts packages/adapters/codex-local/src/server/git-repo.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/codex-local-adapter-environment.test.ts`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`

## Risks

- the repo detector is intentionally simple and filesystem-based; if a future Codex trust model diverges from `.git` presence, Paperclip may need to refine that heuristic
- existing Windows integration tests for `codex-local-execute` still rely on a fake executable stub that is not launchable on this machine, so this PR keeps coverage at the helper + environment-probe level rather than expanding unrelated fixture work

## Checklist

- [x] change is scoped to the Codex local adapter
- [x] fallback non-repo workspaces keep sandbox protections instead of requiring the bypass flag
- [x] repo-backed runs remain unchanged
- [x] focused tests added for the new behavior
- [x] targeted verification commands run
