### PR TITLE
fix(server): refresh detached run recovery on latest master

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -253,7 +253,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   }, 20_000);
 
   afterEach(async () => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     mockAdapterExecute.mockImplementation(async () => ({
       exitCode: 0,
       signal: null,
@@ -1537,5 +1537,27 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+
+  it("still cancels a detached run when SIGTERM returns EPERM", async () => {
+    const pid = 424242;
+    const eperm = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(((targetPid: number, signal?: number | NodeJS.Signals) => {
+      if (targetPid === pid && signal === "SIGTERM") throw eperm;
+      return true;
+    }) as typeof process.kill);
+
+    const { runId } = await seedRunFixture({
+      includeIssue: false,
+      processPid: pid,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${pid} is still alive`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const cancelled = await heartbeat.cancelRun(runId);
+
+    expect(cancelled?.status).toBe("cancelled");
+    expect(killSpy).toHaveBeenCalledWith(pid, "SIGTERM");
   });
 });


### PR DESCRIPTION
## Thinking Path
The original detached-run recovery branch drifted too far from current `master`, so this replacement PR reapplies the cancel-path hardening on a fresh base. The key issue is that detached local runs need to be cancelled through their recorded PID, and that `EPERM` on that signal path must not leave the run stuck in `running`.

Supersedes #2424.

## What Changed
- Reused detached-process termination for cancel flows so cancellation can target recorded child PIDs, not just in-memory handles.
- Treated `EPERM` like a non-fatal failed kill attempt in `killRecordedProcess`.
- Added a regression test covering the `SIGTERM -> EPERM` path during detached-run cancellation.

## Why It Matters
This keeps control-plane state moving forward even when a detached local child cannot be signaled by the current UID.

## Benefits
- Cancels detached local runs via recorded PID.
- Prevents `EPERM` from aborting the cancel flow.
- Adds focused regression coverage for the edge case.

## How To Verify
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts ui/src/context/LiveUpdatesProvider.test.ts ui/src/pages/AgentDetail.test.ts`

## Risks
Treating `EPERM` as a non-fatal failed kill means the process may still be alive if another UID owns it, but the run no longer remains stuck in `running`.
