### PR TITLE
fix(audit): isolate local agent home from operator secrets

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -56,10 +56,37 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(source, target);
+    await fs.symlink(source, target).catch(async (error: NodeJS.ErrnoException) => {
+      if (error.code !== "EEXIST") throw error;
+      const collided = await fs.lstat(target).catch(() => null);
+      if (collided?.isSymbolicLink()) {
+        const linkedPath = await fs.readlink(target).catch(() => null);
+        if (linkedPath) {
+          const resolvedLinkedPath = path.resolve(path.dirname(target), linkedPath);
+          if (resolvedLinkedPath === source) return;
+        }
+      }
+      throw error;
+    });
     return;
   }
-  if (!existing.isSymbolicLink()) return;
+  if (!existing.isSymbolicLink()) {
+    await fs.unlink(target);
+    await ensureParentDir(target);
+    await fs.symlink(source, target).catch(async (error: NodeJS.ErrnoException) => {
+      if (error.code !== "EEXIST") throw error;
+      const collided = await fs.lstat(target).catch(() => null);
+      if (collided?.isSymbolicLink()) {
+        const linkedPath = await fs.readlink(target).catch(() => null);
+        if (linkedPath) {
+          const resolvedLinkedPath = path.resolve(path.dirname(target), linkedPath);
+          if (resolvedLinkedPath === source) return;
+        }
+      }
+      throw error;
+    });
+    return;
+  }
 
   const linkedPath = await fs.readlink(target).catch(() => null);
   if (!linkedPath) return;
@@ -67,7 +94,18 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === source) return;
 
   await fs.unlink(target);
