### PR TITLE
fix(ui): make goal description area scrollable in create dialog

### DIFF
--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -168,7 +168,7 @@ export function NewGoalDialog() {
         </div>
 
         {/* Description */}
-        <div className="px-4 pb-2">
+        <div className="px-4 pb-2 overflow-y-auto max-h-[50vh]">
           <MarkdownEditor
             ref={descriptionEditorRef}
             value={description}


### PR DESCRIPTION
Long goal descriptions pushed the Create button below the viewport with no way to scroll, making it impossible to submit the form. Add overflow-y-auto and max-h-[50vh] to the description container so it scrolls within the dialog while keeping the footer visible.

Closes #2631

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Goals are created through a dialog (`NewGoalDialog`) with a title, properties, description (MarkdownEditor), and a footer with the Create button
> - The description area had no height constraint — long descriptions expanded the dialog beyond the viewport
> - Both the dialog and the page were unscrollable in this state, hiding the Create button entirely
> - Users with detailed goal descriptions were unable to submit the form at all
> - This PR caps the description container at `max-h-[50vh]` with `overflow-y-auto` so it scrolls internally
> - The header, property chips, and footer remain fixed and visible regardless of description length
> - The benefit is users can always reach the Create button, even with very long descriptions

## What Changed

- Added `overflow-y-auto max-h-[50vh]` to the description container div in `NewGoalDialog.tsx`, making the MarkdownEditor area scroll internally when content exceeds 50% of the viewport height

## Verification

- Open the New Goal dialog
- Paste or type a long description (enough to exceed the viewport)
- The description area should scroll internally while the Create button remains visible at the bottom
- Submit the form — it should work normally

## Risks

Low risk — single CSS class change on one container. The `50vh` cap is a reasonable default; on very small viewports the description area may feel cramped, but the form remains functional (per Greptile feedback, this threshold may need tuning).

Image before:
<img width="1280" height="720" alt="goal-before-fix" src="https://github.com/user-attachments/assets/e4a696ea-199c-43c7-a33b-5204decce182" />

Image after:
<img width="1280" height="720" alt="goal-after-fix" src="https://github.com/user-attachments/assets/7295cdf6-96a9-498b-917c-7163acea0250" />


## Model Used

Claude Opus 4.6 (1M context), tool use and extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge