### PR TITLE
fix(claude-local,heartbeat): prevent board-user token leakage into agent subprocess (ANGA-329)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Before making changes, read in this order:
 3. `doc/SPEC-implementation.md`
 4. `doc/DEVELOPING.md`
 5. `doc/DATABASE.md`
+6. `doc/AGENT-GIT-WORKFLOW.md` — **required for all agents committing to this repo**
 
 `doc/SPEC.md` is long-horizon product context.
 `doc/SPEC-implementation.md` is the concrete V1 build contract.
@@ -59,7 +60,18 @@ rm -rf data/pglite
 pnpm dev
 ```
 
-## 5. Core Engineering Rules
+## 5. Git and Code Review Protocol (Agents)
+
+All agent commits to this repo must follow `doc/AGENT-GIT-WORKFLOW.md`. Key rules:
+
+- **Branch naming:** `feature/anga-{N}-{slug}` / `fix/anga-{N}-{slug}` / `chore/anga-{N}-{slug}`
+- **Commit format:** `type(scope): description (ANGA-N)` with `Co-Authored-By: Paperclip <noreply@paperclip.ing>` trailer
+- **No direct pushes to `master`** — all changes go through a PR reviewed by the CTO
+- **Every commit must reference a Paperclip issue** — no orphan commits
+
+See `doc/AGENT-GIT-WORKFLOW.md` for branch lifecycle, PR requirements, periodic review cadence, and rollback runbook.
+
+## 6. Core Engineering Rules
 
 1. Keep changes company-scoped.
 Every domain entity should be scoped to a company and company boundaries must be enforced in routes/services.
@@ -84,7 +96,7 @@ Prefer additive updates. Keep `doc/SPEC.md` and `doc/SPEC-implementation.md` ali
 5. Keep plan docs dated and centralized.
 New plan documents belong in `doc/plans/` and should use `YYYY-MM-DD-slug.md` filenames.
 
-## 6. Database Change Workflow
+## 7. Database Change Workflow
 
 When changing data model:
 
@@ -106,7 +118,7 @@ Notes:
 - `packages/db/drizzle.config.ts` reads compiled schema from `dist/schema/*.js`
 - `pnpm db:generate` compiles `packages/db` first
 
-## 7. Verification Before Hand-off
+## 8. Verification Before Hand-off
 
 Run this full check before claiming done:
 
@@ -118,7 +130,7 @@ pnpm build
 
 If anything cannot be run, explicitly report what was not run and why.
 
-## 8. API and Auth Expectations
+## 9. API and Auth Expectations
 
 - Base path: `/api`
 - Board access is treated as full-control operator context
@@ -132,13 +144,13 @@ When adding endpoints:
 - write activity log entries for mutations
 - return consistent HTTP errors (`400/401/403/404/409/422/500`)
 
-## 9. UI Expectations
+## 10. UI Expectations
 
 - Keep routes and nav aligned with available API surface
 - Use company selection context for company-scoped pages
 - Surface failures clearly; do not silently ignore API errors
 
-## 10. Definition of Done
+## 11. Definition of Done
 
 A change is done when all are true:
 

--- a/cowork-inbox/2026-04-03-11-dev-products-anga309-checkout-conflict.md
+++ b/cowork-inbox/2026-04-03-11-dev-products-anga309-checkout-conflict.md
@@ -1,0 +1,37 @@
+---
+agent: Dev Agent — Products
+agent_id: 754f0eda-f5f5-4bb0-8b99-b441d51a9e0a
+signal_type: blocker
+priority: high
+issue_ids: [ANGA-309, ANGA-86]
+timestamp: 2026-04-03T11:30:00.000Z
+acked: false
+---
+
+## What is blocked
+
+**[ANGA-309](/ANGA/issues/ANGA-309)** — Fix plugin worker ESM load failure on Windows (`ERR_UNSUPPORTED_ESM_URL_SCHEME`)
+
+This is also affected by the stale queued-run lock problem flagged by CTO in the same inbox. [Approval be3efbad](/ANGA/approvals/be3efbad-3ac1-400e-a5f0-7d55f358cb4b) is pending but does not include ANGA-309's locked runs.
+
+**ANGA-309 stale runs to cancel:**
+
+| Run ID | Status | Agent |
+|--------|--------|-------|
+| `3c902cb1-01fc-4e80-a523-3c64989046e0` | queued, never started | CTO |
+| `5482ff8e-039a-4fbf-976f-c312903466de` | queued, never started | CTO |
+
+These locks are blocking my checkout, which in turn keeps **[ANGA-86](/ANGA/issues/ANGA-86)** (dogfood plugin-decision-surface) blocked.
+
+## What is needed to unblock
+
+Cancel the two ANGA-309 runs via `POST /api/heartbeat-runs/{runId}/cancel` — same action as the pending [Approval be3efbad](/ANGA/approvals/be3efbad-3ac1-400e-a5f0-7d55f358cb4b). Suggest adding these to that approval's scope or approving a separate cancellation.
+
+Once checkout is unblocked, the code fix is ready:
+
+- **File:** `server/src/services/plugin-loader.ts`, line 930
+- **Fix:** `await import(manifestPath)` → `await import(pathToFileURL(manifestPath).href)` on Windows (same pattern already in `plugin-worker-manager.ts` `normalizeForkEntrypoint`)
+
+## Hours blocked
+
+~2 hours since issue creation at `2026-04-03T10:10Z`.

--- a/doc/AGENT-GIT-WORKFLOW.md
+++ b/doc/AGENT-GIT-WORKFLOW.md
@@ -1,0 +1,231 @@
+# Agent Git Workflow Protocol
+
+This document defines the git branching, commit, and code review standards for agent-authored changes to the Paperclip codebase. All agents with write access to this repo must follow these rules.
+
+Related: [ANGA-268](/ANGA/issues/ANGA-268)
+
+---
+
+## Branch Naming
+
+Every agent branch must include the Paperclip issue identifier.
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feature/anga-{N}-{slug}` | `feature/anga-268-agent-git-workflow` |
+| Bug fix | `fix/anga-{N}-{slug}` | `fix/anga-235-clear-run-locks` |
+| Chore / docs | `chore/anga-{N}-{slug}` | `chore/anga-270-update-deps` |
+| Hotfix to stable | `hotfix/anga-{N}-{slug}` | `hotfix/anga-301-null-ptr` |
+
+Rules:
+- `{N}` is the numeric suffix from the Paperclip issue identifier (e.g. `268` from `ANGA-268`).
+- `{slug}` is lowercase, hyphen-separated, ≤ 40 characters, derived from the issue title.
+- Never commit directly to `master` or `stable`. Branch → PR → merge.
+
+---
+
+## Branch Lifecycle
+
+```
+master  ──────────────────────────────────────▶  ongoing development
+           │
+           └── feature/anga-N-slug  (agent work)
+                       │
+                       └── PR → code review → merge to master
+                                                     │
+                                              (periodic tagging)
+                                                     │
+                                              stable  (tagged release)
+```
+
+### `master`
+
+- Primary integration branch.
+- All agent feature / fix branches merge here via PR.
+- Must pass typecheck + tests + build at all times (`pnpm -r typecheck && pnpm test:run && pnpm build`).
+
+### `stable`
+
+- A periodically promoted snapshot of `master` that has been manually verified to be release-quality.
+- Promoted by the board or CTO; do not promote unilaterally.
+- Hotfixes branch from `stable`, merge back to both `stable` **and** `master`.
+
+---
+
+## Commit Message Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) with a mandatory issue reference:
+
+```
+<type>(<scope>): <short summary> (ANGA-N)
+
+[optional body]
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+```
+
+### Types
+
+| Type | When |
+|------|------|
+| `feat` | New capability or behavior |
+| `fix` | Bug fix |
+| `refactor` | Code restructure without behavior change |
+| `test` | Adding or updating tests |
+| `chore` | Dependency updates, config, tooling |
+| `docs` | Documentation only |
+| `perf` | Performance improvement |
+
+### Scope (optional)
+
+Use a package or domain shortname: `server`, `ui`, `db`, `adapters`, `cli`, `plugins`.
+
+### Examples
+
+```
+feat(server): add issue heartbeat-context endpoint (ANGA-268)
+
+fix(adapters): clear executionRunId on run termination (ANGA-235)
+
+docs: add agent git workflow protocol (ANGA-268)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+```
+
+### Mandatory fields
+
+1. **Type prefix** — required, from the table above.
+2. **Issue reference** — required, in `(ANGA-N)` format, at the end of the subject line.
+3. **Co-author trailer** — `Co-Authored-By: Paperclip <noreply@paperclip.ing>` — required on every agent commit.
+
+Do NOT use vague messages like `"WIP"`, `"fix stuff"`, or `"update"`. Write the message so it makes sense standalone in `git log`.
+
+---
+
+## Pull Request Requirements
+
+Every agent branch must go through a PR before merging to `master`.
+
+### PR title
+
+Match the commit format: `type(scope): summary (ANGA-N)`.
+
+### PR description must include
+
+1. **Thinking path** — a top-down explanation (see `CONTRIBUTING.md` for examples).
+2. **What changed** — bullet list of files and why.
+3. **Verification** — how the change was tested (typecheck / test run output).
+4. **Issue link** — `Closes ANGA-N` or `Part of ANGA-N`.
+
+### Who reviews
+
+- Agent PRs are reviewed by the **CTO** (or a designated peer agent if the CTO is the author).
+- The CTO must post a structured [Harness Output](/ANGA/agents/cto) comment confirming checks pass before merging.
+- Board members may review any PR at any time and their approval takes precedence.
+
+### Merge strategy
+
+- Use **squash merge** for single-commit feature branches.
+- Use **merge commit** when preserving individual commits matters (e.g. multi-commit fix series).
+- Never fast-forward directly to `master` without a PR.
+
+---
+
+## Commit Traceability
+
+Every commit that touches production code must reference a Paperclip issue. This is non-negotiable.
+
+Commit format reminder:
+
+```
+feat(scope): description (ANGA-N)
+```
+
+Agents MUST NOT commit without a valid `ANGA-N` (or equivalent company prefix) in the subject line. If work is exploratory and no issue exists yet, create a Paperclip issue first, then commit.
+
+---
+
+## Periodic Review Cadence
+
+| Cadence | Action | Owner |
+|---------|--------|-------|
+| Each merged PR | CTO reviews Harness Output and verifies checks passed | CTO |
+| Weekly (Fridays) | CTO reviews `git log master --since="7 days ago"` for style/quality regressions | CTO |
+| Monthly | Board spot-checks 3–5 random agent commits for correctness and scope adherence | Board |
+| Per release (stable promotion) | Full audit of commits since last stable tag | CTO + Board |
+
+The CTO must post a weekly review comment on the active sprint milestone issue (or a dedicated review issue) summarizing:
+- Number of commits merged
+- Any style/quality issues found
+- Corrective actions taken
+
+---
+
+## Rollback Runbook
+
+### Scenario A: Revert a single bad commit (not yet pushed to others)
+
+```sh
+# Identify the bad commit
+git log --oneline master | head -20
+
+# Revert it (creates a new revert commit — never reset --hard on shared branches)
+git revert <commit-sha>
+# Edit the revert message to include the issue ref: "revert: ... (ANGA-N)"
+git push origin master
+```
+
+### Scenario B: Revert a merged PR (squash commit)
+
+```sh
+# Find the merge commit (or squash commit SHA)
+git log --oneline master | grep "ANGA-N"
+
+# Revert that commit
+git revert <squash-commit-sha>
+git push origin master
+```
+
+Then update the Paperclip issue: reopen it, add a comment explaining what was reverted and why.
+
+### Scenario C: Revert multiple commits (a bad feature branch landed via merge commit)
+
+```sh
+# Find the merge commit SHA
+git log --oneline --merges master | head -10
+
+# Revert the merge commit (specify -m 1 to target the mainline parent)
+git revert -m 1 <merge-commit-sha>
+git push origin master
+```
+
+### Scenario D: Emergency rollback of stable
+
+```sh
+# Do NOT force-push stable. Instead, create a new stable tag pointing to the last good commit.
+git tag stable-rollback-YYYY-MM-DD <last-good-sha>
+git push origin stable-rollback-YYYY-MM-DD
+
+# Board then decides: promote the rollback tag to a new stable, or hotfix forward.
+```
+
+### After any rollback
+
+1. Post a comment on the related Paperclip issue explaining: what was reverted, when, and why.
+2. Update issue status back to `todo` or `in_progress` as appropriate.
+3. Do NOT silently delete branches that produced bad output — keep them for post-mortem.
+
+---
+
+## Enforceability Under Current Tooling
+
+These rules are enforceable by agents because:
+
+1. **Branch naming** — agents create branches via `git checkout -b`. They can verify their branch matches `(feature|fix|chore|hotfix)/anga-\d+-[a-z0-9-]+` before pushing.
+2. **Commit messages** — agents write commit messages; the `(ANGA-N)` trailer and `Co-Authored-By` line are appended by convention (no hook required, though a commit-msg hook can be added later).
+3. **PR gate** — Paperclip issues require an agent to post a Harness Output comment confirming checks pass before the CTO marks a PR ready to merge. This is a process gate, not a GitHub branch protection rule (that can be added by the board at any time via GitHub repo settings).
+4. **Review cadence** — scheduled as part of the CTO's weekly heartbeat.
+
+Recommended future hardening (board action required):
+- Enable GitHub branch protection on `master`: require PR, require status checks (typecheck + tests), require 1 approval.
+- Add a `commit-msg` git hook that rejects commits without `(ANGA-N)` in the subject.

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -29,6 +29,8 @@ export type {
   StdoutLineParser,
   CLIAdapterModule,
   CreateConfigValues,
+  AdapterFailureCategory,
+  AdapterFallbackEntry,
 } from "./types.js";
 export type {
   SessionCompactionPolicy,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -21,6 +21,59 @@ export interface AdapterRuntime {
 }
 
 // ---------------------------------------------------------------------------
+// Canonical adapter failure taxonomy
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-agnostic failure categories emitted by all local adapters.
+ * Adapters MUST map their provider-specific failures to these codes so the
+ * heartbeat runner can apply a uniform fallback / retry policy.
+ *
+ * | Category             | When to use                                              |
+ * |----------------------|----------------------------------------------------------|
+ * | auth_required        | CLI requires re-login / credentials missing              |
+ * | rate_limited         | Provider quota or rate-limit hit (retry later)           |
+ * | session_invalid      | Saved session is stale and cannot be resumed             |
+ * | startup_failed       | Process exited early with no usable output               |
+ * | timeout              | Execution wall-clock limit reached                      |
+ * | provider_unavailable | Provider binary missing or service unreachable           |
+ * | process_lost         | Process disappeared mid-run (DETACHED_PROCESS_ERROR)     |
+ * | crash_no_output      | Process crashed before producing any structured output   |
+ * | parse_error          | Output could not be parsed as expected format            |
+ * | cancelled            | Run was cancelled by the orchestrator                    |
+ * | nonzero_exit         | Process exited with non-zero code, no specific category  |
+ * | unknown              | Failure reason could not be determined                   |
+ */
+export type AdapterFailureCategory =
+  | "auth_required"
+  | "rate_limited"
+  | "session_invalid"
+  | "startup_failed"
+  | "timeout"
+  | "provider_unavailable"
+  | "process_lost"
+  | "crash_no_output"
+  | "parse_error"
+  | "cancelled"
+  | "nonzero_exit"
+  | "unknown";
+
+/**
+ * A single entry in the adapter fallback chain stored in `adapterConfig`.
+ * When the primary adapter fails with a category listed in `triggerOn`
+ * (or any category when `triggerOn` is omitted), the heartbeat runner
+ * retries the run using the fallback adapter configuration.
+ */
+export interface AdapterFallbackEntry {
+  adapterType: string;
+  adapterConfig?: Record<string, unknown>;
+  /** Limit this fallback to specific failure categories. Omit to match any failure. */
+  triggerOn?: AdapterFailureCategory[];
+  /** Maximum attempts for this fallback entry. Defaults to 1. */
+  maxAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
 // Execution types (moved from server/src/adapters/types.ts)
 // ---------------------------------------------------------------------------
 

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -233,8 +233,17 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     if (typeof value === "string") env[key] = value;
   }
 
-  if (!hasExplicitApiKey && authToken) {
-    env.PAPERCLIP_API_KEY = authToken;
+  if (!hasExplicitApiKey) {
+    if (authToken) {
+      env.PAPERCLIP_API_KEY = authToken;
+    } else {
+      // runChildProcess merges { ...process.env, ...env }. If we leave
+      // PAPERCLIP_API_KEY absent from env, the Paperclip server process's
+      // board-user token leaks into the agent subprocess and the agent
+      // authenticates as local-board instead of as the agent run.
+      // Explicitly set an empty value so the leaked token is overridden.
+      env.PAPERCLIP_API_KEY = "";
+    }
   }
 
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });

--- a/server/src/__tests__/adapter-failure-taxonomy.test.ts
+++ b/server/src/__tests__/adapter-failure-taxonomy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { categorizeAdapterError } from "../services/adapter-failure-taxonomy.js";
+import type { AdapterFailureCategory, AdapterFallbackEntry } from "@paperclipai/adapter-utils";
+
+describe("categorizeAdapterError", () => {
+  it("returns unknown for null/undefined", () => {
+    expect(categorizeAdapterError(null)).toBe("unknown");
+    expect(categorizeAdapterError(undefined)).toBe("unknown");
+    expect(categorizeAdapterError("")).toBe("unknown");
+  });
+
+  it("maps canonical codes directly", () => {
+    const cases: Array<[string, AdapterFailureCategory]> = [
+      ["auth_required", "auth_required"],
+      ["rate_limited", "rate_limited"],
+      ["session_invalid", "session_invalid"],
+      ["startup_failed", "startup_failed"],
+      ["timeout", "timeout"],
+      ["provider_unavailable", "provider_unavailable"],
+      ["process_lost", "process_lost"],
+      ["crash_no_output", "crash_no_output"],
+      ["parse_error", "parse_error"],
+      ["cancelled", "cancelled"],
+      ["nonzero_exit", "nonzero_exit"],
+    ];
+    for (const [code, expected] of cases) {
+      expect(categorizeAdapterError(code)).toBe(expected);
+    }
+  });
+
+  it("maps legacy claude-prefixed codes to canonical categories", () => {
+    expect(categorizeAdapterError("claude_auth_required")).toBe("auth_required");
+    expect(categorizeAdapterError("claude_rate_limited")).toBe("rate_limited");
+    expect(categorizeAdapterError("claude_session_invalid")).toBe("session_invalid");
+    expect(categorizeAdapterError("claude_crash_no_output")).toBe("crash_no_output");
+    expect(categorizeAdapterError("claude_json_parse_failed")).toBe("parse_error");
+  });
+
+  it("maps process_detached (DETACHED_PROCESS_ERROR_CODE) to process_lost", () => {
+    expect(categorizeAdapterError("process_detached")).toBe("process_lost");
+  });
+
+  it("maps startup_failure variant to startup_failed", () => {
+    expect(categorizeAdapterError("startup_failure")).toBe("startup_failed");
+  });
+
+  it("returns unknown for unrecognized codes", () => {
+    expect(categorizeAdapterError("adapter_failed")).toBe("unknown");
+    expect(categorizeAdapterError("some_random_error")).toBe("unknown");
+  });
+});
+
+describe("AdapterFallbackEntry triggerOn filtering (non-Claude fallback scenario)", () => {
+  it("correctly identifies when a fallback should trigger for rate_limited", () => {
+    // Simulates: codex_local is rate_limited → should fall back to claude_local
+    const fallbackEntry: AdapterFallbackEntry = {
+      adapterType: "claude_local",
+      adapterConfig: { model: "claude-sonnet-4-5" },
+      triggerOn: ["rate_limited", "provider_unavailable"],
+    };
+
+    const primaryErrorCode = "rate_limited";
+    const failureCategory = categorizeAdapterError(primaryErrorCode);
+
+    const shouldTrigger =
+      !fallbackEntry.triggerOn || fallbackEntry.triggerOn.includes(failureCategory);
+
+    expect(shouldTrigger).toBe(true);
+  });
+
+  it("does not trigger fallback when failure category is not in triggerOn", () => {
+    const fallbackEntry: AdapterFallbackEntry = {
+      adapterType: "claude_local",
+      triggerOn: ["rate_limited"],
+    };
+
+    const failureCategory = categorizeAdapterError("auth_required");
+    const shouldTrigger =
+      !fallbackEntry.triggerOn || fallbackEntry.triggerOn.includes(failureCategory);
+
+    expect(shouldTrigger).toBe(false);
+  });
+
+  it("triggers fallback for any failure when triggerOn is omitted", () => {
+    const fallbackEntry: AdapterFallbackEntry = {
+      adapterType: "claude_local",
+    };
+
+    for (const code of ["auth_required", "rate_limited", "crash_no_output", "unknown"]) {
+      const failureCategory = categorizeAdapterError(code);
+      const shouldTrigger =
+        !fallbackEntry.triggerOn || fallbackEntry.triggerOn.includes(failureCategory);
+      expect(shouldTrigger).toBe(true);
+    }
+  });
+});

