### PR TITLE
fix: recover cursor command fallback and harden issue launch path

### DIFF
--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -66,7 +66,7 @@ Core fields:
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Cursor model id (for example auto or gpt-5.3-codex)
 - mode (string, optional): Cursor execution mode passed as --mode (plan|ask). Leave unset for normal autonomous runs.
-- command (string, optional): defaults to "agent"
+- command (string, optional): optional Cursor CLI entrypoint override. When unset, Paperclip tries "agent", then "cursor", then the bundled macOS Cursor app binary.
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables
 
@@ -75,7 +75,7 @@ Operational fields:
 - graceSec (number, optional): SIGTERM grace period in seconds
 
 Notes:
-- Runs are executed with: agent -p --output-format stream-json ...
+- Runs are executed with the standalone "agent -p --output-format stream-json ..." command when available, otherwise Paperclip automatically uses Cursor's "cursor agent ..." entrypoint.
 - Prompts are piped to Cursor via stdin.
 - Sessions are resumed with --resume when stored session cwd matches current cwd.
 - Paperclip auto-injects local skills into "~/.cursor/skills" when missing, so Cursor can discover "$paperclip" and related skills on local runs.

--- a/packages/adapters/cursor-local/src/server/command.test.ts
+++ b/packages/adapters/cursor-local/src/server/command.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCursorCommandCandidates,
+  classifyCursorCommand,
+  resolveCursorCommand,
+} from "./command.js";
+
+describe("classifyCursorCommand", () => {
+  it("treats the legacy standalone agent binary as a direct command", () => {
+    expect(classifyCursorCommand("agent")).toEqual({
+      invocationKind: "standalone_agent",
+      baseArgs: [],
+    });
+  });
+
+  it("treats the Cursor CLI as requiring the agent subcommand", () => {
+    expect(classifyCursorCommand("/Applications/Cursor.app/Contents/Resources/app/bin/cursor")).toEqual({
+      invocationKind: "cursor_subcommand",
+      baseArgs: ["agent"],
+    });
+  });
+
+  it("treats unknown wrappers as custom commands", () => {
+    expect(classifyCursorCommand(process.execPath)).toEqual({
+      invocationKind: "custom",
+      baseArgs: [],
+    });
+  });
+});
+
+describe("buildCursorCommandCandidates", () => {
+  it("tries the legacy agent binary first, then falls back to cursor", () => {
+    expect(buildCursorCommandCandidates("")).toEqual([
+      {
+        command: "agent",
+        invocationKind: "standalone_agent",
+        baseArgs: [],
+      },
+      {
+        command: "cursor",
+        invocationKind: "cursor_subcommand",
+        baseArgs: ["agent"],
+      },
+      {
+        command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+        invocationKind: "cursor_subcommand",
+        baseArgs: ["agent"],
+      },
+      {
+        command: "/Applications/Cursor EAP.app/Contents/Resources/app/bin/cursor",
+        invocationKind: "cursor_subcommand",
+        baseArgs: ["agent"],
+      },
+    ]);
+  });
+
+  it("keeps an explicit custom command as the only candidate", () => {
+    expect(buildCursorCommandCandidates("/custom/bin/cursor")).toEqual([
+      {
+        command: "/custom/bin/cursor",
+        invocationKind: "cursor_subcommand",
+        baseArgs: ["agent"],
+      },
+    ]);
+  });
+});
+
+describe("resolveCursorCommand", () => {
+  it("falls back to the Cursor CLI when the legacy agent binary is unavailable", async () => {
+    const seen: string[] = [];
+
+    const resolved = await resolveCursorCommand({
+      configuredCommand: "",
+      cwd: "/tmp",
+      env: {},
+      ensureResolvable: async (command) => {
+        seen.push(command);
+        if (command === "agent") {
+          throw new Error("agent missing");
+        }
+      },
+    });
+
+    expect(seen).toEqual(["agent", "cursor"]);
+    expect(resolved).toEqual({
+      command: "cursor",
+      invocationKind: "cursor_subcommand",
+      baseArgs: ["agent"],
+    });
+  });
+
+  it("treats an explicit legacy 'agent' command like the old default and still falls back", async () => {
+    const seen: string[] = [];
+
+    const resolved = await resolveCursorCommand({
+      configuredCommand: "agent",
+      cwd: "/tmp",
+      env: {},
+      ensureResolvable: async (command) => {
+        seen.push(command);
+        if (command === "agent") {
+          throw new Error("agent missing");
+        }
+      },
+    });
+
+    expect(seen).toEqual(["agent", "cursor"]);
+    expect(resolved).toEqual({
+      command: "cursor",
+      invocationKind: "cursor_subcommand",
+      baseArgs: ["agent"],
+    });
+  });
+});

