### PR TITLE
Add local-first Ollama routing for opencode_local

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -586,7 +586,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       biller: resolveCodexBiller(effectiveEnv, billingType),
       model,
       billingType,
-      costUsd: null,
+      costUsd: attempt.parsed.costUsd,
       resultJson: {
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
+
+describe("parseCodexJsonl", () => {
+  it("parses usage, cost, assistant text, and session id from JSONL output", () => {
+    const stdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "agent_message",
+          text: "Finished the task",
+        },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        total_cost_usd: 0.123456,
+        usage: {
+          input_tokens: 1200,
+          cached_input_tokens: 200,
+          output_tokens: 80,
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseCodexJsonl(stdout);
+    expect(parsed.sessionId).toBe("thread_123");
+    expect(parsed.summary).toBe("Finished the task");
+    expect(parsed.usage).toEqual({
+      inputTokens: 1200,
+      cachedInputTokens: 200,
+      outputTokens: 80,
+    });
+    expect(parsed.costUsd).toBeCloseTo(0.123456, 6);
+    expect(parsed.errorMessage).toBeNull();
+  });
+
+  it("detects missing-session failures", () => {
+    expect(isCodexUnknownSessionError("unknown session id", "")).toBe(true);
+    expect(isCodexUnknownSessionError("", "thread abc not found")).toBe(true);
+    expect(isCodexUnknownSessionError("all good", "")).toBe(false);
+  });
+});

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -4,6 +4,7 @@ export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
   const messages: string[] = [];
   let errorMessage: string | null = null;
+  let costUsd: number | null = null;
   const usage = {
     inputTokens: 0,
     cachedInputTokens: 0,
@@ -43,6 +44,8 @@ export function parseCodexJsonl(stdout: string) {
       usage.inputTokens = asNumber(usageObj.input_tokens, usage.inputTokens);
       usage.cachedInputTokens = asNumber(usageObj.cached_input_tokens, usage.cachedInputTokens);
       usage.outputTokens = asNumber(usageObj.output_tokens, usage.outputTokens);
+      const totalCostUsd = asNumber(event.total_cost_usd, Number.NaN);
+      if (Number.isFinite(totalCostUsd)) costUsd = totalCostUsd;
       continue;
     }
 
@@ -50,6 +53,8 @@ export function parseCodexJsonl(stdout: string) {
       const err = parseObject(event.error);
       const msg = asString(err.message, "").trim();
       if (msg) errorMessage = msg;
+      const totalCostUsd = asNumber(event.total_cost_usd, Number.NaN);
+      if (Number.isFinite(totalCostUsd)) costUsd = totalCostUsd;
     }
   }
 
@@ -57,6 +62,7 @@ export function parseCodexJsonl(stdout: string) {
     sessionId,
     summary: messages.join("\n\n").trim(),
     usage,
+    costUsd,
     errorMessage,
   };
 }

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -29,6 +29,11 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
+- fallbackModel (string, optional): provider/model to use only when local-first fallback policy allows it
+- fallbackPolicy (string, optional): never | critical_only | always
+- healthcheckUrl (string, optional): explicit URL used to verify local provider availability before each run
+- healthcheckTimeoutMs (number, optional): timeout for the local healthcheck probe; defaults to 1500
+- deferWhenPrimaryUnavailable (boolean, optional): when true, non-eligible fallback cases are deferred cleanly instead of escalating
 - variant (string, optional): provider-specific reasoning/profile variant passed as --variant (for example minimal|low|medium|high|xhigh|max)
 - dangerouslySkipPermissions (boolean, optional): inject a runtime OpenCode config that allows \`external_directory\` access without interactive prompts; defaults to true for unattended Paperclip runs
 - promptTemplate (string, optional): run prompt template
@@ -43,6 +48,8 @@ Operational fields:
 Notes:
 - OpenCode supports multiple providers and models. Use \
   \`opencode models\` to list available options in provider/model format.
+- If \`OLLAMA_HOST\` is configured on the Paperclip server, Paperclip also lists \
+  \`ollama/*\` models discovered from \`/api/tags\` in the UI model selector.
 - Paperclip requires an explicit \`model\` value for \`opencode_local\` agents.
 - Runs are executed with: opencode run --format json ...
 - Sessions are resumed with --session when stored session cwd matches current cwd.

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -6,6 +6,7 @@ import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type Adapter
 import {
   asString,
   asNumber,
+  asBoolean,
   asStringArray,
   parseObject,
   buildPaperclipEnv,
@@ -25,6 +26,16 @@ import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
+import {
+  extractProviderModelName,
+  isOllamaModel,
+  parseFallbackPolicy,
+  parseModelProvider,
+  probeOllamaHealthcheck,
+  readIssuePriority,
+  resolveLocalFirstDecision,
+  resolveOllamaHealthcheckUrl,
+} from "./local-provider.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -35,13 +46,6 @@ function firstNonEmptyLine(text: string): string {
       .map((line) => line.trim())
       .find(Boolean) ?? ""
   );
-}
-
-function parseModelProvider(model: string | null): string | null {
-  if (!model) return null;
-  const trimmed = model.trim();
-  if (!trimmed.includes("/")) return null;
-  return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
 }
 
 function resolveOpenCodeBiller(env: Record<string, string>, provider: string | null): string {
@@ -98,7 +102,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
   const command = asString(config.command, "opencode");
-  const model = asString(config.model, "").trim();
+  const primaryModel = asString(config.model, "").trim();
+  const fallbackModel = asString(config.fallbackModel, "").trim() || null;
+  const fallbackPolicy = parseFallbackPolicy(config.fallbackPolicy);
+  const deferWhenPrimaryUnavailable = asBoolean(config.deferWhenPrimaryUnavailable, true);
+  const healthcheckTimeoutMs = Math.max(100, asNumber(config.healthcheckTimeoutMs, 1500));
   const variant = asString(config.variant, "").trim();
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
@@ -194,13 +202,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resolvedCommand,
     });
 
-    await ensureOpenCodeModelConfiguredAndAvailable({
-      model,
-      command,
-      cwd,
-      env: runtimeEnv,
-    });
-
     const timeoutSec = asNumber(config.timeoutSec, 0);
     const graceSec = asNumber(config.graceSec, 20);
     const extraArgs = (() => {
@@ -222,6 +223,84 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] OpenCode session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
       );
     }
+
+    let selectedModel = primaryModel || null;
+    let selectedSessionId = sessionId;
+    let deferredResult: AdapterExecutionResult | null = null;
+    if (isOllamaModel(primaryModel)) {
+      const healthcheckUrl = resolveOllamaHealthcheckUrl(config, runtimeEnv);
+      const healthcheck = healthcheckUrl
+        ? await probeOllamaHealthcheck({
+            url: healthcheckUrl,
+            timeoutMs: healthcheckTimeoutMs,
+            expectedModel: extractProviderModelName(primaryModel),
+          })
+        : {
+            ok: false,
+            status: null,
+            detail: "OLLAMA_HOST or adapterConfig.healthcheckUrl is not configured",
+            url: "unconfigured",
+          };
+      if (healthcheck.ok) {
+        await onLog(
+          "stdout",
+          `[paperclip] Local Ollama healthcheck OK for ${primaryModel} via ${healthcheck.url}.\n`,
+        );
+      } else {
+        const decision = resolveLocalFirstDecision({
+          primaryModel: primaryModel || null,
+          fallbackModel,
+          fallbackPolicy,
+          deferWhenPrimaryUnavailable,
+          issuePriority: readIssuePriority(context),
+          healthcheck,
+        });
+        await onLog(
+          "stdout",
+          `[paperclip] Local Ollama unavailable for ${primaryModel}: ${healthcheck.detail ?? "healthcheck failed"}.\n`,
+        );
+        if (decision.action === "fallback" && decision.model) {
+          selectedModel = decision.model;
+          selectedSessionId = null;
+          await onLog(
+            "stdout",
+            `[paperclip] Falling back to ${decision.model} due to ${decision.reason}.\n`,
+          );
+        } else if (decision.action === "defer") {
+          deferredResult = {
+            exitCode: 0,
+            signal: null,
+            timedOut: false,
+            errorMessage: null,
+            provider: parseModelProvider(primaryModel),
+            biller: parseModelProvider(primaryModel),
+            model: primaryModel || null,
+            billingType: "unknown",
+            costUsd: null,
+            resultJson: {
+              deferred: true,
+              reason: decision.reason,
+              detail: decision.detail,
+              healthcheckUrl: healthcheck.url,
+              primaryModel: primaryModel || null,
+              fallbackModel,
+            },
+            summary: `Deferred: local model unavailable for ${primaryModel}`,
+          };
+        }
+      }
+    }
+
+    if (deferredResult) {
+      return deferredResult;
+    }
+
+    await ensureOpenCodeModelConfiguredAndAvailable({
+      model: selectedModel,
+      command,
+      cwd,
+      env: runtimeEnv,
+    });
 
     const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
     const resolvedInstructionsFilePath = instructionsFilePath
@@ -273,7 +352,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
     const renderedPrompt = renderTemplate(promptTemplate, templateData);
     const renderedBootstrapPrompt =
-      !sessionId && bootstrapPromptTemplate.trim().length > 0
+      !selectedSessionId && bootstrapPromptTemplate.trim().length > 0
         ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
         : "";
     const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
@@ -291,17 +370,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       heartbeatPromptChars: renderedPrompt.length,
     };
 
-    const buildArgs = (resumeSessionId: string | null) => {
+    const buildArgs = (resumeSessionId: string | null, modelId: string | null) => {
       const args = ["run", "--format", "json"];
       if (resumeSessionId) args.push("--session", resumeSessionId);
-      if (model) args.push("--model", model);
+      if (modelId) args.push("--model", modelId);
       if (variant) args.push("--variant", variant);
       if (extraArgs.length > 0) args.push(...extraArgs);
       return args;
     };
 
-    const runAttempt = async (resumeSessionId: string | null) => {
-      const args = buildArgs(resumeSessionId);
+    const runAttempt = async (resumeSessionId: string | null, modelId: string | null) => {
+      const args = buildArgs(resumeSessionId, modelId);
       if (onMeta) {
         await onMeta({
           adapterType: "opencode_local",
@@ -338,6 +417,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         rawStderr: string;
         parsed: ReturnType<typeof parseOpenCodeJsonl>;
       },
+      modelId: string | null,
       clearSessionOnMissingSession = false,
     ): AdapterExecutionResult => {
       if (attempt.proc.timedOut) {
@@ -371,7 +451,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         parsedError ||
         stderrLine ||
         `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
