### PR TITLE
feat: add open-brain-capture plugin for automatic thought capture

### DIFF
--- a/packages/plugins/examples/plugin-open-brain-capture/.gitignore
+++ b/packages/plugins/examples/plugin-open-brain-capture/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.paperclip-sdk

--- a/packages/plugins/examples/plugin-open-brain-capture/README.md
+++ b/packages/plugins/examples/plugin-open-brain-capture/README.md
@@ -1,0 +1,27 @@
+# Open Brain Capture
+
+Automatically captures thoughts to open-brain on issue lifecycle events
+
+## Development
+
+```bash
+pnpm install
+pnpm dev            # watch builds
+pnpm dev:ui         # local dev server with hot-reload events
+pnpm test
+```
+
+
+
+## Install Into Paperclip
+
+```bash
+curl -X POST http://127.0.0.1:3100/api/plugins/install \
+  -H "Content-Type: application/json" \
+  -d '{"packageName":"C:/apps/paperclip/packages/plugins/examples/plugin-open-brain-capture","isLocalPath":true}'
+```
+
+## Build Options
+
+- `pnpm build` uses esbuild presets from `@paperclipai/plugin-sdk/bundlers`.
+- `pnpm build:rollup` uses rollup presets from the same SDK.

--- a/packages/plugins/examples/plugin-open-brain-capture/esbuild.config.mjs
+++ b/packages/plugins/examples/plugin-open-brain-capture/esbuild.config.mjs
@@ -1,0 +1,16 @@
+import esbuild from "esbuild";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets();
+const watch = process.argv.includes("--watch");
+
+const workerCtx = await esbuild.context(presets.esbuild.worker);
+const manifestCtx = await esbuild.context(presets.esbuild.manifest);
+
+if (watch) {
+  await Promise.all([workerCtx.watch(), manifestCtx.watch()]);
+  console.log("esbuild watch mode enabled for worker and manifest");
+} else {
+  await Promise.all([workerCtx.rebuild(), manifestCtx.rebuild()]);
+  await Promise.all([workerCtx.dispose(), manifestCtx.dispose()]);
+}

--- a/packages/plugins/examples/plugin-open-brain-capture/package.json
+++ b/packages/plugins/examples/plugin-open-brain-capture/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@paperclipai/plugin-open-brain-capture",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Automatically captures thoughts to open-brain on issue lifecycle events",
+  "scripts": {
+    "build": "node ./esbuild.config.mjs",
+    "build:rollup": "rollup -c",
+    "dev": "node ./esbuild.config.mjs --watch",
+    "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "automation"
+  ],
+  "author": "Paperclip",
+  "license": "MIT",
+  "devDependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "esbuild": "^0.27.3",
+    "rollup": "^4.38.0",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-open-brain-capture/rollup.config.mjs
+++ b/packages/plugins/examples/plugin-open-brain-capture/rollup.config.mjs
@@ -1,0 +1,27 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets();
+
+function withPlugins(config) {
+  if (!config) return null;
+  return {
+    ...config,
+    plugins: [
+      nodeResolve({
+        extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
+      }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: false,
+        declarationMap: false,
+      }),
+    ],
+  };
+}
+
+export default [
+  withPlugins(presets.rollup.manifest),
+  withPlugins(presets.rollup.worker),
+].filter(Boolean);

