### PR TITLE
fix(plugin-decision-surface): skip auth header when apiKey empty, remove misleading apiKey config field

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+tasks:
+  run:
+    desc: Run paperclip (UI and Backend are started and accessible via localhost:3100)
+    cmds:
+      - pnpm install
+      - pnpm dev:stop
+      - pnpm dev

--- a/doc/PUSH_CONVENTION.md
+++ b/doc/PUSH_CONVENTION.md
@@ -1,0 +1,144 @@
+# Push Convention — claude-private / claude-plugins
+
+Every skill or plugin created during a session follows a three-stage promotion pipeline:
+
+```
+Session workspace  ──▶  claude-private  ──▶  Paperclip marketplace
+```
+
+---
+
+## Stage 1 — Session (Develop)
+
+Work in the standard locations inside this repo:
+
+| Artifact | Location |
+|----------|----------|
+| Claude skill | `skills/<skill-name>/SKILL.md` + supporting files |
+| Paperclip plugin | `packages/plugins/examples/<plugin-name>/` or `packages/plugins/<name>/` |
+
+Iterate locally. Skills symlinked to `~/.claude/skills/` are live immediately.
+Plugins install via the local-path API (`POST /api/plugins/install`).
+
+---
+
+## Stage 2 — claude-private (Commit)
+
+`claude-private` is a private GitHub repository (`github.com/anhermon/claude-private`)
+that tracks Angel's custom skills and plugins separately from the upstream `paperclip` repo.
+
+**Local path:** `C:\Users\User\claude-private\`
+
+**Repository structure:**
+```
+claude-private/
+  skills/
+    <skill-name>/       ← mirrors paperclip/skills/<skill-name>/
+  plugins/
+    <plugin-name>/      ← mirrors packages/plugins/<plugin-name>/
+  README.md
+```
+
+**Commit convention:**
+```
+feat(skills/<name>): <short description>
+feat(plugins/<name>): <short description>
+fix(skills/<name>): <short description>
+```
+
+Always append:
+```
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+```
+
+---
+
+## Stage 3 — Marketplace (Promote)
+
+"Marketplace" = the Paperclip company skills library.
+
+Skills imported here become installable on any agent in the company
+via `POST /api/agents/:agentId/skills/sync`.
+
+Future path: publish to `skills.sh` (the public Paperclip skill registry)
+for community discovery. Requires a `skills.sh` account (not yet configured).
+
+---
+
+## The `promote-skill.sh` Script
+
+One command covers stages 2 and 3:
+
+```bash
+# From C:\Users\User\paperclip\
+./scripts/promote-skill.sh <skill-name>
+```
+
+What it does:
+1. Copies `paperclip/skills/<name>/` → `claude-private/skills/<name>/`
+2. Commits and pushes to `claude-private` (if remote is configured)
+3. Calls `POST /api/companies/:companyId/skills/import` with the local path
+
+Optional flags:
+- `--no-git`    Skip commit/push (useful during iteration)
+- `--no-import` Skip marketplace import
+
+Required env vars for the import step:
+- `PAPERCLIP_API_KEY`
+- `PAPERCLIP_COMPANY_ID`
+- `PAPERCLIP_API_URL` (defaults to `http://127.0.0.1:3100`)
+
+Optional override:
+- `CLAUDE_PRIVATE_DIR` — path to the `claude-private` checkout (defaults to `../claude-private` relative to the paperclip repo root)
+
+---
+
+## First-time Setup
+
+1. **Create the remote on GitHub:**
+   ```bash
+   # In the GitHub UI: new private repo → anhermon/claude-private
+   cd C:\Users\User\claude-private
+   git remote add origin https://github.com/anhermon/claude-private.git
+   git push -u origin main
+   ```
+
+2. **Configure the `claude-plugins` project workspace** so `scan-projects` can
+   discover skills automatically (one-time, via Paperclip UI or API):
+   ```json
+   {
+     "repoUrl": "https://github.com/anhermon/claude-private",
+     "cwd": "C:\\Users\\User\\claude-private"
+   }
+   ```
+
+3. **Run a promotion** to verify end-to-end:
+   ```bash
+   export PAPERCLIP_API_KEY=<key>
+   export PAPERCLIP_COMPANY_ID=dbc742c7-9a38-4542-936b-523dfa3a7fd2
+   ./scripts/promote-skill.sh paperclip --no-git --no-import  # dry-run copy only
+   ```
+
+---
+
+## Plugin Pipeline
+
+Plugins follow the same convention but the steps differ slightly:
+
+| Step | Action |
+|------|--------|
+| Develop | Scaffold in `packages/plugins/examples/<name>/` using `paperclip-create-plugin` skill |
+| Test    | `pnpm --filter <package> typecheck && pnpm --filter <package> test && pnpm --filter <package> build` |
+| Commit  | Copy built output to `claude-private/plugins/<name>/`, commit |
+| Deploy  | Install via `POST /api/plugins/install` with local path |
+| Publish | Future: `npm publish` with `@anhermon/` scope |
+
+There is no `promote-plugin.sh` yet — plugins are committed manually until the
+build output format stabilises.
+
+---
+
+## Paperclip Issue Tracking
+
+All skill/plugin work is tracked under the `claude-plugins` project in Paperclip.
+Create a task per skill or plugin promoted, linking to the relevant commit.

--- a/docs/plans/2026-04-01-claude-rate-limit-fallback-investigation.md
+++ b/docs/plans/2026-04-01-claude-rate-limit-fallback-investigation.md
@@ -4,6 +4,16 @@ Date: 2026-04-01
 Repo: `C:\Users\User\paperclip`
 Goal: when `claude_local` hits a real Claude Code rate limit, Paperclip must retry the same heartbeat with `codex_local`.
 
+## Current Extension Goal
+
+Extend the single-target Claude rate-limit fallback into an ordered fallback chain so Paperclip can try:
+
+1. `codex_local`
+2. `gemini_local` (Gemini CLI)
+3. a Gemini 3.1 Pro preset for the final fallback slot
+
+The last slot is intentionally modeled as a Gemini-family fallback, not a separate first-class Antigravity adapter, unless we verify an official headless Antigravity CLI contract.
+
 ## Verified Provider Contracts
 
 ### Claude Code
@@ -30,6 +40,44 @@ Goal: when `claude_local` hits a real Claude Code rate limit, Paperclip must ret
   - prompt content is piped on stdin
   - success/failure is determined from JSONL plus exit status
 
+### Gemini CLI
+
+- Official Gemini CLI docs:
+  - https://google-gemini.github.io/gemini-cli/
+- Local CLI help confirms the headless contract Paperclip already relies on:
+  - `--prompt`
+  - `--model`
+  - `--resume`
+  - `--output-format <text|json|stream-json>`
+  - `--approval-mode`
+- Local environment fact on 2026-04-01:
+  - `gemini --version` returned `0.35.3`
+  - headless execution is installed, but the current local environment is unstable
+  - `auto` currently routes to `gemini-3.1-flash-lite-preview` and returns `ModelNotFoundError`
+  - explicit `gemini-3.1-pro` also returned `ModelNotFoundError`
+
+### Antigravity
+
+- Official Google Antigravity onboarding docs are available via Google Codelabs:
+  - https://codelabs.developers.google.com/getting-started-google-antigravity
+- Verified product facts from the official Codelab:
+  - Antigravity is a locally installed agent-first IDE/platform
+  - setup includes an optional `agy` command-line opener
+  - model selection happens inside the Antigravity UI
+- What we did **not** verify:
+  - no official headless/non-interactive Antigravity CLI contract
+  - no official `--prompt` / `--output-format` equivalent for autonomous terminal invocation
+- Working rule:
+  - do not invent an `antigravity_local` adapter without a documented headless contract
+  - represent the requested "antigravity (gemini 3.1 pro)" slot as a Gemini-family preset unless official docs prove otherwise
+
+### Gemini 3.1 Pro model existence
+
+- Official Google DeepMind model cards list `Gemini 3.1 Pro` as of 2026-02-19:
+  - https://deepmind.google/models/model-cards/
+- That proves the model exists at the platform level.
+- It does **not** prove this local Gemini CLI installation/account can invoke it successfully today.
+
 ## Verified Paperclip Facts
 
 - Claude adapter path:
@@ -38,6 +86,9 @@ Goal: when `claude_local` hits a real Claude Code rate limit, Paperclip must ret
   - `packages/adapters/codex-local/src/server/execute.ts`
 - Heartbeat fallback seam:
   - `server/src/services/heartbeat.ts`
+- Existing Gemini local adapter:
+  - `packages/adapters/gemini-local/src/server/execute.ts`
+- There is no existing `antigravity` adapter or integration anywhere in this repo.
 
 ### Claude rate-limit detection in Paperclip
 
@@ -88,6 +139,13 @@ Paperclip must treat adapter telemetry as best-effort around the fallback seam. 
 - Codex retry
 - final run completion
 
+For the extension work:
+
+- Fallback configuration must be ordered, not singular.
+- Existing single-target `rateLimitFallback` config must remain readable for backward compatibility.
+- Additional fallback slots should reuse registered adapters when possible.
+- Do not ship a fake Antigravity adapter with undocumented flags.
+
 ## Verified Opus Root Cause
 
 Blank Claude `adapterConfig.model` did not mean "Sonnet". It meant "do not pass --model", which let the local Claude Code installation choose its own configured default model.
@@ -121,6 +179,8 @@ Success criteria:
 - Claude rate-limit parsing is fixed and covered by tests.
 - Fallback config contamination is fixed and covered by tests.
 - Fallback-seam telemetry is now best-effort instead of being allowed to abort failover.
+- Codex now appends `--skip-git-repo-check` by default when the user did not provide it.
+- Fallback adapters now support user-configurable `model`, `command`, `extra args`, `timeoutSec`, and `graceSec` from the chain editor.
 
 ## Live Validation Result
 
@@ -155,6 +215,191 @@ Observed live sequence:
    - `run succeeded`
 
 That satisfies the fallback DoD: a real Claude rate-limit in Paperclip triggered a live retry with Codex and the run completed successfully.
+
+## Real `:3100` Validation Result
+
+The long-lived real server on `http://127.0.0.1:3100` was initially stale and failed the fallback path again.
+
+Failed stale run:
+
+- run id: `ee7534a5-ff49-4971-b841-d9401e0e1229`
+- Claude emitted a real `rate_limit_event`
+- no `adapter.fallback` event was emitted
+- run finished `failed`
+
+After killing the stale `3100` listener and restarting the real server from repo commit `9015595f`, the same live validation passed on `3100`.
+
+Successful real-server run:
+
+- run id: `282b1606-302d-460d-84ef-11124cae8c29`
+- event stream included:
+  - `adapter.fallback.decision`
+  - `adapter.fallback`
+  - `adapter.invoke` for `codex_local`
+- Codex command:
+  - `codex exec --json --model gpt-5.4 --skip-git-repo-check -`
+- Codex returned:
+  - `LIVE-FALLBACK-OK`
+- run finished:
+  - `succeeded`
+
+That is the authoritative proof that the committed Sonnet -> Codex fallback fix is now active on the real `:3100` server.
+
+## Additional Real `:3100` Validation
+
+Validation agent stayed the same:
+
+- id: `0a130a5e-1486-4829-ae50-6ea6d2763f5f`
+- name: `Temp Fallback Validation`
+
+### Proven `sonnet -> codex` on the current workspace state
+
+Successful run:
+
+- run id: `6607c82e-8cab-42c2-8103-bec39e7f4aac`
+- result: `succeeded`
+
+Observed live sequence:
+
+1. Claude invoked with:
+   - `--model claude-sonnet-4-6`
+2. Claude emitted:
+   - `type: "rate_limit_event"`
+   - `You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)`
+3. Paperclip emitted:
+   - `adapter.fallback.decision`
+   - `adapter.fallback`
+4. Codex invoked with:
+   - `codex exec --json --model gpt-5.4 --skip-git-repo-check -`
+5. Codex returned:
+   - `LIVE-FALLBACK-OK`
+6. Run finished:
+   - `succeeded`
+
+This confirms the Codex default is now safe even when the fallback config does not explicitly include `--skip-git-repo-check`.
+
+### Proven chained fallback `sonnet -> codex failure -> gemini`
+
+First attempt exposed a real operational lesson:
+
+- run id: `01ed06a2-f08d-4c59-9fde-0b61f9d30298`
+- Claude rate-limited
+- Codex was intentionally configured as `codex-missing`
+- Gemini executed and produced `LIVE-FALLBACK-OK`
+- the run still finished `timed_out`
+
+Why that happened:
+
+- Gemini inherited a `timeoutSec: 60` budget
+- the Gemini step crossed that timeout budget in this environment
+- so the chain worked, but the run budget was too small
+
+Follow-up fix and product implication:
+
+- fallback-specific `timeoutSec` / `graceSec` must be user-configurable
+- the fallback-chain editor now exposes those values
+
+Successful chained validation after raising only the Gemini fallback timeout:
+
+- run id: `4640f38f-8e35-45e3-9d67-2731f84776c9`
+- result: `succeeded`
+
+Observed live sequence:
+
+1. Claude invoked with:
+   - `--model claude-sonnet-4-6`
+2. Claude emitted a real rate-limit event
+3. Paperclip emitted:
+   - `adapter.fallback.decision` for `codex_local`
+   - `adapter.fallback` for `codex_local`
+4. Codex was intentionally configured as:
+   - `command: codex-missing`
+5. Paperclip emitted:
+   - `error: Command not found in PATH: "codex-missing"`
+   - `adapter.fallback.decision` for `gemini_local`
+   - `adapter.fallback` with message `codex_local failed; retrying with gemini_local`
+6. Gemini invoked with:
+   - `--output-format stream-json`
+   - `--model gemini-2.5-flash`
+   - `--approval-mode yolo`
+   - `--sandbox=none`
+   - `--prompt ""`
+   - prompt content on stdin
+7. Gemini returned:
+   - `LIVE-FALLBACK-OK`
+8. Run finished:
+   - `succeeded`
+
+That is the current authoritative proof on the real `:3100` server that:
+
+- Claude Sonnet rate limit -> Codex fallback works
+- a failed Codex fallback correctly advances to Gemini
+- Gemini CLI fallback now succeeds in Paperclip
+
+## Warning Log Root Cause And Fix
+
+The remaining warning observed on successful Codex fallback runs was not a fallback-control-flow problem.
+
+Observed warning text:
+
+- `failed to load skill C:\Users\User\paperclip\skills\tradingview\SKILL.md: missing YAML frontmatter delimited by ---`
+
+Root cause:
+
+- `skills/tradingview/SKILL.md` was the only local skill in the Paperclip repo missing the YAML frontmatter required by the local skill loader
+- Codex stderr was surfacing that skill-loader warning during fallback runs
+
+Fix applied:
+
+- added valid YAML frontmatter to `skills/tradingview/SKILL.md`
+
+Live proof after the fix on the real `:3100` server:
+
+- run id: `ebbdcb71-0abf-41ba-8547-1ed3ce862e18`
+- result: `succeeded`
+- Claude emitted a real rate-limit event
+- Codex invoked with:
+  - `codex exec --json --model gpt-5.4 --skip-git-repo-check -`
+- `stderrExcerpt` was empty
+- `resultJson.stderr` was empty
+
+That proves the warning was eliminated without regressing the Codex fallback path.
+
+## Transcript Readability Root Cause And Fix
+
+User-visible symptom:
+
+- fallback runs had unreadable stdout in both `pretty` and `raw` modes on the run detail page
+
+Root cause on the run detail page:
+
+- the UI was selecting the transcript parser from the agent's configured adapter type
+- after fallback, persisted stdout was emitted by a different adapter (`codex_local` or `gemini_local`)
+- the run page therefore parsed fallback output with the wrong parser
+- `raw` mode was also not truly raw; it rendered already-parsed transcript entries instead of the persisted log chunks
+
+Fix applied:
+
+- `ui/src/pages/AgentDetail.tsx`
+  - use the latest `adapter.invoke` payload for adapter detail display
+  - build an adapter-invocation timeline from persisted `adapter.invoke` events
+  - resolve the stdout parser per log chunk timestamp so fallback segments use the correct adapter parser
+  - render true persisted `logLines` in `raw` mode instead of parsed transcript entries
+- `ui/src/adapters/transcript.ts`
+  - added `resolveStdoutParser(ts)` support so parsing can switch parsers across fallback boundaries
+- `ui/src/adapters/transcript.test.ts`
+  - added coverage for timestamp-based parser switching
+
+Verification:
+
+- `pnpm exec tsc --noEmit`
+- `pnpm exec vitest run ui/src/adapters/transcript.test.ts ui/src/components/transcript/RunTranscriptView.test.tsx server/src/__tests__/gemini-local-execute.test.ts server/src/__tests__/heartbeat-rate-limit-fallback.test.ts server/src/__tests__/heartbeat-fallback-chain-execution.test.ts`
+
+Important scope note:
+
+- this transcript fix is applied to the full run detail page
+- the live dashboard widgets still use `ui/src/components/transcript/useLiveRunTranscripts.ts`, which currently parses each run with a single adapter parser
+- if fallback transcript readability is also broken in the live widgets, that needs a separate hardening pass
 
 ## Existing Agent Normalization
 

