### PR TITLE
fix(ui): hard-redirect expired authenticated sessions to auth

### DIFF
--- a/ui/src/components/CloudAccessGate.tsx
+++ b/ui/src/components/CloudAccessGate.tsx
@@ -1,8 +1,10 @@
 import { Navigate, Outlet, useLocation } from "@/lib/router";
+import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { accessApi } from "@/api/access";
 import { authApi } from "@/api/auth";
 import { healthApi } from "@/api/health";
+import { buildAuthRedirectPath } from "@/lib/auth-redirect";
 import { queryKeys } from "@/lib/queryKeys";
 
 function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: boolean }) {
@@ -72,6 +74,17 @@ export function CloudAccessGate() {
     retry: false,
   });
 
+  const authRedirectPath = isAuthenticatedMode && !sessionQuery.isLoading && !sessionQuery.data
+    ? buildAuthRedirectPath(location.pathname, location.search)
+    : null;
+
+  useEffect(() => {
+    if (!authRedirectPath) return;
+    const current = `${window.location.pathname}${window.location.search}`;
+    if (current === authRedirectPath) return;
+    window.location.replace(authRedirectPath);
+  }, [authRedirectPath]);
+
   if (
     healthQuery.isLoading ||
     (isAuthenticatedMode && sessionQuery.isLoading) ||
@@ -96,9 +109,8 @@ export function CloudAccessGate() {
     return <BootstrapPendingPage hasActiveInvite={healthQuery.data.bootstrapInviteActive} />;
   }
 
-  if (isAuthenticatedMode && !sessionQuery.data) {
-    const next = encodeURIComponent(`${location.pathname}${location.search}`);
-    return <Navigate to={`/auth?next=${next}`} replace />;
+  if (authRedirectPath) {
+    return <div className="mx-auto max-w-xl py-10 text-sm text-muted-foreground">Redirecting to sign in...</div>;
   }
 
   if (

--- a/ui/src/lib/auth-redirect.test.ts
+++ b/ui/src/lib/auth-redirect.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthRedirectPath } from "./auth-redirect";
+
+describe("buildAuthRedirectPath", () => {
+  it("preserves the current pathname and search in the next parameter", () => {
+    expect(buildAuthRedirectPath("/PAP/dashboard", "?tab=active&filter=mine")).toBe(
+      "/auth?next=%2FPAP%2Fdashboard%3Ftab%3Dactive%26filter%3Dmine",
+    );
+  });
+
+  it("handles routes without a search string", () => {
+    expect(buildAuthRedirectPath("/issues/123")).toBe("/auth?next=%2Fissues%2F123");
+  });
+});

--- a/ui/src/lib/auth-redirect.ts
+++ b/ui/src/lib/auth-redirect.ts
@@ -1,0 +1,4 @@
+export function buildAuthRedirectPath(pathname: string, search = ""): string {
+  const next = encodeURIComponent(`${pathname}${search}`);
+  return `/auth?next=${next}`;
+}


### PR DESCRIPTION
## Summary
- hard-redirect authenticated-mode users to `/auth` as soon as `/api/auth/get-session` confirms the session is gone
- preserve the current pathname and search string in the `next` parameter so users return to the same board route after signing back in
- add focused tests for auth redirect path construction

## Notes
- issue #2684 refers to `/login`, but the current app route is `/auth`; this change targets the current login route in `App.tsx`
- using `window.location.replace()` avoids getting stuck inside stale SPA state after server restarts or expired cookies

## Testing
- pnpm exec vitest run ui/src/lib/auth-redirect.test.ts
- pnpm --filter @paperclipai/ui typecheck

Closes #2684