### PR TITLE
fix(server): emit issue.comment.created plugin event for comment actions

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1217,7 +1217,7 @@ export function issueRoutes(
         actorId: actor.actorId,
         agentId: actor.agentId,
         runId: actor.runId,
-        action: "issue.comment_added",
+        action: "issue.comment.created",
         entityType: "issue",
         entityId: issue.id,
         details: {
@@ -1689,7 +1689,7 @@ export function issueRoutes(
       actorId: actor.actorId,
       agentId: actor.agentId,
       runId: actor.runId,
-      action: "issue.comment_added",
+      action: "issue.comment.created",
       entityType: "issue",
       entityId: currentIssue.id,
       details: {

--- a/ui/src/components/ActivityRow.tsx
+++ b/ui/src/components/ActivityRow.tsx
@@ -9,6 +9,7 @@ const ACTION_VERBS: Record<string, string> = {
   "issue.updated": "updated",
   "issue.checked_out": "checked out",
   "issue.released": "released",
+  "issue.comment.created": "commented on",
   "issue.comment_added": "commented on",
   "issue.attachment_added": "attached file to",
   "issue.attachment_removed": "removed attachment from",

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -254,7 +254,7 @@ function shouldSuppressAgentStatusToastForVisibleIssue(
   return !!agentId && agentId === context.assigneeAgentId;
 }
 
-const ISSUE_TOAST_ACTIONS = new Set(["issue.created", "issue.updated", "issue.comment_added"]);
+const ISSUE_TOAST_ACTIONS = new Set(["issue.created", "issue.updated", "issue.comment.created", "issue.comment_added"]);
 const AGENT_TOAST_STATUSES = new Set(["error"]);
 const RUN_TOAST_STATUSES = new Set(["failed", "timed_out", "cancelled"]);
 

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -88,6 +88,7 @@ const ACTION_LABELS: Record<string, string> = {
   "issue.updated": "updated the issue",
   "issue.checked_out": "checked out the issue",
   "issue.released": "released the issue",
+  "issue.comment.created": "added a comment",
   "issue.comment_added": "added a comment",
   "issue.feedback_vote_saved": "saved feedback on an AI output",
   "issue.attachment_added": "added an attachment",
@@ -513,7 +514,7 @@ export function IssueDetail() {
       agentIdByRunId.set(run.runId, run.agentId);
     }
     for (const evt of activity ?? []) {
-      if (evt.action !== "issue.comment_added" || !evt.runId) continue;
+      if ((evt.action !== "issue.comment.created" && evt.action !== "issue.comment_added") || !evt.runId) continue;
       const details = evt.details ?? {};
       const commentId = typeof details["commentId"] === "string" ? details["commentId"] : null;
       if (!commentId || runMetaByCommentId.has(commentId)) continue;


### PR DESCRIPTION
## Summary

The `POST /issues/:id/comments` and `PATCH /issues/:id` (comment-add path) routes log activity with action `"issue.comment_added"` -- an underscore-format string that does **not** match the `"issue.comment.created"` entry in `PLUGIN_EVENT_TYPES`. Because `logActivity` (in `activity-log.ts`) only forwards events whose action key is in `PLUGIN_EVENT_SET`, the `issue.comment.created` plugin event was **never emitted**, making it impossible for plugins (e.g. Telegram notifier, Slack integration) to subscribe to new-comment events.

- Align the action string in both comment-creation `logActivity` calls (`PATCH` and `POST`) to the canonical `"issue.comment.created"` plugin event type
- Add `"issue.comment.created"` to all UI look-up maps (`ACTION_VERBS`, `ACTION_LABELS`, `ISSUE_TOAST_ACTIONS`, and the `IssueDetail` run-meta filter) while **keeping** the old `"issue.comment_added"` key so existing activity log entries stored with the old key continue to render correctly

### Thinking Path

| Step | Detail |
|------|--------|
| Observed | Plugins subscribing to `issue.comment.created` never receive the event when comments are added |
| Root cause | `logActivity` checks `PLUGIN_EVENT_SET.has(input.action)` before forwarding to `PluginEventBus`; the action string `"issue.comment_added"` is **not** in `PLUGIN_EVENT_SET` (which contains `"issue.comment.created"`) |
| Fix (server) | Change both comment-creation `logActivity` calls from `"issue.comment_added"` to `"issue.comment.created"` |
| Fix (UI) | Add `"issue.comment.created"` to all UI action-label/verb/filter maps; keep old key for backward compat with existing DB rows |

### Upstream Search Evidence

| Source | Signal |
|--------|--------|
| `packages/shared/src/constants.ts` | `PLUGIN_EVENT_TYPES` includes `"issue.comment.created"` (not `"issue.comment_added"`) |
| `server/src/services/activity-log.ts` L73 | `PLUGIN_EVENT_SET.has(input.action)` -- gate that blocks non-matching action strings from reaching the plugin bus |
| `server/src/routes/issues.ts` L1220, L1692 (upstream/master) | Both comment-creation paths use `"issue.comment_added"` -- mismatch with canonical event type |
| PR [#909](https://github.com/paperclipai/paperclip/pull/909) (merged) | Established the `logActivity` -> `PluginEventBus` bridge; `issue.comment.created` listed as a supported plugin event type |
| No existing upstream PR | Searched `issue.comment.created`, `comment_added plugin`, `plugin event comment` -- no open or merged PR addresses this bug |

## Changes

**`server/src/routes/issues.ts`** (2 lines changed)
- `PATCH /issues/:id` comment path: `"issue.comment_added"` -> `"issue.comment.created"`
- `POST /issues/:id/comments` path: `"issue.comment_added"` -> `"issue.comment.created"`

**`ui/src/components/ActivityRow.tsx`** (+1 line)
- Add `"issue.comment.created": "commented on"` to `ACTION_VERBS` (old key kept for backward compat)

**`ui/src/context/LiveUpdatesProvider.tsx`** (1 line changed)
- Add `"issue.comment.created"` to `ISSUE_TOAST_ACTIONS` set (old key kept)

**`ui/src/pages/IssueDetail.tsx`** (+1 line, 1 line changed)
- Add `"issue.comment.created": "added a comment"` to `ACTION_LABELS` (old key kept)
- Update run-meta filter to match both `"issue.comment.created"` and `"issue.comment_added"`

## Test plan

- [ ] `pnpm -r typecheck` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes
- [ ] Create a comment on an issue and verify the activity log entry uses `issue.comment.created`
- [ ] Existing activity entries with `issue.comment_added` still render correctly in the UI
- [ ] Plugin subscribed to `issue.comment.created` receives the event when a comment is posted

This contribution was developed with AI assistance (Claude Code).