### PR TITLE
fix(ui): clarify first-admin bootstrap invite flow

### DIFF
--- a/ui/src/components/CloudAccessGate.tsx
+++ b/ui/src/components/CloudAccessGate.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { accessApi } from "@/api/access";
 import { authApi } from "@/api/auth";
 import { healthApi } from "@/api/health";
+import { buildBootstrapPendingMessage } from "@/lib/bootstrap-copy";
 import { queryKeys } from "@/lib/queryKeys";
 
 function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: boolean }) {
@@ -10,11 +11,7 @@ function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: b
     <div className="mx-auto max-w-xl py-10">
       <div className="rounded-lg border border-border bg-card p-6">
         <h1 className="text-xl font-semibold">Instance setup required</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {hasActiveInvite
-            ? "No instance admin exists yet. A bootstrap invite is already active. Check your Paperclip startup logs for the first admin invite URL, or run this command to rotate it:"
-            : "No instance admin exists yet. Run this command in your Paperclip environment to generate the first admin invite URL:"}
-        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{buildBootstrapPendingMessage(hasActiveInvite)}</p>
         <pre className="mt-4 overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
 {`pnpm paperclipai auth bootstrap-ceo`}
         </pre>

--- a/ui/src/lib/bootstrap-copy.test.ts
+++ b/ui/src/lib/bootstrap-copy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { buildBootstrapPendingMessage } from "./bootstrap-copy";
+
+describe("buildBootstrapPendingMessage", () => {
+  it("explains that an existing invite must be accepted in the browser", () => {
+    expect(buildBootstrapPendingMessage(true)).toContain("finish setup in the browser");
+    expect(buildBootstrapPendingMessage(true)).toContain("rotate the invite");
+  });
+
+  it("explains that the command only generates the invite URL", () => {
+    expect(buildBootstrapPendingMessage(false)).toContain("generate the first-admin invite URL");
+    expect(buildBootstrapPendingMessage(false)).toContain("open that invite in the browser");
+  });
+});

--- a/ui/src/lib/bootstrap-copy.ts
+++ b/ui/src/lib/bootstrap-copy.ts
@@ -1,0 +1,7 @@
+export function buildBootstrapPendingMessage(hasActiveInvite: boolean) {
+  if (hasActiveInvite) {
+    return "No instance admin exists yet. A bootstrap invite is already active. Use the existing first-admin invite URL to finish setup in the browser, or run this command to rotate the invite if you no longer have that URL:";
+  }
+
+  return "No instance admin exists yet. Run this command in your Paperclip environment to generate the first-admin invite URL, then open that invite in the browser to finish setup:";
+}


### PR DESCRIPTION
## Summary
- clarify that `paperclipai auth bootstrap-ceo` generates or rotates the first-admin invite URL but does not finish setup by itself
- tell operators that setup completes only after the invite is opened and accepted in the browser
- make the existing-invite state and the rotate-invite fallback clearer for appliance / hosted operators
- add a focused copy test for both bootstrap states

## Testing
- pnpm exec vitest run ui/src/lib/bootstrap-copy.test.ts
- pnpm --filter @paperclipai/ui typecheck

Partial fix for #2579