### PR TITLE
fix(server): convert Date to ISO string in comment cursor query binding

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1647,10 +1647,7 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
-        const anchorTs =
-          anchor.createdAt instanceof Date
-            ? anchor.createdAt.toISOString()
-            : String(anchor.createdAt);
+        const anchorTs = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
             ? sql<boolean>`(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1647,15 +1647,19 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorTs =
+          anchor.createdAt instanceof Date
+            ? anchor.createdAt.toISOString()
+            : String(anchor.createdAt);
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorTs}
+                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorTs}
+                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Agents poll for incremental comment updates via `GET /api/issues/:id/comments?after=commentId&order=asc`
- The `listComments` service fetches the anchor comment's `createdAt` and uses it in a cursor comparison query
- `anchor.createdAt` is a `Date` object returned by Drizzle ORM
- The `sql` tagged template passes this `Date` directly to the `postgres` driver's `Bind` function
- `Bind` calls `Function.str()` → `Function.byteLength()` which only accepts `string | Buffer | ArrayBuffer`
- This throws `TypeError [ERR_INVALID_ARG_TYPE]`, causing a 500 on every heartbeat comment poll
- Agents that rely on incremental comment fetching stall and cannot progress their work
- **Fix**: call `.toISOString()` on `anchor.createdAt` before binding into the sql template

## Summary

- Fix 500 error on `GET /api/issues/:id/comments?after=:commentId` caused by passing a `Date` object to the `postgres` driver's `sql` tagged template binding
- Convert `anchor.createdAt` to ISO string before use in cursor comparison query

## Root Cause

`listComments` in `server/src/services/issues.ts` fetches the anchor comment's `createdAt` (returned as a `Date` by Drizzle ORM) and passes it directly into a `sql` template. The `postgres` driver's `Bind` → `Function.str()` → `Function.byteLength()` expects a `string | Buffer | ArrayBuffer`, not a `Date`, causing:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type
string or an instance of Buffer or ArrayBuffer. Received an instance of Date
```

## Impact

Every agent that polls for incremental comment updates (`?after=commentId&order=asc`) hits this error repeatedly, causing heartbeat failures and stalled work.

## Fix

Convert `anchor.createdAt` to an ISO string before binding:

```typescript
const anchorTs = anchor.createdAt.toISOString();
```

## Test plan

- [ ] Call `GET /api/issues/:id/comments?after=:commentId&order=asc` — should return 200 with comments instead of 500
- [ ] Verify agent heartbeat comment polling works without errors

## Risks

- None. The change is minimal and only affects the type coercion of a single value. Drizzle ORM guarantees `createdAt` is a `Date`, so `.toISOString()` will always succeed.

Closes #2612

🤖 Generated with [Claude Code](https://claude.com/claude-code)