### PR TITLE
fix(server): serialize comment cursor timestamps for after queries

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1017,6 +1017,64 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result?.description).toHaveLength(1200);
     expect(result?.description?.endsWith("—")).toBe(true);
   });
+  it("lists comments after an anchor comment without binding Date objects into the cursor query", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const secondCommentId = randomUUID();
+    const thirdCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cursor pagination issue",
+      status: "todo",
+      priority: "medium",
+      createdAt: new Date("2026-03-26T10:00:00.000Z"),
+      updatedAt: new Date("2026-03-26T10:00:00.000Z"),
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "first",
+        createdAt: new Date("2026-03-26T10:01:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:01:00.000Z"),
+      },
+      {
+        id: secondCommentId,
+        companyId,
+        issueId,
+        body: "second",
+        createdAt: new Date("2026-03-26T10:02:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:02:00.000Z"),
+      },
+      {
+        id: thirdCommentId,
+        companyId,
+        issueId,
+        body: "third",
+        createdAt: new Date("2026-03-26T10:03:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:03:00.000Z"),
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      afterCommentId: firstCommentId,
+      order: "asc",
+    });
+
+    expect(comments.map((comment) => comment.id)).toEqual([secondCommentId, thirdCommentId]);
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3136,15 +3136,17 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorCreatedAt =
+          anchor.createdAt instanceof Date ? anchor.createdAt.toISOString() : String(anchor.createdAt);
         conditions.push(
           order === "asc"
             ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
+                ${issueComments.createdAt} > ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} > ${anchor.id})
               )`
             : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
+                ${issueComments.createdAt} < ${anchorCreatedAt}
+                OR (${issueComments.createdAt} = ${anchorCreatedAt} AND ${issueComments.id} < ${anchor.id})
               )`,
         );
       }


### PR DESCRIPTION
## Thinking Path
`GET /api/issues/:id/comments?after=...&order=asc` resolves the anchor comment and then reuses its `createdAt` value inside a cursor predicate. Drizzle returns that field as a JavaScript `Date`, but the downstream postgres binding path here expects a serialized string/buffer value. That mismatch produces the reported 500 when agents poll for incremental comments.

## What Changed
- serialize the anchor comment timestamp before binding it into the cursor SQL predicate
- keep the existing cursor semantics intact for both ascending and descending pagination
- add an embedded-Postgres regression test covering `afterCommentId` comment listing in ascending order

## Verification
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts`
- `pnpm -r typecheck`

## Risks
- low: the change is scoped to cursor binding for comment pagination and does not alter comment shape or ordering rules
- the query now compares against a normalized ISO timestamp string instead of a raw `Date` object

## Model Used
GPT-5 Codex

## Checklist
- [x] Tests added or updated
- [x] Targeted verification completed
- [x] Behavior scoped to the reported bug

Closes #2612
Related: #2567