### PR TITLE
fix(gemini-local): pipe prompt via stdin to fix Windows cmd.exe escaping

### DIFF
--- a/doc/plans/2026-04-03-gemini-stdin-prompt.md
+++ b/doc/plans/2026-04-03-gemini-stdin-prompt.md
@@ -1,0 +1,97 @@
+# Gemini Adapter: Pipe prompt via stdin on Windows
+
+**Date:** 2026-04-03
+**Status:** Resolved
+**Affects:** `packages/adapters/gemini-local`
+
+## Problem
+
+Agent runs using the `gemini_local` adapter fail on Windows with:
+
+```
+Cannot use both a positional prompt and the --prompt (-p) flag together
+```
+
+The Gemini CLI (v0.36.0+) rejects the invocation even though the adapter
+only passes `--prompt <value>` and never supplies a positional argument.
+
+## Root cause
+
+On Windows the globally-installed Gemini CLI resolves to `gemini.CMD`, a
+batch-file wrapper.  The shared `resolveSpawnTarget()` helper in
+`packages/adapter-utils` detects `.cmd` extensions and re-routes the spawn
+through `cmd.exe /d /s /c "<commandLine>"`, quoting each argument with
+`quoteForCmd()`.
+
+`quoteForCmd()` doubles internal double-quotes (`"` → `""`) and wraps the
+argument in outer quotes when it contains whitespace or shell meta-characters.
+For short, simple arguments this works fine.  For the agent prompt — typically
+1 000–3 000+ characters containing `"`, `&`, `|`, `()`, and other
+cmd.exe-special characters — the escaping breaks down:
+
+1. cmd.exe splits the prompt argument at unescaped meta-characters.
+2. The fragment after the split is no longer inside the `--prompt` option.
+3. The Gemini CLI's yargs parser interprets that fragment as a **positional
+   `query` argument**.
+4. Because both a positional prompt *and* `--prompt` are now present, the CLI
+   rejects the invocation.
+
+A secondary issue (fixed in the same change): the adapter passed
+`--sandbox=none`.  In Gemini CLI v0.36.0 `--sandbox` became a boolean flag,
+so `=none` was parsed as the string `"none"` — another accidental positional
+argument.
+
+## Fix
+
+### 1. Pipe the prompt via stdin (`execute.ts`)
+
+Instead of passing the prompt as a CLI argument:
+
+```diff
+-    args.push("--prompt", prompt);
++    // Trigger headless mode with a short non-empty placeholder.
++    // The full prompt is piped via stdin, avoiding all shell escaping.
++    args.push("--prompt", ".");
+```
+
+```diff
+     const proc = await runChildProcess(runId, command, args, {
+       cwd,
+       env,
++      stdin: prompt,
+       timeoutSec,
+```
+
+The Gemini CLI concatenates stdin content with the `--prompt` value
+(`stdin + "\n\n\n" + promptValue`), so the full prompt arrives intact
+regardless of length or special characters.
+
+This mirrors the pattern the Codex adapter already uses (`codex exec … -`
+with prompt on stdin).
+
+### 2. Boolean sandbox flag (`execute.ts`, `test.ts`)
+
+```diff
+-      args.push("--sandbox=none");
++      args.push("--no-sandbox");
+```
+
+`--no-sandbox` is the standard yargs boolean negation for `--sandbox`.
+
+### 3. Test probe consistency (`test.ts`)
+
+The "hello" probe in `testEnvironment()` was updated to match: prompt piped
+via stdin, `--prompt "."` as the headless trigger.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `packages/adapters/gemini-local/src/server/execute.ts` | stdin prompt, `--no-sandbox`, updated command notes |
+| `packages/adapters/gemini-local/src/server/test.ts` | stdin prompt in hello probe, `--no-sandbox` |
+
+## Verification
+
+- `pnpm --filter @paperclipai/adapter-gemini-local typecheck` passes.
+- Manual test: `echo "Respond with hello." | gemini --output-format stream-json --no-sandbox --prompt "."` produces valid stream-json output with the stdin content as the user message.
+- Agent runs complete successfully after the fix.

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -269,7 +269,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
+    const notes: string[] = ["Prompt is piped to Gemini via stdin; --prompt triggers non-interactive (headless) mode."];
     notes.push("Added --approval-mode yolo for unattended execution.");
     if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {
@@ -328,10 +328,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (sandbox) {
       args.push("--sandbox");
     } else {
-      args.push("--sandbox=none");
+      args.push("--no-sandbox");
     }
     if (extraArgs.length > 0) args.push(...extraArgs);
-    args.push("--prompt", prompt);
+    // Prompt is piped via stdin to avoid Windows cmd.exe shell escaping issues
+    // with long prompts containing special characters. The --prompt flag with a
+    // short non-empty value triggers non-interactive (headless) mode; the CLI
+    // prepends stdin content to the --prompt value as the user message.
+    args.push("--prompt", ".");
     return args;
   };
 
