### PR TITLE
feat: native OS folder picker for ChoosePathButton

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -25,6 +25,7 @@ import { activityRoutes } from "./routes/activity.js";
 import { dashboardRoutes } from "./routes/dashboard.js";
 import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { instanceSettingsRoutes } from "./routes/instance-settings.js";
+import { folderPickerRoutes } from "./routes/folder-picker.js";
 import { llmRoutes } from "./routes/llms.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
@@ -163,6 +164,7 @@ export async function createApp(
   api.use(dashboardRoutes(db));
   api.use(sidebarBadgeRoutes(db));
   api.use(instanceSettingsRoutes(db));
+  api.use(folderPickerRoutes());
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = createPluginWorkerManager();
   const pluginRegistry = pluginRegistryService(db);

--- a/server/src/routes/folder-picker.ts
+++ b/server/src/routes/folder-picker.ts
@@ -1,0 +1,73 @@
+import { Router } from "express";
+import { execFile } from "node:child_process";
+
+function pickFolder(): Promise<string | null> {
+  const platform = process.platform;
+
+  return new Promise((resolve) => {
+    if (platform === "darwin") {
+      execFile(
+        "osascript",
+        [
+          "-e",
+          'set chosenFolder to POSIX path of (choose folder with prompt "Select project folder")',
+        ],
+        { timeout: 60_000 },
+        (err, stdout) => {
+          if (err) return resolve(null);
+          const p = stdout.trim().replace(/\/+$/, "");
+          resolve(p || null);
+        },
+      );
+    } else if (platform === "win32") {
+      const ps = [
+        "-NoProfile",
+        "-Command",
+        `Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.Description = 'Select project folder'; if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath } else { '' }`,
+      ];
+      execFile("powershell.exe", ps, { timeout: 60_000 }, (err, stdout) => {
+        if (err) return resolve(null);
+        const p = stdout.trim();
+        resolve(p || null);
+      });
+    } else {
+      // Linux — try zenity, fall back to kdialog
+      execFile(
+        "zenity",
+        ["--file-selection", "--directory", "--title=Select project folder"],
+        { timeout: 60_000 },
+        (err, stdout) => {
+          if (!err && stdout.trim()) return resolve(stdout.trim());
+          execFile(
+            "kdialog",
+            ["--getexistingdirectory", ".", "--title", "Select project folder"],
+            { timeout: 60_000 },
+            (err2, stdout2) => {
+              if (err2) return resolve(null);
+              resolve(stdout2.trim() || null);
+            },
+          );
+        },
+      );
+    }
+  });
+}
+
+export function folderPickerRoutes() {
+  const router = Router();
+
+  router.post("/folder-picker", async (_req, res) => {
+    try {
+      const folder = await pickFolder();
+      if (folder) {
+        res.json({ path: folder });
+      } else {
+        res.json({ path: null });
+      }
+    } catch {
+      res.status(500).json({ error: "Failed to open folder picker" });
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -15,3 +15,4 @@ export { sidebarBadgeRoutes } from "./sidebar-badges.js";
 export { llmRoutes } from "./llms.js";
 export { accessRoutes } from "./access.js";
 export { instanceSettingsRoutes } from "./instance-settings.js";
+export { folderPickerRoutes } from "./folder-picker.js";

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1305,7 +1305,7 @@ export function OnboardingWizard() {
                           setWorkspaceError(null);
                         }}
                       />
-                      <ChoosePathButton />
+                      <ChoosePathButton onPick={(p) => { setWorkspacePath(p); setWorkspaceError(null); }} />
                     </div>
                     {workspaceError && (
                       <p className="text-xs text-destructive mt-1">{workspaceError}</p>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -39,10 +39,12 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
+import { ChoosePathButton } from "./PathInstructionsModal";
 import {
   Building2,
   Bot,
   Code,
+  FolderOpen,
   Gem,
   ListTodo,
   Rocket,
@@ -135,6 +137,10 @@ export function OnboardingWizard() {
   const [taskDescription, setTaskDescription] = useState(
     DEFAULT_TASK_DESCRIPTION
   );
+
+  // Step 4 — workspace
+  const [workspacePath, setWorkspacePath] = useState("");
+  const [workspaceError, setWorkspaceError] = useState<string | null>(null);
 
   // Auto-grow textarea for task description
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -307,6 +313,8 @@ export function OnboardingWizard() {
     setCreatedAgentId(null);
     setCreatedProjectId(null);
     setCreatedIssueRef(null);
+    setWorkspacePath("");
+    setWorkspaceError(null);
   }
 
   function handleClose() {
@@ -543,7 +551,22 @@ export function OnboardingWizard() {
   }
 
   async function handleLaunch() {
-    if (!createdCompanyId || !createdAgentId) return;
+    if (!createdCompanyId || !createdAgentId) {
+      setError(
+        !createdCompanyId
+          ? "Please create a company first (Step 1)."
+          : "Please create an agent first (Step 2)."
+      );
+      return;
+    }
+
+    const localPath = workspacePath.trim();
+    if (localPath && !(localPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(localPath))) {
+      setWorkspaceError("Local folder must be a full absolute path.");
+      return;
+    }
+    setWorkspaceError(null);
+
     setLoading(true);
     setError(null);
     try {
@@ -565,6 +588,18 @@ export function OnboardingWizard() {
         queryClient.invalidateQueries({
           queryKey: queryKeys.projects.list(createdCompanyId)
         });
+      }
+
+      if (localPath && projectId) {
+        const folderName = localPath.split(/[\\/]/).filter(Boolean).pop() ?? "workspace";
+        try {
+          await projectsApi.createWorkspace(projectId, {
+            name: folderName,
+            cwd: localPath,
+          });
+        } catch (wsErr) {
+          console.warn("Workspace creation failed:", wsErr);
+        }
       }
 
       let issueRef = createdIssueRef;
@@ -1247,6 +1282,34 @@ export function OnboardingWizard() {
                       </div>
                       <Check className="h-4 w-4 text-green-500 shrink-0" />
                     </div>
+                  </div>
+
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <label className="text-xs text-muted-foreground">
+                        Project folder
+                      </label>
+                      <span className="text-xs text-muted-foreground/50">optional</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground/70 mb-1.5">
+                      Set the local directory where agents will read and write files.
+                    </p>
+                    <div className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1.5">
+                      <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                      <input
+                        className="w-full bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/50"
+                        placeholder="/path/to/project"
+                        value={workspacePath}
+                        onChange={(e) => {
+                          setWorkspacePath(e.target.value);
+                          setWorkspaceError(null);
+                        }}
+                      />
+                      <ChoosePathButton />
+                    </div>
+                    {workspaceError && (
+                      <p className="text-xs text-destructive mt-1">{workspaceError}</p>
+                    )}
                   </div>
                 </div>
               )}

--- a/ui/src/components/PathInstructionsModal.tsx
+++ b/ui/src/components/PathInstructionsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Apple, Monitor, Terminal } from "lucide-react";
 import {
   Dialog,
@@ -120,22 +120,83 @@ export function PathInstructionsModal({
 }
 
 /**
- * Small "Choose" button that opens the PathInstructionsModal.
- * Drop-in replacement for the old showDirectoryPicker buttons.
+ * Programmatically set a React-controlled input's value by going through the
+ * native setter so React's synthetic onChange fires.
  */
-export function ChoosePathButton({ className }: { className?: string }) {
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+/**
+ * Small "Choose" button that opens a native OS folder picker when the server
+ * supports it, falling back to the PathInstructionsModal otherwise.
+ *
+ * When `onPick` is provided, the selected path is forwarded to the caller.
+ * When omitted, the component finds the nearest sibling `<input>` inside the
+ * same parent container and sets its value automatically.
+ */
+export function ChoosePathButton({
+  className,
+  onPick,
+}: {
+  className?: string;
+  onPick?: (path: string) => void;
+}) {
   const [open, setOpen] = useState(false);
+  const [picking, setPicking] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  function applyPath(path: string) {
+    if (onPick) {
+      onPick(path);
+      return;
+    }
+    // Auto-fill the nearest sibling input in the same container
+    const input = buttonRef.current
+      ?.parentElement?.querySelector("input") as HTMLInputElement | null;
+    if (input) {
+      setInputValue(input, path);
+    }
+  }
+
+  async function handleClick() {
+    try {
+      setPicking(true);
+      const res = await fetch("/api/folder-picker", { method: "POST" });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.path) {
+          applyPath(data.path);
+          return;
+        }
+      }
+    } catch {
+      // Server doesn't support native picker — fall through to modal
+    } finally {
+      setPicking(false);
+    }
+    setOpen(true);
+  }
+
   return (
     <>
       <button
+        ref={buttonRef}
         type="button"
+        disabled={picking}
         className={cn(
           "inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 transition-colors shrink-0",
           className,
         )}
-        onClick={() => setOpen(true)}
+        onClick={handleClick}
       >
-        Choose
+        {picking ? "Opening…" : "Choose"}
       </button>
       <PathInstructionsModal open={open} onOpenChange={setOpen} />
     </>


### PR DESCRIPTION
## Summary

Replaces the manual "copy path" instructions modal with a native OS folder picker dialog that opens Finder (macOS), Explorer (Windows), or zenity/kdialog (Linux).

**Depends on:** #2616

### Problem

The current `ChoosePathButton` opens a modal with platform-specific instructions on how to manually copy an absolute path (open Finder, right-click, hold Option, etc.). This is a poor UX — users expect a standard folder browser dialog.

### Solution

- **New server endpoint** `POST /api/folder-picker` that spawns a native OS dialog via `osascript` (macOS), PowerShell `FolderBrowserDialog` (Windows), or `zenity`/`kdialog` (Linux) and returns the selected path.
- **Updated `ChoosePathButton`** to always try the native picker first. Falls back to the instructions modal if the endpoint is unavailable (e.g. remote deployments).
- When `onPick` callback is provided, the path is forwarded directly. When omitted, the component auto-fills the nearest sibling `<input>` via the native value setter so React's `onChange` fires — **no changes required to any of the 12 existing callsites**.

### Files changed

| File | Change |
|---|---|
| `server/src/routes/folder-picker.ts` | New endpoint: native OS folder dialog |
| `server/src/routes/index.ts` | Export new route |
| `server/src/app.ts` | Mount folder-picker route |
| `ui/src/components/PathInstructionsModal.tsx` | Extend `ChoosePathButton` with native picker + auto-fill |
| `ui/src/components/OnboardingWizard.tsx` | Wire `onPick` for direct state update |

## Test plan

- [ ] Click "Choose" in any path input — native OS folder dialog should open
- [ ] Select a folder — path should auto-populate the input field
- [ ] Cancel the dialog — should fall back to instructions modal
- [ ] Verify on macOS (Finder dialog), Windows (Explorer dialog), Linux (zenity/kdialog)
- [ ] Verify existing callsites work without changes (ProjectProperties, AgentConfigForm, NewProjectDialog, adapter config fields)
- [ ] Verify fallback to instructions modal when server endpoint is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)