### PR TITLE
fix(#2671): disable Claude auto-memory when para-memory-files is active

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -32,6 +32,76 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const PARA_MEMORY_FILES_SKILL_SLUG = "para-memory-files";
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isParaMemoryFilesSkillEntry(entry: { key: string; runtimeName: string }): boolean {
+  return (
+    entry.runtimeName.trim().toLowerCase() === PARA_MEMORY_FILES_SKILL_SLUG ||
+    entry.key.trim().toLowerCase().endsWith(`/${PARA_MEMORY_FILES_SKILL_SLUG}`)
+  );
+}
+
+async function hasActiveParaMemoryFilesSkill(config: Record<string, unknown>): Promise<boolean> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredNames = new Set(resolveClaudeDesiredSkillNames(config, availableEntries));
+  return availableEntries.some((entry) => desiredNames.has(entry.key) && isParaMemoryFilesSkillEntry(entry));
+}
+
+async function ensureClaudeAutoMemoryDisabled(projectRoot: string): Promise<void> {
+  const settingsPath = path.join(projectRoot, ".claude", "settings.json");
+  const currentPayload = await fs.readFile(settingsPath, "utf8").catch((err: unknown) => {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return null;
+    throw err;
+  });
+
+  let nextSettings: Record<string, unknown> = {};
+  if (currentPayload !== null) {
+    try {
+      const parsed = JSON.parse(currentPayload);
+      if (isPlainRecord(parsed)) {
+        nextSettings = { ...parsed };
+      }
+    } catch {
+      nextSettings = {};
+    }
+  }
+
+  if (currentPayload !== null && nextSettings.autoMemoryEnabled === false) {
+    return;
+  }
+
+  nextSettings.autoMemoryEnabled = false;
+  const nextPayload = `${JSON.stringify(nextSettings, null, 2)}
+`;
+  if (currentPayload === nextPayload) {
+    return;
+  }
+
+  await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+  const existing = await fs.lstat(settingsPath).catch(() => null);
+  if (existing && (existing.isSymbolicLink() || !existing.isFile())) {
+    await fs.rm(settingsPath, { recursive: true, force: true });
+  }
+  await fs.writeFile(settingsPath, nextPayload, "utf8");
+}
+
+async function ensureClaudeAutoMemoryDisabledForRun(cwd: string, agentHome?: string | null): Promise<void> {
+  const targets = [path.resolve(cwd)];
+  if (typeof agentHome === "string" && agentHome.trim().length > 0) {
+    const resolvedAgentHome = path.resolve(agentHome);
+    if (resolvedAgentHome !== targets[0]) {
+      targets.push(resolvedAgentHome);
+    }
+  }
+
+  for (const target of targets) {
+    await ensureClaudeAutoMemoryDisabled(target);
+  }
+}
 
 /**
  * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
@@ -352,7 +422,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ),
   );
   const billingType = resolveClaudeBillingType(effectiveEnv);
-  const skillsDir = await buildSkillsDir(config);
+  const [skillsDir, paraMemoryFilesActive] = await Promise.all([
+    buildSkillsDir(config),
+    hasActiveParaMemoryFilesSkill(config),
+  ]);
+  if (paraMemoryFilesActive) {
+    await ensureClaudeAutoMemoryDisabledForRun(cwd, asString(env.AGENT_HOME, "") || null);
+  }
 
   // When instructionsFilePath is configured, create a combined temp file that
   // includes both the file content and the path directive, so we only need

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -26,6 +26,128 @@ console.log(JSON.stringify({ type: "result", session_id: "claude-session-1", res
 }
 
 describe("claude execute", () => {
+  it("disables Claude auto-memory in the run cwd and AGENT_HOME when para-memory-files is active", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-auto-memory-"));
+    const workspace = path.join(root, "workspace");
+    const agentHome = path.join(root, "agent-home");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(path.join(workspace, ".claude"), { recursive: true });
+    await fs.mkdir(path.join(agentHome, ".claude"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace, ".claude", "settings.json"),
+      JSON.stringify({ autoMemoryEnabled: true, permissions: { allow: ["Read"] } }, null, 2),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(agentHome, ".claude", "settings.json"),
+      JSON.stringify({ env: { PAPERCLIP_TEST: "1" } }, null, 2),
+      "utf8",
+    );
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-auto-memory",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          paperclipSkillSync: {
+            desiredSkills: ["para-memory-files"],
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          paperclipWorkspace: {
+            cwd: workspace,
+            agentHome,
+            source: "workspace",
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(JSON.parse(await fs.readFile(path.join(workspace, ".claude", "settings.json"), "utf8"))).toEqual({
+        autoMemoryEnabled: false,
+        permissions: { allow: ["Read"] },
+      });
+      expect(JSON.parse(await fs.readFile(path.join(agentHome, ".claude", "settings.json"), "utf8"))).toEqual({
+        env: { PAPERCLIP_TEST: "1" },
+        autoMemoryEnabled: false,
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not write Claude auto-memory settings when para-memory-files is not active", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-no-auto-memory-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const customSkillDir = path.join(root, "custom-skill");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(customSkillDir, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-custom-skills",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          paperclipRuntimeSkills: [
+            {
+              key: "custom/test-skill",
+              runtimeName: "test-skill",
+              source: customSkillDir,
+            },
+          ],
+          paperclipSkillSync: {
+            desiredSkills: ["custom/test-skill"],
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      await expect(fs.lstat(path.join(workspace, ".claude", "settings.json"))).rejects.toThrow();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("logs HOME, CLAUDE_CONFIG_DIR, and the resolved executable path in invocation metadata", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-meta-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
Fixes #2671

## Problem
When `para-memory-files` skill is enabled, Claude's auto-memory feature creates a split-brain memory state — two independent memory systems writing to different locations.

## Solution
Detect active `para-memory-files` usage at runtime and automatically set `autoMemoryEnabled=false` in both:
- The workspace `.claude/settings.json`
- The `AGENT_HOME` `.claude/settings.json` (if configured)

## Changes
- `hasActiveParaMemoryFilesSkill()` — checks if para-memory-files is in desired skills
- `ensureClaudeAutoMemoryDisabledForRun()` — writes settings to cwd and agent-home
- Integration tests for both enabled and disabled paths

Co-authored-by: Codex AI <codex@openai.com>