-      const modelId = model || null;
 
       return {
         exitCode: synthesizedExitCode,
@@ -400,23 +479,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       };
     };
 
-    const initial = await runAttempt(sessionId);
+    const initial = await runAttempt(selectedSessionId, selectedModel);
     const initialFailed =
       !initial.proc.timedOut && ((initial.proc.exitCode ?? 0) !== 0 || Boolean(initial.parsed.errorMessage));
     if (
-      sessionId &&
+      selectedSessionId &&
       initialFailed &&
       isOpenCodeUnknownSessionError(initial.proc.stdout, initial.rawStderr)
     ) {
       await onLog(
         "stdout",
-        `[paperclip] OpenCode session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+        `[paperclip] OpenCode session "${selectedSessionId}" is unavailable; retrying with a fresh session.\n`,
       );
-      const retry = await runAttempt(null);
-      return toResult(retry, true);
+      const retry = await runAttempt(null, selectedModel);
+      return toResult(retry, selectedModel, true);
     }
 
-    return toResult(initial);
+    return toResult(initial, selectedModel);
   } finally {
     await preparedRuntimeConfig.cleanup();
   }

--- a/packages/adapters/opencode-local/src/server/local-provider.ts
+++ b/packages/adapters/opencode-local/src/server/local-provider.ts
@@ -1,0 +1,226 @@
+import { asNumber, asString } from "@paperclipai/adapter-utils/server-utils";
+
+export type LocalFallbackPolicy = "never" | "critical_only" | "always";
+
+export type LocalHealthcheckResult = {
+  ok: boolean;
+  status: number | null;
+  detail: string | null;
+  url: string;
+};
+
+export type LocalFirstDecision = {
+  action: "primary" | "fallback" | "defer";
+  model: string | null;
+  reason: string | null;
+  detail: string | null;
+};
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function parseModelProvider(model: string | null | undefined): string | null {
+  const normalized = readNonEmptyString(model);
+  if (!normalized || !normalized.includes("/")) return null;
+  return normalized.slice(0, normalized.indexOf("/")).trim() || null;
+}
+
+export function extractProviderModelName(model: string | null | undefined): string | null {
+  const normalized = readNonEmptyString(model);
+  if (!normalized || !normalized.includes("/")) return normalized;
+  return normalized.slice(normalized.indexOf("/") + 1).trim() || null;
+}
+
+export function isOllamaModel(model: string | null | undefined): boolean {
+  return parseModelProvider(model) === "ollama";
+}
+
+export function parseFallbackPolicy(value: unknown): LocalFallbackPolicy {
+  const normalized = asString(value, "").trim().toLowerCase();
+  if (normalized === "always") return "always";
+  if (normalized === "critical_only") return "critical_only";
+  return "never";
+}
+
+export function readIssuePriority(context: Record<string, unknown>): string | null {
+  return readNonEmptyString(context.issuePriority)?.toLowerCase() ?? null;
+}
+
+export function normalizeOllamaBaseUrl(raw: string | null | undefined): string | null {
+  const normalized = readNonEmptyString(raw);
+  if (!normalized) return null;
+  try {
+    const url = new URL(normalized);
+    const pathname = url.pathname.replace(/\/+$/, "");
+    if (!pathname || pathname === "/") {
+      url.pathname = "/v1";
+    } else if (!pathname.endsWith("/v1")) {
+      url.pathname = `${pathname}/v1`;
+    } else {
+      url.pathname = pathname;
+    }
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+export function resolveOllamaBaseUrl(
+  config: Record<string, unknown>,
+  env: Record<string, string>,
+): string | null {
+  const configured =
+    readNonEmptyString(config.ollamaBaseUrl) ??
+    readNonEmptyString(env.OLLAMA_HOST) ??
+    readNonEmptyString(process.env.OLLAMA_HOST);
+  return normalizeOllamaBaseUrl(configured);
+}
+
+export function resolveOllamaHealthcheckUrl(
+  config: Record<string, unknown>,
+  env: Record<string, string>,
+): string | null {
+  const explicit = readNonEmptyString(config.healthcheckUrl);
+  if (explicit) return explicit;
+
+  const baseUrl = resolveOllamaBaseUrl(config, env);
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    url.pathname = "/api/tags";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function collectOllamaModelNames(models: Array<string | null | undefined>): string[] {
+  const result: string[] = [];
+  for (const model of models) {
+    if (!isOllamaModel(model)) continue;
+    const modelName = extractProviderModelName(model);
+    if (!modelName || result.includes(modelName)) continue;
+    result.push(modelName);
+  }
+  return result;
+}
+
+function summarizeError(value: unknown): string | null {
+  if (value instanceof Error && value.message.trim()) return value.message.trim();
+  const text = readNonEmptyString(value);
+  return text ?? null;
+}
+
+export async function probeOllamaHealthcheck(input: {
+  url: string;
+  timeoutMs?: unknown;
+  expectedModel?: string | null;
+}): Promise<LocalHealthcheckResult> {
+  const timeoutMs = Math.max(100, asNumber(input.timeoutMs, 1500));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(input.url, {
+      method: "GET",
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        detail: `healthcheck returned HTTP ${response.status}`,
+        url: input.url,
+      };
+    }
+
+    const payload = await response.json().catch(() => null) as
+      | { models?: Array<{ name?: unknown; model?: unknown }> }
+      | null;
+    const expectedModel = readNonEmptyString(input.expectedModel);
+    if (expectedModel && Array.isArray(payload?.models)) {
+      const modelFound = payload.models.some((entry) => {
+        const name = readNonEmptyString(entry?.name) ?? readNonEmptyString(entry?.model);
+        return name === expectedModel;
+      });
+      if (!modelFound) {
+        return {
+          ok: false,
+          status: response.status,
+          detail: `model ${expectedModel} is not available in Ollama`,
+          url: input.url,
+        };
+      }
+    }
+
+    return {
+      ok: true,
+      status: response.status,
+      detail: null,
+      url: input.url,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: null,
+      detail: summarizeError(error) ?? "healthcheck failed",
+      url: input.url,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function resolveLocalFirstDecision(input: {
+  primaryModel: string | null;
+  fallbackModel: string | null;
+  fallbackPolicy: LocalFallbackPolicy;
+  deferWhenPrimaryUnavailable: boolean;
+  issuePriority: string | null;
+  healthcheck: LocalHealthcheckResult;
+}): LocalFirstDecision {
+  if (input.healthcheck.ok) {
+    return {
+      action: "primary",
+      model: input.primaryModel,
+      reason: null,
+      detail: null,
+    };
+  }
+
+  const allowFallback =
+    Boolean(input.fallbackModel) &&
+    (
+      input.fallbackPolicy === "always" ||
+      (input.fallbackPolicy === "critical_only" && input.issuePriority === "critical")
+    );
+  if (allowFallback) {
+    return {
+      action: "fallback",
+      model: input.fallbackModel,
+      reason: "primary_unavailable",
+      detail: input.healthcheck.detail,
+    };
+  }
+
+  if (input.deferWhenPrimaryUnavailable) {
+    return {
+      action: "defer",
+      model: input.primaryModel,
+      reason: "primary_unavailable",
+      detail: input.healthcheck.detail,
+    };
+  }
+
+  return {
+    action: "primary",
+    model: input.primaryModel,
+    reason: "primary_unavailable",
+    detail: input.healthcheck.detail,
+  };
+}

--- a/packages/adapters/opencode-local/src/server/local-provider.ts
+++ b/packages/adapters/opencode-local/src/server/local-provider.ts
@@ -110,6 +110,25 @@ export function collectOllamaModelNames(models: Array<string | null | undefined>
   return result;
 }
 
+export function parseOllamaTagsPayload(
+  payload: unknown,
+  options?: { prefix?: string },
+): Array<{ id: string; label: string }> {
+  const prefix = readNonEmptyString(options?.prefix) ?? "ollama";
+  const models = Array.isArray((payload as { models?: unknown[] } | null | undefined)?.models)
+    ? ((payload as { models: Array<{ name?: unknown; model?: unknown }> }).models)
+    : [];
+  const result: Array<{ id: string; label: string }> = [];
+  for (const entry of models) {
+    const name = readNonEmptyString(entry?.name) ?? readNonEmptyString(entry?.model);
+    if (!name) continue;
+    const id = `${prefix}/${name}`;
+    if (result.some((model) => model.id === id)) continue;
+    result.push({ id, label: id });
+  }
+  return result;
+}
+
 function summarizeError(value: unknown): string | null {
   if (value instanceof Error && value.message.trim()) return value.message.trim();
   const text = readNonEmptyString(value);
@@ -171,6 +190,29 @@ export async function probeOllamaHealthcheck(input: {
       detail: summarizeError(error) ?? "healthcheck failed",
       url: input.url,
     };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function listOllamaModels(input: {
+  url: string;
+  timeoutMs?: unknown;
+}): Promise<Array<{ id: string; label: string }>> {
+  const timeoutMs = Math.max(100, asNumber(input.timeoutMs, 1500));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(input.url, {
+      method: "GET",
+      signal: controller.signal,
+    });
+    if (!response.ok) return [];
+    const payload = await response.json().catch(() => null);
+    return parseOllamaTagsPayload(payload);
+  } catch {
+    return [];
   } finally {
     clearTimeout(timer);
   }

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -8,6 +8,7 @@ import {
 describe("openCode models", () => {
   afterEach(() => {
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
+    delete process.env.OLLAMA_HOST;
     resetOpenCodeModelsCacheForTests();
   });
 
@@ -29,5 +30,30 @@ describe("openCode models", () => {
         model: "openai/gpt-5",
       }),
     ).rejects.toThrow("Failed to start command");
+  });
+
+  it("returns ollama models for the UI when OLLAMA_HOST is reachable", async () => {
+    const originalFetch = globalThis.fetch;
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    process.env.OLLAMA_HOST = "http://100.64.0.10:11434";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          models: [{ name: "qwen3:14b" }, { model: "llama3.1:8b" }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      )) as typeof fetch;
+
+    try {
+      await expect(listOpenCodeModels()).resolves.toEqual([
+        { id: "ollama/llama3.1:8b", label: "ollama/llama3.1:8b" },
+        { id: "ollama/qwen3:14b", label: "ollama/qwen3:14b" },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -56,4 +56,32 @@ describe("openCode models", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("validates ollama/* models against OLLAMA_HOST instead of opencode models", async () => {
+    const originalFetch = globalThis.fetch;
+    process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
+    process.env.OLLAMA_HOST = "http://100.64.0.10:11434";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          models: [{ name: "qwen3:14b" }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      )) as typeof fetch;
+
+    try {
+      await expect(
+        ensureOpenCodeModelConfiguredAndAvailable({
+          model: "ollama/qwen3:14b",
+        }),
+      ).resolves.toEqual([
+        { id: "ollama/qwen3:14b", label: "ollama/qwen3:14b" },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -6,7 +6,7 @@ import {
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
-import { listOllamaModels, resolveOllamaHealthcheckUrl } from "./local-provider.js";
+import { isOllamaModel, listOllamaModels, resolveOllamaHealthcheckUrl } from "./local-provider.js";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
@@ -195,10 +195,36 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
     throw new Error("OpenCode requires `adapterConfig.model` in provider/model format.");
   }
 
+  const normalizedEnv = normalizeEnv(input.env);
+  if (isOllamaModel(model)) {
+    const healthcheckUrl = resolveOllamaHealthcheckUrl({ model }, normalizedEnv);
+    if (!healthcheckUrl) {
+      throw new Error(
+        "OLLAMA_HOST or adapterConfig.healthcheckUrl is required for ollama/* models.",
+      );
+    }
+    const models = await listOllamaModels({
+      url: healthcheckUrl,
+      timeoutMs: 1500,
+    });
+    if (models.length === 0) {
+      throw new Error(
+        `No Ollama models were discovered from ${healthcheckUrl}. Verify connectivity and that Ollama is serving /api/tags.`,
+      );
+    }
+    if (!models.some((entry) => entry.id === model)) {
+      const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
+      throw new Error(
+        `Configured Ollama model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
+      );
+    }
+    return models;
+  }
+
   const models = await discoverOpenCodeModelsCached({
     command: input.command,
     cwd: input.cwd,
-    env: input.env,
+    env: normalizedEnv,
   });
 
   if (models.length === 0) {

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -6,6 +6,8 @@ import {
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
+import { listOllamaModels, resolveOllamaHealthcheckUrl } from "./local-provider.js";
+import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
@@ -121,30 +123,46 @@ export async function discoverOpenCodeModels(input: {
     // image). Fall back to process.env.HOME.
   }
   // Prevent OpenCode from writing an opencode.json into the working directory.
-  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}), OPENCODE_DISABLE_PROJECT_CONFIG: "true" }));
-
-  const result = await runChildProcess(
-    `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-    command,
-    ["models"],
-    {
-      cwd,
-      env: runtimeEnv,
-      timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
-      graceSec: 3,
-      onLog: async () => {},
-    },
+  const baseRuntimeEnv = normalizeEnv(
+    ensurePathInEnv({
+      ...process.env,
+      ...env,
+      ...(resolvedHome ? { HOME: resolvedHome } : {}),
+      OPENCODE_DISABLE_PROJECT_CONFIG: "true",
+    }),
   );
+  const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({
+    env: baseRuntimeEnv,
+    config: {},
+  });
+  try {
+    const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...baseRuntimeEnv, ...preparedRuntimeConfig.env }));
 
-  if (result.timedOut) {
-    throw new Error(`\`opencode models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
-  }
-  if ((result.exitCode ?? 1) !== 0) {
-    const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
-    throw new Error(detail ? `\`opencode models\` failed: ${detail}` : "`opencode models` failed.");
-  }
+    const result = await runChildProcess(
+      `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command,
+      ["models"],
+      {
+        cwd,
+        env: runtimeEnv,
+        timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
+        graceSec: 3,
+        onLog: async () => {},
+      },
+    );
 
-  return sortModels(parseModelsOutput(result.stdout));
+    if (result.timedOut) {
+      throw new Error(`\`opencode models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    }
+    if ((result.exitCode ?? 1) !== 0) {
+      const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
+      throw new Error(detail ? `\`opencode models\` failed: ${detail}` : "`opencode models` failed.");
+    }
+
+    return sortModels(parseModelsOutput(result.stdout));
+  } finally {
+    await preparedRuntimeConfig.cleanup();
+  }
 }
 
 export async function discoverOpenCodeModelsCached(input: {
@@ -198,10 +216,18 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
 }
 
 export async function listOpenCodeModels(): Promise<AdapterModel[]> {
+  const ollamaHealthcheckUrl = resolveOllamaHealthcheckUrl({}, normalizeEnv(process.env));
+  const ollamaModels = ollamaHealthcheckUrl
+    ? await listOllamaModels({
+        url: ollamaHealthcheckUrl,
+        timeoutMs: 1500,
+      })
+    : [];
   try {
-    return await discoverOpenCodeModelsCached();
+    const discovered = await discoverOpenCodeModelsCached();
+    return sortModels(dedupeModels([...discovered, ...ollamaModels]));
   } catch {
-    return [];
+    return sortModels(dedupeModels([...ollamaModels]));
   }
 }
 

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -76,4 +76,54 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     expect(prepared.notes).toEqual([]);
     await prepared.cleanup();
   });
