### PR TITLE
fix: refresh codex command fallback on macOS

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -889,6 +889,43 @@ export function defaultPathForPlatform() {
   return "/usr/local/bin:/opt/homebrew/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin";
 }
 
+function uniqueNonEmptyPaths(paths: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of paths) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function additionalCommandSearchDirs(command: string, env: NodeJS.ProcessEnv): string[] {
+  const extras: string[] = [];
+  const extraPathValue =
+    typeof env.PAPERCLIP_EXTRA_COMMAND_PATHS === "string"
+      ? env.PAPERCLIP_EXTRA_COMMAND_PATHS
+      : typeof process.env.PAPERCLIP_EXTRA_COMMAND_PATHS === "string"
+        ? process.env.PAPERCLIP_EXTRA_COMMAND_PATHS
+        : "";
+  if (extraPathValue) {
+    extras.push(...extraPathValue.split(path.delimiter));
+  }
+
+  if (process.platform === "darwin") {
+    const homeDir =
+      (typeof env.HOME === "string" && env.HOME.trim().length > 0 ? env.HOME : process.env.HOME) ?? "";
+    if (command === "codex") {
+      extras.push("/Applications/Codex.app/Contents/Resources");
+      if (homeDir) extras.push(path.join(homeDir, "Applications", "Codex.app", "Contents", "Resources"));
+    }
+  }
+
+  return uniqueNonEmptyPaths(extras);
+}
+
 function windowsPathExts(env: NodeJS.ProcessEnv): string[] {
   return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
 }
@@ -916,6 +953,18 @@ async function resolveCommandPath(command: string, cwd: string, env: NodeJS.Proc
   const hasExtension = process.platform === "win32" && path.extname(command).length > 0;
 
   for (const dir of dirs) {
+    const candidates =
+      process.platform === "win32"
+        ? hasExtension
+          ? [path.join(dir, command)]
+          : exts.map((ext) => path.join(dir, `${command}${ext}`))
+        : [path.join(dir, command)];
+    for (const candidate of candidates) {
+      if (await pathExists(candidate)) return candidate;
+    }
+  }
+
+  for (const dir of additionalCommandSearchDirs(command, env)) {
     const candidates =
       process.platform === "win32"
         ? hasExtension
@@ -1620,6 +1669,11 @@ export async function runChildProcess(
         if (opts.stdin != null && stdin) {
           void spawnPersistPromise.finally(() => {
             if (child.killed || stdin.destroyed) return;
+            stdin.on("error", (err: NodeJS.ErrnoException) => {
+              // Short-lived probes can exit before consuming stdin.
+              if (err.code === "EPIPE" || err.code === "ECONNRESET") return;
+              onLogError(err, runId, "stdin stream error");
+            });
             stdin.write(opts.stdin as string);
             stdin.end();
           });

--- a/server/src/__tests__/codex-local-adapter-environment.test.ts
+++ b/server/src/__tests__/codex-local-adapter-environment.test.ts
@@ -99,6 +99,40 @@ describe("codex_local environment diagnostics", () => {
     }
   });
 
+  it("resolves codex from PAPERCLIP_EXTRA_COMMAND_PATHS when PATH does not include it", async () => {
+    const root = path.join(
+      os.tmpdir(),
+      `paperclip-codex-extra-path-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    const binDir = path.join(root, "extra-bin");
+    const cwd = path.join(root, "workspace");
+    const fakeCodex = path.join(binDir, "codex");
+    try {
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.writeFile(fakeCodex, "#!/bin/sh\nexit 0\n", "utf8");
+      await fs.chmod(fakeCodex, 0o755);
+      vi.stubEnv("PAPERCLIP_EXTRA_COMMAND_PATHS", binDir);
+
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: {
+          command: "codex",
+          cwd,
+          env: {
+            PATH: "",
+            OPENAI_API_KEY: "test-key",
+          },
+        },
+      });
+
+      expect(result.checks.some((check) => check.code === "codex_command_resolvable")).toBe(true);
+      expect(result.checks.some((check) => check.code === "codex_command_unresolvable")).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   itWindows("runs the hello probe when Codex is available via a Windows .cmd wrapper", async () => {
     const root = path.join(
       os.tmpdir(),


### PR DESCRIPTION
## Thinking Path
The original fallback work on this topic lived on an older branch. This replacement PR recreates that fix on top of the current `master` and keeps the follow-up CI stability fix so the Codex environment probe no longer fails on short-lived child-process stdin shutdown.

Supersedes #2381.

## What Changed
- Added fallback command search directories in `resolveCommandPath`, including `PAPERCLIP_EXTRA_COMMAND_PATHS` and the macOS Codex app bundle resource path.
- Kept the regression test that resolves `codex` from `PAPERCLIP_EXTRA_COMMAND_PATHS` when `PATH` is empty.
- Tolerate `EPIPE` and `ECONNRESET` on child stdin writes in `runChildProcess` while still logging unexpected stdin errors.

## Why It Matters
This lets Paperclip find the `codex` executable when it is installed outside the server's normal `PATH`, while keeping the probe path stable in CI.

## Benefits
- Fixes Codex command resolution on macOS app-bundle installs.
- Supports explicit extra command search directories for local setups.
- Prevents short-lived probes from failing verification due to broken-pipe stdin shutdown.

## How To Verify
- `pnpm exec vitest run server/src/__tests__/codex-local-adapter-environment.test.ts`

## Risks
The stdin error handling intentionally swallows only broken-pipe style shutdown errors (`EPIPE` / `ECONNRESET`) on child stdin writes. Other stdin failures still go through the existing error logger.
