### PR TITLE
fix(issues): replace non-null assertions with null checks in checkout…

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1469,7 +1469,8 @@ export function issueService(db: Db) {
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (adopted) {
-          const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
+          const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
+          if (!row) throw notFound("Issue not found");
           const [enriched] = await withIssueLabels(db, [row]);
           return enriched;
         }
@@ -1481,7 +1482,8 @@ export function issueService(db: Db) {
         current.status === "in_progress" &&
         sameRunLock(current.checkoutRunId, checkoutRunId)
       ) {
-        const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
+        const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
+        if (!row) throw notFound("Issue not found");
         const [enriched] = await withIssueLabels(db, [row]);
         return enriched;
       }


### PR DESCRIPTION
Two code paths in issueService.checkout() used rows[0]! when re-reading an issue after stale-run adoption or self-ownership verification. If the issue is deleted concurrently (company cascade, API delete), rows[0] is undefined and withIssueLabels crashes with an unhandled TypeError.

Replace both with rows[0] ?? null and throw notFound when the row is missing, returning a clean 404 instead of an uncaught exception.

Fixes #2593

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents check out issues via `issueService.checkout()` which involves multiple DB queries
> - After adopting a stale run or verifying self-ownership, the code re-reads the issue for label enrichment
> - The re-read used TypeScript non-null assertions (`rows[0]!`) which have no runtime effect
> - If the issue is deleted between the adoption write and re-read (race condition during company cascade or API delete), `rows[0]` is `undefined`
> - `withIssueLabels(db, [undefined])` throws an unhandled TypeError, crashing the request
> - This PR replaces `rows[0]!` with `rows[0] ?? null` and throws `notFound` when the row is missing
> - The benefit is a clean 404 response instead of an uncaught exception in a narrow but real race window

## What Changed

- Replaced two `rows[0]!` non-null assertions with `rows[0] ?? null` followed by explicit `notFound` throws in `server/src/services/issues.ts`
- Both the stale-run adoption path (line ~1472) and the self-ownership verification path (line ~1484) are fixed

## Verification

- `pnpm tsc --noEmit --project server/tsconfig.json 2>&1 | grep issues.ts || echo "clean"`
- `pnpm vitest run server/src/__tests__/issue*.test.ts server/src/__tests__/checkout*.test.ts 2>&1 | tail -10`

## Risks

Low risk — the fix is additive (null coalescing + guard) and only fires in the narrow concurrent-delete race window. Normal checkout flow is unaffected. Pattern matches existing conventions in the same file.

## Model Used

Claude Opus 4.6 (1M context), tool use and extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge