### PR TITLE
fix(ui): dim paused agents in list and org chart views

### DIFF
--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -291,7 +291,7 @@ export function Agents() {
       {effectiveView === "org" && filteredOrg.length > 0 && (
         <div className="border border-border py-1">
           {filteredOrg.map((node) => (
-            <OrgTreeNode key={node.id} node={node} depth={0} agentMap={agentMap} liveRunByAgent={liveRunByAgent} />
+            <OrgTreeNode key={node.id} node={node} depth={0} agentMap={agentMap} liveRunByAgent={liveRunByAgent} tab={tab} />
           ))}
         </div>
       )}
@@ -316,11 +316,13 @@ function OrgTreeNode({
   depth,
   agentMap,
   liveRunByAgent,
+  tab,
 }: {
   node: OrgNode;
   depth: number;
   agentMap: Map<string, Agent>;
   liveRunByAgent: Map<string, { runId: string; liveCount: number }>;
+  tab: FilterTab;
 }) {
   const agent = agentMap.get(node.id);
 
@@ -330,7 +332,7 @@ function OrgTreeNode({
     <div style={{ paddingLeft: depth * 24 }}>
       <Link
         to={agent ? agentUrl(agent) : `/agents/${node.id}`}
-        className={cn("flex items-center gap-3 px-3 py-2 hover:bg-accent/30 transition-colors w-full text-left no-underline text-inherit", agent?.pausedAt && "opacity-50")}
+        className={cn("flex items-center gap-3 px-3 py-2 hover:bg-accent/30 transition-colors w-full text-left no-underline text-inherit", agent?.pausedAt && tab !== "paused" && "opacity-50")}
       >
         <span className="relative flex h-2.5 w-2.5 shrink-0">
           <span className={`absolute inline-flex h-full w-full rounded-full ${statusColor}`} />
@@ -381,7 +383,7 @@ function OrgTreeNode({
       {node.reports && node.reports.length > 0 && (
         <div className="border-l border-border/50 ml-4">
           {node.reports.map((child) => (
-            <OrgTreeNode key={child.id} node={child} depth={depth + 1} agentMap={agentMap} liveRunByAgent={liveRunByAgent} />
+            <OrgTreeNode key={child.id} node={child} depth={depth + 1} agentMap={agentMap} liveRunByAgent={liveRunByAgent} tab={tab} />
           ))}
         </div>
       )}


### PR DESCRIPTION
Paused agents were visually identical to active agents in both the list view and org chart, making it hard to distinguish them at a glance. Add opacity-50 to agent rows when pausedAt is set.

Closes #2199

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The agents list page shows all agents with status indicators (colored dots)
> - Paused agents looked identical to active agents, forcing users to click into each agent to check state
> - For operations like the NHU experiment, running vs paused is a critical state that should be visible at a glance
> - This PR adds `opacity-50` dimming to paused agents in both the list view and org chart
> - The dimming is skipped on the "Paused" tab where all agents are already paused (per Greptile review feedback)
> - The benefit is immediate visual feedback on agent operational state without extra clicks

## What Changed

- Added `opacity-50` class to `EntityRow` for paused agents in the list view, skipping dimming when the "Paused" tab is active (`ui/src/pages/Agents.tsx`)
- Added `opacity-50` to org chart `Link` elements for paused agents via `cn()` with optional chain guard (`ui/src/pages/Agents.tsx`)

## Verification

- Pause an agent, navigate to the agents list on the "All" tab — paused agent should appear dimmed
- Switch to the "Paused" tab — agents should appear at full opacity (dimming skipped)
- Check the org chart view — paused agents should appear dimmed there too

## Risks

Low risk — purely visual CSS change. Uses existing `pausedAt` field already available on agent objects. The `cn()` utility and `EntityRow` `className` prop are already established patterns.

## Model Used

Claude Opus 4.6 (1M context), tool use and extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge