### PR TITLE
fix: add terminal completed state for approvals

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -256,10 +256,10 @@ Invariant: each event must attach to agent and company; rollups are aggregation,
 
 - `id` uuid pk
 - `company_id` uuid fk not null
-- `type` enum: `hire_agent | approve_ceo_strategy`
+- `type` enum: `hire_agent | approve_ceo_strategy | budget_override_required`
 - `requested_by_agent_id` uuid fk `agents.id` null
 - `requested_by_user_id` uuid fk `users.id` null
-- `status` enum: `pending | approved | rejected | cancelled`
+- `status` enum: `pending | revision_requested | completed | rejected | cancelled`
 - `payload` jsonb not null
 - `decision_note` text null
 - `decided_by_user_id` uuid fk `users.id` null

--- a/packages/db/src/migrations/0049_novel_butterball.sql
+++ b/packages/db/src/migrations/0049_novel_butterball.sql
@@ -1,0 +1,5 @@
+UPDATE "approvals"
+SET
+  "status" = 'completed',
+  "updated_at" = now()
+WHERE "status" = 'approved';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1775145655557,
       "tag": "0048_flashy_marrow",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1775325600000,
+      "tag": "0049_novel_butterball",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -205,6 +205,7 @@ export const APPROVAL_STATUSES = [
   "pending",
   "revision_requested",
   "approved",
+  "completed",
   "rejected",
   "cancelled",
 ] as const;

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -71,7 +71,7 @@ describe("approval routes idempotent retries", () => {
         id: "approval-1",
         companyId: "company-1",
         type: "hire_agent",
-        status: "approved",
+        status: "completed",
         payload: {},
         requestedByAgentId: "agent-1",
       },

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -93,14 +93,27 @@ describe("approvalService resolution idempotency", () => {
     expect(mockAgentService.terminate).not.toHaveBeenCalled();
   });
 
+  it("treats completed approvals as already resolved on repeated approve retries", async () => {
+    const dbStub = createDbStub([[createApproval("completed")]], []);
+
+    const svc = approvalService(dbStub.db as any);
+    const result = await svc.approve("approval-1", "board", "ship it");
+
+    expect(result.applied).toBe(false);
+    expect(result.approval.status).toBe("completed");
+    expect(mockAgentService.activatePendingApproval).not.toHaveBeenCalled();
+    expect(mockNotifyHireApproved).not.toHaveBeenCalled();
+  });
+
   it("still performs side effects when the resolution update is newly applied", async () => {
-    const approved = createApproval("approved");
-    const dbStub = createDbStub([[createApproval("pending")]], [approved]);
+    const completed = createApproval("completed");
+    const dbStub = createDbStub([[createApproval("pending")]], [completed]);
 
     const svc = approvalService(dbStub.db as any);
     const result = await svc.approve("approval-1", "board", "ship it");
 
     expect(result.applied).toBe(true);
+    expect(result.approval.status).toBe("completed");
     expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1");
     expect(mockNotifyHireApproved).toHaveBeenCalledTimes(1);
   });

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -307,5 +307,12 @@ describe("budgetService", () => {
         updatedAt: expect.any(Date),
       }),
     );
