### PR TITLE
fix(server): support multi-word plain-text agent mentions

### DIFF
--- a/server/src/__tests__/agent-name-mentions.test.ts
+++ b/server/src/__tests__/agent-name-mentions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { bodyIncludesAgentNameMention } from "../services/issues.ts";
+
+describe("bodyIncludesAgentNameMention", () => {
+  it("matches plain-text mentions for multi-word agent names", () => {
+    expect(bodyIncludesAgentNameMention("@QA Engineer can you take a look?", "QA Engineer")).toBe(true);
+  });
+
+  it("matches multi-word mentions followed by punctuation", () => {
+    expect(bodyIncludesAgentNameMention("Please review this, @Staff Engineer.", "Staff Engineer")).toBe(true);
+  });
+
+  it("does not treat partial names as valid mentions", () => {
+    expect(bodyIncludesAgentNameMention("@QA can you take a look?", "QA Engineer")).toBe(false);
+  });
+
+  it("does not match when the @ marker is embedded in another token", () => {
+    expect(bodyIncludesAgentNameMention("email@QA Engineer", "QA Engineer")).toBe(false);
+  });
+
+  it("only handles multi-word names in the fallback matcher", () => {
+    expect(bodyIncludesAgentNameMention("@CEO please review", "CEO")).toBe(false);
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -394,6 +394,17 @@ export function normalizeAgentMentionToken(raw: string): string {
   return s.trim();
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function bodyIncludesAgentNameMention(body: string, agentName: string): boolean {
+  const normalizedName = agentName.trim();
+  if (!normalizedName.includes(" ")) return false;
+  const pattern = new RegExp(`(^|[\\s([\\{])@${escapeRegExp(normalizedName)}(?=$|[\\s,!?;:.\\]\\)\\}])`, "i");
+  return pattern.test(body);
+}
+
 export function deriveIssueUserContext(
   issue: IssueUserContextInput,
   userId: string,
@@ -1922,7 +1933,7 @@ export function issueService(db: Db) {
         .from(agents).where(eq(agents.companyId, companyId));
       const resolved = new Set<string>(explicitAgentMentionIds);
       for (const agent of rows) {
-        if (tokens.has(agent.name.toLowerCase())) {
+        if (tokens.has(agent.name.toLowerCase()) || bodyIncludesAgentNameMention(body, agent.name)) {
           resolved.add(agent.id);
         }
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates humans and agents through tasks, comments, and mention-driven wakeups
> - Agent mentions are part of the routing layer because they can wake the right agent at the right time
> - Some agent names in Paperclip contain spaces, not just single tokens
> - The old mention matching path effectively stopped at whitespace, so plain-text mentions like `@QA Engineer` could be missed
> - This PR adds a fallback matcher for multi-word plain-text agent mentions while keeping the existing token path for single-word names
> - The benefit is that agent wakeups and mention resolution work more reliably for real-world agent names

## What Changed

This PR fixes multi-word plain-text agent mention resolution.

Changes included:
- add `bodyIncludesAgentNameMention` as a fallback matcher for multi-word names
- escape agent names safely before building the matcher regex
- keep the existing token-based path for single-word mentions
- add focused tests for punctuation, partial matches, embedded `@`, and single-word behavior

## Why This Matters

Before this change, comments could contain a valid-looking multi-word mention like `@QA Engineer` and still fail to resolve to the intended agent.

That makes comment-driven coordination less reliable and can prevent the expected wakeup/notification flow from happening.

This PR closes that gap without changing the simpler existing path for single-word agent names.

## How To Verify

- run the mention-related server tests
- verify that comments containing multi-word mentions such as `@QA Engineer` are detected
- verify punctuation-adjacent mentions still work
- verify partial-name matches do not trigger
- verify single-word names are still handled by the existing token path

## Risks

- mention matching now relies on a regex fallback for multi-word names, so future changes to mention syntax should keep this matcher in sync
- this PR intentionally keeps the fallback narrow rather than rewriting the full mention parsing pipeline

Supersedes #2383. This PR was rebuilt cleanly on current upstream `master` so the diff stays focused.
