### PR TITLE
feat(server): global adapter concurrency limiter and heartbeat timer jitter

### DIFF
--- a/server/src/__tests__/heartbeat-scaling-config.test.ts
+++ b/server/src/__tests__/heartbeat-scaling-config.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfig } from "../config.js";
+
+const ENV_KEYS = [
+  "HEARTBEAT_MAX_CONCURRENT_ADAPTER_EXECUTIONS",
+  "HEARTBEAT_TIMER_JITTER_MS",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+});
+
+describe("heartbeat scaling config", () => {
+  it("defaults global adapter concurrency and timer jitter controls to disabled", () => {
+    delete process.env.HEARTBEAT_MAX_CONCURRENT_ADAPTER_EXECUTIONS;
+    delete process.env.HEARTBEAT_TIMER_JITTER_MS;
+
+    const config = loadConfig();
+
+    expect(config.heartbeatMaxConcurrentAdapterExecutions).toBe(0);
+    expect(config.heartbeatTimerJitterMs).toBe(0);
+  });
+
+  it("parses non-negative heartbeat scaling controls from env", () => {
+    process.env.HEARTBEAT_MAX_CONCURRENT_ADAPTER_EXECUTIONS = "7";
+    process.env.HEARTBEAT_TIMER_JITTER_MS = "1250";
+
+    const config = loadConfig();
+
+    expect(config.heartbeatMaxConcurrentAdapterExecutions).toBe(7);
+    expect(config.heartbeatTimerJitterMs).toBe(1250);
+  });
+
+  it("clamps negative heartbeat scaling controls to disabled", () => {
+    process.env.HEARTBEAT_MAX_CONCURRENT_ADAPTER_EXECUTIONS = "-5";
+    process.env.HEARTBEAT_TIMER_JITTER_MS = "-100";
+
+    const config = loadConfig();
+
+    expect(config.heartbeatMaxConcurrentAdapterExecutions).toBe(0);
+    expect(config.heartbeatTimerJitterMs).toBe(0);
+  });
+});

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,6 +85,8 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  heartbeatMaxConcurrentAdapterExecutions: number;
+  heartbeatTimerJitterMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -331,6 +333,10 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    /** Maximum number of adapter executions (LLM calls) that may run concurrently across all agents. 0 = unlimited. */
+    heartbeatMaxConcurrentAdapterExecutions: Math.max(0, Number(process.env.HEARTBEAT_MAX_CONCURRENT_ADAPTER_EXECUTIONS) || 0),
+    /** Maximum random jitter (in ms) added to each agent's heartbeat interval to spread wakeups. 0 = disabled. */
+    heartbeatTimerJitterMs: Math.max(0, Number(process.env.HEARTBEAT_TIMER_JITTER_MS) || 0),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -39,6 +39,7 @@ import {
   backfillPrincipalAccessCompatibility,
   bootstrapExecutionPolicyFromEnv,
   heartbeatService,
+  initHeartbeatScaling,
   instanceSettingsService,
   reconcileCloudUpstreamRunsOnStartup,
   reconcilePersistedRuntimeServicesOnStartup,
@@ -749,6 +750,8 @@ export async function startServer(): Promise<StartedServer> {
     logger.error({ err }, "failed to apply forced execution policy from environment");
     throw err;
   }
+
+  initHeartbeatScaling(config.heartbeatMaxConcurrentAdapterExecutions, config.heartbeatTimerJitterMs);
 
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -226,6 +226,60 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+
+// ---------------------------------------------------------------------------
+// Global adapter execution semaphore – limits how many adapter.execute() calls
+// (i.e. LLM inference requests) run concurrently across all agents. When the
+// limit is reached, new executions wait in a FIFO queue until a slot frees up.
+// This prevents GPU/API saturation when many agents fire simultaneously.
+// ---------------------------------------------------------------------------
+class AdapterSemaphore {
+  private _max: number;
+  private _running = 0;
+  private _queue: Array<() => void> = [];
+
+  constructor(max: number) {
+    this._max = max;
+  }
+
+  get max() { return this._max; }
+  get running() { return this._running; }
+  get queued() { return this._queue.length; }
+
+  async acquire(): Promise<void> {
+    if (this._max <= 0) return; // unlimited
+    if (this._running < this._max) {
+      this._running++;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this._queue.push(() => {
+        this._running++;
+        resolve();
+      });
+    });
+  }
+
+  release(): void {
+    if (this._max <= 0) return; // unlimited
+    this._running--;
+    const next = this._queue.shift();
+    if (next) next();
+  }
+}
+
+let adapterSemaphore: AdapterSemaphore | null = null;
+let heartbeatTimerJitterMs = 0;
+
+/**
+ * Initialise global heartbeat scaling controls. Call once at startup.
+ * @param maxConcurrentAdapterExecutions  Max concurrent adapter.execute() calls (0 = unlimited).
+ * @param timerJitterMs  Max random jitter added to each agent's heartbeat interval to spread wakeups (0 = disabled).
+ */
+export function initHeartbeatScaling(maxConcurrentAdapterExecutions: number, timerJitterMs: number) {
+  adapterSemaphore = new AdapterSemaphore(maxConcurrentAdapterExecutions);
+  heartbeatTimerJitterMs = Math.max(0, timerJitterMs);
+}
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -8997,7 +9051,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
 
       let adapterResult: Awaited<ReturnType<typeof adapter.execute>>;