--- a/packages/plugins/examples/plugin-open-brain-capture/src/manifest.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/src/manifest.ts
@@ -1,0 +1,62 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_ID = "paperclip.open-brain-capture";
+const PLUGIN_VERSION = "0.1.0";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Open Brain Capture",
+  description:
+    "Automatically captures thoughts to open-brain when issues transition to key lifecycle states (done, blocked, delegated).",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [
+    "events.subscribe",
+    "issues.read",
+    "issue.comments.read",
+    "agents.read",
+    "http.outbound",
+    "plugin.state.read",
+    "plugin.state.write",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      openBrainEndpoint: {
+        type: "string",
+        title: "Open Brain Endpoint",
+        description: "Base URL of the open-brain MCP server (e.g. http://127.0.0.1:3010).",
+      },
+      openBrainApiKey: {
+        type: "string",
+        title: "Open Brain API Key",
+        description: "Optional API key for authenticating with the open-brain endpoint.",
+      },
+      captureOnDone: {
+        type: "boolean",
+        title: "Capture on Done",
+        description: "Capture a thought when an issue transitions to done.",
+        default: true,
+      },
+      captureOnBlocked: {
+        type: "boolean",
+        title: "Capture on Blocked",
+        description: "Capture a thought when an issue transitions to blocked.",
+        default: true,
+      },
+      captureOnDelegation: {
+        type: "boolean",
+        title: "Capture on Delegation",
+        description: "Capture a thought when a subtask is created with an assignee (delegation).",
+        default: true,
+      },
+    },
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-open-brain-capture/src/open-brain-client.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/src/open-brain-client.ts
@@ -1,0 +1,50 @@
+import type { PluginHttpClient, PluginLogger } from "@paperclipai/plugin-sdk";
+
+export interface OpenBrainClientConfig {
+  endpoint: string;
+  apiKey?: string;
+}
+
+export interface OpenBrainClient {
+  captureThought(content: string): Promise<void>;
+}
+
+export function createOpenBrainClient(
+  http: PluginHttpClient,
+  logger: PluginLogger,
+  config: OpenBrainClientConfig,
+): OpenBrainClient {
+  const baseUrl = config.endpoint.replace(/\/+$/, "");
+
+  return {
+    async captureThought(content: string): Promise<void> {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (config.apiKey) {
+        headers["Authorization"] = `Bearer ${config.apiKey}`;
+      }
+
+      const response = await http.fetch(`${baseUrl}/capture_thought`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ content }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        logger.error("open-brain capture failed", {
+          status: response.status,
+          body: text,
+        });
+        throw new Error(
+          `open-brain capture_thought failed: ${response.status} ${text}`,
+        );
+      }
+
+      logger.info("Thought captured to open-brain", {
+        contentLength: content.length,
+      });
+    },
+  };
+}

--- a/packages/plugins/examples/plugin-open-brain-capture/src/thought-builder.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/src/thought-builder.ts
@@ -1,0 +1,74 @@
+const MAX_THOUGHT_LENGTH = 500;
+
+interface IssueData {
+  identifier: string | null;
+  title: string;
+}
+
+interface CommentData {
+  body: string;
+}
+
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 3) + "...";
+}
+
+function extractFirstSentence(body: string): string {
+  const cleaned = body
+    .replace(/^#+\s+.*$/gm, "") // strip markdown headings
+    .replace(/^[-*]\s+/gm, "") // strip list markers
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // strip markdown links, keep text
+    .replace(/\*\*([^*]+)\*\*/g, "$1") // strip bold
+    .trim();
+
+  const firstLine = cleaned.split("\n").find((l) => l.trim().length > 0) ?? "";
+  return truncate(firstLine.trim(), 200);
+}
+
+export function buildDoneThought(
+  issue: IssueData,
+  latestComment: CommentData | null,
+  agentName?: string,
+): string {
+  const prefix = issue.identifier ? `[${issue.identifier}]` : "";
+  const agent = agentName ? ` (${agentName})` : "";
+  const context = latestComment
+    ? ` ${extractFirstSentence(latestComment.body)}`
+    : "";
+  return truncate(
+    `${prefix} ${issue.title} — COMPLETED${agent}.${context}`,
+    MAX_THOUGHT_LENGTH,
+  );
+}
+
+export function buildBlockedThought(
+  issue: IssueData,
+  latestComment: CommentData | null,
+  agentName?: string,
+): string {
+  const prefix = issue.identifier ? `[${issue.identifier}]` : "";
+  const agent = agentName ? ` (${agentName})` : "";
+  const context = latestComment
+    ? ` ${extractFirstSentence(latestComment.body)}`
+    : "";
+  return truncate(
+    `${prefix} ${issue.title} — BLOCKED${agent}.${context}`,
+    MAX_THOUGHT_LENGTH,
+  );
+}
+
+export function buildDelegationThought(
+  issue: IssueData,
+  parentIssue: IssueData | null,
+  assigneeName: string,
+): string {
+  const prefix = issue.identifier ? `[${issue.identifier}]` : "";
+  const parentRef = parentIssue
+    ? ` Subtask of ${parentIssue.identifier ?? parentIssue.title}.`
+    : "";
+  return truncate(
+    `${prefix} ${issue.title} — DELEGATED to ${assigneeName}.${parentRef}`,
+    MAX_THOUGHT_LENGTH,
+  );
+}

--- a/packages/plugins/examples/plugin-open-brain-capture/src/worker.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/src/worker.ts
@@ -1,0 +1,27 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.events.on("issue.created", async (event) => {
+      const issueId = event.entityId ?? "unknown";
+      await ctx.state.set({ scopeKind: "issue", scopeId: issueId, stateKey: "seen" }, true);
+      ctx.logger.info("Observed issue.created", { issueId });
+    });
+
+    ctx.data.register("health", async () => {
+      return { status: "ok", checkedAt: new Date().toISOString() };
+    });
+
+    ctx.actions.register("ping", async () => {
+      ctx.logger.info("Ping action invoked");
+      return { pong: true, at: new Date().toISOString() };
+    });
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Plugin worker is running" };
+  }
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-open-brain-capture/src/worker.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/src/worker.ts
@@ -1,26 +1,216 @@
 import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import type { PluginContext, PluginEvent } from "@paperclipai/plugin-sdk";
