### PR TITLE
feat: emit agent run lifecycle events for plugin consumption

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -19,6 +19,7 @@ import {
 import { conflict, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
+import { logActivity } from "./activity-log.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
 import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
@@ -2663,6 +2664,24 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
+      // ── Emit agent.run.started plugin event ─────────────────
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "system",
+        actorId: "heartbeat",
+        action: "agent.run.started",
+        entityType: "agent",
+        entityId: agent.id,
+        agentId: agent.id,
+        runId: run.id,
+        details: {
+          agentName: agent.name,
+          issueId: issueId ?? null,
+          projectId: executionProjectId ?? null,
+          wakeReason: readNonEmptyString(context.wakeReason) ?? null,
+        },
+      }).catch(() => {});
+
       const adapterResult = await adapter.execute({
         runId: run.id,
         agent,
@@ -2866,6 +2885,37 @@ export function heartbeatService(db: Db) {
         }
       }
       await finalizeAgentStatus(agent.id, outcome);
+
+      // ── Emit agent.run.finished/failed/cancelled plugin event ──
+      const runEventAction =
+        outcome === "succeeded"
+          ? "agent.run.finished"
+          : outcome === "failed"
+            ? "agent.run.failed"
+            : "agent.run.cancelled";
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "system",
+        actorId: "heartbeat",
+        action: runEventAction,
+        entityType: "agent",
+        entityId: agent.id,
+        agentId: agent.id,
+        runId: run.id,
+        details: {
+          agentName: agent.name,
+          issueId: issueId ?? null,
+          projectId: executionProjectId ?? null,
+          wakeReason: readNonEmptyString(context.wakeReason) ?? null,
+          exitCode: adapterResult.exitCode ?? null,
+          durationMs: Date.now() - startedAt.getTime(),
+          model: readNonEmptyString(adapterResult.model) ?? null,
+          costUsd: adapterResult.costUsd ?? null,
+          inputTokens: normalizedUsage?.inputTokens ?? null,
+          outputTokens: normalizedUsage?.outputTokens ?? null,
+          summary: adapterResult.summary ?? null,
+        },
+      }).catch(() => {});
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",
@@ -2905,6 +2955,27 @@ export function heartbeatService(db: Db) {
           message,
         });
         await releaseIssueExecutionAndPromote(failedRun);
+
+        // ── Emit agent.run.failed plugin event (exception path) ──
+        await logActivity(db, {
+          companyId: agent.companyId,
+          actorType: "system",
+          actorId: "heartbeat",
+          action: "agent.run.failed",
+          entityType: "agent",
+          entityId: agent.id,
+          agentId: agent.id,
+          runId: run.id,
+          details: {
+            agentName: agent.name,
+            issueId: issueId ?? null,
+            projectId: executionProjectId ?? null,
+            wakeReason: readNonEmptyString(context.wakeReason) ?? null,
+            exitCode: null,
+            durationMs: run.startedAt ? Date.now() - run.startedAt.getTime() : null,
+            error: message,
+          },
+        }).catch(() => {});
 
         await updateRuntimeState(agent, failedRun, {
           exitCode: null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend Paperclip by subscribing to domain events via the event bus
> - The plugin spec declares 4 agent run lifecycle events (started/finished/failed/cancelled)
> - But these events were never actually emitted from the heartbeat service
> - So plugins that subscribe to run lifecycle events (like memory or audit trail plugins) never receive them
> - This PR adds logActivity() calls at the correct points in heartbeat.ts executeRun()
> - The existing logActivity → plugin event bus auto-dispatch handles the rest
> - Plugins can now react to agent run start/completion in real-time

## What changed

Added `logActivity()` calls to `executeRun()` in `server/src/services/heartbeat.ts` (1 file, 71 insertions):

1. **`agent.run.started`** — emitted just before `adapter.execute()`, after all context/workspace setup is complete
2. **`agent.run.finished`** — emitted when outcome is `"succeeded"`, after status is finalized
3. **`agent.run.failed`** — emitted when outcome is `"failed"` (both graceful exit-code path and exception catch path)
4. **`agent.run.cancelled`** — emitted when outcome is `"cancelled"` or `"timed_out"`

All calls are fire-and-forget (`.catch(() => {})`) so they cannot break run execution.

## Event payload

**All events include:** `agentId`, `agentName`, `runId`, `companyId`, `issueId`, `projectId`, `wakeReason`

**Post-run events also include:** `exitCode`, `durationMs`, `model`, `costUsd`, `inputTokens`, `outputTokens`, `summary`

## Why this matters

This enables plugins to:
- **Capture run results** for memory/knowledge systems (post-run extraction)
- **Build audit trails** of agent activity
- **Track performance metrics** (duration, cost, token usage per run)
- **Coordinate multi-agent workflows** (react when one agent completes)

This aligns with the planned [Memory Service Hook Model](https://github.com/paperclipai/paperclip/blob/master/doc/plans/2026-03-17-memory-service-surface-api.md) which specifies `pre-run hydrate` and `post-run capture` as automatic hooks.

## How to verify

1. Install a plugin that subscribes to `agent.run.started` / `agent.run.finished`
2. Assign an issue to an agent and wait for heartbeat execution
3. Verify the plugin receives both events with correct payload
4. Check `activity_log` table for new rows with actions `agent.run.started` / `agent.run.finished`

## Risks

- **Minimal** — all calls are non-blocking and wrapped in `.catch(() => {})`
- No new dependencies, types, or infrastructure
- Uses the exact same `logActivity` → event bus pattern used throughout the codebase
- No behavior change for existing adapters or plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)