### PR TITLE
Add Google Drive tools plugin

### DIFF
--- a/packages/plugins/plugin-google-drive-tools/README.md
+++ b/packages/plugins/plugin-google-drive-tools/README.md
@@ -1,0 +1,48 @@
+# Google Drive Tools Plugin
+
+Plugin nativo de Paperclip para que los agentes puedan trabajar con Google Drive y Google Docs.
+
+## Que hace
+
+- Buscar archivos en Drive
+- Listar carpetas
+- Leer Google Docs
+- Crear Google Docs
+- Anadir contenido a Google Docs existentes
+
+## Configuracion minima
+
+El plugin usa un refresh token de Google y secretos cifrados de Paperclip.
+
+Campos de configuracion:
+
+- `clientId`
+- `clientSecretSecretRef`
+- `refreshTokenSecretRef`
+- `defaultFolderId` opcional
+- `defaultUserEmail` opcional
+- `defaultPageSize` opcional
+
+## Setup recomendado
+
+1. Crear un cliente OAuth de Google.
+   Opcion por defecto: cliente tipo Desktop App.
+2. Obtener un refresh token con scopes:
+   - `https://www.googleapis.com/auth/drive`
+   - `https://www.googleapis.com/auth/documents`
+3. Guardar en Paperclip dos secretos:
+   - client secret
+   - refresh token
+4. Pegar el `clientId` en la config del plugin y referenciar ambos secretos por UUID.
+
+## Tools expuestas
+
+- `search-drive-files`
+- `list-drive-items`
+- `read-google-doc`
+- `create-google-doc`
+- `append-google-doc`
+
+## Limitacion actual
+
+La configuracion es global por instancia. Para este despliegue, lo razonable es apuntarlo a la cuenta general `roselloagents@gmail.com`.

