### PR TITLE
fix: restore workspace directory config in onboarding wizard

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -39,10 +39,12 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
+import { ChoosePathButton } from "./PathInstructionsModal";
 import {
   Building2,
   Bot,
   Code,
+  FolderOpen,
   Gem,
   ListTodo,
   Rocket,
@@ -135,6 +137,10 @@ export function OnboardingWizard() {
   const [taskDescription, setTaskDescription] = useState(
     DEFAULT_TASK_DESCRIPTION
   );
+
+  // Step 4 — workspace
+  const [workspacePath, setWorkspacePath] = useState("");
+  const [workspaceError, setWorkspaceError] = useState<string | null>(null);
 
   // Auto-grow textarea for task description
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -307,6 +313,8 @@ export function OnboardingWizard() {
     setCreatedAgentId(null);
     setCreatedProjectId(null);
     setCreatedIssueRef(null);
+    setWorkspacePath("");
+    setWorkspaceError(null);
   }
 
   function handleClose() {
@@ -543,7 +551,22 @@ export function OnboardingWizard() {
   }
 
   async function handleLaunch() {
-    if (!createdCompanyId || !createdAgentId) return;
+    if (!createdCompanyId || !createdAgentId) {
+      setError(
+        !createdCompanyId
+          ? "Please create a company first (Step 1)."
+          : "Please create an agent first (Step 2)."
+      );
+      return;
+    }
+
+    const localPath = workspacePath.trim();
+    if (localPath && !(localPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(localPath))) {
+      setWorkspaceError("Local folder must be a full absolute path.");
+      return;
+    }
+    setWorkspaceError(null);
+
     setLoading(true);
     setError(null);
     try {
@@ -565,6 +588,18 @@ export function OnboardingWizard() {
         queryClient.invalidateQueries({
           queryKey: queryKeys.projects.list(createdCompanyId)
         });
+      }
+
+      if (localPath && projectId) {
+        const folderName = localPath.split(/[\\/]/).filter(Boolean).pop() ?? "workspace";
+        try {
+          await projectsApi.createWorkspace(projectId, {
+            name: folderName,
+            cwd: localPath,
+          });
+        } catch (wsErr) {
+          console.warn("Workspace creation failed:", wsErr);
+        }
       }
 
       let issueRef = createdIssueRef;
@@ -1247,6 +1282,34 @@ export function OnboardingWizard() {
                       </div>
                       <Check className="h-4 w-4 text-green-500 shrink-0" />
                     </div>
+                  </div>
+
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <label className="text-xs text-muted-foreground">
+                        Project folder
+                      </label>
+                      <span className="text-xs text-muted-foreground/50">optional</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground/70 mb-1.5">
+                      Set the local directory where agents will read and write files.
+                    </p>
+                    <div className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1.5">
+                      <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                      <input
+                        className="w-full bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/50"
+                        placeholder="/path/to/project"
+                        value={workspacePath}
+                        onChange={(e) => {
+                          setWorkspacePath(e.target.value);
+                          setWorkspaceError(null);
+                        }}
+                      />
+                      <ChoosePathButton />
+                    </div>
+                    {workspaceError && (
+                      <p className="text-xs text-destructive mt-1">{workspaceError}</p>
+                    )}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary

Fixes #469

Commit `bf5cfaae` ("Hide deprecated agent working directory by default") removed the working directory field from the onboarding wizard without adding an equivalent project-level workspace step. Since the server's `resolveWorkspaceForRun` in `heartbeat.ts` only checks **project workspaces** (not `agent.adapterConfig.cwd`), new agents created via the wizard had no workspace configured and fell back to a generic directory:

```
[paperclip] No project or prior session workspace was available. Using fallback workspace
```

### Root cause

The intent of `bf5cfaae` was to deprecate the agent-level `cwd` in favor of project-level workspaces. But the onboarding wizard was left with **no way** to configure a directory — neither at the agent level (removed) nor at the project level (never added to the wizard).

### Changes

- **Adds a "Project folder" input to Step 4 (Launch)** of the onboarding wizard. When the user provides a path, a workspace is attached to the project via `projectsApi.createWorkspace()` after project creation — the same proven pattern used by `NewProjectDialog`.
- **Replaces silent early return** in `handleLaunch` with a visible error message when `createdCompanyId` or `createdAgentId` is missing (e.g. user skipped Steps 1-2).
- **Makes workspace creation non-blocking** — wraps `createWorkspace` in its own try/catch so a failure (e.g. duplicate workspace) doesn't prevent issue creation and navigation.
- The field is **optional** — users who skip it get the existing managed-workspace fallback behavior.
- Validates the path is absolute (Unix `/` or Windows `C:\`) before submitting.

### Files changed

| File | Change |
|---|---|
| `ui/src/components/OnboardingWizard.tsx` | Add workspace state, UI field on Step 4, workspace creation in `handleLaunch()`, error handling |

## Test plan

- [ ] Create a new company via the onboarding wizard — Step 4 should show a "Project folder" field
- [ ] Type or paste an absolute path (e.g. `/Users/you/project`)
- [ ] Complete the wizard — the created project should have a workspace with the specified `cwd`
- [ ] Verify the agent heartbeat uses the configured workspace instead of falling back
- [ ] Verify skipping the field (leaving it empty) still works with existing fallback behavior
- [ ] Verify clicking "Create & Open Issue" without completing Steps 1-2 shows an error instead of silently failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)