### PR TITLE
fix: handle browser open failures gracefully in headless environments

### DIFF
--- a/cli/src/client/board-auth.ts
+++ b/cli/src/client/board-auth.ts
@@ -183,7 +183,10 @@ export function openUrl(url: string): Promise<boolean> {
         child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
       }
 
-      child.once("error", () => resolve(false));
+      child.once("error", () => {
+        child.unref();
+        resolve(false);
+      });
       child.once("spawn", () => {
         child.unref();
         resolve(true);

--- a/cli/src/client/board-auth.ts
+++ b/cli/src/client/board-auth.ts
@@ -169,25 +169,29 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export function openUrl(url: string): boolean {
-  const platform = process.platform;
-  try {
-    if (platform === "darwin") {
-      const child = spawn("open", [url], { detached: true, stdio: "ignore" });
-      child.unref();
-      return true;
+export function openUrl(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const platform = process.platform;
+    let child;
+
+    try {
+      if (platform === "darwin") {
+        child = spawn("open", [url], { detached: true, stdio: "ignore" });
+      } else if (platform === "win32") {
+        child = spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" });
+      } else {
+        child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
+      }
+
+      child.once("error", () => resolve(false));
+      child.once("spawn", () => {
+        child.unref();
+        resolve(true);
+      });
+    } catch {
+      resolve(false);
     }
-    if (platform === "win32") {
-      const child = spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" });
-      child.unref();
-      return true;
-    }
-    const child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
-    child.unref();
-    return true;
-  } catch {
-    return false;
-  }
+  });
 }
 
 export async function loginBoardCli(params: {
@@ -219,9 +223,13 @@ export async function loginBoardCli(params: {
     console.error(`Open this URL in your browser to approve CLI access:\n${approvalUrl}`);
   }
 
-  const opened = openUrl(approvalUrl);
-  if (params.print !== false && opened) {
-    console.error(pc.dim("Opened the approval page in your browser."));
+  const opened = await openUrl(approvalUrl);
+  if (params.print !== false) {
+    if (opened) {
+      console.error(pc.dim("Opened the approval page in your browser."));
+    } else {
+      console.error(pc.yellow("!"), "Could not open browser automatically. Please open the URL above manually.");
+    }
   }
 
   const expiresAtMs = Date.parse(challenge.expiresAt);

--- a/cli/src/commands/client/company.ts
+++ b/cli/src/commands/client/company.ts
@@ -1477,7 +1477,7 @@ export function registerCompanyCommands(program: Command): void {
                 initialValue: true,
               });
               if (!p.isCancel(openImportedCompany) && openImportedCompany) {
-                if (openUrl(companyUrl)) {
+                if (await openUrl(companyUrl)) {
                   p.log.info(`Opened ${companyUrl}`);
                 } else {
                   p.log.warn(`Could not open your browser automatically. Open this URL manually:\n${companyUrl}`);


### PR DESCRIPTION
Fixes #2570

**Problem:**
When running CLI auth commands in a headless environment (no display/browser), the process crashes with:
```
Error: spawn xdg-open ENOENT
```

**Root cause:**
The `openUrl()` function used `spawn()` without handling asynchronous errors. The ENOENT error is emitted on the child process `error` event, which was unhandled, causing the process to crash.

**Solution:**
- Changed `openUrl()` to return `Promise<boolean>` 
- Uses the `spawn` event to detect successful browser launch (similar to how the open npm package handles it)
- Shows a helpful message when browser can't open instead of crashing
- Updated callers to handle the async nature

**Before:**
```
Board authentication required
Open this URL in your browser to approve CLI access:
http://localhost:3100/cli-auth/...
Opened the approval page in your browser.
Error: spawn xdg-open ENOENT  <-- CRASH
```

**After:**
```
Board authentication required
Open this URL in your browser to approve CLI access:
http://localhost:3100/cli-auth/...
! Could not open browser automatically. Please open the URL above manually.
```

The auth flow continues normally - user can open the URL manually and approve in their browser.

Inspired by how GitHub CLI handles this gracefully.