### PR TITLE
fix(ui): preserve skill sync when changing adapter type

### DIFF
--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -258,10 +258,15 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
         "env",
         "promptTemplate",
         "instructionsFilePath",
+        "instructionsRootPath",
+        "instructionsEntryFile",
+        "instructionsBundleMode",
         "cwd",
         "timeoutSec",
         "graceSec",
         "bootstrapPromptTemplate",
+        // Skill selections are stored on adapterConfig for all local adapters; preserve across adapter switches.
+        "paperclipSkillSync",
       ];
       const preserved: Record<string, unknown> = {};
       for (const key of adapterAgnosticKeys) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The UI agent edit form rebuilds `adapterConfig` when the operator changes adapter type
> - Only a small allowlist of keys was copied from the previous config, so shared fields were dropped on save
> - `paperclipSkillSync` (stored `desiredSkills`) and managed instruction bundle paths were not preserved
> - Operators lost skill selections and instruction paths after switching adapters (e.g. Cursor → Codex) even though those settings are adapter-agnostic
> - This pull request extends the preserved-key allowlist in `AgentConfigForm` `handleSave` when `adapterType` changes
> - The benefit is skill sync and instruction bundle settings survive adapter switches without manual re-entry

## What Changed

- Preserve `paperclipSkillSync` when changing adapter type in `AgentConfigForm` `handleSave`
- Preserve `instructionsRootPath`, `instructionsEntryFile`, and `instructionsBundleMode` the same way

## Verification

- Manual: edit an agent with skills selected, switch adapter (e.g. Cursor → Codex), save, reload — `desiredSkills` should remain in `adapter_config`
- No new automated tests (no existing `AgentConfigForm` unit coverage)

## Risks

- Low risk: only expands which keys are copied from the prior config; does not change adapter-specific defaults behavior

## Model Used

Cursor-assisted development (exact model ID not recorded).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
