### PR TITLE
fix(ui): truncate long agent names in Kanban card

### DIFF
--- a/ui/src/components/Identity.tsx
+++ b/ui/src/components/Identity.tsx
@@ -33,7 +33,7 @@ export function Identity({ name, avatarUrl, initials, size = "default", classNam
         {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
         <AvatarFallback>{displayInitials}</AvatarFallback>
       </Avatar>
-      <span className={cn("truncate", textSize[size])}>{name}</span>
+      <span className={cn("truncate", textSize[size])} title={name}>{name}</span>
     </span>
   );
 }

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -160,12 +160,12 @@ function KanbanCard({
           )}
         </div>
         <p className="text-sm leading-snug line-clamp-2 mb-2">{issue.title}</p>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <PriorityIcon priority={issue.priority} />
           {issue.assigneeAgentId && (() => {
             const name = agentName(issue.assigneeAgentId);
             return name ? (
-              <Identity name={name} size="xs" />
+              <Identity name={name} size="xs" className="min-w-0" />
             ) : (
               <span className="text-xs text-muted-foreground font-mono">
                 {issue.assigneeAgentId.slice(0, 8)}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The board/Kanban view shows task cards with agent names in fixed-width (260px) columns
> - Long agent names (e.g. "QA and Repo Compliance Engineer") overflow the card boundary
> - The Identity component already has a `truncate` class but it never activates because parent flex containers lack `min-w-0`
> - This pull request adds `min-w-0` to the metadata row and Identity wrapper so truncation works correctly
> - The benefit is consistent card layout regardless of agent name length, with full name available on hover

## What Changed

- Added `min-w-0` to the bottom metadata flex row in `KanbanCard` so flex children can shrink
- Passed `className="min-w-0"` to the `Identity` component inside `KanbanCard` to allow the existing `truncate` class to activate
- Added `title` attribute to the name span in `Identity.tsx` so the full agent name appears on hover as a tooltip

## Verification

**Before:**

<img width="730" height="286" alt="image" src="https://github.com/user-attachments/assets/99af83fb-c4f4-4dea-aebe-d0c7eb959dec" />

**After:**

<img width="546" height="222" alt="image" src="https://github.com/user-attachments/assets/5591d3ab-038c-4fed-b4c4-af202590604e" />

- Long agent names (e.g. "QA and Repo Compliance Engineer") are now truncated with ellipsis inside Kanban cards
- Hovering over a truncated name shows the full name via native tooltip
- Short agent names render unchanged
- PriorityIcon retains its natural size and is never squished
- Existing tests pass (861 passed, 2 pre-existing failures unrelated to this change)

## Risks

Low risk. Only adds standard Tailwind utility classes (`min-w-0`) and a native HTML `title` attribute. No behavioral or data changes.

## Model Used

None — human-authored

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and domented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #2711