### PR TITLE
fix(ui): persist skip-permissions toggles for imported agents

### DIFF
--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -103,7 +103,7 @@ export function ClaudeLocalAdvancedFields({
             : eff(
                 "adapterConfig",
                 "dangerouslySkipPermissions",
-                config.dangerouslySkipPermissions !== false,
+                config.dangerouslySkipPermissions === true,
               )
         }
         onChange={(v) =>

--- a/ui/src/adapters/opencode-local/config-fields.tsx
+++ b/ui/src/adapters/opencode-local/config-fields.tsx
@@ -58,7 +58,7 @@ export function OpenCodeLocalConfigFields({
             : eff(
                 "adapterConfig",
                 "dangerouslySkipPermissions",
-                config.dangerouslySkipPermissions !== false,
+                config.dangerouslySkipPermissions === true,
               )
         }
         onChange={(v) =>

--- a/ui/src/adapters/skip-permissions-toggle.test.tsx
+++ b/ui/src/adapters/skip-permissions-toggle.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ClaudeLocalAdvancedFields } from "./claude-local/config-fields";
+import { OpenCodeLocalConfigFields } from "./opencode-local/config-fields";
+
+vi.mock("../../components/PathInstructionsModal", () => ({
+  ChoosePathButton: () => null,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => children,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../local-workspace-runtime-fields", () => ({
+  LocalWorkspaceRuntimeFields: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const editModeProps = {
+  mode: "edit" as const,
+  isCreate: false as const,
+  values: null,
+  set: null,
+  models: [],
+  hideInstructionsFile: false,
+};
+
+describe("skip permissions toggles", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("treats a missing Claude skip-permissions flag as disabled in edit mode", () => {
+    const mark = vi.fn();
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ClaudeLocalAdvancedFields
+          {...editModeProps}
+          adapterType="claude_local"
+          config={{}}
+          eff={(_group, _field, original) => original}
+          mark={mark}
+        />,
+      );
+    });
+
+    const toggles = Array.from(container.querySelectorAll('button[data-slot="toggle"]'));
+    const skipPermissionsToggle = toggles[1] as HTMLButtonElement | undefined;
+    expect(skipPermissionsToggle).toBeDefined();
+    expect(skipPermissionsToggle?.className).toContain("bg-muted");
+
+    act(() => {
+      skipPermissionsToggle?.click();
+    });
+
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "dangerouslySkipPermissions", true);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("treats a missing OpenCode skip-permissions flag as disabled in edit mode", () => {
+    const mark = vi.fn();
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <OpenCodeLocalConfigFields
+          {...editModeProps}
+          adapterType="opencode_local"
+          config={{}}
+          eff={(_group, _field, original) => original}
+          mark={mark}
+        />,
+      );
+    });
+
+    const toggle = container.querySelector('button[data-slot="toggle"]') as HTMLButtonElement | null;
+    expect(toggle).not.toBeNull();
+    expect(toggle?.className).toContain("bg-muted");
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "dangerouslySkipPermissions", true);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Thinking Path
Imported Claude/OpenCode agents can arrive without an explicit `dangerouslySkipPermissions` key in `adapterConfig`. The edit form currently treats a missing value as enabled, so the toggle renders green even though nothing is persisted. Because the UI already appears “on”, operators cannot create a meaningful dirty patch just by saving, and imported agents stay blocked behind permission prompts.

## What Changed
- treat missing `dangerouslySkipPermissions` values as disabled in edit mode for Claude and OpenCode config forms
- keep create-mode defaults unchanged
- add a focused UI regression test covering the missing-value edit path for both adapters

## Verification
- `pnpm exec vitest run ui/src/adapters/skip-permissions-toggle.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`

## Risks
- Existing agents that relied on the previous optimistic UI state will now correctly display the persisted value instead of assuming enabled when the key is absent
- This intentionally changes only edit-mode fallback behavior; it does not alter onboarding defaults or server-side adapter config defaults

## Model Used
GPT-5 Codex

## Checklist
- [x] Tests added or updated
- [x] Targeted verification completed
- [x] Behavior scoped to the reported bug

Closes #2676