### PR TITLE
[codex] Restore feedback trace export fixes

### DIFF
--- a/docs/feedback-voting.md
+++ b/docs/feedback-voting.md
@@ -19,7 +19,7 @@ Each vote creates two local records:
 
 All data lives in your local Paperclip database. Nothing leaves your machine unless you explicitly choose to share.
 
-When a vote is marked for sharing, Paperclip also queues the trace bundle for background export through the Telemetry Backend. The app server never uploads raw feedback trace bundles directly to object storage.
+When a vote is marked for sharing, Paperclip immediately tries to upload the trace bundle through the Telemetry Backend. The upload is compressed in transit so full trace bundles stay under gateway size limits. If that immediate push fails, the trace is left in a retriable failed state for later flush attempts. The app server never uploads raw feedback trace bundles directly to object storage.
 
 ## Viewing your votes
 
@@ -148,6 +148,8 @@ Open any file in `traces/` to see:
 
 Open `full-traces/<issue>-<trace>/bundle.json` to see the expanded export metadata, including capture notes, adapter type, integrity metadata, and the inventory of raw files written alongside it.
 
+Each entry in `bundle.json.files[]` includes the actual captured file payload under `contents`, not just a pathname. For text artifacts this is stored as UTF-8 text; binary artifacts use base64 plus an `encoding` marker.
+
 Built-in local adapters now export their native session artifacts more directly:
 
 - `codex_local`: `adapter/codex/session.jsonl`
@@ -168,19 +170,21 @@ Your preference is saved per-company. You can change it any time via the feedbac
 | Status | Meaning |
 |--------|---------|
 | `local_only` | Vote stored locally, not marked for sharing |
-| `pending` | Marked for sharing, waiting to be sent |
+| `pending` | Marked for sharing, saved locally, and waiting for the immediate upload attempt |
 | `sent` | Successfully transmitted |
-| `failed` | Transmission attempted but failed (will retry) |
+| `failed` | Transmission attempted but failed (for example the backend is unreachable or not configured); later flushes retry once a backend is available |
 
 Your local database always retains the full vote and trace data regardless of sharing status.
 
 ## Remote sync
 
-Votes you choose to share are queued as `pending` traces and flushed by the server's background worker to the Telemetry Backend. The Telemetry Backend validates the request, then persists the bundle into its configured object storage.
+Votes you choose to share are sent to the Telemetry Backend immediately from the vote request. The server also keeps a background flush worker so failed traces can retry later. The Telemetry Backend validates the request, then persists the bundle into its configured object storage.
 
 - App server responsibility: build the bundle, POST it to Telemetry Backend, update trace status
 - Telemetry Backend responsibility: authenticate the request, validate payload shape, compress/store the bundle, return the final object key
 - Retry behavior: failed uploads move to `failed` with an error message in `failureReason`, and the worker retries them on later ticks
+- Default endpoint: when no feedback export backend URL is configured, Paperclip falls back to `https://telemetry.paperclip.ing`
+- Important nuance: the uploaded object is a snapshot of the full bundle at vote time. If you fetch a local bundle later and the underlying adapter session file has continued to grow, the local regenerated bundle may be larger than the already-uploaded snapshot for that same trace.
 
 Exported objects use a deterministic key pattern so they are easy to inspect:
 

--- a/server/src/__tests__/feedback-service.test.ts
+++ b/server/src/__tests__/feedback-service.test.ts
@@ -1069,6 +1069,73 @@ describe("feedbackService.saveIssueVote", () => {
     });
   });
 
