### PR TITLE
fix: allow Vite dev middleware to serve public-exposure hostnames

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -275,7 +275,11 @@ export async function createApp(
           port: hmrPort,
           clientPort: hmrPort,
         },
-        allowedHosts: privateHostnameGateEnabled ? Array.from(privateHostnameAllowSet) : undefined,
+        allowedHosts: privateHostnameGateEnabled
+          ? Array.from(privateHostnameAllowSet)
+          : opts.deploymentExposure === "public"
+            ? true
+            : undefined,
       },
     });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The server supports three deployment modes: local_trusted, authenticated/private, and authenticated/public
> - In dev, the UI is served via Vite dev middleware (`createViteServer` with `middlewareMode`)
> - Vite 6.x introduced strict hostname checking that blocks non-localhost Host headers by default
> - When deploying in authenticated/public mode behind a reverse proxy (e.g. Caddy, nginx), browser requests arrive with the public hostname (e.g. `paperclip.example.com`), not `localhost`
> - The current code only passes `allowedHosts` to Vite for `private` exposure, leaving `public` exposure with Vite's default restrictive behavior — causing a 403 for all UI requests
> - This pull request sets `allowedHosts: true` for public exposure mode, since public mode is explicitly internet-facing and the reverse proxy handles host validation
> - The benefit is that authenticated/public deployments behind a reverse proxy can serve the UI without Vite blocking the hostname

## What Changed

- In `server/src/app.ts`, updated the Vite `server.allowedHosts` config to set `true` (allow all hosts) when `deploymentExposure === "public"`, matching the expectation that public-mode deployments use a reverse proxy for host-level security

## Verification

1. Deploy Paperclip in `authenticated/public` mode
2. Place it behind a reverse proxy (Caddy/nginx) with a public hostname
3. Access the UI via the public hostname — should load without 403
4. Verify `local_trusted` and `authenticated/private` modes are unaffected (private still uses the explicit allowSet, local_trusted uses Vite defaults)

## Risks

- Low risk. Only affects the Vite dev middleware `allowedHosts` setting in `public` exposure mode. Public mode explicitly assumes an internet-facing proxy, so relaxing Vite's hostname check is appropriate. No change to private or local_trusted modes.

## Model Used

- Claude Opus 4.6 (1M context) via Claude Code CLI, with tool use and extended reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)