### PR TITLE
fix: redact Paperclip secrets from logs and Codex artifacts

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -7,9 +7,134 @@ const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const DEFAULT_PAPERCLIP_INSTANCE_ID = "default";
+const REDACTED_VALUE = "***REDACTED***";
+const SENSITIVE_KEY_RE =
+  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie)/i;
+const JWT_TEXT_RE = /\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?\b/g;
+const BEARER_TEXT_RE = /\bBearer\s+[^\s"',}]+/gi;
+const SHELL_EXPORT_RE = /^(\s*(?:export\s+)?)(([A-Za-z_][A-Za-z0-9_]*))(=.*)$/;
 
 function nonEmpty(value: string | undefined): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redactText(text: string): string {
+  let redacted = text.replace(BEARER_TEXT_RE, `Bearer ${REDACTED_VALUE}`);
+  redacted = redacted.replace(JWT_TEXT_RE, REDACTED_VALUE);
+
+  const lines = redacted.split(/\r?\n/);
+  let changed = false;
+  const rewritten = lines.map((line) => {
+    const match = line.match(SHELL_EXPORT_RE);
+    if (!match) return line;
+    const [, prefix, key] = match;
+    if (!SENSITIVE_KEY_RE.test(key)) return line;
+    changed = true;
+    return `${prefix}${key}=${REDACTED_VALUE}`;
+  });
+  return changed ? rewritten.join("\n") : redacted;
+}
+
+function sanitizeArtifactValue(value: unknown): unknown {
+  if (typeof value === "string") return redactText(value);
+  if (Array.isArray(value)) return value.map((entry) => sanitizeArtifactValue(entry));
+  if (!isPlainObject(value)) return value;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (SENSITIVE_KEY_RE.test(key)) {
+      sanitized[key] = REDACTED_VALUE;
+      continue;
+    }
+    sanitized[key] = sanitizeArtifactValue(entry);
+  }
+  return sanitized;
+}
+
+async function chmodSafe(target: string, mode: number): Promise<void> {
+  await fs.chmod(target, mode).catch(() => undefined);
+}
+
+async function scrubJsonlFile(target: string): Promise<boolean> {
+  const original = await fs.readFile(target, "utf8");
+  const endsWithNewline = original.endsWith("\n");
+  let changed = false;
+  const scrubbed = original
+    .split(/\r?\n/)
+    .map((line) => {
+      if (!line) return line;
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        const sanitized = sanitizeArtifactValue(parsed);
+        const rewritten = JSON.stringify(sanitized);
+        if (rewritten !== line) changed = true;
+        return rewritten;
+      } catch {
+        const rewritten = redactText(line);
+        if (rewritten !== line) changed = true;
+        return rewritten;
+      }
+    })
+    .join("\n");
+  if (!changed) return false;
+  await fs.writeFile(target, endsWithNewline ? `${scrubbed}\n` : scrubbed, "utf8");
+  return true;
+}
+
+async function scrubShellSnapshotFile(target: string): Promise<boolean> {
+  const original = await fs.readFile(target, "utf8");
+  const rewritten = redactText(original);
+  if (rewritten === original) return false;
+  await fs.writeFile(target, rewritten, "utf8");
+  return true;
+}
+
+async function scrubArtifactFile(target: string): Promise<boolean> {
+  if (target.endsWith(".jsonl")) return scrubJsonlFile(target);
+  if (target.endsWith(".sh")) return scrubShellSnapshotFile(target);
+  return false;
+}
+
+async function scrubArtifactTree(root: string): Promise<number> {
+  let scrubbedFiles = 0;
+  const queue = [root];
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    const entries = await fs.readdir(current, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const target = path.join(current, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        await chmodSafe(target, 0o700);
+        queue.push(target);
+        continue;
+      }
+      await chmodSafe(target, 0o600);
+      if (await scrubArtifactFile(target)) scrubbedFiles += 1;
+    }
+  }
+  return scrubbedFiles;
+}
+
+export async function scrubCodexHomeArtifacts(
+  codexHome: string,
+  onLog?: AdapterExecutionContext["onLog"],
+): Promise<void> {
+  await chmodSafe(codexHome, 0o700);
+  let scrubbedFiles = 0;
+  for (const subdir of ["sessions", "shell_snapshots"]) {
+    const target = path.join(codexHome, subdir);
+    if (!(await pathExists(target))) continue;
+    scrubbedFiles += await scrubArtifactTree(target);
+  }
+  if (scrubbedFiles > 0 && onLog) {
+    await onLog("stdout", `[paperclip] Scrubbed ${scrubbedFiles} Codex artifact file(s) under "${codexHome}".\n`);
+  }
 }
 
 export async function pathExists(candidate: string): Promise<boolean> {
@@ -94,6 +219,9 @@ export async function prepareManagedCodexHome(
     if (!(await pathExists(source))) continue;
     await ensureCopiedFile(path.join(targetHome, name), source);
   }
+
+  await chmodSafe(targetHome, 0o700);
+  await scrubCodexHomeArtifacts(targetHome);
 
   await onLog(
     "stdout",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -22,7 +22,13 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
-import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
+import {
+  pathExists,
+  prepareManagedCodexHome,
+  resolveManagedCodexHomeDir,
+  resolveSharedCodexHomeDir,
+  scrubCodexHomeArtifacts,
+} from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -608,8 +614,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
     );
     const retry = await runAttempt(null);
+    await scrubCodexHomeArtifacts(effectiveCodexHome, onLog);
     return toResult(retry, true);
   }
 