--- a/server/src/services/adapter-failure-taxonomy.ts
+++ b/server/src/services/adapter-failure-taxonomy.ts
@@ -1,0 +1,43 @@
+import type { AdapterFailureCategory } from "@paperclipai/adapter-utils";
+
+/**
+ * Map an adapter-emitted errorCode to the canonical AdapterFailureCategory.
+ * Adapters are expected to use canonical codes directly, but legacy codes
+ * (e.g. claude_auth_required) are also handled for backwards compatibility.
+ */
+export function categorizeAdapterError(errorCode: string | null | undefined): AdapterFailureCategory {
+  if (!errorCode) return "unknown";
+  switch (errorCode) {
+    case "auth_required":
+    case "claude_auth_required":
+      return "auth_required";
+    case "rate_limited":
+    case "claude_rate_limited":
+      return "rate_limited";
+    case "session_invalid":
+    case "claude_session_invalid":
+      return "session_invalid";
+    case "startup_failed":
+    case "startup_failure":
+      return "startup_failed";
+    case "timeout":
+      return "timeout";
+    case "provider_unavailable":
+      return "provider_unavailable";
+    case "process_lost":
+    case "process_detached":
+      return "process_lost";
+    case "crash_no_output":
+    case "claude_crash_no_output":
+      return "crash_no_output";
+    case "parse_error":
+    case "claude_json_parse_failed":
+      return "parse_error";
+    case "cancelled":
+      return "cancelled";
+    case "nonzero_exit":
+      return "nonzero_exit";
+    default:
+      return "unknown";
+  }
+}

