### PR TITLE
fix: run openclaw-smoke container as non-root user

### DIFF
--- a/docker/openclaw-smoke/Dockerfile
+++ b/docker/openclaw-smoke/Dockerfile
@@ -3,6 +3,7 @@ FROM node:22-alpine
 RUN addgroup -S smoke && adduser -S smoke -G smoke
 
 WORKDIR /app
+RUN chown smoke:smoke /app
 COPY --chown=smoke:smoke server.mjs /app/server.mjs
 
 USER smoke

--- a/docker/openclaw-smoke/Dockerfile
+++ b/docker/openclaw-smoke/Dockerfile
@@ -1,7 +1,11 @@
 FROM node:22-alpine
 
+RUN addgroup -S smoke && adduser -S smoke -G smoke
+
 WORKDIR /app
-COPY server.mjs /app/server.mjs
+COPY --chown=smoke:smoke server.mjs /app/server.mjs
+
+USER smoke
 
 EXPOSE 8787
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Docker images are used for deployment and smoke testing
> - The openclaw-smoke Dockerfile runs its container as root
> - The server.mjs inside only listens on port 8787 for webhook events — it has zero root requirements
> - Running containers as root violates the principle of least privilege and is flagged by container security scanners
> - This pull request adds a dedicated non-root `smoke` user to the openclaw-smoke Dockerfile
> - The benefit is reduced attack surface if the container is compromised, and alignment with the non-root patterns already used in `Dockerfile.onboard-smoke` (USER paperclip) and `untrusted-review/Dockerfile` (USER reviewer)

## What Changed

- Added a dedicated `smoke` system user/group to `docker/openclaw-smoke/Dockerfile`
- Changed `COPY` to use `--chown=smoke:smoke` for correct file ownership
- Added `USER smoke` directive before `EXPOSE` and `CMD`

## Verification

- Build the image: `docker build -t openclaw-smoke-test docker/openclaw-smoke/`
- Run it: `docker run --rm -p 8787:8787 openclaw-smoke-test`
- Confirm it starts: `curl http://localhost:8787/health` should return `{"ok":true,...}`
- Confirm non-root: `docker run --rm openclaw-smoke-test whoami` should return `smoke`

## Risks

- Low risk. The server.mjs binds to port 8787 (>1024), so no privileged port binding is needed. The change is consistent with the existing non-root patterns in the other Dockerfiles.

## Model Used

- Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code CLI, standard reasoning mode with tool use

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge