### PR TITLE
Add plugin discovery entry to the dashboard

### DIFF
--- a/ui/src/components/PluginDiscoveryCard.test.tsx
+++ b/ui/src/components/PluginDiscoveryCard.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginDiscoveryCard, getPluginDiscoveryDescription } from "./PluginDiscoveryCard";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, className, to, ...props }: ComponentProps<"a"> & { to?: string }) => (
+    <a className={className} href={to} {...props}>{children}</a>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("getPluginDiscoveryDescription", () => {
+  it("highlights bundled examples when no plugins are installed", () => {
+    expect(getPluginDiscoveryDescription(0, 3)).toContain("3 bundled examples");
+  });
+
+  it("highlights installed plugins when plugins are already active", () => {
+    expect(getPluginDiscoveryDescription(2, 1)).toContain("2 installed");
+  });
+});
+
+describe("PluginDiscoveryCard", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("links directly to Plugin Manager from the dashboard card", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<PluginDiscoveryCard installedCount={1} exampleCount={2} />);
+    });
+
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("/instance/settings/plugins");
+    expect(container.textContent).toContain("Discover and manage plugins");
+    expect(container.textContent).toContain("1 installed");
+    expect(container.textContent).toContain("2 bundled examples");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/PluginDiscoveryCard.tsx
+++ b/ui/src/components/PluginDiscoveryCard.tsx
@@ -1,0 +1,56 @@
+import { ArrowUpRight, Puzzle } from "lucide-react";
+import { Link } from "@/lib/router";
+
+interface PluginDiscoveryCardProps {
+  installedCount?: number;
+  exampleCount?: number;
+}
+
+export function getPluginDiscoveryDescription(installedCount?: number, exampleCount?: number): string {
+  if ((installedCount ?? 0) > 0) {
+    if ((exampleCount ?? 0) > 0) {
+      return `${installedCount} installed. ${exampleCount} bundled examples are also available to browse and install.`;
+    }
+    return `${installedCount} installed. Open Plugin Manager to configure, enable, disable, or install more plugins.`;
+  }
+
+  if ((exampleCount ?? 0) > 0) {
+    return `${exampleCount} bundled examples are ready to browse and install from Plugin Manager.`;
+  }
+
+  return "Browse available plugins, install them from the UI, and manage enable or disable state from Plugin Manager.";
+}
+
+export function PluginDiscoveryCard({ installedCount, exampleCount }: PluginDiscoveryCardProps) {
+  return (
+    <Link
+      to="/instance/settings/plugins"
+      className="group block rounded-xl border border-border bg-card p-5 text-inherit no-underline shadow-sm transition-colors hover:bg-accent/30"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="rounded-lg border border-border/70 bg-background/80 p-2 text-muted-foreground">
+              <Puzzle className="h-4 w-4" />
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="font-medium uppercase tracking-wide">Plugins</span>
+              <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                Alpha
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold text-foreground">Discover and manage plugins</h3>
+            <p className="text-sm leading-6 text-muted-foreground">
+              {getPluginDiscoveryDescription(installedCount, exampleCount)}
+            </p>
+          </div>
+        </div>
+
+        <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+      </div>
+    </Link>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import { accessApi } from "../api/access";
 import { issuesApi } from "../api/issues";
 import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
+import { pluginsApi } from "../api/plugins";
 import { buildCompanyUserProfileMap } from "../lib/company-members";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
@@ -24,6 +25,7 @@ import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle }
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
+import { PluginDiscoveryCard } from "../components/PluginDiscoveryCard";
 import type { Agent, Issue } from "@paperclipai/shared";
 import { PluginSlotOutlet } from "@/plugins/slots";
 
@@ -81,6 +83,16 @@ export function Dashboard() {
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
     queryFn: () => accessApi.listUserDirectory(selectedCompanyId!),
     enabled: !!selectedCompanyId,
+  });
+
+  const { data: plugins } = useQuery({
+    queryKey: queryKeys.plugins.all,
+    queryFn: () => pluginsApi.list(),
+  });
+
+  const { data: pluginExamples } = useQuery({
+    queryKey: queryKeys.plugins.examples,
+    queryFn: () => pluginsApi.listExamples(),
   });
 
   const userProfileMap = useMemo(
@@ -311,6 +323,11 @@ export function Dashboard() {
             context={{ companyId: selectedCompanyId }}
             className="grid gap-4 md:grid-cols-2"
             itemClassName="rounded-lg border bg-card p-4 shadow-sm"
+          />
+
+          <PluginDiscoveryCard
+            installedCount={plugins?.length}
+            exampleCount={pluginExamples?.length}
           />
 
           <div className="grid md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- add a dedicated plugin discovery card to the dashboard
- surface installed plugin and bundled example counts in the entry copy
- add a focused UI test for the new dashboard discovery card

## Testing
- pnpm exec vitest run ui/src/components/PluginDiscoveryCard.test.tsx
- pnpm --filter @paperclipai/ui typecheck

Closes #2678