### PR TITLE
fix(claude-local,codex-local): add isolateSession option to prevent session context bleed

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -31,6 +31,7 @@ Core fields:
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
 - graceSec (number, optional): SIGTERM grace period in seconds
+- isolateSession (boolean, optional): when true, discard any stored session before each run and do not persist the resulting session; each task run starts from a clean context
 
 Notes:
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -378,7 +378,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const isolateSession = asBoolean(config.isolateSession, false);
   const canResumeSession =
+    !isolateSession &&
     runtimeSessionId.length > 0 &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
   const sessionId = canResumeSession ? runtimeSessionId : null;
@@ -574,7 +576,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       costUsd: parsedStream.costUsd ?? asNumber(parsed.total_cost_usd, 0),
       resultJson: parsed,
       summary: parsedStream.summary || asString(parsed.result, ""),
-      clearSession: clearSessionForMaxTurns || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+      clearSession: clearSessionForMaxTurns || isolateSession || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
     };
   };
 

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -385,9 +385,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
   const sessionId = canResumeSession ? runtimeSessionId : null;
   if (runtimeSessionId && !canResumeSession) {
+    const reason = isolateSession
+      ? "isolateSession=true"
+      : `saved for cwd "${runtimeSessionCwd}" and current cwd is "${cwd}"`;
     await onLog(
       "stdout",
-      `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+      `[paperclip] Claude session "${runtimeSessionId}" will not be resumed (${reason}).\n`,
     );
   }
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
@@ -510,7 +513,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorMessage: `Timed out after ${timeoutSec}s`,
         errorCode: "timeout",
         errorMeta,
-        clearSession: Boolean(opts.clearSessionOnMissingSession),
+        clearSession: isolateSession || Boolean(opts.clearSessionOnMissingSession),
       };
     }
 
@@ -526,7 +529,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stdout: proc.stdout,
           stderr: proc.stderr,
         },
-        clearSession: Boolean(opts.clearSessionOnMissingSession),
+        clearSession: isolateSession || Boolean(opts.clearSessionOnMissingSession),
       };
     }
 

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -37,6 +37,7 @@ Core fields:
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
 - graceSec (number, optional): SIGTERM grace period in seconds
+- isolateSession (boolean, optional): when true, discard any stored session before each run and do not persist the resulting session; each task run starts from a clean context
 
 Notes:
 - Prompts are piped via stdin (Codex receives "-" prompt argument).

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -402,7 +402,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const isolateSession = asBoolean(config.isolateSession, false);
   const canResumeSession =
+    !isolateSession &&
     runtimeSessionId.length > 0 &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
   const sessionId = canResumeSession ? runtimeSessionId : null;
@@ -592,7 +594,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderr: attempt.proc.stderr,
       },
       summary: attempt.parsed.summary,
-      clearSession: Boolean(clearSessionOnMissingSession && !resolvedSessionId),
+      clearSession: isolateSession || Boolean(clearSessionOnMissingSession && !resolvedSessionId),
     };
   };
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -409,9 +409,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
   const sessionId = canResumeSession ? runtimeSessionId : null;
   if (runtimeSessionId && !canResumeSession) {
+    const reason = isolateSession
+      ? "isolateSession=true"
+      : `saved for cwd "${runtimeSessionCwd}" and current cwd is "${cwd}"`;
     await onLog(
       "stdout",
-      `[paperclip] Codex session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+      `[paperclip] Codex session "${runtimeSessionId}" will not be resumed (${reason}).\n`,
     );
   }
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
@@ -551,7 +554,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         signal: attempt.proc.signal,
         timedOut: true,
         errorMessage: `Timed out after ${timeoutSec}s`,
-        clearSession: clearSessionOnMissingSession,
+        clearSession: isolateSession || clearSessionOnMissingSession,
       };
     }
 


### PR DESCRIPTION
> **Thinking Path**
>
> 1. Paperclip's purpose is orchestration for zero-human companies — agents run tasks on wakeup, often unrelated to what they did before.
> 2. Local adapters maintain state across runs via session IDs so long-running agents can resume where they left off. That's the intended design for stateful workflows.
> 3. However, there is no way to opt out. Agents running independent tasks (one task per wakeup) inherit all prior conversation history on every run.
> 4. The result: `bootstrapPromptTemplate` fires only on the very first run; subsequent runs resume silently into a growing context; costs accumulate from irrelevant prior turns.
> 5. The fix must be opt-in and backwards-compatible — existing agents should see no change unless they set the new flag.
> 6. The right place to control this is the adapter config, not a global server setting, since some agents on the same server may want sessions and others may not.
> 7. The minimal change: add `isolateSession` to the config, add `!isolateSession` guard to `canResumeSession`, and set `clearSession: true` on the result so the server doesn't persist the new session ID either.
> 8. Both `claude_local` and `codex_local` share the same pattern and need the same fix.

## What Changed

**`packages/adapters/claude-local/src/server/execute.ts`**
- Added `const isolateSession = asBoolean(config.isolateSession, false)` after the runtime session extraction
- Added `!isolateSession &&` guard to `canResumeSession` — when true, forces a fresh session on every run
- Propagated `isolateSession` into `clearSession` in `toAdapterResult` — prevents the server from storing the resulting session ID

**`packages/adapters/codex-local/src/server/execute.ts`**
- Identical changes at the equivalent locations

**`packages/adapters/claude-local/src/index.ts`**
- Added `isolateSession` to `agentConfigurationDoc` under Operational fields

**`packages/adapters/codex-local/src/index.ts`**
- Same addition

## Verification

1. Configure a `claude_local` (or `codex_local`) agent with `isolateSession: true` in its config
2. Trigger two task runs back-to-back
3. Confirm: each run logs a new session ID (no `[paperclip] Claude session "..." is unavailable` or silent resume)
4. Confirm: `bootstrapPromptTemplate` fires on every run, not just the first
5. Confirm: agents without `isolateSession` in their config behave exactly as before (session resumption unchanged)

## Risks

Low. The new option defaults to `false` — all existing agents are unaffected. The `!isolateSession` guard is the only change to the session-resumption path. No schema migrations, no registry changes, no new dependencies.

## Model Used

None — human-authored

## Checklist

- [x] Thinking path traces from project purpose to specific change
- [x] Model use disclosed
- [x] Tested locally (verified session isolation behaviour with a local adapter run)
- [x] No new test coverage required — the change is a boolean guard on an existing conditional; behaviour is observable from adapter logs
- [x] No screenshots needed — no UI changes
- [x] No documentation updates beyond `agentConfigurationDoc` (already updated)
- [x] Risk assessed — low, opt-in, backwards-compatible
- [x] No Greptile comments to resolve at time of opening

Closes #2682