### PR TITLE
fix: handle explicit claude success results

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -26,6 +26,7 @@ import {
   parseClaudeStreamJson,
   describeClaudeFailure,
   detectClaudeLoginRequired,
+  isClaudeSuccessResult,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
 } from "./parse.js";
@@ -552,13 +553,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
+    const explicitSuccess = isClaudeSuccessResult(parsed);
 
     return {
       exitCode: proc.exitCode,
       signal: proc.signal,
       timedOut: false,
       errorMessage:
-        (proc.exitCode ?? 0) === 0
+        (proc.exitCode ?? 0) === 0 || explicitSuccess
           ? null
           : describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`,
       errorCode: loginMeta.requiresLogin ? "claude_auth_required" : null,

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -4,6 +4,7 @@ export { testEnvironment } from "./test.js";
 export {
   parseClaudeStreamJson,
   describeClaudeFailure,
+  isClaudeSuccessResult,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
 } from "./parse.js";

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -139,6 +139,10 @@ export function detectClaudeLoginRequired(input: {
 }
 
 export function describeClaudeFailure(parsed: Record<string, unknown>): string | null {
+  if (isClaudeSuccessResult(parsed)) {
+    return null;
+  }
+
   const subtype = asString(parsed.subtype, "");
   const resultText = asString(parsed.result, "").trim();
   const errors = extractClaudeErrorMessages(parsed);
@@ -152,6 +156,21 @@ export function describeClaudeFailure(parsed: Record<string, unknown>): string |
   if (subtype) parts.push(`subtype=${subtype}`);
   if (detail) parts.push(detail);
   return parts.length > 1 ? parts.join(": ") : null;
+}
+
+export function isClaudeSuccessResult(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+  if (parsed.is_error === true) return false;
+
+  const subtype = asString(parsed.subtype, "").trim().toLowerCase();
+  if (subtype === "success") return true;
+  if (subtype === "error" || subtype === "failed" || subtype.startsWith("error_")) return false;
+
+  const status = asString(parsed.status, "").trim().toLowerCase();
+  if (status === "success" || status === "succeeded" || status === "ok") return true;
+  if (status === "error" || status === "failed") return false;
+
+  return false;
 }
 
 export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | undefined): boolean {

--- a/server/src/__tests__/claude-local-adapter.test.ts
+++ b/server/src/__tests__/claude-local-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isClaudeMaxTurnsResult } from "@paperclipai/adapter-claude-local/server";
+import { describeClaudeFailure, isClaudeMaxTurnsResult, isClaudeSuccessResult } from "@paperclipai/adapter-claude-local/server";
 import { parseClaudeStdoutLine } from "@paperclipai/adapter-claude-local/ui";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 
@@ -28,6 +28,27 @@ describe("claude_local max-turn detection", () => {
         stop_reason: "end_turn",
       }),
     ).toBe(false);
+  });
+});
+
+describe("claude_local success detection", () => {
+  it("treats subtype=success as an explicit success result", () => {
+    expect(
+      isClaudeSuccessResult({
+        subtype: "success",
+        is_error: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not synthesize a failure message for explicit success", () => {
+    expect(
+      describeClaudeFailure({
+        subtype: "success",
+        is_error: false,
+        result: "Done",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -25,6 +25,17 @@ console.log(JSON.stringify({ type: "result", session_id: "claude-session-1", res
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeFakeClaudeSuccessWithNonZeroExitCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-2", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "assistant", session_id: "claude-session-2", message: { content: [{ type: "text", text: "completed" }] } }));
+console.log(JSON.stringify({ type: "result", session_id: "claude-session-2", subtype: "success", is_error: false, result: "completed", usage: { input_tokens: 2, cache_read_input_tokens: 0, output_tokens: 3 } }));
+process.exit(1);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 describe("claude execute", () => {
   it("logs HOME, CLAUDE_CONFIG_DIR, and the resolved executable path in invocation metadata", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-meta-"));
@@ -93,6 +104,60 @@ describe("claude execute", () => {
       else process.env.PATH = previousPath;
       if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
       else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps explicit success results successful even when claude exits non-zero", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-explicit-success-"));
+    const workspace = path.join(root, "workspace");
+    const binDir = path.join(root, "bin");
+    const commandPath = path.join(binDir, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(binDir, { recursive: true });
+    await writeFakeClaudeSuccessWithNonZeroExitCommand(commandPath);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+    try {
+      const result = await execute({
+        runId: "run-explicit-success",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "claude",
+          cwd: workspace,
+          env: {},
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorMessage).toBeNull();
+      expect(result.summary).toBe("completed");
+      expect(result.resultJson).toMatchObject({
+        subtype: "success",
+        is_error: false,
+        result: "completed",
+      });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/heartbeat-run-outcome.test.ts
+++ b/server/src/__tests__/heartbeat-run-outcome.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { hasExplicitSuccessfulResult } from "../services/heartbeat.js";
+
+describe("heartbeat run outcome helpers", () => {
+  it("treats subtype=success as an explicit success", () => {
+    expect(
+      hasExplicitSuccessfulResult({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        resultJson: {
+          subtype: "success",
+          is_error: false,
+          result: "completed",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat explicit error results as success", () => {
+    expect(
+      hasExplicitSuccessfulResult({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "boom",
+        resultJson: {
+          subtype: "error",
+          is_error: true,
+          result: "boom",
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -80,6 +80,22 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "pi_local",
 ]);
 
+export function hasExplicitSuccessfulResult(result: AdapterExecutionResult): boolean {
+  const parsed = parseObject(result.resultJson);
+  if (Object.keys(parsed).length === 0) return false;
+  if (asBoolean(parsed.is_error, false)) return false;
+
+  const subtype = readNonEmptyString(parsed.subtype)?.toLowerCase();
+  if (subtype === "success") return true;
+  if (subtype === "error" || subtype === "failed" || subtype?.startsWith("error_")) return false;
+
+  const status = readNonEmptyString(parsed.status)?.toLowerCase();
+  if (status === "success" || status === "succeeded" || status === "ok") return true;
+  if (status === "error" || status === "failed") return false;
+
+  return false;
+}
+
 export function applyPersistedExecutionWorkspaceConfig(input: {
   config: Record<string, unknown>;
   workspaceConfig: ExecutionWorkspaceConfig | null;
@@ -2742,11 +2758,12 @@ export function heartbeatService(db: Db) {
 
       let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
+      const explicitSuccess = hasExplicitSuccessfulResult(adapterResult);
       if (latestRun?.status === "cancelled") {
         outcome = "cancelled";
       } else if (adapterResult.timedOut) {
         outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
+      } else if (((adapterResult.exitCode ?? 0) === 0 || explicitSuccess) && !adapterResult.errorMessage) {
         outcome = "succeeded";
       } else {
         outcome = "failed";


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs local and remote agents and treats heartbeat outcomes as the source of truth for task progress
> - Local adapter processes sometimes report success through structured result JSON rather than only through OS exit codes
> - Claude-local can emit an explicit success result even when the wrapper process exits non-zero
> - When that happens, Paperclip should trust the explicit success payload instead of marking the run as failed
> - This PR teaches both the claude-local adapter and the heartbeat outcome layer to recognize explicit successful results
> - The benefit is that valid successful runs are no longer misclassified as failures just because the wrapper exited with a non-zero code

## What Changed

This PR fixes a case where Claude emits an explicit successful result payload but the process exits with a non-zero exit code.

Changes included:
- add `isClaudeSuccessResult` in the claude-local parse layer
- suppress adapter-level error handling when the result payload explicitly reports success
- add matching heartbeat-side success detection so run outcome classification is upgraded correctly at the service layer
- add tests for adapter parsing/execution and heartbeat run outcome handling

## Why This Matters

Before this change, a successful Claude-local run could still appear failed in Paperclip if the wrapper exited with a non-zero code after already emitting a valid success result.

That created incorrect run status, misleading error reporting, and unnecessary follow-up work on runs that had actually completed successfully.

This change makes run outcome handling more faithful to the structured result data emitted by the adapter.

## How To Verify

- run the claude-local execute tests
- run the heartbeat run outcome tests
- verify the integration case where a fake Claude binary emits a success result and exits with code `1`
- confirm the adapter returns no error message in that case
- confirm the heartbeat run is classified as succeeded rather than failed

## Risks

- there is duplicated success-detection logic between the adapter parse layer and the heartbeat service; if the success-shape heuristic changes later, both places need to stay aligned
- this PR intentionally keeps the fix small and local rather than doing a broader refactor of success-result classification across adapters

Supersedes #2345. This PR was rebuilt cleanly on current upstream `master` so the diff stays focused.