+
+      let semaphoreAcquired = false;
       try {
+        // Acquire a slot from the global adapter semaphore before invoking the
+        // adapter. This prevents GPU/API saturation when many agents wake up in
+        // the same scheduler tick.
+        if (adapterSemaphore) {
+          await adapterSemaphore.acquire();
+          semaphoreAcquired = true;
+        }
         adapterResult = await adapter.execute({
           runId: run.id,
           agent,
@@ -9047,6 +9110,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           );
         }
         throw adapterErr;
+      } finally {
+        if (semaphoreAcquired && adapterSemaphore) adapterSemaphore.release();
       }
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
@@ -11495,7 +11560,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         checked += 1;
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
-        if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        // When jitter is enabled, add a stable per-agent offset derived from
+        // the agent ID so that agents with the same interval don't all fire on
+        // the same scheduler tick.  The offset is deterministic (not random) so
+        // that repeated ticks for the same agent produce the same threshold –
+        // this prevents starvation while still spreading the load.
+        let jitterMs = 0;
+        if (heartbeatTimerJitterMs > 0) {
+          let hash = 0;
+          for (let i = 0; i < agent.id.length; i++) {
+            hash = ((hash << 5) - hash + agent.id.charCodeAt(i)) | 0;
+          }
+          jitterMs = Math.abs(hash) % heartbeatTimerJitterMs;
+        }
+
+        if (elapsedMs < policy.intervalSec * 1000 + jitterMs) continue;
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -35,7 +35,7 @@ export { secretService } from "./secrets.js";
 export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
-export { heartbeatService } from "./heartbeat.js";
+export { heartbeatService, initHeartbeatScaling } from "./heartbeat.js";
 export {
   productivityReviewService,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies where many agents can run against shared local or remote adapter infrastructure.
> - The heartbeat subsystem is responsible for timer wakeups, manual wakeups, queued run recovery, and adapter execution.
> - Operators running many agents against one local LLM/GPU backend can create a thundering herd when heartbeats fire on the same scheduler tick.
> - Existing per-agent concurrency protects individual agents, but it does not cap aggregate adapter execution across all agents.
> - This pull request adds opt-in global adapter execution concurrency and deterministic per-agent timer jitter, both disabled by default.
> - The benefit is safer high-agent-count operation without changing default behavior for existing instances.

## Linked Issues or Issue Description

Subsystem affected: server/ — REST API & orchestration services

Problem or motivation:
Operators running 50+ agents against a shared LLM backend need a way to reduce simultaneous adapter executions and spread timer-triggered heartbeat wakeups. Many agents with the same heartbeat interval can wake together, and shared local GPU/API backends can saturate when too many adapter executions start at once.

Proposed solution:
Add environment-level controls that can be tuned without code changes. Default behavior remains unchanged. Setting a global adapter execution cap queues excess adapter executions FIFO, and setting timer jitter spreads heartbeat timer eligibility by a stable per-agent offset.

Alternatives considered:
Per-agent concurrency already exists, but it does not cap aggregate backend pressure across all agents. Random jitter was avoided because a stable per-agent offset spreads wakeups without starvation or inconsistent eligibility between ticks.

Roadmap alignment:
This is server orchestration hardening for high-agent-count deployments. It does not duplicate a specific ROADMAP.md item.

Additional context:
The controls are opt-in and default to disabled for backwards compatibility.

## What Changed

- Added `HEARTBEAT_MAX_CONCURRENT_ADAPTER_EXECUTIONS` config, defaulting to `0` for unlimited.
- Added `HEARTBEAT_TIMER_JITTER_MS` config, defaulting to `0` for disabled.
- Added a global FIFO semaphore around adapter execution, initialized at startup regardless of scheduler state so manual wakeups are capped too.
- Added deterministic per-agent heartbeat timer jitter derived from agent ID.
- Exported the heartbeat scaling initializer through service exports.
- Added config tests covering defaults, env parsing, and negative-value clamping.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm vitest run server/src/__tests__/heartbeat-scaling-config.test.ts server/src/__tests__/heartbeat-start-lock.test.ts server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts server/src/__tests__/heartbeat-retry-scheduling.test.ts server/src/__tests__/heartbeat-runtime-state.test.ts`

## Risks

- Low default risk: both controls default to disabled.
- If an operator sets the global concurrency cap too low, adapter executions can queue and increase run latency.
- Timer jitter is additive and can delay timer-triggered wakeups by up to `HEARTBEAT_TIMER_JITTER_MS - 1` ms.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, coding-agent tool use, conflict resolution and local validation. Original PR content was Claude-assisted per commit metadata.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
