### PR TITLE
fix(claude-local): disable native auto-memory with para memory

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -106,6 +106,44 @@ function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscri
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }
 
+function shouldDisableClaudeAutoMemory(desiredSkillNames: Iterable<string>): boolean {
+  for (const skillName of desiredSkillNames) {
+    const normalized = skillName.trim().toLowerCase();
+    if (!normalized) continue;
+    if (normalized === "para-memory-files" || normalized.endsWith("/para-memory-files")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function ensureClaudeAutoMemoryDisabled(baseDir: string): Promise<void> {
+  const claudeDir = path.join(baseDir, ".claude");
+  const settingsPath = path.join(claudeDir, "settings.json");
+  await fs.mkdir(claudeDir, { recursive: true });
+
+  let current: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(settingsPath, "utf8");
+    const parsed = parseJson(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      current = parsed;
+    }
+  } catch {
+    // Missing or unreadable settings files should not block the run; we rewrite below.
+  }
+
+  if (current.autoMemoryEnabled === false) {
+    return;
+  }
+
+  await fs.writeFile(
+    settingsPath,
+    `${JSON.stringify({ ...current, autoMemoryEnabled: false }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
   const { runId, agent, config, context, executionTarget, authToken } = input;
 
@@ -352,6 +390,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
+  if (shouldDisableClaudeAutoMemory(desiredSkillNames)) {
+    const claudeConfigRoots = new Set<string>([path.resolve(cwd)]);
+    const agentHomeDir = typeof env.AGENT_HOME === "string" && env.AGENT_HOME.trim().length > 0
+      ? path.resolve(env.AGENT_HOME)
+      : null;
+    if (agentHomeDir) claudeConfigRoots.add(agentHomeDir);
+
+    for (const rootDir of claudeConfigRoots) {
+      await ensureClaudeAutoMemoryDisabled(rootDir);
+    }
+  }
   // When instructionsFilePath is configured, build a stable content-addressed
   // file that includes both the file content and the path directive, so we only
   // need --append-system-prompt-file (Claude CLI forbids using both flags together).

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -167,6 +167,85 @@ describe("claude execute", () => {
     }
   });
 
+  it("disables Claude auto-memory when para-memory-files is active", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-auto-memory-"));
+    const workspace = path.join(root, "workspace");
+    const agentHome = path.join(root, "agent-home");
+    const binDir = path.join(root, "bin");
+    const commandPath = path.join(binDir, "claude");
+    const paraMemoryDir = path.join(root, "para-memory-files");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(agentHome, { recursive: true });
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.mkdir(paraMemoryDir, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    const previousPath = process.env.PATH;
+    process.env.HOME = root;
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+    try {
+      const result = await execute({
+        runId: "run-auto-memory",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "claude",
+          cwd: workspace,
+          paperclipRuntimeSkills: [
+            {
+              name: "para-memory-files",
+              source: paraMemoryDir,
+            },
+          ],
+          paperclipSkillSync: {
+            desiredSkills: ["para-memory-files"],
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            agentHome,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const workspaceSettings = JSON.parse(
+        await fs.readFile(path.join(workspace, ".claude", "settings.json"), "utf8"),
+      ) as { autoMemoryEnabled?: boolean };
+      const agentHomeSettings = JSON.parse(
+        await fs.readFile(path.join(agentHome, ".claude", "settings.json"), "utf8"),
+      ) as { autoMemoryEnabled?: boolean };
+
+      expect(workspaceSettings.autoMemoryEnabled).toBe(false);
+      expect(agentHomeSettings.autoMemoryEnabled).toBe(false);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("omits --append-system-prompt-file on a resumed session even when instructionsFile is set", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-resume-"));
     const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);


### PR DESCRIPTION
## Summary
- detect when `para-memory-files` is active for `claude_local` runs
- write `.claude/settings.json` with `autoMemoryEnabled: false` before launching Claude Code
- cover both the effective run cwd and `AGENT_HOME` when they differ
- add an execute-level regression test covering the new settings bootstrap

## Testing
- pnpm exec vitest run server/src/__tests__/claude-local-execute.test.ts
- pnpm -r typecheck

Closes #2671