--- a/docs/plans/2026-04-01-claude-rate-limit-fallback-investigation.md
+++ b/docs/plans/2026-04-01-claude-rate-limit-fallback-investigation.md
@@ -1,0 +1,176 @@
+# Claude Rate-Limit Fallback Investigation
+
+Date: 2026-04-01
+Repo: `C:\Users\User\paperclip`
+Goal: when `claude_local` hits a real Claude Code rate limit, Paperclip must retry the same heartbeat with `codex_local`.
+
+## Verified Provider Contracts
+
+### Claude Code
+
+- Official Anthropic docs confirm the headless contract: `claude --print` runs non-interactively, and `--output-format` supports `text`, `json`, and `stream-json`.
+  - Source: https://docs.anthropic.com/zh-TW/docs/claude-code/sdk/sdk-headless
+- Local CLI help confirms the exact flags Paperclip relies on:
+  - `--print`
+  - `--output-format <text|json|stream-json>`
+  - `--resume`
+  - `--model`
+  - `--append-system-prompt-file`
+  - `--add-dir`
+- There is no verified doc that says Claude rate limits map to one stable exit code. The robust signal is therefore the output shape, not the exit code.
+
+### Codex CLI
+
+- Official OpenAI docs page for Codex CLI exists here:
+  - https://developers.openai.com/codex/cli
+- Local CLI help confirms the non-interactive entry point:
+  - `codex exec`
+- In this repo, the real adapter contract is stdin-based:
+  - Paperclip runs `codex exec --json ... -`
+  - prompt content is piped on stdin
+  - success/failure is determined from JSONL plus exit status
+
+## Verified Paperclip Facts
+
+- Claude adapter path:
+  - `packages/adapters/claude-local/src/server/execute.ts`
+- Codex adapter path:
+  - `packages/adapters/codex-local/src/server/execute.ts`
+- Heartbeat fallback seam:
+  - `server/src/services/heartbeat.ts`
+
+### Claude rate-limit detection in Paperclip
+
+- Paperclip now classifies Claude rate limits from:
+  - JSON lines with `type: "rate_limit_event"`
+  - JSON lines containing `rate_limit_info`
+  - plain text such as `You're out of extra usage`
+- This logic lives in `packages/adapters/claude-local/src/server/parse.ts`.
+
+### Live Claude evidence from the failing run
+
+Observed real output:
+
+```text
+{"type":"rate_limit_event", ...}
+You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)
+```
+
+Observed run outcome:
+
+- final run `errorCode` was `adapter_failed`
+- no `adapter.fallback` event was persisted
+- no Codex invocation appeared
+
+## What That Means
+
+The fallback branch in `server/src/services/heartbeat.ts` only runs after the primary `adapter.execute(...)` resolves and the run reaches `shouldUseRateLimitFallback(...)`.
+
+Given the live evidence above, the failure had to happen in one of these places:
+
+1. `adapter.execute(...)` threw instead of returning a structured `AdapterExecutionResult`
+2. a telemetry write immediately after `adapter.execute(...)` threw before fallback could start
+
+The strongest post-return candidate is the event write for:
+
+- `adapter.invoke`
+- `adapter.fallback.decision`
+- `adapter.fallback`
+
+Those are operational telemetry, not correctness-critical control flow. Letting them throw can suppress a valid fallback.
+
+## Working Rule For This Fix
+
+Paperclip must treat adapter telemetry as best-effort around the fallback seam. A logging/event persistence failure must not prevent:
+
+- rate-limit classification
+- fallback decision
+- Codex retry
+- final run completion
+
+## Verified Opus Root Cause
+
+Blank Claude `adapterConfig.model` did not mean "Sonnet". It meant "do not pass --model", which let the local Claude Code installation choose its own configured default model.
+
+In this environment, that local default resolved to Opus on at least one live run, which is why agents with no explicit Opus config still ran as Opus.
+
+Fix applied:
+
+- Claude runtime now defaults missing/blank model to `claude-sonnet-4-6`
+- server-side agent create defaults now materialize `claude-sonnet-4-6` for `claude_local`
+- new-agent / adapter-switch UI defaults now materialize `claude-sonnet-4-6` for `claude_local`
+
+## Validation Loop
+
+Use this exact live check:
+
+```powershell
+cd C:\Users\User\paperclip
+npx paperclipai heartbeat run --agent-id afd391e7-1220-4c55-81a0-1fb04a3df504 --debug --timeout-ms 120000
+```
+
+Success criteria:
+
+- run events include `adapter.fallback`
+- fallback target is `codex_local`
+- a later adapter invocation is for `codex_local`
+- the validation issue gets `LIVE-FALLBACK-OK`
+
+## Current Status
+
+- Claude rate-limit parsing is fixed and covered by tests.
+- Fallback config contamination is fixed and covered by tests.
+- Fallback-seam telemetry is now best-effort instead of being allowed to abort failover.
+
+## Live Validation Result
+
+Validated on a clean server instance started from current source on `http://127.0.0.1:51716`.
+
+Validation agent:
+
+- id: `0a130a5e-1486-4829-ae50-6ea6d2763f5f`
+- name: `Temp Fallback Validation`
+- model: `claude-sonnet-4-6`
+- fallback: `codex_local` with model `gpt-5.4`
+
+Successful run proving `sonnet -> codex 5.4`:
+
+- run id: `ebd3f12e-32a5-4f07-80d6-59b4661370cb`
+- result: `succeeded`
+
+Observed live sequence:
+
+1. Claude emitted:
+   - `type: "rate_limit_event"`
+   - `You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)`
+2. Paperclip emitted:
+   - `adapter.fallback.decision`
+   - `adapter.fallback`
+   - log line: `claude_local hit a rate limit; retrying this heartbeat with codex_local.`
+3. Codex executed:
+   - `codex exec --json --model gpt-5.4 --skip-git-repo-check -`
+4. Codex returned:
+   - `LIVE-FALLBACK-OK`
+5. Heartbeat finished:
+   - `run succeeded`
+
+That satisfies the fallback DoD: a real Claude rate-limit in Paperclip triggered a live retry with Codex and the run completed successfully.
+
+## Existing Agent Normalization
+
+To stop non-explicit agents from inheriting Opus from the local Claude CLI, existing blank-model Claude agents in the shared instance were normalized to explicit Sonnet:
+
+- `754f0eda-f5f5-4bb0-8b99-b441d51a9e0a` `Dev Agent — Plugins`
+- `205a0623-5586-4b61-9ffd-4a37c952890a` `Career Monitor`
+- `7f688d51-cf70-495b-806e-e672e7175da6` `Dev Agent — Open source`
+- `afd391e7-1220-4c55-81a0-1fb04a3df504` `Visibility Agent`
+- `99d9d47a-dd68-4070-8851-dfaa075c7e6b` `Operations Lead`
+
+Example post-normalization evidence:
+
+- `Visibility Agent` now has `adapterConfig.model = "claude-sonnet-4-6"` on the clean server.
+
+## Residual Notes
+
+- The older long-lived server on port `3100` had process/watcher ambiguity and produced inconsistent live behavior during debugging.
+- The clean instance on `51716` is the run that should be treated as authoritative validation for this fix.

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -29,6 +29,7 @@ export type {
   StdoutLineParser,
   CLIAdapterModule,
   CreateConfigValues,
+  AdapterFallbackChainEntryConfig,
 } from "./types.js";
 export type {
   SessionCompactionPolicy,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -316,7 +316,6 @@ export type StdoutLineParser = (line: string, ts: string) => TranscriptEntry[];
 // ---------------------------------------------------------------------------
 // CLI types (moved from cli/src/adapters/types.ts)
 // ---------------------------------------------------------------------------
-
 export interface CLIAdapterModule {
   type: string;
   formatStdoutEvent: (line: string, debug: boolean) => void;
@@ -325,6 +324,13 @@ export interface CLIAdapterModule {
 // ---------------------------------------------------------------------------
 // UI config form values (moved from ui/src/components/AgentConfigForm.tsx)
 // ---------------------------------------------------------------------------
+
+export interface AdapterFallbackChainEntryConfig {
+  adapterType: string;
+  model?: string;
+  adapterConfig?: Record<string, unknown>;
+  enabled?: boolean;
+}
 
 export interface CreateConfigValues {
   adapterType: string;
@@ -350,7 +356,10 @@ export interface CreateConfigValues {
   workspaceBranchTemplate?: string;
   worktreeParentDir?: string;
   runtimeServicesJson?: string;
+  /** @deprecated Use adapterFallbackChain instead */
   fallbackToCodexOnRateLimit?: boolean;
+  /** Ordered list of fallback adapters tried on rate-limit errors */
+  adapterFallbackChain?: AdapterFallbackChainEntryConfig[];
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;
   intervalSec: number;

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -350,6 +350,7 @@ export interface CreateConfigValues {
   workspaceBranchTemplate?: string;
   worktreeParentDir?: string;
   runtimeServicesJson?: string;
+  fallbackToCodexOnRateLimit?: boolean;
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;
   intervalSec: number;

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -1,9 +1,10 @@
 export const type = "claude_local";
 export const label = "Claude Code (local)";
+export const DEFAULT_CLAUDE_LOCAL_MODEL = "claude-sonnet-4-6";
 
 export const models = [
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: DEFAULT_CLAUDE_LOCAL_MODEL, label: "Claude Sonnet 4.6" },
   { id: "claude-haiku-4-6", label: "Claude Haiku 4.6" },
   { id: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
@@ -16,12 +17,13 @@ Adapter: claude_local
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file injected at runtime
-- model (string, optional): Claude model id
+- model (string, optional): Claude model id. Defaults to ${DEFAULT_CLAUDE_LOCAL_MODEL} when omitted.
 - effort (string, optional): reasoning effort passed via --effort (low|medium|high)
 - chrome (boolean, optional): pass --chrome when running Claude
 - promptTemplate (string, optional): run prompt template
 - maxTurnsPerRun (number, optional): max turns for one run
 - dangerouslySkipPermissions (boolean, optional): pass --dangerously-skip-permissions to claude
+- rateLimitFallback (object, optional): fallback policy when Claude exits due to rate limit; currently supports { adapterType: "codex_local", adapterConfig? }
 - command (string, optional): defaults to "claude"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -26,10 +26,12 @@ import {
   parseClaudeStreamJson,
   describeClaudeFailure,
   detectClaudeLoginRequired,
+  detectClaudeRateLimited,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
+import { DEFAULT_CLAUDE_LOCAL_MODEL } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -313,7 +315,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
-  const model = asString(config.model, "");
+  const model = asString(config.model, "").trim() || DEFAULT_CLAUDE_LOCAL_MODEL;
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
@@ -493,6 +495,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stdout: proc.stdout,
       stderr: proc.stderr,
     });
+    const rateLimited = detectClaudeRateLimited({
+      parsed,
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+    });
     const errorMeta =
       loginMeta.loginUrl != null
         ? {
@@ -518,7 +525,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         signal: proc.signal,
         timedOut: false,
         errorMessage: parseFallbackErrorMessage(proc),
-        errorCode: loginMeta.requiresLogin ? "claude_auth_required" : null,
+        errorCode: loginMeta.requiresLogin
+          ? "claude_auth_required"
+          : rateLimited
+            ? "claude_rate_limited"
+            : null,
         errorMeta,
         resultJson: {
           stdout: proc.stdout,
@@ -561,7 +572,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (proc.exitCode ?? 0) === 0
           ? null
           : describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`,
-      errorCode: loginMeta.requiresLogin ? "claude_auth_required" : null,
+      errorCode: loginMeta.requiresLogin
+        ? "claude_auth_required"
+        : rateLimited
+          ? "claude_rate_limited"
+          : null,
       errorMeta,
       usage,
       sessionId: resolvedSessionId,

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -2,6 +2,7 @@ import type { UsageSummary } from "@paperclipai/adapter-utils";
 import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
 
 const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
+const CLAUDE_RATE_LIMIT_RE = /(?:rate(?:_| |-)?limit(?:ed)?|too many requests|\b429\b|quota exceeded|usage limit reached|resource exhausted|out of extra usage|overage(?:status)?\W*rejected|rate_limit_event|resets?\s+[a-z]{3,9}\s+\d)/i;
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 export function parseClaudeStreamJson(stdout: string) {
@@ -136,6 +137,35 @@ export function detectClaudeLoginRequired(input: {
     requiresLogin,
     loginUrl: extractClaudeLoginUrl([input.stdout, input.stderr].join("\n")),
   };
+}
+
+export function detectClaudeRateLimited(input: {
+  parsed: Record<string, unknown> | null;
+  stdout: string;
+  stderr: string;
+}): boolean {
+  const rateLimitEventDetected = [input.stdout, input.stderr].some((text) =>
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .some((line) => {
+        const parsedLine = parseJson(line);
+        if (!parsedLine) return false;
+        if (asString(parsedLine.type, "") === "rate_limit_event") return true;
+        return Object.keys(parseObject(parsedLine.rate_limit_info)).length > 0;
+      }),
+  );
+  if (rateLimitEventDetected) return true;
+
+  const resultText = asString(input.parsed?.result, "").trim();
+  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+    .join("\n")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return messages.some((line) => CLAUDE_RATE_LIMIT_RE.test(line));
 }
 
 export function describeClaudeFailure(parsed: Record<string, unknown>): string | null {

--- a/packages/adapters/claude-local/src/ui/build-config.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.ts
@@ -83,6 +83,11 @@ export function buildClaudeLocalConfig(v: CreateConfigValues): Record<string, un
   if (Object.keys(env).length > 0) ac.env = env;
   ac.maxTurnsPerRun = v.maxTurnsPerRun;
   ac.dangerouslySkipPermissions = v.dangerouslySkipPermissions;
+  if (v.fallbackToCodexOnRateLimit) {
+    ac.rateLimitFallback = {
+      adapterType: "codex_local",
+    };
+  }
   if (v.workspaceStrategyType === "git_worktree") {
     ac.workspaceStrategy = {
       type: "git_worktree",

--- a/packages/adapters/claude-local/src/ui/build-config.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.ts
@@ -83,7 +83,9 @@ export function buildClaudeLocalConfig(v: CreateConfigValues): Record<string, un
   if (Object.keys(env).length > 0) ac.env = env;
   ac.maxTurnsPerRun = v.maxTurnsPerRun;
   ac.dangerouslySkipPermissions = v.dangerouslySkipPermissions;
-  if (v.fallbackToCodexOnRateLimit) {
+  if (v.adapterFallbackChain && v.adapterFallbackChain.length > 0) {
+    ac.adapterFallbackChain = v.adapterFallbackChain;
+  } else if (v.fallbackToCodexOnRateLimit) {
     ac.rateLimitFallback = {
       adapterType: "codex_local",
     };

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -398,6 +398,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (fromExtraArgs.length > 0) return fromExtraArgs;
     return asStringArray(config.args);
   })();
+  const codexExtraArgs = extraArgs.includes("--skip-git-repo-check")
+    ? extraArgs
+    : [...extraArgs, "--skip-git-repo-check"];
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
@@ -486,7 +489,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
     if (model) args.push("--model", model);
     if (modelReasoningEffort) args.push("-c", `model_reasoning_effort=${JSON.stringify(modelReasoningEffort)}`);
-    if (extraArgs.length > 0) args.push(...extraArgs);
+    if (codexExtraArgs.length > 0) args.push(...codexExtraArgs);
     if (resumeSessionId) args.push("resume", resumeSessionId, "-");
     else args.push("-");
     return args;

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -89,6 +89,9 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
     typeof v.dangerouslyBypassSandbox === "boolean"
       ? v.dangerouslyBypassSandbox
       : DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+  if (v.adapterFallbackChain && v.adapterFallbackChain.length > 0) {
+    ac.adapterFallbackChain = v.adapterFallbackChain;
+  }
   if (v.workspaceStrategyType === "git_worktree") {
     ac.workspaceStrategy = {
       type: "git_worktree",

--- a/packages/adapters/cursor-local/src/ui/build-config.ts
+++ b/packages/adapters/cursor-local/src/ui/build-config.ts
@@ -76,6 +76,9 @@ export function buildCursorLocalConfig(v: CreateConfigValues): Record<string, un
     }
   }
   if (Object.keys(env).length > 0) ac.env = env;
+  if (v.adapterFallbackChain && v.adapterFallbackChain.length > 0) {
+    ac.adapterFallbackChain = v.adapterFallbackChain;
+  }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
   return ac;

--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,6 +4,7 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.1-pro", label: "Gemini 3.1 Pro" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -269,7 +269,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
+    const notes: string[] = ["Prompt is passed to Gemini on stdin with --prompt \"\" for non-interactive execution."];
     notes.push("Added --approval-mode yolo for unattended execution.");
     if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {
@@ -331,7 +331,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--sandbox=none");
     }
     if (extraArgs.length > 0) args.push(...extraArgs);
-    args.push("--prompt", prompt);
+    args.push("--prompt", "");
     return args;
   };
 
@@ -344,7 +344,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         cwd,
         commandNotes,
         commandArgs: args.map((value, index) => (
-          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
+          index === args.length - 1 ? '""' : value
         )),
         env: loggedEnv,
         prompt,
@@ -360,6 +360,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       graceSec,
       onSpawn,
       onLog,
+      stdin: prompt,
     });
     return {
       proc,

--- a/packages/adapters/gemini-local/src/ui/build-config.ts
+++ b/packages/adapters/gemini-local/src/ui/build-config.ts
@@ -69,6 +69,9 @@ export function buildGeminiLocalConfig(v: CreateConfigValues): Record<string, un
   }
   if (Object.keys(env).length > 0) ac.env = env;
   ac.sandbox = !v.dangerouslyBypassSandbox;
+  if (v.adapterFallbackChain && v.adapterFallbackChain.length > 0) {
+    ac.adapterFallbackChain = v.adapterFallbackChain;
+  }
 
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -71,6 +71,9 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
     }
   }
   if (Object.keys(env).length > 0) ac.env = env;
+  if (v.adapterFallbackChain && v.adapterFallbackChain.length > 0) {
+    ac.adapterFallbackChain = v.adapterFallbackChain;
+  }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
   return ac;

--- a/packages/adapters/pi-local/src/ui/build-config.ts
+++ b/packages/adapters/pi-local/src/ui/build-config.ts
@@ -64,6 +64,9 @@ export function buildPiLocalConfig(v: CreateConfigValues): Record<string, unknow
     }
   }
   if (Object.keys(env).length > 0) ac.env = env;
+  if (v.adapterFallbackChain && v.adapterFallbackChain.length > 0) {
+    ac.adapterFallbackChain = v.adapterFallbackChain;
+  }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = v.extraArgs;
   if (v.args) ac.args = v.args;

--- a/packages/plugins/examples/plugin-agent-activity/package.json
+++ b/packages/plugins/examples/plugin-agent-activity/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@paperclipai/plugin-agent-activity",
+  "version": "0.1.0",
+  "description": "Clean, noise-free view of agent activity. Strips injected context and surfaces only the meaningful work turns: tool calls, comments posted, and current task per running agent.",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-agent-activity/src/constants.ts
+++ b/packages/plugins/examples/plugin-agent-activity/src/constants.ts
@@ -1,0 +1,18 @@
+export const PLUGIN_ID = "paperclip.agent-activity";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const TOOL_NAMES = {
+  AGENT_STATUS: "agent_status",
+  RUN_SUMMARY: "run_summary",
+} as const;
+
+export const DATA_KEYS = {
+  LIVE: "live",
+} as const;
+
+export const WIDGET_SLOT_ID = "agent-activity-dashboard-widget";
+export const WIDGET_EXPORT_NAME = "AgentActivityWidget";
+
+export const PAGE_SLOT_ID = "agent-activity-page";
+export const PAGE_EXPORT_NAME = "AgentActivityPage";
+export const PAGE_ROUTE = "agent-activity";

--- a/packages/plugins/examples/plugin-agent-activity/src/index.ts
+++ b/packages/plugins/examples/plugin-agent-activity/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-agent-activity/src/manifest.ts
+++ b/packages/plugins/examples/plugin-agent-activity/src/manifest.ts
@@ -1,0 +1,56 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import {
+  PAGE_EXPORT_NAME,
+  PAGE_ROUTE,
+  PAGE_SLOT_ID,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  WIDGET_EXPORT_NAME,
+  WIDGET_SLOT_ID,
+} from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Agent Activity",
+  description:
+    "Clean, noise-free view of what each agent is doing right now. Strips injected context and surfaces only the meaningful work turns: tool calls, comments posted, and current task.",
+  author: "Paperclip",
+  categories: ["automation", "ui"],
+  capabilities: [
+    "issues.read",
+    "companies.read",
+    "agents.read",
+    "plugin.state.read",
+    "plugin.state.write",
+    "agent.tools.register",
+    "ui.action.register",
+    "ui.dashboardWidget.register",
+    "ui.page.register",
+    "http.outbound",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "dashboardWidget",
+        id: WIDGET_SLOT_ID,
+        displayName: "Agent Activity",
+        exportName: WIDGET_EXPORT_NAME,
+      },
+      {
+        type: "page",
+        id: PAGE_SLOT_ID,
+        displayName: "Agent Activity",
+        exportName: PAGE_EXPORT_NAME,
+        routePath: PAGE_ROUTE,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-agent-activity/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-agent-activity/src/ui/index.tsx
@@ -1,0 +1,190 @@
+import { usePluginData } from "@paperclipai/plugin-sdk/ui";
+import type { PluginWidgetProps, PluginPageProps } from "@paperclipai/plugin-sdk/ui";
+import { DATA_KEYS } from "../constants.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RunTurn = {
+  kind: "tool_call" | "text" | "tool_result";
+  label: string;
+  preview: string;
+  ts: string;
+};
+
+type AgentStatusEntry = {
+  runId: string;
+  agentId: string;
+  agentName: string;
+  status: string;
+  taskId: string | null;
+  taskTitle: string | null;
+  elapsedMs: number | null;
+  recentTurns: RunTurn[];
+  lastActionAt: string | null;
+};
+
+type LiveData = {
+  agents: AgentStatusEntry[];
+  fetchedAt?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatElapsed(ms: number | null): string {
+  if (ms === null) return "queued";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+function turnIcon(kind: string): string {
+  if (kind === "tool_call") return "⚡";
+  if (kind === "tool_result") return "↩";
+  return "💬";
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TurnRow({ turn }: { turn: RunTurn }) {
+  return (
+    <li style={{ padding: "4px 0", fontSize: 12, borderBottom: "1px solid #1e1e1e" }}>
+      <span style={{ marginRight: 6 }}>{turnIcon(turn.kind)}</span>
+      <code style={{ color: "#7ec8e3" }}>{turn.label}</code>
+      {turn.preview && (
+        <span style={{ color: "#999", marginLeft: 8 }}>
+          {turn.preview.slice(0, 100)}{turn.preview.length > 100 ? "…" : ""}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function AgentCard({ entry }: { entry: AgentStatusEntry }) {
+  const statusColor = entry.status === "running" ? "#4caf50" : "#888";
+  return (
+    <div style={{
+      border: "1px solid #2a2a2a",
+      borderRadius: 6,
+      padding: "12px 14px",
+      marginBottom: 12,
+      background: "#141414",
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 6 }}>
+        <div>
+          <strong style={{ fontSize: 14 }}>{entry.agentName}</strong>
+          {entry.taskTitle && (
+            <span style={{ color: "#aaa", fontSize: 12, marginLeft: 8 }}>→ {entry.taskTitle.slice(0, 60)}</span>
+          )}
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <span style={{ color: statusColor, fontSize: 12, fontWeight: 600 }}>{entry.status}</span>
+          {entry.elapsedMs !== null && (
+            <span style={{ color: "#666", fontSize: 11, marginLeft: 8 }}>{formatElapsed(entry.elapsedMs)}</span>
+          )}
+        </div>
+      </div>
+
+      {entry.recentTurns.length > 0 ? (
+        <ul style={{ listStyle: "none", padding: 0, margin: "6px 0 0 0" }}>
+          {entry.recentTurns.map((turn, i) => (
+            <TurnRow key={i} turn={turn} />
+          ))}
+        </ul>
+      ) : (
+        <p style={{ color: "#666", fontSize: 12, margin: "6px 0 0 0" }}>No activity yet.</p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard widget (compact)
+// ---------------------------------------------------------------------------
+
+export function AgentActivityWidget({ context }: PluginWidgetProps) {
+  const { data, loading, error } = usePluginData<LiveData>(DATA_KEYS.LIVE, {
+    companyId: context.companyId,
+  });
+
+  const running = data?.agents.filter((a) => a.status === "running") ?? [];
+
+  return (
+    <section style={{ fontFamily: "inherit", fontSize: 14 }}>
+      <strong style={{ fontSize: 15 }}>Agent Activity</strong>
+      {loading && <p style={{ color: "#888" }}>Loading…</p>}
+      {error && <p style={{ color: "red" }}>Error loading activity.</p>}
+      {data && (
+        <>
+          <div style={{ color: "#555", marginBottom: 8, fontSize: 12 }}>
+            {running.length} agent{running.length !== 1 ? "s" : ""} running
+            {data.agents.length - running.length > 0
+              ? ` · ${data.agents.length - running.length} queued`
+              : ""}
+          </div>
+          {running.slice(0, 3).map((entry) => (
+            <AgentCard key={entry.runId} entry={entry} />
+          ))}
+          {running.length === 0 && (
+            <p style={{ color: "#888" }}>No agents running right now.</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Full page (/agent-activity)
+// ---------------------------------------------------------------------------
+
+export function AgentActivityPage({ context }: PluginPageProps) {
+  const { data, loading, error, refresh } = usePluginData<LiveData>(DATA_KEYS.LIVE, {
+    companyId: context.companyId,
+  });
+
+  return (
+    <main style={{ maxWidth: 800, margin: "0 auto", padding: "24px 16px", fontFamily: "inherit" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+        <h1 style={{ margin: 0, fontSize: 22 }}>Agent Activity</h1>
+        <button
+          onClick={() => refresh?.()}
+          style={{ padding: "6px 14px", fontSize: 13, cursor: "pointer", borderRadius: 4, border: "1px solid #333", background: "#1e1e1e", color: "#ccc" }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading && <p style={{ color: "#888" }}>Loading…</p>}
+      {error && <p style={{ color: "red" }}>Failed to load activity. Check plugin health.</p>}
+
+      {data && (
+        <>
+          <div style={{ color: "#666", marginBottom: 16, fontSize: 13 }}>
+            <strong style={{ color: "#ccc" }}>{data.agents.length}</strong> run{data.agents.length !== 1 ? "s" : ""} live
+            {data.fetchedAt && (
+              <span style={{ marginLeft: 8, fontSize: 11, color: "#555" }}>
+                (as of {new Date(data.fetchedAt).toLocaleTimeString()})
+              </span>
+            )}
+          </div>
+
+          {data.agents.length > 0 ? (
+            data.agents.map((entry) => (
+              <AgentCard key={entry.runId} entry={entry} />
+            ))
+          ) : (
+            <p style={{ color: "#888" }}>No active agent runs. All quiet.</p>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/packages/plugins/examples/plugin-agent-activity/src/worker.ts
+++ b/packages/plugins/examples/plugin-agent-activity/src/worker.ts
@@ -165,6 +165,12 @@ function parseRunLog(logContent: string, maxTurns = 8): RunTurn[] {
 // API helpers
 // ---------------------------------------------------------------------------
 
+function buildAuthHeaders(apiKey: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+  return headers;
+}
+
 async function fetchLiveRuns(
   ctx: PluginContext,
   companyId: string,
@@ -174,7 +180,7 @@ async function fetchLiveRuns(
   try {
     const res = await ctx.http.fetch(
       `${apiUrl}/api/companies/${companyId}/live-runs`,
-      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+      { method: "GET", headers: buildAuthHeaders(apiKey) },
     );
     if (!res.ok) return [];
     return (await res.json()) as LiveRun[];
@@ -193,7 +199,7 @@ async function fetchRunLog(
   try {
     const res = await ctx.http.fetch(
       `${apiUrl}/api/heartbeat-runs/${runId}/log?limitBytes=${limitBytes}`,
-      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+      { method: "GET", headers: buildAuthHeaders(apiKey) },
     );
     if (!res.ok) return "";
     const data = (await res.json()) as { content?: string };
@@ -212,7 +218,7 @@ async function fetchIssueTitleHttp(
   try {
     const res = await ctx.http.fetch(
       `${apiUrl}/api/issues/${issueId}`,
-      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+      { method: "GET", headers: buildAuthHeaders(apiKey) },
     );
     if (!res.ok) return null;
     const data = (await res.json()) as { title?: string };
@@ -291,7 +297,7 @@ async function buildRunSummary(
   try {
     const runRes = await ctx.http.fetch(
       `${apiUrl}/api/heartbeat-runs/${runId}`,
-      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+      { method: "GET", headers: buildAuthHeaders(apiKey) },
     );
     if (!runRes.ok) return null;
     const run = (await runRes.json()) as {
@@ -303,7 +309,7 @@ async function buildRunSummary(
 
     const agentRes = await ctx.http.fetch(
       `${apiUrl}/api/agents/${run.agentId}`,
-      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+      { method: "GET", headers: buildAuthHeaders(apiKey) },
     );
     const agentName: string = agentRes.ok
       ? ((await agentRes.json()) as { name?: string }).name ?? run.agentId

--- a/packages/plugins/examples/plugin-agent-activity/src/worker.ts
+++ b/packages/plugins/examples/plugin-agent-activity/src/worker.ts
@@ -1,0 +1,436 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { DATA_KEYS, TOOL_NAMES } from "./constants.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type LiveRun = {
+  id: string;
+  status: string;
+  agentId: string;
+  agentName: string;
+  adapterType: string;
+  issueId: string | null;
+  startedAt: string | null;
+  createdAt: string;
+};
+
+type RunTurn = {
+  kind: "tool_call" | "text" | "tool_result";
+  /** Tool name for tool_call, summary for text/result */
+  label: string;
+  /** Truncated preview */
+  preview: string;
+  ts: string;
+};
+
+type AgentStatusEntry = {
+  runId: string;
+  agentId: string;
+  agentName: string;
+  status: "queued" | "running" | string;
+  taskId: string | null;
+  taskTitle: string | null;
+  elapsedMs: number | null;
+  recentTurns: RunTurn[];
+  lastActionAt: string | null;
+};
+
+type AgentStatusResult = {
+  agents: AgentStatusEntry[];
+  fetchedAt: string;
+};
+
+type RunSummaryResult = {
+  runId: string;
+  agentId: string;
+  agentName: string;
+  status: string;
+  taskId: string | null;
+  turns: RunTurn[];
+  toolCallCount: number;
+  commentCount: number;
+  totalTurns: number;
+  fetchedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Log parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse NDJSON run log content into meaningful turns.
+ * Skips: system/init, injected skill content, raw user prompt injection.
+ * Includes: assistant tool_use calls, assistant text, tool results.
+ */
+function parseRunLog(logContent: string, maxTurns = 8): RunTurn[] {
+  const turns: RunTurn[] = [];
+
+  for (const line of logContent.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const chunk = entry["chunk"];
+    if (typeof chunk !== "string") continue;
+
+    // Each chunk is itself a JSON object (Claude Code stream-json format)
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(chunk) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const msgType = msg["type"] as string | undefined;
+
+    // Skip system messages (init, injected context, skill loading)
+    if (msgType === "system") continue;
+
+    // Skip user messages that are just long injected context blocks
+    if (msgType === "user") {
+      const content = msg["message"] as Record<string, unknown> | undefined;
+      if (!content) continue;
+      const msgContent = content["content"] as unknown[] | undefined;
+      // Only include tool_result turns (these are real action results)
+      if (Array.isArray(msgContent)) {
+        for (const item of msgContent) {
+          const it = item as Record<string, unknown>;
+          if (it["type"] === "tool_result") {
+            const resultContent = it["content"];
+            const preview = typeof resultContent === "string"
+              ? resultContent.slice(0, 120)
+              : JSON.stringify(resultContent).slice(0, 120);
+            turns.push({
+              kind: "tool_result",
+              label: "tool_result",
+              preview,
+              ts: (entry["ts"] as string) ?? "",
+            });
+          }
+        }
+      }
+      continue;
+    }
+
+    // Process assistant messages
+    if (msgType === "assistant") {
+      const msgData = msg["message"] as Record<string, unknown> | undefined;
+      if (!msgData) continue;
+      const content = msgData["content"] as unknown[] | undefined;
+      if (!Array.isArray(content)) continue;
+
+      for (const item of content) {
+        const it = item as Record<string, unknown>;
+        if (it["type"] === "thinking") continue; // skip thinking blocks
+
+        if (it["type"] === "tool_use") {
+          const toolName = (it["name"] as string) ?? "unknown_tool";
+          const input = it["input"] as Record<string, unknown> | undefined;
+          const preview = input ? JSON.stringify(input).slice(0, 120) : "";
+          turns.push({
+            kind: "tool_call",
+            label: toolName,
+            preview,
+            ts: (entry["ts"] as string) ?? "",
+          });
+        } else if (it["type"] === "text") {
+          const text = (it["text"] as string) ?? "";
+          if (text.trim().length > 0) {
+            turns.push({
+              kind: "text",
+              label: "text",
+              preview: text.slice(0, 120),
+              ts: (entry["ts"] as string) ?? "",
+            });
+          }
+        }
+      }
+    }
+
+    if (turns.length >= maxTurns * 3) break; // read enough, we'll slice later
+  }
+
+  // Return the most recent maxTurns
+  return turns.slice(-maxTurns);
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchLiveRuns(
+  ctx: PluginContext,
+  companyId: string,
+  apiUrl: string,
+  apiKey: string,
+): Promise<LiveRun[]> {
+  try {
+    const res = await ctx.http.fetch(
+      `${apiUrl}/api/companies/${companyId}/live-runs`,
+      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!res.ok) return [];
+    return (await res.json()) as LiveRun[];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchRunLog(
+  ctx: PluginContext,
+  runId: string,
+  apiUrl: string,
+  apiKey: string,
+  limitBytes = 32768,
+): Promise<string> {
+  try {
+    const res = await ctx.http.fetch(
+      `${apiUrl}/api/heartbeat-runs/${runId}/log?limitBytes=${limitBytes}`,
+      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!res.ok) return "";
+    const data = (await res.json()) as { content?: string };
+    return data.content ?? "";
+  } catch {
+    return "";
+  }
+}
+
+async function fetchIssueTitleHttp(
+  ctx: PluginContext,
+  issueId: string,
+  apiUrl: string,
+  apiKey: string,
+): Promise<string | null> {
+  try {
+    const res = await ctx.http.fetch(
+      `${apiUrl}/api/issues/${issueId}`,
+      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as { title?: string };
+    return data.title ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core: build agent status
+// ---------------------------------------------------------------------------
+
+async function buildAgentStatus(
+  ctx: PluginContext,
+  companyId: string,
+  agentId: string | undefined,
+  apiUrl: string,
+  apiKey: string,
+): Promise<AgentStatusResult> {
+  const allRuns = await fetchLiveRuns(ctx, companyId, apiUrl, apiKey);
+  const runs = agentId ? allRuns.filter((r) => r.agentId === agentId) : allRuns;
+
+  const entries = await Promise.all(
+    runs.map(async (run): Promise<AgentStatusEntry> => {
+      const now = Date.now();
+      const startedAt = run.startedAt ? new Date(run.startedAt).getTime() : null;
+      const elapsedMs = startedAt ? now - startedAt : null;
+
+      let recentTurns: RunTurn[] = [];
+      let lastActionAt: string | null = null;
+
+      if (run.status === "running") {
+        const logContent = await fetchRunLog(ctx, run.id, apiUrl, apiKey);
+        if (logContent) {
+          recentTurns = parseRunLog(logContent, 5);
+          lastActionAt = recentTurns.length > 0
+            ? recentTurns[recentTurns.length - 1]!.ts
+            : null;
+        }
+      }
+
+      const taskTitle = run.issueId
+        ? await fetchIssueTitleHttp(ctx, run.issueId, apiUrl, apiKey)
+        : null;
+
+      return {
+        runId: run.id,
+        agentId: run.agentId,
+        agentName: run.agentName,
+        status: run.status,
+        taskId: run.issueId,
+        taskTitle,
+        elapsedMs,
+        recentTurns,
+        lastActionAt,
+      };
+    }),
+  );
+
+  const result: AgentStatusResult = { agents: entries, fetchedAt: new Date().toISOString() };
+  await ctx.state.set({ scopeKind: "instance", stateKey: DATA_KEYS.LIVE }, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Core: build run summary
+// ---------------------------------------------------------------------------
+
+async function buildRunSummary(
+  ctx: PluginContext,
+  runId: string,
+  apiUrl: string,
+  apiKey: string,
+): Promise<RunSummaryResult | null> {
+  try {
+    const runRes = await ctx.http.fetch(
+      `${apiUrl}/api/heartbeat-runs/${runId}`,
+      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!runRes.ok) return null;
+    const run = (await runRes.json()) as {
+      id: string;
+      agentId: string;
+      status: string;
+      contextSnapshot?: { issueId?: string };
+    } & Record<string, unknown>;
+
+    const agentRes = await ctx.http.fetch(
+      `${apiUrl}/api/agents/${run.agentId}`,
+      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    const agentName: string = agentRes.ok
+      ? ((await agentRes.json()) as { name?: string }).name ?? run.agentId
+      : run.agentId;
+
+    const logContent = await fetchRunLog(ctx, runId, apiUrl, apiKey, 131072);
+    const turns = parseRunLog(logContent, 50);
+
+    const toolCallCount = turns.filter((t) => t.kind === "tool_call").length;
+    const commentCount = turns.filter(
+      (t) => t.kind === "tool_call" && (t.label === "post_comment" || t.label.includes("comment")),
+    ).length;
+
+    const taskId = run.contextSnapshot?.issueId ?? null;
+
+    return {
+      runId,
+      agentId: run.agentId,
+      agentName,
+      status: run.status,
+      taskId,
+      turns,
+      toolCallCount,
+      commentCount,
+      totalTurns: turns.length,
+      fetchedAt: new Date().toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("agent-activity plugin setup");
+
+    const apiUrl = process.env["PAPERCLIP_API_URL"] ?? "http://127.0.0.1:3100";
+    const apiKey = process.env["PAPERCLIP_API_KEY"] ?? "";
+
+    // ------------------------------------------------------------------
+    // Agent tool: agent_status
+    // ------------------------------------------------------------------
+    ctx.tools.register(
+      TOOL_NAMES.AGENT_STATUS,
+      {
+        displayName: "Agent Status",
+        description:
+          "Return a clean, noise-free view of what each agent is doing right now. Shows recent tool calls and current task without injected system context. Use to check if an agent is stuck or progressing.",
+        parametersSchema: {
+          type: "object",
+          properties: {
+            companyId: {
+              type: "string",
+              description: "Company to query. Omit to use context company.",
+            },
+            agentId: {
+              type: "string",
+              description: "Filter to a specific agent. Omit for all running agents.",
+            },
+          },
+          required: [],
+        },
+      },
+      async (params, runCtx) => {
+        const cid = (params as { companyId?: string }).companyId ?? runCtx.companyId;
+        const aid = (params as { agentId?: string }).agentId;
+        if (!cid) return { content: "companyId is required", data: null };
+        const result = await buildAgentStatus(ctx, cid, aid, apiUrl, apiKey);
+        return { content: JSON.stringify(result, null, 2), data: result };
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // Agent tool: run_summary
+    // ------------------------------------------------------------------
+    ctx.tools.register(
+      TOOL_NAMES.RUN_SUMMARY,
+      {
+        displayName: "Run Summary",
+        description:
+          "Summarize the meaningful content of a heartbeat run — tool calls made, comments posted, decisions taken. Strips injected skill content and system prompts.",
+        parametersSchema: {
+          type: "object",
+          properties: {
+            runId: {
+              type: "string",
+              description: "UUID of the heartbeat run to summarize.",
+            },
+          },
+          required: ["runId"],
+        },
+      },
+      async (params) => {
+        const { runId } = params as { runId: string };
+        const result = await buildRunSummary(ctx, runId, apiUrl, apiKey);
+        if (!result) return { content: `Run ${runId} not found or not accessible.`, data: null };
+        return { content: JSON.stringify(result, null, 2), data: result };
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // Data endpoint for UI widget / page
+    // ------------------------------------------------------------------
+    ctx.data.register(DATA_KEYS.LIVE, async (params) => {
+      const companyId = (params as { companyId?: string } | undefined)?.companyId;
+      if (!companyId) {
+        return (
+          (await ctx.state.get({ scopeKind: "instance", stateKey: DATA_KEYS.LIVE })) ?? {
+            agents: [],
+            fetchedAt: null,
+          }
+        );
+      }
+      return await buildAgentStatus(ctx, companyId, undefined, apiUrl, apiKey);
+    });
+
+    ctx.logger.info("agent-activity plugin ready");
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Agent Activity plugin ready" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-agent-activity/tsconfig.json
+++ b/packages/plugins/examples/plugin-agent-activity/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/examples/plugin-decision-surface/package.json
+++ b/packages/plugins/examples/plugin-decision-surface/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@paperclipai/plugin-decision-surface",
+  "version": "0.1.0",
+  "description": "Surfaces the decision + action queue: pending approvals and blocked issues in one view, with auto-unblock on approval completion.",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-decision-surface/src/constants.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/constants.ts
@@ -1,0 +1,18 @@
+export const PLUGIN_ID = "paperclip.decision-surface";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const TOOL_NAMES = {
+  DECISIONS: "decisions",
+  UNBLOCK_ISSUE: "unblock_issue",
+} as const;
+
+export const DATA_KEYS = {
+  QUEUE: "queue",
+} as const;
+
+export const WIDGET_SLOT_ID = "decision-surface-dashboard-widget";
+export const WIDGET_EXPORT_NAME = "DecisionSurfaceWidget";
+
+export const PAGE_SLOT_ID = "decision-surface-page";
+export const PAGE_EXPORT_NAME = "DecisionSurfacePage";
+export const PAGE_ROUTE = "decisions";

--- a/packages/plugins/examples/plugin-decision-surface/src/index.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-decision-surface/src/manifest.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/manifest.ts
@@ -32,6 +32,23 @@ const manifest: PaperclipPluginManifestV1 = {
     "ui.page.register",
     "http.outbound",
   ],
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      apiKey: {
+        type: "string",
+        title: "API Key",
+        description:
+          "Paperclip API key used to fetch pending approvals. If omitted, approval data will be unavailable. Use a long-lived token from your Paperclip instance.",
+      },
+      apiUrl: {
+        type: "string",
+        title: "API URL",
+        description: "Base URL of the Paperclip server. Defaults to http://127.0.0.1:3100.",
+        default: "http://127.0.0.1:3100",
+      },
+    },
+  },
   entrypoints: {
     worker: "./dist/worker.js",
     ui: "./dist/ui",

--- a/packages/plugins/examples/plugin-decision-surface/src/manifest.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/manifest.ts
@@ -35,12 +35,6 @@ const manifest: PaperclipPluginManifestV1 = {
   instanceConfigSchema: {
     type: "object",
     properties: {
-      apiKey: {
-        type: "string",
-        title: "API Key",
-        description:
-          "Paperclip API key used to fetch pending approvals. If omitted, approval data will be unavailable. Use a long-lived token from your Paperclip instance.",
-      },
       apiUrl: {
         type: "string",
         title: "API URL",

--- a/packages/plugins/examples/plugin-decision-surface/src/manifest.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/manifest.ts
@@ -1,0 +1,58 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import {
+  PAGE_EXPORT_NAME,
+  PAGE_ROUTE,
+  PAGE_SLOT_ID,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  WIDGET_EXPORT_NAME,
+  WIDGET_SLOT_ID,
+} from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Decision Surface",
+  description:
+    "Surfaces pending approvals and blocked issues in one actionable view. Provides a decisions tool for agents and auto-unblocks issues when approvals are resolved.",
+  author: "Paperclip",
+  categories: ["automation", "ui"],
+  capabilities: [
+    "events.subscribe",
+    "issues.read",
+    "issues.update",
+    "issue.comments.create",
+    "companies.read",
+    "plugin.state.read",
+    "plugin.state.write",
+    "agent.tools.register",
+    "ui.action.register",
+    "ui.dashboardWidget.register",
+    "ui.page.register",
+    "http.outbound",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "dashboardWidget",
+        id: WIDGET_SLOT_ID,
+        displayName: "Decision Queue",
+        exportName: WIDGET_EXPORT_NAME,
+      },
+      {
+        type: "page",
+        id: PAGE_SLOT_ID,
+        displayName: "Decisions",
+        exportName: PAGE_EXPORT_NAME,
+        routePath: PAGE_ROUTE,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-decision-surface/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-decision-surface/src/ui/index.tsx
@@ -1,0 +1,175 @@
+import { usePluginData, usePluginAction } from "@paperclipai/plugin-sdk/ui";
+import type { PluginWidgetProps, PluginPageProps } from "@paperclipai/plugin-sdk/ui";
+import { DATA_KEYS, TOOL_NAMES } from "../constants.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type DecisionItem =
+  | { kind: "approval"; companyId: string; data: { id: string; type: string; payload: Record<string, unknown>; requestedAt: string } }
+  | { kind: "blocked_issue"; companyId: string; data: { id: string; identifier: string; title: string; updatedAt: string } };
+
+type QueueData = {
+  items: DecisionItem[];
+  totalApprovals: number;
+  totalBlockedIssues: number;
+  fetchedAt?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function ApprovalRow({ item }: { item: Extract<DecisionItem, { kind: "approval" }> }) {
+  const plan = (item.data.payload as { plan?: string }).plan ?? "(no description)";
+  return (
+    <li style={{ padding: "8px 0", borderBottom: "1px solid #eee" }}>
+      <strong>Approval</strong> — {item.data.type}
+      <div style={{ color: "#555", fontSize: 13, marginTop: 2 }}>{plan.slice(0, 120)}{plan.length > 120 ? "…" : ""}</div>
+      <div style={{ color: "#888", fontSize: 11, marginTop: 2 }}>
+        {new Date(item.data.requestedAt).toLocaleString()}
+      </div>
+    </li>
+  );
+}
+
+function BlockedIssueRow({ item }: { item: Extract<DecisionItem, { kind: "blocked_issue" }> }) {
+  const unblock = usePluginAction(TOOL_NAMES.UNBLOCK_ISSUE);
+  const handleUnblock = () => {
+    unblock({
+      issueId: item.data.id,
+      companyId: item.companyId,
+      reason: "Manually unblocked via Decision Surface",
+    });
+  };
+  return (
+    <li style={{ padding: "8px 0", borderBottom: "1px solid #eee", display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+      <div>
+        <strong>{item.data.identifier}</strong> — {item.data.title}
+        <div style={{ color: "#888", fontSize: 11, marginTop: 2 }}>
+          Updated {new Date(item.data.updatedAt).toLocaleString()}
+        </div>
+      </div>
+      <button
+        onClick={handleUnblock}
+        style={{ marginLeft: 12, padding: "4px 10px", fontSize: 12, cursor: "pointer", borderRadius: 4, border: "1px solid #ccc", background: "#f5f5f5" }}
+      >
+        Unblock
+      </button>
+    </li>
+  );
+}
+
+function QueueList({ data, companyId }: { data: QueueData; companyId: string }) {
+  const items = data.items ?? [];
+  if (items.length === 0) {
+    return <p style={{ color: "#888" }}>Nothing requires action right now.</p>;
+  }
+  return (
+    <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+      {items.map((item, i) =>
+        item.kind === "approval" ? (
+          <ApprovalRow key={`a-${item.data.id}-${i}`} item={item} />
+        ) : (
+          <BlockedIssueRow key={`b-${item.data.id}-${i}`} item={{ ...item, companyId }} />
+        ),
+      )}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard widget (compact)
+// ---------------------------------------------------------------------------
+
+export function DecisionSurfaceWidget({ context }: PluginWidgetProps) {
+  const { data, loading, error } = usePluginData<QueueData>(DATA_KEYS.QUEUE, {
+    companyId: context.companyId,
+  });
+
+  return (
+    <section style={{ fontFamily: "inherit", fontSize: 14 }}>
+      <strong style={{ fontSize: 15 }}>Decision Queue</strong>
+      {loading && <p style={{ color: "#888" }}>Loading…</p>}
+      {error && <p style={{ color: "red" }}>Error loading queue.</p>}
+      {data && (
+        <>
+          <div style={{ color: "#555", marginBottom: 8, fontSize: 12 }}>
+            {data.totalApprovals} approval{data.totalApprovals !== 1 ? "s" : ""} · {data.totalBlockedIssues} blocked issue{data.totalBlockedIssues !== 1 ? "s" : ""}
+          </div>
+          <QueueList data={data} companyId={context.companyId ?? ""} />
+        </>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Full page (/decisions)
+// ---------------------------------------------------------------------------
+
+export function DecisionSurfacePage({ context }: PluginPageProps) {
+  const { data, loading, error, refresh } = usePluginData<QueueData>(DATA_KEYS.QUEUE, {
+    companyId: context.companyId,
+  });
+
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "24px 16px", fontFamily: "inherit" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+        <h1 style={{ margin: 0, fontSize: 22 }}>Decision Queue</h1>
+        <button
+          onClick={() => refresh?.()}
+          style={{ padding: "6px 14px", fontSize: 13, cursor: "pointer", borderRadius: 4, border: "1px solid #ccc", background: "#f5f5f5" }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading && <p style={{ color: "#888" }}>Loading…</p>}
+      {error && <p style={{ color: "red" }}>Failed to load queue. Check plugin health.</p>}
+
+      {data && (
+        <>
+          <div style={{ color: "#555", marginBottom: 16 }}>
+            <strong>{data.items?.length ?? 0}</strong> item{(data.items?.length ?? 0) !== 1 ? "s" : ""} requiring action
+            {data.fetchedAt && (
+              <span style={{ marginLeft: 8, fontSize: 12, color: "#aaa" }}>
+                (as of {new Date(data.fetchedAt).toLocaleTimeString()})
+              </span>
+            )}
+          </div>
+
+          {data.totalApprovals > 0 && (
+            <section style={{ marginBottom: 24 }}>
+              <h2 style={{ fontSize: 16, marginBottom: 8 }}>Pending Approvals ({data.totalApprovals})</h2>
+              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {data.items.filter((i) => i.kind === "approval").map((item, idx) => (
+                  <ApprovalRow key={idx} item={item as Extract<DecisionItem, { kind: "approval" }>} />
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {data.totalBlockedIssues > 0 && (
+            <section>
+              <h2 style={{ fontSize: 16, marginBottom: 8 }}>Blocked Issues ({data.totalBlockedIssues})</h2>
+              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {data.items.filter((i) => i.kind === "blocked_issue").map((item, idx) => (
+                  <BlockedIssueRow
+                    key={idx}
+                    item={item as Extract<DecisionItem, { kind: "blocked_issue" }>}
+                  />
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {(data.items?.length ?? 0) === 0 && (
+            <p style={{ color: "#888" }}>Nothing requires action right now. ✓</p>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/packages/plugins/examples/plugin-decision-surface/src/worker.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/worker.ts
@@ -47,9 +47,11 @@ async function fetchApprovals(
   apiKey: string,
 ): Promise<Approval[]> {
   try {
+    const authHeaders: Record<string, string> = {};
+    if (apiKey) authHeaders["Authorization"] = `Bearer ${apiKey}`;
     const res = await ctx.http.fetch(
       `${apiUrl}/api/companies/${companyId}/approvals?status=pending&limit=50`,
-      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+      { method: "GET", headers: authHeaders },
     );
     if (!res.ok) return [];
     const data = (await res.json()) as Approval[] | { approvals?: Approval[] };
@@ -112,8 +114,7 @@ const plugin = definePlugin({
       (config["apiUrl"] as string | undefined) ??
       process.env["PAPERCLIP_API_URL"] ??
       "http://127.0.0.1:3100";
-    const apiKey =
-      (config["apiKey"] as string | undefined) ?? process.env["PAPERCLIP_API_KEY"] ?? "";
+    const apiKey = process.env["PAPERCLIP_API_KEY"] ?? "";
 
     // ------------------------------------------------------------------
     // Agent tool: decisions
@@ -214,9 +215,11 @@ const plugin = definePlugin({
       const { companyId, entityId: approvalId } = event;
       ctx.logger.info("approval decided — checking linked issues", { approvalId, companyId });
       try {
+        const authHeaders: Record<string, string> = {};
+        if (apiKey) authHeaders["Authorization"] = `Bearer ${apiKey}`;
         const res = await ctx.http.fetch(
           `${apiUrl}/api/approvals/${approvalId}/issues`,
-          { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+          { method: "GET", headers: authHeaders },
         );
         if (!res.ok) return;
         const linked = (await res.json()) as Array<{ id: string; status: string }>;

--- a/packages/plugins/examples/plugin-decision-surface/src/worker.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/worker.ts
@@ -1,0 +1,244 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+import { DATA_KEYS, TOOL_NAMES } from "./constants.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Approval = {
+  id: string;
+  type: string;
+  status: string;
+  payload: Record<string, unknown>;
+  requestedAt: string;
+  requestedByAgentId: string | null;
+};
+
+type BlockedIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  assigneeAgentId: string | null;
+  updatedAt: Date | string;
+};
+
+type DecisionItem =
+  | { kind: "approval"; companyId: string; data: Approval }
+  | { kind: "blocked_issue"; companyId: string; data: BlockedIssue };
+
+type DecisionsResult = {
+  items: DecisionItem[];
+  totalApprovals: number;
+  totalBlockedIssues: number;
+  fetchedAt: string;
+};
+
+const QUEUE_STATE_KEY = "queue";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchApprovals(
+  ctx: PluginContext,
+  companyId: string,
+  apiUrl: string,
+  apiKey: string,
+): Promise<Approval[]> {
+  try {
+    const res = await ctx.http.fetch(
+      `${apiUrl}/api/companies/${companyId}/approvals?status=pending&limit=50`,
+      { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!res.ok) return [];
+    const data = (await res.json()) as Approval[] | { approvals?: Approval[] };
+    if (Array.isArray(data)) return data;
+    return data.approvals ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchBlockedIssues(ctx: PluginContext, companyId: string): Promise<BlockedIssue[]> {
+  try {
+    const issues = await ctx.issues.list({ companyId, status: "blocked", limit: 50, offset: 0 });
+    return issues.map((issue) => ({
+      id: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+      assigneeAgentId: issue.assigneeAgentId ?? null,
+      updatedAt: issue.updatedAt,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function buildDecisionsResult(
+  ctx: PluginContext,
+  companyId: string,
+  apiUrl: string,
+  apiKey: string,
+): Promise<DecisionsResult> {
+  const [approvals, blockedIssues] = await Promise.all([
+    fetchApprovals(ctx, companyId, apiUrl, apiKey),
+    fetchBlockedIssues(ctx, companyId),
+  ]);
+  const items: DecisionItem[] = [
+    ...approvals.map((a): DecisionItem => ({ kind: "approval", companyId, data: a })),
+    ...blockedIssues.map((i): DecisionItem => ({ kind: "blocked_issue", companyId, data: i })),
+  ];
+  const result: DecisionsResult = {
+    items,
+    totalApprovals: approvals.length,
+    totalBlockedIssues: blockedIssues.length,
+    fetchedAt: new Date().toISOString(),
+  };
+  await ctx.state.set({ scopeKind: "instance", stateKey: QUEUE_STATE_KEY }, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("decision-surface plugin setup");
+
+    const apiUrl = process.env["PAPERCLIP_API_URL"] ?? "http://127.0.0.1:3100";
+    const apiKey = process.env["PAPERCLIP_API_KEY"] ?? "";
+
+    // ------------------------------------------------------------------
+    // Agent tool: decisions
+    // ------------------------------------------------------------------
+    ctx.tools.register(
+      TOOL_NAMES.DECISIONS,
+      {
+        displayName: "Decisions",
+        description:
+          "Return all items requiring board or human action: pending CEO-strategy approvals and blocked agent issues. Use this to triage blockers.",
+        parametersSchema: {
+          type: "object",
+          properties: {
+            companyId: { type: "string", description: "Company to query. Omit to use context company." },
+          },
+          required: [],
+        },
+      },
+      async (params, runCtx) => {
+        const cid = (params as { companyId?: string }).companyId ?? runCtx.companyId;
+        if (!cid) return { content: "companyId is required", data: null };
+        const result = await buildDecisionsResult(ctx, cid, apiUrl, apiKey);
+        return { content: JSON.stringify(result, null, 2), data: result };
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // Agent tool: unblock_issue
+    // ------------------------------------------------------------------
+    ctx.tools.register(
+      TOOL_NAMES.UNBLOCK_ISSUE,
+      {
+        displayName: "Unblock Issue",
+        description: "Move a blocked issue back to todo and post a comment explaining what cleared the blocker.",
+        parametersSchema: {
+          type: "object",
+          properties: {
+            issueId: { type: "string", description: "UUID or identifier of the blocked issue." },
+            companyId: { type: "string", description: "Company that owns the issue." },
+            reason: { type: "string", description: "Short explanation of what cleared the blocker." },
+          },
+          required: ["issueId", "companyId", "reason"],
+        },
+      },
+      async (params) => {
+        const { issueId, companyId, reason } = params as {
+          issueId: string;
+          companyId: string;
+          reason: string;
+        };
+        try {
+          await ctx.issues.update(issueId, { status: "todo" }, companyId);
+          await ctx.issues.createComment(issueId, `Unblocked: ${reason}`, companyId);
+          return { content: `Issue ${issueId} unblocked.`, data: { issueId, status: "todo" } };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return { content: `Failed to unblock ${issueId}: ${msg}`, data: null };
+        }
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // UI action: unblock_issue (for the dashboard widget / page button)
+    // ------------------------------------------------------------------
+    ctx.actions.register(TOOL_NAMES.UNBLOCK_ISSUE, async (params) => {
+      const { issueId, companyId, reason } = params as {
+        issueId: string;
+        companyId: string;
+        reason: string;
+      };
+      await ctx.issues.update(issueId, { status: "todo" }, companyId);
+      await ctx.issues.createComment(issueId, `Unblocked: ${reason}`, companyId);
+      return { issueId, status: "todo" };
+    });
+
+    // ------------------------------------------------------------------
+    // Data endpoint for the UI widget / page
+    // ------------------------------------------------------------------
+    ctx.data.register(DATA_KEYS.QUEUE, async (params) => {
+      const companyId = (params as { companyId?: string } | undefined)?.companyId;
+      if (!companyId) {
+        return (
+          (await ctx.state.get({ scopeKind: "instance", stateKey: QUEUE_STATE_KEY })) ?? {
+            items: [],
+            totalApprovals: 0,
+            totalBlockedIssues: 0,
+            fetchedAt: null,
+          }
+        );
+      }
+      return await buildDecisionsResult(ctx, companyId, apiUrl, apiKey);
+    });
+
+    // ------------------------------------------------------------------
+    // Event: approval.decided → auto-unblock linked issues
+    // ------------------------------------------------------------------
+    ctx.events.on("approval.decided", async (event) => {
+      const { companyId, entityId: approvalId } = event;
+      ctx.logger.info("approval decided — checking linked issues", { approvalId, companyId });
+      try {
+        const res = await ctx.http.fetch(
+          `${apiUrl}/api/approvals/${approvalId}/issues`,
+          { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } },
+        );
+        if (!res.ok) return;
+        const linked = (await res.json()) as Array<{ id: string; status: string }>;
+        for (const issue of linked.filter((i) => i.status === "blocked")) {
+          await ctx.issues.update(issue.id, { status: "todo" }, companyId);
+          await ctx.issues.createComment(
+            issue.id,
+            `Approval \`${approvalId}\` was decided. Auto-unblocked by decision-surface plugin.`,
+            companyId,
+          );
+          ctx.logger.info("auto-unblocked issue", { issueId: issue.id, approvalId });
+        }
+      } catch (err) {
+        ctx.logger.error("failed to auto-unblock after approval", {
+          approvalId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+
+    ctx.logger.info("decision-surface plugin ready");
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Decision Surface plugin ready" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-decision-surface/src/worker.ts
+++ b/packages/plugins/examples/plugin-decision-surface/src/worker.ts
@@ -107,8 +107,13 @@ const plugin = definePlugin({
   async setup(ctx) {
     ctx.logger.info("decision-surface plugin setup");
 
-    const apiUrl = process.env["PAPERCLIP_API_URL"] ?? "http://127.0.0.1:3100";
-    const apiKey = process.env["PAPERCLIP_API_KEY"] ?? "";
+    const config = await ctx.config.get();
+    const apiUrl =
+      (config["apiUrl"] as string | undefined) ??
+      process.env["PAPERCLIP_API_URL"] ??
+      "http://127.0.0.1:3100";
+    const apiKey =
+      (config["apiKey"] as string | undefined) ?? process.env["PAPERCLIP_API_KEY"] ?? "";
 
     // ------------------------------------------------------------------
     // Agent tool: decisions

--- a/packages/plugins/examples/plugin-decision-surface/tsconfig.json
+++ b/packages/plugins/examples/plugin-decision-surface/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/examples/plugin-feedback-collection/README.md
+++ b/packages/plugins/examples/plugin-feedback-collection/README.md
@@ -1,0 +1,75 @@
+# Feedback Collection Plugin (Example)
+
+`@paperclipai/plugin-feedback-collection` normalizes external feedback payloads from Jira, Bitbucket, and Slack into actionable Paperclip issues.
+
+## What It Supports
+
+- Agent tool: `ingest_feedback`
+- Webhook endpoints:
+  - `/api/plugins/:pluginId/webhooks/jira`
+  - `/api/plugins/:pluginId/webhooks/bitbucket`
+  - `/api/plugins/:pluginId/webhooks/slack`
+
+Core flow:
+
+1. Receive source payload
+2. Normalize title/description/priority
+3. Create a Paperclip issue
+4. Optionally append raw payload as an issue comment
+
+## Configuration
+
+Set plugin config in Paperclip settings:
+
+- `defaultCompanyId`: fallback company when tool/webhook payload does not include one
+- `defaultProjectId`: optional default project placement
+- `defaultGoalId`: optional default goal placement
+- `defaultParentId`: optional default parent issue
+- `appendRawPayloadComment`: append raw payload to a comment on each created issue
+- `webhookAuthSecretRef`: optional secret ref for webhook auth token
+
+If `webhookAuthSecretRef` is set, each webhook request must include:
+
+- Header: `x-feedback-token: <resolved secret value>`
+
+## Varlock Credential Workflow
+
+Board request asked for `varlock`-based credential guidance. Recommended pattern:
+
+1. Define a varlock secret for webhook token:
+   - Key: `FEEDBACK_WEBHOOK_TOKEN`
+2. Configure plugin `webhookAuthSecretRef` to your secret reference.
+3. In your webhook relay script/service, load token via varlock and send:
+   - `x-feedback-token: $FEEDBACK_WEBHOOK_TOKEN`
+
+This keeps webhook auth credentials out of plaintext configs while letting the plugin enforce ingestion auth.
+
+## Tool Usage Example
+
+```json
+{
+  "source": "jira",
+  "payload": {
+    "key": "ENG-42",
+    "fields": {
+      "summary": "Build fails on Windows",
+      "description": "npm install fails with ENOENT",
+      "priority": { "name": "High" }
+    }
+  },
+  "labels": ["feedback", "jira"]
+}
+```
+
+Expected result:
+
+- New Paperclip issue created with normalized title/description/priority
+- Tool result includes created issue ID
+
+## Development
+
+```bash
+pnpm --filter @paperclipai/plugin-feedback-collection typecheck
+pnpm --filter @paperclipai/plugin-feedback-collection test
+pnpm --filter @paperclipai/plugin-feedback-collection build
+```

--- a/packages/plugins/examples/plugin-feedback-collection/package.json
+++ b/packages/plugins/examples/plugin-feedback-collection/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@paperclipai/plugin-feedback-collection",
+  "version": "0.1.0",
+  "description": "Feedback ingestion plugin for Jira, Bitbucket, and Slack payloads into structured Paperclip issues.",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/plugins/examples/plugin-feedback-collection/src/constants.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/src/constants.ts
@@ -1,0 +1,14 @@
+export const PLUGIN_ID = "paperclip.feedback-collection";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const TOOL_NAMES = {
+  INGEST_FEEDBACK: "ingest_feedback",
+} as const;
+
+export const WEBHOOK_KEYS = {
+  JIRA: "jira",
+  BITBUCKET: "bitbucket",
+  SLACK: "slack",
+} as const;
+
+export type FeedbackSource = "jira" | "bitbucket" | "slack";

--- a/packages/plugins/examples/plugin-feedback-collection/src/index.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-feedback-collection/src/manifest.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/src/manifest.ts
@@ -1,0 +1,105 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import { PLUGIN_ID, PLUGIN_VERSION, TOOL_NAMES, WEBHOOK_KEYS } from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Feedback Collection",
+  description:
+    "Normalizes Jira, Bitbucket, and Slack feedback into actionable Paperclip issues via tool calls or webhooks.",
+  author: "Paperclip",
+  categories: ["connector", "automation"],
+  capabilities: [
+    "issues.read",
+    "issues.create",
+    "issue.comments.create",
+    "plugin.state.read",
+    "plugin.state.write",
+    "agent.tools.register",
+    "webhooks.receive",
+    "secrets.read-ref",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      defaultCompanyId: {
+        type: "string",
+        title: "Default Company ID",
+        description: "Fallback company ID when no company is provided by tool run context or payload.",
+      },
+      defaultProjectId: {
+        type: "string",
+        title: "Default Project ID",
+      },
+      defaultGoalId: {
+        type: "string",
+        title: "Default Goal ID",
+      },
+      defaultParentId: {
+        type: "string",
+        title: "Default Parent Issue ID",
+      },
+      appendRawPayloadComment: {
+        type: "boolean",
+        title: "Append Raw Payload Comment",
+        default: false,
+      },
+      webhookAuthSecretRef: {
+        type: "string",
+        title: "Webhook Auth Secret Ref",
+        description:
+          "Optional secret reference. If set, incoming webhooks must include header `x-feedback-token` equal to the resolved secret value.",
+      },
+    },
+  },
+  webhooks: [
+    {
+      endpointKey: WEBHOOK_KEYS.JIRA,
+      displayName: "Jira Feedback Ingest",
+      description: "Ingest Jira issue payloads as Paperclip issues.",
+    },
+    {
+      endpointKey: WEBHOOK_KEYS.BITBUCKET,
+      displayName: "Bitbucket Feedback Ingest",
+      description: "Ingest Bitbucket PR/comment payloads as Paperclip issues.",
+    },
+    {
+      endpointKey: WEBHOOK_KEYS.SLACK,
+      displayName: "Slack Feedback Ingest",
+      description: "Ingest Slack message payloads as Paperclip issues.",
+    },
+  ],
+  tools: [
+    {
+      name: TOOL_NAMES.INGEST_FEEDBACK,
+      displayName: "Ingest Feedback",
+      description: "Normalize Jira/Bitbucket/Slack payloads and create a Paperclip issue.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          source: { type: "string", enum: ["jira", "bitbucket", "slack"] },
+          payload: { type: "object" },
+          companyId: { type: "string" },
+          title: { type: "string" },
+          description: { type: "string" },
+          priority: { type: "string", enum: ["critical", "high", "medium", "low"] },
+          labels: {
+            type: "array",
+            items: { type: "string" },
+          },
+          projectId: { type: "string" },
+          goalId: { type: "string" },
+          parentId: { type: "string" },
+          rawPayloadComment: { type: "boolean" },
+        },
+        required: ["source", "payload"],
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-feedback-collection/src/worker.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/src/worker.ts
@@ -1,0 +1,258 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import type { PluginContext, PluginWebhookInput, ToolResult, ToolRunContext } from "@paperclipai/plugin-sdk";
+import { FEEDBACK_PRIORITIES } from "./worker_internal.js";
+import { FEEDBACK_STATE_KEY, normalizeFeedbackPayload } from "./worker_internal.js";
+import { TOOL_NAMES, WEBHOOK_KEYS, type FeedbackSource } from "./constants.js";
+
+type PluginConfig = {
+  defaultCompanyId?: string;
+  defaultProjectId?: string;
+  defaultGoalId?: string;
+  defaultParentId?: string;
+  appendRawPayloadComment?: boolean;
+  webhookAuthSecretRef?: string;
+};
+
+type IngestParams = {
+  source: FeedbackSource;
+  payload: Record<string, unknown>;
+  companyId?: string;
+  title?: string;
+  description?: string;
+  priority?: string;
+  labels?: string[];
+  projectId?: string;
+  goalId?: string;
+  parentId?: string;
+  rawPayloadComment?: boolean;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toPriority(value: unknown): "critical" | "high" | "medium" | "low" {
+  if (typeof value !== "string") return "medium";
+  const normalized = value.trim().toLowerCase();
+  return FEEDBACK_PRIORITIES.has(normalized)
+    ? (normalized as "critical" | "high" | "medium" | "low")
+    : "medium";
+}
+
+function truncate(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 3)}...`;
+}
+
+async function readConfig(ctx: PluginContext): Promise<PluginConfig> {
+  const raw = await ctx.config.get();
+  return {
+    defaultCompanyId: asString(raw.defaultCompanyId),
+    defaultProjectId: asString(raw.defaultProjectId),
+    defaultGoalId: asString(raw.defaultGoalId),
+    defaultParentId: asString(raw.defaultParentId),
+    appendRawPayloadComment: Boolean(raw.appendRawPayloadComment),
+    webhookAuthSecretRef: asString(raw.webhookAuthSecretRef),
+  };
+}
+
+function buildIssueDescription(input: {
+  source: FeedbackSource;
+  normalizedTitle: string;
+  normalizedDescription: string;
+  labels: string[];
+  sourceRef?: string;
+  payload: Record<string, unknown>;
+}): string {
+  const lines = [
+    `Source: ${input.source}`,
+    input.sourceRef ? `Source Ref: ${input.sourceRef}` : undefined,
+    input.labels.length > 0 ? `Labels: ${input.labels.join(", ")}` : undefined,
+    "",
+    input.normalizedDescription,
+    "",
+    "Payload Snapshot:",
+    "```json",
+    truncate(JSON.stringify(input.payload, null, 2), 4000),
+    "```",
+  ].filter((line): line is string => Boolean(line));
+  return lines.join("\n");
+}
+
+async function ingestFeedback(
+  ctx: PluginContext,
+  params: IngestParams,
+  runCtx: Partial<ToolRunContext>,
+): Promise<{ issueId: string; title: string; priority: string; source: FeedbackSource }> {
+  const config = await readConfig(ctx);
+  const source = params.source;
+  const payload = asObject(params.payload);
+  const normalized = normalizeFeedbackPayload(source, payload);
+
+  const companyId =
+    asString(params.companyId) ??
+    asString(runCtx.companyId) ??
+    config.defaultCompanyId;
+  if (!companyId) throw new Error("companyId is required (tool context, params, or plugin config defaultCompanyId)");
+
+  const labels = Array.isArray(params.labels)
+    ? params.labels.filter((label): label is string => typeof label === "string" && label.trim().length > 0)
+    : [];
+
+  const title = asString(params.title) ?? normalized.title;
+  const description = asString(params.description) ?? normalized.description;
+  const priority = toPriority(asString(params.priority) ?? normalized.priority);
+
+  const issue = await ctx.issues.create({
+    companyId,
+    title,
+    description: buildIssueDescription({
+      source,
+      normalizedTitle: title,
+      normalizedDescription: description,
+      labels,
+      sourceRef: normalized.sourceRef,
+      payload,
+    }),
+    priority,
+    projectId: asString(params.projectId) ?? config.defaultProjectId,
+    goalId: asString(params.goalId) ?? config.defaultGoalId,
+    parentId: asString(params.parentId) ?? config.defaultParentId,
+  });
+
+  if (params.rawPayloadComment || config.appendRawPayloadComment) {
+    await ctx.issues.createComment(
+      issue.id,
+      `Raw payload for ${source}:\n\n\`\`\`json\n${truncate(JSON.stringify(payload, null, 2), 6000)}\n\`\`\``,
+      companyId,
+    );
+  }
+
+  await ctx.state.set(
+    { scopeKind: "instance", stateKey: FEEDBACK_STATE_KEY },
+    {
+      issueId: issue.id,
+      source,
+      ingestedAt: new Date().toISOString(),
+      title,
+      priority,
+    },
+  );
+
+  return {
+    issueId: issue.id,
+    title,
+    priority,
+    source,
+  };
+}
+
+async function parseWebhookPayload(input: PluginWebhookInput): Promise<Record<string, unknown>> {
+  if (input.parsedBody && typeof input.parsedBody === "object") {
+    return asObject(input.parsedBody);
+  }
+  if (!input.rawBody) return {};
+  try {
+    return asObject(JSON.parse(input.rawBody));
+  } catch {
+    return {};
+  }
+}
+
+async function authorizeWebhook(ctx: PluginContext, input: PluginWebhookInput): Promise<void> {
+  const config = await readConfig(ctx);
+  if (!config.webhookAuthSecretRef) return;
+
+  const expected = await ctx.secrets.resolve(config.webhookAuthSecretRef);
+  const header = input.headers["x-feedback-token"];
+  const token = Array.isArray(header) ? header[0] : header;
+
+  if (!token || token !== expected) {
+    throw new Error("Unauthorized webhook: invalid x-feedback-token");
+  }
+}
+
+function sourceFromEndpoint(endpointKey: string): FeedbackSource {
+  if (endpointKey === WEBHOOK_KEYS.JIRA) return "jira";
+  if (endpointKey === WEBHOOK_KEYS.BITBUCKET) return "bitbucket";
+  if (endpointKey === WEBHOOK_KEYS.SLACK) return "slack";
+  throw new Error(`Unsupported endpointKey '${endpointKey}'`);
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    pluginContext = ctx;
+    ctx.tools.register(
+      TOOL_NAMES.INGEST_FEEDBACK,
+      {
+        displayName: "Ingest Feedback",
+        description: "Normalize Jira, Bitbucket, or Slack payloads and create a Paperclip issue.",
+        parametersSchema: {
+          type: "object",
+          properties: {
+            source: { type: "string", enum: ["jira", "bitbucket", "slack"] },
+            payload: { type: "object" },
+            companyId: { type: "string" },
+            title: { type: "string" },
+            description: { type: "string" },
+            priority: { type: "string", enum: ["critical", "high", "medium", "low"] },
+            labels: { type: "array", items: { type: "string" } },
+            projectId: { type: "string" },
+            goalId: { type: "string" },
+            parentId: { type: "string" },
+            rawPayloadComment: { type: "boolean" },
+          },
+          required: ["source", "payload"],
+        },
+      },
+      async (params, runCtx): Promise<ToolResult> => {
+        try {
+          const result = await ingestFeedback(ctx, params as IngestParams, runCtx);
+          return {
+            content: `Created issue ${result.issueId} from ${result.source} feedback.`,
+            data: result,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: `Failed to ingest feedback: ${message}`,
+            data: null,
+          };
+        }
+      },
+    );
+  },
+
+  async onWebhook(input) {
+    if (!pluginContext) {
+      throw new Error("Plugin context is not initialized");
+    }
+    await authorizeWebhook(pluginContext, input);
+    const payload = await parseWebhookPayload(input);
+    const source = sourceFromEndpoint(input.endpointKey);
+    await ingestFeedback(
+      pluginContext,
+      {
+        source,
+        payload,
+        companyId: asString(payload.companyId),
+      },
+      {},
+    );
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Feedback Collection plugin ready" };
+  },
+});
+
+let pluginContext: PluginContext | null = null;
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-feedback-collection/src/worker_internal.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/src/worker_internal.ts
@@ -1,0 +1,101 @@
+import type { FeedbackSource } from "./constants.js";
+
+type NormalizedFeedback = {
+  title: string;
+  description: string;
+  priority: "critical" | "high" | "medium" | "low";
+  sourceRef?: string;
+};
+
+export const FEEDBACK_STATE_KEY = "last-feedback-ingest";
+
+export const FEEDBACK_PRIORITIES = new Set([
+  "critical",
+  "high",
+  "medium",
+  "low",
+]);
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizePriority(value: unknown): "critical" | "high" | "medium" | "low" {
+  const raw = asString(value)?.toLowerCase();
+  if (!raw) return "medium";
+  if (raw.includes("blocker") || raw.includes("critical")) return "critical";
+  if (raw.includes("high")) return "high";
+  if (raw.includes("low") || raw.includes("minor") || raw.includes("trivial")) return "low";
+  return "medium";
+}
+
+function pickJira(payload: Record<string, unknown>): NormalizedFeedback {
+  const fields = asObject(payload.fields);
+  const priority = asObject(fields.priority);
+  const issueKey = asString(payload.key);
+  const title = asString(fields.summary) ?? `Jira feedback ${issueKey ?? "(no-key)"}`;
+  const description = asString(fields.description) ?? asString(payload.description) ?? "No description provided.";
+  const sourceRef = issueKey ?? asString(payload.id);
+  return {
+    title,
+    description,
+    sourceRef,
+    priority: normalizePriority(asString(priority.name) ?? asString(fields.priority)),
+  };
+}
+
+function pickBitbucket(payload: Record<string, unknown>): NormalizedFeedback {
+  const pullrequest = asObject(payload.pullrequest);
+  const comment = asObject(payload.comment);
+  const actor = asObject(payload.actor);
+  const links = asObject(pullrequest.links);
+  const html = asObject(links.html);
+
+  const prTitle = asString(pullrequest.title);
+  const commentBody = asString(asObject(comment.content).raw) ?? asString(comment.content);
+  const actorName = asString(actor.display_name) ?? asString(actor.nickname);
+
+  const title = prTitle
+    ? `Bitbucket PR feedback: ${prTitle}`
+    : "Bitbucket feedback";
+  const description = commentBody
+    ? `${commentBody}${actorName ? `\n\nFrom: ${actorName}` : ""}`
+    : "Bitbucket event received without comment payload.";
+
+  return {
+    title,
+    description,
+    sourceRef: asString(html.href) ?? asString(pullrequest.id),
+    priority: "medium",
+  };
+}
+
+function pickSlack(payload: Record<string, unknown>): NormalizedFeedback {
+  const event = asObject(payload.event);
+  const text = asString(event.text) ?? asString(payload.text) ?? "Slack message payload received.";
+  const channel = asString(event.channel) ?? asString(payload.channel);
+  const user = asString(event.user) ?? asString(payload.user);
+  const permalink = asString(payload.permalink);
+
+  return {
+    title: `Slack feedback${channel ? ` (${channel})` : ""}`,
+    description: `${text}${user ? `\n\nFrom: ${user}` : ""}`,
+    sourceRef: permalink ?? asString(event.ts),
+    priority: "medium",
+  };
+}
+
+export function normalizeFeedbackPayload(
+  source: FeedbackSource,
+  payload: Record<string, unknown>,
+): NormalizedFeedback {
+  if (source === "jira") return pickJira(payload);
+  if (source === "bitbucket") return pickBitbucket(payload);
+  return pickSlack(payload);
+}

--- a/packages/plugins/examples/plugin-feedback-collection/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/tests/plugin.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+describe("plugin-feedback-collection", () => {
+  it("ingests Jira feedback through tool call and creates an issue", async () => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+
+    const result = await harness.executeTool(
+      "ingest_feedback",
+      {
+        source: "jira",
+        payload: {
+          key: "ENG-42",
+          fields: {
+            summary: "Build fails on Windows",
+            description: "npm install fails with ENOENT",
+            priority: { name: "High" },
+          },
+        },
+        labels: ["feedback", "jira"],
+      },
+      { companyId: "cmp-1" },
+    );
+
+    expect(result.content).toContain("Created issue");
+
+    const issues = await harness.ctx.issues.list({ companyId: "cmp-1", limit: 20, offset: 0 });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.title).toContain("Build fails on Windows");
+    expect(issues[0]?.priority).toBe("high");
+  });
+
+  it("requires webhook token when webhookAuthSecretRef is configured", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: { defaultCompanyId: "cmp-2", webhookAuthSecretRef: "secrets://feedback-token" },
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(
+      plugin.definition.onWebhook?.({
+        endpointKey: "slack",
+        headers: {},
+        rawBody: JSON.stringify({ text: "No token request" }),
+        requestId: "req-1",
+      }),
+    ).rejects.toThrow("Unauthorized webhook");
+
+    await plugin.definition.onWebhook?.({
+      endpointKey: "slack",
+      headers: { "x-feedback-token": "resolved:secrets://feedback-token" },
+      rawBody: JSON.stringify({ text: "Token ok", companyId: "cmp-2" }),
+      requestId: "req-2",
+    });
+
+    const issues = await harness.ctx.issues.list({ companyId: "cmp-2", limit: 20, offset: 0 });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.title).toContain("Slack feedback");
+  });
+});

--- a/packages/plugins/examples/plugin-feedback-collection/tsconfig.json
+++ b/packages/plugins/examples/plugin-feedback-collection/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2023", "DOM"]
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/plugins/examples/plugin-feedback-collection/vitest.config.ts
+++ b/packages/plugins/examples/plugin-feedback-collection/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -26,6 +26,7 @@ export const AGENT_ADAPTER_TYPES = [
   "http",
   "claude_local",
   "codex_local",
+  "gemini_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,31 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/examples/plugin-agent-activity:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugins/examples/plugin-authoring-smoke-example:
     dependencies:
       '@paperclipai/plugin-sdk':
@@ -300,6 +325,31 @@ importers:
       vitest:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
+  packages/plugins/examples/plugin-decision-surface:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
 
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
@@ -527,6 +577,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      svix:
+        specifier: ^1.24.0
+        version: 1.89.0
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -534,6 +587,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@clerk/clerk-sdk-node':
+        specifier: ^5.0.9
+        version: 5.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svix@1.89.0)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -1021,6 +1077,49 @@ packages:
 
   '@clack/prompts@0.10.1':
     resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
+
+  '@clerk/backend@1.34.0':
+    resolution: {integrity: sha512-9rZ8hQJVpX5KX2bEpiuVXfpjhojQCiqCWADJDdCI0PCeKxn58Ep0JPYiIcczg4VKUc3a7jve9vXylykG2XajLQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      svix: ^1.62.0
+    peerDependenciesMeta:
+      svix:
+        optional: true
+
+  '@clerk/clerk-sdk-node@5.1.6':
+    resolution: {integrity: sha512-KeF5p0XP0gNoCx+YIHrfrkNNADBz8ZabwPAhOiJZ9Wo14r93WlzRA51IE0Qgteej8IpWwnvKu4/MpiV7FFoLqA==}
+    engines: {node: '>=18.17.0'}
+    deprecated: 'January 10 2025 marks the end of support for @clerk/clerk-sdk-node as previously announced in our October 2024 deprecation notice. Express users can migrate to the @clerk/express package. For more information, you can find our changelog here: https://clerk.com/changelog/2025-01-10-node-sdk-eol'
+
+  '@clerk/shared@2.22.0':
+    resolution: {integrity: sha512-VWBeddOJVa3sqUPdvquaaQYw4h5hACSG3EUDOW7eSu2F6W3BXUozyLJQPBJ9C0MuoeHhOe/DeV8x2KqOgxVZaQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/shared@3.47.3':
+    resolution: {integrity: sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@4.101.20':
+    resolution: {integrity: sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==}
+    engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@codemirror/autocomplete@6.20.0':
     resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
@@ -3149,6 +3248,9 @@ packages:
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3823,6 +3925,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -3860,6 +3966,9 @@ packages:
   cssstyle@6.2.0:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
     engines: {node: '>=20'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -4113,6 +4222,9 @@ packages:
     resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
     engines: {node: '>=20'}
 
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -4361,6 +4473,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -4439,6 +4554,9 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4590,6 +4708,10 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4738,6 +4860,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -4756,6 +4881,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -5019,6 +5148,9 @@ packages:
 
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -5478,6 +5610,13 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  snakecase-keys@8.0.1:
+    resolution: {integrity: sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw==}
+    engines: {node: '>=18'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -5501,6 +5640,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   static-browser-server@1.0.3:
     resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
@@ -5558,6 +5700,19 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.89.0:
+    resolution: {integrity: sha512-Yg/5OtdjN3zjWoQSoX+mkauUtLKiW/+DQWKcG2VaEfWoBBB9NmZoKMw7rQQVU5Nn/Wko3kNbo4cvo/ms48d2KQ==}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5633,6 +5788,9 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  tslib@2.4.1:
+    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -5640,6 +5798,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -5737,6 +5899,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -6653,6 +6819,61 @@ snapshots:
       '@clack/core': 0.4.2
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@clerk/backend@1.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svix@1.89.0)':
+    dependencies:
+      '@clerk/shared': 3.47.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/types': 4.101.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      cookie: 1.0.2
+      snakecase-keys: 8.0.1
+      tslib: 2.8.1
+    optionalDependencies:
+      svix: 1.89.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/clerk-sdk-node@5.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svix@1.89.0)':
+    dependencies:
+      '@clerk/backend': 1.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svix@1.89.0)
+      '@clerk/shared': 2.22.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/types': 4.101.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svix
+
+  '@clerk/shared@2.22.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/types': 4.101.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.4.1(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@clerk/shared@3.47.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@clerk/types@4.101.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 3.47.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@codemirror/autocomplete@6.20.0':
     dependencies:
@@ -8967,6 +9188,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@stitches/core@1.2.8': {}
@@ -9641,6 +9864,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.0.2: {}
+
   cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
@@ -9679,6 +9904,8 @@ snapshots:
       '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
       css-tree: 3.2.1
       lru-cache: 11.2.7
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -9939,6 +10166,11 @@ snapshots:
   dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
 
   dotenv@16.6.1: {}
 
@@ -10217,6 +10449,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fast-xml-parser@5.3.6:
@@ -10297,6 +10531,8 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob-to-regexp@0.4.1: {}
 
   gopd@1.2.0: {}
 
@@ -10442,6 +10678,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-cookie@3.0.5: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -10570,6 +10808,10 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
@@ -10585,6 +10827,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  map-obj@4.3.0: {}
 
   markdown-table@3.0.4: {}
 
@@ -11155,6 +11399,11 @@ snapshots:
   negotiator@1.0.0: {}
 
   next-tick@1.1.0: {}
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
 
   node-releases@2.0.27: {}
 
@@ -11766,6 +12015,17 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  snakecase-keys@8.0.1:
+    dependencies:
+      map-obj: 4.3.0
+      snake-case: 3.0.4
+      type-fest: 4.41.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -11784,6 +12044,11 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   static-browser-server@1.0.3:
     dependencies:
@@ -11853,6 +12118,23 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svix@1.89.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
+
+  swr@2.3.4(react@19.2.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
+  swr@2.4.1(react@19.2.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
@@ -11906,6 +12188,8 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
+  tslib@2.4.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -11914,6 +12198,8 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -12011,6 +12297,8 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/examples/plugin-feedback-collection:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
       '@codemirror/lang-javascript':
@@ -5968,46 +5984,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -9566,21 +9542,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -12393,41 +12369,11 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.2.3
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12445,7 +12391,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12470,7 +12416,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12488,7 +12434,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/scripts/promote-skill.sh
+++ b/scripts/promote-skill.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# promote-skill.sh — Push a skill from the paperclip session workspace to
+# claude-private and import it into the Paperclip company skills library.
+#
+# Usage:
+#   ./scripts/promote-skill.sh <skill-name> [--no-git] [--no-import]
+#
+# Environment (required for --no-import=false):
+#   PAPERCLIP_API_URL        defaults to http://127.0.0.1:3100
+#   PAPERCLIP_API_KEY        bearer token
+#   PAPERCLIP_COMPANY_ID     target company
+#
+# Steps:
+#   1. Copy skill from paperclip/skills/<name>/ → claude-private/skills/<name>/
+#   2. Commit + push in claude-private (unless --no-git)
+#   3. POST /api/companies/:companyId/skills/import with local path (unless --no-import)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_PRIVATE="${CLAUDE_PRIVATE_DIR:-"$(dirname "$REPO_ROOT")/claude-private"}"
+API_URL="${PAPERCLIP_API_URL:-http://127.0.0.1:3100}"
+COMPANY_ID="${PAPERCLIP_COMPANY_ID:-}"
+API_KEY="${PAPERCLIP_API_KEY:-}"
+
+NO_GIT=false
+NO_IMPORT=false
+
+usage() {
+  echo "Usage: $0 <skill-name> [--no-git] [--no-import]"
+  echo ""
+  echo "  skill-name   Directory name under paperclip/skills/"
+  echo "  --no-git     Skip commit/push to claude-private"
+  echo "  --no-import  Skip Paperclip company skills import"
+  exit 1
+}
+
+SKILL_NAME=""
+for arg in "$@"; do
+  case "$arg" in
+    --no-git)     NO_GIT=true ;;
+    --no-import)  NO_IMPORT=true ;;
+    --help|-h)    usage ;;
+    -*)           echo "Unknown flag: $arg"; usage ;;
+    *)            SKILL_NAME="$arg" ;;
+  esac
+done
+
+if [[ -z "$SKILL_NAME" ]]; then
+  usage
+fi
+
+SOURCE="$REPO_ROOT/skills/$SKILL_NAME"
+DEST="$CLAUDE_PRIVATE/skills/$SKILL_NAME"
+
+if [[ ! -d "$SOURCE" ]]; then
+  echo "ERROR: skill not found at $SOURCE"
+  exit 1
+fi
+
+if [[ ! -d "$CLAUDE_PRIVATE" ]]; then
+  echo "ERROR: claude-private repo not found at $CLAUDE_PRIVATE"
+  echo "  Set CLAUDE_PRIVATE_DIR env var or clone to $(dirname "$REPO_ROOT")/claude-private"
+  exit 1
+fi
+
+echo "==> Promoting skill: $SKILL_NAME"
+
+# ── Step 1: Sync skill files ──────────────────────────────────────────────────
+echo "  [1/3] Syncing $SOURCE → $DEST"
+mkdir -p "$(dirname "$DEST")"
+rsync -a --delete "$SOURCE/" "$DEST/" 2>/dev/null || {
+  # rsync fallback: plain copy
+  rm -rf "$DEST"
+  cp -r "$SOURCE" "$DEST"
+}
+echo "        Done."
+
+# ── Step 2: Commit + push to claude-private ──────────────────────────────────
+if [[ "$NO_GIT" == "false" ]]; then
+  echo "  [2/3] Committing to claude-private"
+  cd "$CLAUDE_PRIVATE"
+
+  if ! git diff --quiet HEAD -- "skills/$SKILL_NAME" 2>/dev/null || \
+     [[ -n "$(git ls-files --others --exclude-standard "skills/$SKILL_NAME")" ]]; then
+    git add "skills/$SKILL_NAME"
+    git commit -m "$(cat <<EOF
+feat(skills/$SKILL_NAME): promote from session workspace
+
+Auto-promoted by scripts/promote-skill.sh from:
+  $SOURCE
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+EOF
+)"
+    echo "        Committed."
+    if git remote | grep -q origin; then
+      git push origin main
+      echo "        Pushed to origin."
+    else
+      echo "        WARNING: no remote 'origin' — skipping push."
+      echo "        Add remote: git remote add origin https://github.com/anhermon/claude-private.git"
+    fi
+  else
+    echo "        No changes to commit."
+  fi
+  cd "$REPO_ROOT"
+else
+  echo "  [2/3] Skipping git (--no-git)"
+fi
+
+# ── Step 3: Import into Paperclip company skills library ─────────────────────
+if [[ "$NO_IMPORT" == "false" ]]; then
+  echo "  [3/3] Importing into Paperclip skills library"
+
+  if [[ -z "$COMPANY_ID" ]]; then
+    echo "        ERROR: PAPERCLIP_COMPANY_ID is not set"
+    exit 1
+  fi
+  if [[ -z "$API_KEY" ]]; then
+    echo "        ERROR: PAPERCLIP_API_KEY is not set"
+    exit 1
+  fi
+
+  ABS_DEST="$(cd "$DEST" && pwd -W 2>/dev/null || pwd)"
+  RESPONSE=$(curl -sS -X POST "$API_URL/api/companies/$COMPANY_ID/skills/import" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"source\": \"$ABS_DEST\"}")
+
+  if echo "$RESPONSE" | grep -q '"id"'; then
+    echo "        Imported. Response: $RESPONSE"
+  elif echo "$RESPONSE" | grep -q '"error"'; then
+    echo "        WARNING: Import returned error — $RESPONSE"
+    echo "        (Skill may already be installed; try install-update instead)"
+  else
+    echo "        Response: $RESPONSE"
+  fi
+else
+  echo "  [3/3] Skipping import (--no-import)"
+fi
+
+echo ""
+echo "Done. Skill '$SKILL_NAME' promoted to claude-private/skills/$SKILL_NAME"

--- a/server/package.json
+++ b/server/package.json
@@ -74,10 +74,12 @@
     "pino-http": "^10.4.0",
     "pino-pretty": "^13.1.3",
     "sharp": "^0.34.5",
+    "svix": "^1.24.0",
     "ws": "^8.19.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@clerk/clerk-sdk-node": "^5.0.9",
     "@types/express": "^5.0.0",
     "@types/express-serve-static-core": "^5.0.0",
     "@types/jsdom": "^28.0.0",

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -4,6 +4,30 @@ import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-claude-local/server";
 
+function normalizeResolvedCommandForAssert(value: string | null): string | null {
+  if (value == null) return null;
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}
+
+async function rmWithRetry(target: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await fs.rm(target, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (
+        attempt === 9 ||
+        !(error instanceof Error) ||
+        !("code" in error) ||
+        (error as NodeJS.ErrnoException).code !== "EBUSY"
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+}
+
 async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
   const script = `#!/usr/bin/env node
 const fs = require("node:fs");
@@ -25,6 +49,25 @@ console.log(JSON.stringify({ type: "result", session_id: "claude-session-1", res
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeWindowsCommandShim(commandPath: string): Promise<string> {
+  const shimPath = `${commandPath}.cmd`;
+  const escapedCommandPath = commandPath.replaceAll('"', '""');
+  const shim = `@echo off\r\nnode "${escapedCommandPath}" %*\r\n`;
+  await fs.writeFile(shimPath, shim, "utf8");
+  return shimPath;
+}
+
+async function writeFakeClaudeRateLimitedCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "rate_limit_event", rate_limit_info: { status: "rejected", resetsAt: 1775260800, rateLimitType: "seven_day_sonnet", overageStatus: "rejected", overageDisabledReason: "out_of_credits", isUsingOverage: false }, uuid: "4895ab2a-02cc-47a9-b54e-2cbd794731da", session_id: "claude-session-1" }));
+console.log("You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)");
+process.exit(1);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 describe("claude execute", () => {
   it("logs HOME, CLAUDE_CONFIG_DIR, and the resolved executable path in invocation metadata", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-meta-"));
@@ -37,6 +80,8 @@ describe("claude execute", () => {
     await fs.mkdir(binDir, { recursive: true });
     await fs.mkdir(claudeConfigDir, { recursive: true });
     await writeFakeClaudeCommand(commandPath);
+    const resolvedCommandPath =
+      process.platform === "win32" ? await writeWindowsCommandShim(commandPath) : commandPath;
 
     const previousHome = process.env.HOME;
     const previousPath = process.env.PATH;
@@ -82,10 +127,14 @@ describe("claude execute", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.errorMessage).toBeNull();
-      expect(loggedCommand).toBe(commandPath);
+      expect(normalizeResolvedCommandForAssert(loggedCommand)).toBe(
+        normalizeResolvedCommandForAssert(resolvedCommandPath),
+      );
       expect(loggedEnv.HOME).toBe(root);
       expect(loggedEnv.CLAUDE_CONFIG_DIR).toBe(claudeConfigDir);
-      expect(loggedEnv.PAPERCLIP_RESOLVED_COMMAND).toBe(commandPath);
+      expect(normalizeResolvedCommandForAssert(loggedEnv.PAPERCLIP_RESOLVED_COMMAND ?? null)).toBe(
+        normalizeResolvedCommandForAssert(resolvedCommandPath),
+      );
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;
@@ -93,7 +142,57 @@ describe("claude execute", () => {
       else process.env.PATH = previousPath;
       if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
       else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
-      await fs.rm(root, { recursive: true, force: true });
+      await rmWithRetry(root);
     }
   });
+
+  it("classifies rate-limit failures with a dedicated error code", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-rate-limit-"));
+    const workspace = path.join(root, "workspace");
+    const binDir = path.join(root, "bin");
+    const commandPath = path.join(binDir, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(binDir, { recursive: true });
+    await writeFakeClaudeRateLimitedCommand(commandPath);
+    if (process.platform === "win32") {
+      await writeWindowsCommandShim(commandPath);
+    }
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+    try {
+      const result = await execute({
+        runId: "run-rate-limit",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "claude",
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("claude_rate_limited");
+      expect(result.errorMessage).toContain("Claude exited with code 1");
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await rmWithRetry(root);
+    }
+  }, 15000);
 });

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -9,8 +9,10 @@ async function writeFakeGeminiCommand(commandPath: string): Promise<void> {
 const fs = require("node:fs");
 
 const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const stdin = fs.readFileSync(0, "utf8");
 const payload = {
   argv: process.argv.slice(2),
+  stdin,
   paperclipEnvKeys: Object.keys(process.env)
     .filter((key) => key.startsWith("PAPERCLIP_"))
     .sort(),
@@ -39,8 +41,17 @@ console.log(JSON.stringify({
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeWindowsCommandShim(commandPath: string): Promise<string> {
+  const shimPath = `${commandPath}.cmd`;
+  const escapedCommandPath = commandPath.replaceAll('"', '""');
+  const shim = `@echo off\r\nnode "${escapedCommandPath}" %*\r\n`;
+  await fs.writeFile(shimPath, shim, "utf8");
+  return shimPath;
+}
+
 type CapturePayload = {
   argv: string[];
+  stdin: string;
   paperclipEnvKeys: string[];
 };
 
@@ -52,6 +63,8 @@ describe("gemini execute", () => {
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
     await writeFakeGeminiCommand(commandPath);
+    const resolvedCommandPath =
+      process.platform === "win32" ? await writeWindowsCommandShim(commandPath) : commandPath;
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -75,6 +88,7 @@ describe("gemini execute", () => {
         },
         config: {
           command: commandPath,
+          ...(process.platform === "win32" ? { command: resolvedCommandPath } : {}),
           cwd: workspace,
           model: "gemini-2.5-pro",
           env: {
@@ -101,8 +115,9 @@ describe("gemini execute", () => {
       expect(capture.argv).toContain("yolo");
       const promptFlagIndex = capture.argv.indexOf("--prompt");
       const promptArg = promptFlagIndex >= 0 ? capture.argv[promptFlagIndex + 1] : "";
-      expect(promptArg).toContain("Follow the paperclip heartbeat.");
-      expect(promptArg).toContain("Paperclip runtime note:");
+      expect(["", '""']).toContain(promptArg);
+      expect(capture.stdin).toContain("Follow the paperclip heartbeat.");
+      expect(capture.stdin).toContain("Paperclip runtime note:");
       expect(capture.paperclipEnvKeys).toEqual(
         expect.arrayContaining([
           "PAPERCLIP_AGENT_ID",
@@ -134,6 +149,8 @@ describe("gemini execute", () => {
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
     await writeFakeGeminiCommand(commandPath);
+    const resolvedCommandPath =
+      process.platform === "win32" ? await writeWindowsCommandShim(commandPath) : commandPath;
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -145,6 +162,7 @@ describe("gemini execute", () => {
         runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
         config: {
           command: commandPath,
+          ...(process.platform === "win32" ? { command: resolvedCommandPath } : {}),
           cwd: workspace,
           env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
         },

--- a/server/src/__tests__/heartbeat-fallback-chain-execution.test.ts
+++ b/server/src/__tests__/heartbeat-fallback-chain-execution.test.ts
@@ -1,0 +1,325 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { getServerAdapter } from "../adapters/index.ts";
+import type { ServerAdapterModule, AdapterExecutionResult } from "@paperclipai/adapter-utils/server";
+
+vi.mock("../adapters/index.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../adapters/index.ts")>();
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres fallback chain tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat execution fallback chain", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeEach(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-fallback-chain-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  async function seedRunFixture(chainConfig: unknown[]) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Fallback Coder",
+      role: "engineer",
+      status: "paused",
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "claude-3-7-sonnet",
+        adapterFallbackChain: chainConfig,
+      },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {},
+      status: "claimed",
+      runId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId,
+      contextSnapshot: {},
+      startedAt: now,
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    return { companyId, agentId, runId, wakeupRequestId };
+  }
+
+  function mockAdapters(adapters: Record<string, ServerAdapterModule['execute']>) {
+    vi.mocked(getServerAdapter).mockImplementation((type: string) => {
+      const executeMock = adapters[type];
+      if (!executeMock) throw new Error(`Adapter ${type} not mocked`);
+      return {
+        type,
+        execute: executeMock,
+        supportsLocalAgentJwt: false,
+        testEnvironment: vi.fn(),
+      } as unknown as ServerAdapterModule;
+    });
+  }
+
+  it("completes normally without falling back if primary adapter succeeds", async () => {
+    const { runId } = await seedRunFixture([
+      { adapterType: "codex_local", adapterConfig: { model: "gpt-5.4" } }
+    ]);
+    
+    const claudeExecute = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Success",
+    } as AdapterExecutionResult);
+    
+    mockAdapters({ claude_local: claudeExecute });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.executeRun(runId);
+
+    expect(claudeExecute).toHaveBeenCalledOnce();
+    
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("succeeded");
+    
+    // Check events: should NOT have fallback records
+    const events = await db.select().from(heartbeatRunEvents).where(eq(heartbeatRunEvents.runId, runId));
+    const fallbackDecisions = events.filter(e => e.eventType === "adapter.fallback.decision");
+    
+    expect(fallbackDecisions).toHaveLength(1);
+    expect((fallbackDecisions[0]?.payload as Record<string, unknown>)?.fallbackAdapterType).toBe("codex_local");
+    expect(fallbackDecisions[0]?.level).toBe("info"); // no retry needed
+  });
+
+  it("falls back to the first available adapter when primary is rate limited", async () => {
+    const { runId } = await seedRunFixture([
+      { adapterType: "codex_local", adapterConfig: { model: "gpt-5.4" } }
+    ]);
+    
+    const claudeExecute = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      errorCode: "claude_rate_limited",
+      signal: null,
+      timedOut: false,
+      summary: "Rate limited",
+    } as AdapterExecutionResult);
+
+    const codexExecute = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Success on fallback",
+    } as AdapterExecutionResult);
+    
+    mockAdapters({ 
+      claude_local: claudeExecute,
+      codex_local: codexExecute 
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.executeRun(runId);
+
+    expect(claudeExecute).toHaveBeenCalledOnce();
+    expect(codexExecute).toHaveBeenCalledOnce();
+    
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("succeeded");
+    
+    const events = await db.select().from(heartbeatRunEvents).where(eq(heartbeatRunEvents.runId, runId));
+    const fallbacks = events.filter(e => e.eventType === "adapter.fallback");
+    
+    expect(fallbacks).toHaveLength(1);
+    expect((fallbacks[0]?.payload as Record<string, unknown>)?.to).toBe("codex_local");
+  });
+
+  it("exhausts the entire fallback chain if everything is rate limited", async () => {
+    const { runId } = await seedRunFixture([
+      { adapterType: "codex_local", adapterConfig: { model: "gpt-5.4" } },
+      { adapterType: "gemini_local", adapterConfig: { model: "gemini-3.1-pro" } }
+    ]);
+    
+    const rateLimitResponse = {
+      exitCode: 1,
+      errorCode: "claude_rate_limited",
+      signal: null,
+      timedOut: false,
+      summary: "Rate limited",
+    } as AdapterExecutionResult;
+
+    const claudeExecute = vi.fn().mockResolvedValue(rateLimitResponse);
+    const codexExecute = vi.fn().mockResolvedValue(rateLimitResponse);
+    const geminiExecute = vi.fn().mockResolvedValue(rateLimitResponse); // Last one also fails
+    
+    mockAdapters({ 
+      claude_local: claudeExecute,
+      codex_local: codexExecute,
+      gemini_local: geminiExecute
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.executeRun(runId);
+
+    expect(claudeExecute).toHaveBeenCalledOnce();
+    expect(codexExecute).toHaveBeenCalledOnce();
+    expect(geminiExecute).toHaveBeenCalledOnce();
+    
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("claude_rate_limited"); 
+    
+    const events = await db.select().from(heartbeatRunEvents).where(eq(heartbeatRunEvents.runId, runId));
+    const fallbacks = events.filter(e => e.eventType === "adapter.fallback");
+    
+    expect(fallbacks).toHaveLength(2);
+    expect((fallbacks[0]?.payload as Record<string, unknown>)?.to).toBe("codex_local");
+    expect((fallbacks[1]?.payload as Record<string, unknown>)?.to).toBe("gemini_local");
+  });
+
+  it("continues from a failed codex fallback to a later gemini fallback", async () => {
+    const { runId } = await seedRunFixture([
+      { adapterType: "codex_local", adapterConfig: { model: "gpt-5.4" } },
+      { adapterType: "gemini_local", adapterConfig: { model: "gemini-2.5-flash" } },
+    ]);
+
+    const claudeExecute = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      errorCode: "claude_rate_limited",
+      signal: null,
+      timedOut: false,
+      summary: "Primary rate limited",
+    } as AdapterExecutionResult);
+
+    const codexExecute = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      errorCode: "adapter_failed",
+      errorMessage: "Codex command failed",
+      signal: null,
+      timedOut: false,
+      summary: "Codex failed",
+    } as AdapterExecutionResult);
+
+    const geminiExecute = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Gemini succeeded",
+    } as AdapterExecutionResult);
+
+    mockAdapters({
+      claude_local: claudeExecute,
+      codex_local: codexExecute,
+      gemini_local: geminiExecute,
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.executeRun(runId);
+
+    expect(claudeExecute).toHaveBeenCalledOnce();
+    expect(codexExecute).toHaveBeenCalledOnce();
+    expect(geminiExecute).toHaveBeenCalledOnce();
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("succeeded");
+
+    const events = await db.select().from(heartbeatRunEvents).where(eq(heartbeatRunEvents.runId, runId));
+    const fallbacks = events.filter((e) => e.eventType === "adapter.fallback");
+
+    expect(fallbacks).toHaveLength(2);
+    expect((fallbacks[0]?.payload as Record<string, unknown>)?.to).toBe("codex_local");
+    expect((fallbacks[1]?.payload as Record<string, unknown>)?.to).toBe("gemini_local");
+  });
+
+  it("continues to the next fallback when a fallback adapter throws", async () => {
+    const { runId } = await seedRunFixture([
+      { adapterType: "codex_local", adapterConfig: { model: "gpt-5.4" } },
+      { adapterType: "gemini_local", adapterConfig: { model: "gemini-2.5-flash" } },
+    ]);
+
+    const claudeExecute = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      errorCode: "claude_rate_limited",
+      signal: null,
+      timedOut: false,
+      summary: "Primary rate limited",
+    } as AdapterExecutionResult);
+
+    const codexExecute = vi.fn().mockRejectedValue(new Error("Command not found in PATH: \"codex-missing\""));
+
+    const geminiExecute = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Gemini succeeded",
+    } as AdapterExecutionResult);
+
+    mockAdapters({
+      claude_local: claudeExecute,
+      codex_local: codexExecute,
+      gemini_local: geminiExecute,
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.executeRun(runId);
+
+    expect(claudeExecute).toHaveBeenCalledOnce();
+    expect(codexExecute).toHaveBeenCalledOnce();
+    expect(geminiExecute).toHaveBeenCalledOnce();
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("succeeded");
+  });
+});

--- a/server/src/__tests__/heartbeat-rate-limit-fallback.test.ts
+++ b/server/src/__tests__/heartbeat-rate-limit-fallback.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRateLimitFallbackConfig,
+  resolveRateLimitFallbackTarget,
+  shouldUseRateLimitFallback,
+  stripAdapterSessionState,
+} from "../services/heartbeat.js";
+
+describe("heartbeat rate-limit fallback helpers", () => {
+  it("resolves claude -> codex fallback config", () => {
+    expect(
+      resolveRateLimitFallbackTarget("claude_local", {
+        rateLimitFallback: {
+          adapterType: "codex_local",
+          adapterConfig: { model: "gpt-5.4" },
+        },
+      }),
+    ).toEqual({
+      adapterType: "codex_local",
+      adapterConfig: { model: "gpt-5.4" },
+    });
+  });
+
+  it("ignores fallback config for non-claude adapters", () => {
+    expect(
+      resolveRateLimitFallbackTarget("codex_local", {
+        rateLimitFallback: { adapterType: "codex_local" },
+      }),
+    ).toBeNull();
+  });
+
+  it("retries only when the primary result is rate limited", () => {
+    const fallback = { adapterType: "codex_local", adapterConfig: {} };
+
+    expect(
+      shouldUseRateLimitFallback(
+        { errorCode: "claude_rate_limited", timedOut: false, exitCode: 1 },
+        fallback,
+      ),
+    ).toBe(true);
+    expect(
+      shouldUseRateLimitFallback(
+        { errorCode: "claude_auth_required", timedOut: false, exitCode: 1 },
+        fallback,
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseRateLimitFallback(
+        { errorCode: "claude_rate_limited", timedOut: true, exitCode: 1 },
+        fallback,
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseRateLimitFallback(
+        {
+          errorCode: null,
+          errorMessage: "Claude run failed: subtype=success: You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)",
+          resultJson: {
+            result: "You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)",
+          },
+          timedOut: false,
+          exitCode: 1,
+        },
+        fallback,
+      ),
+    ).toBe(true);
+  });
+
+  it("strips incompatible session state from fallback adapter results", () => {
+    expect(
+      stripAdapterSessionState({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        sessionId: "codex-thread-1",
+        sessionDisplayId: "codex-thread-1",
+        sessionParams: { sessionId: "codex-thread-1", cwd: "C:\\work" },
+        clearSession: true,
+        summary: "done",
+      }),
+    ).toEqual({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      sessionId: null,
+      sessionDisplayId: null,
+      sessionParams: null,
+      clearSession: false,
+      summary: "done",
+    });
+  });
+
+  it("builds fallback config from portable shared settings instead of reusing claude-only command fields", () => {
+    expect(
+      buildRateLimitFallbackConfig(
+        {
+          command: "claude",
+          promptTemplate: "Continue",
+          bootstrapPromptTemplate: "Boot",
+          instructionsFilePath: "C:\\agents\\AGENTS.md",
+          cwd: "C:\\repo",
+          env: { PAPERCLIP_TEST: "1" },
+          timeoutSec: 30,
+          graceSec: 15,
+          effort: "max",
+          maxTurnsPerRun: 300,
+          chrome: true,
+          extraArgs: ["--verbose"],
+          paperclipRuntimeSkills: [{ key: "paperclip" }],
+        },
+        {
+          adapterType: "codex_local",
+          adapterConfig: {
+            model: "gpt-5.4",
+          },
+        },
+      ),
+    ).toEqual({
+      promptTemplate: "Continue",
+      bootstrapPromptTemplate: "Boot",
+      instructionsFilePath: "C:\\agents\\AGENTS.md",
+      cwd: "C:\\repo",
+      env: { PAPERCLIP_TEST: "1" },
+      timeoutSec: 30,
+      graceSec: 15,
+      paperclipRuntimeSkills: [{ key: "paperclip" }],
+      model: "gpt-5.4",
+    });
+  });
+});

--- a/server/src/__tests__/heartbeat-rate-limit-fallback.test.ts
+++ b/server/src/__tests__/heartbeat-rate-limit-fallback.test.ts
@@ -1,69 +1,104 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildRateLimitFallbackConfig,
-  resolveRateLimitFallbackTarget,
-  shouldUseRateLimitFallback,
+  buildFallbackConfig,
+  resolveAdapterFallbackChain,
+  isRateLimitError,
+  shouldContinueFallbackChain,
   stripAdapterSessionState,
 } from "../services/heartbeat.js";
 
-describe("heartbeat rate-limit fallback helpers", () => {
-  it("resolves claude -> codex fallback config", () => {
+describe("heartbeat adapter fallback chain helpers", () => {
+  it("resolves multi-step fallback chain", () => {
     expect(
-      resolveRateLimitFallbackTarget("claude_local", {
+      resolveAdapterFallbackChain("claude_local", {
+        adapterFallbackChain: [
+          {
+            adapterType: "codex_local",
+            adapterConfig: { model: "gpt-5.4" },
+            enabled: true,
+          },
+          {
+            adapterType: "gemini_local",
+            adapterConfig: { model: "gemini-3.1-pro" },
+            enabled: true,
+          },
+          {
+            adapterType: "pi_local",
+            adapterConfig: {},
+            enabled: false, // Should be filtered out
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        adapterType: "codex_local",
+        adapterConfig: { model: "gpt-5.4" },
+        enabled: true,
+      },
+      {
+        adapterType: "gemini_local",
+        adapterConfig: { model: "gemini-3.1-pro" },
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("resolves legacy rateLimitFallback into a single-entry chain for backward compat", () => {
+    expect(
+      resolveAdapterFallbackChain("claude_local", {
         rateLimitFallback: {
           adapterType: "codex_local",
           adapterConfig: { model: "gpt-5.4" },
         },
       }),
-    ).toEqual({
-      adapterType: "codex_local",
-      adapterConfig: { model: "gpt-5.4" },
-    });
+    ).toEqual([
+      {
+        adapterType: "codex_local",
+        adapterConfig: { model: "gpt-5.4" },
+        enabled: true,
+      },
+    ]);
   });
 
-  it("ignores fallback config for non-claude adapters", () => {
+  it("allows non-claude primary adapters to have fallbacks", () => {
     expect(
-      resolveRateLimitFallbackTarget("codex_local", {
-        rateLimitFallback: { adapterType: "codex_local" },
+      resolveAdapterFallbackChain("codex_local", {
+        adapterFallbackChain: [
+          { adapterType: "gemini_local", adapterConfig: {} },
+        ],
       }),
-    ).toBeNull();
+    ).toEqual([
+      { adapterType: "gemini_local", adapterConfig: {}, enabled: true },
+    ]);
   });
 
-  it("retries only when the primary result is rate limited", () => {
-    const fallback = { adapterType: "codex_local", adapterConfig: {} };
-
+  it("identifies rate limit and quota errors accurately", () => {
     expect(
-      shouldUseRateLimitFallback(
-        { errorCode: "claude_rate_limited", timedOut: false, exitCode: 1 },
-        fallback,
-      ),
+      isRateLimitError({ errorCode: "claude_rate_limited", timedOut: false, exitCode: 1 }),
     ).toBe(true);
     expect(
-      shouldUseRateLimitFallback(
-        { errorCode: "claude_auth_required", timedOut: false, exitCode: 1 },
-        fallback,
-      ),
+      isRateLimitError({ errorCode: "claude_auth_required", timedOut: false, exitCode: 1 }),
     ).toBe(false);
     expect(
-      shouldUseRateLimitFallback(
-        { errorCode: "claude_rate_limited", timedOut: true, exitCode: 1 },
-        fallback,
-      ),
-    ).toBe(false);
+      isRateLimitError({ errorCode: "claude_rate_limited", timedOut: true, exitCode: 1 }),
+    ).toBe(false); // Timeouts are not treated as rate limits for fallback purposes
     expect(
-      shouldUseRateLimitFallback(
-        {
-          errorCode: null,
-          errorMessage: "Claude run failed: subtype=success: You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)",
-          resultJson: {
-            result: "You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)",
-          },
-          timedOut: false,
-          exitCode: 1,
+      isRateLimitError({
+        errorCode: null,
+        errorMessage: "Claude run failed: subtype=success: You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)",
+        resultJson: {
+          result: "You're out of extra usage · resets Apr 4, 3am (Asia/Jerusalem)",
         },
-        fallback,
-      ),
+        timedOut: false,
+        exitCode: 1,
+      }),
     ).toBe(true);
+  });
+
+  it("continues fallback-chain execution after any failed fallback step", () => {
+    expect(shouldContinueFallbackChain({ exitCode: 1, timedOut: false })).toBe(true);
+    expect(shouldContinueFallbackChain({ exitCode: null, timedOut: true })).toBe(true);
+    expect(shouldContinueFallbackChain({ exitCode: 0, timedOut: false })).toBe(false);
   });
 
   it("strips incompatible session state from fallback adapter results", () => {
@@ -90,9 +125,9 @@ describe("heartbeat rate-limit fallback helpers", () => {
     });
   });
 
-  it("builds fallback config from portable shared settings instead of reusing claude-only command fields", () => {
+  it("builds fallback config from portable shared settings instead of reusing primary-only command fields", () => {
     expect(
-      buildRateLimitFallbackConfig(
+      buildFallbackConfig(
         {
           command: "claude",
           promptTemplate: "Continue",
@@ -125,6 +160,55 @@ describe("heartbeat rate-limit fallback helpers", () => {
       graceSec: 15,
       paperclipRuntimeSkills: [{ key: "paperclip" }],
       model: "gpt-5.4",
+      dangerouslyBypassApprovalsAndSandbox: true,
+      extraArgs: ["--skip-git-repo-check"],
+    });
+  });
+
+  it("adds --skip-git-repo-check to codex fallbacks when the user did not provide it", () => {
+    expect(
+      buildFallbackConfig(
+        {
+          cwd: "C:\\repo",
+        },
+        {
+          adapterType: "codex_local",
+          adapterConfig: {
+            command: "codex",
+            model: "gpt-5.4",
+          },
+        },
+      ),
+    ).toEqual({
+      cwd: "C:\\repo",
+      command: "codex",
+      model: "gpt-5.4",
+      dangerouslyBypassApprovalsAndSandbox: true,
+      extraArgs: ["--skip-git-repo-check"],
+    });
+  });
+
+  it("preserves an explicit codex fallback sandbox choice instead of forcing bypass", () => {
+    expect(
+      buildFallbackConfig(
+        {
+          cwd: "C:\\repo",
+        },
+        {
+          adapterType: "codex_local",
+          adapterConfig: {
+            command: "codex",
+            model: "gpt-5.4",
+            dangerouslyBypassApprovalsAndSandbox: false,
+          },
+        },
+      ),
+    ).toEqual({
+      cwd: "C:\\repo",
+      command: "codex",
+      model: "gpt-5.4",
+      dangerouslyBypassApprovalsAndSandbox: false,
+      extraArgs: ["--skip-git-repo-check"],
     });
   });
 });

--- a/server/src/__tests__/local-service-supervisor.test.ts
+++ b/server/src/__tests__/local-service-supervisor.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findAdoptableLocalService,
+  readLocalServiceRegistryRecord,
+  writeLocalServiceRegistryRecord,
+} from "../services/local-service-supervisor.ts";
+
+const originalPaperclipHome = process.env.PAPERCLIP_HOME;
+const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+
+async function withTempPaperclipHome<T>(fn: (tempHome: string) => Promise<T>) {
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-local-service-"));
+  process.env.PAPERCLIP_HOME = tempHome;
+  process.env.PAPERCLIP_INSTANCE_ID = "test";
+  try {
+    return await fn(tempHome);
+  } finally {
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+  else process.env.PAPERCLIP_HOME = originalPaperclipHome;
+  if (originalPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+  else process.env.PAPERCLIP_INSTANCE_ID = originalPaperclipInstanceId;
+});
+
+describe("findAdoptableLocalService", () => {
+  it("drops stale registry records when the tracked child pid is gone", async () => {
+    await withTempPaperclipHome(async () => {
+      await writeLocalServiceRegistryRecord({
+        version: 1,
+        serviceKey: "paperclip-dev-test",
+        profileKind: "paperclip-dev",
+        serviceName: "paperclip-dev-watch",
+        command: "dev-runner.ts",
+        cwd: "C:\\Users\\User\\paperclip",
+        envFingerprint: "env-fingerprint",
+        port: 3100,
+        url: "http://127.0.0.1:3100",
+        pid: process.pid,
+        processGroupId: null,
+        provider: "local_process",
+        runtimeServiceId: null,
+        reuseKey: null,
+        startedAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        metadata: {
+          childPid: 999_999_999,
+          url: "http://127.0.0.1:3100",
+        },
+      });
+
+      const adopted = await findAdoptableLocalService({
+        serviceKey: "paperclip-dev-test",
+        cwd: "C:\\Users\\User\\paperclip",
+        envFingerprint: "env-fingerprint",
+        port: 3100,
+      });
+
+      expect(adopted).toBeNull();
+      await expect(readLocalServiceRegistryRecord("paperclip-dev-test")).resolves.toBeNull();
+    });
+  });
+});

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { appendStderrExcerpt, formatWorkerFailureMessage } from "../services/plugin-worker-manager.js";
+import {
+  appendStderrExcerpt,
+  formatWorkerFailureMessage,
+  normalizeForkEntrypoint,
+} from "../services/plugin-worker-manager.js";
 
 describe("plugin-worker-manager stderr failure context", () => {
   it("appends worker stderr context to failure messages", () => {
@@ -39,5 +43,17 @@ describe("plugin-worker-manager stderr failure context", () => {
     expect(excerpt).not.toContain("first line");
     expect(excerpt).not.toContain("second line");
     expect(excerpt.length).toBeLessThanOrEqual(8_000);
+  });
+});
+
+describe("normalizeForkEntrypoint", () => {
+  it("converts absolute Windows paths to file URLs", () => {
+    expect(normalizeForkEntrypoint("C:\\plugins\\decision-surface\\dist\\worker.js", "win32"))
+      .toBe("file:///C:/plugins/decision-surface/dist/worker.js");
+  });
+
+  it("keeps non-Windows paths unchanged", () => {
+    expect(normalizeForkEntrypoint("/tmp/plugin/dist/worker.js"))
+      .toBe("/tmp/plugin/dist/worker.js");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -198,6 +198,7 @@ export async function startServer(): Promise<StartedServer> {
     if (!existingUser) {
       await db.insert(authUsers).values({
         id: LOCAL_BOARD_USER_ID,
+        clerkId: "local-board-clerk-id",
         name: LOCAL_BOARD_USER_NAME,
         email: LOCAL_BOARD_USER_EMAIL,
         emailVerified: true,
@@ -500,8 +501,9 @@ export async function startServer(): Promise<StartedServer> {
     authReady = true;
   }
   
-  const listenPort = await detectPort(config.port);
-  if (listenPort !== config.port) {
+  const requestedListenPort = config.port;
+  const listenPort = await detectPort(requestedListenPort);
+  if (listenPort !== requestedListenPort) {
     config.port = listenPort;
   }
   if (resolvedEmbeddedPostgresPort !== null && resolvedEmbeddedPostgresPort !== config.embeddedPostgresPort) {
@@ -531,8 +533,8 @@ export async function startServer(): Promise<StartedServer> {
   });
   const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
   
-  if (listenPort !== config.port) {
-    logger.warn(`Requested port is busy; using next free port (requestedPort=${config.port}, selectedPort=${listenPort})`);
+  if (listenPort !== requestedListenPort) {
+    logger.warn(`Requested port is busy; using next free port (requestedPort=${requestedListenPort}, selectedPort=${listenPort})`);
   }
   
   const runtimeListenHost = config.host;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -51,6 +51,7 @@ import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { runClaudeLogin } from "@paperclipai/adapter-claude-local/server";
+import { DEFAULT_CLAUDE_LOCAL_MODEL } from "@paperclipai/adapter-claude-local";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
@@ -383,6 +384,10 @@ export function agentRoutes(db: Db) {
     adapterConfig: Record<string, unknown>,
   ): Record<string, unknown> {
     const next = { ...adapterConfig };
+    if (adapterType === "claude_local" && !asNonEmptyString(next.model)) {
+      next.model = DEFAULT_CLAUDE_LOCAL_MODEL;
+      return ensureGatewayDeviceKey(adapterType, next);
+    }
     if (adapterType === "codex_local") {
       if (!asNonEmptyString(next.model)) {
         next.model = DEFAULT_CODEX_LOCAL_MODEL;

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -147,6 +147,14 @@ const BUNDLED_PLUGIN_EXAMPLES: AvailablePluginExample[] = [
     localPath: "packages/plugins/examples/plugin-decision-surface",
     tag: "example",
   },
+  {
+    packageName: "@paperclipai/plugin-feedback-collection",
+    pluginKey: "paperclip.feedback-collection",
+    displayName: "Feedback Collection",
+    description: "Ingests Jira, Bitbucket, and Slack feedback payloads into normalized Paperclip issues via tool calls or webhooks.",
+    localPath: "packages/plugins/examples/plugin-feedback-collection",
+    tag: "example",
+  },
 ];
 
 function listBundledPluginExamples(): AvailablePluginExample[] {

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -139,6 +139,14 @@ const BUNDLED_PLUGIN_EXAMPLES: AvailablePluginExample[] = [
     localPath: "packages/plugins/examples/plugin-kitchen-sink-example",
     tag: "example",
   },
+  {
+    packageName: "@paperclipai/plugin-decision-surface",
+    pluginKey: "paperclip.decision-surface",
+    displayName: "Decision Surface",
+    description: "Surfaces pending approvals and blocked issues in a single decision queue. Provides a `decisions` tool for agents, a dashboard widget, and a full /decisions page. Auto-unblocks issues after approvals resolve.",
+    localPath: "packages/plugins/examples/plugin-decision-surface",
+    tag: "example",
+  },
 ];
 
 function listBundledPluginExamples(): AvailablePluginExample[] {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -309,6 +309,25 @@ type SessionCompactionDecision = {
   previousRunId: string | null;
 };
 
+export type RateLimitFallbackTarget = {
+  adapterType: string;
+  adapterConfig: Record<string, unknown>;
+};
+
+const PORTABLE_RATE_LIMIT_FALLBACK_CONFIG_KEYS = [
+  "bootstrapPromptTemplate",
+  "cwd",
+  "env",
+  "graceSec",
+  "instructionsFilePath",
+  "paperclipRuntimeSkills",
+  "paperclipSkillSync",
+  "promptTemplate",
+  "timeoutSec",
+  "workspaceRuntime",
+  "workspaceStrategy",
+] as const;
+
 interface ParsedIssueAssigneeAdapterOverrides {
   adapterConfig: Record<string, unknown> | null;
   useProjectWorkspace: boolean | null;
@@ -636,6 +655,80 @@ export function formatRuntimeWorkspaceWarningLog(warning: string) {
   return {
     stream: "stdout" as const,
     chunk: `[paperclip] ${warning}\n`,
+  };
+}
+
+export function resolveRateLimitFallbackTarget(
+  primaryAdapterType: string,
+  runtimeConfig: Record<string, unknown>,
+): RateLimitFallbackTarget | null {
+  if (primaryAdapterType !== "claude_local") return null;
+
+  const fallback = parseObject(runtimeConfig.rateLimitFallback);
+  if (Object.keys(fallback).length === 0) return null;
+  if (fallback.enabled === false) return null;
+
+  const adapterType = readNonEmptyString(fallback.adapterType);
+  if (adapterType !== "codex_local") return null;
+
+  return {
+    adapterType,
+    adapterConfig: parseObject(fallback.adapterConfig),
+  };
+}
+
+export function shouldUseRateLimitFallback(
+  result: Pick<AdapterExecutionResult, "errorCode" | "errorMessage" | "resultJson" | "timedOut" | "exitCode">,
+  fallback: RateLimitFallbackTarget | null,
+): fallback is RateLimitFallbackTarget {
+  if (!fallback) return false;
+  if (result.timedOut) return false;
+  if ((result.exitCode ?? 0) === 0) return false;
+  if (result.errorCode === "claude_rate_limited") return true;
+
+  const resultJson = parseObject(result.resultJson);
+  const errorMessage = [
+    readNonEmptyString(result.errorMessage),
+    readNonEmptyString(resultJson.result),
+    readNonEmptyString(resultJson.error),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n")
+    .toLowerCase();
+  return (
+    errorMessage.includes("rate limit") ||
+    errorMessage.includes("out of extra usage") ||
+    errorMessage.includes("too many requests") ||
+    errorMessage.includes("quota exceeded") ||
+    errorMessage.includes("usage limit")
+  );
+}
+
+export function stripAdapterSessionState(result: AdapterExecutionResult): AdapterExecutionResult {
+  return {
+    ...result,
+    sessionId: null,
+    sessionParams: null,
+    sessionDisplayId: null,
+    clearSession: false,
+  };
+}
+
+export function buildRateLimitFallbackConfig(
+  primaryRuntimeConfig: Record<string, unknown>,
+  fallback: RateLimitFallbackTarget,
+): Record<string, unknown> {
+  const portableConfig = Object.fromEntries(
+    PORTABLE_RATE_LIMIT_FALLBACK_CONFIG_KEYS.flatMap((key) =>
+      Object.prototype.hasOwnProperty.call(primaryRuntimeConfig, key)
+        ? [[key, primaryRuntimeConfig[key]]]
+        : [],
+    ),
+  );
+
+  return {
+    ...portableConfig,
+    ...fallback.adapterConfig,
   };
 }
 
@@ -1539,6 +1632,35 @@ export function heartbeatService(db: Db) {
         payload: sanitizedPayload ?? null,
       },
     });
+  }
+
+  async function appendRunEventBestEffort(
+    run: typeof heartbeatRuns.$inferSelect,
+    seq: number,
+    event: {
+      eventType: string;
+      stream?: "system" | "stdout" | "stderr";
+      level?: "info" | "warn" | "error";
+      color?: string;
+      message?: string;
+      payload?: Record<string, unknown>;
+    },
+    contextLabel: string,
+  ) {
+    try {
+      await appendRunEvent(run, seq, event);
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          runId: run.id,
+          agentId: run.agentId,
+          eventType: event.eventType,
+          contextLabel,
+        },
+        "heartbeat run event append failed; continuing",
+      );
+    }
   }
 
   async function nextRunEventSeq(runId: string) {
@@ -2600,16 +2722,21 @@ export function heartbeatService(db: Db) {
             if (key in meta.env) meta.env[key] = "***REDACTED***";
           }
         }
-        await appendRunEvent(currentRun, seq++, {
+        const eventSeq = seq++;
+        await appendRunEventBestEffort(currentRun, eventSeq, {
           eventType: "adapter.invoke",
           stream: "system",
           level: "info",
           message: "adapter invocation",
           payload: meta as unknown as Record<string, unknown>,
-        });
+        }, "adapter.invoke");
       };
 
       const adapter = getServerAdapter(agent.adapterType);
+      const rateLimitFallback =
+        resolveRateLimitFallbackTarget(agent.adapterType, mergedConfig) ??
+        resolveRateLimitFallbackTarget(agent.adapterType, parseObject(agent.adapterConfig)) ??
+        resolveRateLimitFallbackTarget(agent.adapterType, executionRunConfig);
       const authToken = adapter.supportsLocalAgentJwt
         ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
         : null;
@@ -2624,7 +2751,8 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
-      const adapterResult = await adapter.execute({
+      let executedAdapterType = agent.adapterType;
+      let adapterResult = await adapter.execute({
         runId: run.id,
         agent,
         runtime: runtimeForAdapter,
@@ -2637,10 +2765,90 @@ export function heartbeatService(db: Db) {
         },
         authToken: authToken ?? undefined,
       });
+      const shouldFallback = shouldUseRateLimitFallback(adapterResult, rateLimitFallback);
+      if (rateLimitFallback) {
+        const eventSeq = seq++;
+        await appendRunEventBestEffort(currentRun, eventSeq, {
+          eventType: "adapter.fallback.decision",
+          stream: "system",
+          level: shouldFallback ? "warn" : "info",
+          message: shouldFallback
+            ? `fallback decision: retry with ${rateLimitFallback.adapterType}`
+            : "fallback decision: no retry",
+          payload: {
+            configured: true,
+            fallbackAdapterType: rateLimitFallback.adapterType,
+            errorCode: adapterResult.errorCode ?? null,
+            errorMessage: adapterResult.errorMessage ?? null,
+            exitCode: adapterResult.exitCode ?? null,
+            timedOut: adapterResult.timedOut,
+          },
+        }, "adapter.fallback.decision");
+      }
+      if (shouldFallback) {
+        const fallbackAdapter = getServerAdapter(rateLimitFallback.adapterType);
+        const fallbackConfig = buildRateLimitFallbackConfig(runtimeConfig, rateLimitFallback);
+        const fallbackAuthToken = fallbackAdapter.supportsLocalAgentJwt
+          ? createLocalAgentJwt(agent.id, agent.companyId, rateLimitFallback.adapterType, run.id)
+          : null;
+        if (fallbackAdapter.supportsLocalAgentJwt && !fallbackAuthToken) {
+          logger.warn(
+            {
+              companyId: agent.companyId,
+              agentId: agent.id,
+              runId: run.id,
+              adapterType: rateLimitFallback.adapterType,
+            },
+            "local agent jwt secret missing or invalid for fallback adapter; running without injected PAPERCLIP_API_KEY",
+          );
+        }
+        const eventSeq = seq++;
+        await appendRunEventBestEffort(currentRun, eventSeq, {
+          eventType: "adapter.fallback",
+          stream: "system",
+          level: "warn",
+          message: `primary adapter rate limited; retrying with ${rateLimitFallback.adapterType}`,
+          payload: {
+            from: agent.adapterType,
+            to: rateLimitFallback.adapterType,
+            reason: adapterResult.errorCode,
+          },
+        }, "adapter.fallback");
+        await onLog(
+          "stdout",
+          `[paperclip] ${agent.adapterType} hit a rate limit; retrying this heartbeat with ${rateLimitFallback.adapterType}.\n`,
+        );
+        const fallbackAgent = {
+          ...agent,
+          adapterType: rateLimitFallback.adapterType,
+          adapterConfig: fallbackConfig,
+        };
+        const fallbackRuntime = {
+          ...runtimeForAdapter,
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+        };
+        const fallbackResult = await fallbackAdapter.execute({
+          runId: run.id,
+          agent: fallbackAgent,
+          runtime: fallbackRuntime,
+          config: fallbackConfig,
+          context,
+          onLog,
+          onMeta: onAdapterMeta,
+          onSpawn: async (meta) => {
+            await persistRunProcessMetadata(run.id, meta);
+          },
+          authToken: fallbackAuthToken ?? undefined,
+        });
+        executedAdapterType = rateLimitFallback.adapterType;
+        adapterResult = stripAdapterSessionState(fallbackResult);
+      }
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,
-            adapterType: agent.adapterType,
+            adapterType: executedAdapterType,
             runId: run.id,
             agent: {
               id: agent.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -309,12 +309,16 @@ type SessionCompactionDecision = {
   previousRunId: string | null;
 };
 
-export type RateLimitFallbackTarget = {
+export type AdapterFallbackChainEntry = {
   adapterType: string;
   adapterConfig: Record<string, unknown>;
+  enabled?: boolean;
 };
 
-const PORTABLE_RATE_LIMIT_FALLBACK_CONFIG_KEYS = [
+/** @deprecated Use AdapterFallbackChainEntry instead */
+export type RateLimitFallbackTarget = AdapterFallbackChainEntry;
+
+const PORTABLE_FALLBACK_CONFIG_KEYS = [
   "bootstrapPromptTemplate",
   "cwd",
   "env",
@@ -510,6 +514,11 @@ function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
   };
 }
 
+function describeAdapterExecutionError(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) return error.message;
+  return String(error);
+}
+
 function deriveNormalizedUsageDelta(current: UsageTotals | null, previous: UsageTotals | null): UsageTotals | null {
   if (!current) return null;
   if (!previous) return { ...current };
@@ -658,30 +667,92 @@ export function formatRuntimeWorkspaceWarningLog(warning: string) {
   };
 }
 
+/**
+ * Read the legacy single-entry rateLimitFallback from a config object.
+ * Returns a 1-entry chain or empty array. Backward-compatible: no adapter restriction.
+ */
+function readLegacyRateLimitFallback(
+  runtimeConfig: Record<string, unknown>,
+): AdapterFallbackChainEntry[] {
+  const fallback = parseObject(runtimeConfig.rateLimitFallback);
+  if (Object.keys(fallback).length === 0) return [];
+  if (fallback.enabled === false) return [];
+
+  const adapterType = readNonEmptyString(fallback.adapterType);
+  if (!adapterType) return [];
+
+  return [{
+    adapterType,
+    adapterConfig: parseObject(fallback.adapterConfig),
+    enabled: true,
+  }];
+}
+
+/**
+ * Read the new adapterFallbackChain array from a config object.
+ * Each entry must have a valid adapterType. Entries with enabled=false are filtered out.
+ */
+function readAdapterFallbackChainConfig(
+  runtimeConfig: Record<string, unknown>,
+): AdapterFallbackChainEntry[] {
+  const raw = runtimeConfig.adapterFallbackChain;
+  if (!Array.isArray(raw)) return [];
+
+  const entries: AdapterFallbackChainEntry[] = [];
+  for (const item of raw) {
+    const entry = parseObject(item);
+    if (entry.enabled === false) continue;
+    const adapterType = readNonEmptyString(entry.adapterType);
+    if (!adapterType) continue;
+    entries.push({
+      adapterType,
+      adapterConfig: parseObject(entry.adapterConfig),
+      enabled: true,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Resolve the adapter fallback chain from multiple config sources.
+ * Tries adapterFallbackChain first, then falls back to legacy rateLimitFallback.
+ * No adapter-type restriction — any adapter can have any fallback chain.
+ */
+export function resolveAdapterFallbackChain(
+  _primaryAdapterType: string,
+  ...configs: Record<string, unknown>[]
+): AdapterFallbackChainEntry[] {
+  for (const cfg of configs) {
+    const chain = readAdapterFallbackChainConfig(cfg);
+    if (chain.length > 0) return chain;
+  }
+  // Fall back to legacy single-entry format
+  for (const cfg of configs) {
+    const legacy = readLegacyRateLimitFallback(cfg);
+    if (legacy.length > 0) return legacy;
+  }
+  return [];
+}
+
+/**
+ * @deprecated Use resolveAdapterFallbackChain instead.
+ * Kept for backward-compat with existing tests during migration.
+ */
 export function resolveRateLimitFallbackTarget(
   primaryAdapterType: string,
   runtimeConfig: Record<string, unknown>,
-): RateLimitFallbackTarget | null {
-  if (primaryAdapterType !== "claude_local") return null;
-
-  const fallback = parseObject(runtimeConfig.rateLimitFallback);
-  if (Object.keys(fallback).length === 0) return null;
-  if (fallback.enabled === false) return null;
-
-  const adapterType = readNonEmptyString(fallback.adapterType);
-  if (adapterType !== "codex_local") return null;
-
-  return {
-    adapterType,
-    adapterConfig: parseObject(fallback.adapterConfig),
-  };
+): AdapterFallbackChainEntry | null {
+  const chain = resolveAdapterFallbackChain(primaryAdapterType, runtimeConfig);
+  return chain.length > 0 ? chain[0]! : null;
 }
 
-export function shouldUseRateLimitFallback(
+/**
+ * Check if a fallback should be attempted based on the adapter result.
+ * Returns true when the result indicates a rate-limit or quota error.
+ */
+export function isRateLimitError(
   result: Pick<AdapterExecutionResult, "errorCode" | "errorMessage" | "resultJson" | "timedOut" | "exitCode">,
-  fallback: RateLimitFallbackTarget | null,
-): fallback is RateLimitFallbackTarget {
-  if (!fallback) return false;
+): boolean {
   if (result.timedOut) return false;
   if ((result.exitCode ?? 0) === 0) return false;
   if (result.errorCode === "claude_rate_limited") return true;
@@ -704,6 +775,31 @@ export function shouldUseRateLimitFallback(
   );
 }
 
+export function shouldContinueFallbackChain(
+  result: Pick<AdapterExecutionResult, "timedOut" | "exitCode">,
+): boolean {
+  if (result.timedOut) return true;
+  return result.exitCode !== 0;
+}
+
+function describeFallbackReason(result: Pick<AdapterExecutionResult, "timedOut" | "errorCode">): string {
+  if (result.timedOut) return "timed out";
+  if (isRateLimitError({ ...result, exitCode: 1 })) return "hit a rate limit";
+  return "failed";
+}
+
+/**
+ * @deprecated Use isRateLimitError instead.
+ * Kept for backward-compat with existing tests.
+ */
+export function shouldUseRateLimitFallback(
+  result: Pick<AdapterExecutionResult, "errorCode" | "errorMessage" | "resultJson" | "timedOut" | "exitCode">,
+  fallback: AdapterFallbackChainEntry | null,
+): fallback is AdapterFallbackChainEntry {
+  if (!fallback) return false;
+  return isRateLimitError(result);
+}
+
 export function stripAdapterSessionState(result: AdapterExecutionResult): AdapterExecutionResult {
   return {
     ...result,
@@ -714,22 +810,50 @@ export function stripAdapterSessionState(result: AdapterExecutionResult): Adapte
   };
 }
 
-export function buildRateLimitFallbackConfig(
+export function buildFallbackConfig(
   primaryRuntimeConfig: Record<string, unknown>,
-  fallback: RateLimitFallbackTarget,
+  fallback: AdapterFallbackChainEntry,
 ): Record<string, unknown> {
   const portableConfig = Object.fromEntries(
-    PORTABLE_RATE_LIMIT_FALLBACK_CONFIG_KEYS.flatMap((key) =>
+    PORTABLE_FALLBACK_CONFIG_KEYS.flatMap((key) =>
       Object.prototype.hasOwnProperty.call(primaryRuntimeConfig, key)
         ? [[key, primaryRuntimeConfig[key]]]
         : [],
     ),
   );
 
-  return {
-    ...portableConfig,
+  const adapterSpecificConfig = {
     ...fallback.adapterConfig,
   };
+  if (fallback.adapterType === "codex_local") {
+    if (
+      typeof adapterSpecificConfig.dangerouslyBypassApprovalsAndSandbox !== "boolean" &&
+      typeof adapterSpecificConfig.dangerouslyBypassSandbox !== "boolean"
+    ) {
+      adapterSpecificConfig.dangerouslyBypassApprovalsAndSandbox = true;
+    }
+    const extraArgs = Array.isArray(adapterSpecificConfig.extraArgs)
+      ? adapterSpecificConfig.extraArgs.filter((value): value is string => typeof value === "string")
+      : [];
+    if (!extraArgs.includes("--skip-git-repo-check")) {
+      adapterSpecificConfig.extraArgs = [...extraArgs, "--skip-git-repo-check"];
+    }
+  }
+
+  return {
+    ...portableConfig,
+    ...adapterSpecificConfig,
+  };
+}
+
+/**
+ * @deprecated Use buildFallbackConfig instead.
+ */
+export function buildRateLimitFallbackConfig(
+  primaryRuntimeConfig: Record<string, unknown>,
+  fallback: AdapterFallbackChainEntry,
+): Record<string, unknown> {
+  return buildFallbackConfig(primaryRuntimeConfig, fallback);
 }
 
 function describeSessionResetReason(
@@ -2726,17 +2850,18 @@ export function heartbeatService(db: Db) {
         await appendRunEventBestEffort(currentRun, eventSeq, {
           eventType: "adapter.invoke",
           stream: "system",
-          level: "info",
+        level: "info",
           message: "adapter invocation",
           payload: meta as unknown as Record<string, unknown>,
         }, "adapter.invoke");
       };
-
       const adapter = getServerAdapter(agent.adapterType);
-      const rateLimitFallback =
-        resolveRateLimitFallbackTarget(agent.adapterType, mergedConfig) ??
-        resolveRateLimitFallbackTarget(agent.adapterType, parseObject(agent.adapterConfig)) ??
-        resolveRateLimitFallbackTarget(agent.adapterType, executionRunConfig);
+      const fallbackChain = resolveAdapterFallbackChain(
+        agent.adapterType,
+        mergedConfig,
+        parseObject(agent.adapterConfig),
+        executionRunConfig,
+      );
       const authToken = adapter.supportsLocalAgentJwt
         ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
         : null;
@@ -2765,31 +2890,43 @@ export function heartbeatService(db: Db) {
         },
         authToken: authToken ?? undefined,
       });
-      const shouldFallback = shouldUseRateLimitFallback(adapterResult, rateLimitFallback);
-      if (rateLimitFallback) {
-        const eventSeq = seq++;
-        await appendRunEventBestEffort(currentRun, eventSeq, {
+
+      // --- Adapter fallback chain ---
+      // Iterate through configured fallback adapters on rate-limit/quota errors.
+      // Each step: try the fallback adapter; if it also hits rate limits, continue to next.
+      let previousAdapterType = agent.adapterType;
+      let shouldAttemptFallback = isRateLimitError(adapterResult);
+      for (let chainIdx = 0; chainIdx < fallbackChain.length; chainIdx++) {
+        const chainEntry = fallbackChain[chainIdx]!;
+
+        // Log the fallback decision for this chain entry
+        const decisionSeq = seq++;
+        await appendRunEventBestEffort(currentRun, decisionSeq, {
           eventType: "adapter.fallback.decision",
           stream: "system",
-          level: shouldFallback ? "warn" : "info",
-          message: shouldFallback
-            ? `fallback decision: retry with ${rateLimitFallback.adapterType}`
-            : "fallback decision: no retry",
+          level: shouldAttemptFallback ? "warn" : "info",
+          message: shouldAttemptFallback
+            ? `fallback decision: retry with ${chainEntry.adapterType} (chain step ${chainIdx + 1}/${fallbackChain.length})`
+            : `fallback decision: no retry needed (chain step ${chainIdx + 1}/${fallbackChain.length})`,
           payload: {
             configured: true,
-            fallbackAdapterType: rateLimitFallback.adapterType,
+            chainIndex: chainIdx,
+            chainLength: fallbackChain.length,
+            fallbackAdapterType: chainEntry.adapterType,
             errorCode: adapterResult.errorCode ?? null,
             errorMessage: adapterResult.errorMessage ?? null,
             exitCode: adapterResult.exitCode ?? null,
             timedOut: adapterResult.timedOut,
           },
         }, "adapter.fallback.decision");
-      }
-      if (shouldFallback) {
-        const fallbackAdapter = getServerAdapter(rateLimitFallback.adapterType);
-        const fallbackConfig = buildRateLimitFallbackConfig(runtimeConfig, rateLimitFallback);
+
+        if (!shouldAttemptFallback) break;
+
+        // Execute the fallback adapter
+        const fallbackAdapter = getServerAdapter(chainEntry.adapterType);
+        const fallbackConfig = buildFallbackConfig(runtimeConfig, chainEntry);
         const fallbackAuthToken = fallbackAdapter.supportsLocalAgentJwt
-          ? createLocalAgentJwt(agent.id, agent.companyId, rateLimitFallback.adapterType, run.id)
+          ? createLocalAgentJwt(agent.id, agent.companyId, chainEntry.adapterType, run.id)
           : null;
         if (fallbackAdapter.supportsLocalAgentJwt && !fallbackAuthToken) {
           logger.warn(
@@ -2797,30 +2934,31 @@ export function heartbeatService(db: Db) {
               companyId: agent.companyId,
               agentId: agent.id,
               runId: run.id,
-              adapterType: rateLimitFallback.adapterType,
+              adapterType: chainEntry.adapterType,
             },
             "local agent jwt secret missing or invalid for fallback adapter; running without injected PAPERCLIP_API_KEY",
           );
         }
-        const eventSeq = seq++;
-        await appendRunEventBestEffort(currentRun, eventSeq, {
+        const fbEventSeq = seq++;
+        await appendRunEventBestEffort(currentRun, fbEventSeq, {
           eventType: "adapter.fallback",
           stream: "system",
           level: "warn",
-          message: `primary adapter rate limited; retrying with ${rateLimitFallback.adapterType}`,
+          message: `${previousAdapterType} ${describeFallbackReason(adapterResult)}; retrying with ${chainEntry.adapterType} (chain step ${chainIdx + 1}/${fallbackChain.length})`,
           payload: {
-            from: agent.adapterType,
-            to: rateLimitFallback.adapterType,
+            from: previousAdapterType,
+            to: chainEntry.adapterType,
+            chainIndex: chainIdx,
             reason: adapterResult.errorCode,
           },
         }, "adapter.fallback");
         await onLog(
           "stdout",
-          `[paperclip] ${agent.adapterType} hit a rate limit; retrying this heartbeat with ${rateLimitFallback.adapterType}.\n`,
+          `[paperclip] ${previousAdapterType} ${describeFallbackReason(adapterResult)}; retrying this heartbeat with ${chainEntry.adapterType} (fallback ${chainIdx + 1}/${fallbackChain.length}).\n`,
         );
         const fallbackAgent = {
           ...agent,
-          adapterType: rateLimitFallback.adapterType,
+          adapterType: chainEntry.adapterType,
           adapterConfig: fallbackConfig,
         };
         const fallbackRuntime = {
@@ -2829,21 +2967,41 @@ export function heartbeatService(db: Db) {
           sessionParams: null,
           sessionDisplayId: null,
         };
-        const fallbackResult = await fallbackAdapter.execute({
-          runId: run.id,
-          agent: fallbackAgent,
-          runtime: fallbackRuntime,
-          config: fallbackConfig,
-          context,
-          onLog,
-          onMeta: onAdapterMeta,
-          onSpawn: async (meta) => {
-            await persistRunProcessMetadata(run.id, meta);
-          },
-          authToken: fallbackAuthToken ?? undefined,
-        });
-        executedAdapterType = rateLimitFallback.adapterType;
+        let fallbackResult: AdapterExecutionResult;
+        try {
+          fallbackResult = await fallbackAdapter.execute({
+            runId: run.id,
+            agent: fallbackAgent,
+            runtime: fallbackRuntime,
+            config: fallbackConfig,
+            context,
+            onLog,
+            onMeta: onAdapterMeta,
+            onSpawn: async (meta) => {
+              await persistRunProcessMetadata(run.id, meta);
+            },
+            authToken: fallbackAuthToken ?? undefined,
+          });
+        } catch (error) {
+          const message = describeAdapterExecutionError(error);
+          await appendRunEventBestEffort(currentRun, seq++, {
+            eventType: "error",
+            stream: "system",
+            level: "error",
+            message,
+          }, "adapter.fallback.error");
+          fallbackResult = {
+            exitCode: null,
+            signal: null,
+            timedOut: false,
+            errorCode: "adapter_failed",
+            errorMessage: message,
+          };
+        }
+        previousAdapterType = chainEntry.adapterType;
+        executedAdapterType = chainEntry.adapterType;
         adapterResult = stripAdapterSessionState(fallbackResult);
+        shouldAttemptFallback = shouldContinueFallbackChain(adapterResult);
       }
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
@@ -4004,6 +4162,7 @@ export function heartbeatService(db: Db) {
     },
 
     getRun,
+    executeRun,
 
     getRuntimeState: async (agentId: string) => {
       const state = await getRuntimeState(agentId);

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -223,6 +223,11 @@ export async function findAdoptableLocalService(input: {
     await removeLocalServiceRegistryRecord(input.serviceKey);
     return null;
   }
+  const childPid = typeof record.metadata?.childPid === "number" ? record.metadata.childPid : null;
+  if (childPid !== null && !isPidAlive(childPid)) {
+    await removeLocalServiceRegistryRecord(input.serviceKey);
+    return null;
+  }
   if (!(await isLikelyMatchingCommand(record))) {
     await removeLocalServiceRegistryRecord(input.serviceKey);
     return null;

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import type {
@@ -926,8 +926,12 @@ export function pluginLoader(
     let raw: unknown;
 
     try {
-      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const mod = await import(manifestPath) as Record<string, unknown>;
+      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests.
+      // On Windows, absolute paths must be file:// URLs for the ESM loader.
+      const importSpecifier = path.isAbsolute(manifestPath)
+        ? pathToFileURL(manifestPath).href
+        : manifestPath;
+      const mod = await import(importSpecifier) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -52,6 +52,10 @@ import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// On Windows, npm is a .cmd batch file and cannot be invoked via execFile
+// without shell:true. Use "npm.cmd" directly on Windows to avoid ENOENT.
+const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -833,7 +837,7 @@ export function pluginLoader(
         // --ignore-scripts prevents preinstall/install/postinstall hooks from
         // executing arbitrary code on the host before manifest validation.
         await execFileAsync(
-          "npm",
+          npmCmd,
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
           { timeout: 120_000 }, // 2 minute timeout for npm install
         );
@@ -1403,7 +1407,7 @@ export function pluginLoader(
       if (existsSync(packageJsonPath)) {
         try {
           await execFileAsync(
-            "npm",
+            npmCmd,
             ["uninstall", plugin.packageName, "--prefix", localPluginDir, "--ignore-scripts"],
             { timeout: 120_000 },
           );

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -21,6 +21,7 @@
 import { fork, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import { pathToFileURL } from "node:url";
 import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
 import {
   JSONRPC_VERSION,
@@ -147,6 +148,19 @@ export function formatWorkerFailureMessage(message: string, stderrExcerpt: strin
   if (!excerpt) return message;
   if (message.includes(excerpt)) return message;
   return `${message}\n\nWorker stderr:\n${excerpt}`;
+}
+
+/**
+ * Node's ESM loader on Windows expects absolute paths as file:// URLs.
+ * Normalize fork entrypoints so ESM workers can boot reliably cross-platform.
+ */
+export function normalizeForkEntrypoint(
+  modulePath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === "win32" && modulePath.match(/^[A-Za-z]:[\\/]/)
+    ? pathToFileURL(modulePath).href
+    : modulePath;
 }
 
 /**
@@ -616,7 +630,7 @@ export function createPluginWorkerHandle(
       TZ: process.env.TZ ?? "UTC",
     };
 
-    const child = fork(options.entrypointPath, [], {
+    const child = fork(normalizeForkEntrypoint(options.entrypointPath), [], {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
       execArgv: options.execArgv ?? [],
       env: workerEnv,

--- a/skills/derive-issues/SKILL.md
+++ b/skills/derive-issues/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: derive-issues
+description: >
+  Analyze the current codebase and generate prioritized improvement issues for Paperclip.
+  Use when you want to extract follow-up work from: TODO/FIXME comments, test gaps,
+  CI failures, refactoring opportunities, missing docs, or post-implementation review.
+  Creates issues directly in Paperclip under a specified parent and goal.
+argument-hint: "[--parent ISSUE-ID] [--dry-run] [focus: tests|docs|ci|refactor|all]"
+---
+
+# Derive Issues Skill
+
+Analyze the current project and produce a prioritized list of improvement issues, then create them in Paperclip.
+
+## When to use
+
+After implementing a feature, merging a PR, or whenever the board asks for the "generate feedback → derive issues" loop. This skill closes the gap between "code exists" and "improvement backlog exists in Paperclip."
+
+## Step 1 — Gather context
+
+Collect the raw signals. Run these in parallel:
+
+```bash
+# Recent commits (understand what just landed)
+git log --oneline -15
+
+# Uncommitted or staged work
+git status --short
+
+# TODO/FIXME/HACK/XXX in source (exclude vendor/node_modules)
+grep -rn "TODO\|FIXME\|HACK\|XXX" --include="*.go" --include="*.ts" --include="*.tsx" --include="*.js" . \
+  | grep -v node_modules | grep -v vendor | grep -v dist | head -40
+
+# Test files — spot which packages have tests and which don't
+find . -name "*_test.go" -o -name "*.spec.ts" -o -name "*.test.ts" 2>/dev/null | grep -v node_modules | sort
+
+# CI config (understand what's being checked)
+cat .github/workflows/*.yml 2>/dev/null | head -80
+
+# Recent CI runs (if gh is available)
+gh run list --limit 5 2>/dev/null || echo "gh not available"
+
+# Coverage report if present
+cat coverage.out 2>/dev/null | tail -5 || echo "no coverage.out"
+
+# Open issues already in Paperclip for this project (avoid duplicates)
+# (Use Paperclip API if PAPERCLIP_API_KEY is set)
+```
+
+Also read key files: README, main entrypoint, any CLAUDE.md.
+
+## Step 2 — Identify gaps
+
+Think systematically across these categories:
+
+| Category | Questions to ask |
+|----------|-----------------|
+| **Tests** | Which packages/modules lack tests? What error paths are untested? Is race detection enabled? Is there a coverage threshold? |
+| **CI/Build** | Are there flaky tests? Missing lint rules? No branch protection? Release pipeline incomplete? |
+| **Docs** | Is the README accurate? Are CLI flags documented? Are span attributes documented for all code paths? |
+| **Code quality** | TODOs in hot paths? Error handling gaps (unchecked errors, missing context propagation)? Magic numbers? |
+| **Features** | What's in the roadmap but not tracked as an issue? What did the last PR intentionally defer? |
+| **Security** | Hardcoded secrets? Missing TLS options? Unvalidated inputs at boundaries? |
+| **Observability** | Missing log levels? No health check? Metrics not tracked? |
+
+## Step 3 — Draft issues
+
+For each identified gap, draft a Paperclip issue with:
+
+```
+Title: <imperative verb> <what> (e.g. "Add race detector to test matrix", "Document --trace-all flag behavior")
+Priority: critical | high | medium | low
+  - critical: breaks builds or causes data loss
+  - high: significant improvement to reliability or correctness
+  - medium: quality of life, coverage, docs
+  - low: nice-to-have, cosmetic
+Description:
+  ## Why
+  (one sentence on the impact or risk if not done)
+
+  ## What
+  (concrete, actionable steps)
+
+  ## Acceptance criteria
+  - [ ] specific, testable condition
+```
+
+Aim for 3–8 issues per run. Do not pad. Each issue must be actionable in one session.
+
+## Step 4 — Parse arguments
+
+From `$ARGUMENTS`:
+
+- `--parent ISSUE-ID` — set as `parentId` on all created issues (e.g. `--parent ANGA-17`)
+- `--dry-run` — print issues but do NOT call the API to create them
+- Focus keywords: `tests`, `docs`, `ci`, `refactor`, `security`, `all` (default: `all`)
+
+If no `--parent` is given, ask the user or check `PAPERCLIP_TASK_ID` for the current issue.
+
+## Step 5 — Create issues in Paperclip
+
+Unless `--dry-run`, create each issue via the Paperclip API. Resolve the parent issue's `goalId` and `projectId` first (GET the parent issue), then post each derived issue.
+
+Use Python urllib (not curl + pipe) for reliability on Windows:
+
+```python
+import json, urllib.request, os
+
+api_key = os.environ['PAPERCLIP_API_KEY']
+api_url = os.environ.get('PAPERCLIP_API_URL', 'http://127.0.0.1:3100')
+company_id = os.environ['PAPERCLIP_COMPANY_ID']
+run_id = os.environ.get('PAPERCLIP_RUN_ID', '')
+
+# 1. Resolve parent issue
+parent_id = '<resolved-from-args>'
+req = urllib.request.Request(
+    f'{api_url}/api/issues/{parent_id}',
+    headers={'Authorization': f'Bearer {api_key}'}
+)
+with urllib.request.urlopen(req) as resp:
+    parent = json.loads(resp.read()).get('issue', {})
+    goal_id = parent.get('goalId')
+    project_id = parent.get('projectId')
+
+# 2. Create each derived issue
+issues_to_create = [
+    # {"title": "...", "priority": "high", "description": "..."},
+]
+
+for issue in issues_to_create:
+    body = {
+        "title": issue["title"],
+        "priority": issue["priority"],
+        "description": issue["description"],
+        "parentId": parent_id,  # resolved UUID or identifier
+        "goalId": goal_id,
+        "projectId": project_id,
+        "status": "todo",
+        "assigneeAgentId": os.environ.get('PAPERCLIP_AGENT_ID'),
+    }
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        f'{api_url}/api/companies/{company_id}/issues',
+        data=data, method='POST',
+        headers={
+            'Authorization': f'Bearer {api_key}',
+            'X-Paperclip-Run-Id': run_id,
+            'Content-Type': 'application/json',
+        }
+    )
+    with urllib.request.urlopen(req) as resp:
+        created = json.loads(resp.read())
+        print(f"Created {created.get('identifier')}: {created.get('title')}")
+```
+
+## Step 6 — Report
+
+After creation, post a summary comment on the parent issue listing all created issues with their identifiers and priorities. Use the standard comment style (links, not bare identifiers).
+
+## Key rules
+
+- **No padding**: if the codebase is clean, say so and create 0–1 issues
+- **No duplicates**: check existing Paperclip issues before creating; skip if similar issue exists
+- **Actionable only**: each issue must be completable in a single agent session
+- **Always set parentId + goalId**: never create orphaned issues

--- a/skills/tradingview/SKILL.md
+++ b/skills/tradingview/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: tradingview
+description: >
+  Fetch market data through the verified stockanalysis.com workflow when asked
+  for TradingView-style price, volume, range, analyst, earnings, and news
+  checks. TradingView itself is egress-blocked in this environment.
+---
+
+# Market Data Browser Skill
+# (TradingView is egress-blocked — stockanalysis.com is the verified working equivalent)
+
+Fetch deep market data per position using Claude in Chrome → stockanalysis.com.
+Covers: price, volume vs avg, 52-week range position, beta, analyst consensus, earnings dates, news headlines, fundamentals.
+
+---
+
+## Verified Working Sources
+
+| Source | URL pattern | What it gives |
+|--------|-------------|---------------|
+| **stockanalysis.com** ✅ | `/stocks/{ticker}/` | Price, volume, 52wk, beta, analyst target, earnings, PE, news |
+| **stockanalysis.com forecast** ✅ | `/stocks/{ticker}/forecast/` | Analyst PT breakdown (low/avg/high), buy/hold/sell split |
+| **stockanalysis.com financials** ✅ | `/stocks/{ticker}/financials/` | Revenue, earnings, margins |
+
+TradingView (tradingview.com) — ❌ egress blocked. Do not attempt.
+Finviz (finviz.com) — ❌ egress blocked. Do not attempt.
+
+---
+
+## Angel's Positions — Ticker Map
+
+| Ticker | URL slug | Priority | Notes |
+|--------|----------|----------|-------|
+| PGY | `/stocks/pgy/` | 1 — highest value ~$39.7K | Israeli AI fintech, speculative |
+| IREN | `/stocks/iren/` | 2 — ~$34.3K | AI infra pivot + BTC mining |
+| GOOG | `/stocks/goog/` | 3 — ~$12.9K | Earnings Apr 23 |
+| AMD | `/stocks/amd/` | 4 — ~$12.2K | Earnings May 5 |
+| NVDA | `/stocks/nvda/` | 5 — ~$9.6K | Just reported (Feb 25) |
+| AMZN | `/stocks/amzn/` | 6 — ~$3.1K | Earnings Apr 30 |
+| ESLT | `/stocks/eslt/` | 7 — TASE | Israeli defense |
+| NVMI | `/stocks/nvmi/` | 8 — TASE | Semiconductor equipment |
+
+---
+
+## Extraction Workflow
+
+### Step 1 — Navigate + wait
+
+```
+navigate("https://stockanalysis.com/stocks/{ticker}/")
+# No explicit sleep needed — page is SSR, content is immediate
+```
+
+### Step 2 — JS extraction (use this exact pattern, it's verified working)
+
+```javascript
+const t = document.body.innerText;
+const pick = (label) => {
+  const i = t.indexOf(label);
+  return i !== -1 ? t.substring(i, i + 120).replace(/\n/g, ' ').trim() : null;
+};
+JSON.stringify({
+  price:    pick('At close:'),
+  volume:   pick('Volume'),
+  range52:  pick('52-Week Range'),
+  beta:     pick('Beta'),
+  target:   pick('Price Target'),
+  earnings: pick('Earnings Date'),
+  pe:       pick('PE Ratio'),
+  fpe:      pick('Forward PE'),
+  marketCap: pick('Market Cap'),
+  revenue:  pick('Revenue (ttm)'),
+});
+```
+
+### Step 3 — Parse results
+
+From the `price` field extract: close price, $ change, % change, date.
+From `volume` extract: today's volume, open price, previous close, day's range.
+From `range52` extract: 52wk low and high → compute % position = (price - low) / (high - low).
+From `beta` extract: beta value and analyst consensus label.
+From `target` extract: analyst target price and % upside.
+From `earnings` extract: next earnings date.
+
+### Step 4 — Get news headlines
+
+Use `get_page_text()` then extract the news section — it's at the bottom of the overview page.
+Take the first 5 headlines (title + date + source). These are the most recent.
+
+---
+
+## Key Metrics to Compute Per Position
+
+| Metric | Formula | Signal |
+|--------|---------|--------|
+| **52wk position** | (price − 52wk low) / (52wk high − 52wk low) | <20% = near bottom; >80% = near top |
+| **Volume conviction** | today vol / avg vol | >1.5x = high conviction; <0.5x = low conviction |
+| **Analyst upside** | (target − price) / price | Prioritize by position size × upside |
+| **P&L impact per 1%** | position_value × 0.01 | IREN: $342/1%, PGY: $397/1% |
+
+Avg volume reference (from historical data, verify if page shows it):
+- IREN avg: ~18–25M shares/day → March 31 vol 32.6M = ~1.5x (HIGH CONVICTION)
+- PGY avg: ~3–5M shares/day → March 31 vol 2.76M = ~0.7x (below avg — LOW CONVICTION)
+- NVDA avg: ~200–250M/day → March 31 vol 225.7M = ~1.0x (normal)
+- GOOG avg: ~25–35M/day → March 31 vol 31.5M = ~1.0x (normal)
+- AMD avg: ~35–55M/day → March 31 vol 42.6M = ~1.0x (normal)
+- AMZN avg: ~40–60M/day → March 31 vol 58.8M = ~1.2x (slightly elevated)
+
+---
+
+## IREN-Specific Context (critical for thesis accuracy)
+
+IREN is NOT simply a Bitcoin miner. Updated thesis as of March 2026:
+- **Pivot to AI infrastructure**: targeting $3.7B in AI Cloud ARR by late 2026
+- **$9.7B Microsoft contract** for AI compute
+- **50,000 Nvidia B300 GPUs** purchased (announced March 4, 2026)
+- **4.5 GW secured power capacity** — 10x what's needed for current $3.4B AI ARR target
+- **MSCI USA Index** addition (Feb 2026) — forced institutional buying
+- **Risk**: $6B ATM equity program = significant dilution risk
+- **Risk**: 91% revenue still from BTC mining; AI ARR is forward-looking
+- BTC price still affects the stock but is no longer the primary thesis driver
+- Correlation to check: NVDA (GPU demand), hyperscaler capex (MSFT/GOOG/AMZN spending)
+
+When scanning IREN news, flag:
+1. GPU delivery updates (B300 deployment timeline)
+2. Microsoft contract execution milestones
+3. ATM program usage (equity issuance = dilution)
+4. BTC price moves (secondary signal now, not primary)
+5. Power capacity additions or delays
+
+## PGY-Specific Context (critical for thesis accuracy)
+
+PGY is near its 52-week low (8.6% of range). Key fundamentals as of March 2026:
+- **Forward PE: 4.06x** — one of the cheapest AI/fintech names by this metric
+- **Revenue TTM: $1.30B +26.1%** — growing, profitable
+- **Net income: $77.28M** — GAAP profitable
+- **8 analysts: Strong Buy, target $34.50** (+196% from $11.65)
+- **High short interest** — significant bearish positioning
+- **Q4 2025**: Beat EPS ($0.80 vs $0.69 est.) but missed revenue — analysts cut forecasts
+- **Capital markets active**: $800M consumer ABS, $450M auto resecuritization, $720M forward flow
+- **Earnings May 6, 2026** — key catalyst
+- **Beta 5.94** — moves violently on sentiment
+
+When scanning PGY news, flag:
+1. Volume vs average (thin float → low-volume moves are suspect)
+2. ABS issuance (confirms capital market access, thesis-validating)
+3. Partner bank additions
+4. CFPB or lending regulation news
+5. Short interest changes
+
+---
+
+## Output Schema
+
+After all tickers processed, produce this structured block:
+
+```
+=== MARKET DATA: {DATE} ===
+
+{TICKER}:
+  close: ${price} ({pct}%)
+  volume: {vol} ({conviction}: {x}x avg)
+  52wk_position: {pct}% of range (${low} – ${high})
+  analyst: {consensus} | target ${target} ({upside}% upside)
+  earnings: {date}
+  beta: {beta}
+  forward_pe: {fpe}
+  headline_1: {title} ({date} – {source})
+  headline_2: {title} ({date} – {source})
+  flag: {any notable signal}
+```
+
+---
+
+## HEATMAP Scoring Guide
+
+Score each dimension 1–5 for the `[!HEATMAP]` component in the report:
+
+| Dimension | 1 | 3 | 5 |
+|-----------|---|---|---|
+| Analyst | Sell | Neutral/Buy | Strong Buy |
+| 52wk pos | >80% (near top) | 40–60% | <20% (near bottom = oversold opportunity) |
+| Conviction | <0.5x avg vol | ~1x | >1.5x avg vol |
+| Valuation | fPE >50x | fPE 20–30x | fPE <10x |
+| Earnings risk | <2 weeks away | 4–8 weeks | Just reported |
+
+Note: For 52wk position, LOW score (1) = near 52wk high (overbought risk), HIGH score (5) = near 52wk low (value opportunity). Invert the intuition — a score of 5 here means "cheap relative to recent range."
+
+---
+
+## Rate Limiting
+
+- stockanalysis.com has no captcha and handles sequential requests fine
+- One tab, navigate sequentially — no parallel tabs needed
+- If a page 404s: try `/stocks/{ticker.lower()}/` then skip with DATA_UNAVAILABLE
+
+---
+
+## Failure Fallback
+
+If stockanalysis.com is unreachable, fall back to:
+1. `https://finance.yahoo.com/quote/{TICKER}` — price + volume + 52wk
+2. WebSearch: `"{TICKER} stock price today site:finance.yahoo.com"`

--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -112,6 +112,31 @@ export function ClaudeLocalAdvancedFields({
             : mark("adapterConfig", "dangerouslySkipPermissions", v)
         }
       />
+      <ToggleField
+        label="Fallback to Codex on rate limit"
+        hint={help.fallbackToCodexOnRateLimit}
+        checked={
+          isCreate
+            ? Boolean(values!.fallbackToCodexOnRateLimit)
+            : eff(
+                "adapterConfig",
+                "rateLimitFallback",
+                typeof config.rateLimitFallback === "object" &&
+                  config.rateLimitFallback !== null &&
+                  !Array.isArray(config.rateLimitFallback) &&
+                  (config.rateLimitFallback as Record<string, unknown>).adapterType === "codex_local",
+              )
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ fallbackToCodexOnRateLimit: v })
+            : mark(
+                "adapterConfig",
+                "rateLimitFallback",
+                v ? { adapterType: "codex_local" } : undefined,
+              )
+        }
+      />
       <Field label="Max turns per run" hint={help.maxTurnsPerRun}>
         {isCreate ? (
           <input

--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -112,31 +112,6 @@ export function ClaudeLocalAdvancedFields({
             : mark("adapterConfig", "dangerouslySkipPermissions", v)
         }
       />
-      <ToggleField
-        label="Fallback to Codex on rate limit"
-        hint={help.fallbackToCodexOnRateLimit}
-        checked={
-          isCreate
-            ? Boolean(values!.fallbackToCodexOnRateLimit)
-            : eff(
-                "adapterConfig",
-                "rateLimitFallback",
-                typeof config.rateLimitFallback === "object" &&
-                  config.rateLimitFallback !== null &&
-                  !Array.isArray(config.rateLimitFallback) &&
-                  (config.rateLimitFallback as Record<string, unknown>).adapterType === "codex_local",
-              )
-        }
-        onChange={(v) =>
-          isCreate
-            ? set!({ fallbackToCodexOnRateLimit: v })
-            : mark(
-                "adapterConfig",
-                "rateLimitFallback",
-                v ? { adapterType: "codex_local" } : undefined,
-              )
-        }
-      />
       <Field label="Max turns per run" hint={help.maxTurnsPerRun}>
         {isCreate ? (
           <input

--- a/ui/src/adapters/transcript.test.ts
+++ b/ui/src/adapters/transcript.test.ts
@@ -27,4 +27,21 @@ describe("buildTranscript", () => {
       { kind: "stderr", ts, text: "stderr /Users/d****/project" },
     ]);
   });
