### PR TITLE
feat: add authenticated screenshot utility

### DIFF
--- a/scripts/screenshot.cjs
+++ b/scripts/screenshot.cjs
@@ -74,8 +74,8 @@ const origin = new URL(url).origin;
 
     const page = await context.newPage();
     // Scope the auth header to the Paperclip origin only
-    await page.route(`${origin}/**`, (route) => {
-      route.continue({
+    await page.route(`${origin}/**`, async (route) => {
+      await route.continue({
         headers: { ...route.request().headers(), Authorization: `Bearer ${cred.token}` },
       });
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents sometimes need to capture UI screenshots for visual verification of fixes
> - The Paperclip UI requires authentication, so headless browser screenshots fail without auth
> - The CLI already stores a board token in `~/.paperclip/auth.json`
> - This pull request adds a Playwright-based screenshot script that reads the board token and injects it as a Bearer header
> - The benefit is agents can now take authenticated screenshots of any Paperclip UI page without storing email/password credentials

## What Changed

- Added `scripts/screenshot.cjs` — a Node.js script that:
  - Reads the board token from `~/.paperclip/auth.json`
  - Launches Chromium via Playwright with the token as an `Authorization` header
  - Navigates to the specified URL and saves a screenshot
  - Supports `--width`, `--height`, and `--wait` flags
  - Accepts both full URLs and path-only shortcuts (e.g., `/PAPA/agents/cto/instructions`)

## Verification

```bash
node scripts/screenshot.cjs /PAPA/agents/cto/instructions /tmp/test.png --width 1920
```

Should produce an authenticated screenshot of the agent instructions page.

## Risks

- Low risk — standalone utility script with no impact on the main application. Requires Playwright (already a dev dependency) and a valid board token in `~/.paperclip/auth.json`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge