### PR TITLE
fix(server): prevent crash when issue deleted during concurrent checkout

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1469,7 +1469,8 @@ export function issueService(db: Db) {
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (adopted) {
-          const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
+          const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
+          if (!row) return null;
           const [enriched] = await withIssueLabels(db, [row]);
           return enriched;
         }
@@ -1481,7 +1482,8 @@ export function issueService(db: Db) {
         current.status === "in_progress" &&
         sameRunLock(current.checkoutRunId, checkoutRunId)
       ) {
-        const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0]!);
+        const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
+        if (!row) return null;
         const [enriched] = await withIssueLabels(db, [row]);
         return enriched;
       }


### PR DESCRIPTION
## Problem

issueService.checkout() uses TypeScript non-null assertions (rows[0]!) when re-reading an issue after stale-run adoption. If the issue is deleted between the adoption write and the re-read, rows[0] is undefined and the subsequent withIssueLabels(db, [undefined]) throws an unhandled error, crashing the request.

## Fix

Replaced `rows[0]!` with `rows[0] ?? null` and added explicit null checks that return null gracefully, allowing callers to handle the deleted issue case.

## Changes

- server/src/services/issues.ts — 2 null-safety fixes (lines 1472, 1484)

Fixes #2593