--- a/packages/plugins/plugin-google-drive-tools/package.json
+++ b/packages/plugins/plugin-google-drive-tools/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@paperclipai/plugin-google-drive-tools",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Google Drive and Google Docs tools for Paperclip agents",
+  "scripts": {
+    "prebuild": "node ../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "corepack pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit -p tsconfig.json"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "google-drive",
+    "google-docs"
+  ],
+  "author": "Paperclip",
+  "license": "MIT",
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/plugins/plugin-google-drive-tools/src/google-drive.ts
+++ b/packages/plugins/plugin-google-drive-tools/src/google-drive.ts
@@ -1,0 +1,298 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
+
+export interface GoogleDrivePluginConfig {
+  clientId: string;
+  clientSecretSecretRef: string;
+  refreshTokenSecretRef: string;
+  defaultFolderId?: string;
+  defaultUserEmail?: string;
+  defaultPageSize?: number;
+}
+
+interface GoogleTokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  error?: string;
+  error_description?: string;
+}
+
+interface GoogleDocumentTextRun {
+  content?: string;
+}
+
+interface GoogleDocumentParagraphElement {
+  textRun?: GoogleDocumentTextRun;
+}
+
+interface GoogleDocumentParagraph {
+  elements?: GoogleDocumentParagraphElement[];
+}
+
+interface GoogleDocumentContentBlock {
+  endIndex?: number;
+  paragraph?: GoogleDocumentParagraph;
+  table?: {
+    tableRows?: Array<{
+      tableCells?: Array<{
+        content?: GoogleDocumentContentBlock[];
+      }>;
+    }>;
+  };
+  tableOfContents?: {
+    content?: GoogleDocumentContentBlock[];
+  };
+}
+
+export interface GoogleDocumentResponse {
+  title?: string;
+  body?: {
+    content?: GoogleDocumentContentBlock[];
+  };
+}
+
+const DEFAULT_PAGE_SIZE = 10;
+const TOKEN_SAFETY_MS = 30_000;
+const DOC_TEXT_LIMIT = 12_000;
+const accessTokenCache = new Map<string, { accessToken: string; expiresAt: number }>();
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+function mapMimeTypeFilter(value: unknown): string | null {
+  switch (value) {
+    case "document":
+      return "application/vnd.google-apps.document";
+    case "folder":
+      return "application/vnd.google-apps.folder";
+    case "pdf":
+      return "application/pdf";
+    default:
+      return null;
+  }
+}
+
+function summarizeApiError(body: unknown): string {
+  if (typeof body === "string" && body.trim().length > 0) {
+    return body.slice(0, 300);
+  }
+
+  if (body && typeof body === "object") {
+    const candidate = body as {
+      error?: { message?: string } | string;
+      error_description?: string;
+      message?: string;
+    };
+
+    if (typeof candidate.error === "object" && typeof candidate.error.message === "string") {
+      return candidate.error.message;
+    }
+
+    if (typeof candidate.error_description === "string") return candidate.error_description;
+    if (typeof candidate.message === "string") return candidate.message;
+    if (typeof candidate.error === "string") return candidate.error;
+  }
+
+  return "Unexpected Google API error";
+}
+
+async function parseJsonSafe(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+export function extractDocumentPlainText(document: GoogleDocumentResponse): string {
+  const chunks: string[] = [];
+
+  function walk(content: GoogleDocumentContentBlock[] | undefined): void {
+    if (!content) return;
+
+    for (const block of content) {
+      const paragraphText = (block.paragraph?.elements ?? [])
+        .map((element: GoogleDocumentParagraphElement) => element.textRun?.content ?? "")
+        .join("")
+        .replace(/\u000b/g, "\n");
+
+      if (paragraphText.trim().length > 0) {
+        chunks.push(paragraphText.trimEnd());
+      }
+
+      for (const row of block.table?.tableRows ?? []) {
+        for (const cell of row.tableCells ?? []) {
+          walk(cell.content);
+        }
+      }
+
+      walk(block.tableOfContents?.content);
+    }
+  }
+
+  walk(document.body?.content);
+  return chunks.join("\n\n").trim();
+}
+
+export function buildDriveSearchQuery(input: {
+  query?: string;
+  folderId?: string;
+  mimeType?: unknown;
+}): string {
+  const parts = ["trashed = false"];
+
+  if (input.query && input.query.trim().length > 0) {
+    parts.push(`name contains '${escapeDriveQueryValue(input.query.trim())}'`);
+  }
+
+  if (input.folderId && input.folderId.trim().length > 0) {
+    parts.push(`'${escapeDriveQueryValue(input.folderId.trim())}' in parents`);
+  }
+
+  const mimeType = mapMimeTypeFilter(input.mimeType);
+  if (mimeType) {
+    parts.push(`mimeType = '${mimeType}'`);
+  }
+
+  return parts.join(" and ");
+}
+
+export async function getPluginConfig(ctx: PluginContext): Promise<GoogleDrivePluginConfig> {
+  const raw = await ctx.config.get();
+  return {
+    clientId: asString(raw.clientId).trim(),
+    clientSecretSecretRef: asString(raw.clientSecretSecretRef).trim(),
+    refreshTokenSecretRef: asString(raw.refreshTokenSecretRef).trim(),
+    defaultFolderId: asString(raw.defaultFolderId).trim() || undefined,
+    defaultUserEmail: asString(raw.defaultUserEmail).trim() || undefined,
+    defaultPageSize: asNumber(raw.defaultPageSize, DEFAULT_PAGE_SIZE),
+  };
+}
+
+async function getAccessToken(ctx: PluginContext, config?: GoogleDrivePluginConfig): Promise<string> {
+  const resolvedConfig = config ?? await getPluginConfig(ctx);
+  if (!resolvedConfig.clientId || !resolvedConfig.clientSecretSecretRef || !resolvedConfig.refreshTokenSecretRef) {
+    throw new Error("Google Drive plugin is not configured");
+  }
+
+  const [clientSecret, refreshToken] = await Promise.all([
+    ctx.secrets.resolve(resolvedConfig.clientSecretSecretRef),
+    ctx.secrets.resolve(resolvedConfig.refreshTokenSecretRef),
+  ]);
+
+  const cacheKey = `${resolvedConfig.clientId}:${resolvedConfig.refreshTokenSecretRef}`;
+  const cached = accessTokenCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now() + TOKEN_SAFETY_MS) {
+    return cached.accessToken;
+  }
+
+  const response = await ctx.http.fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: resolvedConfig.clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+
+  const payload = await parseJsonSafe(response) as GoogleTokenResponse;
+  if (!response.ok || typeof payload.access_token !== "string" || payload.access_token.length === 0) {
+    throw new Error(`Google OAuth refresh failed: ${summarizeApiError(payload)}`);
+  }
+
+  const expiresIn = typeof payload.expires_in === "number" ? payload.expires_in : 3600;
+  accessTokenCache.set(cacheKey, {
+    accessToken: payload.access_token,
+    expiresAt: Date.now() + expiresIn * 1000,
+  });
+
+  return payload.access_token;
+}
+
+export async function googleJson<T>(
+  ctx: PluginContext,
+  input: {
+    url: string;
+    method?: string;
+    body?: unknown;
+    config?: GoogleDrivePluginConfig;
+  },
+): Promise<T> {
+  const accessToken = await getAccessToken(ctx, input.config);
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${accessToken}`,
+  };
+
+  let body: string | undefined;
+  if (input.body !== undefined) {
+    headers["content-type"] = "application/json";
+    body = JSON.stringify(input.body);
+  }
+
+  const response = await ctx.http.fetch(input.url, {
+    method: input.method ?? (body ? "POST" : "GET"),
+    headers,
+    body,
+  });
+
+  const payload = await parseJsonSafe(response);
+  if (!response.ok) {
+    throw new Error(`Google API ${response.status}: ${summarizeApiError(payload)}`);
+  }
+
+  return payload as T;
+}
+
+export function formatDriveFilesForAgent(
+  files: Array<{ id: string; name: string; mimeType?: string; webViewLink?: string; modifiedTime?: string }>,
+): string {
+  if (files.length === 0) return "No se han encontrado archivos.";
+
+  return files
+    .map((file, index) => {
+      const details = [
+        file.mimeType ? `mime=${file.mimeType}` : null,
+        file.modifiedTime ? `updated=${file.modifiedTime}` : null,
+        file.webViewLink ? `url=${file.webViewLink}` : null,
+      ].filter(Boolean);
+
+      return `${index + 1}. ${file.name} (${file.id})${details.length > 0 ? ` - ${details.join(" | ")}` : ""}`;
+    })
+    .join("\n");
+}
+
+export function truncateForAgent(text: string, maxLength = DOC_TEXT_LIMIT): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}\n\n[truncated]`;
+}
+
+export function getDocumentAppendIndex(document: GoogleDocumentResponse): number {
+  const lastEndIndex = document.body?.content?.at(-1)?.endIndex;
+  if (typeof lastEndIndex === "number" && lastEndIndex > 1) {
+    return lastEndIndex - 1;
+  }
+  return 1;
+}
+
+export function normalizePageSize(value: unknown, fallback: number): number {
+  const candidate = asNumber(value, fallback);
+  return Math.max(1, Math.min(100, candidate));
+}
+
+export function buildGoogleDocUrl(documentId: string): string {
+  return `https://docs.google.com/document/d/${documentId}/edit`;
+}