+  it("can flush a single shared trace immediately by trace id", async () => {
+    const { companyId, issueId, commentId: firstCommentId } = await seedIssueWithAgentComment();
+    const secondCommentId = randomUUID();
+    const agentId = await db
+      .select({ authorAgentId: issueComments.authorAgentId })
+      .from(issueComments)
+      .where(eq(issueComments.id, firstCommentId))
+      .then((rows) => rows[0]?.authorAgentId ?? null);
+
+    await db.insert(issueComments).values({
+      id: secondCommentId,
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      body: "Second AI generated update",
+    });
+
+    const uploadTraceBundle = vi.fn().mockResolvedValue({
+      objectKey: `feedback-traces/${companyId}/2026/04/01/test-trace.json`,
+    });
+    const flushingSvc = feedbackService(db, {
+      shareClient: {
+        uploadTraceBundle,
+      },
+    });
+
+    const first = await flushingSvc.saveIssueVote({
+      issueId,
+      targetType: "issue_comment",
+      targetId: firstCommentId,
+      vote: "up",
+      authorUserId: "user-1",
+      allowSharing: true,
+    });
+    await flushingSvc.saveIssueVote({
+      issueId,
+      targetType: "issue_comment",
+      targetId: secondCommentId,
+      vote: "up",
+      authorUserId: "user-1",
+      allowSharing: true,
+    });
+
+    const flushResult = await flushingSvc.flushPendingFeedbackTraces({
+      companyId,
+      traceId: first.traceId ?? undefined,
+      limit: 1,
+    });
+
+    expect(flushResult).toMatchObject({
+      attempted: 1,
+      sent: 1,
+      failed: 0,
+    });
+    expect(uploadTraceBundle).toHaveBeenCalledTimes(1);
+
+    const traces = await flushingSvc.listFeedbackTraces({
+      companyId,
+      issueId,
+      includePayload: true,
+    });
+    const firstTrace = traces.find((trace) => trace.targetId === firstCommentId);
+    const secondTrace = traces.find((trace) => trace.targetId === secondCommentId);
+    expect(firstTrace?.status).toBe("sent");
+    expect(secondTrace?.status).toBe("pending");
+  });
+
   it("marks pending shared traces as failed when remote export upload fails", async () => {
     const { companyId, issueId, commentId } = await seedIssueWithAgentComment();
     const uploadTraceBundle = vi.fn().mockRejectedValue(new Error("telemetry unavailable"));
@@ -1105,5 +1172,40 @@ describe("feedbackService.saveIssueVote", () => {
     expect(traces[0]?.failureReason).toContain("telemetry unavailable");
     expect(traces[0]?.exportedAt).toBeNull();
     expect(uploadTraceBundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks pending shared traces as failed when no feedback export backend is configured", async () => {
+    const { companyId, issueId, commentId } = await seedIssueWithAgentComment();
+
+    const result = await svc.saveIssueVote({
+      issueId,
+      targetType: "issue_comment",
+      targetId: commentId,
+      vote: "up",
+      authorUserId: "user-1",
+      allowSharing: true,
+    });
+
+    const flushResult = await svc.flushPendingFeedbackTraces({
+      companyId,
+      traceId: result.traceId ?? undefined,
+      limit: 1,
+    });
+
+    expect(flushResult).toMatchObject({
+      attempted: 1,
+      sent: 0,
+      failed: 1,
+    });
+
+    const traces = await svc.listFeedbackTraces({
+      companyId,
+      issueId,
+      includePayload: true,
+    });
+    expect(traces[0]?.status).toBe("failed");
+    expect(traces[0]?.attemptCount).toBe(1);
+    expect(traces[0]?.failureReason).toBe("Feedback export backend is not configured");
+    expect(traces[0]?.exportedAt).toBeNull();
   });
 });

--- a/server/src/__tests__/feedback-share-client.test.ts
+++ b/server/src/__tests__/feedback-share-client.test.ts
@@ -1,0 +1,101 @@
+import { gunzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFeedbackTraceShareClientFromConfig } from "../services/feedback-share-client.js";
+
+describe("feedback trace share client", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ objectKey: "feedback-traces/test.json" }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to telemetry.paperclip.ing when no backend url is configured", async () => {
+    const client = createFeedbackTraceShareClientFromConfig({
+      feedbackExportBackendUrl: undefined,
+      feedbackExportBackendToken: undefined,
+    });
+
+    await client.uploadTraceBundle({
+      traceId: "trace-1",
+      exportId: "export-1",
+      companyId: "company-1",
+      issueId: "issue-1",
+      issueIdentifier: "PAP-1",
+      adapterType: "codex_local",
+      captureStatus: "full",
+      notes: [],
+      envelope: {},
+      surface: null,
+      paperclipRun: null,
+      rawAdapterTrace: null,
+      normalizedAdapterTrace: null,
+      privacy: null,
+      integrity: {},
+      files: [],
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://telemetry.paperclip.ing/feedback-traces",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("wraps the feedback trace payload as gzip+base64 json before upload", async () => {
+    const client = createFeedbackTraceShareClientFromConfig({
+      feedbackExportBackendUrl: "https://telemetry.paperclip.ing",
+      feedbackExportBackendToken: "test-token",
+    });
+
+    await client.uploadTraceBundle({
+      traceId: "trace-1",
+      exportId: "export-1",
+      companyId: "company-1",
+      issueId: "issue-1",
+      issueIdentifier: "PAP-1",
+      adapterType: "codex_local",
+      captureStatus: "full",
+      notes: [],
+      envelope: { hello: "world" },
+      surface: null,
+      paperclipRun: null,
+      rawAdapterTrace: null,
+      normalizedAdapterTrace: null,
+      privacy: null,
+      integrity: {},
+      files: [],
+    });
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(call?.[0]).toBe("https://telemetry.paperclip.ing/feedback-traces");
+    expect(call?.[1]).toMatchObject({
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-token",
+      },
+    });
+
+    const body = JSON.parse(String(call?.[1]?.body ?? "{}")) as {
+      encoding?: string;
+      payload?: string;
+    };
+    expect(body.encoding).toBe("gzip+base64+json");
+    expect(typeof body.payload).toBe("string");
+
+    const decoded = gunzipSync(Buffer.from(body.payload ?? "", "base64")).toString("utf8");
+    const parsed = JSON.parse(decoded) as {
+      objectKey: string;
+      bundle: { envelope: { hello: string } };
+    };
+    expect(parsed.objectKey).toContain("feedback-traces/company-1/");
+    expect(parsed.objectKey.endsWith("/export-1.json")).toBe(true);
+    expect(parsed.bundle.envelope).toEqual({ hello: "world" });
+  });
+});

