### PR TITLE
fix(ui): show agent identity for run-authored comments

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -18,6 +18,7 @@ import { OutputFeedbackButtons } from "./OutputFeedbackButtons";
 import { StatusBadge } from "./StatusBadge";
 import { AgentIcon } from "./AgentIconPicker";
 import { formatAssigneeUserLabel } from "../lib/assignees";
+import { resolveCommentAuthorIdentity } from "../lib/comment-authors";
 import type { IssueTimelineAssignee, IssueTimelineEvent } from "../lib/issue-timeline-events";
 import { timeAgo } from "../lib/timeAgo";
 import { cn, formatDateTime } from "../lib/utils";
@@ -230,6 +231,7 @@ function CommentCard({
   feedbackTermsUrl = null,
   onVote,
   voting = false,
+  currentUserId,
   highlightCommentId,
   queued = false,
 }: {
@@ -245,12 +247,14 @@ function CommentCard({
     options?: { allowSharing?: boolean; reason?: string },
   ) => Promise<void>;
   voting?: boolean;
+  currentUserId?: string | null;
   highlightCommentId?: string | null;
   queued?: boolean;
 }) {
   const isHighlighted = highlightCommentId === comment.id;
   const isPending = comment.clientStatus === "pending";
   const isQueued = queued || comment.queueState === "queued" || comment.clientStatus === "queued";
+  const authorIdentity = resolveCommentAuthorIdentity(comment, currentUserId);
 
   return (
     <div
@@ -265,15 +269,15 @@ function CommentCard({
       } ${isPending ? "opacity-80" : ""}`}
     >
       <div className="flex items-center justify-between mb-1">
-        {comment.authorAgentId ? (
-          <Link to={`/agents/${comment.authorAgentId}`} className="hover:underline">
+        {authorIdentity.kind === "agent" && authorIdentity.agentId ? (
+          <Link to={`/agents/${authorIdentity.agentId}`} className="hover:underline">
             <Identity
-              name={agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)}
+              name={agentMap?.get(authorIdentity.agentId)?.name ?? authorIdentity.agentId.slice(0, 8)}
               size="sm"
             />
           </Link>
         ) : (
-          <Identity name="You" size="sm" />
+          <Identity name={authorIdentity.name} size="sm" />
         )}
         <span className="flex items-center gap-1.5">
           {isQueued ? (
@@ -522,6 +526,7 @@ const TimelineList = memo(function TimelineList({
             feedbackTermsUrl={feedbackTermsUrl}
             onVote={onVote ? (vote, options) => onVote(comment.id, vote, options) : undefined}
             voting={votingTargetId === comment.id}
+            currentUserId={currentUserId}
             highlightCommentId={highlightCommentId}
           />
         );
@@ -774,6 +779,7 @@ export function CommentThread({
                 agentMap={agentMap}
                 companyId={companyId}
                 projectId={projectId}
+                currentUserId={currentUserId}
                 highlightCommentId={highlightCommentId}
                 queued
               />

--- a/ui/src/lib/comment-authors.test.ts
+++ b/ui/src/lib/comment-authors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCommentAuthorIdentity } from "./comment-authors";
+
+describe("resolveCommentAuthorIdentity", () => {
+  it("prefers the explicit author agent", () => {
+    expect(
+      resolveCommentAuthorIdentity(
+        {
+          authorAgentId: "agent-ceo",
+          authorUserId: "local-board",
+          runAgentId: "agent-other",
+        },
+        "local-board",
+      ),
+    ).toEqual({
+      kind: "agent",
+      agentId: "agent-ceo",
+      name: "agent-ceo",
+    });
+  });
+
+  it("uses the linked run agent when a board-authored comment belongs to an agent run", () => {
+    expect(
+      resolveCommentAuthorIdentity(
+        {
+          authorAgentId: null,
+          authorUserId: "local-board",
+          runAgentId: "agent-ceo",
+        },
+        "local-board",
+      ),
+    ).toEqual({
+      kind: "agent",
+      agentId: "agent-ceo",
+      name: "agent-ceo",
+    });
+  });
+
+  it("shows You only for the current user's own non-agent comment", () => {
+    expect(
+      resolveCommentAuthorIdentity(
+        {
+          authorAgentId: null,
+          authorUserId: "local-board",
+          runAgentId: null,
+        },
+        "local-board",
+      ),
+    ).toEqual({
+      kind: "user",
+      agentId: null,
+      name: "You",
+    });
+  });
+
+  it("falls back to Board for board-authored comments from someone else", () => {
+    expect(
+      resolveCommentAuthorIdentity(
+        {
+          authorAgentId: null,
+          authorUserId: "local-board",
+          runAgentId: null,
+        },
+        "someone-else",
+      ),
+    ).toEqual({
+      kind: "user",
+      agentId: null,
+      name: "Board",
+    });
+  });
+});

--- a/ui/src/lib/comment-authors.ts
+++ b/ui/src/lib/comment-authors.ts
@@ -1,0 +1,48 @@
+import { formatAssigneeUserLabel } from "./assignees";
+
+export interface CommentAuthorIdentityInput {
+  authorAgentId?: string | null;
+  authorUserId?: string | null;
+  runAgentId?: string | null;
+}
+
+export interface CommentAuthorIdentity {
+  kind: "agent" | "user";
+  agentId: string | null;
+  name: string;
+}
+
+export function resolveCommentAuthorIdentity(
+  comment: CommentAuthorIdentityInput,
+  currentUserId: string | null | undefined,
+): CommentAuthorIdentity {
+  if (comment.authorAgentId) {
+    return {
+      kind: "agent",
+      agentId: comment.authorAgentId,
+      name: comment.authorAgentId,
+    };
+  }
+
+  if (comment.runAgentId) {
+    return {
+      kind: "agent",
+      agentId: comment.runAgentId,
+      name: comment.runAgentId,
+    };
+  }
+
+  if (comment.authorUserId && currentUserId && comment.authorUserId === currentUserId) {
+    return {
+      kind: "user",
+      agentId: null,
+      name: "You",
+    };
+  }
+
+  return {
+    kind: "user",
+    agentId: null,
+    name: formatAssigneeUserLabel(comment.authorUserId, currentUserId) ?? "Board",
+  };
+}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1509,6 +1509,7 @@ export function IssueDetail() {
             timelineEvents={timelineEvents}
             companyId={issue.companyId}
             projectId={issue.projectId}
+            currentUserId={currentUserId}
             issueStatus={issue.status}
             agentMap={agentMap}
             currentUserId={currentUserId}


### PR DESCRIPTION
Supersedes #2511.

This rebuilt PR is based directly on current upstream `master` and keeps the diff focused on comment author identity handling for run-authored comments.