--- a/packages/plugins/plugin-google-drive-tools/src/manifest.ts
+++ b/packages/plugins/plugin-google-drive-tools/src/manifest.ts
@@ -1,0 +1,135 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: "paperclipai.plugin-google-drive-tools",
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Google Drive Tools",
+  description: "Google Drive and Google Docs tools for Paperclip agents.",
+  author: "Paperclip",
+  categories: ["connector"],
+  capabilities: [
+    "http.outbound",
+    "secrets.read-ref",
+    "agent.tools.register"
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js"
+  },
+  instanceConfigSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      clientId: {
+        type: "string",
+        title: "Google OAuth Client ID",
+        minLength: 1
+      },
+      clientSecretSecretRef: {
+        type: "string",
+        title: "Client secret secret ref",
+        format: "secret-ref"
+      },
+      refreshTokenSecretRef: {
+        type: "string",
+        title: "Refresh token secret ref",
+        format: "secret-ref"
+      },
+      defaultFolderId: {
+        type: "string",
+        title: "Default folder ID"
+      },
+      defaultUserEmail: {
+        type: "string",
+        title: "Default Google account email"
+      },
+      defaultPageSize: {
+        type: "integer",
+        title: "Default page size",
+        minimum: 1,
+        maximum: 100,
+        default: 10
+      }
+    },
+    required: ["clientId", "clientSecretSecretRef", "refreshTokenSecretRef"]
+  },
+  tools: [
+    {
+      name: "search-drive-files",
+      displayName: "Search Drive Files",
+      description: "Search files in Google Drive by name and optional filters.",
+      parametersSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          query: { type: "string", minLength: 1 },
+          folderId: { type: "string" },
+          mimeType: {
+            type: "string",
+            enum: ["any", "document", "folder", "pdf"],
+            default: "any"
+          },
+          pageSize: { type: "integer", minimum: 1, maximum: 100 }
+        },
+        required: ["query"]
+      }
+    },
+    {
+      name: "list-drive-items",
+      displayName: "List Drive Items",
+      description: "List files and folders inside a Google Drive folder.",
+      parametersSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          folderId: { type: "string" },
+          pageSize: { type: "integer", minimum: 1, maximum: 100 }
+        }
+      }
+    },
+    {
+      name: "read-google-doc",
+      displayName: "Read Google Doc",
+      description: "Read a Google Doc and return plain text content.",
+      parametersSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          documentId: { type: "string", minLength: 1 }
+        },
+        required: ["documentId"]
+      }
+    },
+    {
+      name: "create-google-doc",
+      displayName: "Create Google Doc",
+      description: "Create a Google Doc, optionally with initial content and folder placement.",
+      parametersSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: { type: "string", minLength: 1 },
+          content: { type: "string" },
+          folderId: { type: "string" }
+        },
+        required: ["title"]
+      }
+    },
+    {
+      name: "append-google-doc",
+      displayName: "Append Google Doc",
+      description: "Append text to the end of an existing Google Doc.",
+      parametersSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          documentId: { type: "string", minLength: 1 },
+          content: { type: "string", minLength: 1 }
+        },
+        required: ["documentId", "content"]
+      }
+    }
+  ]
+};
+
+export default manifest;

