### PR TITLE
fix: render issue documents as static markdown in read mode

### DIFF
--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -1079,7 +1079,7 @@ export function IssueDocumentsSection({
                         onChange={(body) => {
                           markDocumentDirty(doc.key);
                           setDraft((current) =>
-                            current && current.key === doc.key && !current.isNew
+                            current && current.key === doc.key
                               ? { ...current, body }
                               : current,
                           );
@@ -1093,7 +1093,12 @@ export function IssueDocumentsSection({
                         onSubmit={() => void commitDraft(activeDraft, { clearAfterSave: false, trackAutosave: true })}
                       />
                     ) : (
-                      <div className="w-full rounded-md p-0 text-left">
+                      <div
+                        className="w-full cursor-text rounded-md p-0 text-left"
+                        onClick={() => {
+                          if (!isHistoricalPreview) beginEdit(doc.key);
+                        }}
+                      >
                         {renderBody(displayedBody, documentBodyContentClassName)}
                       </div>
                     )}

--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -947,18 +947,14 @@ export function IssueDocumentsSection({
               {!isFolded ? (
                 <div
                   className="mt-3 space-y-3"
-                  onBlurCapture={!isHistoricalPreview
+                  onBlurCapture={activeDraft && !isHistoricalPreview
                     ? async (event) => {
-                        if (activeDraft) {
-                          await handleDraftBlur(event);
-                        }
+                        await handleDraftBlur(event);
                       }
                     : undefined}
-                  onKeyDown={!isHistoricalPreview
+                  onKeyDown={activeDraft && !isHistoricalPreview
                     ? async (event) => {
-                        if (activeDraft) {
-                          await handleDraftKeyDown(event);
-                        }
+                        await handleDraftKeyDown(event);
                       }
                     : undefined}
                 >
@@ -1079,15 +1075,14 @@ export function IssueDocumentsSection({
                       </div>
                     ) : activeDraft ? (
                       <MarkdownEditor
-                        value={displayedBody}
+                        value={activeDraft.body}
                         onChange={(body) => {
                           markDocumentDirty(doc.key);
-                          setDraft((current) => {
-                            if (current && current.key === doc.key && !current.isNew) {
-                              return { ...current, body };
-                            }
-                            return current;
-                          });
+                          setDraft((current) =>
+                            current && current.key === doc.key && !current.isNew
+                              ? { ...current, body }
+                              : current,
+                          );
                         }}
                         placeholder="Markdown body"
                         bordered={false}
@@ -1095,10 +1090,10 @@ export function IssueDocumentsSection({
                         contentClassName={documentBodyContentClassName}
                         mentions={mentions}
                         imageUploadHandler={imageUploadHandler}
-                        onSubmit={() => void commitDraft(activeDraft ?? draft, { clearAfterSave: false, trackAutosave: true })}
+                        onSubmit={() => void commitDraft(activeDraft, { clearAfterSave: false, trackAutosave: true })}
                       />
                     ) : (
-                      <div className="rounded-md border border-border/60 bg-background/40 p-3">
+                      <div className="w-full rounded-md p-0 text-left">
                         {renderBody(displayedBody, documentBodyContentClassName)}
                       </div>
                     )}


### PR DESCRIPTION
## Summary

- Documents created via the REST API (e.g., by agents using `PUT /api/issues/{issueId}/documents/{key}`) render as an empty "Markdown body" placeholder in the web UI, even though the content is stored and returned correctly by the API
- Root cause: `IssueDocumentsSection` always mounts `MDXEditor` in edit mode. For large or agent-produced markdown, the editor fires `onChange` during initialization with empty/normalized content, creating a blank draft that overwrites the actual document body
- The fix separates read and edit modes — read mode uses `renderBody()` for static markdown rendering, and `MDXEditor` only mounts when a draft is explicitly active

## Reproduction

1. Create an issue document via API: `PUT /api/issues/{id}/documents/plan` with a markdown body
2. Open the issue in the web UI and navigate to the document
3. **Expected:** document content renders as formatted markdown
4. **Actual:** empty text box with "Markdown body" placeholder

## Test plan

- [ ] Verify API-created documents render correctly in the UI (read mode)
- [ ] Verify clicking into a document still allows editing when a draft is active
- [ ] Verify manually created documents (via UI) still work as expected
- [ ] Test with large markdown documents (>10KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)