### PR TITLE
fix(ui): normalize inline editor saves and extra args parsing

### DIFF
--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -9,8 +9,8 @@ describe("resolveExtraArgsValue", () => {
     ]);
   });
 
-  it("returns an empty array when the field is cleared", () => {
-    expect(resolveExtraArgsValue("")).toEqual([]);
-    expect(resolveExtraArgsValue("   ")).toEqual([]);
+  it("returns undefined when the field is cleared", () => {
+    expect(resolveExtraArgsValue("")).toBeUndefined();
+    expect(resolveExtraArgsValue("   ")).toBeUndefined();
   });
 });

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -125,8 +125,9 @@ function parseCommaArgs(value: string): string[] {
     .filter(Boolean);
 }
 
-export function resolveExtraArgsValue(value: string): string[] {
-  return parseCommaArgs(value);
+export function resolveExtraArgsValue(value: string): string[] | undefined {
+  const parsed = parseCommaArgs(value);
+  return parsed.length > 0 ? parsed : undefined;
 }
 
 function formatArgList(value: unknown): string {

--- a/ui/src/components/InlineEditor.test.ts
+++ b/ui/src/components/InlineEditor.test.ts
@@ -13,6 +13,10 @@ describe("InlineEditor save behavior", () => {
     expect(shouldSaveInlineEditorValue("  hello  ", "hello")).toBe(false);
   });
 
+  it("normalizes the current value before comparing", () => {
+    expect(shouldSaveInlineEditorValue("hello", "  hello  ")).toBe(false);
+  });
+
   it("saves when clearing an existing value", () => {
     expect(shouldSaveInlineEditorValue("", "Has description")).toBe(true);
     expect(shouldSaveInlineEditorValue("   ", "Has description")).toBe(true);

--- a/ui/src/components/InlineEditor.tsx
+++ b/ui/src/components/InlineEditor.tsx
@@ -24,7 +24,7 @@ export function normalizeInlineEditorValue(value: string): string {
 }
 
 export function shouldSaveInlineEditorValue(nextValue: string, currentValue: string): boolean {
-  return normalizeInlineEditorValue(nextValue) !== currentValue;
+  return normalizeInlineEditorValue(nextValue) !== normalizeInlineEditorValue(currentValue);
 }
 
 export function InlineEditor({
@@ -124,8 +124,8 @@ export function InlineEditor({
   useEffect(() => {
     if (!multiline) return;
     if (!multilineFocused) return;
-    const trimmed = draft.trim();
-    if (!trimmed || trimmed === value) {
+    const normalizedDraft = normalizeInlineEditorValue(draft);
+    if (!shouldSaveInlineEditorValue(draft, value)) {
       if (autosaveState !== "saved") {
         reset();
       }
@@ -136,7 +136,7 @@ export function InlineEditor({
       clearTimeout(autosaveDebounceRef.current);
     }
     autosaveDebounceRef.current = setTimeout(() => {
-      void runSave(() => commit(trimmed));
+      void runSave(() => commit(normalizedDraft));
     }, AUTOSAVE_DEBOUNCE_MS);
 
     return () => {
@@ -161,8 +161,7 @@ export function InlineEditor({
             clearTimeout(autosaveDebounceRef.current);
           }
           setMultilineFocused(false);
-          const trimmed = draft.trim();
-          if (!trimmed || trimmed === value) {
+          if (!shouldSaveInlineEditorValue(draft, value)) {
             reset();
             void commit();
             return;
@@ -182,8 +181,7 @@ export function InlineEditor({
           imageUploadHandler={imageUploadHandler}
           mentions={mentions}
           onSubmit={() => {
-            const trimmed = draft.trim();
-            if (!trimmed || trimmed === value) {
+            if (!shouldSaveInlineEditorValue(draft, value)) {
               reset();
               void commit();
               return;


### PR DESCRIPTION
## Thinking Path
This PR already extracted helpers for inline-save normalization and extra-args parsing, but the helper usage was still inconsistent across multiline save paths and the cleared `extraArgs` field had changed semantics from `undefined` to `[]`. The follow-up keeps every save path on the same comparison logic and restores the prior clear-on-empty behavior.

## What Changed
- Normalize both `nextValue` and `currentValue` in `shouldSaveInlineEditorValue`.
- Reuse the shared save guard in multiline autosave, blur, and submit paths.
- Restore `resolveExtraArgsValue("")` / blank input to `undefined` instead of `[]`.
- Added tests covering current-value normalization and the restored empty extra-args semantics.

## Why It Matters
This keeps inline saves consistent across code paths and avoids unintentionally changing the meaning of clearing adapter extra args.

## Benefits
- Prevents spurious resaves when stored values contain surrounding whitespace.
- Makes multiline autosave, blur, and submit follow the same logic.
- Preserves the prior adapter-config patch semantics for clearing `extraArgs`.

## How To Verify
- `pnpm exec vitest run ui/src/components/InlineEditor.test.ts ui/src/components/AgentConfigForm.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks
Clearing extra args now intentionally maps back to `undefined`, matching the previous edit-path behavior. This is a semantics-preserving change for updates, but it is different from the intermediate `[]` behavior on the branch before this follow-up.