+
+  it("injects an Ollama-compatible provider when an ollama/* model is configured", async () => {
+    const configHome = await makeConfigHome({
+      provider: {
+        openai: {
+          name: "OpenAI",
+        },
+      },
+    });
+
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: {
+        XDG_CONFIG_HOME: configHome,
+        OLLAMA_HOST: "http://100.64.0.10:11434",
+      },
+      config: {
+        model: "ollama/qwen3:14b",
+        fallbackModel: "openai/gpt-5.4",
+      },
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(runtimeConfig).toMatchObject({
+      provider: {
+        openai: {
+          name: "OpenAI",
+        },
+        ollama: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Ollama",
+          options: {
+            baseURL: "http://100.64.0.10:11434/v1",
+          },
+          models: {
+            "qwen3:14b": {},
+          },
+        },
+      },
+    });
+    expect(prepared.notes.some((note) => note.includes("Ollama provider config"))).toBe(true);
+
+    await prepared.cleanup();
+    cleanupPaths.delete(prepared.env.XDG_CONFIG_HOME);
+  });
 });

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+import { collectOllamaModelNames, resolveOllamaBaseUrl } from "./local-provider.js";
 
 type PreparedOpenCodeRuntimeConfig = {
   env: Record<string, string>;
@@ -29,6 +30,55 @@ async function readJsonObject(filepath: string): Promise<Record<string, unknown>
   } catch {
     return {};
   }
