### PR TITLE
fix(server): decode multer Latin-1 filenames as UTF-8 for non-ASCII support

### DIFF
--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -8,6 +8,25 @@ import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+/**
+ * Multer decodes the filename from the Content-Disposition header using
+ * Latin-1 (per RFC 7578). When the browser sends a UTF-8 filename, each
+ * UTF-8 byte is misinterpreted as a Latin-1 code point, producing a
+ * double-encoded string. This helper re-encodes the Latin-1 string back
+ * to bytes and decodes them as UTF-8 to recover the original filename.
+ */
+function fixMulterFilename(name: string): string {
+  try {
+    const bytes = Buffer.from(name, "latin1");
+    const decoded = bytes.toString("utf8");
+    // If re-decoding produces replacement characters the original was
+    // genuinely Latin-1, so return it unchanged.
+    return decoded.includes("\uFFFD") ? name : decoded;
+  } catch {
+    return name;
+  }
+}
+
 const SVG_CONTENT_TYPE = "image/svg+xml";
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
   "image/png",
@@ -161,7 +180,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
     const stored = await storage.putFile({
       companyId,
       namespace: `assets/${namespaceSuffix}`,
-      originalFilename: file.originalname || null,
+      originalFilename: file.originalname ? fixMulterFilename(file.originalname) : null,
       contentType,
       body: fileBody,
     });
@@ -259,7 +278,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
     const stored = await storage.putFile({
       companyId,
       namespace: "assets/companies",
-      originalFilename: file.originalname || null,
+      originalFilename: file.originalname ? fixMulterFilename(file.originalname) : null,
       contentType,
       body: fileBody,
     });

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -8,24 +8,7 @@ import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
-/**
- * Multer decodes the filename from the Content-Disposition header using
- * Latin-1 (per RFC 7578). When the browser sends a UTF-8 filename, each
- * UTF-8 byte is misinterpreted as a Latin-1 code point, producing a
- * double-encoded string. This helper re-encodes the Latin-1 string back
- * to bytes and decodes them as UTF-8 to recover the original filename.
- */
-function fixMulterFilename(name: string): string {
-  try {
-    const bytes = Buffer.from(name, "latin1");
-    const decoded = bytes.toString("utf8");
-    // If re-decoding produces replacement characters the original was
-    // genuinely Latin-1, so return it unchanged.
-    return decoded.includes("\uFFFD") ? name : decoded;
-  } catch {
-    return name;
-  }
-}
+import { fixMulterFilename } from "../utils/filename.js";
 
 const SVG_CONTENT_TYPE = "image/svg+xml";
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -46,23 +46,7 @@ import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
-
-/**
- * Multer decodes the filename from the Content-Disposition header using
- * Latin-1 (per RFC 7578). When the browser sends a UTF-8 filename, each
- * UTF-8 byte is misinterpreted as a Latin-1 code point, producing a
- * double-encoded string. This helper re-encodes the Latin-1 string back
- * to bytes and decodes them as UTF-8 to recover the original filename.
- */
-function fixMulterFilename(name: string): string {
-  try {
-    const bytes = Buffer.from(name, "latin1");
-    const decoded = bytes.toString("utf8");
-    return decoded.includes("\uFFFD") ? name : decoded;
-  } catch {
-    return name;
-  }
-}
+import { fixMulterFilename } from "../utils/filename.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -47,6 +47,23 @@ import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 
+/**
+ * Multer decodes the filename from the Content-Disposition header using
+ * Latin-1 (per RFC 7578). When the browser sends a UTF-8 filename, each
+ * UTF-8 byte is misinterpreted as a Latin-1 code point, producing a
+ * double-encoded string. This helper re-encodes the Latin-1 string back
+ * to bytes and decodes them as UTF-8 to recover the original filename.
+ */
+function fixMulterFilename(name: string): string {
+  try {
+    const bytes = Buffer.from(name, "latin1");
+    const decoded = bytes.toString("utf8");
+    return decoded.includes("\uFFFD") ? name : decoded;
+  } catch {
+    return name;
+  }
+}
+
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
@@ -1935,7 +1952,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
     const stored = await storage.putFile({
       companyId,
       namespace: `issues/${issueId}`,
-      originalFilename: file.originalname || null,
+      originalFilename: file.originalname ? fixMulterFilename(file.originalname) : null,
       contentType,
       body: file.buffer,
     });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1647,19 +1647,15 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