--- a/packages/plugins/plugin-google-drive-tools/src/worker.ts
+++ b/packages/plugins/plugin-google-drive-tools/src/worker.ts
@@ -1,0 +1,323 @@
+import type { ToolResult } from "@paperclipai/plugin-sdk";
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import {
+  buildDriveSearchQuery,
+  buildGoogleDocUrl,
+  extractDocumentPlainText,
+  formatDriveFilesForAgent,
+  getDocumentAppendIndex,
+  getPluginConfig,
+  type GoogleDocumentResponse,
+  googleJson,
+  normalizePageSize,
+  truncateForAgent,
+} from "./google-drive.js";
+
+type DriveFile = {
+  id: string;
+  name: string;
+  mimeType?: string;
+  webViewLink?: string;
+  modifiedTime?: string;
+};
+
+function getTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.tools.register(
+      "search-drive-files",
+      {
+        displayName: "Search Drive Files",
+        description: "Search files in Google Drive by name and optional filters.",
+        parametersSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            query: { type: "string", minLength: 1 },
+            folderId: { type: "string" },
+            mimeType: { type: "string" },
+            pageSize: { type: "integer", minimum: 1, maximum: 100 },
+          },
+          required: ["query"],
+        },
+      },
+      async (params): Promise<ToolResult> => {
+        const config = await getPluginConfig(ctx);
+        const typedParams = params as {
+          query?: unknown;
+          folderId?: unknown;
+          mimeType?: unknown;
+          pageSize?: unknown;
+        };
+
+        const queryValue = getTrimmedString(typedParams.query);
+        if (!queryValue) throw new Error("Missing or invalid \"query\"");
+
+        const pageSize = normalizePageSize(typedParams.pageSize, config.defaultPageSize ?? 10);
+        const query = buildDriveSearchQuery({
+          query: queryValue,
+          folderId: getTrimmedString(typedParams.folderId) || undefined,
+          mimeType: typedParams.mimeType,
+        });
+
+        const searchParams = new URLSearchParams({
+          q: query,
+          pageSize: String(pageSize),
+          includeItemsFromAllDrives: "true",
+          supportsAllDrives: "true",
+          orderBy: "modifiedTime desc",
+          fields: "files(id,name,mimeType,webViewLink,modifiedTime)",
+        });
+
+        const response = await googleJson<{ files?: DriveFile[] }>(ctx, {
+          url: `https://www.googleapis.com/drive/v3/files?${searchParams.toString()}`,
+          config,
+        });
+
+        const files = response.files ?? [];
+        return {
+          content: formatDriveFilesForAgent(files),
+          data: { files },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "list-drive-items",
+      {
+        displayName: "List Drive Items",
+        description: "List files and folders inside a Google Drive folder.",
+        parametersSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            folderId: { type: "string" },
+            pageSize: { type: "integer", minimum: 1, maximum: 100 },
+          },
+        },
+      },
+      async (params): Promise<ToolResult> => {
+        const config = await getPluginConfig(ctx);
+        const typedParams = params as {
+          folderId?: unknown;
+          pageSize?: unknown;
+        };
+
+        const folderId = getTrimmedString(typedParams.folderId) || config.defaultFolderId || "root";
+        const pageSize = normalizePageSize(typedParams.pageSize, config.defaultPageSize ?? 10);
+        const searchParams = new URLSearchParams({
+          q: buildDriveSearchQuery({ folderId }),
+          pageSize: String(pageSize),
+          includeItemsFromAllDrives: "true",
+          supportsAllDrives: "true",
+          orderBy: "folder,name",
+          fields: "files(id,name,mimeType,webViewLink,modifiedTime)",
+        });
+
+        const response = await googleJson<{ files?: DriveFile[] }>(ctx, {
+          url: `https://www.googleapis.com/drive/v3/files?${searchParams.toString()}`,
+          config,
+        });
+
+        const files = response.files ?? [];
+        return {
+          content: formatDriveFilesForAgent(files),
+          data: { folderId, files },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "read-google-doc",
+      {
+        displayName: "Read Google Doc",
+        description: "Read a Google Doc and return plain text content.",
+        parametersSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            documentId: { type: "string", minLength: 1 },
+          },
+          required: ["documentId"],
+        },
+      },
+      async (params): Promise<ToolResult> => {
+        const config = await getPluginConfig(ctx);
+        const documentId = getTrimmedString((params as { documentId?: unknown }).documentId);
+        if (!documentId) throw new Error("Missing or invalid \"documentId\"");
+
+        const document = await googleJson<GoogleDocumentResponse>(ctx, {
+          url: `https://docs.googleapis.com/v1/documents/${encodeURIComponent(documentId)}`,
+          config,
+        });
+
+        const text = extractDocumentPlainText(document);
+        const url = buildGoogleDocUrl(documentId);
+        return {
+          content: `Documento: ${document.title ?? documentId}\nURL: ${url}\n\n${truncateForAgent(text)}`,
+          data: { documentId, title: document.title ?? null, text, url },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "create-google-doc",
+      {
+        displayName: "Create Google Doc",
+        description: "Create a Google Doc, optionally with initial content and folder placement.",
+        parametersSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            title: { type: "string", minLength: 1 },
+            content: { type: "string" },
+            folderId: { type: "string" },
+          },
+          required: ["title"],
+        },
+      },
+      async (params): Promise<ToolResult> => {
+        const config = await getPluginConfig(ctx);
+        const typedParams = params as {
+          title?: unknown;
+          content?: unknown;
+          folderId?: unknown;
+        };
+
+        const title = getTrimmedString(typedParams.title);
+        if (!title) throw new Error("Missing or invalid \"title\"");
+
+        const content = typeof typedParams.content === "string" ? typedParams.content : "";
+        const folderId = getTrimmedString(typedParams.folderId) || config.defaultFolderId;
+
+        const created = await googleJson<{ documentId: string; title?: string }>(ctx, {
+          url: "https://docs.googleapis.com/v1/documents",
+          method: "POST",
+          body: { title },
+          config,
+        });
+
+        if (content.trim().length > 0) {
+          await googleJson(ctx, {
+            url: `https://docs.googleapis.com/v1/documents/${encodeURIComponent(created.documentId)}:batchUpdate`,
+            method: "POST",
+            body: {
+              requests: [
+                {
+                  insertText: {
+                    location: { index: 1 },
+                    text: content,
+                  },
+                },
+              ],
+            },
+            config,
+          });
+        }
+
+        if (folderId) {
+          await googleJson(ctx, {
+            url: `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(created.documentId)}?addParents=${encodeURIComponent(folderId)}&removeParents=root&supportsAllDrives=true`,
+            method: "PATCH",
+            body: {},
+            config,
+          });
+        }
+
+        const url = buildGoogleDocUrl(created.documentId);
+        return {
+          content: `Documento creado: ${created.title ?? title}\nID: ${created.documentId}\nURL: ${url}`,
+          data: {
+            documentId: created.documentId,
+            title: created.title ?? title,
+            url,
+            folderId: folderId ?? null,
+          },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "append-google-doc",
+      {
+        displayName: "Append Google Doc",
+        description: "Append text to the end of an existing Google Doc.",
+        parametersSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            documentId: { type: "string", minLength: 1 },
+            content: { type: "string", minLength: 1 },
+          },
+          required: ["documentId", "content"],
+        },
+      },
+      async (params): Promise<ToolResult> => {
+        const config = await getPluginConfig(ctx);
+        const typedParams = params as {
+          documentId?: unknown;
+          content?: unknown;
+        };
+
+        const documentId = getTrimmedString(typedParams.documentId);
+        const content = typeof typedParams.content === "string" ? typedParams.content : "";
+        if (!documentId) throw new Error("Missing or invalid \"documentId\"");
+        if (!content.trim()) throw new Error("Missing or invalid \"content\"");
+
+        const document = await googleJson<GoogleDocumentResponse>(ctx, {
+          url: `https://docs.googleapis.com/v1/documents/${encodeURIComponent(documentId)}`,
+          config,
+        });
+        const insertionIndex = getDocumentAppendIndex(document);
+
+        await googleJson(ctx, {
+          url: `https://docs.googleapis.com/v1/documents/${encodeURIComponent(documentId)}:batchUpdate`,
+          method: "POST",
+          body: {
+            requests: [
+              {
+                insertText: {
+                  location: { index: insertionIndex },
+                  text: `\n\n${content}`,
+                },
+              },
+            ],
+          },
+          config,
+        });
+
+        const url = buildGoogleDocUrl(documentId);
+        return {
+          content: `Contenido anadido al documento ${documentId}\nURL: ${url}`,
+          data: { documentId, url, insertedCharacters: content.length },
+        };
+      },
+    );
+  },
+
+  async onValidateConfig(config) {
+    const errors: string[] = [];
+
+    if (typeof config.clientId !== "string" || config.clientId.trim().length === 0) {
+      errors.push("clientId is required");
+    }
+    if (typeof config.clientSecretSecretRef !== "string" || config.clientSecretSecretRef.trim().length === 0) {
+      errors.push("clientSecretSecretRef is required");
+    }
+    if (typeof config.refreshTokenSecretRef !== "string" || config.refreshTokenSecretRef.trim().length === 0) {
+      errors.push("refreshTokenSecretRef is required");
+    }
+
+    return errors.length > 0 ? { ok: false, errors } : { ok: true };
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Google Drive Tools worker is running" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/plugin-google-drive-tools/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-google-drive-tools/tests/plugin.spec.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+import {
+  buildDriveSearchQuery,
+  extractDocumentPlainText,
+  getDocumentAppendIndex,
+} from "../src/google-drive.js";
+
+describe("plugin-google-drive-tools", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds a safe Drive query", () => {
+    expect(buildDriveSearchQuery({
+      query: "LinkedIn plan",
+      folderId: "folder-123",
+      mimeType: "document",
+    })).toBe(
+      "trashed = false and name contains 'LinkedIn plan' and 'folder-123' in parents and mimeType = 'application/vnd.google-apps.document'",
+    );
+  });
+
+  it("extracts plain text from a Google Doc response", () => {
+    const text = extractDocumentPlainText({
+      title: "Test",
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [
+                { textRun: { content: "Hola" } },
+                { textRun: { content: " mundo" } },
+              ],
+            },
+          },
+          {
+            table: {
+              tableRows: [
+                {
+                  tableCells: [
+                    {
+                      content: [
+                        {
+                          paragraph: {
+                            elements: [{ textRun: { content: "Celda" } }],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(text).toContain("Hola mundo");
+    expect(text).toContain("Celda");
+  });
+
+  it("computes the append index from the document tail", () => {
+    expect(getDocumentAppendIndex({
+      body: { content: [{ endIndex: 1 }, { endIndex: 14 }] },
+    })).toBe(13);
+  });
+
+  it("registers the search tool and calls Google Drive through OAuth refresh", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        clientId: "client-id",
+        clientSecretSecretRef: "secret-ref",
+        refreshTokenSecretRef: "refresh-ref",
+        defaultPageSize: 5,
+      },
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: "access-token",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            files: [
+              {
+                id: "doc-1",
+                name: "LinkedIn Q2",
+                mimeType: "application/vnd.google-apps.document",
+                webViewLink: "https://docs.google.com/document/d/doc-1/edit",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    const result = await harness.executeTool("search-drive-files", {
+      query: "LinkedIn",
+      mimeType: "document",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.content).toContain("LinkedIn Q2");
+    expect(result.data).toEqual({
+      files: [
+        {
+          id: "doc-1",
+          name: "LinkedIn Q2",
+          mimeType: "application/vnd.google-apps.document",
+          webViewLink: "https://docs.google.com/document/d/doc-1/edit",
+        },
+      ],
+    });
+  });
+});

--- a/packages/plugins/plugin-google-drive-tools/tsconfig.json
+++ b/packages/plugins/plugin-google-drive-tools/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/plugins/plugin-google-drive-tools/vitest.config.ts
+++ b/packages/plugins/plugin-google-drive-tools/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/plugin-google-drive-tools:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/sdk:
     dependencies:
       '@paperclipai/shared':


### PR DESCRIPTION
## Summary
- add a native Paperclip plugin that exposes Google Drive and Google Docs tools to agents
- support OAuth refresh token auth via Paperclip secret refs
- cover the new plugin with focused unit tests

## Validation
- corepack pnpm --filter @paperclipai/plugin-google-drive-tools test
- corepack pnpm --filter @paperclipai/plugin-google-drive-tools build
- corepack pnpm exec tsc --noEmit -p packages/plugins/plugin-google-drive-tools/tsconfig.json