--- a/server/src/__tests__/issue-feedback-routes.test.ts
+++ b/server/src/__tests__/issue-feedback-routes.test.ts
@@ -12,6 +12,18 @@ const mockFeedbackService = vi.hoisted(() => ({
   saveIssueVote: vi.fn(),
 }));
 
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(),
+}));
+
+const mockFeedbackExportService = vi.hoisted(() => ({
+  flushPendingFeedbackTraces: vi.fn(async () => ({ attempted: 1, sent: 1, failed: 0 })),
+}));
+
 vi.mock("../services/index.js", () => ({
   accessService: () => ({
     canUser: vi.fn(),
@@ -42,12 +54,7 @@ vi.mock("../services/index.js", () => ({
     listCompanyIds: vi.fn(async () => ["company-1"]),
   }),
   issueApprovalService: () => ({}),
-  issueService: () => ({
-    getById: vi.fn(),
-    update: vi.fn(),
-    addComment: vi.fn(),
-    findMentionedAgents: vi.fn(),
-  }),
+  issueService: () => mockIssueService,
   logActivity: vi.fn(async () => undefined),
   projectService: () => ({}),
   routineService: () => ({
@@ -63,7 +70,7 @@ function createApp(actor: Record<string, unknown>) {
     (req as any).actor = actor;
     next();
   });
-  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use("/api", issueRoutes({} as any, {} as any, { feedbackExportService: mockFeedbackExportService }));
   app.use(errorHandler);
   return app;
 }
@@ -71,6 +78,50 @@ function createApp(actor: Record<string, unknown>) {
 describe("issue feedback trace routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("flushes a newly shared feedback trace immediately after saving the vote", async () => {
+    const targetId = "11111111-1111-4111-8111-111111111111";
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-1",
+    });
+    mockFeedbackService.saveIssueVote.mockResolvedValue({
+      vote: {
+        targetType: "issue_comment",
+        targetId,
+        vote: "up",
+        reason: null,
+      },
+      traceId: "trace-1",
+      consentEnabledNow: false,
+      persistedSharingPreference: null,
+      sharingEnabled: true,
+    });
+    const app = createApp({
+      type: "board",
+      userId: "user-1",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: ["company-1"],
+    });
+
+    const res = await request(app)
+      .post("/api/issues/issue-1/feedback-votes")
+      .send({
+        targetType: "issue_comment",
+        targetId,
+        vote: "up",
+        allowSharing: true,
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockFeedbackExportService.flushPendingFeedbackTraces).toHaveBeenCalledWith({
+      companyId: "company-1",
+      traceId: "trace-1",
+      limit: 1,
+    });
   });
 
   it("rejects non-board callers before fetching a feedback trace", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -67,6 +67,7 @@ export async function createApp(
     feedbackExportService?: {
       flushPendingFeedbackTraces(input?: {
         companyId?: string;
+        traceId?: string;
         limit?: number;
         now?: Date;
       }): Promise<unknown>;
@@ -152,7 +153,9 @@ export async function createApp(
   api.use(agentRoutes(db));
   api.use(assetRoutes(db, opts.storageService));
   api.use(projectRoutes(db));
-  api.use(issueRoutes(db, opts.storageService));
+  api.use(issueRoutes(db, opts.storageService, {
+    feedbackExportService: opts.feedbackExportService,
+  }));
   api.use(routineRoutes(db));
   api.use(executionWorkspaceRoutes(db));
   api.use(goalRoutes(db));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -525,7 +525,7 @@ export async function startServer(): Promise<StartedServer> {
   const uiMode = config.uiDevMiddleware ? "vite-dev" : config.serveUi ? "static" : "none";
   const storageService = createStorageServiceFromConfig(config);
   const feedback = feedbackService(db as any, {
-    shareClient: createFeedbackTraceShareClientFromConfig(config) ?? undefined,
+    shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
   const app = await createApp(db as any, {
     uiMode,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -52,7 +52,20 @@ const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
 
-export function issueRoutes(db: Db, storage: StorageService) {
+export function issueRoutes(
+  db: Db,
+  storage: StorageService,
+  opts?: {
+    feedbackExportService?: {
+      flushPendingFeedbackTraces(input?: {
+        companyId?: string;
+        traceId?: string;
+        limit?: number;
+        now?: Date;
+      }): Promise<unknown>;
+    };
+  },
+) {
   const router = Router();
   const svc = issueService(db);
   const access = accessService(db);
@@ -67,6 +80,7 @@ export function issueRoutes(db: Db, storage: StorageService) {
   const workProductsSvc = workProductService(db);
   const documentsSvc = documentService(db);
   const routinesSvc = routineService(db);
+  const feedbackExportService = opts?.feedbackExportService;
   const upload = multer({
     storage: multer.memoryStorage(),
     limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
@@ -1865,6 +1879,18 @@ export function issueRoutes(db: Db, storage: StorageService) {
           }),
         ),
       );
+    }
+
+    if (result.sharingEnabled && result.traceId && feedbackExportService) {
+      try {
+        await feedbackExportService.flushPendingFeedbackTraces({
+          companyId: issue.companyId,
+          traceId: result.traceId,
+          limit: 1,
+        });
+      } catch (err) {
+        logger.warn({ err, issueId: issue.id, traceId: result.traceId }, "failed to flush shared feedback trace immediately");
+      }
     }
 
     res.status(201).json(result.vote);

--- a/server/src/services/feedback-share-client.ts
+++ b/server/src/services/feedback-share-client.ts
@@ -1,5 +1,8 @@
+import { gzipSync } from "node:zlib";
 import type { FeedbackTraceBundle } from "@paperclipai/shared";
 import type { Config } from "../config.js";
+
+const DEFAULT_FEEDBACK_EXPORT_BACKEND_URL = "https://telemetry.paperclip.ing";
 
 function buildFeedbackShareObjectKey(bundle: FeedbackTraceBundle, exportedAt: Date) {
   const year = String(exportedAt.getUTCFullYear());
@@ -14,10 +17,8 @@ export interface FeedbackTraceShareClient {
 
 export function createFeedbackTraceShareClientFromConfig(
   config: Pick<Config, "feedbackExportBackendUrl" | "feedbackExportBackendToken">,
-): FeedbackTraceShareClient | null {
-  const baseUrl = config.feedbackExportBackendUrl?.trim();
-  if (!baseUrl) return null;
-
+): FeedbackTraceShareClient {
+  const baseUrl = config.feedbackExportBackendUrl?.trim() || DEFAULT_FEEDBACK_EXPORT_BACKEND_URL;
   const token = config.feedbackExportBackendToken?.trim();
   const endpoint = new URL("/feedback-traces", baseUrl).toString();
 
@@ -25,6 +26,11 @@ export function createFeedbackTraceShareClientFromConfig(
     async uploadTraceBundle(bundle) {
       const exportedAt = new Date();
       const objectKey = buildFeedbackShareObjectKey(bundle, exportedAt);
+      const requestBody = JSON.stringify({
+        objectKey,
+        exportedAt: exportedAt.toISOString(),
+        bundle,
+      });
       const response = await fetch(endpoint, {
         method: "POST",
         headers: {
@@ -32,9 +38,8 @@ export function createFeedbackTraceShareClientFromConfig(
           ...(token ? { authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({
-          objectKey,
-          exportedAt: exportedAt.toISOString(),
-          bundle,
+          encoding: "gzip+base64+json",
+          payload: gzipSync(requestBody).toString("base64"),
         }),
       });
 

--- a/server/src/services/feedback.ts
+++ b/server/src/services/feedback.ts
@@ -63,6 +63,7 @@ const MAX_SKILLS = 20;
 const MAX_INSTRUCTION_FILES = 20;
 const MAX_TRACE_FILE_CHARS = 10_000_000;
 const DEFAULT_INSTANCE_SETTINGS_SINGLETON_KEY = "default";
+const FEEDBACK_EXPORT_BACKEND_NOT_CONFIGURED = "Feedback export backend is not configured";
 
 type FeedbackTraceRow = typeof feedbackExports.$inferSelect & {
   issueIdentifier: string | null;
@@ -1742,15 +1743,48 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
 
     flushPendingFeedbackTraces: async (input?: {
       companyId?: string;
+      traceId?: string;
       limit?: number;
       now?: Date;
     }) => {
       const shareClient = options.shareClient;
       if (!shareClient) {
+        const filters = [eq(feedbackExports.status, "pending")];
+        if (input?.companyId) {
+          filters.push(eq(feedbackExports.companyId, input.companyId));
+        }
+        if (input?.traceId) {
+          filters.push(eq(feedbackExports.id, input.traceId));
+        }
+
+        const rows = await db
+          .select({
+            id: feedbackExports.id,
+            attemptCount: feedbackExports.attemptCount,
+          })
+          .from(feedbackExports)
+          .where(and(...filters))
+          .orderBy(asc(feedbackExports.createdAt), asc(feedbackExports.id))
+          .limit(Math.max(1, Math.min(input?.limit ?? 25, 200)));
+
+        const attemptAt = input?.now ?? new Date();
+        for (const row of rows) {
+          await db
+            .update(feedbackExports)
+            .set({
+              status: "failed",
+              attemptCount: row.attemptCount + 1,
+              lastAttemptedAt: attemptAt,
+              failureReason: FEEDBACK_EXPORT_BACKEND_NOT_CONFIGURED,
+              updatedAt: attemptAt,
+            })
+            .where(eq(feedbackExports.id, row.id));
+        }
+
         return {
-          attempted: 0,
+          attempted: rows.length,
           sent: 0,
-          failed: 0,
+          failed: rows.length,
         };
       }
 
@@ -1760,6 +1794,9 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
       ];
       if (input?.companyId) {
         filters.push(eq(feedbackExports.companyId, input.companyId));
+      }
+      if (input?.traceId) {
+        filters.push(eq(feedbackExports.id, input.traceId));
       }
 
       const rows = await db
@@ -1983,7 +2020,7 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
           })
           .where(eq(feedbackVotes.id, savedVote.id));
 
-        await tx
+        const [savedTrace] = await tx
           .insert(feedbackExports)
           .values({
             companyId: issue.companyId,
@@ -2030,6 +2067,9 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
               failureReason: null,
               updatedAt: now,
             },
+          })
+          .returning({
+            id: feedbackExports.id,
           });
 
         return {
@@ -2037,6 +2077,7 @@ export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
             ...savedVote,
             redactionSummary: artifacts.redactionSummary,
           },
+          traceId: savedTrace?.id ?? null,
           consentEnabledNow,
           persistedSharingPreference,
           sharingEnabled: sharedWithLabs,


### PR DESCRIPTION
## Summary

- restore the missing feedback trace export behavior from the detached work onto current `public-gh/master`
- flush shared feedback traces immediately after a vote is saved, targeting the new trace by `traceId`
- default feedback exports to `https://telemetry.paperclip.ing` and gzip+base64 wrap the upload payload
- document the updated feedback export lifecycle and add regression coverage for service, route, and share-client behavior

## Root Cause

The detached branch contained feedback export fixes that never landed on `public-gh/master`. Current `master` still queued shared traces for background export only, did not support trace-scoped immediate flushes, and did not apply the telemetry endpoint/compression behavior from that detached work.

## Validation

- `pnpm exec vitest run server/src/__tests__/feedback-service.test.ts server/src/__tests__/feedback-share-client.test.ts server/src/__tests__/issue-feedback-routes.test.ts`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` hit one unrelated failure in `server/src/__tests__/instance-settings-routes.test.ts`, but that file passes when run in isolation with `pnpm exec vitest run server/src/__tests__/instance-settings-routes.test.ts`
