### PR TITLE
fix(ui): keep new goal dialog scrollable for long descriptions

### DIFF
--- a/ui/src/components/NewGoalDialog.test.tsx
+++ b/ui/src/components/NewGoalDialog.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NewGoalDialog } from "./NewGoalDialog";
+
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => ({
+    newGoalOpen: true,
+    newGoalDefaults: {},
+    closeNewGoal: () => {},
+  }),
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({
+    selectedCompanyId: "company-1",
+    selectedCompany: {
+      id: "company-1",
+      name: "Acme",
+    },
+  }),
+}));
+
+vi.mock("../api/goals", () => ({
+  goalsApi: {
+    list: vi.fn(async () => []),
+    create: vi.fn(async () => ({})),
+  },
+}));
+
+vi.mock("../api/assets", () => ({
+  assetsApi: {
+    uploadImage: vi.fn(async () => ({ contentPath: "/api/assets/test" })),
+  },
+}));
+
+vi.mock("./MarkdownEditor", () => ({
+  MarkdownEditor: ({
+    contentClassName,
+  }: {
+    contentClassName?: string;
+  }) => <div data-testid="goal-markdown-editor" className={contentClassName}>Editor</div>,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("NewGoalDialog", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("keeps long descriptions inside a bounded scrollable dialog body", async () => {
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <NewGoalDialog />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    const dialogContent = document.querySelector('[data-slot="dialog-content"]');
+    expect(dialogContent?.className).toContain("max-h-[calc(100dvh-2rem)]");
+    expect(dialogContent?.className).toContain("flex");
+    expect(dialogContent?.className).toContain("flex-col");
+
+    const descriptionWrapper = document.querySelector(".overflow-y-auto.min-h-0");
+    expect(descriptionWrapper).not.toBeNull();
+    expect(document.body.textContent).toContain("Create goal");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -116,7 +116,10 @@ export function NewGoalDialog() {
     >
       <DialogContent
         showCloseButton={false}
-        className={cn("p-0 gap-0", expanded ? "sm:max-w-2xl" : "sm:max-w-lg")}
+        className={cn(
+          "p-0 gap-0 flex flex-col max-h-[calc(100dvh-2rem)]",
+          expanded ? "sm:max-w-2xl h-[calc(100dvh-2rem)]" : "sm:max-w-lg",
+        )}
         onKeyDown={handleKeyDown}
       >
         {/* Header */}
@@ -168,14 +171,17 @@ export function NewGoalDialog() {
         </div>
 
         {/* Description */}
-        <div className="px-4 pb-2 overflow-y-auto max-h-[50vh]">
+        <div className={cn("px-4 pb-2 overflow-y-auto min-h-0", expanded && "flex-1")}>
           <MarkdownEditor
             ref={descriptionEditorRef}
             value={description}
             onChange={setDescription}
             placeholder="Add description..."
             bordered={false}
-            contentClassName={cn("text-sm text-muted-foreground", expanded ? "min-h-[220px]" : "min-h-[120px]")}
+            contentClassName={cn(
+              "text-sm text-muted-foreground pb-12",
+              expanded ? "min-h-[220px]" : "min-h-[120px]",
+            )}
             imageUploadHandler={async (file) => {
               const asset = await uploadDescriptionImage.mutateAsync(file);
               return asset.contentPath;
@@ -184,7 +190,7 @@ export function NewGoalDialog() {
         </div>
 
         {/* Property chips */}
-        <div className="flex items-center gap-1.5 px-4 py-2 border-t border-border flex-wrap">
+        <div className="flex items-center gap-1.5 px-4 py-2 border-t border-border flex-wrap shrink-0">
           {/* Status */}
           <Popover open={statusOpen} onOpenChange={setStatusOpen}>
             <PopoverTrigger asChild>
@@ -267,7 +273,7 @@ export function NewGoalDialog() {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end px-4 py-2.5 border-t border-border">
+        <div className="flex items-center justify-end px-4 py-2.5 border-t border-border shrink-0">
           <Button
             size="sm"
             disabled={!title.trim() || createGoal.isPending}


### PR DESCRIPTION
## Summary
- bound the new-goal dialog height to the viewport and keep it in a flex column layout
- make the description area the scrollable body so long markdown does not hide the action bar
- add a regression test covering the bounded, scrollable dialog structure

## Testing
- pnpm exec vitest run ui/src/components/NewGoalDialog.test.tsx
- pnpm --filter @paperclipai/ui typecheck

Closes #2631