+import {
+  createOpenBrainClient,
+  type OpenBrainClient,
+} from "./open-brain-client.js";
+import {
+  buildDoneThought,
+  buildBlockedThought,
+  buildDelegationThought,
+} from "./thought-builder.js";
+
+interface PluginConfig {
+  openBrainEndpoint: string;
+  openBrainApiKey?: string;
+  captureOnDone: boolean;
+  captureOnBlocked: boolean;
+  captureOnDelegation: boolean;
+}
+
+const DEFAULT_CONFIG: PluginConfig = {
+  openBrainEndpoint: "http://127.0.0.1:3010",
+  captureOnDone: true,
+  captureOnBlocked: true,
+  captureOnDelegation: true,
+};
+
+async function resolveConfig(ctx: PluginContext): Promise<PluginConfig> {
+  const raw = await ctx.config.get();
+  return { ...DEFAULT_CONFIG, ...(raw as Partial<PluginConfig>) };
+}
+
+async function resolveAgentName(
+  ctx: PluginContext,
+  agentId: string | null,
+  companyId: string,
+): Promise<string | undefined> {
+  if (!agentId) return undefined;
+  try {
+    const agent = await ctx.agents.get(agentId, companyId);
+    return agent?.name ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getLatestComment(
+  ctx: PluginContext,
+  issueId: string,
+  companyId: string,
+) {
+  try {
+    const comments = await ctx.issues.listComments(issueId, companyId);
+    return comments.length > 0 ? comments[comments.length - 1] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function handleIssueUpdated(
+  ctx: PluginContext,
+  config: PluginConfig,
+  client: OpenBrainClient,
+  event: PluginEvent,
+): Promise<void> {
+  const issueId = event.entityId;
+  if (!issueId) return;
+
+  const issue = await ctx.issues.get(issueId, event.companyId);
+  if (!issue) return;
+
+  const isDone = issue.status === "done" && config.captureOnDone;
+  const isBlocked = issue.status === "blocked" && config.captureOnBlocked;
+
+  if (!isDone && !isBlocked) return;
+
+  // Dedup: check if we already captured for this status transition
+  const stateKey = `captured-${issue.status}`;
+  const alreadyCaptured = await ctx.state.get({
+    scopeKind: "issue",
+    scopeId: issueId,
+    stateKey,
+  });
+  if (alreadyCaptured) {
+    ctx.logger.info("Already captured for this status, skipping", {
+      issueId,
+      status: issue.status,
+    });
+    return;
+  }
+
+  const latestComment = await getLatestComment(ctx, issueId, event.companyId);
+  const agentName = await resolveAgentName(
+    ctx,
+    issue.assigneeAgentId,
+    event.companyId,
+  );
+
+  const thought = isDone
+    ? buildDoneThought(issue, latestComment, agentName)
+    : buildBlockedThought(issue, latestComment, agentName);
+
+  await client.captureThought(thought);
+
+  await ctx.state.set(
+    { scopeKind: "issue", scopeId: issueId, stateKey },
+    new Date().toISOString(),
+  );
+
+  ctx.logger.info("Captured thought for issue status change", {
+    issueId,
+    identifier: issue.identifier,
+    status: issue.status,
+  });
+}
+
+async function handleIssueCreated(
+  ctx: PluginContext,
+  config: PluginConfig,
+  client: OpenBrainClient,
+  event: PluginEvent,
+): Promise<void> {
+  if (!config.captureOnDelegation) return;
+
+  const issueId = event.entityId;
+  if (!issueId) return;
+
+  const issue = await ctx.issues.get(issueId, event.companyId);
+  if (!issue) return;
+
+  // Delegation signal: has both parentId and assigneeAgentId
+  if (!issue.parentId || !issue.assigneeAgentId) return;
+
+  const assigneeName =
+    (await resolveAgentName(ctx, issue.assigneeAgentId, event.companyId)) ??
+    "unknown agent";
+
+  let parentIssue: { identifier: string | null; title: string } | null = null;
+  try {
+    parentIssue = await ctx.issues.get(issue.parentId, event.companyId);
+  } catch {
+    // parent may not be accessible
+  }
+
+  const thought = buildDelegationThought(issue, parentIssue, assigneeName);
+  await client.captureThought(thought);
+
+  ctx.logger.info("Captured delegation thought", {
+    issueId,
+    identifier: issue.identifier,
+    parentId: issue.parentId,
+    assigneeAgentId: issue.assigneeAgentId,
+  });
+}
 
 const plugin = definePlugin({
   async setup(ctx) {
-    ctx.events.on("issue.created", async (event) => {
-      const issueId = event.entityId ?? "unknown";
-      await ctx.state.set({ scopeKind: "issue", scopeId: issueId, stateKey: "seen" }, true);
-      ctx.logger.info("Observed issue.created", { issueId });
+    const config = await resolveConfig(ctx);
+
+    if (!config.openBrainEndpoint) {
+      ctx.logger.warn(
+        "openBrainEndpoint not configured, plugin will not capture thoughts",
+      );
+      return;
+    }
+
+    const client = createOpenBrainClient(ctx.http, ctx.logger, {
+      endpoint: config.openBrainEndpoint,
+      apiKey: config.openBrainApiKey,
     });
 
-    ctx.data.register("health", async () => {
-      return { status: "ok", checkedAt: new Date().toISOString() };
+    ctx.events.on("issue.updated", async (event: PluginEvent) => {
+      try {
+        await handleIssueUpdated(ctx, config, client, event);
+      } catch (err) {
+        ctx.logger.error("Failed to handle issue.updated", {
+          issueId: event.entityId,
+          error: String(err),
+        });
+      }
     });
 
-    ctx.actions.register("ping", async () => {
-      ctx.logger.info("Ping action invoked");
-      return { pong: true, at: new Date().toISOString() };
+    ctx.events.on("issue.created", async (event: PluginEvent) => {
+      try {
+        await handleIssueCreated(ctx, config, client, event);
+      } catch (err) {
+        ctx.logger.error("Failed to handle issue.created", {
+          issueId: event.entityId,
+          error: String(err),
+        });
+      }
+    });
+
+    ctx.data.register("health", async () => ({
+      status: "ok",
+      endpoint: config.openBrainEndpoint,
+      captureOnDone: config.captureOnDone,
+      captureOnBlocked: config.captureOnBlocked,
+      captureOnDelegation: config.captureOnDelegation,
+      checkedAt: new Date().toISOString(),
+    }));
+
+    ctx.logger.info("open-brain-capture plugin initialized", {
+      endpoint: config.openBrainEndpoint,
+      captureOnDone: config.captureOnDone,
+      captureOnBlocked: config.captureOnBlocked,
+      captureOnDelegation: config.captureOnDelegation,
     });
   },
 
   async onHealth() {
-    return { status: "ok", message: "Plugin worker is running" };
-  }
+    return { status: "ok", message: "open-brain-capture worker is running" };
+  },
 });
 
 export default plugin;

--- a/packages/plugins/examples/plugin-open-brain-capture/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/tests/plugin.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+describe("plugin scaffold", () => {
+  it("registers data + actions and handles events", async () => {
+    const harness = createTestHarness({ manifest, capabilities: [...manifest.capabilities, "events.emit"] });
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.emit("issue.created", { issueId: "iss_1" }, { entityId: "iss_1", entityType: "issue" });
+    expect(harness.getState({ scopeKind: "issue", scopeId: "iss_1", stateKey: "seen" })).toBe(true);
+
+    const data = await harness.getData<{ status: string }>("health");
+    expect(data.status).toBe("ok");
+
+    const action = await harness.performAction<{ pong: boolean }>("ping");
+    expect(action.pong).toBe(true);
+  });
+});

--- a/packages/plugins/examples/plugin-open-brain-capture/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/tests/plugin.spec.ts
@@ -1,20 +1,419 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import type { TestHarness } from "@paperclipai/plugin-sdk/testing";
 import manifest from "../src/manifest.js";
 import plugin from "../src/worker.js";
+import {
+  buildDoneThought,
+  buildBlockedThought,
+  buildDelegationThought,
+} from "../src/thought-builder.js";
 
-describe("plugin scaffold", () => {
-  it("registers data + actions and handles events", async () => {
-    const harness = createTestHarness({ manifest, capabilities: [...manifest.capabilities, "events.emit"] });
+const TEST_COMPANY_ID = "comp-1";
+const TEST_ENDPOINT = "http://localhost:3010";
+
+function makeHarness(configOverrides: Record<string, unknown> = {}) {
+  return createTestHarness({
+    manifest,
+    capabilities: [...manifest.capabilities, "events.emit"],
+    config: {
+      openBrainEndpoint: TEST_ENDPOINT,
+      captureOnDone: true,
+      captureOnBlocked: true,
+      captureOnDelegation: true,
+      ...configOverrides,
+    },
+  });
+}
+
+function mockHttpFetch(harness: TestHarness) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(""),
+  });
+  harness.ctx.http.fetch = fetchMock;
+  return fetchMock;
+}
+
+describe("thought-builder", () => {
+  it("buildDoneThought includes identifier and COMPLETED", () => {
+    const thought = buildDoneThought(
+      { identifier: "STA-99", title: "Fix the thing" },
+      { body: "All issues resolved." },
+      "Senior Engineer",
+    );
+    expect(thought).toContain("[STA-99]");
+    expect(thought).toContain("COMPLETED");
+    expect(thought).toContain("Senior Engineer");
+    expect(thought).toContain("All issues resolved");
+    expect(thought.length).toBeLessThanOrEqual(500);
+  });
+
+  it("buildBlockedThought includes BLOCKED", () => {
+    const thought = buildBlockedThought(
+      { identifier: "STA-42", title: "Deploy service" },
+      { body: "Waiting on infra team" },
+    );
+    expect(thought).toContain("[STA-42]");
+    expect(thought).toContain("BLOCKED");
+    expect(thought).toContain("Waiting on infra team");
+    expect(thought.length).toBeLessThanOrEqual(500);
+  });
+
+  it("buildDelegationThought includes DELEGATED and parent ref", () => {
+    const thought = buildDelegationThought(
+      { identifier: "STA-72", title: "Implement worker" },
+      { identifier: "STA-70", title: "Build plugin" },
+      "Senior Engineer",
+    );
+    expect(thought).toContain("[STA-72]");
+    expect(thought).toContain("DELEGATED to Senior Engineer");
+    expect(thought).toContain("STA-70");
+    expect(thought.length).toBeLessThanOrEqual(500);
+  });
+
+  it("handles null comments gracefully", () => {
+    const thought = buildDoneThought(
+      { identifier: "STA-1", title: "Test" },
+      null,
+    );
+    expect(thought).toContain("[STA-1]");
+    expect(thought).toContain("COMPLETED");
+  });
+
+  it("handles null identifier", () => {
+    const thought = buildDoneThought(
+      { identifier: null, title: "No id task" },
+      null,
+    );
+    expect(thought).toContain("No id task");
+    expect(thought).toContain("COMPLETED");
+  });
+
+  it("truncates long thoughts to 500 chars", () => {
+    const longComment = { body: "A".repeat(600) };
+    const thought = buildDoneThought(
+      { identifier: "STA-1", title: "Test" },
+      longComment,
+    );
+    expect(thought.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("worker — issue.updated", () => {
+  let harness: TestHarness;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    harness = makeHarness();
+    fetchMock = mockHttpFetch(harness);
+
+    harness.seed({
+      companies: [{ id: TEST_COMPANY_ID } as any],
+      issues: [
+        {
+          id: "iss-done",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-100",
+          title: "Complete the feature",
+          status: "done",
+          assigneeAgentId: "agent-1",
+          parentId: null,
+        } as any,
+        {
+          id: "iss-blocked",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-101",
+          title: "Blocked on infra",
+          status: "blocked",
+          assigneeAgentId: "agent-1",
+          parentId: null,
+        } as any,
+        {
+          id: "iss-in-progress",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-102",
+          title: "Still working",
+          status: "in_progress",
+          assigneeAgentId: "agent-1",
+          parentId: null,
+        } as any,
+      ],
+      issueComments: [
+        {
+          id: "comment-1",
+          issueId: "iss-done",
+          companyId: TEST_COMPANY_ID,
+          body: "All tests passing, merged to main.",
+          authorAgentId: "agent-1",
+        } as any,
+        {
+          id: "comment-2",
+          issueId: "iss-blocked",
+          companyId: TEST_COMPANY_ID,
+          body: "Waiting for DNS propagation.",
+          authorAgentId: "agent-1",
+        } as any,
+      ],
+      agents: [
+        {
+          id: "agent-1",
+          companyId: TEST_COMPANY_ID,
+          name: "Senior Engineer",
+        } as any,
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+  });
+
+  it("captures thought when issue transitions to done", async () => {
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-done",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${TEST_ENDPOINT}/capture_thought`);
+    const body = JSON.parse(init.body);
+    expect(body.content).toContain("[STA-100]");
+    expect(body.content).toContain("COMPLETED");
+    expect(body.content).toContain("All tests passing");
+  });
+
+  it("captures thought when issue transitions to blocked", async () => {
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-blocked",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.content).toContain("[STA-101]");
+    expect(body.content).toContain("BLOCKED");
+  });
+
+  it("does not capture for in_progress status", async () => {
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-in-progress",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates: does not capture same status twice", async () => {
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-done",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-done",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+    // Still only called once
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("records dedup state after capture", async () => {
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-done",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    const state = harness.getState({
+      scopeKind: "issue",
+      scopeId: "iss-done",
+      stateKey: "captured-done",
+    });
+    expect(state).toBeTruthy();
+  });
+});
+
+describe("worker — issue.updated with config flags disabled", () => {
+  it("does not capture done when captureOnDone is false", async () => {
+    const harness = makeHarness({ captureOnDone: false });
+    const fetchMock = mockHttpFetch(harness);
+
+    harness.seed({
+      issues: [
+        {
+          id: "iss-done",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-100",
+          title: "Complete the feature",
+          status: "done",
+          assigneeAgentId: null,
+          parentId: null,
+        } as any,
+      ],
+    });
+
     await plugin.definition.setup(harness.ctx);
 
-    await harness.emit("issue.created", { issueId: "iss_1" }, { entityId: "iss_1", entityType: "issue" });
-    expect(harness.getState({ scopeKind: "issue", scopeId: "iss_1", stateKey: "seen" })).toBe(true);
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-done",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
 
-    const data = await harness.getData<{ status: string }>("health");
-    expect(data.status).toBe("ok");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 
-    const action = await harness.performAction<{ pong: boolean }>("ping");
-    expect(action.pong).toBe(true);
+  it("does not capture blocked when captureOnBlocked is false", async () => {
+    const harness = makeHarness({ captureOnBlocked: false });
+    const fetchMock = mockHttpFetch(harness);
+
+    harness.seed({
+      issues: [
+        {
+          id: "iss-blocked",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-101",
+          title: "Blocked on infra",
+          status: "blocked",
+          assigneeAgentId: null,
+          parentId: null,
+        } as any,
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.emit("issue.updated", {}, {
+      entityId: "iss-blocked",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("worker — issue.created (delegation)", () => {
+  it("captures delegation thought for subtask with assignee", async () => {
+    const harness = makeHarness();
+    const fetchMock = mockHttpFetch(harness);
+
+    harness.seed({
+      issues: [
+        {
+          id: "parent-1",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-70",
+          title: "Build plugin",
+          status: "in_progress",
+          assigneeAgentId: "agent-cto",
+          parentId: null,
+        } as any,
+        {
+          id: "child-1",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-72",
+          title: "Implement worker",
+          status: "todo",
+          assigneeAgentId: "agent-se",
+          parentId: "parent-1",
+        } as any,
+      ],
+      agents: [
+        { id: "agent-se", companyId: TEST_COMPANY_ID, name: "Senior Engineer" } as any,
+        { id: "agent-cto", companyId: TEST_COMPANY_ID, name: "CTO" } as any,
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.emit("issue.created", {}, {
+      entityId: "child-1",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.content).toContain("[STA-72]");
+    expect(body.content).toContain("DELEGATED to Senior Engineer");
+    expect(body.content).toContain("STA-70");
+  });
+
+  it("does not capture when issue has no parentId", async () => {
+    const harness = makeHarness();
+    const fetchMock = mockHttpFetch(harness);
+
+    harness.seed({
+      issues: [
+        {
+          id: "top-level",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-80",
+          title: "Top level task",
+          status: "todo",
+          assigneeAgentId: "agent-1",
+          parentId: null,
+        } as any,
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.emit("issue.created", {}, {
+      entityId: "top-level",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not capture when captureOnDelegation is false", async () => {
+    const harness = makeHarness({ captureOnDelegation: false });
+    const fetchMock = mockHttpFetch(harness);
+
+    harness.seed({
+      issues: [
+        {
+          id: "child-1",
+          companyId: TEST_COMPANY_ID,
+          identifier: "STA-72",
+          title: "Implement worker",
+          status: "todo",
+          assigneeAgentId: "agent-1",
+          parentId: "parent-1",
+        } as any,
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.emit("issue.created", {}, {
+      entityId: "child-1",
+      entityType: "issue",
+      companyId: TEST_COMPANY_ID,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("worker — health check", () => {
+  it("returns health data with config", async () => {
+    const harness = makeHarness();
+    mockHttpFetch(harness);
+    await plugin.definition.setup(harness.ctx);
+
+    const health = await harness.getData<{ status: string; endpoint: string }>("health");
+    expect(health.status).toBe("ok");
+    expect(health.endpoint).toBe(TEST_ENDPOINT);
   });
 });

--- a/packages/plugins/examples/plugin-open-brain-capture/tsconfig.json
+++ b/packages/plugins/examples/plugin-open-brain-capture/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/plugins/examples/plugin-open-brain-capture/vitest.config.ts
+++ b/packages/plugins/examples/plugin-open-brain-capture/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,43 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/examples/plugin-open-brain-capture:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.2.4
+    devDependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.3(rollup@4.57.1)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.2
+        version: 12.3.0(rollup@4.57.1)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      rollup:
+        specifier: ^4.38.0
+        version: 4.57.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/sdk:
     dependencies:
       '@paperclipai/shared':


### PR DESCRIPTION
## Summary

Adds `@paperclipai/plugin-open-brain-capture` — a worker-only Paperclip plugin that automatically captures thoughts to open-brain when issues transition to key lifecycle states.

- **Done/Blocked capture**: On `issue.updated`, captures a summary thought when status transitions to `done` or `blocked`
- **Delegation capture**: On `issue.created`, captures when a subtask is created with both `parentId` and `assigneeAgentId` (delegation signal)
- **Configurable**: Per-instance config for endpoint, API key, and toggle flags (`captureOnDone`, `captureOnBlocked`, `captureOnDelegation`)
- **Deduplication**: State-based dedup prevents duplicate captures for the same status transition
- **17 tests passing**: Covers all event handlers, config flag suppression, dedup, thought builder format, and health check

## Files

- `packages/plugins/examples/plugin-open-brain-capture/src/manifest.ts` — Plugin manifest with capabilities and config schema
- `packages/plugins/examples/plugin-open-brain-capture/src/worker.ts` — Event handlers for issue lifecycle
- `packages/plugins/examples/plugin-open-brain-capture/src/thought-builder.ts` — Pure functions for formatting thoughts (≤500 chars)
- `packages/plugins/examples/plugin-open-brain-capture/src/open-brain-client.ts` — HTTP client for open-brain API
- `packages/plugins/examples/plugin-open-brain-capture/tests/plugin.spec.ts` — Comprehensive test suite

## Verification

```
✓ pnpm typecheck — clean
✓ pnpm test — 17/17 passed
✓ pnpm build — clean
```

## Test plan

- [x] `issue.updated` with status `done` triggers thought capture
- [x] `issue.updated` with status `blocked` triggers thought capture
- [x] `issue.created` with `parentId` + `assigneeAgentId` triggers delegation capture
- [x] Config flags (`captureOnDone: false`, etc.) suppress capture
- [x] Thought builder output is standalone, includes identifier, under 500 chars
- [x] Deduplication prevents duplicate captures
- [x] Health check returns config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>