### PR TITLE
hardening: clamp runtime permissions and disable codex bypass by default

### DIFF
--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { doctor } from "../commands/doctor.js";
 import { writeConfig } from "../config/store.js";
 import type { PaperclipConfig } from "../config/schema.js";
+import { readPathMode } from "../utils/fs-permissions.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -98,5 +99,47 @@ describe("doctor", () => {
     expect(summary.failed).toBe(0);
     expect(summary.warned).toBe(0);
     expect(process.env.PAPERCLIP_AGENT_JWT_SECRET).toBeTruthy();
+  });
+
+  it("repairs runtime paths that are too permissive", async () => {
+    const configPath = createTempConfig();
+    const runtimeRoot = path.join(path.dirname(path.dirname(configPath)), "runtime");
+    const envPath = path.join(path.dirname(configPath), ".env");
+    const logDir = path.join(runtimeRoot, "logs");
+    const storageDir = path.join(runtimeRoot, "storage");
+    const backupDir = path.join(runtimeRoot, "backups");
+    const secretsDir = path.join(runtimeRoot, "secrets");
+    const secretsKeyPath = path.join(secretsDir, "master.key");
+
+    fs.mkdirSync(logDir, { recursive: true, mode: 0o777 });
+    fs.mkdirSync(storageDir, { recursive: true, mode: 0o777 });
+    fs.mkdirSync(backupDir, { recursive: true, mode: 0o777 });
+    fs.mkdirSync(secretsDir, { recursive: true, mode: 0o777 });
+    fs.writeFileSync(envPath, "PAPERCLIP_AGENT_JWT_SECRET=test\n", { mode: 0o666 });
+    fs.writeFileSync(secretsKeyPath, "0123456789abcdef0123456789abcdef", { mode: 0o666 });
+    fs.chmodSync(path.dirname(configPath), 0o777);
+    fs.chmodSync(configPath, 0o666);
+    fs.chmodSync(envPath, 0o666);
+    fs.chmodSync(logDir, 0o777);
+    fs.chmodSync(storageDir, 0o777);
+    fs.chmodSync(backupDir, 0o777);
+    fs.chmodSync(secretsDir, 0o777);
+    fs.chmodSync(secretsKeyPath, 0o666);
+
+    const summary = await doctor({
+      config: configPath,
+      repair: true,
+      yes: true,
+    });
+
+    expect(summary.failed).toBe(0);
+    expect(readPathMode(path.dirname(configPath))).toBe(0o700);
+    expect(readPathMode(configPath)).toBe(0o600);
+    expect(readPathMode(envPath)).toBe(0o600);
+    expect(readPathMode(logDir)).toBe(0o700);
+    expect(readPathMode(storageDir)).toBe(0o700);
+    expect(readPathMode(backupDir)).toBe(0o700);
+    expect(readPathMode(secretsDir)).toBe(0o700);
+    expect(readPathMode(secretsKeyPath)).toBe(0o600);
   });
 });

--- a/cli/src/checks/database-check.ts
+++ b/cli/src/checks/database-check.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
 import { resolveRuntimeLikePath } from "./path-resolver.js";