-        const anchorTs =
-          anchor.createdAt instanceof Date
-            ? anchor.createdAt.toISOString()
-            : String(anchor.createdAt);
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchorTs}
-                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchor.createdAt}
+                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchorTs}
-                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchor.createdAt}
+                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1647,15 +1647,19 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorTs =
+          anchor.createdAt instanceof Date
+            ? anchor.createdAt.toISOString()
+            : String(anchor.createdAt);
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorTs}
+                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorTs}
+                OR (${issueComments.createdAt} = ${anchorTs} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }

--- a/server/src/utils/filename.ts
+++ b/server/src/utils/filename.ts
@@ -1,0 +1,19 @@
+/**
+ * Multer decodes the filename from the Content-Disposition header using
+ * Latin-1 (per RFC 7578 §4.2). When the browser sends a UTF-8 filename,
+ * each UTF-8 byte is misinterpreted as a Latin-1 code point, producing a
+ * double-encoded string. This helper re-encodes the Latin-1 string back
+ * to bytes and decodes them as UTF-8 to recover the original filename.
+ *
+ * Falls back to the original string if the bytes are not valid UTF-8
+ * (i.e. the filename was genuinely Latin-1).
+ */
+export function fixMulterFilename(name: string): string {
+  try {
+    const bytes = Buffer.from(name, "latin1");
+    const decoded = bytes.toString("utf8");
+    return decoded.includes("\uFFFD") ? name : decoded;
+  } catch {
+    return name;
+  }
+}


### PR DESCRIPTION
## Thinking Path

- Paperclip web UI allows file uploads (issue attachments, asset images, company logos)
- File uploads use multer for multipart parsing
- Multer decodes the `filename` from Content-Disposition using Latin-1 (per RFC 7578 §4.2)
- Modern browsers send UTF-8 filenames, but multer interprets each UTF-8 byte as a Latin-1 code point
- The resulting Latin-1 string is stored as UTF-8 in PostgreSQL → double-encoded filename
- Non-ASCII filenames (Korean, Japanese, Chinese, etc.) become unreadable garbled text
- **Fix**: re-encode Latin-1 bytes back and decode as UTF-8 to recover the original filename

## Summary

- Fix double-UTF-8-encoding of non-ASCII (Korean, Japanese, Chinese, etc.) filenames on file upload
- Add `fixMulterFilename()` shared utility in `server/src/utils/filename.ts`
- Apply to all 3 upload paths in `assets.ts` (2) and `issues.ts` (1)

## Root Cause

Multer decodes the `filename` from the `Content-Disposition` header using Latin-1 (per [RFC 7578 §4.2](https://www.rfc-editor.org/rfc/rfc7578#section-4.2)). Modern browsers send UTF-8 filenames, but multer interprets each UTF-8 byte as a Latin-1 code point:

```
Original: "입" → UTF-8 bytes: ec 9e 85
After multer: "ì\x9e\x85" (3 Latin-1 chars)
Stored as UTF-8 in DB: c3ac c29e c285 (double-encoded)
Displayed as: "ìì£¼ì ì²­ì..."
```

## Fix

`fixMulterFilename(name)` re-encodes the Latin-1 string back to bytes and decodes as UTF-8:

```typescript
export function fixMulterFilename(name: string): string {
  try {
    const bytes = Buffer.from(name, "latin1");
    const decoded = bytes.toString("utf8");
    return decoded.includes("\uFFFD") ? name : decoded;
  } catch {
    return name;
  }
}
```

Safe fallback: if the bytes aren't valid UTF-8 (genuinely Latin-1 filename), returns the original unchanged.

## Changed Files

- `server/src/utils/filename.ts` — new shared utility (extracted per review feedback)
- `server/src/routes/assets.ts` — image/logo upload (2 occurrences)
- `server/src/routes/issues.ts` — issue attachment upload (1 occurrence)

## Risks

- Low. The helper safely falls back to the original string for genuinely Latin-1 filenames. ASCII-only filenames pass through unchanged since Latin-1 and UTF-8 share the same byte values for ASCII.

## Test plan

- [ ] Upload a file with a Korean filename (e.g. `입주신청서_다스터스(주).pdf`) — verify the filename is stored and displayed correctly
- [ ] Upload a file with an ASCII-only filename — verify no regression
- [ ] Upload a file with a genuinely Latin-1 filename (e.g. `café.pdf`) — verify fallback works

Closes #2325

🤖 Generated with [Claude Code](https://claude.com/claude-code)