### PR TITLE
feat: add copy button to run transcript

### DIFF
--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TranscriptEntry } from "../../adapters";
 import { MarkdownBody } from "../MarkdownBody";
 import { cn, formatTokens } from "../../lib/utils";
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   CircleAlert,
+  Copy,
   TerminalSquare,
   User,
   Wrench,
@@ -1159,6 +1160,16 @@ function TranscriptStdoutRow({
   );
 }
 
+function serializeRawEntry(entry: TranscriptEntry): string {
+  if (entry.kind === "tool_call") return `${entry.name}\n${formatToolPayload(entry.input)}`;
+  if (entry.kind === "tool_result") return formatToolPayload(entry.content);
+  if (entry.kind === "result")
+    return `${entry.text}\n${formatTokens(entry.inputTokens)} / ${formatTokens(entry.outputTokens)} / $${entry.costUsd.toFixed(6)}`;
+  if (entry.kind === "init")
+    return `model=${entry.model}${entry.sessionId ? ` session=${entry.sessionId}` : ""}`;
+  return entry.text;
+}
+
 function RawTranscriptView({
   entries,
   density,
@@ -1167,8 +1178,54 @@ function RawTranscriptView({
   density: TranscriptDensity;
 }) {
   const compact = density === "compact";
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    const text = entries
+      .map((e) => `[${e.kind}] ${serializeRawEntry(e)}`)
+      .join("\n\n");
+    navigator.clipboard.writeText(text).then(() => {
+      clearTimeout(timerRef.current);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      // Clipboard write failed — silently ignore
+    });
+  }, [entries]);
+
   return (
     <div className={cn("font-mono", compact ? "space-y-1 text-[11px]" : "space-y-1.5 text-xs")}>
+      <div className="flex justify-end mb-1.5">
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-1 rounded-md border border-border/70 bg-background/70 px-2 py-1 text-[11px] font-medium transition-colors",
+            copied
+              ? "text-green-600 dark:text-green-400"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          onClick={handleCopy}
+        >
+          {copied ? (
+            <>
+              <Check className="h-3 w-3" />
+              Copied!
+            </>
+          ) : (
+            <>
+              <Copy className="h-3 w-3" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
       {entries.map((entry, idx) => (
         <div
           key={`${entry.kind}-${entry.ts}-${idx}`}
@@ -1181,15 +1238,7 @@ function RawTranscriptView({
             {entry.kind}
           </span>
           <pre className="min-w-0 whitespace-pre-wrap break-words text-foreground/80">
-            {entry.kind === "tool_call"
-              ? `${entry.name}\n${formatToolPayload(entry.input)}`
-              : entry.kind === "tool_result"
-                ? formatToolPayload(entry.content)
-                : entry.kind === "result"
-                  ? `${entry.text}\n${formatTokens(entry.inputTokens)} / ${formatTokens(entry.outputTokens)} / $${entry.costUsd.toFixed(6)}`
-                  : entry.kind === "init"
-                    ? `model=${entry.model}${entry.sessionId ? ` session=${entry.sessionId}` : ""}`
-                    : entry.text}
+            {serializeRawEntry(entry)}
           </pre>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- Adds a "Copy" button to the raw transcript view on run detail pages
- Clicking copies all transcript entries as formatted plain text to the clipboard
- Shows brief "Copied!" feedback with a green checkmark icon after copying
- Uses existing UI patterns (lucide icons, Tailwind classes, same button styling as mode toggle)

Why? Because when I'm trying to figure out why a model isn't working and I want to copy the raw data to a claude session, this is a nice feature to have.

<img width="565" height="145" alt="image" src="https://github.com/user-attachments/assets/3aba74a5-77db-4bd9-8057-2d69a84ac907" />


## Test plan
- [ ] Navigate to a run detail page with transcript data
- [ ] Switch to "raw" transcript mode
- [ ] Verify the "Copy" button appears in the top-right of the raw transcript
- [ ] Click "Copy" and verify clipboard contains the full transcript text
- [ ] Verify button shows "Copied!" with green check briefly, then reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)