+import { ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 export async function databaseCheck(config: PaperclipConfig, configPath?: string): Promise<CheckResult> {
   if (config.database.mode === "postgres") {
@@ -39,7 +40,7 @@ export async function databaseCheck(config: PaperclipConfig, configPath?: string
     const dataDir = resolveRuntimeLikePath(config.database.embeddedPostgresDataDir, configPath);
     const reportedPath = dataDir;
     if (!fs.existsSync(dataDir)) {
-      fs.mkdirSync(reportedPath, { recursive: true });
+      ensureDirectoryMode(reportedPath);
     }
 
     return {

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -14,5 +14,6 @@ export { databaseCheck } from "./database-check.js";
 export { llmCheck } from "./llm-check.js";
 export { logCheck } from "./log-check.js";
 export { portCheck } from "./port-check.js";
+export { runtimePermissionsCheck } from "./runtime-permissions-check.js";
 export { secretsCheck } from "./secrets-check.js";
 export { storageCheck } from "./storage-check.js";

--- a/cli/src/checks/log-check.ts
+++ b/cli/src/checks/log-check.ts
@@ -2,13 +2,14 @@ import fs from "node:fs";
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
 import { resolveRuntimeLikePath } from "./path-resolver.js";
+import { ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 export function logCheck(config: PaperclipConfig, configPath?: string): CheckResult {
   const logDir = resolveRuntimeLikePath(config.logging.logDir, configPath);
   const reportedDir = logDir;
 
   if (!fs.existsSync(logDir)) {
-    fs.mkdirSync(reportedDir, { recursive: true });
+    ensureDirectoryMode(reportedDir);
   }
 
   try {

--- a/cli/src/checks/runtime-permissions-check.ts
+++ b/cli/src/checks/runtime-permissions-check.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { PaperclipConfig } from "../config/schema.js";
+import type { CheckResult } from "./index.js";
+import { resolveConfigPath } from "../config/store.js";
+import { resolvePaperclipEnvFile } from "../config/env.js";
+import { applyPathMode, formatMode, isModeTooPermissive, readPathMode } from "../utils/fs-permissions.js";
+import { resolveRuntimeLikePath } from "./path-resolver.js";
+
+type PathCheck = {
+  label: string;
+  targetPath: string;
+  maxMode: number;
+};
+
+type PathViolation = PathCheck & {
+  actualMode: number;
+};
+
+function collectViolation(violations: PathViolation[], check: PathCheck): void {
+  if (!fs.existsSync(check.targetPath)) return;
+  const actualMode = readPathMode(check.targetPath);
+  if (actualMode === null || !isModeTooPermissive(actualMode, check.maxMode)) return;
+  violations.push({ ...check, actualMode });
+}
+
+export function runtimePermissionsCheck(config: PaperclipConfig, configPath?: string): CheckResult {
+  const resolvedConfigPath = resolveConfigPath(configPath);
+  const envPath = resolvePaperclipEnvFile(configPath);
+  const checks: PathCheck[] = [
+    {
+      label: "config directory",
+      targetPath: path.dirname(resolvedConfigPath),
+      maxMode: 0o700,
+    },
+    {
+      label: "config file",
+      targetPath: resolvedConfigPath,
+      maxMode: 0o600,
+    },
+    {
+      label: "agent env file",
+      targetPath: envPath,
+      maxMode: 0o600,
+    },
+    {
+      label: "log directory",
+      targetPath: resolveRuntimeLikePath(config.logging.logDir, configPath),
+      maxMode: 0o700,
+    },
+    {
+      label: "backup directory",
+      targetPath: resolveRuntimeLikePath(config.database.backup.dir, configPath),
+      maxMode: 0o700,
+    },
+  ];
+
+  if (config.database.mode === "embedded-postgres") {
+    checks.push({
+      label: "embedded Postgres data directory",
+      targetPath: resolveRuntimeLikePath(config.database.embeddedPostgresDataDir, configPath),
+      maxMode: 0o700,
+    });
+  }
+
+  if (config.storage.provider === "local_disk") {
+    checks.push({
+      label: "storage directory",
+      targetPath: resolveRuntimeLikePath(config.storage.localDisk.baseDir, configPath),
+      maxMode: 0o700,
+    });
+  }
+
+  if (config.secrets.provider === "local_encrypted") {
+    const keyFilePath = resolveRuntimeLikePath(config.secrets.localEncrypted.keyFilePath, configPath);
+    checks.push(
+      {
+        label: "secrets directory",
+        targetPath: path.dirname(keyFilePath),
+        maxMode: 0o700,
+      },
+      {
+        label: "secrets key file",
+        targetPath: keyFilePath,
+        maxMode: 0o600,
+      },
+    );
+  }
+
+  const violations: PathViolation[] = [];
+  for (const check of checks) {
+    collectViolation(violations, check);
+  }
+
+  if (violations.length === 0) {
+    return {
+      name: "Runtime permissions",
+      status: "pass",
+      message: "Existing runtime paths satisfy the hardening baseline",
+    };
+  }
+
+  return {
+    name: "Runtime permissions",
+    status: "fail",
+    message: violations
+      .map((violation) => `${violation.label} ${violation.targetPath} is ${formatMode(violation.actualMode)} (max ${formatMode(violation.maxMode)})`)
+      .join("; "),
+    canRepair: true,
+    repair: () => {
+      for (const violation of violations) {
+        applyPathMode(violation.targetPath, violation.maxMode);
+      }
+    },
+    repairHint: "Run with --repair to clamp existing runtime paths to least-privilege modes",
+  };
+}

--- a/cli/src/checks/secrets-check.ts
+++ b/cli/src/checks/secrets-check.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
 import { resolveRuntimeLikePath } from "./path-resolver.js";
+import { applyPathMode, ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 function decodeMasterKey(raw: string): Buffer | null {
   const trimmed = raw.trim();
@@ -95,16 +96,12 @@ export function secretsCheck(config: PaperclipConfig, configPath?: string): Chec
         message: `Secrets key file does not exist yet: ${keyFilePath}`,
         canRepair: true,
         repair: () => {
-          fs.mkdirSync(path.dirname(keyFilePath), { recursive: true });
+          ensureDirectoryMode(path.dirname(keyFilePath));
           fs.writeFileSync(keyFilePath, randomBytes(32).toString("base64"), {
             encoding: "utf8",
             mode: 0o600,
           });
-          try {
-            fs.chmodSync(keyFilePath, 0o600);
-          } catch {
-            // best effort
-          }
+          applyPathMode(keyFilePath, 0o600);
         },
         repairHint: "Run with --repair to create a local encrypted secrets key file",
       },

--- a/cli/src/checks/storage-check.ts
+++ b/cli/src/checks/storage-check.ts
@@ -2,12 +2,13 @@ import fs from "node:fs";
 import type { PaperclipConfig } from "../config/schema.js";
 import type { CheckResult } from "./index.js";
 import { resolveRuntimeLikePath } from "./path-resolver.js";
+import { ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 export function storageCheck(config: PaperclipConfig, configPath?: string): CheckResult {
   if (config.storage.provider === "local_disk") {
     const baseDir = resolveRuntimeLikePath(config.storage.localDisk.baseDir, configPath);
     if (!fs.existsSync(baseDir)) {
-      fs.mkdirSync(baseDir, { recursive: true });
+      ensureDirectoryMode(baseDir);
     }
 
     try {
@@ -48,4 +49,3 @@ export function storageCheck(config: PaperclipConfig, configPath?: string): Chec
     repairHint: "Verify credentials and endpoint in deployment environment",
   };
 }
-

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -10,6 +10,7 @@ import {
   llmCheck,
   logCheck,
   portCheck,
+  runtimePermissionsCheck,
   secretsCheck,
   storageCheck,
   type CheckResult,
@@ -65,7 +66,16 @@ export async function doctor(opts: {
   results.push(deploymentAuthResult);
   printResult(deploymentAuthResult);
 
-  // 3. Agent JWT check
+  // 3. Runtime filesystem permissions check
+  results.push(
+    await runRepairableCheck({
+      run: () => runtimePermissionsCheck(config, configPath),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 4. Agent JWT check
   results.push(
     await runRepairableCheck({
       run: () => agentJwtSecretCheck(opts.config),
@@ -74,7 +84,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 4. Secrets adapter check
+  // 5. Secrets adapter check
   results.push(
     await runRepairableCheck({
       run: () => secretsCheck(config, configPath),
@@ -83,7 +93,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 5. Storage check
+  // 6. Storage check
   results.push(
     await runRepairableCheck({
       run: () => storageCheck(config, configPath),
@@ -92,7 +102,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 6. Database check
+  // 7. Database check
   results.push(
     await runRepairableCheck({
       run: () => databaseCheck(config, configPath),
@@ -101,12 +111,12 @@ export async function doctor(opts: {
     }),
   );
 
-  // 7. LLM check
+  // 8. LLM check
   const llmResult = await llmCheck(config);
   results.push(llmResult);
   printResult(llmResult);
 
-  // 8. Log directory check
+  // 9. Log directory check
   results.push(
     await runRepairableCheck({
       run: () => logCheck(config, configPath),
@@ -115,7 +125,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 9. Port check
+  // 10. Port check
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -15,6 +15,7 @@ import {
   resolvePaperclipHomeDir,
   resolvePaperclipInstanceId,
 } from "../config/home.js";
+import { ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 interface RunOptions {
   config?: string;
@@ -35,10 +36,10 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   process.env.PAPERCLIP_INSTANCE_ID = instanceId;
 
   const homeDir = resolvePaperclipHomeDir();
-  fs.mkdirSync(homeDir, { recursive: true });
+  ensureDirectoryMode(homeDir);
 
   const paths = describeLocalInstancePaths(instanceId);
-  fs.mkdirSync(paths.instanceRoot, { recursive: true });
+  ensureDirectoryMode(paths.instanceRoot);
 
   const configPath = resolveConfigPath(opts.config);
   process.env.PAPERCLIP_CONFIG = configPath;

--- a/cli/src/config/env.ts
+++ b/cli/src/config/env.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { config as loadDotenv, parse as parseEnvFileContents } from "dotenv";
 import { resolveConfigPath } from "./store.js";
+import { applyPathMode, ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 const JWT_SECRET_ENV_KEY = "PAPERCLIP_AGENT_JWT_SECRET";
 function resolveEnvFilePath(configPath?: string) {
@@ -103,10 +104,11 @@ export function readPaperclipEnvEntries(filePath = resolveEnvFilePath()): Record
 
 export function writePaperclipEnvEntries(entries: Record<string, string>, filePath = resolveEnvFilePath()): void {
   const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
+  ensureDirectoryMode(dir);
   fs.writeFileSync(filePath, renderEnvFile(entries), {
     mode: 0o600,
   });
+  applyPathMode(filePath, 0o600);
 }
 
 export function mergePaperclipEnvEntries(

--- a/cli/src/config/secrets-key.ts
+++ b/cli/src/config/secrets-key.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { PaperclipConfig } from "./schema.js";
 import { resolveRuntimeLikePath } from "../utils/path-resolver.js";
+import { applyPathMode, ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 export type EnsureSecretsKeyResult =
   | { status: "created"; path: string }
@@ -34,15 +35,11 @@ export function ensureLocalSecretsKeyFile(
     return { status: "existing", path: keyFilePath };
   }
 
-  fs.mkdirSync(path.dirname(keyFilePath), { recursive: true });
+  ensureDirectoryMode(path.dirname(keyFilePath));
   fs.writeFileSync(keyFilePath, randomBytes(32).toString("base64"), {
     encoding: "utf8",
     mode: 0o600,
   });
-  try {
-    fs.chmodSync(keyFilePath, 0o600);
-  } catch {
-    // best effort
-  }
+  applyPathMode(keyFilePath, 0o600);
   return { status: "created", path: keyFilePath };
 }

--- a/cli/src/config/store.ts
+++ b/cli/src/config/store.ts
@@ -5,6 +5,7 @@ import {
   resolveDefaultConfigPath,
   resolvePaperclipInstanceId,
 } from "./home.js";
+import { applyPathMode, ensureDirectoryMode } from "../utils/fs-permissions.js";
 
 const DEFAULT_CONFIG_BASENAME = "config.json";
 
@@ -101,18 +102,19 @@ export function writeConfig(
 ): void {
   const filePath = resolveConfigPath(configPath);
   const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
+  ensureDirectoryMode(dir);
 
   // Backup existing config before overwriting
   if (fs.existsSync(filePath)) {
     const backupPath = filePath + ".backup";
     fs.copyFileSync(filePath, backupPath);
-    fs.chmodSync(backupPath, 0o600);
+    applyPathMode(backupPath, 0o600);
   }
 
   fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", {
     mode: 0o600,
   });
+  applyPathMode(filePath, 0o600);
 }
 
 export function configExists(configPath?: string): boolean {

--- a/cli/src/utils/fs-permissions.ts
+++ b/cli/src/utils/fs-permissions.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+
+export function ensureDirectoryMode(dirPath: string, mode = 0o700): void {
+  fs.mkdirSync(dirPath, { recursive: true, mode });
+  applyPathMode(dirPath, mode);
+}
+
+export function applyPathMode(targetPath: string, mode: number): void {
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch {
+    // best effort
+  }
+}
+
+export function readPathMode(targetPath: string): number | null {
+  try {
+    return fs.statSync(targetPath).mode & 0o777;
+  } catch {
+    return null;
+  }
+}
+
+export function isModeTooPermissive(actualMode: number, maxMode: number): boolean {
+  return (actualMode & ~maxMode) !== 0;
+}
+
+export function formatMode(mode: number): string {
+  return `0o${mode.toString(8).padStart(3, "0")}`;
+}

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -1,7 +1,7 @@
 export const type = "codex_local";
 export const label = "Codex (local)";
 export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.3-codex";
-export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = true;
+export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = false;
 
 export const models = [
   { id: "gpt-5.4", label: "gpt-5.4" },

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { buildCodexLocalConfig } from "./build-config.js";
+
+function createValues(): CreateConfigValues {
+  return {
+    adapterType: "codex_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "none",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 3600,
+  };
+}
+
+describe("buildCodexLocalConfig", () => {
+  it("defaults bypass mode to explicit opt-in", () => {
+    const values = { ...createValues(), dangerouslyBypassSandbox: undefined } as unknown as CreateConfigValues;
+    const config = buildCodexLocalConfig(values);
+    expect(config.dangerouslyBypassApprovalsAndSandbox).toBe(false);
+  });
+});

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { chmodSync, createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import postgres from "postgres";
@@ -143,7 +143,7 @@ function tableKey(schemaName: string, tableName: string): string {
 }
 
 export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
-  const stream = createWriteStream(filePath, { encoding: "utf8" });
+  const stream = createWriteStream(filePath, { encoding: "utf8", mode: 0o600 });
   const flushThreshold = Math.max(1, Math.trunc(maxBufferedBytes));
   let bufferedLines: string[] = [];
   let bufferedBytes = 0;
@@ -246,7 +246,12 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
   const sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
-  mkdirSync(opts.backupDir, { recursive: true });
+  mkdirSync(opts.backupDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(opts.backupDir, 0o700);
+  } catch {
+    // best effort
+  }
   const backupFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql`);
   const writer = createBufferedTextFileWriter(backupFile);
 

--- a/server/src/fs-permissions.ts
+++ b/server/src/fs-permissions.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+
+export function ensureDirectoryMode(dirPath: string, mode = 0o700): void {
+  fs.mkdirSync(dirPath, { recursive: true, mode });
+  applyPathMode(dirPath, mode);
+}
+
+export function ensureFileMode(filePath: string, mode = 0o600): void {
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, "", { flag: "a", mode });
+  }
+  applyPathMode(filePath, mode);
+}
+
+export function applyPathMode(targetPath: string, mode: number): void {
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch {
+    // best effort
+  }
+}

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
-import fs from "node:fs";
 import pino from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
+import { ensureDirectoryMode, ensureFileMode } from "../fs-permissions.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -16,9 +16,10 @@ function resolveServerLogDir(): string {
 }
 
 const logDir = resolveServerLogDir();
-fs.mkdirSync(logDir, { recursive: true });
+ensureDirectoryMode(logDir);
 
 const logFile = path.join(logDir, "server.log");
+ensureFileMode(logFile);
 
 const sharedOpts = {
   translateTime: "HH:MM:ss",

--- a/server/src/secrets/local-encrypted-provider.ts
+++ b/server/src/secrets/local-encrypted-provider.ts
@@ -61,7 +61,12 @@ function loadOrCreateMasterKey(): Buffer {
   }
 
   const dir = path.dirname(keyPath);
-  mkdirSync(dir, { recursive: true });
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // best effort
+  }
   const generated = randomBytes(32);
   writeFileSync(keyPath, generated.toString("base64"), { encoding: "utf8", mode: 0o600 });
   try {


### PR DESCRIPTION
## Summary
- clamp existing Paperclip runtime/config paths to least-privilege modes via a new doctor hardening check and secure creation helpers
- create logs, secrets, backups, and config artifacts with secure modes by default
- make `codex_local` bypass execution an explicit opt-in instead of a silent default and add regression coverage

## Verification
- `/opt/homebrew/bin/pnpm -C /Users/aiSandbox/github/paperclip-roo-41 -r typecheck`
- `/opt/homebrew/bin/pnpm -C /Users/aiSandbox/github/paperclip-roo-41 --filter paperclipai exec vitest run src/__tests__/doctor.test.ts --reporter=verbose`
- `/opt/homebrew/bin/pnpm -C /Users/aiSandbox/github/paperclip-roo-41 --filter @paperclipai/adapter-codex-local exec vitest run src/ui/build-config.test.ts --reporter=verbose`

## References
- Paperclip task: ROO-41
- Audit source: ROO-39
- Separate ops rollout/runbook remains tracked outside this PR

cc @halfwitgaslit for review context and merge