+
+  it("can switch stdout parsers by timestamp", () => {
+    const entries = buildTranscript([
+      { ts: "2026-03-20T13:00:00.000Z", stream: "stdout", chunk: "one\n" },
+      { ts: "2026-03-20T13:01:00.000Z", stream: "stdout", chunk: "two\n" },
+    ], (line, entryTs) => [{ kind: "stdout", ts: entryTs, text: `default:${line}` }], {
+      resolveStdoutParser: (entryTs) =>
+        entryTs < "2026-03-20T13:01:00.000Z"
+          ? (line, ts) => [{ kind: "stdout", ts, text: `claude:${line}` }]
+          : (line, ts) => [{ kind: "stdout", ts, text: `codex:${line}` }],
+    });
+
+    expect(entries).toEqual([
+      { kind: "stdout", ts: "2026-03-20T13:00:00.000Z", text: "claude:one" },
+      { kind: "stdout", ts: "2026-03-20T13:01:00.000Z", text: "codex:two" },
+    ]);
+  });
 });

--- a/ui/src/adapters/transcript.ts
+++ b/ui/src/adapters/transcript.ts
@@ -2,7 +2,10 @@ import { redactHomePathUserSegments, redactTranscriptEntryPaths } from "@papercl
 import type { TranscriptEntry, StdoutLineParser } from "./types";
 
 export type RunLogChunk = { ts: string; stream: "stdout" | "stderr" | "system"; chunk: string };
