### PR TITLE
Fix server build by preparing plugin SDK before compile

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "dev": "pnpm run preflight:workspace-links && tsx src/index.ts",
     "dev:watch": "pnpm run preflight:workspace-links && cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
-    "build": "pnpm run preflight:workspace-links && tsc && mkdir -p dist/onboarding-assets && cp -R src/onboarding-assets/. dist/onboarding-assets/",
+    "build": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk build && tsc && mkdir -p dist/onboarding-assets && cp -R src/onboarding-assets/. dist/onboarding-assets/",
     "prepack": "pnpm run prepare:ui-dist",
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
- align `@paperclipai/server` build with the already-working typecheck flow
- build `@paperclipai/plugin-sdk` before running `tsc` in the server package

## Validation
- isolated Linux checkout: `pnpm --filter @paperclipai/server build` PASS after this change
- isolated Linux checkout: stage-1 scoped vitest still PASS
- isolated Linux checkout: UI typecheck PASS
- isolated Linux checkout: UI build PASS

## Notes
- this is intentionally separate from PR #2632
- this addresses the repo-level build blocker tracked in #2633