### PR TITLE
ci: add workflow_dispatch trigger to Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - "master"
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Docker build workflow so we can manually trigger image builds from the Actions UI
- No other changes — the existing Dockerfile and build pipeline from upstream are used as-is

## Test plan

- [ ] Merge to master, then trigger manually from Actions tab
- [ ] Verify image is pushed to `ghcr.io/osodevops/docker-paperclip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)