@@ -344,7 +348,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         cwd,
         commandNotes,
         commandArgs: args.map((value, index) => (
-          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
+          index === args.length - 1 ? `<prompt ${prompt.length} chars via stdin>` : value
         )),
         env: loggedEnv,
         prompt,
@@ -356,6 +360,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const proc = await runChildProcess(runId, command, args, {
       cwd,
       env,
+      stdin: prompt,
       timeoutSec,
       graceSec,
       onSpawn,

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -142,13 +142,14 @@ export async function testEnvironment(
         return asStringArray(config.args);
       })();
 
-      const args = ["--output-format", "stream-json", "--prompt", "Respond with hello."];
+      const helloPrompt = "Respond with hello.";
+      const args = ["--output-format", "stream-json", "--prompt", "."];
       if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
       if (approvalMode !== "default") args.push("--approval-mode", approvalMode);
       if (sandbox) {
         args.push("--sandbox");
       } else {
-        args.push("--sandbox=none");
+        args.push("--no-sandbox");
       }
       if (extraArgs.length > 0) args.push(...extraArgs);
 
@@ -159,6 +160,7 @@ export async function testEnvironment(
         {
           cwd,
           env,
+          stdin: helloPrompt,
           timeoutSec: helloProbeTimeoutSec,
           graceSec: 5,
           onLog: async () => { },


### PR DESCRIPTION
## Problem

Agent runs using the `gemini_local` adapter fail on Windows with:

```
Cannot use both a positional prompt and the --prompt (-p) flag together
```

## Root Cause

On Windows, `gemini.CMD` is a batch-file wrapper, so Node.js spawns it through `cmd.exe /d /s /c`. The `quoteForCmd()` helper in `adapter-utils` escapes arguments, but long prompts (1000-3000+ chars) containing `&`, `|`, `()`, and `"` cause cmd.exe to fragment the argument. The Gemini CLI then sees part of the prompt as a positional `query` argument alongside `--prompt`, triggering the rejection.

A secondary issue: `--sandbox=none` was also parsed incorrectly since Gemini CLI v0.36.0 changed `--sandbox` to a boolean flag.

## Fix

1. **Pipe prompt via stdin** instead of passing as a CLI argument (mirrors the Codex adapter pattern). Use `--prompt '.'` as a short non-empty headless-mode trigger.
2. **Replace `--sandbox=none` with `--no-sandbox`** (standard yargs boolean negation).
3. **Update test probe** to match the new stdin approach.

## Files Changed

- `packages/adapters/gemini-local/src/server/execute.ts` — stdin prompt, --no-sandbox, updated command notes
- `packages/adapters/gemini-local/src/server/test.ts` — stdin prompt in hello probe, --no-sandbox
- `doc/plans/2026-04-03-gemini-stdin-prompt.md` — detailed writeup

## Verification

- `pnpm --filter @paperclipai/adapter-gemini-local typecheck` passes
- Manual test confirms stdin prompt delivery works correctly
- Agent runs complete successfully after the fix
