### PR TITLE
feat(heartbeat): auto-reap stale executionRunId locks on run termination

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2827,4 +2827,49 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("reapStaleExecutionRunLocks: clears both locks when executionRunId references a terminal run", async () => {
+    const { issueId, runId } = await seedRunFixture({
+      runStatus: "failed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapStaleExecutionRunLocks();
+    expect(result.reaped).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+  });
+
+  it("reapStaleExecutionRunLocks: does not touch issues whose executionRunId references a live run", async () => {
+    const { issueId, runId } = await seedRunFixture({
+      runStatus: "running",
+      processPid: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapStaleExecutionRunLocks();
+    expect(result.reaped).toBe(0);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(runId);
+    expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("reapStaleExecutionRunLocks: is a no-op when no stale locks exist", async () => {
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapStaleExecutionRunLocks();
+    expect(result.reaped).toBe(0);
+    expect(result.issueIds).toHaveLength(0);
+  });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -674,9 +674,11 @@ export async function startServer(): Promise<StartedServer> {
     const routines = routineService(db as any, { pluginWorkerManager });
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
+    // clear any stale executionRunId/checkoutRunId locks left over from a crash,
     // then resume any persisted queued runs that were waiting on the previous process.
     void heartbeat
       .reapOrphanedRuns()
+      .then(() => heartbeat.reapStaleExecutionRunLocks())
       .then(() => heartbeat.promoteDueScheduledRetries())
       .then(async (promotion) => {
         await heartbeat.resumeQueuedRuns();
@@ -738,11 +740,12 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "routine scheduler tick failed");
         });
-  
-      // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-      // persisted queued work is still being driven forward.
+
+      // Periodically reap orphaned runs (5-min staleness threshold), clear any
+      // stale executionRunId locks, and drive queued work forward.
       void heartbeat
         .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .then(() => heartbeat.reapStaleExecutionRunLocks())
         .then(() => heartbeat.promoteDueScheduledRetries())
         .then(async (promotion) => {
           await heartbeat.resumeQueuedRuns();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -180,6 +180,7 @@ export function redactDetectedSuccessfulRunProgressSummaryForBoard(
 
 const MAX_RUN_EVENT_PAYLOAD_OBJECT_KEYS = 100;
 const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
+const TERMINAL_RUN_STATUSES = ["skipped", "succeeded", "failed", "cancelled", "timed_out"] as const;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
@@ -6364,8 +6365,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
    * Called on startup and on every heartbeat-scheduler tick.
    */
   async function reapStaleExecutionRunLocks() {
-    const TERMINAL_RUN_STATUSES = ["skipped", "succeeded", "failed", "cancelled", "timed_out"] as const;
-
     const stale = await db
       .select({
         issueId: issues.id,
@@ -6383,29 +6382,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     if (stale.length === 0) return { reaped: 0, issueIds: [] as string[] };
 
-    const reaped: string[] = [];
-    for (const row of stale) {
-      const updated = await db
-        .update(issues)
-        .set({
-          executionRunId: null,
-          executionAgentNameKey: null,
-          executionLockedAt: null,
-          // Only clear checkoutRunId when it belongs to the same terminal run;
-          // leave it untouched if it references a different (valid) run.
-          checkoutRunId: sql`CASE WHEN checkout_run_id = ${row.runId} THEN NULL ELSE checkout_run_id END`,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(issues.id, row.issueId),
-            eq(issues.executionRunId, row.runId),
-          ),
-        )
-        .returning({ id: issues.id })
-        .then((rows) => rows[0] ?? null);
-      if (updated) reaped.push(row.issueId);
-    }
+    // Single bulk UPDATE — one round-trip for all stale locks.
+    // The OR predicate preserves the per-row (id, executionRunId) guard so
+    // a concurrent checkout that already moved to a live run is never cleared.
+    // The CASE on checkoutRunId mirrors the same guard: only clear it when it
+    // still points at the same terminal run being reaped.
+    const updated = await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        checkoutRunId: sql`CASE WHEN checkout_run_id = execution_run_id THEN NULL ELSE checkout_run_id END`,
+        updatedAt: new Date(),
+      })
+      .where(
+        or(...stale.map((r) => and(eq(issues.id, r.issueId), eq(issues.executionRunId, r.runId))))!,
+      )
+      .returning({ id: issues.id });
+
+    const reaped = updated.map((r) => r.id);
 
     if (reaped.length > 0) {
       logger.warn(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNotNull, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -6353,6 +6353,68 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileIssueGraphLiveness(opts);
   }
 
+  /**
+   * Reap issues whose executionRunId references a terminal run.
+   *
+   * This is a safety net for cases where releaseIssueExecutionAndPromote was
+   * skipped or threw — leaving an issue locked to a dead run.  Clears both
+   * executionRunId and checkoutRunId so the issue can be checked out again
+   * without manual board intervention.
+   *
+   * Called on startup and on every heartbeat-scheduler tick.
+   */
+  async function reapStaleExecutionRunLocks() {
+    const TERMINAL_RUN_STATUSES = ["skipped", "succeeded", "failed", "cancelled", "timed_out"] as const;
+
+    const stale = await db
+      .select({
+        issueId: issues.id,
+        runId: heartbeatRuns.id,
+      })
+      .from(issues)
+      .innerJoin(
+        heartbeatRuns,
+        and(
+          eq(heartbeatRuns.id, issues.executionRunId),
+          inArray(heartbeatRuns.status, TERMINAL_RUN_STATUSES),
+        ),
+      )
+      .where(isNotNull(issues.executionRunId));
+
+    if (stale.length === 0) return { reaped: 0, issueIds: [] as string[] };
+
+    const reaped: string[] = [];
+    for (const row of stale) {
+      const updated = await db
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          checkoutRunId: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(issues.id, row.issueId),
+            eq(issues.executionRunId, row.runId),
+          ),
+        )
+        .returning({ id: issues.id })
+        .then((rows) => rows[0] ?? null);
+      if (updated) reaped.push(row.issueId);
+    }
+
+    if (reaped.length > 0) {
+      logger.warn(
+        { reaped: reaped.length, issueIds: reaped },
+        "reaped stale executionRunId locks on issues",
+      );
+    }
+
+    return { reaped: reaped.length, issueIds: reaped };
+  }
+
   async function updateRuntimeState(
     agent: typeof agents.$inferSelect,
     run: typeof heartbeatRuns.$inferSelect,
@@ -7862,17 +7924,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!issue) return null;
       if (issue.executionRunId && issue.executionRunId !== run.id) return null;
 
-      if (issue.executionRunId === run.id) {
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: null,
-            executionAgentNameKey: null,
-            executionLockedAt: null,
-            updatedAt: new Date(),
-          })
-          .where(eq(issues.id, issue.id));
-      }
+      await tx
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          checkoutRunId: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issue.id));
 
       while (true) {
         const deferred = await tx
@@ -9383,6 +9444,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reapOrphanedRuns,
 
     promoteDueScheduledRetries,
+    reapStaleExecutionRunLocks,
 
     resumeQueuedRuns,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6391,7 +6391,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           executionRunId: null,
           executionAgentNameKey: null,
           executionLockedAt: null,
-          checkoutRunId: null,
+          // Only clear checkoutRunId when it belongs to the same terminal run;
+          // leave it untouched if it references a different (valid) run.
+          checkoutRunId: sql`CASE WHEN checkout_run_id = ${row.runId} THEN NULL ELSE checkout_run_id END`,
           updatedAt: new Date(),
         })
         .where(


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents check out issues and run as heartbeat processes; the server tracks each active run with `executionRunId` and `checkoutRunId` on the issue row
> - When a run terminates abnormally (crash, timeout, force-kill), `releaseIssueExecutionAndPromote` may be skipped or throw, leaving `executionRunId` pointing at a dead run
> - The issue stays locked — no agent can check it out again — requiring manual board intervention to clear the lock
> - `reapStaleExecutionRunLocks()` fixes this: it scans for issues whose `executionRunId` references a terminal run and atomically clears both lock fields so the issue becomes checkout-eligible again
> - It runs at startup and on every scheduler tick (≤60 s recovery latency), removing the entire class of "stuck issue" board escalations
> - This PR also corrects `releaseIssueExecutionAndPromote` to clear `checkoutRunId` alongside `executionRunId` — a gap that left a partial-lock survivor even on the happy path

## What Changed

- Added `reapStaleExecutionRunLocks()` to `heartbeatService`: queries issues whose `executionRunId` is in a terminal run status (skipped/succeeded/failed/cancelled/timed_out) and bulk-clears `executionRunId`, `checkoutRunId`, `executionAgentNameKey`, `executionLockedAt`
- Moved `TERMINAL_RUN_STATUSES` to module scope (Greptile P2 refactor)
- Replaced N+1 per-row UPDATE loop with a single bulk UPDATE using `OR` predicates and a `CASE WHEN` for `checkoutRunId` (only cleared when it still references the terminal run — guards against clobbering a lock taken by a different run)
- Hooked `reapStaleExecutionRunLocks()` into the server startup chain (after `reapOrphanedRuns`, before `promoteDueScheduledRetries`) and into the periodic scheduler tick
- Fixed `releaseIssueExecutionAndPromote` to include `checkoutRunId: null` in the clear (previously omitted)
- Exported `reapStaleExecutionRunLocks` from the `heartbeatService` return object

## Verification

- 3 new integration tests in `server/src/__tests__/heartbeat-process-recovery.test.ts`:
  - `reapStaleExecutionRunLocks: clears both locks when executionRunId references a terminal run`
  - `reapStaleExecutionRunLocks: does not touch issues whose executionRunId references a live run`
  - `reapStaleExecutionRunLocks: is a no-op when no stale locks exist`
- Run: `cd server && pnpm test heartbeat-process-recovery`
- CI checks: rebased onto current master HEAD

## Risks

- **Low risk overall.** The reaper only touches issues whose `executionRunId` points at a run that has already reached a terminal status — it cannot race with a live run.
- The bulk UPDATE includes a per-row `eq(issues.executionRunId, row.runId)` predicate, so a new run that re-locks the issue between the SELECT and UPDATE is protected from being cleared.
- The `checkoutRunId` clear uses `CASE WHEN checkoutRunId = terminal_run_id THEN NULL ELSE checkoutRunId END`, so a checkout by a different run (different runId) is never clobbered.
- No schema changes; no migrations required.
- Called at startup before queued runs resume, so recovery happens before any agent picks up the unlocked issue.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Context window: 200K tokens
- Mode: tool use, code editing, interactive rebase conflict resolution via Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-235

🤖 Generated with [Claude Code](https://claude.com/claude-code)