### PR TITLE
fix(ui): refresh inline save normalization and extra args parsing

### DIFF
--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { resolveExtraArgsValue } from "./AgentConfigForm";
+
+describe("resolveExtraArgsValue", () => {
+  it("parses comma-separated args", () => {
+    expect(resolveExtraArgsValue(" --foo , --bar=baz , , --qux ")).toEqual([
+      "--foo",
+      "--bar=baz",
+      "--qux",
+    ]);
+  });
+
+  it("returns null for empty or whitespace-only values", () => {
+    expect(resolveExtraArgsValue("")).toBeNull();
+    expect(resolveExtraArgsValue("   ")).toBeNull();
+  });
+});

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -126,6 +126,10 @@ function parseCommaArgs(value: string): string[] {
     .filter(Boolean);
 }
 
+export function resolveExtraArgsValue(value: string): string[] | null {
+  return value.trim() ? parseCommaArgs(value) : null;
+}
+
 function formatArgList(value: unknown): string {
   if (Array.isArray(value)) {
     return value
@@ -891,7 +895,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   onCommit={(v) =>
                     isCreate
                       ? set!({ extraArgs: v })
-                      : mark("adapterConfig", "extraArgs", v?.trim() ? parseCommaArgs(v) : null)
+                      : mark("adapterConfig", "extraArgs", resolveExtraArgsValue(v))
                   }
                   immediate
                   className={inputClass}

--- a/ui/src/components/InlineEditor.test.tsx
+++ b/ui/src/components/InlineEditor.test.tsx
@@ -3,6 +3,11 @@
 import { act, forwardRef, useImperativeHandle, useRef, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeInlineEditorValue,
+  queueContainedBlurCommit,
+  shouldSaveInlineEditorValue,
+} from "./InlineEditor";
 
 vi.mock("./MarkdownEditor", () => ({
   MarkdownEditor: forwardRef<
@@ -30,7 +35,7 @@ vi.mock("./MarkdownBody", () => ({
   ),
 }));
 
-import { InlineEditor, queueContainedBlurCommit } from "./InlineEditor";
+import { InlineEditor } from "./InlineEditor";
 
 /** Enter multiline edit mode by clicking the preview surface. */
 function enterMultilineEdit(container: HTMLDivElement) {
@@ -368,5 +373,25 @@ describe("queueContainedBlurCommit", () => {
 
     expect(onCommit).not.toHaveBeenCalled();
     cancel();
+  });
+});
+
+describe("normalizeInlineEditorValue", () => {
+  it("trims values before save comparisons", () => {
+    expect(normalizeInlineEditorValue("  hello world  ")).toBe("hello world");
+  });
+});
+
+describe("shouldSaveInlineEditorValue", () => {
+  it("skips saves when normalized values are unchanged", () => {
+    expect(shouldSaveInlineEditorValue("  hello  ", "hello")).toBe(false);
+  });
+
+  it("normalizes the current value before comparing", () => {
+    expect(shouldSaveInlineEditorValue("hello", "  hello  ")).toBe(false);
+  });
+
+  it("saves when clearing an existing value", () => {
+    expect(shouldSaveInlineEditorValue("   ", "hello")).toBe(true);
   });
 });

--- a/ui/src/components/InlineEditor.tsx
+++ b/ui/src/components/InlineEditor.tsx
@@ -26,6 +26,14 @@ const pad = "px-1 -mx-1";
 const markdownPad = "px-1";
 const AUTOSAVE_DEBOUNCE_MS = 900;
 
+export function normalizeInlineEditorValue(value: string): string {
+  return value.trim();
+}
+
+export function shouldSaveInlineEditorValue(nextValue: string, currentValue: string): boolean {
+  return normalizeInlineEditorValue(nextValue) !== normalizeInlineEditorValue(currentValue);
+}
+
 export function queueContainedBlurCommit(container: HTMLDivElement, onCommit: () => void) {
   let frameId = requestAnimationFrame(() => {
     frameId = requestAnimationFrame(() => {
@@ -154,13 +162,13 @@ export function InlineEditor({
 
 
   const commit = useCallback(async (nextValue = draft) => {
-    const valueToSave = nextValue.trim();
-    const valueChanged = valueToSave !== value;
-    const shouldSave = nullable
+    const normalizedNextValue = normalizeInlineEditorValue(nextValue);
+    const valueChanged = shouldSaveInlineEditorValue(nextValue, value);
+    const shouldPersist = nullable
       ? valueChanged
-      : Boolean(valueToSave && valueChanged);
-    if (shouldSave) {
-      await Promise.resolve(onSave(valueToSave));
+      : Boolean(normalizedNextValue && valueChanged);
+    if (shouldPersist) {
+      await Promise.resolve(onSave(normalizedNextValue));
     } else {
       setDraft(value);
     }
@@ -171,18 +179,18 @@ export function InlineEditor({
 
   /** Multiline blur/submit: show autosave indicator when persisting */
   const finalizeMultilineBlurOrSubmit = useCallback(() => {
-    const trimmed = draft.trim();
-    if (trimmed === value) {
+    if (!shouldSaveInlineEditorValue(draft, value)) {
       reset();
       void commit();
       return;
     }
-    if (!trimmed && !nullable) {
+    const normalizedDraft = normalizeInlineEditorValue(draft);
+    if (!normalizedDraft && !nullable) {
       reset();
       void commit();
       return;
     }
-    void runSave(() => commit());
+    void runSave(() => commit(normalizedDraft));
   }, [commit, draft, nullable, reset, runSave, value]);
 
   const cancelPendingBlurCommit = useCallback(() => {
@@ -230,9 +238,14 @@ export function InlineEditor({
   useEffect(() => {
     if (!multiline) return;
     if (!multilineFocused) return;
-    const trimmed = draft.trim();
-    // Nullable: empty draft can still be a real edit (clearing); only skip debounce when unchanged or empty is invalid.
-    if (trimmed === value || (!trimmed && !nullable)) {
+    const normalizedDraft = normalizeInlineEditorValue(draft);
+    if (!shouldSaveInlineEditorValue(draft, value)) {
+      if (autosaveState !== "saved") {
+        reset();
+      }
+      return;
+    }
+    if (!normalizedDraft && !nullable) {
       if (autosaveState !== "saved") {
         reset();
       }
@@ -243,7 +256,7 @@ export function InlineEditor({
       clearTimeout(autosaveDebounceRef.current);
     }
     autosaveDebounceRef.current = setTimeout(() => {
-      void runSave(() => commit(trimmed));
+      void runSave(() => commit(normalizedDraft));
     }, AUTOSAVE_DEBOUNCE_MS);
 
     return () => {


### PR DESCRIPTION
## Thinking Path
The original inline-save PR was based on an older branch and no longer reflected current `master`. This refresh reapplies the useful normalization changes on top of the latest UI code and keeps the current cleared `extraArgs` edit semantics explicit and tested.

Supersedes #2577.

## What Changed
- Exported `normalizeInlineEditorValue` and `shouldSaveInlineEditorValue` so every save path compares normalized values consistently.
- Reused the shared save guard across multiline autosave, delayed blur commit, and submit paths.
- Added `resolveExtraArgsValue` to centralize comma-arg parsing while preserving the current `null`-on-clear edit semantics.
- Added focused tests for inline save normalization, clearing an existing inline value, and cleared `extraArgs` behavior.

## Why It Matters
This keeps inline saves consistent across newer blur scheduling code paths and prevents extra-args clearing behavior from drifting again as the config form evolves.

## Benefits
- Prevents spurious resaves when the stored value only differs by surrounding whitespace.
- Lets inline editors save intentional clears instead of silently restoring the old value.
- Keeps autosave, blur, and submit behavior aligned.
- Preserves the current edit-path semantics when clearing `extraArgs`.

## How To Verify
- `pnpm exec vitest run ui/src/components/InlineEditor.test.tsx ui/src/components/AgentConfigForm.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`

## Notes
`pnpm --filter @paperclipai/ui typecheck` is currently blocked on pre-existing `IssueProperties.tsx` type errors on latest `master`, not by this PR.

## Risks
This intentionally keeps the post-plugin-system `null` semantics for clearing `extraArgs` in edit mode, rather than reverting to the older `undefined` behavior from the pre-conflict branch.