+}
+
+function mergeOllamaProviderConfig(input: {
+  config: Record<string, unknown>;
+  env: Record<string, string>;
+  runtimeConfig: Record<string, unknown>;
+}): { nextConfig: Record<string, unknown>; notes: string[] } {
+  const baseUrl = resolveOllamaBaseUrl(input.config, input.env);
+  const modelNames = collectOllamaModelNames([
+    typeof input.config.model === "string" ? input.config.model : null,
+    typeof input.config.fallbackModel === "string" ? input.config.fallbackModel : null,
+  ]);
+  if (!baseUrl || modelNames.length === 0) {
+    return { nextConfig: input.runtimeConfig, notes: [] };
+  }
+
+  const provider = isPlainObject(input.runtimeConfig.provider) ? input.runtimeConfig.provider : {};
+  const existingOllama = isPlainObject(provider.ollama) ? provider.ollama : {};
+  const existingOptions = isPlainObject(existingOllama.options) ? existingOllama.options : {};
+  const existingModels = isPlainObject(existingOllama.models) ? existingOllama.models : {};
+
+  const mergedModels: Record<string, unknown> = { ...existingModels };
+  for (const modelName of modelNames) {
+    if (!isPlainObject(mergedModels[modelName])) {
+      mergedModels[modelName] = {};
+    }
+  }
+
+  return {
+    nextConfig: {
+      ...input.runtimeConfig,
+      provider: {
+        ...provider,
+        ollama: {
+          ...existingOllama,
+          npm: "@ai-sdk/openai-compatible",
+          name: "Ollama",
+          options: {
+            ...existingOptions,
+            baseURL: baseUrl,
+          },
+          models: mergedModels,
+        },
+      },
+    },
+    notes: [
+      `Injected OpenCode Ollama provider config for ${modelNames.join(", ")} via ${baseUrl}.`,
+    ],
+  };
 }
 
 export async function prepareOpenCodeRuntimeConfig(input: {
@@ -67,13 +117,18 @@ export async function prepareOpenCodeRuntimeConfig(input: {
   const existingPermission = isPlainObject(existingConfig.permission)
     ? existingConfig.permission
     : {};
-  const nextConfig = {
+  const permissionConfig = {
     ...existingConfig,
     permission: {
       ...existingPermission,
       external_directory: "allow",
     },
   };
+  const { nextConfig, notes } = mergeOllamaProviderConfig({
+    config: input.config,
+    env: input.env,
+    runtimeConfig: permissionConfig,
+  });
   await fs.writeFile(runtimeConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
 
   return {
@@ -83,6 +138,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     },
     notes: [
       "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
+      ...notes,
     ],
     cleanup: async () => {
       await fs.rm(runtimeConfigHome, { recursive: true, force: true });

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -13,6 +13,12 @@ import {
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
+import {
+  extractProviderModelName,
+  isOllamaModel,
+  probeOllamaHealthcheck,
+  resolveOllamaHealthcheckUrl,
+} from "./local-provider.js";
 import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
 import { parseOpenCodeJsonl } from "./parse.js";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
@@ -201,6 +207,37 @@ export async function testEnvironment(
             hint: "Run `opencode models` manually to verify provider auth and config.",
           });
         }
+      }
+    }
+
+    if (isOllamaModel(configuredModel)) {
+      const healthcheckUrl = resolveOllamaHealthcheckUrl(config, runtimeEnv);
+      if (!healthcheckUrl) {
+        checks.push({
+          code: "opencode_ollama_healthcheck_missing",
+          level: "warn",
+          message: "No Ollama healthcheck URL could be derived for the local-first model.",
+          hint: "Set OLLAMA_HOST or adapterConfig.healthcheckUrl before enabling local-first routing.",
+        });
+      } else {
+        const healthcheck = await probeOllamaHealthcheck({
+          url: healthcheckUrl,
+          timeoutMs: config.healthcheckTimeoutMs,
+          expectedModel: extractProviderModelName(configuredModel),
+        });
+        checks.push({
+          code: healthcheck.ok ? "opencode_ollama_healthcheck_ok" : "opencode_ollama_healthcheck_failed",
+          level: healthcheck.ok ? "info" : "warn",
+          message: healthcheck.ok
+            ? `Ollama healthcheck succeeded: ${healthcheckUrl}`
+            : "Ollama healthcheck failed for the configured local model.",
+          ...(healthcheck.detail ? { detail: healthcheck.detail } : {}),
+          ...(healthcheck.ok
+            ? {}
+            : {
+                hint: "Verify the tailnet route and that Ollama is listening on the configured Tailscale address.",
+              }),
+        });
       }
     }
 

--- a/scripts/backfill-codex-metered-costs.ts
+++ b/scripts/backfill-codex-metered-costs.ts
@@ -1,0 +1,198 @@
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import {
+  agentRuntimeState,
+  costEvents,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import type { BillingType } from "@paperclipai/shared";
+import { resolveBilledCost, type CostUsageTotals } from "../server/src/services/cost-estimation.js";
+
+function parseArgs(argv: string[]) {
+  const companyId = argv.find((arg) => arg.startsWith("--company-id="))?.slice("--company-id=".length) ?? null;
+  const apply = argv.includes("--apply");
+  if (!companyId) {
+    throw new Error("Missing required --company-id=<uuid>");
+  }
+  return { companyId, apply };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function readRawUsageTotals(usageJson: unknown): CostUsageTotals | null {
+  const parsed = asRecord(usageJson);
+  if (!parsed) return null;
+
+  const inputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawInputTokens, asNumber(parsed.inputTokens, 0))),
+  );
+  const cachedInputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawCachedInputTokens, asNumber(parsed.cachedInputTokens, 0))),
+  );
+  const outputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawOutputTokens, asNumber(parsed.outputTokens, 0))),
+  );
+
+  if (inputTokens <= 0 && cachedInputTokens <= 0 && outputTokens <= 0) {
+    return null;
+  }
+
+  return {
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+  };
+}
+
+async function main() {
+  const { companyId, apply } = parseArgs(process.argv.slice(2));
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const db = createDb(databaseUrl);
+
+  const runs = await db
+    .select({
+      id: heartbeatRuns.id,
+      agentId: heartbeatRuns.agentId,
+      sessionIdAfter: heartbeatRuns.sessionIdAfter,
+      startedAt: heartbeatRuns.startedAt,
+      usageJson: heartbeatRuns.usageJson,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.companyId, companyId))
+    .orderBy(asc(heartbeatRuns.agentId), asc(heartbeatRuns.startedAt));
+
+  const previousRawUsageByRunId = new Map<string, CostUsageTotals | null>();
+  const latestRawUsageBySessionKey = new Map<string, CostUsageTotals>();
+
+  for (const run of runs) {
+    const sessionId = typeof run.sessionIdAfter === "string" && run.sessionIdAfter.trim().length > 0
+      ? run.sessionIdAfter.trim()
+      : null;
+    const sessionKey = sessionId ? `${run.agentId}:${sessionId}` : null;
+    previousRawUsageByRunId.set(run.id, sessionKey ? latestRawUsageBySessionKey.get(sessionKey) ?? null : null);
+
+    const rawUsage = readRawUsageTotals(run.usageJson);
+    if (sessionKey && rawUsage) {
+      latestRawUsageBySessionKey.set(sessionKey, rawUsage);
+    }
+  }
+
+  const runsById = new Map(runs.map((run) => [run.id, run]));
+
+  const events = await db
+    .select({
+      id: costEvents.id,
+      agentId: costEvents.agentId,
+      heartbeatRunId: costEvents.heartbeatRunId,
+      provider: costEvents.provider,
+      biller: costEvents.biller,
+      model: costEvents.model,
+      billingType: costEvents.billingType,
+      inputTokens: costEvents.inputTokens,
+      cachedInputTokens: costEvents.cachedInputTokens,
+      outputTokens: costEvents.outputTokens,
+      costCents: costEvents.costCents,
+    })
+    .from(costEvents)
+    .where(and(
+      eq(costEvents.companyId, companyId),
+      eq(costEvents.billingType, "metered_api"),
+      eq(costEvents.costCents, 0),
+    ))
+    .orderBy(desc(costEvents.occurredAt));
+
+  let estimatedEvents = 0;
+  let estimatedCents = 0;
+  const updates: Array<{ id: string; costCents: number }> = [];
+  const affectedAgentIds = new Set<string>();
+
+  for (const event of events) {
+    const usage: CostUsageTotals = {
+      inputTokens: event.inputTokens,
+      cachedInputTokens: event.cachedInputTokens,
+      outputTokens: event.outputTokens,
+    };
+    const run = event.heartbeatRunId ? runsById.get(event.heartbeatRunId) ?? null : null;
+    const rawUsage = run ? readRawUsageTotals(run.usageJson) : null;
+    const previousRawUsage = run ? previousRawUsageByRunId.get(run.id) ?? null : null;
+    const resolved = resolveBilledCost({
+      providerCostUsd: null,
+      provider: event.provider,
+      biller: event.biller,
+      model: event.model,
+      billingType: event.billingType as BillingType,
+      usage,
+      rawUsage,
+      previousRawUsage,
+    });
+
+    if (resolved.costCents <= 0) continue;
+    updates.push({ id: event.id, costCents: resolved.costCents });
+    affectedAgentIds.add(event.agentId);
+    estimatedEvents += 1;
+    estimatedCents += resolved.costCents;
+  }
+
+  console.log(JSON.stringify({
+    companyId,
+    apply,
+    scannedEvents: events.length,
+    estimatedEvents,
+    estimatedCents,
+  }, null, 2));
+
+  if (!apply || updates.length === 0) return;
+
+  for (const update of updates) {
+    await db
+      .update(costEvents)
+      .set({ costCents: update.costCents })
+      .where(eq(costEvents.id, update.id));
+  }
+
+  for (const agentId of affectedAgentIds) {
+    const sumRow = await db
+      .select({
+        totalCostCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
+      })
+      .from(costEvents)
+      .where(and(eq(costEvents.companyId, companyId), eq(costEvents.agentId, agentId)))
+      .then((rows) => rows[0] ?? { totalCostCents: 0 });
+
+    await db
+      .update(agentRuntimeState)
+      .set({
+        totalCostCents: sumRow.totalCostCents,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(agentRuntimeState.companyId, companyId),
+        eq(agentRuntimeState.agentId, agentId),
+      ));
+  }
+
+  console.log(JSON.stringify({
+    companyId,
+    updatedEvents: updates.length,
+    affectedAgents: affectedAgentIds.size,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -26,4 +26,11 @@ if [ "$changed" = "1" ]; then
     chown -R node:node /paperclip
 fi
 
+# OpenCode persists cache and sqlite state under /paperclip. If those paths are
+# ever touched as root (for example by maintenance execs), later headless runs
+# as node fail with SQLite WAL and cache permission errors. Repair the specific
+# OpenCode paths on every boot without recursively chowning the whole volume.
+mkdir -p /paperclip/.cache/opencode /paperclip/.local/share/opencode
+chown -R node:node /paperclip/.cache/opencode /paperclip/.local/share/opencode
+
 exec gosu node "$@"

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -274,13 +274,13 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(false);
   });
 
-  it("preserves session context on manual on-demand invokes by default", () => {
+  it("resets session context on manual on-demand invokes without task context", () => {
     expect(
       shouldResetTaskSessionForWake({
         wakeSource: "on_demand",
         wakeTriggerDetail: "manual",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("resets session context when a fresh session is explicitly requested", () => {
@@ -324,6 +324,17 @@ describe("shouldResetTaskSessionForWake", () => {
       shouldResetTaskSessionForWake({
         wakeSource: "on_demand",
         wakeTriggerDetail: "callback",
+        issueId: "issue-123",
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves session context on manual on-demand invokes when task context exists", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeSource: "on_demand",
+        wakeTriggerDetail: "manual",
+        issueId: "issue-123",
       }),
     ).toBe(false);
   });

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -62,18 +62,29 @@ describe("opencode_local environment diagnostics", () => {
   it("classifies ProviderModelNotFoundError probe output as model-unavailable warning", async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-cwd-"));
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-probe-bin-"));
-    const fakeOpencode = path.join(binDir, "opencode");
-    const script = [
-      "#!/bin/sh",
-      "echo 'ProviderModelNotFoundError: ProviderModelNotFoundError' 1>&2",
-      "echo 'data: { providerID: \"openai\", modelID: \"gpt-5.3-codex\", suggestions: [] }' 1>&2",
-      "exit 1",
-      "",
-    ].join("\n");
+    const isWindows = process.platform === "win32";
+    const fakeOpencode = path.join(binDir, isWindows ? "opencode.cmd" : "opencode");
+    const script = isWindows
+      ? [
+          "@echo off",
+          "echo ProviderModelNotFoundError: ProviderModelNotFoundError 1>&2",
+          "echo data: { providerID: \"openai\", modelID: \"gpt-5.3-codex\", suggestions: [] } 1>&2",
+          "exit /b 1",
+          "",
+        ].join("\r\n")
+      : [
+          "#!/bin/sh",
+          "echo 'ProviderModelNotFoundError: ProviderModelNotFoundError' 1>&2",
+          "echo 'data: { providerID: \"openai\", modelID: \"gpt-5.3-codex\", suggestions: [] }' 1>&2",
+          "exit 1",
+          "",
+        ].join("\n");
 
     try {
       await fs.writeFile(fakeOpencode, script, "utf8");
-      await fs.chmod(fakeOpencode, 0o755);
+      if (!isWindows) {
+        await fs.chmod(fakeOpencode, 0o755);
+      }
 
       const result = await testEnvironment({
         companyId: "company-1",

--- a/server/src/__tests__/opencode-local-adapter.test.ts
+++ b/server/src/__tests__/opencode-local-adapter.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import http from "node:http";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "@paperclipai/adapter-opencode-local/server";
 import { parseOpenCodeStdoutLine } from "@paperclipai/adapter-opencode-local/ui";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
+import {
+  probeOllamaHealthcheck,
+  resolveLocalFirstDecision,
+} from "../../../packages/adapters/opencode-local/src/server/local-provider.ts";
 
 describe("opencode_local parser", () => {
   it("extracts session, summary, usage, cost, and terminal error message", () => {
@@ -45,6 +50,94 @@ describe("opencode_local parser", () => {
     });
     expect(parsed.costUsd).toBeCloseTo(0.003, 6);
     expect(parsed.errorMessage).toBe("model access denied");
+  });
+});
+
+describe("opencode_local local-first routing", () => {
+  it("defers non-critical work when the primary local model is unavailable", () => {
+    const decision = resolveLocalFirstDecision({
+      primaryModel: "ollama/qwen3:14b",
+      fallbackModel: "openai/gpt-5.4",
+      fallbackPolicy: "critical_only",
+      deferWhenPrimaryUnavailable: true,
+      issuePriority: "medium",
+      healthcheck: {
+        ok: false,
+        status: null,
+        detail: "connect ECONNREFUSED",
+        url: "http://100.64.0.10:11434/api/tags",
+      },
+    });
+
+    expect(decision).toEqual({
+      action: "defer",
+      model: "ollama/qwen3:14b",
+      reason: "primary_unavailable",
+      detail: "connect ECONNREFUSED",
+    });
+  });
+
+  it("falls back for critical work when policy allows it", () => {
+    const decision = resolveLocalFirstDecision({
+      primaryModel: "ollama/qwen3:14b",
+      fallbackModel: "openai/gpt-5.4",
+      fallbackPolicy: "critical_only",
+      deferWhenPrimaryUnavailable: true,
+      issuePriority: "critical",
+      healthcheck: {
+        ok: false,
+        status: 503,
+        detail: "healthcheck returned HTTP 503",
+        url: "http://100.64.0.10:11434/api/tags",
+      },
+    });
+
+    expect(decision).toEqual({
+      action: "fallback",
+      model: "openai/gpt-5.4",
+      reason: "primary_unavailable",
+      detail: "healthcheck returned HTTP 503",
+    });
+  });
+});
+
+describe("opencode_local Ollama healthcheck", () => {
+  const servers: http.Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          }),
+      ),
+    );
+    servers.length = 0;
+  });
+
+  it("verifies the expected local model is present", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ models: [{ name: "qwen3:14b" }] }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing address");
+
+    const result = await probeOllamaHealthcheck({
+      url: `http://127.0.0.1:${address.port}/api/tags`,
+      expectedModel: "qwen3:14b",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      detail: null,
+      url: `http://127.0.0.1:${address.port}/api/tags`,
+    });
   });
 });
 

--- a/server/src/services/cost-estimation.test.ts
+++ b/server/src/services/cost-estimation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { estimateMeteredCostUsd, resolveBilledCost } from "./cost-estimation.js";
+
+describe("estimateMeteredCostUsd", () => {
+  it("estimates gpt-5.4 standard metered cost from token usage", () => {
+    const estimated = estimateMeteredCostUsd({
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 1_000_000,
+        cachedInputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      },
+      rawUsage: {
+        inputTokens: 200_000,
+        cachedInputTokens: 50_000,
+        outputTokens: 1_000_000,
+      },
+    });
+
+    expect(estimated).toBeCloseTo(17.75, 6);
+  });
+
+  it("applies the long-context uplift only to the portion above the threshold", () => {
+    const estimated = estimateMeteredCostUsd({
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 100_000,
+        cachedInputTokens: 20_000,
+        outputTokens: 10_000,
+      },
+      rawUsage: {
+        inputTokens: 260_000,
+        cachedInputTokens: 90_000,
+        outputTokens: 25_000,
+      },
+      previousRawUsage: {
+        inputTokens: 180_000,
+        cachedInputTokens: 50_000,
+        outputTokens: 15_000,
+      },
+    });
+
+    expect(estimated).toBeCloseTo(0.6195, 6);
+  });
+});
+
+describe("resolveBilledCost", () => {
+  it("prefers provider-reported cost when available", () => {
+    const resolved = resolveBilledCost({
+      providerCostUsd: 1.234,
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 10,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+    });
+
+    expect(resolved).toEqual({
+      costUsd: 1.234,
+      costCents: 123,
+      estimated: false,
+      source: "provider_reported",
+    });
+  });
+
+  it("returns an estimated metered cost when the provider does not report dollars", () => {
+    const resolved = resolveBilledCost({
+      providerCostUsd: null,
+      provider: "openai",
+      biller: "openai",
+      model: "gpt-5.4",
+      billingType: "metered_api",
+      usage: {
+        inputTokens: 1_000_000,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      rawUsage: {
+        inputTokens: 1_000_000,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+    });
+
+    expect(resolved.costUsd).toBeCloseTo(4.32, 6);
+    expect(resolved.costCents).toBe(432);
+    expect(resolved.estimated).toBe(true);
+    expect(resolved.source).toBe("openai_model_pricing");
+  });
+});

--- a/server/src/services/cost-estimation.test.ts
+++ b/server/src/services/cost-estimation.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { estimateMeteredCostUsd, resolveBilledCost } from "./cost-estimation.js";
 
 describe("estimateMeteredCostUsd", () => {
-  it("estimates gpt-5.4 standard metered cost from token usage", () => {
+  it("treats cached input as a subset of total input tokens", () => {
     const estimated = estimateMeteredCostUsd({
       provider: "openai",
       biller: "openai",
       model: "gpt-5.4",
       billingType: "metered_api",
       usage: {
-        inputTokens: 1_000_000,
-        cachedInputTokens: 1_000_000,
+        inputTokens: 200_000,
+        cachedInputTokens: 50_000,
         outputTokens: 1_000_000,
       },
       rawUsage: {
@@ -20,10 +20,10 @@ describe("estimateMeteredCostUsd", () => {
       },
     });
 
-    expect(estimated).toBeCloseTo(17.75, 6);
+    expect(estimated).toBeCloseTo(15.3875, 6);
   });
 
-  it("applies the long-context uplift only to the portion above the threshold", () => {
+  it("applies the long-context uplift to uncached input and output only", () => {
     const estimated = estimateMeteredCostUsd({
       provider: "openai",
       biller: "openai",
@@ -35,18 +35,18 @@ describe("estimateMeteredCostUsd", () => {
         outputTokens: 10_000,
       },
       rawUsage: {
-        inputTokens: 260_000,
+        inputTokens: 350_000,
         cachedInputTokens: 90_000,
         outputTokens: 25_000,
       },
       previousRawUsage: {
-        inputTokens: 180_000,
+        inputTokens: 230_000,
         cachedInputTokens: 50_000,
         outputTokens: 15_000,
       },
     });
 
-    expect(estimated).toBeCloseTo(0.6195, 6);
+    expect(estimated).toBeCloseTo(0.5695, 6);
   });
 });
 
@@ -82,18 +82,18 @@ describe("resolveBilledCost", () => {
       billingType: "metered_api",
       usage: {
         inputTokens: 1_000_000,
-        cachedInputTokens: 0,
+        cachedInputTokens: 400_000,
         outputTokens: 0,
       },
       rawUsage: {
         inputTokens: 1_000_000,
-        cachedInputTokens: 0,
+        cachedInputTokens: 400_000,
         outputTokens: 0,
       },
     });
 
-    expect(resolved.costUsd).toBeCloseTo(4.32, 6);
-    expect(resolved.costCents).toBe(432);
+    expect(resolved.costUsd).toBeCloseTo(2.692, 6);
+    expect(resolved.costCents).toBe(269);
     expect(resolved.estimated).toBe(true);
     expect(resolved.source).toBe("openai_model_pricing");
   });

--- a/server/src/services/cost-estimation.ts
+++ b/server/src/services/cost-estimation.ts
@@ -19,7 +19,6 @@ type ModelPricing = {
   outputUsdPerMillion: number;
   longContextThresholdPromptTokens?: number;
   longContextInputMultiplier?: number;
-  longContextCachedInputMultiplier?: number;
   longContextOutputMultiplier?: number;
 };
 
@@ -35,13 +34,17 @@ const OPENAI_MODEL_PRICING: Array<{ match: (model: string) => boolean; pricing: 
       longContextThresholdPromptTokens: 272_000,
       longContextInputMultiplier: 2,
       // OpenAI documents the long-context uplift for input/output on GPT-5.4.
-      // We apply the same input uplift to cached input because cached prompt
-      // tokens still consume the long-context window and are billed as discounted input.
-      longContextCachedInputMultiplier: 2,
+      // We do not apply an extra uplift to cached input because the cached-token
+      // pricing is documented separately and the long-context docs do not state
+      // an additional cached-input multiplier.
       longContextOutputMultiplier: 1.5,
     },
   },
 ];
+
+function resolveUncachedInputTokens(usage: CostUsageTotals): number {
+  return Math.max(0, usage.inputTokens - usage.cachedInputTokens);
+}
 
 function normalizeKnownParty(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
@@ -78,17 +81,13 @@ function resolveLongContextShare(input: {
   const threshold = input.pricing.longContextThresholdPromptTokens ?? 0;
   if (threshold <= 0) return 0;
 
-  const deltaPromptTokens = Math.max(0, input.usage.inputTokens + input.usage.cachedInputTokens);
+  const deltaPromptTokens = Math.max(0, input.usage.inputTokens);
   if (deltaPromptTokens <= 0) return 0;
 
-  const currentPromptTokens = Math.max(
-    0,
-    (input.rawUsage?.inputTokens ?? input.usage.inputTokens) +
-      (input.rawUsage?.cachedInputTokens ?? input.usage.cachedInputTokens),
-  );
+  const currentPromptTokens = Math.max(0, input.rawUsage?.inputTokens ?? input.usage.inputTokens);
   const previousPromptTokens =
     input.previousRawUsage
-      ? Math.max(0, input.previousRawUsage.inputTokens + input.previousRawUsage.cachedInputTokens)
+      ? Math.max(0, input.previousRawUsage.inputTokens)
       : Math.max(0, currentPromptTokens - deltaPromptTokens);
 
   if (previousPromptTokens >= threshold) return 1;
@@ -122,19 +121,17 @@ export function estimateMeteredCostUsd(input: {
     pricing,
   });
   const standardShare = 1 - longContextShare;
+  const uncachedInputTokens = resolveUncachedInputTokens(input.usage);
   const inputMultiplier = standardShare + longContextShare * (pricing.longContextInputMultiplier ?? 1);
-  const cachedInputMultiplier =
-    standardShare + longContextShare * (pricing.longContextCachedInputMultiplier ?? pricing.longContextInputMultiplier ?? 1);
   const outputMultiplier = standardShare + longContextShare * (pricing.longContextOutputMultiplier ?? 1);
 
   const inputCostUsd =
-    (input.usage.inputTokens / TOKENS_PER_MILLION) *
+    (uncachedInputTokens / TOKENS_PER_MILLION) *
     pricing.inputUsdPerMillion *
     inputMultiplier;
   const cachedInputCostUsd =
     (input.usage.cachedInputTokens / TOKENS_PER_MILLION) *
-    pricing.cachedInputUsdPerMillion *
-    cachedInputMultiplier;
+    pricing.cachedInputUsdPerMillion;
   const outputCostUsd =
     (input.usage.outputTokens / TOKENS_PER_MILLION) *
     pricing.outputUsdPerMillion *

--- a/server/src/services/cost-estimation.ts
+++ b/server/src/services/cost-estimation.ts
@@ -1,0 +1,199 @@
+import type { BillingType } from "@paperclipai/shared";
+
+export interface CostUsageTotals {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+}
+
+export interface BilledCostResolution {
+  costUsd: number | null;
+  costCents: number;
+  estimated: boolean;
+  source: "provider_reported" | "openai_model_pricing" | "unknown";
+}
+
+type ModelPricing = {
+  inputUsdPerMillion: number;
+  cachedInputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  longContextThresholdPromptTokens?: number;
+  longContextInputMultiplier?: number;
+  longContextCachedInputMultiplier?: number;
+  longContextOutputMultiplier?: number;
+};
+
+const TOKENS_PER_MILLION = 1_000_000;
+
+const OPENAI_MODEL_PRICING: Array<{ match: (model: string) => boolean; pricing: ModelPricing }> = [
+  {
+    match: (model) => model === "gpt-5.4" || model.startsWith("gpt-5.4-"),
+    pricing: {
+      inputUsdPerMillion: 2.5,
+      cachedInputUsdPerMillion: 0.25,
+      outputUsdPerMillion: 15,
+      longContextThresholdPromptTokens: 272_000,
+      longContextInputMultiplier: 2,
+      // OpenAI documents the long-context uplift for input/output on GPT-5.4.
+      // We apply the same input uplift to cached input because cached prompt
+      // tokens still consume the long-context window and are billed as discounted input.
+      longContextCachedInputMultiplier: 2,
+      longContextOutputMultiplier: 1.5,
+    },
+  },
+];
+
+function normalizeKnownParty(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeModel(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function roundUsdToCents(costUsd: number | null | undefined): number {
+  if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
+  return Math.max(0, Math.round(costUsd * 100));
+}
+
+function resolveOpenAiPricing(model: string | null | undefined): ModelPricing | null {
+  const normalizedModel = normalizeModel(model);
+  if (!normalizedModel) return null;
+  for (const entry of OPENAI_MODEL_PRICING) {
+    if (entry.match(normalizedModel)) return entry.pricing;
+  }
+  return null;
+}
+
+function resolveLongContextShare(input: {
+  usage: CostUsageTotals;
+  rawUsage: CostUsageTotals | null | undefined;
+  previousRawUsage: CostUsageTotals | null | undefined;
+  pricing: ModelPricing;
+}): number {
+  const threshold = input.pricing.longContextThresholdPromptTokens ?? 0;
+  if (threshold <= 0) return 0;
+
+  const deltaPromptTokens = Math.max(0, input.usage.inputTokens + input.usage.cachedInputTokens);
+  if (deltaPromptTokens <= 0) return 0;
+
+  const currentPromptTokens = Math.max(
+    0,
+    (input.rawUsage?.inputTokens ?? input.usage.inputTokens) +
+      (input.rawUsage?.cachedInputTokens ?? input.usage.cachedInputTokens),
+  );
+  const previousPromptTokens =
+    input.previousRawUsage
+      ? Math.max(0, input.previousRawUsage.inputTokens + input.previousRawUsage.cachedInputTokens)
+      : Math.max(0, currentPromptTokens - deltaPromptTokens);
+
+  if (previousPromptTokens >= threshold) return 1;
+  if (currentPromptTokens <= threshold) return 0;
+
+  return Math.max(0, Math.min(1, (currentPromptTokens - threshold) / deltaPromptTokens));
+}
+
+export function estimateMeteredCostUsd(input: {
+  provider: string | null | undefined;
+  biller: string | null | undefined;
+  model: string | null | undefined;
+  billingType: BillingType;
+  usage: CostUsageTotals | null | undefined;
+  rawUsage?: CostUsageTotals | null | undefined;
+  previousRawUsage?: CostUsageTotals | null | undefined;
+}): number | null {
+  if (input.billingType !== "metered_api" || !input.usage) return null;
+
+  const provider = normalizeKnownParty(input.provider);
+  const biller = normalizeKnownParty(input.biller);
+  if (provider !== "openai" && biller !== "openai") return null;
+
+  const pricing = resolveOpenAiPricing(input.model);
+  if (!pricing) return null;
+
+  const longContextShare = resolveLongContextShare({
+    usage: input.usage,
+    rawUsage: input.rawUsage,
+    previousRawUsage: input.previousRawUsage,
+    pricing,
+  });
+  const standardShare = 1 - longContextShare;
+  const inputMultiplier = standardShare + longContextShare * (pricing.longContextInputMultiplier ?? 1);
+  const cachedInputMultiplier =
+    standardShare + longContextShare * (pricing.longContextCachedInputMultiplier ?? pricing.longContextInputMultiplier ?? 1);
+  const outputMultiplier = standardShare + longContextShare * (pricing.longContextOutputMultiplier ?? 1);
+
+  const inputCostUsd =
+    (input.usage.inputTokens / TOKENS_PER_MILLION) *
+    pricing.inputUsdPerMillion *
+    inputMultiplier;
+  const cachedInputCostUsd =
+    (input.usage.cachedInputTokens / TOKENS_PER_MILLION) *
+    pricing.cachedInputUsdPerMillion *
+    cachedInputMultiplier;
+  const outputCostUsd =
+    (input.usage.outputTokens / TOKENS_PER_MILLION) *
+    pricing.outputUsdPerMillion *
+    outputMultiplier;
+
+  const total = inputCostUsd + cachedInputCostUsd + outputCostUsd;
+  return Number.isFinite(total) ? total : null;
+}
+
+export function resolveBilledCost(input: {
+  providerCostUsd: number | null | undefined;
+  provider: string | null | undefined;
+  biller: string | null | undefined;
+  model: string | null | undefined;
+  billingType: BillingType;
+  usage: CostUsageTotals | null | undefined;
+  rawUsage?: CostUsageTotals | null | undefined;
+  previousRawUsage?: CostUsageTotals | null | undefined;
+}): BilledCostResolution {
+  if (input.billingType === "subscription_included") {
+    return {
+      costUsd: 0,
+      costCents: 0,
+      estimated: false,
+      source: "provider_reported",
+    };
+  }
+
+  if (typeof input.providerCostUsd === "number" && Number.isFinite(input.providerCostUsd)) {
+    return {
+      costUsd: input.providerCostUsd,
+      costCents: roundUsdToCents(input.providerCostUsd),
+      estimated: false,
+      source: "provider_reported",
+    };
+  }
+
+  const estimatedUsd = estimateMeteredCostUsd({
+    provider: input.provider,
+    biller: input.biller,
+    model: input.model,
+    billingType: input.billingType,
+    usage: input.usage,
+    rawUsage: input.rawUsage,
+    previousRawUsage: input.previousRawUsage,
+  });
+  if (estimatedUsd !== null) {
+    return {
+      costUsd: estimatedUsd,
+      costCents: roundUsdToCents(estimatedUsd),
+      estimated: true,
+      source: "openai_model_pricing",
+    };
+  }
+
+  return {
+    costUsd: null,
+    costCents: 0,
+    estimated: false,
+    source: "unknown",
+  };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -30,6 +30,7 @@ import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
+import { resolveBilledCost, type BilledCostResolution } from "./cost-estimation.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -370,12 +371,6 @@ function normalizeLedgerBillingType(value: unknown): BillingType {
 
 function resolveLedgerBiller(result: AdapterExecutionResult): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
-}
-
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
-  if (billingType === "subscription_included") return 0;
-  if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
-  return Math.max(0, Math.round(costUsd * 100));
 }
 
 async function resolveLedgerScopeForRun(
@@ -1960,6 +1955,7 @@ export function heartbeatService(db: Db) {
     result: AdapterExecutionResult,
     session: { legacySessionId: string | null },
     normalizedUsage?: UsageTotals | null,
+    costResolution?: BilledCostResolution | null,
   ) {
     await ensureRuntimeState(agent);
     const usage = normalizedUsage ?? normalizeUsageTotals(result.usage);
@@ -1967,7 +1963,15 @@ export function heartbeatService(db: Db) {
     const outputTokens = usage?.outputTokens ?? 0;
     const cachedInputTokens = usage?.cachedInputTokens ?? 0;
     const billingType = normalizeLedgerBillingType(result.billingType);
-    const additionalCostCents = normalizeBilledCostCents(result.costUsd, billingType);
+    const resolvedCost = costResolution ?? resolveBilledCost({
+      providerCostUsd: result.costUsd,
+      provider: result.provider,
+      biller: result.biller,
+      model: result.model,
+      billingType,
+      usage,
+    });
+    const additionalCostCents = resolvedCost.costCents;
     const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
@@ -2730,6 +2734,18 @@ export function heartbeatService(db: Db) {
         rawUsage,
       });
       const normalizedUsage = sessionUsageResolution.normalizedUsage;
+      const resolvedBiller = resolveLedgerBiller(adapterResult);
+      const resolvedBillingType = normalizeLedgerBillingType(adapterResult.billingType);
+      const costResolution = resolveBilledCost({
+        providerCostUsd: adapterResult.costUsd,
+        provider: adapterResult.provider,
+        biller: resolvedBiller,
+        model: adapterResult.model,
+        billingType: resolvedBillingType,
+        usage: normalizedUsage,
+        rawUsage,
+        previousRawUsage: sessionUsageResolution.previousRawUsage,
+      });
 
       let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
@@ -2776,10 +2792,16 @@ export function heartbeatService(db: Db) {
               sessionRotated: sessionCompaction.rotate,
               sessionRotationReason: sessionCompaction.reason,
               provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
-              biller: resolveLedgerBiller(adapterResult),
+              biller: resolvedBiller,
               model: readNonEmptyString(adapterResult.model) ?? "unknown",
               ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
-              billingType: normalizeLedgerBillingType(adapterResult.billingType),
+              ...(costResolution.estimated && costResolution.costUsd != null
+                ? {
+                    estimatedCostUsd: costResolution.costUsd,
+                    estimatedCostSource: costResolution.source,
+                  }
+                : {}),
+              billingType: resolvedBillingType,
             } as Record<string, unknown>)
           : null;
 
@@ -2835,7 +2857,7 @@ export function heartbeatService(db: Db) {
       if (finalizedRun) {
         await updateRuntimeState(agent, finalizedRun, adapterResult, {
           legacySessionId: nextSessionState.legacySessionId,
-        }, normalizedUsage);
+        }, normalizedUsage, costResolution);
         if (taskKey) {
           if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
             await clearTaskSessions(agent.companyId, agent.id, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2093,6 +2093,7 @@ export function heartbeatService(db: Db) {
             id: issues.id,
             identifier: issues.identifier,
             title: issues.title,
+            priority: issues.priority,
             projectId: issues.projectId,
             projectWorkspaceId: issues.projectWorkspaceId,
             executionWorkspaceId: issues.executionWorkspaceId,
@@ -2111,6 +2112,11 @@ export function heartbeatService(db: Db) {
             issueContext.assigneeAdapterOverrides,
           )
         : null;
+    if (issueContext?.priority) {
+      context.issuePriority = issueContext.priority;
+    } else {
+      delete context.issuePriority;
+    }
     const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
     const issueExecutionWorkspaceSettings = isolatedWorkspacesEnabled
       ? parseIssueExecutionWorkspaceSettings(issueContext?.executionWorkspaceSettings)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -654,6 +654,13 @@ export function shouldResetTaskSessionForWake(
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (wakeReason === "issue_assigned") return true;
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  const hasExplicitTask =
+    !!readNonEmptyString(contextSnapshot?.taskKey) ||
+    !!readNonEmptyString(contextSnapshot?.taskId) ||
+    !!readNonEmptyString(contextSnapshot?.issueId);
+  if (wakeSource === "on_demand" && !hasExplicitTask) return true;
   return false;
 }
 
@@ -671,6 +678,15 @@ function describeSessionResetReason(
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  const hasExplicitTask =
+    !!readNonEmptyString(contextSnapshot?.taskKey) ||
+    !!readNonEmptyString(contextSnapshot?.taskId) ||
+    !!readNonEmptyString(contextSnapshot?.issueId);
+  if (wakeSource === "on_demand" && !hasExplicitTask) {
+    return "manual on-demand heartbeat without task context";
+  }
   return null;
 }
 

--- a/skills/web-search-lite/SKILL.md
+++ b/skills/web-search-lite/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: web-search-lite
+description: >
+  Search and inspect public web sources from local adapters when no dedicated
+  search tool is available. Use this when you need current information and the
+  runtime only exposes tools such as bash and webfetch.
+---
+
+# Web Search Lite
+
+Use this skill when you need current public web information but the runtime does
+not provide a native search tool such as `google:search`.
+
+Do not call unavailable tools. In this environment, the reliable path is:
+
+1. search with `bash` using a public HTML search endpoint
+2. inspect the most relevant URLs with `webfetch`
+3. cite the URLs you actually used
+
+## Rules
+
+- Do not say "I cannot access the internet" if `bash` or `webfetch` is available.
+- Do not call `google:search`.
+- Use search only when current web information is actually needed.
+- Prefer 2 to 4 relevant sources over broad scraping.
+- If search results are noisy, refine the query and retry once.
+
+## Search Procedure
+
+### Option A — quick search with `bash`
+
+Run a DuckDuckGo HTML search and extract the first result URLs:
+
+```bash
+python3 - <<'PY'
+import json, re, sys, urllib.parse, urllib.request
+
+query = "YOUR QUERY HERE"
+url = "https://html.duckduckgo.com/html/?q=" + urllib.parse.quote(query)
+req = urllib.request.Request(
+    url,
+    headers={"User-Agent": "Mozilla/5.0"},
+)
+html = urllib.request.urlopen(req, timeout=20).read().decode("utf-8", errors="ignore")
+matches = re.findall(r'nofollow" class="[^"]*result__a" href="(.*?)"', html)
+out = []
+for raw in matches[:5]:
+    clean = urllib.parse.unquote(raw)
+    if clean.startswith("//"):
+        clean = "https:" + clean
+    out.append(clean)
+print(json.dumps({"query": query, "results": out}, ensure_ascii=False, indent=2))
+PY
+```
+
+If the query is company or product specific, tighten it:
+
+- add the brand/site name
+- add a year or month if freshness matters
+- add `site:linkedin.com`, `site:company.com`, `site:docs...` only when helpful
+
+### Option B — open a specific result with `webfetch`
+
+After you have a URL, inspect it with `webfetch` instead of scraping more.
+
+Use it for:
+
+- articles
+- LinkedIn posts/pages
+- docs
+- landing pages
+- press releases
+
+## Output expectations
+
+When your task depends on web research, include:
+
+- what you searched
+- which URLs you used
+- the concrete facts extracted
+- any uncertainty or conflict between sources
+
+If no reliable source is found after one refinement pass, say that clearly and
+continue with the best defensible answer instead of pretending certainty.


### PR DESCRIPTION
## Summary
- add local-first Ollama healthcheck and fallback routing to opencode_local
- inject runtime Ollama provider config for OpenCode when ollama/* models are configured
- pass issue priority through heartbeat so critical-only fallback can be enforced
- add focused tests for routing, healthcheck, runtime config, and Windows-safe env probing

## Validation
- corepack pnpm exec vitest run --project @paperclipai/server server/src/__tests__/opencode-local-adapter.test.ts server/src/__tests__/opencode-local-adapter-environment.test.ts
- corepack pnpm exec vitest run --project @paperclipai/adapter-opencode-local packages/adapters/opencode-local/src/server/runtime-config.test.ts

## Notes
- production rollout still needs Tailscale login on the VPS and mini PC before OLLAMA_HOST and agent migration can be completed safely.
- existing Codex 5.4 token/cost files were intentionally left untouched except for adding issuePriority into heartbeat context.