-  await fs.symlink(source, target);
+  await fs.symlink(source, target).catch(async (error: NodeJS.ErrnoException) => {
+    if (error.code !== "EEXIST") throw error;
+    const collided = await fs.lstat(target).catch(() => null);
+    if (collided?.isSymbolicLink()) {
+      const nextLinkedPath = await fs.readlink(target).catch(() => null);
+      if (nextLinkedPath) {
+        const resolvedLinkedPath = path.resolve(path.dirname(target), nextLinkedPath);
+        if (resolvedLinkedPath === source) return;
+      }
+    }
+    throw error;
+  });
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {
@@ -304,7 +342,9 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
 
   for (const [key, value] of Object.entries(envConfig)) {
-    if (typeof value === "string") env[key] = value;
+    if (typeof value !== "string") continue;
+    if (key === "CLAUDE_CONFIG_DIR" && typeof env.CLAUDE_CONFIG_DIR === "string") continue;
+    env[key] = value;
   }
 
   if (!hasExplicitApiKey && authToken) {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -32,6 +32,74 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const CLAUDE_COPIED_SHARED_FILES = ["config.json", "config.toml", "settings.json"] as const;
+const CLAUDE_SYMLINKED_SHARED_FILES = [".credentials.json", "credentials.json"] as const;
+
+async function pathExists(candidate: string): Promise<boolean> {
+  return fs.access(candidate).then(() => true).catch(() => false);
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveSharedClaudeConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+  const fromEnv = nonEmpty(env.CLAUDE_CONFIG_DIR);
+  return fromEnv ? path.resolve(fromEnv) : path.join(os.homedir(), ".claude");
+}
+
+async function ensureParentDir(target: string): Promise<void> {
+  await fs.mkdir(path.dirname(target), { recursive: true });
+}
+
+async function ensureSymlink(target: string, source: string): Promise<void> {
+  const existing = await fs.lstat(target).catch(() => null);
+  if (!existing) {
+    await ensureParentDir(target);
+    await fs.symlink(source, target);
+    return;
+  }
+  if (!existing.isSymbolicLink()) return;
+
+  const linkedPath = await fs.readlink(target).catch(() => null);
+  if (!linkedPath) return;
+  const resolvedLinkedPath = path.resolve(path.dirname(target), linkedPath);
+  if (resolvedLinkedPath === source) return;
+
+  await fs.unlink(target);
+  await fs.symlink(source, target);
+}
+
+async function ensureCopiedFile(target: string, source: string): Promise<void> {
+  const existing = await fs.lstat(target).catch(() => null);
+  if (existing) return;
+  await ensureParentDir(target);
+  await fs.copyFile(source, target);
+}
+
+async function prepareManagedClaudeConfigDir(
+  env: NodeJS.ProcessEnv,
+  agentHome: string,
+): Promise<string> {
+  const targetDir = path.join(agentHome, ".claude");
+  const sourceDir = resolveSharedClaudeConfigDir(env);
+  await fs.mkdir(targetDir, { recursive: true });
+  if (path.resolve(sourceDir) === path.resolve(targetDir)) return targetDir;
+
+  for (const name of CLAUDE_SYMLINKED_SHARED_FILES) {
+    const source = path.join(sourceDir, name);
+    if (!(await pathExists(source))) continue;
+    await ensureSymlink(path.join(targetDir, name), source);
+  }
+
+  for (const name of CLAUDE_COPIED_SHARED_FILES) {
+    const source = path.join(sourceDir, name);
+    if (!(await pathExists(source))) continue;
+    await ensureCopiedFile(path.join(targetDir, name), source);
+  }
+
+  return targetDir;
+}
 
 /**
  * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
@@ -144,6 +212,10 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const explicitClaudeConfigDir =
+    typeof envConfig.CLAUDE_CONFIG_DIR === "string" && envConfig.CLAUDE_CONFIG_DIR.trim().length > 0
+      ? path.resolve(envConfig.CLAUDE_CONFIG_DIR.trim())
+      : null;
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
   env.PAPERCLIP_RUN_ID = runId;
 
@@ -215,6 +287,8 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
   if (agentHome) {
     env.AGENT_HOME = agentHome;
+    env.HOME = agentHome;
+    env.CLAUDE_CONFIG_DIR = explicitClaudeConfigDir ?? await prepareManagedClaudeConfigDir(process.env, agentHome);
   }
   if (workspaceHints.length > 0) {
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -357,6 +357,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   if (agentHome) {
     env.AGENT_HOME = agentHome;
+    env.HOME = agentHome;
   }
   if (workspaceHints.length > 0) {
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -12,6 +12,7 @@ const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
 const payload = {
   argv: process.argv.slice(2),
   prompt: fs.readFileSync(0, "utf8"),
+  home: process.env.HOME || null,
   claudeConfigDir: process.env.CLAUDE_CONFIG_DIR || null,
 };
 if (capturePath) {
@@ -86,6 +87,85 @@ describe("claude execute", () => {
       expect(loggedEnv.HOME).toBe(root);
       expect(loggedEnv.CLAUDE_CONFIG_DIR).toBe(claudeConfigDir);
       expect(loggedEnv.PAPERCLIP_RESOLVED_COMMAND).toBe(commandPath);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses agent home as HOME and isolates Claude config during heartbeat runs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-agent-home-"));
+    const workspace = path.join(root, "workspace");
+    const binDir = path.join(root, "bin");
+    const commandPath = path.join(binDir, "claude");
+    const capturePath = path.join(root, "capture.json");
+    const agentHome = path.join(root, "agent-home");
+    const sharedClaudeConfigDir = path.join(root, ".claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.mkdir(agentHome, { recursive: true });
+    await fs.mkdir(sharedClaudeConfigDir, { recursive: true });
+    await fs.writeFile(path.join(sharedClaudeConfigDir, "credentials.json"), '{"token":"shared"}\n', "utf8");
+    await writeFakeClaudeCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    const previousPath = process.env.PATH;
+    const previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.HOME = root;
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    try {
+      const result = await execute({
+        runId: "run-agent-home",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "claude",
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            agentHome,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as {
+        home: string | null;
+        claudeConfigDir: string | null;
+      };
+      expect(capture.home).toBe(agentHome);
+      expect(capture.claudeConfigDir).toBe(path.join(agentHome, ".claude"));
+      expect((await fs.lstat(path.join(agentHome, ".claude", "credentials.json"))).isSymbolicLink()).toBe(true);
+      expect(await fs.realpath(path.join(agentHome, ".claude", "credentials.json"))).toBe(
+        await fs.realpath(path.join(sharedClaudeConfigDir, "credentials.json")),
+      );
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -176,4 +176,152 @@ describe("claude execute", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("keeps an explicit relative CLAUDE_CONFIG_DIR resolved when agent home is present", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-explicit-config-"));
+    const workspace = path.join(root, "workspace");
+    const binDir = path.join(root, "bin");
+    const commandPath = path.join(binDir, "claude");
+    const capturePath = path.join(root, "capture.json");
+    const agentHome = path.join(root, "agent-home");
+    const explicitClaudeConfigDir = path.join(root, "custom-claude-config");
+    const relativeClaudeConfigDir = path.relative(process.cwd(), explicitClaudeConfigDir);
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.mkdir(agentHome, { recursive: true });
+    await fs.mkdir(explicitClaudeConfigDir, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    const previousPath = process.env.PATH;
+    const previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.HOME = root;
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    try {
+      const result = await execute({
+        runId: "run-explicit-config",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "claude",
+          cwd: workspace,
+          env: {
+            CLAUDE_CONFIG_DIR: relativeClaudeConfigDir,
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            agentHome,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as {
+        claudeConfigDir: string | null;
+      };
+      expect(capture.claudeConfigDir).toBe(path.resolve(relativeClaudeConfigDir));
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces stale credential files in the managed Claude config dir with symlinks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-managed-config-"));
+    const workspace = path.join(root, "workspace");
+    const binDir = path.join(root, "bin");
+    const commandPath = path.join(binDir, "claude");
+    const capturePath = path.join(root, "capture.json");
+    const agentHome = path.join(root, "agent-home");
+    const sharedClaudeConfigDir = path.join(root, ".claude");
+    const managedCredentialsPath = path.join(agentHome, ".claude", "credentials.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.mkdir(path.dirname(managedCredentialsPath), { recursive: true });
+    await fs.mkdir(sharedClaudeConfigDir, { recursive: true });
+    await fs.writeFile(path.join(sharedClaudeConfigDir, "credentials.json"), '{"token":"shared"}\n', "utf8");
+    await fs.writeFile(managedCredentialsPath, '{"token":"stale"}\n', "utf8");
+    await writeFakeClaudeCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    const previousPath = process.env.PATH;
+    const previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.HOME = root;
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+    delete process.env.CLAUDE_CONFIG_DIR;
+
+    try {
+      const result = await execute({
+        runId: "run-stale-credentials",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "claude",
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            agentHome,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect((await fs.lstat(managedCredentialsPath)).isSymbolicLink()).toBe(true);
+      expect(await fs.realpath(managedCredentialsPath)).toBe(
+        await fs.realpath(path.join(sharedClaudeConfigDir, "credentials.json")),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -12,6 +12,7 @@ const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
 const payload = {
   argv: process.argv.slice(2),
   prompt: fs.readFileSync(0, "utf8"),
+  home: process.env.HOME || null,
   codexHome: process.env.CODEX_HOME || null,
   paperclipEnvKeys: Object.keys(process.env)
     .filter((key) => key.startsWith("PAPERCLIP_"))
@@ -31,6 +32,7 @@ console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, c
 type CapturePayload = {
   argv: string[];
   prompt: string;
+  home: string | null;
   codexHome: string | null;
   paperclipEnvKeys: string[];
 };
@@ -446,6 +448,89 @@ describe("codex execute", () => {
       else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
       if (previousPaperclipInWorktree === undefined) delete process.env.PAPERCLIP_IN_WORKTREE;
       else process.env.PAPERCLIP_IN_WORKTREE = previousPaperclipInWorktree;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses agent home as HOME when workspace context provides one", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-agent-home-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const sharedCodexHome = path.join(root, "shared-codex-home");
+    const paperclipHome = path.join(root, "paperclip-home");
+    const managedCodexHome = path.join(
+      paperclipHome,
+      "instances",
+      "default",
+      "companies",
+      "company-1",
+      "codex-home",
+    );
+    const agentHome = path.join(root, "agent-home");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(sharedCodexHome, { recursive: true });
+    await fs.mkdir(agentHome, { recursive: true });
+    await fs.writeFile(path.join(sharedCodexHome, "auth.json"), '{"token":"shared"}\n', "utf8");
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    const previousPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = root;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    process.env.CODEX_HOME = sharedCodexHome;
+
+    try {
+      const result = await execute({
+        runId: "run-agent-home",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            agentHome,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.home).toBe(agentHome);
+      expect(capture.codexHome).toBe(managedCodexHome);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+      if (previousPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
       if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
       else process.env.CODEX_HOME = previousCodexHome;
       await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Supersedes #2498.

This rebuilt PR is based directly on current upstream `master` and keeps the diff focused on isolating local agent home/config state from operator secrets for Claude and Codex local adapters.