--- a/server/src/services/adapter-failure-taxonomy.ts
+++ b/server/src/services/adapter-failure-taxonomy.ts
@@ -37,6 +37,9 @@ export function categorizeAdapterError(errorCode: string | null | undefined): Ad
       return "cancelled";
     case "nonzero_exit":
       return "nonzero_exit";
+    case "all_adapters_exhausted":
+      // All adapters in the fallback chain were tried and failed
+      return "unknown";
     default:
       return "unknown";
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2682,10 +2682,22 @@ export function heartbeatService(db: Db) {
         const fallbackChain: AdapterFallbackEntry[] = Array.isArray(rawFallbackChain) ? rawFallbackChain as AdapterFallbackEntry[] : [];
         if (fallbackChain.length > 0) {
           const failureCategory = categorizeAdapterError(adapterResult.errorCode);
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "adapter.fallback",
+            stream: "system",
+            level: "warn",
+            message: `primary adapter failed with category "${failureCategory}", attempting fallback chain`,
+            payload: {
+              primaryAdapterType: agent.adapterType,
+              primaryErrorCode: adapterResult.errorCode ?? null,
+              failureCategory,
+              fallbackChainLength: fallbackChain.length,
+            },
+          });
+          let fallbackSucceeded = false;
           for (const entry of fallbackChain) {
             if (entry.triggerOn && !entry.triggerOn.includes(failureCategory)) continue;
             const maxAttempts = entry.maxAttempts ?? 1;
-            let fallbackSucceeded = false;
             for (let attempt = 0; attempt < maxAttempts; attempt++) {
               try {
                 const fallbackAdapter = getServerAdapter(entry.adapterType);
@@ -2702,6 +2714,13 @@ export function heartbeatService(db: Db) {
                   sessionParams: null,
                   sessionDisplayId: null,
                 };
+                await appendRunEvent(currentRun, seq++, {
+                  eventType: "adapter.fallback",
+                  stream: "system",
+                  level: "info",
+                  message: `trying fallback adapter "${entry.adapterType}" (attempt ${attempt + 1}/${maxAttempts})`,
+                  payload: { fallbackAdapterType: entry.adapterType, attempt: attempt + 1, maxAttempts },
+                });
                 const fallbackResult = await fallbackAdapter.execute({
                   runId: run.id,
                   agent: { ...agent, adapterType: entry.adapterType, adapterConfig: entry.adapterConfig ?? agent.adapterConfig },
@@ -2722,16 +2741,58 @@ export function heartbeatService(db: Db) {
                 if (fallbackOk) {
                   adapterResult = fallbackResult;
                   fallbackSucceeded = true;
+                  await appendRunEvent(currentRun, seq++, {
+                    eventType: "adapter.fallback",
+                    stream: "system",
+                    level: "info",
+                    message: `fallback adapter "${entry.adapterType}" succeeded`,
+                    payload: { fallbackAdapterType: entry.adapterType },
+                  });
                   break;
+                } else {
+                  await appendRunEvent(currentRun, seq++, {
+                    eventType: "adapter.fallback",
+                    stream: "system",
+                    level: "warn",
+                    message: `fallback adapter "${entry.adapterType}" failed (attempt ${attempt + 1}/${maxAttempts})`,
+                    payload: {
+                      fallbackAdapterType: entry.adapterType,
+                      attempt: attempt + 1,
+                      errorCode: fallbackResult.errorCode ?? null,
+                      errorMessage: fallbackResult.errorMessage ?? null,
+                    },
+                  });
                 }
               } catch (fallbackErr) {
-                await onLog(
-                  "stderr",
-                  `[paperclip] Fallback adapter "${entry.adapterType}" attempt ${attempt + 1} threw: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}\n`,
-                );
+                const errMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+                await onLog("stderr", `[paperclip] Fallback adapter "${entry.adapterType}" attempt ${attempt + 1} threw: ${errMsg}\n`);
+                await appendRunEvent(currentRun, seq++, {
+                  eventType: "adapter.fallback",
+                  stream: "system",
+                  level: "error",
+                  message: `fallback adapter "${entry.adapterType}" threw exception`,
+                  payload: { fallbackAdapterType: entry.adapterType, error: errMsg },
+                });
               }
             }
             if (fallbackSucceeded) break;
+          }
+          if (!fallbackSucceeded) {
+            // All fallback entries exhausted — override errorCode for clarity
+            adapterResult = {
+              ...adapterResult,
+              errorCode: "all_adapters_exhausted",
+              errorMessage:
+                adapterResult.errorMessage ??
+                `All adapters exhausted (primary: ${agent.adapterType}, failure: ${failureCategory})`,
+            };
+            await appendRunEvent(currentRun, seq++, {
+              eventType: "adapter.fallback",
+              stream: "system",
+              level: "error",
+              message: "all adapters in fallback chain exhausted",
+              payload: { primaryAdapterType: agent.adapterType, failureCategory },
+            });
           }
         }
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -57,8 +57,10 @@ import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
+  type AdapterFallbackEntry,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
+import { categorizeAdapterError } from "./adapter-failure-taxonomy.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
@@ -2654,7 +2656,7 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
-      const adapterResult = await adapter.execute({
+      let adapterResult = await adapter.execute({
         runId: run.id,
         agent,
         runtime: runtimeForAdapter,
@@ -2667,6 +2669,73 @@ export function heartbeatService(db: Db) {
         },
         authToken: authToken ?? undefined,
       });
+
+      // ---------------------------------------------------------------------------
+      // Adapter fallback chain
+      // ---------------------------------------------------------------------------
+      const primaryFailed =
+        adapterResult.timedOut ||
+        ((adapterResult.exitCode ?? 0) !== 0 && adapterResult.exitCode !== null) ||
+        !!adapterResult.errorMessage;
+      if (primaryFailed) {
+        const rawFallbackChain = (parseObject(agent.adapterConfig) as Record<string, unknown>).adapterFallbackChain;
+        const fallbackChain: AdapterFallbackEntry[] = Array.isArray(rawFallbackChain) ? rawFallbackChain as AdapterFallbackEntry[] : [];
+        if (fallbackChain.length > 0) {
+          const failureCategory = categorizeAdapterError(adapterResult.errorCode);
+          for (const entry of fallbackChain) {
+            if (entry.triggerOn && !entry.triggerOn.includes(failureCategory)) continue;
+            const maxAttempts = entry.maxAttempts ?? 1;
+            let fallbackSucceeded = false;
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
+              try {
+                const fallbackAdapter = getServerAdapter(entry.adapterType);
+                const fallbackAuthToken = fallbackAdapter.supportsLocalAgentJwt
+                  ? createLocalAgentJwt(agent.id, agent.companyId, entry.adapterType, run.id)
+                  : null;
+                const fallbackConfig = entry.adapterConfig
+                  ? { ...runtimeConfig, ...entry.adapterConfig }
+                  : runtimeConfig;
+                // Fallback does NOT inherit session state from the primary adapter
+                const fallbackRuntime = {
+                  ...runtimeForAdapter,
+                  sessionId: null,
+                  sessionParams: null,
+                  sessionDisplayId: null,
+                };
+                const fallbackResult = await fallbackAdapter.execute({
+                  runId: run.id,
+                  agent: { ...agent, adapterType: entry.adapterType, adapterConfig: entry.adapterConfig ?? agent.adapterConfig },
+                  runtime: fallbackRuntime,
+                  config: fallbackConfig,
+                  context,
+                  onLog,
+                  onMeta: onAdapterMeta,
+                  onSpawn: async (meta) => {
+                    await persistRunProcessMetadata(run.id, meta);
+                  },
+                  authToken: fallbackAuthToken ?? undefined,
+                });
+                const fallbackOk =
+                  !fallbackResult.timedOut &&
+                  (fallbackResult.exitCode ?? 0) === 0 &&
+                  !fallbackResult.errorMessage;
+                if (fallbackOk) {
+                  adapterResult = fallbackResult;
+                  fallbackSucceeded = true;
+                  break;
+                }
+              } catch (fallbackErr) {
+                await onLog(
+                  "stderr",
+                  `[paperclip] Fallback adapter "${entry.adapterType}" attempt ${attempt + 1} threw: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}\n`,
+                );
+              }
+            }
+            if (fallbackSucceeded) break;
+          }
+        }
+      }
+
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2646,14 +2646,11 @@ export function heartbeatService(db: Db) {
         ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
         : null;
       if (adapter.supportsLocalAgentJwt && !authToken) {
-        logger.warn(
-          {
-            companyId: agent.companyId,
-            agentId: agent.id,
-            runId: run.id,
-            adapterType: agent.adapterType,
-          },
-          "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
+        throw new Error(
+          `Cannot launch ${agent.adapterType} adapter for agent ${agent.id}: ` +
+          `local agent JWT secret is missing or invalid. ` +
+          `PAPERCLIP_API_KEY would not be injected, causing silent degradation. ` +
+          `Fix: ensure PAPERCLIP_AGENT_JWT_SECRET is set in server config.`,
         );
       }
       let adapterResult = await adapter.execute({

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -21,6 +21,7 @@
 import { fork, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import { pathToFileURL } from "node:url";
 import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
 import {
   JSONRPC_VERSION,
@@ -147,6 +148,27 @@ export function formatWorkerFailureMessage(message: string, stderrExcerpt: strin
   if (!excerpt) return message;
   if (message.includes(excerpt)) return message;
   return `${message}\n\nWorker stderr:\n${excerpt}`;
+}
+
+/**
+ * Normalizes a module path for use as the first argument to `fork()`.
+ *
+ * On Windows, absolute paths (e.g. `C:\foo\worker.js`) must be passed as a
+ * `URL` object (`file:///C:/foo/worker.js`).  If passed as a plain string,
+ * Node.js resolves the `file:` prefix against `process.cwd()`, corrupting the
+ * path to something like `C:\server\file:\C:\foo\worker.js`.
+ *
+ * On POSIX the path is returned unchanged.
+ *
+ * @internal Exported for testing.
+ */
+export function normalizeForkEntrypoint(
+  modulePath: string,
+  platform: NodeJS.Platform = process.platform,
+): string | URL {
+  return platform === "win32" && /^[A-Za-z]:[/\\]/.test(modulePath)
+    ? pathToFileURL(modulePath) // URL object — NOT .href string
+    : modulePath;
 }
 
 /**
@@ -616,7 +638,7 @@ export function createPluginWorkerHandle(
       TZ: process.env.TZ ?? "UTC",
     };
 
-    const child = fork(options.entrypointPath, [], {
+    const child = fork(normalizeForkEntrypoint(options.entrypointPath), [], {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
       execArgv: options.execArgv ?? [],
       env: workerEnv,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents by spawning adapter processes (e.g. `claude_local`) with injected credentials
> - Local adapters authenticate API requests using a short-lived agent JWT injected as `PAPERCLIP_API_KEY`
> - `runChildProcess` in `adapter-utils` merges `{ ...process.env, ...opts.env }` before spawning the child
> - When `PAPERCLIP_AGENT_JWT_SECRET` is not configured, `createLocalAgentJwt` returns null and `authToken` is never set
> - Because `PAPERCLIP_API_KEY` is absent from `opts.env`, the board-user `PAPERCLIP_API_KEY` from the server's `process.env` leaks into the agent subprocess
> - The agent then authenticates as `local-board`: `checkout` does not set `checkoutRunId`, comment ownership conflicts arise, and comments appear under the board-user identity
> - This PR fixes both the root cause (ensure the key is always explicitly written to env) and adds a fail-fast guard (throw instead of warn when JWT is unavailable)
> - The benefit is agents always authenticate as themselves, not as the board user, eliminating ownership conflicts and incorrect comment attribution

## What Changed

- **`packages/adapters/claude-local/src/server/execute.ts`**: When no explicit `PAPERCLIP_API_KEY` is configured in `adapterConfig.env`, always write `PAPERCLIP_API_KEY` into the child process env — set to `authToken` when available, or to `""` otherwise. This ensures `process.env` inheritance from the server process is blocked regardless of JWT availability.
- **`server/src/services/heartbeat.ts`**: Change the `supportsLocalAgentJwt && !authToken` branch from `logger.warn` + continue to `throw`. If the JWT secret is missing or invalid, the heartbeat now fails immediately instead of silently launching an agent that will authenticate as the board user.

## Verification

1. Start the Paperclip server **without** `PAPERCLIP_AGENT_JWT_SECRET` set — trigger a `claude_local` agent heartbeat. Expected: run fails fast with a clear error instead of launching with board-user auth.
2. Start the server **with** `PAPERCLIP_AGENT_JWT_SECRET` set — trigger a heartbeat. Expected: `checkout` sets `checkoutRunId` to the run ID, comments appear with `authorAgentId` set (not `authorUserId: local-board`).
3. `pnpm --filter @paperclipai/adapter-claude-local typecheck` — passes.
4. `pnpm --filter @paperclipai/server typecheck` — passes.
5. `pnpm vitest run` — pre-existing Windows EBUSY flake in `claude-local-execute.test.ts`; all other tests pass unchanged.

## Risks

- **Fail-fast behavior change**: Previously, agents with a missing JWT secret would launch and degrade silently. Now they throw. Any deployment missing `PAPERCLIP_AGENT_JWT_SECRET` will see heartbeat failures instead of board-user impersonation. This is intentional — silent degradation was the bug.
- **Empty string `PAPERCLIP_API_KEY`**: When `authToken` is null and no explicit key is set, the subprocess now receives `PAPERCLIP_API_KEY=""`. This will cause 401s rather than board-user auth. Belt-and-suspenders given the fail-fast guard above.
- **Low risk overall**: The fail-fast path only triggers when the JWT secret is absent, which is a misconfiguration. All correctly-configured deployments are unaffected.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-329