### PR TITLE
SHA-11: Document and enforce gstack sprint pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,12 @@ Prefer additive updates. Keep `doc/SPEC.md` and `doc/SPEC-implementation.md` ali
 5. Keep plan docs dated and centralized.
 New plan documents belong in `doc/plans/` and should use `YYYY-MM-DD-slug.md` filenames.
 
-## 6. Database Change Workflow
+6. Follow the gstack sprint pipeline for all new features.
+See `doc/SPRINT-PIPELINE.md` for the complete workflow.
+All features must progress through: brainstorm → plan-ceo-review → plan-eng-review → BUILD → review → QA → ship.
+This ensures architectural alignment, proper review gates, and code quality.
+
+## 7. Database Change Workflow
 
 When changing data model:
 
@@ -106,7 +111,7 @@ Notes:
 - `packages/db/drizzle.config.ts` reads compiled schema from `dist/schema/*.js`
 - `pnpm db:generate` compiles `packages/db` first
 
-## 7. Verification Before Hand-off
+## 8. Verification Before Hand-off
 
 Run this full check before claiming done:
 
@@ -118,7 +123,7 @@ pnpm build
 
 If anything cannot be run, explicitly report what was not run and why.
 
-## 8. API and Auth Expectations
+## 9. API and Auth Expectations
 
 - Base path: `/api`
 - Board access is treated as full-control operator context
@@ -132,13 +137,13 @@ When adding endpoints:
 - write activity log entries for mutations
 - return consistent HTTP errors (`400/401/403/404/409/422/500`)
 
-## 9. UI Expectations
+## 10. UI Expectations
 
 - Keep routes and nav aligned with available API surface
 - Use company selection context for company-scoped pages
 - Surface failures clearly; do not silently ignore API errors
 
-## 10. Definition of Done
+## 11. Definition of Done
 
 A change is done when all are true:
 

--- a/doc/SPRINT-PIPELINE.md
+++ b/doc/SPRINT-PIPELINE.md
@@ -1,0 +1,106 @@
+# Gstack Sprint Pipeline
+
+## Overview
+
+All new features must follow the gstack sprint pipeline. This is a structured workflow that ensures quality, architectural alignment, and proper review gates before code ships.
+
+## Pipeline Stages
+
+```
+brainstorm → plan-ceo-review → plan-eng-review → BUILD → review → QA → ship
+```
+
+### 1. Brainstorm
+- Initial concept ideation and requirements gathering
+- Team discussion on approach and feasibility
+- Output: Feature outline or spike plan
+
+### 2. Plan (CEO Review)
+- Architecture and design document prepared
+- Business impact and scope defined
+- CEO/product reviews for alignment with company goals
+- Output: Approved design doc
+
+### 3. Plan (Engineering Review)
+- Technical design reviewed by engineering leads
+- Implementation approach validated
+- Tech debt and dependencies identified
+- Output: Engineering approval and tech spec
+
+### 4. BUILD
+- Implementation phase
+- Code written according to spec
+- Unit tests included
+- Output: Pull request(s) with working code
+
+### 5. Review
+- Code review by peers (Cursor BugBot, manual review)
+- Architectural feedback from leads
+- Test coverage verification
+- Output: Approved PR
+
+### 6. QA
+- Integration testing
+- Manual testing against acceptance criteria
+- Performance/security checks
+- Output: QA sign-off
+
+### 7. Ship
+- Merge to main
+- Deploy to production
+- Monitor for issues
+- Output: Live feature
+
+## Gates and Checkpoints
+
+### Before BUILD:
+- Design must be approved by CEO and Engineering
+- Scope must be clear and bounded
+- Success criteria defined
+
+### Before Review:
+- Code must compile and pass tests
+- PR must reference design doc
+- Must include test coverage
+
+### Before QA:
+- All PR comments resolved
+- At least one approving review
+- CI/CD passing
+
+### Before Ship:
+- QA approval obtained
+- Release notes prepared
+- Monitoring/alerts configured
+
+## For Pull Requests
+
+Every PR should:
+1. Reference the related issue (e.g., "Fixes SHA-11")
+2. Include a summary linking to the design/plan document
+3. Describe testing done
+4. Request review from at least one other engineer
+
+## For Issues
+
+When creating a feature issue:
+1. Include clear acceptance criteria
+2. Link to design document (when available)
+3. Assign to an engineer with clear ownership
+4. Set priority and target milestone
+
+## Tools
+
+- **Planning**: Paperclip issues, design docs in `doc/plans/`
+- **Code**: GitHub branches and PRs
+- **Reviews**: Cursor BugBot + manual review on all PRs
+- **Testing**: Vitest, manual QA, staging environment
+
+## Exemptions
+
+Minor bugfixes and documentation updates may skip Planning stages if:
+- The change is isolated and low-risk
+- The issue clearly describes the fix
+- Full test coverage is included
+
+Use judgment. When in doubt, follow the full pipeline.


### PR DESCRIPTION
## Summary

This PR documents and enforces the gstack sprint pipeline for all new features.

### Changes

- **doc/SPRINT-PIPELINE.md** (new): Complete workflow documentation covering:
  - Pipeline stages: brainstorm → plan-ceo-review → plan-eng-review → BUILD → review → QA → ship
  - Gates and checkpoints before each transition
  - PR and issue requirements
  - Tool usage and exemptions

- **AGENTS.md**: Added section 6 mandating sprint pipeline compliance and referencing the new documentation

### Rationale

Enforcing the sprint pipeline ensures:
1. Architectural alignment with CEO/engineering review gates
2. Proper scoping and design before implementation begins
3. Code quality through mandatory reviews and testing
4. Consistent workflow across all engineers and agents

### Notes

Minor bugfixes and docs can skip planning stages if isolated and low-risk with full test coverage.

Fixes SHA-11