### PR TITLE
Fix OpenClaw gateway default wait timeout

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -84,6 +84,7 @@ const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";
 const DEFAULT_ROLE = "operator";
+const DISABLED_WAIT_TIMEOUT_FALLBACK_MS = 24 * 60 * 60 * 1000;
 
 const SENSITIVE_LOG_KEY_PATTERN =
   /(^|[_-])(auth|authorization|token|secret|password|api[_-]?key|private[_-]?key)([_-]|$)|^x-openclaw-(auth|token)$/i;
@@ -106,6 +107,17 @@ function parseOptionalPositiveInteger(value: unknown): number | null {
   if (typeof value === "string" && value.trim().length > 0) {
     const parsed = Number.parseInt(value.trim(), 10);
     if (Number.isFinite(parsed)) return Math.max(1, Math.floor(parsed));
+  }
+  return null;
+}
+
+function parseOptionalNonNegativeInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isFinite(parsed)) return Math.max(0, Math.floor(parsed));
   }
   return null;
 }
@@ -1029,7 +1041,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const timeoutSec = Math.max(0, Math.floor(asNumber(ctx.config.timeoutSec, 120)));
   const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : 0;
   const connectTimeoutMs = timeoutMs > 0 ? Math.min(timeoutMs, 15_000) : 10_000;
-  const waitTimeoutMs = parseOptionalPositiveInteger(ctx.config.waitTimeoutMs) ?? (timeoutMs > 0 ? timeoutMs : 30_000);
+  const configuredWaitTimeoutMs = parseOptionalNonNegativeInteger(ctx.config.waitTimeoutMs);
+  const waitTimeoutMs = configuredWaitTimeoutMs ?? (timeoutMs > 0 ? timeoutMs : 30_000);
+  const gatewayWaitTimeoutMs = configuredWaitTimeoutMs === 0 ? DISABLED_WAIT_TIMEOUT_FALLBACK_MS : waitTimeoutMs;
 
   const payloadTemplate = parseObject(ctx.config.payloadTemplate);
   const transportHint = nonEmpty(ctx.config.streamTransport) ?? nonEmpty(ctx.config.transport);
@@ -1081,7 +1095,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     agentParams.agentId = configuredAgentId;
   }
 
-  if (typeof agentParams.timeout !== "number") {
+  if (typeof agentParams.timeout !== "number" && configuredWaitTimeoutMs !== 0) {
     agentParams.timeout = waitTimeoutMs;
   }
 
@@ -1279,8 +1293,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       if (acceptedStatus !== "ok") {
         const waitPayload = await client.request<Record<string, unknown>>(
           "agent.wait",
-          { runId: acceptedRunId, timeoutMs: waitTimeoutMs },
-          { timeoutMs: waitTimeoutMs + connectTimeoutMs },
+          { runId: acceptedRunId, timeoutMs: gatewayWaitTimeoutMs },
+          { timeoutMs: gatewayWaitTimeoutMs + connectTimeoutMs },
         );
 
         latestResultPayload = waitPayload;

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -112,12 +112,12 @@ function parseOptionalPositiveInteger(value: unknown): number | null {
 }
 
 function parseOptionalNonNegativeInteger(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.max(0, Math.floor(value));
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
   }
   if (typeof value === "string" && value.trim().length > 0) {
     const parsed = Number.parseInt(value.trim(), 10);
-    if (Number.isFinite(parsed)) return Math.max(0, Math.floor(parsed));
+    if (Number.isFinite(parsed) && parsed >= 0) return Math.floor(parsed);
   }
   return null;
 }
@@ -1305,7 +1305,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             exitCode: 1,
             signal: null,
             timedOut: true,
-            errorMessage: `OpenClaw gateway run timed out after ${waitTimeoutMs}ms`,
+            errorMessage: `OpenClaw gateway run timed out after ${gatewayWaitTimeoutMs}ms`,
             errorCode: "openclaw_gateway_wait_timeout",
             resultJson: waitPayload,
           };

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -46,6 +46,7 @@ async function createMockGatewayServer(options?: {
   const wss = new WebSocketServer({ server });
 
   let agentPayload: Record<string, unknown> | null = null;
+  let waitPayload: Record<string, unknown> | null = null;
 
   wss.on("connection", (socket) => {
     socket.send(
@@ -136,6 +137,7 @@ async function createMockGatewayServer(options?: {
       }
 
       if (frame.method === "agent.wait") {
+        waitPayload = frame.params ?? null;
         socket.send(
           JSON.stringify({
             type: "res",
@@ -165,6 +167,7 @@ async function createMockGatewayServer(options?: {
   return {
     url: `ws://127.0.0.1:${address.port}`,
     getAgentPayload: () => agentPayload,
+    getWaitPayload: () => waitPayload,
     close: async () => {
       await new Promise<void>((resolve) => wss.close(() => resolve()));
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -549,6 +552,30 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(logs.some((entry) => entry.includes("auto-approved pairing request"))).toBe(true);
       expect(gateway.getAgentPayload()).toBeTruthy();
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("allows wait timeout to be disabled with 0", async () => {
+    const gateway = await createMockGatewayServer({ waitDelayMs: 50 });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          timeoutSec: 0,
+          waitTimeoutMs: 0,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.timedOut).toBe(false);
+      expect(gateway.getAgentPayload()?.timeout).toBeUndefined();
+      expect(gateway.getWaitPayload()).toEqual({ runId: "run-123", timeoutMs: 86_400_000 });
     } finally {
       await gateway.close();
     }

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -558,7 +558,7 @@ describe("openclaw gateway adapter execute", () => {
   });
 
   it("allows wait timeout to be disabled with 0", async () => {
-    const gateway = await createMockGatewayServer({ waitDelayMs: 50 });
+    const gateway = await createMockGatewayServer();
 
     try {
       const result = await execute(
@@ -575,6 +575,59 @@ describe("openclaw gateway adapter execute", () => {
       expect(result.exitCode).toBe(0);
       expect(result.timedOut).toBe(false);
       expect(gateway.getAgentPayload()?.timeout).toBeUndefined();
+      expect(gateway.getWaitPayload()).toEqual({ runId: "run-123", timeoutMs: 86_400_000 });
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("falls back to the default wait timeout when waitTimeoutMs is negative", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          timeoutSec: 0,
+          waitTimeoutMs: -1,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.timedOut).toBe(false);
+      expect(gateway.getAgentPayload()?.timeout).toBe(30_000);
+      expect(gateway.getWaitPayload()).toEqual({ runId: "run-123", timeoutMs: 30_000 });
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("reports the gateway wait timeout duration that was actually used", async () => {
+    const gateway = await createMockGatewayServer({
+      waitPayload: {
+        runId: "run-123",
+        status: "timeout",
+      },
+    });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          timeoutSec: 0,
+          waitTimeoutMs: 0,
+        }),
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.timedOut).toBe(true);
+      expect(result.errorMessage).toBe("OpenClaw gateway run timed out after 86400000ms");
       expect(gateway.getWaitPayload()).toEqual({ runId: "run-123", timeoutMs: 86_400_000 });
     } finally {
       await gateway.close();


### PR DESCRIPTION
Fresh clean PR based directly on current upstream `master`.

This change applies a safer default wait timeout for `agent.wait` while preserving the explicit `waitTimeoutMs=0` disable behavior expected by the current adapter flow.