### PR TITLE
fix: clear stale issue execution locks

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { pathToFileURL } from "node:url";
 import type { Request as ExpressRequest, RequestHandler } from "express";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
   createDb,
   ensurePostgresDatabase,
@@ -617,6 +617,24 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
+
+      // Clear issue execution locks referencing terminal heartbeat runs
+      void db
+        .execute(
+          sql`
+            UPDATE issues
+            SET execution_run_id = NULL,
+                execution_agent_name_key = NULL,
+                execution_locked_at = NULL,
+                updated_at = NOW()
+            WHERE execution_run_id IS NOT NULL
+              AND execution_run_id IN (
+                SELECT id FROM heartbeat_runs
+                WHERE status IN ('succeeded', 'failed', 'cancelled', 'timed_out')
+              )
+          `,
+        )
+        .catch((err) => logger.error({ err }, "stale execution lock cleanup failed"));
     }, config.heartbeatSchedulerIntervalMs);
   }
   

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1581,6 +1581,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary

When heartbeat runs fail or get interrupted, issue-level execution locks (`execution_run_id`, `execution_agent_name_key`, `execution_locked_at`) remain set indefinitely. This prevents other agents from picking up work — we had to manually clear 79 stale locks via direct DB access.

**Two fixes:**

- **`release()` now clears execution lock fields** — the `.set()` call in `services/issues.ts` was only clearing `status`, `assigneeAgentId`, and `checkoutRunId`, leaving execution locks orphaned
- **Periodic stale lock reaper** — piggybacks on the existing heartbeat scheduler interval (~30s) to clear execution locks on issues whose referenced `heartbeat_run` is in a terminal state (`succeeded`, `failed`, `cancelled`, `timed_out`)

## Root Cause

`reapOrphanedRuns()` handles stuck heartbeat runs but does NOT propagate cleanup to issue execution locks. `adoptStaleCheckoutRun()` only fires reactively when a new agent tries to checkout the same issue — there was no proactive cleanup path.

## Test plan

- [x] Verified on local instance: stale lock count dropped from 1 → 0 after one scheduler tick
- [ ] Create a test issue, have an agent checkout, kill the heartbeat run mid-execution
- [ ] Wait for one scheduler tick (~30s) and verify execution lock is automatically cleared
- [ ] Verify `release` endpoint fully clears all lock fields
- [ ] Confirm no regressions: `SELECT count(*) FROM issues WHERE execution_run_id IS NOT NULL` returns 0 for all terminal runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)