+  await scrubCodexHomeArtifacts(effectiveCodexHome, onLog);
   return toResult(initial);
 }

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -7,6 +7,7 @@ import { execute } from "@paperclipai/adapter-codex-local/server";
 async function writeFakeCodexCommand(commandPath: string): Promise<void> {
   const script = `#!/usr/bin/env node
 const fs = require("node:fs");
+const path = require("node:path");
 
 const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
 const payload = {
@@ -19,6 +20,36 @@ const payload = {
 };
 if (capturePath) {
   fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+if (process.env.PAPERCLIP_TEST_WRITE_ARTIFACTS === "1" && process.env.CODEX_HOME) {
+  const codexHome = process.env.CODEX_HOME;
+  fs.mkdirSync(path.join(codexHome, "shell_snapshots"), { recursive: true });
+  fs.mkdirSync(path.join(codexHome, "sessions", "2026", "04", "03"), { recursive: true });
+  fs.writeFileSync(
+    path.join(codexHome, "shell_snapshots", "snapshot.sh"),
+    [
+      "export PAPERCLIP_API_KEY=" + (process.env.PAPERCLIP_API_KEY || ""),
+      "export PAPERCLIP_AGENT_JWT_SECRET=" + (process.env.PAPERCLIP_AGENT_JWT_SECRET || ""),
+      "export SAFE=value",
+      "",
+    ].join("\\n"),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(codexHome, "sessions", "2026", "04", "03", "session.jsonl"),
+    [
+      JSON.stringify({
+        type: "tool_call",
+        headers: { authorization: "Bearer " + (process.env.PAPERCLIP_API_KEY || "") },
+        env: {
+          PAPERCLIP_API_KEY: process.env.PAPERCLIP_API_KEY || "",
+          PAPERCLIP_AGENT_JWT_SECRET: process.env.PAPERCLIP_AGENT_JWT_SECRET || "",
+        },
+      }),
+      "",
+    ].join("\\n"),
+    "utf8",
+  );
 }
 console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-1" }));
 console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "hello" } }));
@@ -255,6 +286,106 @@ describe("codex execute", () => {
       else process.env.HOME = previousHome;
       if (previousPath === undefined) delete process.env.PATH;
       else process.env.PATH = previousPath;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scrubs sensitive values from managed Codex artifacts after execution", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-scrub-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const sharedCodexHome = path.join(root, "shared-codex-home");
+    const paperclipHome = path.join(root, "paperclip-home");
+    const managedCodexHome = path.join(
+      paperclipHome,
+      "instances",
+      "default",
+      "companies",
+      "company-1",
+      "codex-home",
+    );
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(sharedCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sharedCodexHome, "auth.json"), '{"token":"shared"}\n', "utf8");
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    const previousPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = root;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    process.env.CODEX_HOME = sharedCodexHome;
+
+    try {
+      const result = await execute({
+        runId: "run-scrub",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            PAPERCLIP_TEST_WRITE_ARTIFACTS: "1",
+            PAPERCLIP_AGENT_JWT_SECRET: "super-secret-agent-jwt",
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const snapshot = await fs.readFile(
+        path.join(managedCodexHome, "shell_snapshots", "snapshot.sh"),
+        "utf8",
+      );
+      const session = await fs.readFile(
+        path.join(managedCodexHome, "sessions", "2026", "04", "03", "session.jsonl"),
+        "utf8",
+      );
+      const snapshotStat = await fs.stat(path.join(managedCodexHome, "shell_snapshots", "snapshot.sh"));
+      const sessionStat = await fs.stat(path.join(managedCodexHome, "sessions", "2026", "04", "03", "session.jsonl"));
+
+      expect(snapshot).toContain("export PAPERCLIP_API_KEY=***REDACTED***");
+      expect(snapshot).toContain("export PAPERCLIP_AGENT_JWT_SECRET=***REDACTED***");
+      expect(snapshot).not.toContain("run-jwt-token");
+      expect(snapshot).not.toContain("super-secret-agent-jwt");
+
+      expect(session).toContain('"authorization":"***REDACTED***"');
+      expect(session).toContain('"PAPERCLIP_API_KEY":"***REDACTED***"');
+      expect(session).toContain('"PAPERCLIP_AGENT_JWT_SECRET":"***REDACTED***"');
+      expect(session).not.toContain("run-jwt-token");
+      expect(session).not.toContain("super-secret-agent-jwt");
+
+      expect(snapshotStat.mode & 0o777).toBe(0o600);
+      expect(sessionStat.mode & 0o777).toBe(0o600);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+      if (previousPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, sanitizeRecord } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactEventPayload,
+  redactSensitiveText,
+  sanitizeLogValue,
+  sanitizeRecord,
+} from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -61,6 +67,38 @@ describe("redaction", () => {
     expect(redactEventPayload({ password: "hunter2", safe: "value" })).toEqual({
       password: REDACTED_EVENT_VALUE,
       safe: "value",
+    });
+  });
+
+  it("redacts bearer tokens and shell exports from log text", () => {
+    const input = [
+      'authorization: "Bearer abc.def.ghi"',
+      "export PAPERCLIP_API_KEY=run-jwt-token",
+      "normal=value",
+    ].join("\n");
+
+    expect(redactSensitiveText(input)).toBe([
+      `authorization: "Bearer ${REDACTED_EVENT_VALUE}"`,
+      `export PAPERCLIP_API_KEY=${REDACTED_EVENT_VALUE}`,
+      "normal=value",
+    ].join("\n"));
+  });
+
+  it("sanitizes nested log objects and inline sensitive strings", () => {
+    const result = sanitizeLogValue({
+      headers: {
+        authorization: "Bearer abc.def.ghi",
+      },
+      command: 'curl -H "Authorization: Bearer abc.def.ghi"',
+      nested: [{ token: "top-secret" }],
+    });
+
+    expect(result).toEqual({
+      headers: {
+        authorization: REDACTED_EVENT_VALUE,
+      },
+      command: `curl -H "Authorization: Bearer ${REDACTED_EVENT_VALUE}"`,
+      nested: [{ token: REDACTED_EVENT_VALUE }],
     });
   });
 });

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -4,6 +4,7 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
+import { REDACTED_EVENT_VALUE, sanitizeLogValue } from "../redaction.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -28,6 +29,22 @@ const sharedOpts = {
 
 export const logger = pino({
   level: "debug",
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      "req.headers.x-api-key",
+      "req.raw.headers.authorization",
+      "req.raw.headers.cookie",
+      "req.raw.headers.x-api-key",
+      "errorContext.authorization",
+      "reqBody.authorization",
+      "reqBody.apiKey",
+      "reqBody.token",
+      "reqBody.secret",
+    ],
+    censor: REDACTED_EVENT_VALUE,
+  },
 }, pino.transport({
   targets: [
     {
@@ -45,6 +62,17 @@ export const logger = pino({
 
 export const httpLogger = pinoHttp({
   logger,
+  serializers: {
+    req(req) {
+      return sanitizeLogValue(pino.stdSerializers.req(req));
+    },
+    res(res) {
+      return sanitizeLogValue(pino.stdSerializers.res(res));
+    },
+    err(err) {
+      return sanitizeLogValue(pino.stdSerializers.err(err));
+    },
+  },
   customLogLevel(_req, res, err) {
     if (err || res.statusCode >= 500) return "error";
     if (res.statusCode >= 400) return "warn";
@@ -63,22 +91,22 @@ export const httpLogger = pinoHttp({
       const ctx = (res as any).__errorContext;
       if (ctx) {
         return {
-          errorContext: ctx.error,
-          reqBody: ctx.reqBody,
-          reqParams: ctx.reqParams,
-          reqQuery: ctx.reqQuery,
+          errorContext: sanitizeLogValue(ctx.error),
+          reqBody: sanitizeLogValue(ctx.reqBody),
+          reqParams: sanitizeLogValue(ctx.reqParams),
+          reqQuery: sanitizeLogValue(ctx.reqQuery),
         };
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = sanitizeLogValue(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
-        props.reqParams = params;
+        props.reqParams = sanitizeLogValue(params);
       }
       if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = query;
+        props.reqQuery = sanitizeLogValue(query);
       }
       if ((req as any).route?.path) {
         props.routePath = (req as any).route.path;

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,6 +1,9 @@
 const SECRET_PAYLOAD_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
+  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
 const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?$/;
+const JWT_TEXT_RE = /\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?\b/g;
+const BEARER_TEXT_RE = /\bBearer\s+[^\s"',}]+/gi;
+const SHELL_EXPORT_RE = /^(\s*(?:export\s+)?)(([A-Za-z_][A-Za-z0-9_]*))(=.*)$/;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -9,8 +12,26 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
+export function redactSensitiveText(text: string): string {
+  let redacted = text.replace(BEARER_TEXT_RE, `Bearer ${REDACTED_EVENT_VALUE}`);
+  redacted = redacted.replace(JWT_TEXT_RE, REDACTED_EVENT_VALUE);
+
+  const lines = redacted.split(/\r?\n/);
+  let changed = false;
+  const rewritten = lines.map((line) => {
+    const match = line.match(SHELL_EXPORT_RE);
+    if (!match) return line;
+    const [, prefix, key] = match;
+    if (!SECRET_PAYLOAD_KEY_RE.test(key)) return line;
+    changed = true;
+    return `${prefix}${key}=${REDACTED_EVENT_VALUE}`;
+  });
+  return changed ? rewritten.join("\n") : redacted;
+}
+
 function sanitizeValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
+  if (typeof value === "string") return redactSensitiveText(value);
   if (Array.isArray(value)) return value.map(sanitizeValue);
   if (isSecretRefBinding(value)) return value;
   if (isPlainBinding(value)) return { type: "plain", value: sanitizeValue(value.value) };
@@ -56,4 +77,8 @@ export function redactEventPayload(payload: Record<string, unknown> | null): Rec
   if (!payload) return null;
   if (!isPlainObject(payload)) return payload;
   return sanitizeRecord(payload);
+}
+
+export function sanitizeLogValue(value: unknown): unknown {
+  return sanitizeValue(value);
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -56,6 +56,7 @@ import {
 } from "./execution-workspace-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
+import { redactSensitiveText } from "../redaction.js";
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
@@ -2549,7 +2550,10 @@ export function heartbeatService(db: Db) {
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
-        const sanitizedChunk = redactCurrentUserText(chunk, currentUserRedactionOptions);
+        const sanitizedChunk = redactCurrentUserText(
+          redactSensitiveText(chunk),
+          currentUserRedactionOptions,
+        );
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
         const ts = new Date().toISOString();

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { redactSensitiveText } from "../redaction.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -109,10 +110,11 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
     async append(handle, event) {
       if (handle.store !== "local_file") return;
       const absPath = resolveWithin(basePath, handle.logRef);
+      const sanitizedChunk = redactSensitiveText(event.chunk);
       const line = JSON.stringify({
         ts: event.ts,
         stream: event.stream,
-        chunk: event.chunk,
+        chunk: sanitizedChunk,
       });
       await fs.appendFile(absPath, `${line}\n`, "utf8");
     },
@@ -153,4 +155,3 @@ export function getRunLogStore() {
   cachedStore = createLocalFileRunLogStore(basePath);
   return cachedStore;
 }
-


### PR DESCRIPTION
## Summary
- redact bearer tokens, JWT-like values, and sensitive env exports before they land in server request logs or heartbeat run logs
- scrub managed Codex `shell_snapshots` and `sessions` artifacts after execution and tighten artifact file permissions
- add focused regression tests for log redaction and Codex artifact scrubbing

## Verification
- `/opt/homebrew/bin/pnpm -r typecheck`
- `/opt/homebrew/bin/pnpm --filter @paperclipai/server exec vitest run src/__tests__/redaction.test.ts src/__tests__/codex-local-execute.test.ts --reporter=verbose`
- `/opt/homebrew/bin/pnpm build`

## Full Test Suite
- `/opt/homebrew/bin/pnpm test:run` still fails on unrelated existing tests:
  - `server/src/__tests__/worktree-config.test.ts`
  - `server/src/__tests__/workspace-runtime.test.ts`
  - `ui/src/components/IssueDocumentsSection.test.tsx`

## Context
This addresses the credential leakage described in internal remediation work for `ROO-40` / `ROO-39` by covering three leak paths:
1. HTTP/server logs
2. heartbeat run logs
3. persisted Codex artifacts under managed `codex-home`

@cryppadotta review requested for the logging/runtime-security paths.
