### PR TITLE
feat(docker): add server health check and restart policy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,13 @@ services:
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3100/api/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
     volumes:
       - paperclip-data:/paperclip
     depends_on:


### PR DESCRIPTION
## Summary

- Add HTTP health check for the server container using the `/api/health/` endpoint (30s interval, 10s timeout, 3 retries, 40s start period)
- Add `restart: unless-stopped` to server service for automatic crash recovery

## Changed file

`docker/docker-compose.yml` — 7 lines added (healthcheck block + restart policy)

## Rollback

Remove the `healthcheck:` and `restart:` keys from the server service in `docker/docker-compose.yml`.

## Test plan

- [ ] `docker compose config --quiet` validates syntax
- [ ] Server container reports healthy after startup via `docker compose ps`
- [ ] Container auto-restarts after `docker kill`