### PR TITLE
Fix issue comment polling after anchor comment

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1647,15 +1647,17 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt =
+          anchor.createdAt instanceof Date ? anchor.createdAt.toISOString() : anchor.createdAt;
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Summary

Fixes incremental issue comment polling when `after=<commentId>` is provided.

The comments route could throw `500 Internal server error` because `listComments()` interpolated `anchor.createdAt` directly into the SQL fragment. In the failing case, `anchor.createdAt` was a `Date`, which caused the postgres binding path to throw:

```text
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date
```

## Change

- normalize `anchor.createdAt` to an ISO string before using it in the `afterCommentId` cursor comparison
- use that normalized value in both the ascending and descending query branches

## Why this matters

This broke agent workflows that poll incremental issue comments after the current comment cursor. With this change, the route returns comments normally instead of failing with `500`.

## Validation

- reproduced the failure locally against a Paperclip instance
- applied the same fix in the local server
- verified the previously failing route returned successfully afterwards
