### PR TITLE
feat(heartbeat): add lightweight nudge path for fast follow-up runs

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -28,6 +28,7 @@ import {
   detectClaudeLoginRequired,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
+  isClaudeRateLimitError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
@@ -404,16 +405,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
-  const prompt = joinPromptSections([
-    renderedBootstrapPrompt,
-    sessionHandoffNote,
-    renderedPrompt,
-  ]);
+  const nudgeMessage = asString(context.nudgeMessage, "").trim();
+  const isNudgeRun = nudgeMessage.length > 0 && !!sessionId;
+  const prompt = isNudgeRun
+    ? [
+        "[FOLLOW-UP] This is a direct follow-up message from the user on the same task.",
+        "Do NOT re-run the heartbeat protocol, do NOT call GET /agents/me or check assignments.",
+        "Simply respond to the request below using context already in this session.\n",
+        nudgeMessage,
+      ].join("\n")
+    : joinPromptSections([
+        renderedBootstrapPrompt,
+        sessionHandoffNote,
+        renderedPrompt,
+      ]);
   const promptMetrics = {
     promptChars: prompt.length,
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
-    heartbeatPromptChars: renderedPrompt.length,
+    heartbeatPromptChars: isNudgeRun ? 0 : renderedPrompt.length,
   };
 
   const buildClaudeArgs = (resumeSessionId: string | null) => {
@@ -424,10 +434,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (model) args.push("--model", model);
     if (effort) args.push("--effort", effort);
     if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
-    if (effectiveInstructionsFilePath) {
-      args.push("--append-system-prompt-file", effectiveInstructionsFilePath);
+    // Nudge runs resume an existing session that already has instructions and
+    // skills loaded — re-injecting them would duplicate system prompt content
+    // and cause the agent to re-run its heartbeat protocol.
+    if (!isNudgeRun) {
+      if (effectiveInstructionsFilePath) {
+        args.push("--append-system-prompt-file", effectiveInstructionsFilePath);
+      }
+      args.push("--add-dir", skillsDir);
     }
-    args.push("--add-dir", skillsDir);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };
@@ -578,15 +593,34 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  const maxRateLimitRetries = asNumber(config.maxRateLimitRetries, 3);
+  const rateLimitRetryDelaySec = asNumber(config.rateLimitRetryDelaySec, 10);
+
+  const checkRateLimit = (attempt: { proc: RunProcessResult; parsedStream: ReturnType<typeof parseClaudeStreamJson>; parsed: Record<string, unknown> | null }) =>
+    !attempt.proc.timedOut &&
+    isClaudeRateLimitError({
+      parsed: attempt.parsed,
+      summary: attempt.parsedStream.summary ?? "",
+      stdout: attempt.proc.stdout,
+    });
+
   try {
-    const initial = await runAttempt(sessionId ?? null);
+    let current = await runAttempt(sessionId ?? null);
+
     if (
       sessionId &&
-      !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
-      initial.parsed &&
-      isClaudeUnknownSessionError(initial.parsed)
+      !current.proc.timedOut &&
+      (current.proc.exitCode ?? 0) !== 0 &&
+      current.parsed &&
+      isClaudeUnknownSessionError(current.parsed)
     ) {
+      // Nudge runs depend on the existing session — can't fall back to fresh
+      if (isNudgeRun) {
+        return toAdapterResult(current, {
+          fallbackSessionId: sessionId,
+          clearSessionOnMissingSession: true,
+        });
+      }
       await onLog(
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
@@ -595,7 +629,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    for (let attempt = 1; attempt <= maxRateLimitRetries; attempt++) {
+      if (!checkRateLimit(current)) break;
+      const delaySec = rateLimitRetryDelaySec * attempt;
+      await onLog(
+        "stdout",
+        `[paperclip] Rate limit detected; waiting ${delaySec}s before retry ${attempt}/${maxRateLimitRetries}.\n`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delaySec * 1000));
+      current = await runAttempt(sessionId ?? null);
+    }
+
+    return toAdapterResult(current, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
   } finally {
     fs.rm(skillsDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -625,8 +625,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
-      const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      current = await runAttempt(null);
+      // Continue into rate-limit loop with the fresh-session result
     }
 
     for (let attempt = 1; attempt <= maxRateLimitRetries; attempt++) {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -167,7 +167,7 @@ export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | 
   return /max(?:imum)?\s+turns?/i.test(resultText);
 }
 
-const RATE_LIMIT_RE = /api\s+error[:\s]+429|rate[-_]?limit(?:ed)?|too\s+many\s+requests|temporarily\s+rate[-_]?limited|upstream.*rate|provider\s+returned\s+error.*429/i;
+const RATE_LIMIT_RE = /api\s+error[:\s]+429|rate[-_]?limit(?:ed)?|too\s+many\s+requests|temporarily\s+rate[-_]?limited|provider\s+returned\s+error.*429/i;
 
 export function isClaudeRateLimitError(input: {
   parsed: Record<string, unknown> | null;

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -167,6 +167,22 @@ export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | 
   return /max(?:imum)?\s+turns?/i.test(resultText);
 }
 
+const RATE_LIMIT_RE = /api\s+error[:\s]+429|rate[-_]?limit(?:ed)?|too\s+many\s+requests|temporarily\s+rate[-_]?limited|upstream.*rate|provider\s+returned\s+error.*429/i;
+
+export function isClaudeRateLimitError(input: {
+  parsed: Record<string, unknown> | null;
+  summary: string;
+  stdout: string;
+}): boolean {
+  const candidates = [
+    input.summary,
+    asString(input.parsed?.result, ""),
+    ...extractClaudeErrorMessages(input.parsed ?? {}),
+    input.stdout,
+  ];
+  return candidates.some((t) => RATE_LIMIT_RE.test(t));
+}
+
 export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2265,6 +2265,44 @@ export function agentRoutes(db: Db) {
     res.json(run);
   });
 
+  router.post("/heartbeat-runs/:runId/nudge", async (req, res) => {
+    assertBoard(req);
+    const runId = req.params.runId as string;
+    const message = typeof req.body.message === "string" ? req.body.message.trim() : "";
+    if (!message) {
+      res.status(400).json({ error: "message is required" });
+      return;
+    }
+    if (message.length > 10_000) {
+      res.status(400).json({ error: "message too long (max 10000 characters)" });
+      return;
+    }
+
+    const parentRun = await heartbeat.getRun(runId);
+    if (!parentRun) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    assertCompanyAccess(req, parentRun.companyId);
+
+    const run = await heartbeat.nudge(runId, message, {
+      actorType: req.actor.type === "agent" ? "agent" : "user",
+      actorId: req.actor.type === "agent" ? req.actor.agentId ?? null : req.actor.userId ?? null,
+    });
+
+    await logActivity(db, {
+      companyId: parentRun.companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "heartbeat.nudged",
+      entityType: "heartbeat_run",
+      entityId: run.id,
+      details: { parentRunId: runId, agentId: parentRun.agentId },
+    });
+
+    res.status(202).json(run);
+  });
+
   router.get("/heartbeat-runs/:runId/events", async (req, res) => {
     const runId = req.params.runId as string;
     const run = await heartbeat.getRun(runId);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2292,8 +2292,8 @@ export function agentRoutes(db: Db) {
 
     await logActivity(db, {
       companyId: parentRun.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: req.actor.type === "agent" ? "agent" : "user",
+      actorId: req.actor.type === "agent" ? req.actor.agentId ?? "board" : req.actor.userId ?? "board",
       action: "heartbeat.nudged",
       entityType: "heartbeat_run",
       entityId: run.id,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2297,7 +2297,7 @@ export function agentRoutes(db: Db) {
       action: "heartbeat.nudged",
       entityType: "heartbeat_run",
       entityId: run.id,
-      details: { parentRunId: runId, agentId: parentRun.agentId },
+      details: { agentId: parentRun.agentId },
     });
 
     res.status(202).json(run);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -19,7 +19,7 @@ import {
 import { conflict, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
-import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
+import { getRunLogStore, type RunLogHandle, type RunLogStoreType } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
@@ -2553,10 +2553,10 @@ export function heartbeatService(db: Db) {
       runtimeWorkspaceWarnings = [];
     }
 
-    let seq = 1;
+    let seq = isNudge ? await nextRunEventSeq(runId) : 1;
     let handle: RunLogHandle | null = null;
-    let stdoutExcerpt = "";
-    let stderrExcerpt = "";
+    let stdoutExcerpt = isNudge ? (run.stdoutExcerpt ?? "") : "";
+    let stderrExcerpt = isNudge ? (run.stderrExcerpt ?? "") : "";
     try {
       const startedAt = run.startedAt ?? new Date();
       const runningWithSession = await db
@@ -2596,23 +2596,29 @@ export function heartbeatService(db: Db) {
         eventType: "lifecycle",
         stream: "system",
         level: "info",
-        message: "run started",
+        message: isNudge ? "nudge follow-up started" : "run started",
       });
 
-      handle = await runLogStore.begin({
-        companyId: run.companyId,
-        agentId: run.agentId,
-        runId,
-      });
+      // For nudge runs, reuse the existing log file instead of creating a new one
+      // (runLogStore.begin() would truncate the existing log)
+      if (isNudge && run.logStore && run.logRef) {
+        handle = { store: run.logStore as RunLogStoreType, logRef: run.logRef };
+      } else {
+        handle = await runLogStore.begin({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          runId,
+        });
 
-      await db
-        .update(heartbeatRuns)
-        .set({
-          logStore: handle.store,
-          logRef: handle.logRef,
-          updatedAt: new Date(),
-        })
-        .where(eq(heartbeatRuns.id, runId));
+        await db
+          .update(heartbeatRuns)
+          .set({
+            logStore: handle.store,
+            logRef: handle.logRef,
+            updatedAt: new Date(),
+          })
+          .where(eq(heartbeatRuns.id, runId));
+      }
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
@@ -2862,6 +2868,26 @@ export function heartbeatService(db: Db) {
               billingType: normalizeLedgerBillingType(adapterResult.billingType),
             } as Record<string, unknown>)
           : null;
+
+      // For nudge runs, accumulate usage from the previous run completion
+      const finalUsageJson = isNudge && usageJson
+        ? (() => {
+            const prevUsage = parseObject(context.nudgePreviousUsageJson);
+            if (!prevUsage) return usageJson;
+            const accumulated = { ...usageJson };
+            const numOr0 = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+            accumulated.inputTokens = numOr0(accumulated.inputTokens) + numOr0(prevUsage.inputTokens);
+            accumulated.outputTokens = numOr0(accumulated.outputTokens) + numOr0(prevUsage.outputTokens);
+            accumulated.cachedInputTokens = numOr0(accumulated.cachedInputTokens) + numOr0(prevUsage.cachedInputTokens);
+            accumulated.rawInputTokens = numOr0(accumulated.rawInputTokens) + numOr0(prevUsage.rawInputTokens);
+            accumulated.rawOutputTokens = numOr0(accumulated.rawOutputTokens) + numOr0(prevUsage.rawOutputTokens);
+            accumulated.rawCachedInputTokens = numOr0(accumulated.rawCachedInputTokens) + numOr0(prevUsage.rawCachedInputTokens);
+            if (numOr0(prevUsage.costUsd) > 0 || numOr0(accumulated.costUsd) > 0) {
+              accumulated.costUsd = numOr0(accumulated.costUsd) + numOr0(prevUsage.costUsd);
+            }
+            return accumulated;
+          })()
+        : usageJson;
 
       await setRunStatus(run.id, status, {
         finishedAt: new Date(),
@@ -3750,7 +3776,7 @@ export function heartbeatService(db: Db) {
     const serializedParams = sessionCodec.serialize({ sessionId: parentSessionIdAfter });
     if (serializedParams) contextSnapshot.resumeSessionParams = serializedParams;
 
-    // 5. Create wakeup request and run records directly (bypass coalescing/issue locks)
+    // 5. Create wakeup request and re-open the parent run (no new run record)
     const wakeupRequest = await db.insert(agentWakeupRequests).values({
       companyId: agent.companyId,
       agentId: agent.id,
@@ -3761,40 +3787,52 @@ export function heartbeatService(db: Db) {
       status: "queued",
       requestedByActorType: actor.actorType,
       requestedByActorId: actor.actorId,
+      runId: parentRunId,
     }).returning().then((rows) => rows[0]);
 
-    const newRun = await db.insert(heartbeatRuns).values({
-      companyId: agent.companyId,
-      agentId: agent.id,
-      invocationSource: "on_demand",
-      triggerDetail: "nudge",
+    // Stash previous usage so executeRun can accumulate it after the nudge completes
+    contextSnapshot.nudgePreviousUsageJson = parentRun.usageJson ?? null;
+
+    // Re-open the parent run: transition back to "queued" so executeRun can claim it
+    const reopenedRun = await db.update(heartbeatRuns).set({
       status: "queued",
+      finishedAt: null,
+      error: null,
+      errorCode: null,
+      exitCode: null,
+      signal: null,
       wakeupRequestId: wakeupRequest.id,
       contextSnapshot,
       sessionIdBefore: parentSessionIdAfter,
-    }).returning().then((rows) => rows[0]);
-
-    await db.update(agentWakeupRequests).set({
-      runId: newRun.id,
       updatedAt: new Date(),
-    }).where(eq(agentWakeupRequests.id, wakeupRequest.id));
+    }).where(eq(heartbeatRuns.id, parentRunId)).returning().then((rows) => rows[0]);
+
+    // Inject a nudge boundary marker into the existing log file
+    if (parentRun.logStore && parentRun.logRef) {
+      const handle: RunLogHandle = { store: parentRun.logStore as RunLogStoreType, logRef: parentRun.logRef };
+      await runLogStore.append(handle, {
+        stream: "system",
+        chunk: `--- Follow-up: ${nudgeMessage} ---`,
+        ts: new Date().toISOString(),
+      });
+    }
 
     // 6. Publish live event + start executing
     publishLiveEvent({
-      companyId: newRun.companyId,
+      companyId: reopenedRun.companyId,
       type: "heartbeat.run.queued",
       payload: {
-        runId: newRun.id,
-        agentId: newRun.agentId,
-        invocationSource: newRun.invocationSource,
-        triggerDetail: newRun.triggerDetail,
-        wakeupRequestId: newRun.wakeupRequestId,
+        runId: reopenedRun.id,
+        agentId: reopenedRun.agentId,
+        invocationSource: reopenedRun.invocationSource,
+        triggerDetail: reopenedRun.triggerDetail,
+        wakeupRequestId: reopenedRun.wakeupRequestId,
       },
     });
 
     await startNextQueuedRunForAgent(agent.id);
 
-    return newRun;
+    return reopenedRun;
   }
 
   async function listProjectScopedRunIds(companyId: string, projectId: string) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2091,7 +2091,29 @@ export function heartbeatService(db: Db) {
     const context = parseObject(run.contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
+
+    // --- Lightweight nudge detection ---
+    const isNudge = readNonEmptyString(context.wakeReason) === "run_followup" &&
+      readNonEmptyString(context.nudgeParentRunId);
+
+    // --- Shared variable declarations (set by either nudge or regular path) ---
     const issueId = readNonEmptyString(context.issueId);
+    let runtimeForAdapter!: { sessionId: string | null; sessionParams: Record<string, unknown> | null; sessionDisplayId: string | null; taskKey: string | null };
+    let runtimeConfig!: Record<string, unknown>;
+    let resolvedConfig!: Record<string, unknown>;
+    let secretKeys!: Set<string>;
+    let issueRef: { id: string; identifier: string | null; title: string; projectId: string | null; projectWorkspaceId: string | null; executionWorkspaceId: string | null; executionWorkspacePreference: string | null } | null = null;
+    let persistedExecutionWorkspace: any = null;
+    let runtimeWorkspaceWarnings: string[] = [];
+    let executionWorkspace: RealizedExecutionWorkspace | null = null;
+    let taskSession: typeof agentTaskSessions.$inferSelect | null = null;
+    let taskSessionForRun: typeof agentTaskSessions.$inferSelect | null = null;
+    let previousSessionParams: Record<string, unknown> | null = null;
+    let previousSessionDisplayId: string | null = null;
+    let sessionCompaction: SessionCompactionDecision = { rotate: false, reason: null, handoffMarkdown: null, previousRunId: null };
+
+    // --- Regular run path (non-nudge) ---
+    if (!isNudge) {
     const issueContext = issueId
       ? await db
           .select({
@@ -2133,12 +2155,12 @@ export function heartbeatService(db: Db) {
               isolatedWorkspacesEnabled,
             ))
       : null;
-    const taskSession = taskKey
+    taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;
     const resetTaskSession = shouldResetTaskSessionForWake(context);
     const sessionResetReason = describeSessionResetReason(context);
-    const taskSessionForRun = resetTaskSession ? null : taskSession;
+    taskSessionForRun = resetTaskSession ? null : taskSession;
     const explicitResumeSessionParams = normalizeSessionParams(
       sessionCodec.deserialize(parseObject(context.resumeSessionParams)),
     );
@@ -2147,7 +2169,7 @@ export function heartbeatService(db: Db) {
         (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(explicitResumeSessionParams) : null) ??
         readNonEmptyString(explicitResumeSessionParams?.sessionId),
     );
-    const previousSessionParams =
+    previousSessionParams =
       explicitResumeSessionParams ??
       (explicitResumeSessionDisplayId ? { sessionId: explicitResumeSessionDisplayId } : null) ??
       normalizeSessionParams(sessionCodec.deserialize(taskSessionForRun?.sessionParamsJson ?? null));
@@ -2163,7 +2185,7 @@ export function heartbeatService(db: Db) {
       previousSessionParams,
       { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
     );
-    const issueRef = issueContext
+    issueRef = issueContext
       ? {
           id: issueContext.id,
           identifier: issueContext.identifier,
@@ -2208,12 +2230,12 @@ export function heartbeatService(db: Db) {
       : persistedWorkspaceManagedConfig;
     const configSnapshot = buildExecutionWorkspaceConfigSnapshot(mergedConfig);
     const executionRunConfig = stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
-    const { config: resolvedConfig, secretKeys } = await secretsSvc.resolveAdapterConfigForRuntime(
+    ({ config: resolvedConfig, secretKeys } = await secretsSvc.resolveAdapterConfigForRuntime(
       agent.companyId,
       executionRunConfig,
-    );
+    ));
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
-    const runtimeConfig = {
+    runtimeConfig = {
       ...resolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
@@ -2236,7 +2258,7 @@ export function heartbeatService(db: Db) {
           workspace: existingExecutionWorkspace,
         })
       : null;
-    const executionWorkspace = reusedExecutionWorkspace ?? await realizeExecutionWorkspace({
+    executionWorkspace = reusedExecutionWorkspace ?? await realizeExecutionWorkspace({
           base: executionWorkspaceBase,
           config: runtimeConfig,
           issue: issueRef,
@@ -2249,7 +2271,6 @@ export function heartbeatService(db: Db) {
         });
     const resolvedProjectId = executionWorkspace.projectId ?? issueRef?.projectId ?? executionProjectId ?? null;
     const resolvedProjectWorkspaceId = issueRef?.projectWorkspaceId ?? resolvedWorkspace.workspaceId ?? null;
-    let persistedExecutionWorkspace = null;
     const nextExecutionWorkspaceMetadataBase = {
       ...(existingExecutionWorkspace?.metadata ?? {}),
       source: executionWorkspace.source,
@@ -2398,9 +2419,9 @@ export function heartbeatService(db: Db) {
       },
     });
     const runtimeSessionParams = runtimeSessionResolution.sessionParams;
-    const runtimeWorkspaceWarnings = [
+    runtimeWorkspaceWarnings = [
       ...resolvedWorkspace.warnings,
-      ...executionWorkspace.warnings,
+      ...executionWorkspace!.warnings,
       ...(runtimeSessionResolution.warning ? [runtimeSessionResolution.warning] : []),
       ...(resetTaskSession && sessionResetReason
         ? [
@@ -2445,7 +2466,7 @@ export function heartbeatService(db: Db) {
       context.projectId = executionWorkspace.projectId;
     }
     const runtimeSessionFallback = taskKey || resetTaskSession ? null : runtime.sessionId;
-    let previousSessionDisplayId = truncateDisplayId(
+    previousSessionDisplayId = truncateDisplayId(
       explicitResumeSessionDisplayId ??
         taskSessionForRun?.sessionDisplayId ??
         (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(runtimeSessionParams) : null) ??
@@ -2456,7 +2477,7 @@ export function heartbeatService(db: Db) {
       readNonEmptyString(runtimeSessionParams?.sessionId) ?? runtimeSessionFallback;
     let runtimeSessionParamsForAdapter = runtimeSessionParams;
 
-    const sessionCompaction = await evaluateSessionCompaction({
+    sessionCompaction = await evaluateSessionCompaction({
       agent,
       sessionId: previousSessionDisplayId ?? runtimeSessionIdForAdapter,
       issueId,
@@ -2479,12 +2500,58 @@ export function heartbeatService(db: Db) {
       delete context.paperclipPreviousSessionId;
     }
 
-    const runtimeForAdapter = {
+    runtimeForAdapter = {
       sessionId: runtimeSessionIdForAdapter,
       sessionParams: runtimeSessionParamsForAdapter,
       sessionDisplayId: previousSessionDisplayId,
       taskKey,
     };
+    } // end if (!isNudge) block
+
+    // --- Lightweight nudge shortcut: set up variables directly from carried-forward context ---
+    if (isNudge) {
+      // Read parent workspace from context (carried forward by enqueueNudge)
+      const parentWorkspace = parseObject(context.paperclipWorkspace);
+      const nudgeCwd = readNonEmptyString(parentWorkspace.cwd);
+      if (nudgeCwd) {
+        const cwdExists = await fs.stat(nudgeCwd).then(() => true).catch(() => false);
+        if (cwdExists) {
+          const parentWorkspaceId = readNonEmptyString(parentWorkspace.workspaceId);
+          const executionWorkspaceId = readNonEmptyString(context.executionWorkspaceId);
+          if (parentWorkspaceId && executionWorkspaceId) {
+            persistedExecutionWorkspace = await executionWorkspacesSvc.getById(executionWorkspaceId).catch(() => null);
+          }
+        }
+      }
+      const nudgeTaskKey = readNonEmptyString(context.taskKey);
+
+      previousSessionParams = normalizeSessionParams(
+        sessionCodec.deserialize(parseObject(context.resumeSessionParams)),
+      );
+      previousSessionDisplayId = truncateDisplayId(
+        readNonEmptyString(context.resumeSessionDisplayId),
+      );
+
+      runtimeForAdapter = {
+        sessionId: readNonEmptyString(previousSessionParams?.sessionId) ?? null,
+        sessionParams: previousSessionParams,
+        sessionDisplayId: previousSessionDisplayId,
+        taskKey: nudgeTaskKey,
+      };
+
+      // Still need to resolve secrets for env vars
+      const config = parseObject(agent.adapterConfig);
+      const secretResult = await secretsSvc.resolveAdapterConfigForRuntime(agent.companyId, config);
+      resolvedConfig = secretResult.config;
+      secretKeys = secretResult.secretKeys;
+
+      runtimeConfig = {
+        ...resolvedConfig,
+        paperclipRuntimeSkills: await companySkills.listRuntimeSkillEntries(agent.companyId),
+      };
+
+      runtimeWorkspaceWarnings = [];
+    }
 
     let seq = 1;
     let handle: RunLogHandle | null = null;
@@ -2589,21 +2656,25 @@ export function heartbeatService(db: Db) {
           (entry): entry is [string, string] => typeof entry[0] === "string" && typeof entry[1] === "string",
         ),
       );
-      const runtimeServices = await ensureRuntimeServicesForRun({
-        db,
-        runId: run.id,
-        agent: {
-          id: agent.id,
-          name: agent.name,
-          companyId: agent.companyId,
-        },
-        issue: issueRef,
-        workspace: executionWorkspace,
-        executionWorkspaceId: persistedExecutionWorkspace?.id ?? issueRef?.executionWorkspaceId ?? null,
-        config: resolvedConfig,
-        adapterEnv,
-        onLog,
-      });
+      // For nudge runs, runtime services are carried forward from the parent run's context.
+      // Only set up new runtime services for non-nudge runs.
+      const runtimeServices = !isNudge && executionWorkspace
+        ? await ensureRuntimeServicesForRun({
+            db,
+            runId: run.id,
+            agent: {
+              id: agent.id,
+              name: agent.name,
+              companyId: agent.companyId,
+            },
+            issue: issueRef,
+            workspace: executionWorkspace,
+            executionWorkspaceId: persistedExecutionWorkspace?.id ?? issueRef?.executionWorkspaceId ?? null,
+            config: resolvedConfig,
+            adapterEnv,
+            onLog,
+          })
+        : [];
       if (runtimeServices.length > 0) {
         context.paperclipRuntimeServices = runtimeServices;
         context.paperclipRuntimePrimaryUrl =
@@ -2616,7 +2687,7 @@ export function heartbeatService(db: Db) {
           })
           .where(eq(heartbeatRuns.id, run.id));
       }
-      if (issueId && (executionWorkspace.created || runtimeServices.some((service) => !service.reused))) {
+      if (executionWorkspace && issueId && (executionWorkspace.created || runtimeServices.some((service) => !service.reused))) {
         try {
           await issuesSvc.addComment(
             issueId,
@@ -2676,7 +2747,7 @@ export function heartbeatService(db: Db) {
         },
         authToken: authToken ?? undefined,
       });
-      const adapterManagedRuntimeServices = adapterResult.runtimeServices
+      const adapterManagedRuntimeServices = adapterResult.runtimeServices && executionWorkspace
         ? await persistAdapterManagedRuntimeServices({
             db,
             adapterType: agent.adapterType,
@@ -2711,7 +2782,7 @@ export function heartbeatService(db: Db) {
             await issuesSvc.addComment(
               issueId,
               buildWorkspaceReadyComment({
-                workspace: executionWorkspace,
+                workspace: executionWorkspace!,
                 runtimeServices: adapterManagedRuntimeServices,
               }),
               { agentId: agent.id, runId: run.id },
@@ -3616,6 +3687,116 @@ export function heartbeatService(db: Db) {
     return newRun;
   }
 
+  async function enqueueNudge(parentRunId: string, nudgeMessage: string, actor: { actorType: "user" | "agent"; actorId: string | null }) {
+    // 1. Validate parent run
+    const parentRun = await getRun(parentRunId);
+    if (!parentRun) throw notFound("Heartbeat run not found");
+
+    const terminalStatuses = new Set(["succeeded", "failed", "timed_out", "cancelled"]);
+    if (!terminalStatuses.has(parentRun.status)) {
+      throw conflict("Can only nudge runs in a terminal state");
+    }
+
+    const parentSessionIdAfter = readNonEmptyString(parentRun.sessionIdAfter);
+    if (!parentSessionIdAfter) {
+      throw conflict("Parent run has no session to resume");
+    }
+
+    // 2. Validate agent
+    const agent = await getAgent(parentRun.agentId);
+    if (!agent) throw notFound("Agent not found");
+    if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
+      throw notFound("Agent is not invokable in its current state");
+    }
+
+    // 3. Budget check — reuse parent's issue/project scope if available
+    const parentContext = parseObject(parentRun.contextSnapshot);
+    const parentId = readNonEmptyString(parentContext.issueId);
+    const parentProjectId = readNonEmptyString(parentContext.projectId);
+    await budgets.getInvocationBlock(parentRun.companyId, agent.id, {
+      issueId: parentId,
+      projectId: parentProjectId,
+    });
+
+    // 4. Build context snapshot carrying forward parent's resolved data
+    const sessionCodec = getAdapterSessionCodec(agent.adapterType);
+    const contextSnapshot: Record<string, unknown> = {
+      issueId: readNonEmptyString(parentContext.issueId),
+      taskId: readNonEmptyString(parentContext.taskId),
+      taskKey: readNonEmptyString(parentContext.taskKey),
+      projectId: readNonEmptyString(parentContext.projectId),
+      wakeReason: "run_followup",
+      wakeSource: "on_demand",
+      wakeTriggerDetail: "nudge",
+      nudgeMessage,
+      nudgeParentRunId: parentRunId,
+    };
+
+    // Carry forward resolved workspace so executeRun can skip realization
+    const parentWorkspace = parentContext.paperclipWorkspace;
+    if (parentWorkspace) {
+      contextSnapshot.paperclipWorkspace = parentWorkspace;
+    }
+    // Carry forward runtime services
+    const parentRuntimeServices = parentContext.paperclipRuntimeServices;
+    if (parentRuntimeServices && Array.isArray(parentRuntimeServices)) {
+      contextSnapshot.paperclipRuntimeServices = parentRuntimeServices;
+      const parentPrimaryUrl = readNonEmptyString(parentContext.paperclipRuntimePrimaryUrl);
+      if (parentPrimaryUrl) contextSnapshot.paperclipRuntimePrimaryUrl = parentPrimaryUrl;
+    }
+    // Session resume params
+    contextSnapshot.resumeFromRunId = parentRunId;
+    contextSnapshot.resumeSessionDisplayId = parentSessionIdAfter;
+    const serializedParams = sessionCodec.serialize({ sessionId: parentSessionIdAfter });
+    if (serializedParams) contextSnapshot.resumeSessionParams = serializedParams;
+
+    // 5. Create wakeup request and run records directly (bypass coalescing/issue locks)
+    const wakeupRequest = await db.insert(agentWakeupRequests).values({
+      companyId: agent.companyId,
+      agentId: agent.id,
+      source: "on_demand",
+      triggerDetail: "nudge",
+      reason: "run_followup",
+      payload: { nudgeMessage, nudgeParentRunId: parentRunId },
+      status: "queued",
+      requestedByActorType: actor.actorType,
+      requestedByActorId: actor.actorId,
+    }).returning().then((rows) => rows[0]);
+
+    const newRun = await db.insert(heartbeatRuns).values({
+      companyId: agent.companyId,
+      agentId: agent.id,
+      invocationSource: "on_demand",
+      triggerDetail: "nudge",
+      status: "queued",
+      wakeupRequestId: wakeupRequest.id,
+      contextSnapshot,
+      sessionIdBefore: parentSessionIdAfter,
+    }).returning().then((rows) => rows[0]);
+
+    await db.update(agentWakeupRequests).set({
+      runId: newRun.id,
+      updatedAt: new Date(),
+    }).where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+    // 6. Publish live event + start executing
+    publishLiveEvent({
+      companyId: newRun.companyId,
+      type: "heartbeat.run.queued",
+      payload: {
+        runId: newRun.id,
+        agentId: newRun.agentId,
+        invocationSource: newRun.invocationSource,
+        triggerDetail: newRun.triggerDetail,
+        wakeupRequestId: newRun.wakeupRequestId,
+      },
+    });
+
+    await startNextQueuedRunForAgent(agent.id);
+
+    return newRun;
+  }
+
   async function listProjectScopedRunIds(companyId: string, projectId: string) {
     const runIssueId = sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`;
     const effectiveProjectId = sql<string | null>`coalesce(${heartbeatRuns.contextSnapshot} ->> 'projectId', ${issues.projectId}::text)`;
@@ -3947,6 +4128,8 @@ export function heartbeatService(db: Db) {
       }),
 
     wakeup: enqueueWakeup,
+
+    nudge: enqueueNudge,
 
     reportRunActivity: clearDetachedRunWarning,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3776,6 +3776,12 @@ export function heartbeatService(db: Db) {
     const serializedParams = sessionCodec.serialize({ sessionId: parentSessionIdAfter });
     if (serializedParams) contextSnapshot.resumeSessionParams = serializedParams;
 
+    // Carry forward executionWorkspaceId for execution-workspace bookkeeping
+    const parentExecutionWorkspaceId = readNonEmptyString(parentContext.executionWorkspaceId);
+    if (parentExecutionWorkspaceId) {
+      contextSnapshot.executionWorkspaceId = parentExecutionWorkspaceId;
+    }
+
     // 5. Create wakeup request and re-open the parent run (no new run record)
     const wakeupRequest = await db.insert(agentWakeupRequests).values({
       companyId: agent.companyId,
@@ -3793,7 +3799,7 @@ export function heartbeatService(db: Db) {
     // Stash previous usage so executeRun can accumulate it after the nudge completes
     contextSnapshot.nudgePreviousUsageJson = parentRun.usageJson ?? null;
 
-    // Re-open the parent run: transition back to "queued" so executeRun can claim it
+    // Re-open the parent run: guard against concurrent nudges re-opening the same run
     const reopenedRun = await db.update(heartbeatRuns).set({
       status: "queued",
       finishedAt: null,
@@ -3805,7 +3811,11 @@ export function heartbeatService(db: Db) {
       contextSnapshot,
       sessionIdBefore: parentSessionIdAfter,
       updatedAt: new Date(),
-    }).where(eq(heartbeatRuns.id, parentRunId)).returning().then((rows) => rows[0]);
+    }).where(and(eq(heartbeatRuns.id, parentRunId), inArray(heartbeatRuns.status, [...terminalStatuses]))).returning().then((rows) => rows[0]);
+
+    if (!reopenedRun) {
+      throw conflict("Can only nudge runs in a terminal state");
+    }
 
     // Inject a nudge boundary marker into the existing log file
     if (parentRun.logStore && parentRun.logRef) {

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -50,6 +50,8 @@ export const heartbeatsApi = {
       `/workspace-operations/${operationId}/log?offset=${encodeURIComponent(String(offset))}&limitBytes=${encodeURIComponent(String(limitBytes))}`,
     ),
   cancel: (runId: string) => api.post<void>(`/heartbeat-runs/${runId}/cancel`, {}),
+  nudge: (runId: string, message: string) =>
+    api.post<HeartbeatRun>(`/heartbeat-runs/${runId}/nudge`, { message }),
   liveRunsForIssue: (issueId: string) =>
     api.get<LiveRunForIssue[]>(`/issues/${issueId}/live-runs`),
   activeRunForIssue: (issueId: string) =>

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   CircleAlert,
+  MessageSquare,
   TerminalSquare,
   User,
   Wrench,
@@ -104,6 +105,11 @@ type TranscriptBlock =
       tone: "info" | "warn" | "error" | "neutral";
       text: string;
       detail?: string;
+    }
+  | {
+      type: "nudge_separator";
+      ts: string;
+      message: string;
     };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -541,6 +547,15 @@ export function normalizeTranscript(entries: TranscriptEntry[], streaming: boole
             pendingActivityBlocks.set(activity.activityId, block);
           }
         }
+        continue;
+      }
+      const nudgeMatch = entry.text.match(/^---\s*Follow-up:\s*(.*?)\s*---$/);
+      if (nudgeMatch) {
+        blocks.push({
+          type: "nudge_separator",
+          ts: entry.ts,
+          message: nudgeMatch[1] ?? "",
+        });
         continue;
       }
       blocks.push({
@@ -1159,6 +1174,23 @@ function TranscriptStdoutRow({
   );
 }
 
+function TranscriptNudgeSeparator({
+  block,
+}: {
+  block: Extract<TranscriptBlock, { type: "nudge_separator" }>;
+}) {
+  return (
+    <div className="flex items-center gap-3 py-1">
+      <div className="flex-1 border-t border-blue-400/30" />
+      <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400 flex items-center gap-1.5">
+        <MessageSquare className="h-3 w-3" />
+        Follow-up: {block.message}
+      </span>
+      <div className="flex-1 border-t border-blue-400/30" />
+    </div>
+  );
+}
+
 function RawTranscriptView({
   entries,
   density,
@@ -1248,6 +1280,7 @@ export function RunTranscriptView({
           )}
           {block.type === "activity" && <TranscriptActivityRow block={block} density={density} />}
           {block.type === "event" && <TranscriptEventRow block={block} density={density} />}
+          {block.type === "nudge_separator" && <TranscriptNudgeSeparator block={block} />}
         </div>
       ))}
     </div>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -70,10 +70,12 @@ import {
   ArrowLeft,
   HelpCircle,
   FolderOpen,
+  Send,
 } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { AgentIcon, AgentIconPicker } from "../components/AgentIconPicker";
 import { RunTranscriptView, type TranscriptMode } from "../components/transcript/RunTranscriptView";
 import {
@@ -929,15 +931,8 @@ export function AgentDetail() {
       )}
 
       {/* Floating Save/Cancel (desktop) */}
-      {!isMobile && (
-        <div
-          className={cn(
-            "sticky top-6 z-10 float-right transition-opacity duration-150",
-            showConfigActionBar
-              ? "opacity-100"
-              : "opacity-0 pointer-events-none"
-          )}
-        >
+      {!isMobile && showConfigActionBar && (
+        <div className="sticky top-6 z-10 float-right">
           <div className="flex items-center gap-2 bg-background/90 backdrop-blur-sm border border-border rounded-lg px-3 py-1.5 shadow-lg">
             <Button
               variant="ghost"
@@ -2911,6 +2906,26 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
     },
   });
+  // Can only nudge completed runs with a session
+  const canNudge = useMemo(() => {
+    if (!["succeeded", "failed", "timed_out"].includes(run.status)) return false;
+    return !!run.sessionIdAfter;
+  }, [run.status, run.sessionIdAfter]);
+  const [nudgeMessage, setNudgeMessage] = useState("");
+  const nudgeRun = useMutation({
+    mutationFn: async () => {
+      const trimmed = nudgeMessage.trim();
+      if (!trimmed) throw new Error("Message is required");
+      const result = await heartbeatsApi.nudge(run.id, trimmed);
+      return result;
+    },
+    onSuccess: (newRun) => {
+      setNudgeMessage("");
+      queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
+      navigate(`/agents/${agentRouteId}/runs/${newRun.id}`);
+    },
+  });
+
   const canResumeLostRun = run.errorCode === "process_lost" && run.status === "failed";
   const resumePayload = useMemo(() => {
     const payload: Record<string, unknown> = {
@@ -3293,6 +3308,48 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
 
       {/* Log viewer */}
       <LogViewer run={run} adapterType={adapterType} />
+
+      {/* Nudge follow-up input */}
+      {canNudge && (
+        <div className="border border-border rounded-lg p-3 space-y-2">
+          <div className="text-xs text-muted-foreground font-medium">Follow up</div>
+          <div className="flex gap-2">
+            <Textarea
+              value={nudgeMessage}
+              onChange={(e) => setNudgeMessage(e.target.value)}
+              placeholder="Ask a follow-up question..."
+              className="min-h-[38px] text-sm resize-none"
+              rows={1}
+              disabled={nudgeRun.isPending}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey && nudgeMessage.trim()) {
+                  e.preventDefault();
+                  nudgeRun.mutate();
+                }
+              }}
+            />
+            <Button
+              variant="default"
+              size="sm"
+              className="shrink-0 self-end"
+              onClick={() => nudgeRun.mutate()}
+              disabled={nudgeRun.isPending || !nudgeMessage.trim()}
+            >
+              {nudgeRun.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+          {nudgeRun.isError && (
+            <div className="text-xs text-destructive">
+              {nudgeRun.error instanceof Error ? nudgeRun.error.message : "Failed to send follow-up"}
+            </div>
+          )}
+        </div>
+      )}
+
       <ScrollToBottom />
     </div>
   );

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2919,10 +2919,13 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType }: { run: Heartb
       const result = await heartbeatsApi.nudge(run.id, trimmed);
       return result;
     },
-    onSuccess: (newRun) => {
+    onSuccess: () => {
       setNudgeMessage("");
+      // Invalidate run queries so the current run refreshes with status "running"
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
-      navigate(`/agents/${agentRouteId}/runs/${newRun.id}`);
+      queryClient.invalidateQueries({ queryKey: queryKeys.runDetail(run.id) });
+      // Stay on the same page — the run status changes to "running", reactivating
+      // WebSocket streaming + log polling to show the nudge output in real time.
     },
   });
 


### PR DESCRIPTION
## Summary
- Add lightweight nudge path for fast follow-up runs with improved logging
- Make nudge runs skip instructions/skills and frame as follow-up messages
- Improve follow-up message display and logging in heartbeat service

## Test plan
- [ ] Verify nudge runs skip instructions/skills parsing
- [ ] Confirm follow-up messages display correctly in UI
- [ ] Check heartbeat logs for nudge-related entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)