--- a/packages/adapters/cursor-local/src/server/command.ts
+++ b/packages/adapters/cursor-local/src/server/command.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+import { ensureCommandResolvable } from "@paperclipai/adapter-utils/server-utils";
+
+export type CursorInvocationKind = "standalone_agent" | "cursor_subcommand" | "custom";
+
+export type CursorCommandCandidate = {
+  command: string;
+  invocationKind: CursorInvocationKind;
+  baseArgs: string[];
+};
+
+type ResolveCursorCommandInput = {
+  configuredCommand: string | null | undefined;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  ensureResolvable?: (
+    command: string,
+    cwd: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<void>;
+};
+
+const MAC_CURSOR_APP_COMMANDS = [
+  "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+  "/Applications/Cursor EAP.app/Contents/Resources/app/bin/cursor",
+] as const;
+
+function commandBasename(command: string): string {
+  return path.basename(command.trim()).toLowerCase();
+}
+
+function isLegacyAgentCommand(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+  const base = commandBasename(trimmed);
+  if (base !== "agent" && base !== "agent.cmd" && base !== "agent.exe") return false;
+  return !trimmed.includes("/") && !trimmed.includes("\\");
+}
+
+export function classifyCursorCommand(command: string): Omit<CursorCommandCandidate, "command"> {
+  const base = commandBasename(command);
+  if (base === "cursor" || base === "cursor.cmd" || base === "cursor.exe") {
+    return {
+      invocationKind: "cursor_subcommand",
+      baseArgs: ["agent"],
+    };
+  }
+  if (base === "agent" || base === "agent.cmd" || base === "agent.exe") {
+    return {
+      invocationKind: "standalone_agent",
+      baseArgs: [],
+    };
+  }
+
+  return {
+    invocationKind: "custom",
+    baseArgs: [],
+  };
+}
+
+export function buildCursorCommandCandidates(configuredCommand: string | null | undefined): CursorCommandCandidate[] {
+  const trimmed = configuredCommand?.trim() ?? "";
+  if (trimmed && !isLegacyAgentCommand(trimmed)) {
+    return [{ command: trimmed, ...classifyCursorCommand(trimmed) }];
+  }
+
+  return ["agent", "cursor", ...MAC_CURSOR_APP_COMMANDS].map((command) => ({
+    command,
+    ...classifyCursorCommand(command),
+  }));
+}
+
+export function describeCursorCommand(candidate: Pick<CursorCommandCandidate, "command" | "baseArgs">): string {
+  return [candidate.command, ...candidate.baseArgs].join(" ");
+}
+
+export function cursorLoginCommand(candidate: Pick<CursorCommandCandidate, "command" | "baseArgs">): string {
+  return describeCursorCommand({
+    command: candidate.command,
+    baseArgs: [...candidate.baseArgs, "login"],
+  });
+}
+
+export async function resolveCursorCommand(input: ResolveCursorCommandInput): Promise<CursorCommandCandidate> {
+  const ensureResolvable = input.ensureResolvable ?? ensureCommandResolvable;
+  const candidates = buildCursorCommandCandidates(input.configuredCommand);
+  let firstError: unknown = null;
+
+  for (const candidate of candidates) {
+    try {
+      await ensureResolvable(candidate.command, input.cwd, input.env);
+      return candidate;
+    } catch (err) {
+      if (firstError == null) firstError = err;
+    }
+  }
+
+  if (firstError instanceof Error) throw firstError;
+  throw new Error("Unable to resolve a Cursor CLI command");
+}

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -11,7 +11,6 @@ import {
   buildPaperclipEnv,
   buildInvocationEnvForLogs,
   ensureAbsoluteDirectory,
-  ensureCommandResolvable,
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   readPaperclipRuntimeSkillEntries,
@@ -26,6 +25,7 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
+import { describeCursorCommand, resolveCursorCommand } from "./command.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -164,7 +164,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   );
-  const command = asString(config.command, "agent");
+  const configuredCommand = asString(config.command, "");
   const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
   const mode = normalizeMode(asString(config.mode, ""));
 
@@ -271,8 +271,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const billingType = resolveCursorBillingType(effectiveEnv);
   const runtimeEnv = ensurePathInEnv(effectiveEnv);
-  await ensureCommandResolvable(command, cwd, runtimeEnv);
-  const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
+  const resolvedCursorCommand = await resolveCursorCommand({
+    configuredCommand,
+    cwd,
+    env: runtimeEnv,
+  });
+  const resolvedCommand = await resolveCommandForLogs(resolvedCursorCommand.command, cwd, runtimeEnv);
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
     includeRuntimeKeys: ["HOME"],
@@ -382,7 +386,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (mode) args.push("--mode", mode);
     if (autoTrustEnabled) args.push("--yolo");
     if (extraArgs.length > 0) args.push(...extraArgs);
-    return args;
+    return [...resolvedCursorCommand.baseArgs, ...args];
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {
@@ -390,7 +394,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (onMeta) {
       await onMeta({
         adapterType: "cursor",
-        command: resolvedCommand,
+        command: describeCursorCommand({
+          command: resolvedCommand,
+          baseArgs: resolvedCursorCommand.baseArgs,
+        }),
         cwd,
         commandNotes,
         commandArgs: args,
@@ -425,7 +432,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
     };
 
-    const proc = await runChildProcess(runId, command, args, {
+    const proc = await runChildProcess(runId, resolvedCursorCommand.command, args, {
       cwd,
       env,
       timeoutSec,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -25,7 +25,7 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
-import { describeCursorCommand, resolveCursorCommand } from "./command.js";
+import { resolveCursorCommand } from "./command.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -394,10 +394,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (onMeta) {
       await onMeta({
         adapterType: "cursor",
-        command: describeCursorCommand({
-          command: resolvedCommand,
-          baseArgs: resolvedCursorCommand.baseArgs,
-        }),
+        command: resolvedCommand,
         cwd,
         commandNotes,
         commandArgs: args,

--- a/packages/adapters/cursor-local/src/server/test.ts
+++ b/packages/adapters/cursor-local/src/server/test.ts
@@ -8,7 +8,6 @@ import {
   asStringArray,
   parseObject,
   ensureAbsoluteDirectory,
-  ensureCommandResolvable,
   ensurePathInEnv,
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -18,6 +17,11 @@ import path from "node:path";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl } from "./parse.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
+import {
+  cursorLoginCommand,
+  describeCursorCommand,
+  resolveCursorCommand,
+} from "./command.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -36,11 +40,6 @@ function firstNonEmptyLine(text: string): string {
       .map((line) => line.trim())
       .find(Boolean) ?? ""
   );
-}
-
-function commandLooksLike(command: string, expected: string): boolean {
-  const base = path.basename(command).toLowerCase();
-  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
 }
 
 function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
@@ -94,7 +93,7 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const command = asString(config.command, "agent");
+  const configuredCommand = asString(config.command, "");
   const cwd = asString(config.cwd, process.cwd());
 
   try {
@@ -119,19 +118,26 @@ export async function testEnvironment(
     if (typeof value === "string") env[key] = value;
   }
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  let resolvedCursorCommand:
+    | Awaited<ReturnType<typeof resolveCursorCommand>>
+    | null = null;
   try {
-    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    resolvedCursorCommand = await resolveCursorCommand({
+      configuredCommand,
+      cwd,
+      env: runtimeEnv,
+    });
     checks.push({
       code: "cursor_command_resolvable",
       level: "info",
-      message: `Command is executable: ${command}`,
+      message: `Command is executable: ${describeCursorCommand(resolvedCursorCommand)}`,
     });
   } catch (err) {
     checks.push({
       code: "cursor_command_unresolvable",
       level: "error",
       message: err instanceof Error ? err.message : "Command is not executable",
-      detail: command,
+      detail: configuredCommand || "agent / cursor",
     });
   }
 
@@ -152,7 +158,7 @@ export async function testEnvironment(
       checks.push({
         code: "cursor_native_auth_present",
         level: "info",
-        message: "Cursor is authenticated via `agent login`.",
+        message: "Cursor CLI authentication is configured.",
         detail: cursorAuth.email
           ? `Logged in as ${cursorAuth.email}.`
           : `Credentials found in ${cursorConfigPath(cursorHome)}.`,
@@ -162,21 +168,22 @@ export async function testEnvironment(
         code: "cursor_api_key_missing",
         level: "warn",
         message: "CURSOR_API_KEY is not set. Cursor runs may fail until authentication is configured.",
-        hint: "Set CURSOR_API_KEY in adapter env or run `agent login`.",
+        hint: `Set CURSOR_API_KEY in adapter env or run \`${cursorLoginCommand(
+          resolvedCursorCommand ?? { command: configuredCommand || "cursor", baseArgs: ["agent"] },
+        )}\`.`,
       });
     }
   }
 
   const canRunProbe =
     checks.every((check) => check.code !== "cursor_cwd_invalid" && check.code !== "cursor_command_unresolvable");
-  if (canRunProbe) {
-    if (!commandLooksLike(command, "agent")) {
+  if (canRunProbe && resolvedCursorCommand) {
+    if (resolvedCursorCommand.invocationKind === "custom") {
       checks.push({
         code: "cursor_hello_probe_skipped_custom_command",
         level: "info",
-        message: "Skipped hello probe because command is not `agent`.",
-        detail: command,
-        hint: "Use the `agent` CLI command to run the automatic installation and auth probe.",
+        message: "Skipped hello probe because command is not a known Cursor CLI entrypoint.",
+        detail: resolvedCursorCommand.command,
       });
     } else {
       const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
@@ -194,8 +201,8 @@ export async function testEnvironment(
 
       const probe = await runChildProcess(
         `cursor-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-        command,
-        args,
+        resolvedCursorCommand.command,
+        [...resolvedCursorCommand.baseArgs, ...args],
         {
           cwd,
           env,
@@ -213,7 +220,9 @@ export async function testEnvironment(
           code: "cursor_hello_probe_timed_out",
           level: "warn",
           message: "Cursor hello probe timed out.",
-          hint: "Retry the probe. If this persists, verify `agent -p --mode ask --output-format json \"Respond with hello.\"` manually.",
+          hint: `Retry the probe. If this persists, verify \`${describeCursorCommand(
+            resolvedCursorCommand,
+          )} -p --mode ask --output-format json "Respond with hello."\` manually.`,
         });
       } else if ((probe.exitCode ?? 1) === 0) {
         const summary = parsed.summary.trim();
@@ -228,7 +237,9 @@ export async function testEnvironment(
           ...(hasHello
             ? {}
             : {
-                hint: "Try `agent -p --mode ask --output-format json \"Respond with hello.\"` manually to inspect full output.",
+                hint: `Try \`${describeCursorCommand(
+                  resolvedCursorCommand,
+                )} -p --mode ask --output-format json "Respond with hello."\` manually to inspect full output.`,
               }),
         });
       } else if (CURSOR_AUTH_REQUIRED_RE.test(authEvidence)) {
@@ -237,7 +248,9 @@ export async function testEnvironment(
           level: "warn",
           message: "Cursor CLI is installed, but authentication is not ready.",
           ...(detail ? { detail } : {}),
-          hint: "Run `agent login` or configure CURSOR_API_KEY in adapter env/shell, then retry the probe.",
+          hint: `Run \`${cursorLoginCommand(
+            resolvedCursorCommand,
+          )}\` or configure CURSOR_API_KEY in adapter env/shell, then retry the probe.`,
         });
       } else {
         checks.push({
@@ -245,7 +258,9 @@ export async function testEnvironment(
           level: "error",
           message: "Cursor hello probe failed.",
           ...(detail ? { detail } : {}),
-          hint: "Run `agent -p --mode ask --output-format json \"Respond with hello.\"` manually in this working directory to debug.",
+          hint: `Run \`${describeCursorCommand(
+            resolvedCursorCommand,
+          )} -p --mode ask --output-format json "Respond with hello."\` manually in this working directory to debug.`,
         });
       }
     }

--- a/packages/adapters/cursor-local/vitest.config.ts
+++ b/packages/adapters/cursor-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -7,6 +7,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -857,5 +858,211 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     expect(followUp.executionWorkspaceSettings).toEqual({
       mode: "operator_branch",
     });
+  });
+});
+
+describeEmbeddedPostgres("issueService.checkout stale execution lock recovery", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-checkout-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("adopts a stale execution lock when checkoutRunId is null on a blocked issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const staleExecutionRunId = randomUUID();
+    const actorRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CheckoutAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const now = new Date();
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleExecutionRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "failed",
+        startedAt: new Date(now.getTime() - 60_000),
+        finishedAt: now,
+      },
+      {
+        id: actorRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "running",
+        startedAt: now,
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale execution lock repro",
+      status: "blocked",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: staleExecutionRunId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo", "backlog", "blocked"], actorRunId);
+
+    expect(checkedOut.status).toBe("in_progress");
+    expect(checkedOut.assigneeAgentId).toBe(agentId);
+    expect(checkedOut.checkoutRunId).toBe(actorRunId);
+    expect(checkedOut.executionRunId).toBe(actorRunId);
+    expect(checkedOut.startedAt).toBeTruthy();
+  });
+
+  it("clears execution lock metadata when status leaves in_progress", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "StatusTransitionAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const now = new Date();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      startedAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Status transition lock cleanup",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionLockedAt: now,
+    });
+
+    const updated = await svc.update(issueId, { status: "blocked" });
+    expect(updated?.status).toBe("blocked");
+    expect(updated?.checkoutRunId).toBeNull();
+    expect(updated?.executionRunId).toBeNull();
+    expect(updated?.executionLockedAt).toBeNull();
+  });
+
+  it("clears execution lock metadata when releasing an in-progress issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReleaseAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const now = new Date();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      startedAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Release lock cleanup",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionLockedAt: now,
+    });
+
+    const released = await svc.release(issueId, agentId, runId);
+    expect(released?.status).toBe("todo");
+    expect(released?.assigneeAgentId).toBeNull();
+    expect(released?.checkoutRunId).toBeNull();
+    expect(released?.executionRunId).toBeNull();
+    expect(released?.executionLockedAt).toBeNull();
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1291,12 +1291,16 @@ export function issueService(db: Db) {
       }
       if (issueData.status && issueData.status !== "in_progress") {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionLockedAt = null;
       }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {
@@ -1426,6 +1430,47 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
+
+      if (
+        checkoutRunId &&
+        current.checkoutRunId == null &&
+        current.executionRunId &&
+        current.executionRunId !== checkoutRunId &&
+        expectedStatuses.includes(current.status) &&
+        (current.assigneeAgentId == null || current.assigneeAgentId === agentId)
+      ) {
+        const staleExecutionRun = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
+        if (staleExecutionRun) {
+          const now = new Date();
+          const recovered = await db
+            .update(issues)
+            .set({
+              assigneeAgentId: agentId,
+              assigneeUserId: null,
+              checkoutRunId,
+              executionRunId: checkoutRunId,
+              executionLockedAt: now,
+              status: "in_progress",
+              startedAt: now,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(issues.id, id),
+                eq(issues.status, current.status),
+                or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
+                isNull(issues.checkoutRunId),
+                eq(issues.executionRunId, current.executionRunId),
+              ),
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (recovered) {
+            const [enriched] = await withIssueLabels(db, [recovered]);
+            return enriched;
+          }
+        }
+      }
 
       if (
         current.assigneeAgentId === agentId &&
@@ -1581,6 +1626,8 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -730,7 +730,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                         : adapterType === "pi_local"
                           ? "pi"
                         : adapterType === "cursor"
-                          ? "agent"
+                          ? "cursor"
                         : adapterType === "opencode_local"
                           ? "opencode"
                           : "claude"

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -225,7 +225,7 @@ export function OnboardingWizard() {
       : adapterType === "pi_local"
       ? "pi"
       : adapterType === "cursor"
-      ? "agent"
+      ? "cursor agent"
       : adapterType === "opencode_local"
       ? "opencode"
       : "claude");
@@ -1113,9 +1113,9 @@ export function OnboardingWizard() {
                                     : "OPENAI_API_KEY"}
                               </span>{" "}
                               in env or run{" "}
-                              <span className="font-mono">
+                                <span className="font-mono">
                                 {adapterType === "cursor"
-                                  ? "agent login"
+                                  ? "cursor agent login"
                                   : adapterType === "codex_local"
                                     ? "codex login"
                                     : adapterType === "gemini_local"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       "packages/db",
       "packages/adapters/codex-local",
+      "packages/adapters/cursor-local",
       "packages/adapters/opencode-local",
       "server",
       "ui",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates agent runtimes and execution adapters across local/remote environments.
> - This PR touches the `cursor-local` adapter execution path and issue checkout lock handling.
> - The adapter previously depended on a single command shape, which could fail when only `cursor` (not `agent`) is installed.
> - Failed command resolution blocked execution and made onboarding defaults inconsistent with the runtime expectation.
> - Issue checkout also needed stronger stale-lock recovery/cleanup semantics so retry flows are reliable.
> - This pull request adds command fallback resolution, wires it through execution/test paths, and hardens issue lock cleanup.
> - The benefit is more reliable local execution and safer checkout/retry behavior without manual lock intervention.

## What Changed

- Added structured cursor command candidate resolution with fallback order (`agent` -> `cursor` -> macOS Cursor app paths).
- Added unit coverage for cursor command classification and fallback resolution logic.
- Wired resolved cursor command/base args into the cursor-local execution path and environment test harness.
- Adjusted execution metadata logging to avoid duplicated `agent` subcommand representation (`command` now logs executable only; full invocation remains in `commandArgs`).
- Hardened `server/src/services/issues.ts` checkout/status transition logic to clear stale execution lock state (`executionRunId`, `executionLockedAt`) in more transitions.
- Added integration tests in `server/src/__tests__/issues-service.test.ts` for stale-lock recovery and lock cleanup transitions.
- Updated onboarding/config UI copy defaults from `agent` to `cursor` command wording where relevant.
- Included `cursor-local` package in workspace Vitest config and added package-local Vitest config.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -r typecheck`
- `pnpm vitest run packages/adapters/cursor-local/src/server/command.test.ts server/src/__tests__/cursor-local-execute.test.ts server/src/__tests__/issues-service.test.ts`
- `pnpm build`
- `pnpm test:run` (local machine currently reports unrelated pre-existing failures in:
  - `server/src/__tests__/worktree-config.test.ts`
  - `ui/src/components/IssueDocumentsSection.test.tsx`)

UI before/after (text-visible change):
- Before: onboarding/help copy referenced `agent login` / `agent`.
- After: onboarding/help copy references `cursor agent login` / `cursor agent`.

## Risks

- Low to medium risk: adapter invocation behavior changed for command resolution and metadata representation.
- Lock-cleanup changes in issue status transitions could affect edge-case concurrent checkout flows; guarded by added tests, but CI verification remains important.
- UI copy changes are low-risk but visible.

## Model Used

- OpenAI Codex agent (`gpt-5` family runtime in Codex CLI environment)
- Tool-assisted workflow with shell execution, git operations, and GitHub CLI/API integration
- Reasoning mode: standard Codex agentic execution with iterative verification commands

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