-type TranscriptBuildOptions = { censorUsernameInLogs?: boolean };
+type TranscriptBuildOptions = {
+  censorUsernameInLogs?: boolean;
+  resolveStdoutParser?: (ts: string) => StdoutLineParser;
+};
 
 export function appendTranscriptEntry(entries: TranscriptEntry[], entry: TranscriptEntry) {
   if ((entry.kind === "thinking" || entry.kind === "assistant") && entry.delta) {
@@ -44,17 +47,19 @@ export function buildTranscript(
     const combined = stdoutBuffer + chunk.chunk;
     const lines = combined.split(/\r?\n/);
     stdoutBuffer = lines.pop() ?? "";
+    const lineParser = opts?.resolveStdoutParser?.(chunk.ts) ?? parser;
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
-      appendTranscriptEntries(entries, parser(trimmed, chunk.ts).map((entry) => redactTranscriptEntryPaths(entry, redactionOptions)));
+      appendTranscriptEntries(entries, lineParser(trimmed, chunk.ts).map((entry) => redactTranscriptEntryPaths(entry, redactionOptions)));
     }
   }
 
   const trailing = stdoutBuffer.trim();
   if (trailing) {
     const ts = chunks.length > 0 ? chunks[chunks.length - 1]!.ts : new Date().toISOString();
-    appendTranscriptEntries(entries, parser(trailing, ts).map((entry) => redactTranscriptEntryPaths(entry, redactionOptions)));
+    const trailingParser = opts?.resolveStdoutParser?.(ts) ?? parser;
+    appendTranscriptEntries(entries, trailingParser(trailing, ts).map((entry) => redactTranscriptEntryPaths(entry, redactionOptions)));
   }
 
   return entries;

--- a/ui/src/components/AdapterFallbackChainEditor.tsx
+++ b/ui/src/components/AdapterFallbackChainEditor.tsx
@@ -1,0 +1,377 @@
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, Plus, Trash2 } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { cn } from "../lib/utils";
+import { queryKeys } from "../lib/queryKeys";
+import { agentsApi } from "../api/agents";
+import { AGENT_ADAPTER_TYPES } from "@paperclipai/shared";
+import { ToggleField, adapterLabels, help } from "./agent-config-primitives";
+import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
+import { extractModelName, extractProviderId } from "../lib/model-utils";
+import type { AdapterFallbackChainEntryConfig } from "@paperclipai/adapter-utils";
+
+interface AdapterFallbackChainEditorProps {
+  companyId: string;
+  chain: AdapterFallbackChainEntryConfig[];
+  onChange: (chain: AdapterFallbackChainEntryConfig[]) => void;
+  primaryAdapterType: string;
+}
+
+const ENABLED_ADAPTER_TYPES = new Set<string>([
+  "claude_local",
+  "codex_local",
+  "gemini_local",
+  "opencode_local",
+  "openclaw_gateway",
+  "process",
+  "http",
+  "pi_local",
+  "hermes_local",
+  "cursor",
+]);
+
+const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [
+  ...AGENT_ADAPTER_TYPES.map((t) => ({
+    value: t,
+    label: adapterLabels[t] ?? t,
+    comingSoon: !ENABLED_ADAPTER_TYPES.has(t),
+  })),
+];
+
+function AdapterSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (type: string) => void;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-[160px] justify-between">
+          <span className="inline-flex items-center gap-1.5 truncate">
+            {value === "opencode_local" ? <OpenCodeLogoIcon className="h-3.5 w-3.5" /> : null}
+            <span className="truncate">{adapterLabels[value] ?? value}</span>
+          </span>
+          <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[160px] p-1" align="start">
+        {ADAPTER_DISPLAY_LIST.map((item) => (
+          <button
+            key={item.value}
+            disabled={item.comingSoon}
+            className={cn(
+              "flex items-center justify-between w-full px-2 py-1.5 text-sm rounded",
+              item.comingSoon
+                ? "opacity-40 cursor-not-allowed"
+                : "hover:bg-accent/50",
+              item.value === value && !item.comingSoon && "bg-accent",
+            )}
+            onClick={() => {
+              if (!item.comingSoon) onChange(item.value);
+            }}
+          >
+            <span className="inline-flex items-center gap-1.5 truncate">
+              {item.value === "opencode_local" ? <OpenCodeLogoIcon className="h-3.5 w-3.5 shrink-0" /> : null}
+              <span className="truncate">{item.label}</span>
+            </span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ModelSelect({
+  companyId,
+  adapterType,
+  value,
+  onChange,
+}: {
+  companyId: string;
+  adapterType: string;
+  value: string;
+  onChange: (model: string) => void;
+}) {
+  const { data: models = [] } = useQuery({
+    queryKey: queryKeys.agents.adapterModels(companyId, adapterType),
+    queryFn: () => agentsApi.adapterModels(companyId, adapterType),
+    enabled: Boolean(companyId && adapterType),
+  });
+
+  const hasModels = models.length > 0;
+  
+  if (adapterType === "process" || adapterType === "http" || adapterType === "openclaw_gateway") {
+    return (
+      <div className="flex-1 opacity-50 px-2.5 py-1.5 text-sm">
+        N/A
+      </div>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button 
+          className="inline-flex flex-1 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors justify-between text-left"
+          disabled={!hasModels}
+        >
+          <span className="text-muted-foreground truncate">
+            {value || (hasModels ? "Select model..." : "No models")}
+          </span>
+          <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[220px] p-1 max-h-[300px] overflow-y-auto" align="start">
+        {models.map((m) => (
+          <button
+            key={m.id}
+            className={cn(
+              "flex flex-col items-start w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50 text-left",
+              m.id === value && "bg-accent"
+            )}
+            onClick={() => onChange(m.id)}
+          >
+            <span className="truncate w-full">{extractModelName(m.id)}</span>
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wider truncate w-full">
+              {extractProviderId(m.id)}
+            </span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function parseExtraArgsInput(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function formatExtraArgsInput(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return value.filter((item): item is string => typeof item === "string").join(", ");
+}
+
+function formatNumberInput(value: unknown): string {
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : "";
+}
+
+function defaultAdapterConfigForType(adapterType: string): Record<string, unknown> {
+  switch (adapterType) {
+    case "codex_local":
+      return {
+        command: "codex",
+        model: "gpt-5.4",
+        extraArgs: ["--skip-git-repo-check"],
+        dangerouslyBypassApprovalsAndSandbox: true,
+      };
+    case "gemini_local":
+      return {
+        command: "gemini",
+        model: "gemini-2.5-flash",
+      };
+    case "claude_local":
+      return {
+        command: "claude",
+        model: "claude-sonnet-4-6",
+      };
+    default:
+      return {};
+  }
+}
+
+export function AdapterFallbackChainEditor({
+  companyId,
+  chain,
+  onChange,
+  primaryAdapterType,
+}: AdapterFallbackChainEditorProps) {
+  function addFallback() {
+    onChange([
+      ...chain,
+      { adapterType: "codex_local", adapterConfig: defaultAdapterConfigForType("codex_local") }
+    ]);
+  }
+
+  function updateFallback(index: number, updates: Partial<AdapterFallbackChainEntryConfig>) {
+    const next = [...chain];
+    next[index] = { ...next[index], ...updates };
+    onChange(next);
+  }
+
+  function removeFallback(index: number) {
+    const next = [...chain];
+    next.splice(index, 1);
+    onChange(next);
+  }
+
+  function moveUp(index: number) {
+    if (index === 0) return;
+    const next = [...chain];
+    const temp = next[index - 1];
+    next[index - 1] = next[index];
+    next[index] = temp;
+    onChange(next);
+  }
+
+  function moveDown(index: number) {
+    if (index === chain.length - 1) return;
+    const next = [...chain];
+    const temp = next[index + 1];
+    next[index + 1] = next[index];
+    next[index] = temp;
+    onChange(next);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">Fallback Adapters</span>
+        <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={addFallback}>
+          <Plus className="h-3 w-3 mr-1" /> Add fallback
+        </Button>
+      </div>
+      
+      {chain.length === 0 ? (
+        <div className="text-xs text-muted-foreground bg-muted/50 rounded-md p-3 text-center border border-dashed border-border">
+          Only primary adapter ({adapterLabels[primaryAdapterType] ?? primaryAdapterType}) will be used.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {chain.map((entry, index) => (
+            <div key={index} className="bg-background border border-border rounded-md p-2 space-y-2">
+              <div className="flex items-center gap-2">
+              <div className="flex flex-col gap-0.5 px-1">
+                <button
+                  type="button"
+                  disabled={index === 0}
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                  onClick={() => moveUp(index)}
+                >
+                  <ChevronDown className="h-3 w-3 rotate-180" />
+                </button>
+                <button
+                  type="button"
+                  disabled={index === chain.length - 1}
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                  onClick={() => moveDown(index)}
+                >
+                  <ChevronDown className="h-3 w-3" />
+                </button>
+              </div>
+              
+              <div className="flex items-center gap-2 flex-1">
+                <AdapterSelect
+                  value={entry.adapterType}
+                  onChange={(t) => updateFallback(index, { adapterType: t, adapterConfig: defaultAdapterConfigForType(t) })}
+                />
+                <ModelSelect
+                  companyId={companyId}
+                  adapterType={entry.adapterType}
+                  value={entry.adapterConfig?.model as string || ""}
+                  onChange={(m) => updateFallback(index, { adapterConfig: { ...entry.adapterConfig, model: m } })}
+                />
+              </div>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-destructive shrink-0 mx-1"
+                onClick={() => removeFallback(index)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 pl-10">
+                <input
+                  className="rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
+                  value={String(entry.adapterConfig?.command ?? "")}
+                  onChange={(e) =>
+                    updateFallback(index, {
+                      adapterConfig: {
+                        ...entry.adapterConfig,
+                        command: e.target.value,
+                      },
+                    })
+                  }
+                  placeholder="command"
+                />
+                <input
+                  className="rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
+                  value={formatExtraArgsInput(entry.adapterConfig?.extraArgs)}
+                  onChange={(e) =>
+                    updateFallback(index, {
+                      adapterConfig: {
+                        ...entry.adapterConfig,
+                        extraArgs: parseExtraArgsInput(e.target.value),
+                      },
+                    })
+                  }
+                  placeholder="extra args, comma-separated"
+                />
+                <input
+                  type="number"
+                  className="rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
+                  value={formatNumberInput(entry.adapterConfig?.timeoutSec)}
+                  onChange={(e) =>
+                    updateFallback(index, {
+                      adapterConfig: {
+                        ...entry.adapterConfig,
+                        timeoutSec: e.target.value === "" ? undefined : Number(e.target.value),
+                      },
+                    })
+                  }
+                  placeholder="timeout seconds"
+                />
+                <input
+                  type="number"
+                  className="rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
+                  value={formatNumberInput(entry.adapterConfig?.graceSec)}
+                  onChange={(e) =>
+                    updateFallback(index, {
+                      adapterConfig: {
+                        ...entry.adapterConfig,
+                        graceSec: e.target.value === "" ? undefined : Number(e.target.value),
+                      },
+                    })
+                  }
+                  placeholder="grace seconds"
+                />
+                {entry.adapterType === "codex_local" ? (
+                  <div className="md:col-span-2 rounded-md border border-border px-2.5 py-2">
+                    <ToggleField
+                      label="Bypass approvals/sandbox"
+                      hint={help.dangerouslyBypassSandbox}
+                      checked={
+                        entry.adapterConfig?.dangerouslyBypassApprovalsAndSandbox !== false &&
+                        entry.adapterConfig?.dangerouslyBypassSandbox !== false
+                      }
+                      onChange={(checked) =>
+                        updateFallback(index, {
+                          adapterConfig: {
+                            ...entry.adapterConfig,
+                            dangerouslyBypassApprovalsAndSandbox: checked,
+                          },
+                        })
+                      }
+                    />
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
 } from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CLAUDE_LOCAL_MODEL } from "@paperclipai/adapter-claude-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import {
@@ -590,6 +591,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
                       nextValues.dangerouslyBypassSandbox =
                         DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+                    } else if (t === "claude_local") {
+                      nextValues.model = DEFAULT_CLAUDE_LOCAL_MODEL;
                     } else if (t === "gemini_local") {
                       nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
                     } else if (t === "cursor") {
@@ -606,7 +609,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       adapterType: t,
                       adapterConfig: {
                         model:
-                          t === "codex_local"
+                          t === "claude_local"
+                            ? DEFAULT_CLAUDE_LOCAL_MODEL
+                            : t === "codex_local"
                             ? DEFAULT_CODEX_LOCAL_MODEL
                             : t === "gemini_local"
                               ? DEFAULT_GEMINI_LOCAL_MODEL

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -47,6 +47,8 @@ import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 import { ReportsToPicker } from "./ReportsToPicker";
 import { shouldShowLegacyWorkingDirectoryField } from "../lib/legacy-agent-config";
+import { AdapterFallbackChainEditor } from "./AdapterFallbackChainEditor";
+import type { AdapterFallbackChainEntryConfig } from "@paperclipai/adapter-utils";
 
 /* ---- Create mode values ---- */
 
@@ -461,6 +463,11 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       heartbeat: mergedHeartbeat,
     };
   }, [isCreate, overlay.heartbeat, runtimeConfig, val]);
+
+  const currentFallbackChain = isCreate
+    ? (val!.adapterFallbackChain ?? [])
+    : eff("adapterConfig", "adapterFallbackChain", Array.isArray(config.adapterFallbackChain) ? config.adapterFallbackChain : (config.rateLimitFallback ? [config.rateLimitFallback] : []) as AdapterFallbackChainEntryConfig[]);
+
   return (
     <div className={cn("relative", cards && "space-y-6")}>
       {/* ---- Floating Save button (edit mode, when dirty) ---- */}
@@ -770,6 +777,24 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     ? fetchedModelsError.message
                     : "Failed to load adapter models."}
                 </p>
+              )}
+
+              {isLocal && (
+                <div className="pt-2 pb-2">
+                  <AdapterFallbackChainEditor
+                    companyId={selectedCompanyId!}
+                    primaryAdapterType={adapterType}
+                    chain={currentFallbackChain}
+                    onChange={(newChain) => {
+                      if (isCreate) {
+                        set!({ adapterFallbackChain: newChain });
+                        return;
+                      }
+                      mark("adapterConfig", "adapterFallbackChain", newChain.length > 0 ? newChain : []);
+                      mark("adapterConfig", "rateLimitFallback", null);
+                    }}
+                  />
+                </div>
               )}
 
               {showThinkingEffort && (

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -26,6 +26,7 @@ export const defaultCreateValues: CreateConfigValues = {
   worktreeParentDir: "",
   runtimeServicesJson: "",
   fallbackToCodexOnRateLimit: false,
+  adapterFallbackChain: [],
   maxTurnsPerRun: 300,
   heartbeatEnabled: false,
   intervalSec: 300,

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -1,11 +1,12 @@
 import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_CLAUDE_LOCAL_MODEL } from "@paperclipai/adapter-claude-local";
 
 export const defaultCreateValues: CreateConfigValues = {
   adapterType: "claude_local",
   cwd: "",
   instructionsFilePath: "",
   promptTemplate: "",
-  model: "",
+  model: DEFAULT_CLAUDE_LOCAL_MODEL,
   thinkingEffort: "",
   chrome: false,
   dangerouslySkipPermissions: true,
@@ -24,6 +25,7 @@ export const defaultCreateValues: CreateConfigValues = {
   workspaceBranchTemplate: "",
   worktreeParentDir: "",
   runtimeServicesJson: "",
+  fallbackToCodexOnRateLimit: false,
   maxTurnsPerRun: 300,
   heartbeatEnabled: false,
   intervalSec: 300,

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -38,6 +38,7 @@ export const help: Record<string, string> = {
   workspaceBranchTemplate: "Template for naming derived branches. Supports {{issue.identifier}}, {{issue.title}}, {{agent.name}}, {{project.id}}, {{workspace.repoRef}}, and {{slug}}.",
   worktreeParentDir: "Directory where derived worktrees should be created. Absolute, ~-prefixed, and repo-relative paths are supported.",
   runtimeServicesJson: "Optional workspace runtime service definitions. Use this for shared app servers, workers, or other long-lived companion processes attached to the workspace.",
+  fallbackToCodexOnRateLimit: "When Claude hits a provider rate limit, retry the heartbeat once with the Codex local adapter instead of failing immediately.",
   maxTurnsPerRun: "Maximum number of agentic turns (tool calls) per heartbeat run.",
   command: "The command to execute (e.g. node, python).",
   localCommand: "Override the path to the CLI command you want the adapter to call (e.g. /usr/local/bin/claude, codex, opencode).",

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -38,7 +38,7 @@ export const help: Record<string, string> = {
   workspaceBranchTemplate: "Template for naming derived branches. Supports {{issue.identifier}}, {{issue.title}}, {{agent.name}}, {{project.id}}, {{workspace.repoRef}}, and {{slug}}.",
   worktreeParentDir: "Directory where derived worktrees should be created. Absolute, ~-prefixed, and repo-relative paths are supported.",
   runtimeServicesJson: "Optional workspace runtime service definitions. Use this for shared app servers, workers, or other long-lived companion processes attached to the workspace.",
-  fallbackToCodexOnRateLimit: "When Claude hits a provider rate limit, retry the heartbeat once with the Codex local adapter instead of failing immediately.",
+  fallbackToCodexOnRateLimit: "Ordered fallback adapters tried after a provider rate limit or fallback adapter failure. Each fallback can override model, command, and extra CLI args.",
   maxTurnsPerRun: "Maximum number of agentic turns (tool calls) per heartbeat run.",
   command: "The command to execute (e.g. node, python).",
   localCommand: "Override the path to the CLI command you want the adapter to call (e.g. /usr/local/bin/claude, codex, opencode).",

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -3666,14 +3666,43 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   }).data?.censorUsernameInLogs === true;
 
   const adapterInvokePayload = useMemo(() => {
-    const evt = events.find((e) => e.eventType === "adapter.invoke");
+    const evt = [...events].reverse().find((e) => e.eventType === "adapter.invoke");
     return redactPathValue(asRecord(evt?.payload ?? null), censorUsernameInLogs);
   }, [censorUsernameInLogs, events]);
 
+  const adapterInvocationTimeline = useMemo(() => {
+    return events
+      .filter((event) => event.eventType === "adapter.invoke")
+      .map((event) => {
+        const payload = asRecord(event.payload);
+        const invokedAdapterType = asNonEmptyString(payload?.adapterType);
+        if (!invokedAdapterType) return null;
+        return {
+          adapterType: invokedAdapterType,
+          tsMs: new Date(event.createdAt).getTime(),
+        };
+      })
+      .filter((entry): entry is { adapterType: string; tsMs: number } => entry !== null)
+      .sort((a, b) => a.tsMs - b.tsMs);
+  }, [events]);
   const adapter = useMemo(() => getUIAdapter(adapterType), [adapterType]);
   const transcript = useMemo(
-    () => buildTranscript(logLines, adapter.parseStdoutLine, { censorUsernameInLogs }),
-    [adapter, censorUsernameInLogs, logLines],
+    () => buildTranscript(logLines, adapter.parseStdoutLine, {
+      censorUsernameInLogs,
+      resolveStdoutParser: (entryTs) => {
+        const entryTsMs = new Date(entryTs).getTime();
+        let resolvedAdapterType = adapterType;
+        for (const invocation of adapterInvocationTimeline) {
+          if (invocation.tsMs <= entryTsMs) {
+            resolvedAdapterType = invocation.adapterType;
+          } else {
+            break;
+          }
+        }
+        return getUIAdapter(resolvedAdapterType).parseStdoutLine;
+      },
+    }),
+    [adapter, adapterInvocationTimeline, adapterType, censorUsernameInLogs, logLines],
   );
 
   useEffect(() => {
@@ -3820,12 +3849,43 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
         </div>
       </div>
       <div className="max-h-[38rem] overflow-y-auto rounded-2xl border border-border/70 bg-background/40 p-3 sm:p-4">
-        <RunTranscriptView
-          entries={transcript}
-          mode={transcriptMode}
-          streaming={isLive}
-          emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
-        />
+        {transcriptMode === "raw" ? (
+          logLines.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-border/70 bg-background/40 p-4 text-sm text-muted-foreground">
+              {run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
+            </div>
+          ) : (
+            <div className="space-y-2 font-mono text-xs">
+              {logLines.map((line, index) => (
+                <div key={`${line.ts}-${line.stream}-${index}`} className="grid grid-cols-[auto_auto_1fr] gap-x-3">
+                  <span className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                    {line.ts}
+                  </span>
+                  <span className={cn(
+                    "text-[10px] uppercase tracking-[0.18em]",
+                    line.stream === "stderr"
+                      ? "text-red-600 dark:text-red-300"
+                      : line.stream === "system"
+                        ? "text-blue-600 dark:text-blue-300"
+                        : "text-muted-foreground",
+                  )}>
+                    {line.stream}
+                  </span>
+                  <pre className="min-w-0 whitespace-pre-wrap break-words text-foreground/80">
+                    {line.chunk}
+                  </pre>
+                </div>
+              ))}
+            </div>
+          )
+        ) : (
+          <RunTranscriptView
+            entries={transcript}
+            mode={transcriptMode}
+            streaming={isLive}
+            emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
+          />
+        )}
         {logError && (
           <div className="mt-3 rounded-xl border border-red-500/20 bg-red-500/[0.06] px-3 py-2 text-xs text-red-700 dark:text-red-300">
             {logError}

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -25,6 +25,7 @@ import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
 } from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CLAUDE_LOCAL_MODEL } from "@paperclipai/adapter-claude-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 
@@ -44,7 +45,9 @@ function createValuesForAdapterType(
 ): CreateConfigValues {
   const { adapterType: _discard, ...defaults } = defaultCreateValues;
   const nextValues: CreateConfigValues = { ...defaults, adapterType };
-  if (adapterType === "codex_local") {
+  if (adapterType === "claude_local") {
+    nextValues.model = DEFAULT_CLAUDE_LOCAL_MODEL;
+  } else if (adapterType === "codex_local") {
     nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
     nextValues.dangerouslyBypassSandbox =
       DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The plugin-decision-surface example plugin surfaces approvals and blocked issues for the board
> - The worker read PAPERCLIP_API_KEY (a short-lived run JWT) to add an Authorization header on outbound API calls
> - In local_trusted mode, unauthenticated requests are treated as board level, so the auth header is unnecessary and the JWT expires anyway
> - The instanceConfigSchema also exposed an apiKey field in the UI that the worker silently ignored, confusing operators
> - This PR makes the auth header conditional (only sent when non-empty) and removes the misleading config field
> - The benefit is that the plugin works out-of-the-box in local_trusted mode without any configuration

## What Changed

- `worker.ts`: `fetchApprovals` - build authHeaders map conditionally; only set Authorization when apiKey is non-empty string
- `worker.ts`: `approval.decided` event handler - same conditional header pattern on GET /api/approvals/{approvalId}/issues
- `manifest.ts`: removed `apiKey` property from `instanceConfigSchema.properties` (kept `apiUrl` field)
- `pnpm-lock.yaml`: updated after dependency install

## Verification

```sh
pnpm --filter @paperclipai/plugin-decision-surface typecheck  # PASS
pnpm --filter @paperclipai/plugin-decision-surface build      # PASS
```

Manual: after ANGA-269 (fork fix) lands, re-enable the plugin and confirm `GET /api/plugins/4d41619d-aec5-42c4-884e-ab61acb6c938` returns `status: ready` without any `apiKey` config set.

## Risks

Low risk. The change only affects whether an Authorization header is sent. When apiKey is empty (local_trusted mode), omitting the header grants board-level access. When non-empty, behavior is unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-271