+    expect(dbStub.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "completed",
+        decidedByUserId: "board-user",
+        updatedAt: expect.any(Date),
+      }),
+    );
   });
 });

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -17,6 +17,20 @@ export function approvalService(db: Db) {
   type ApprovalRecord = typeof approvals.$inferSelect;
   type ResolutionResult = { approval: ApprovalRecord; applied: boolean };
 
+  function storedResolutionStatus(targetStatus: "approved" | "rejected") {
+    return targetStatus === "approved" ? "completed" : "rejected";
+  }
+
+  function isEquivalentResolvedStatus(
+    status: ApprovalRecord["status"],
+    targetStatus: "approved" | "rejected",
+  ) {
+    if (targetStatus === "approved") {
+      return status === "approved" || status === "completed";
+    }
+    return status === "rejected";
+  }
+
   function redactApprovalComment<T extends { body: string }>(comment: T, censorUsernameInLogs: boolean): T {
     return {
       ...comment,
@@ -41,8 +55,9 @@ export function approvalService(db: Db) {
     decisionNote: string | null | undefined,
   ): Promise<ResolutionResult> {
     const existing = await getExistingApproval(id);
+    const nextStatus = storedResolutionStatus(targetStatus);
     if (!canResolveStatuses.has(existing.status)) {
-      if (existing.status === targetStatus) {
+      if (isEquivalentResolvedStatus(existing.status, targetStatus)) {
         return { approval: existing, applied: false };
       }
       throw unprocessable(
@@ -54,7 +69,7 @@ export function approvalService(db: Db) {
     const updated = await db
       .update(approvals)
       .set({
-        status: targetStatus,
+        status: nextStatus,
         decidedByUserId,
         decisionNote: decisionNote ?? null,
         decidedAt: now,
@@ -69,7 +84,7 @@ export function approvalService(db: Db) {
     }
 
     const latest = await getExistingApproval(id);
-    if (latest.status === targetStatus) {
+    if (isEquivalentResolvedStatus(latest.status, targetStatus)) {
       return { approval: latest, applied: false };
     }
 

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -197,10 +197,11 @@ async function markApprovalStatus(
   decidedByUserId: string,
 ) {
   if (!approvalId) return;
+  const nextStatus = status === "approved" ? "completed" : status;
   await db
     .update(approvals)
     .set({
-      status,
+      status: nextStatus,
       decisionNote: decisionNote ?? null,
       decidedByUserId,
       decidedAt: new Date(),

--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -7,6 +7,7 @@ import { timeAgo } from "../lib/timeAgo";
 import type { Approval, Agent } from "@paperclipai/shared";
 
 function statusIcon(status: string) {
+  if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />;
   if (status === "approved") return <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />;
   if (status === "rejected") return <XCircle className="h-3.5 w-3.5 text-red-600 dark:text-red-400" />;
   if (status === "revision_requested") return <Clock className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />;

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -328,7 +328,7 @@ describe("inbox helpers", () => {
 
   it("shows recent approvals in updated order and unread approvals as actionable only", () => {
     const approvals = [
-      makeApprovalWithTimestamps("approval-approved", "approved", "2026-03-11T02:00:00.000Z"),
+      makeApprovalWithTimestamps("approval-completed", "completed", "2026-03-11T02:00:00.000Z"),
       makeApprovalWithTimestamps("approval-pending", "pending", "2026-03-11T01:00:00.000Z"),
       makeApprovalWithTimestamps(
         "approval-revision",
@@ -339,12 +339,12 @@ describe("inbox helpers", () => {
 
     expect(getApprovalsForTab(approvals, "mine", "all").map((approval) => approval.id)).toEqual([
       "approval-revision",
-      "approval-approved",
+      "approval-completed",
       "approval-pending",
     ]);
     expect(getApprovalsForTab(approvals, "recent", "all").map((approval) => approval.id)).toEqual([
       "approval-revision",
-      "approval-approved",
+      "approval-completed",
       "approval-pending",
     ]);
     expect(getApprovalsForTab(approvals, "unread", "all").map((approval) => approval.id)).toEqual([
@@ -352,7 +352,7 @@ describe("inbox helpers", () => {
       "approval-pending",
     ]);
     expect(getApprovalsForTab(approvals, "all", "resolved").map((approval) => approval.id)).toEqual([
-      "approval-approved",
+      "approval-completed",
     ]);
   });
 

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -149,7 +149,8 @@ export function ApprovalDetail() {
   const isActionable = approval.status === "pending" || approval.status === "revision_requested";
   const isBudgetApproval = approval.type === "budget_override_required";
   const TypeIcon = typeIcon[approval.type] ?? defaultTypeIcon;
-  const showApprovedBanner = searchParams.get("resolved") === "approved" && approval.status === "approved";
+  const isApprovedResolution = approval.status === "approved" || approval.status === "completed";
+  const showApprovedBanner = searchParams.get("resolved") === "approved" && isApprovedResolution;
   const primaryLinkedIssue = linkedIssues?.[0] ?? null;
   const resolvedCta =
     primaryLinkedIssue


### PR DESCRIPTION
## Summary
- add a terminal `completed` approval state for approved requests
- backfill legacy `approved` approvals to `completed` with a migration
- update the approval UI and tests for the new lifecycle

## Verification
- pnpm vitest run server/src/__tests__/approvals-service.test.ts server/src/__tests__/approval-routes-idempotency.test.ts server/src/__tests__/budgets-service.test.ts ui/src/lib/inbox.test.ts
- pnpm -r typecheck
- pnpm test:run
- pnpm build

Closes #2718