### PR TITLE
feat: add Qodo CLI adapter (qodo_local)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
+COPY packages/adapters/qodo-local/package.json packages/adapters/qodo-local/
 COPY packages/plugins/sdk/package.json packages/plugins/sdk/
 COPY patches/ patches/
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paperclipai",
   "version": "0.3.1",
-  "description": "Paperclip CLI — orchestrate AI agent teams to run a business",
+  "description": "Paperclip CLI \u2014 orchestrate AI agent teams to run a business",
   "type": "module",
   "bin": {
     "paperclipai": "./dist/index.js"
@@ -41,16 +41,17 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
-    "@paperclipai/adapter-openclaw-gateway": "workspace:*",
+    "@paperclipai/adapter-qodo-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
     "@paperclipai/server": "workspace:*",
     "@paperclipai/shared": "workspace:*",
-    "drizzle-orm": "0.38.4",
-    "dotenv": "^17.0.1",
     "commander": "^13.1.0",
+    "dotenv": "^17.0.1",
+    "drizzle-orm": "0.38.4",
     "embedded-postgres": "^18.1.0-beta.16",
     "picocolors": "^1.1.1"
   },

--- a/packages/adapters/qodo-local/README.md
+++ b/packages/adapters/qodo-local/README.md
@@ -1,0 +1,21 @@
+# Qodo Local Adapter
+
+Paperclip adapter that integrates [Qodo CLI](https://www.qodo.ai/) as a local agent backend.
+
+## What it does
+
+Runs Qodo CLI (`@qodo/command`) on the host machine as a Paperclip agent. Supports session persistence (`--resume`), CI-friendly non-interactive mode (`--ci --yes`), and Qodo's built-in tools (git, filesystem, shell, ripgrep, web search).
+
+## Supported Models
+
+Claude Sonnet/Opus 4.5–4.6, GPT-5.2–5.4, o4-mini, Gemini 2.5 Pro, Grok 4.
+
+## Prerequisites
+
+```bash
+npm install -g @qodo/command
+```
+
+## Usage
+
+Select `qodo_local` as the adapter type when creating a Paperclip agent. The adapter spawns Qodo CLI processes and bridges them to the Paperclip agent protocol.

--- a/packages/adapters/qodo-local/package.json
+++ b/packages/adapters/qodo-local/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@paperclipai/adapter-qodo-local",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+      "./server": { "types": "./dist/server/index.d.ts", "import": "./dist/server/index.js" },
+      "./ui": { "types": "./dist/ui/index.d.ts", "import": "./dist/ui/index.js" },
+      "./cli": { "types": "./dist/cli/index.d.ts", "import": "./dist/cli/index.js" }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/qodo-local/src/cli/format-event.ts
+++ b/packages/adapters/qodo-local/src/cli/format-event.ts
@@ -1,0 +1,31 @@
+import pc from "picocolors";
+
+export function printQodoStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try { parsed = JSON.parse(line) as Record<string, unknown>; } catch { console.log(line); return; }
+
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+
+  if (type === "assistant") {
+    const text = typeof parsed.text === "string" ? parsed.text : "";
+    if (text) console.log(pc.green(`assistant: ${text}`));
+    return;
+  }
+
+  if (type === "error") {
+    const message = typeof parsed.message === "string" ? parsed.message : "unknown error";
+    console.log(pc.red(`error: ${message}`));
+    return;
+  }
+
+  if (type === "result") {
+    const text = typeof parsed.result === "string" ? parsed.result : "";
+    if (text) { console.log(pc.green("result:")); console.log(text); }
+    return;
+  }
+
+  if (debug) console.log(pc.gray(line));
+}

--- a/packages/adapters/qodo-local/src/cli/index.ts
+++ b/packages/adapters/qodo-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printQodoStreamEvent } from "./format-event.js";

--- a/packages/adapters/qodo-local/src/index.ts
+++ b/packages/adapters/qodo-local/src/index.ts
@@ -4,16 +4,29 @@ export const label = "Qodo CLI (local)";
 export const models = [
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-opus-4-6-200k", label: "Claude Opus 4.6 (200K)" },
   { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
   { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6 (Anthropic)" },
+  { id: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6 (Anthropic)" },
+  { id: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5 (Anthropic)" },
   { id: "gpt-5.4", label: "GPT-5.4" },
   { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
   { id: "gpt-5.2", label: "GPT-5.2" },
   { id: "gpt-5.2-codex", label: "GPT-5.2 Codex" },
+  { id: "gpt-5.2-high", label: "GPT-5.2 High" },
+  { id: "gpt-5.2-max", label: "GPT-5.2 Max" },
+  { id: "gpt-5.2-ultra", label: "GPT-5.2 Ultra" },
+  { id: "gpt-5.2-pro", label: "GPT-5.2 Pro" },
+  { id: "gpt-5.1", label: "GPT-5.1" },
+  { id: "gpt-5.1-codex", label: "GPT-5.1 Codex" },
+  { id: "gpt-5-nano", label: "GPT-5 Nano" },
+  { id: "gpt-5-mini", label: "GPT-5 Mini" },
   { id: "o4-mini", label: "o4-mini" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "grok-4", label: "Grok 4" },
+  { id: "grok-code-fast-1", label: "Grok Code Fast 1" },
 ];
 
 export const agentConfigurationDoc = `# qodo_local agent configuration
@@ -32,7 +45,7 @@ Don't use when:
 
 Core fields:
 - cwd (string, optional): absolute working directory for the agent process
-- model (string, optional): model name (run \`qodo models\` for available models)
+- model (string, optional): model name — discovered dynamically via \`qodo models\`. Run \`qodo models\` for the current list.
 - promptTemplate (string, optional): run prompt template
 - autoApprove (boolean, optional): pass --yes to confirm all prompts automatically (default: true)
 - actMode (boolean, optional): pass --act to let the agent execute actions immediately (default: true)

--- a/packages/adapters/qodo-local/src/index.ts
+++ b/packages/adapters/qodo-local/src/index.ts
@@ -1,0 +1,46 @@
+export const type = "qodo_local";
+export const label = "Qodo CLI (local)";
+
+export const models = [
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  { id: "gpt-5.4", label: "GPT-5.4" },
+  { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+  { id: "gpt-5.2", label: "GPT-5.2" },
+  { id: "gpt-5.2-codex", label: "GPT-5.2 Codex" },
+  { id: "o4-mini", label: "o4-mini" },
+  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  { id: "grok-4", label: "Grok 4" },
+];
+
+export const agentConfigurationDoc = `# qodo_local agent configuration
+
+Adapter: qodo_local
+
+Use when:
+- The agent needs to run Qodo CLI locally on the host machine
+- You need session persistence across runs (Qodo supports --resume)
+- You want CI-friendly non-interactive execution (--ci --yes)
+- The task benefits from Qodo's built-in tools (git, filesystem, shell, ripgrep, web search)
+
+Don't use when:
+- Qodo CLI is not installed (install via: npm install -g @qodo/command)
+- You need a simple one-shot script execution (use the "process" adapter instead)
+
+Core fields:
+- cwd (string, optional): absolute working directory for the agent process
+- model (string, optional): model name (run \`qodo models\` for available models)
+- promptTemplate (string, optional): run prompt template
+- autoApprove (boolean, optional): pass --yes to confirm all prompts automatically (default: true)
+- actMode (boolean, optional): pass --act to let the agent execute actions immediately (default: true)
+- command (string, optional): defaults to "qodo"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+`;

--- a/packages/adapters/qodo-local/src/server/execute.ts
+++ b/packages/adapters/qodo-local/src/server/execute.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import {
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  redactEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  renderTemplate,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { parseQodoOutput, describeQodoFailure, isQodoUnknownSessionError } from "./parse.js";
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, authToken } = ctx;
+
+  const promptTemplate = asString(config.promptTemplate, "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.");
+  const model = asString(config.model, "");
+  const autoApprove = asBoolean(config.autoApprove, true);
+  const actMode = asBoolean(config.actMode, true);
+  const command = asString(config.command, "qodo");
+  const configuredCwd = asString(config.cwd, "");
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason = typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0 ? context.wakeReason.trim() : null;
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  if (authToken) {
+    const hasExplicitApiKey = typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+    if (!hasExplicitApiKey) env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  env.NO_COLOR = "1";
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog("stderr", `[paperclip] Qodo session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`);
+  }
+
+  const prompt = renderTemplate(promptTemplate, {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  });
+
+  const buildArgs = (resumeSessionId: string | null) => {
+    const args = ["chat"];
+    if (resumeSessionId) args.push(`--resume=${resumeSessionId}`);
+    if (autoApprove) args.push("--yes");
+    if (actMode) args.push("--act");
+    if (model) args.push(`--model=${model}`);
+    args.push("--ci");
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    args.push(prompt);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildArgs(resumeSessionId);
+    if (onMeta) {
+      await onMeta({ adapterType: "qodo_local", command, cwd, commandArgs: args, env: redactEnvForLogs(env), prompt, context });
+    }
+    const proc = await runChildProcess(runId, command, args, { cwd, env, timeoutSec, graceSec, onLog });
+    const parsed = parseQodoOutput(proc.stdout);
+    return { proc, parsed };
+  };
+
+  const toResult = (
+    attempt: { proc: RunProcessResult; parsed: ReturnType<typeof parseQodoOutput> },
+    opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
+  ): AdapterExecutionResult => {
+    const { proc, parsed } = attempt;
+
+    if (proc.timedOut) {
+      return { exitCode: proc.exitCode, signal: proc.signal, timedOut: true, errorMessage: `Timed out after ${timeoutSec}s`, errorCode: "timeout" };
+    }
+
+    const stderrLine = proc.stderr.split(/\r?\n/).map((l) => l.trim()).find(Boolean) ?? "";
+    const resolvedSessionId = parsed.sessionId ?? opts.fallbackSessionId;
+    const resolvedSessionParams = resolvedSessionId ? { sessionId: resolvedSessionId, cwd } as Record<string, unknown> : null;
+
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: false,
+      errorMessage: (proc.exitCode ?? 0) === 0 ? null : (parsed.errorMessage ?? (stderrLine || `Qodo exited with code ${proc.exitCode ?? -1}`)),
+      usage: parsed.usage ?? undefined,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "qodo",
+      model: parsed.model || model,
+      billingType: "subscription",
+      costUsd: parsed.costUsd ?? 0,
+      resultJson: parsed.resultJson,
+      summary: parsed.summary,
+      clearSession: Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+    };
+  };
+
+  const initial = await runAttempt(sessionId);
+  if (
+    sessionId &&
+    !initial.proc.timedOut &&
+    (initial.proc.exitCode ?? 0) !== 0 &&
+    isQodoUnknownSessionError(initial.proc.stdout, initial.proc.stderr)
+  ) {
+    await onLog("stderr", `[paperclip] Qodo resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`);
+    const retry = await runAttempt(null);
+    return toResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+  }
+
+  return toResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+}

--- a/packages/adapters/qodo-local/src/server/index.ts
+++ b/packages/adapters/qodo-local/src/server/index.ts
@@ -1,0 +1,31 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { parseQodoOutput, describeQodoFailure, isQodoUnknownSessionError } from "./parse.js";
+export { listQodoSkills, syncQodoSkills } from "./skills.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(record.cwd) ?? readNonEmptyString(record.workdir);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd) ?? readNonEmptyString(params.workdir);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};

--- a/packages/adapters/qodo-local/src/server/parse.ts
+++ b/packages/adapters/qodo-local/src/server/parse.ts
@@ -1,0 +1,80 @@
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
+
+export function parseQodoOutput(stdout: string) {
+  let sessionId: string | null = null;
+  let model = "";
+  let errorMessage: string | null = null;
+  let resultJson: Record<string, unknown> | null = null;
+  const textParts: string[] = [];
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) {
+      if (line.length > 0) textParts.push(rawLine);
+      continue;
+    }
+
+    const type = asString(event.type, "");
+
+    if (type === "system" || type === "init") {
+      sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
+      model = asString(event.model, model);
+      continue;
+    }
+
+    if (type === "assistant") {
+      const text = asString(event.text, "");
+      if (text) textParts.push(text);
+      sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
+      continue;
+    }
+
+    if (type === "error") {
+      errorMessage = asString(event.message, "") || asString(event.error, "") || null;
+      continue;
+    }
+
+    if (type === "result") {
+      resultJson = event;
+      sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
+    }
+  }
+
+  const summary = textParts.join("\n").trim();
+
+  if (!resultJson) {
+    return { sessionId, model, costUsd: null as number | null, usage: null as UsageSummary | null, summary, resultJson: null as Record<string, unknown> | null, errorMessage };
+  }
+
+  const usageObj = parseObject(resultJson.usage);
+  const usage: UsageSummary = {
+    inputTokens: asNumber(usageObj.input_tokens, 0),
+    cachedInputTokens: asNumber(usageObj.cache_read_input_tokens, 0),
+    outputTokens: asNumber(usageObj.output_tokens, 0),
+  };
+  const costRaw = resultJson.total_cost_usd;
+  const costUsd = typeof costRaw === "number" && Number.isFinite(costRaw) ? costRaw : null;
+
+  return {
+    sessionId,
+    model,
+    costUsd,
+    usage,
+    summary: asString(resultJson.result, summary).trim(),
+    resultJson,
+    errorMessage: errorMessage ?? (asString(resultJson.error, "") || null),
+  };
+}
+
+export function describeQodoFailure(parsed: Record<string, unknown>): string | null {
+  const detail = asString(parsed.result, "").trim() || asString(parsed.error, "").trim();
+  return detail ? `Qodo run failed: ${detail}` : null;
+}
+
+export function isQodoUnknownSessionError(stdout: string, stderr: string): boolean {
+  const combined = `${stdout}\n${stderr}`;
+  return /(?:unknown session|session .* not found|no (?:conversation|session) found|invalid session)/i.test(combined);
+}

--- a/packages/adapters/qodo-local/src/server/skills.ts
+++ b/packages/adapters/qodo-local/src/server/skills.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterSkillContext, AdapterSkillSnapshot } from "@paperclipai/adapter-utils";
+import {
+  buildPersistentSkillSnapshot,
+  ensurePaperclipSkillSymlink,
+  readPaperclipRuntimeSkillEntries,
+  readInstalledSkillTargets,
+  resolvePaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function resolveQodoSkillsHome() {
+  return path.join(os.homedir(), ".qodo", "skills");
+}
+
+async function buildSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkills = resolvePaperclipDesiredSkillNames(config, availableEntries);
+  const skillsHome = resolveQodoSkillsHome();
+  const installed = await readInstalledSkillTargets(skillsHome);
+  return buildPersistentSkillSnapshot({
+    adapterType: "qodo_local",
+    availableEntries,
+    desiredSkills,
+    installed,
+    skillsHome,
+    locationLabel: "~/.qodo/skills",
+    missingDetail: "Configured but not currently linked into the Qodo skills home.",
+    externalConflictDetail: "Skill name is occupied by an external installation.",
+    externalDetail: "Installed outside Paperclip management.",
+  });
+}
+
+export async function listQodoSkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return buildSnapshot(ctx.config);
+}
+
+export async function syncQodoSkills(ctx: AdapterSkillContext, desiredSkills: string[]): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(ctx.config, __moduleDir);
+  const desiredSet = new Set([
+    ...desiredSkills,
+    ...availableEntries.filter((e) => e.required).map((e) => e.key),
+  ]);
+  const skillsHome = resolveQodoSkillsHome();
+  await fs.mkdir(skillsHome, { recursive: true });
+  const installed = await readInstalledSkillTargets(skillsHome);
+  const availableByRuntimeName = new Map(availableEntries.map((e) => [e.runtimeName, e]));
+
+  for (const available of availableEntries) {
+    if (!desiredSet.has(available.key)) continue;
+    await ensurePaperclipSkillSymlink(available.source, path.join(skillsHome, available.runtimeName));
+  }
+
+  for (const [name, entry] of installed.entries()) {
+    const available = availableByRuntimeName.get(name);
+    if (!available) continue;
+    if (desiredSet.has(available.key)) continue;
+    if (entry.targetPath !== available.source) continue;
+    await fs.unlink(path.join(skillsHome, name)).catch(() => {});
+  }
+
+  return buildSnapshot(ctx.config);
+}

--- a/packages/adapters/qodo-local/src/server/skills.ts
+++ b/packages/adapters/qodo-local/src/server/skills.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AdapterSkillContext, AdapterSkillSnapshot } from "@paperclipai/adapter-utils";
+import type { AdapterSkillContext, AdapterSkillEntry, AdapterSkillSnapshot } from "@paperclipai/adapter-utils";
 import {
   buildPersistentSkillSnapshot,
   ensurePaperclipSkillSymlink,
@@ -17,12 +17,92 @@ function resolveQodoSkillsHome() {
   return path.join(os.homedir(), ".qodo", "skills");
 }
 
+function parseSkillFrontmatter(content: string): Record<string, string> {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    let val = line.slice(idx + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    frontmatter[key] = val;
+  }
+  return frontmatter;
+}
+
+async function findKiroSkillsDir(startDir: string): Promise<string | null> {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root;
+  while (dir !== root) {
+    const candidate = path.join(dir, ".kiro", "skills");
+    const stat = await fs.stat(candidate).catch(() => null);
+    if (stat?.isDirectory()) return candidate;
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+async function scanKiroSkills(config: Record<string, unknown>): Promise<AdapterSkillEntry[]> {
+  const cwd =
+    typeof config.cwd === "string" && config.cwd.length > 0
+      ? config.cwd
+      : process.cwd();
+  const skillsDir = await findKiroSkillsDir(cwd);
+  if (!skillsDir) return [];
+
+  const entries: AdapterSkillEntry[] = [];
+  let items: import("node:fs").Dirent[];
+  try {
+    items = await fs.readdir(skillsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const item of items) {
+    if (!item.isDirectory() && !item.isSymbolicLink()) continue;
+    const skillDir = path.join(skillsDir, item.name);
+    const skillMd = path.join(skillDir, "SKILL.md");
+    const stat = await fs.stat(skillMd).catch(() => null);
+    if (!stat) continue;
+
+    let description: string | null = null;
+    try {
+      const content = await fs.readFile(skillMd, "utf8");
+      const fm = parseSkillFrontmatter(content);
+      description = fm.description ?? null;
+    } catch {
+      // ignore
+    }
+
+    entries.push({
+      key: item.name,
+      runtimeName: item.name,
+      desired: true,
+      managed: false,
+      state: "installed",
+      origin: "user_installed",
+      originLabel: "Skill (via skillz MCP)",
+      locationLabel: `.agents/skills/${item.name}`,
+      readOnly: true,
+      sourcePath: skillDir,
+      targetPath: null,
+      detail: description,
+    });
+  }
+
+  return entries.sort((a, b) => a.key.localeCompare(b.key));
+}
+
 async function buildSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
   const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkills = resolvePaperclipDesiredSkillNames(config, availableEntries);
   const skillsHome = resolveQodoSkillsHome();
   const installed = await readInstalledSkillTargets(skillsHome);
-  return buildPersistentSkillSnapshot({
+  const snapshot = await buildPersistentSkillSnapshot({
     adapterType: "qodo_local",
     availableEntries,
     desiredSkills,
@@ -33,6 +113,16 @@ async function buildSnapshot(config: Record<string, unknown>): Promise<AdapterSk
     externalConflictDetail: "Skill name is occupied by an external installation.",
     externalDetail: "Installed outside Paperclip management.",
   });
+
+  // Merge .kiro/skills/ entries (loaded at runtime via skillz MCP)
+  const kiroSkills = await scanKiroSkills(config);
+  const existingKeys = new Set(snapshot.entries.map((e) => e.key));
+  for (const entry of kiroSkills) {
+    if (existingKeys.has(entry.key)) continue;
+    snapshot.entries.push(entry);
+  }
+
+  return snapshot;
 }
 
 export async function listQodoSkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {

--- a/packages/adapters/qodo-local/src/server/test.ts
+++ b/packages/adapters/qodo-local/src/server/test.ts
@@ -1,0 +1,57 @@
+import type { AdapterEnvironmentCheck, AdapterEnvironmentTestContext, AdapterEnvironmentTestResult } from "@paperclipai/adapter-utils";
+import { asString, parseObject, ensureAbsoluteDirectory, ensureCommandResolvable, ensurePathInEnv, runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import path from "node:path";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+function firstNonEmptyLine(text: string): string {
+  return text.split(/\r?\n/).map((l) => l.trim()).find(Boolean) ?? "";
+}
+
+export async function testEnvironment(ctx: AdapterEnvironmentTestContext): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "qodo");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({ code: "qodo_cwd_valid", level: "info", message: `Working directory is valid: ${cwd}` });
+  } catch (err) {
+    checks.push({ code: "qodo_cwd_invalid", level: "error", message: err instanceof Error ? err.message : "Invalid working directory", detail: cwd });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({ code: "qodo_command_resolvable", level: "info", message: `Command is executable: ${command}` });
+  } catch (err) {
+    checks.push({ code: "qodo_command_unresolvable", level: "error", message: err instanceof Error ? err.message : "Command is not executable", detail: command, hint: "Install Qodo CLI: npm install -g @qodo/command" });
+  }
+
+  const canRunProbe = checks.every((c) => c.code !== "qodo_cwd_invalid" && c.code !== "qodo_command_unresolvable");
+  if (canRunProbe && path.basename(command).replace(/\.(cmd|exe)$/i, "") === "qodo") {
+    const probe = await runChildProcess(`qodo-envtest-${Date.now()}`, command, ["--version"], { cwd, env, timeoutSec: 15, graceSec: 5, onLog: async () => {} });
+    const detail = firstNonEmptyLine(probe.stdout) || firstNonEmptyLine(probe.stderr);
+
+    if (probe.timedOut) {
+      checks.push({ code: "qodo_version_probe_timed_out", level: "warn", message: "Qodo version probe timed out." });
+    } else if ((probe.exitCode ?? 1) === 0) {
+      checks.push({ code: "qodo_version_probe_passed", level: "info", message: `Qodo CLI detected: ${detail || "ok"}` });
+    } else {
+      checks.push({ code: "qodo_version_probe_failed", level: "error", message: "Qodo version probe failed.", ...(detail ? { detail } : {}), hint: "Run `qodo --version` manually to debug." });
+    }
+  }
+
+  return { adapterType: ctx.adapterType, status: summarizeStatus(checks), checks, testedAt: new Date().toISOString() };
+}

--- a/packages/adapters/qodo-local/src/ui/build-config.ts
+++ b/packages/adapters/qodo-local/src/ui/build-config.ts
@@ -1,0 +1,31 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+export function buildQodoLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.model) ac.model = v.model;
+  ac.autoApprove = true;
+  ac.actMode = true;
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) {
+    const parsed = v.extraArgs.split(",").map((s) => s.trim()).filter(Boolean);
+    if (parsed.length > 0) ac.extraArgs = parsed;
+  }
+  if (v.envVars) {
+    const env: Record<string, unknown> = {};
+    for (const line of v.envVars.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      const value = trimmed.slice(eq + 1);
+      if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) env[key] = { type: "plain", value };
+    }
+    if (Object.keys(env).length > 0) ac.env = env;
+  }
+  return ac;
+}

--- a/packages/adapters/qodo-local/src/ui/index.ts
+++ b/packages/adapters/qodo-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseQodoStdoutLine } from "./parse-stdout.js";
+export { buildQodoLocalConfig } from "./build-config.js";

--- a/packages/adapters/qodo-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/qodo-local/src/ui/parse-stdout.ts
@@ -1,0 +1,41 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try { return JSON.parse(text); } catch { return null; }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function parseQodoStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+
+  if (type === "assistant") {
+    const text = typeof parsed.text === "string" ? parsed.text : "";
+    if (text) return [{ kind: "assistant", ts, text }];
+  }
+
+  if (type === "error") {
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    if (message) return [{ kind: "stderr", ts, text: message }];
+  }
+
+  if (type === "result") {
+    const text = typeof parsed.result === "string" ? parsed.result : "";
+    const usage = (typeof parsed.usage === "object" && parsed.usage !== null) ? parsed.usage as Record<string, unknown> : {};
+    const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+    const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
+    const cachedTokens = typeof usage.cache_read_input_tokens === "number" ? usage.cache_read_input_tokens : 0;
+    const costUsd = typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : 0;
+    return [{ kind: "result", ts, text, inputTokens, outputTokens, cachedTokens, costUsd, subtype: "", isError: false, errors: [] }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/qodo-local/tsconfig.json
+++ b/packages/adapters/qodo-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -34,6 +34,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "qodo_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local
+      '@paperclipai/adapter-qodo-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/qodo-local
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../packages/adapter-utils
@@ -208,6 +211,22 @@ importers:
         version: 5.9.3
 
   packages/adapters/pi-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/qodo-local:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -486,6 +505,9 @@ importers:
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local
+      '@paperclipai/adapter-qodo-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/qodo-local
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../packages/adapter-utils
@@ -643,6 +665,9 @@ importers:
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local
+      '@paperclipai/adapter-qodo-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/qodo-local
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../packages/adapter-utils

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-qodo-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",

--- a/server/src/adapters/qodo-models.ts
+++ b/server/src/adapters/qodo-models.ts
@@ -1,0 +1,43 @@
+import type { AdapterModel } from "./types.js";
+import { models as qodoFallbackModels } from "@paperclipai/adapter-qodo-local";
+
+const CACHE_TTL_MS = 120_000;
+let cached: { expiresAt: number; models: AdapterModel[] } | null = null;
+
+async function fetchQodoModels(): Promise<AdapterModel[]> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const exec = promisify(execFile);
+
+  try {
+    const { stdout } = await exec("qodo", ["models"], { timeout: 10_000 });
+    const models: AdapterModel[] = [];
+    for (const line of stdout.split(/\r?\n/)) {
+      const match = line.match(/^-\s+(.+)$/);
+      if (!match) continue;
+      const id = match[1].trim();
+      if (id) models.push({ id, label: id });
+    }
+    return models;
+  } catch {
+    return [];
+  }
+}
+
+let inflight: Promise<AdapterModel[]> | null = null;
+
+export async function listQodoModels(): Promise<AdapterModel[]> {
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) return cached.models;
+
+  if (!inflight) {
+    inflight = fetchQodoModels().finally(() => { inflight = null; });
+  }
+  const fetched = await inflight;
+  if (fetched.length > 0) {
+    cached = { expiresAt: Date.now() + CACHE_TTL_MS, models: fetched };
+    return fetched;
+  }
+
+  return qodoFallbackModels;
+}

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -81,6 +81,18 @@ import {
   models as hermesModels,
 } from "hermes-paperclip-adapter";
 import { BUILTIN_ADAPTER_TYPES } from "./builtin-adapter-types.js";
+import {
+  execute as qodoExecute,
+  listQodoSkills,
+  syncQodoSkills,
+  testEnvironment as qodoTestEnvironment,
+  sessionCodec as qodoSessionCodec,
+} from "@paperclipai/adapter-qodo-local/server";
+import {
+  agentConfigurationDoc as qodoAgentConfigurationDoc,
+  models as qodoModels,
+} from "@paperclipai/adapter-qodo-local";
+import { listQodoModels } from "./qodo-models.js";
 import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
@@ -227,6 +239,21 @@ const builtinFallbacks = new Map<string, ServerAdapterModule>();
 // external.  Persisted across reloads via the same disabled-adapters store.
 const pausedOverrides = new Set<string>();
 
+
+const qodoLocalAdapter: ServerAdapterModule = {
+  type: "qodo_local",
+  execute: qodoExecute,
+  testEnvironment: qodoTestEnvironment,
+  listSkills: listQodoSkills,
+  syncSkills: syncQodoSkills,
+  sessionCodec: qodoSessionCodec,
+  sessionManagement: getAdapterSessionManagement("qodo_local") ?? undefined,
+  models: qodoModels,
+  listModels: listQodoModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: qodoAgentConfigurationDoc,
+};
+
 function registerBuiltInAdapters() {
   for (const adapter of [
     claudeLocalAdapter,
@@ -237,6 +264,7 @@ function registerBuiltInAdapters() {
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
+    qodoLocalAdapter,
     processAdapter,
     httpAdapter,
   ]) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -102,6 +102,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "hermes_local",
   "opencode_local",
   "pi_local",
+  "qodo_local",
 ]);
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "./packages/adapters/openclaw-gateway" },
     { "path": "./packages/adapters/opencode-local" },
     { "path": "./packages/adapters/pi-local" },
+    { "path": "./packages/adapters/qodo-local" },
     { "path": "./server" },
     { "path": "./ui" },
     { "path": "./cli" }

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-qodo-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/shared": "workspace:*",
     "@radix-ui/react-slot": "^1.2.4",

--- a/ui/src/adapters/qodo-local/config-fields.tsx
+++ b/ui/src/adapters/qodo-local/config-fields.tsx
@@ -1,0 +1,30 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+
+export function QodoLocalConfigFields({
+  mode,
+  isCreate,
+  adapterType,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/qodo-local/index.ts
+++ b/ui/src/adapters/qodo-local/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { buildQodoLocalConfig, parseQodoStdoutLine } from "@paperclipai/adapter-qodo-local/ui";
+import { QodoLocalConfigFields } from "./config-fields";
+
+export const qodoLocalUIAdapter: UIAdapterModule = {
+  type: "qodo_local",
+  label: "Qodo CLI (local)",
+  parseStdoutLine: parseQodoStdoutLine,
+  ConfigFields: QodoLocalConfigFields,
+  buildAdapterConfig: buildQodoLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -7,6 +7,7 @@ import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
+import { qodoLocalUIAdapter } from "./qodo-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 import { loadDynamicParser, invalidateDynamicParser } from "./dynamic-loader";
@@ -51,6 +52,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
     hermesLocalUIAdapter,
+    qodoLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,

--- a/ui/src/components/QodoLogoIcon.tsx
+++ b/ui/src/components/QodoLogoIcon.tsx
@@ -1,0 +1,9 @@
+import { cn } from "../lib/utils";
+
+export function QodoLogoIcon({ className }: { className?: string }) {
+  return (
+    <svg fill="currentColor" viewBox="0 0 24 24" className={cn(className)} xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 2a8 8 0 00-8 8v4a8 8 0 0013.06 6.19l2.65 2.65a1.25 1.25 0 001.77-1.77l-2.42-2.42A8 8 0 0020 14v-4a8 8 0 00-8-8zm0 2.5A5.5 5.5 0 0117.5 10v4A5.5 5.5 0 1112 4.5z" />
+    </svg>
+  );
+}

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -25,6 +25,7 @@ const ENABLED_INVITE_ADAPTERS = new Set([
   "gemini_local",
   "opencode_local",
   "pi_local",
+  "qodo_local",
   "cursor",
 ]);
 


### PR DESCRIPTION
## Thinking Path

**Problem**: Paperclip doesn't support [Qodo CLI](https://qodo.ai) as an adapter. Similar to the pattern in #690 (Qwen adapter request).

**Solution**: Add a full `qodo_local` adapter with dynamic model discovery, following the existing adapter pattern.

## Changes

### New adapter package: `packages/adapters/qodo-local/`
- `execute.ts` — runs `qodo chat --ci --yes --act --model=X "prompt"`
- `parse.ts` — parses JSON stdout events and plain text fallback
- `test.ts` — verifies qodo is installed via `qodo --version`
- `skills.ts` — skill sync to `~/.qodo/skills/`
- Session resume via `--resume` flag

### Dynamic model discovery
- `server/src/adapters/qodo-models.ts` — shells out to `qodo models`, parses output, caches for 2 minutes
- Falls back to static model list if command fails

### Registration
- Server: `server/src/adapters/registry.ts`
- UI: `ui/src/adapters/registry.ts` + `ui/src/adapters/qodo-local/`
- Shared: `packages/shared/src/constants.ts`
- Heartbeat: `server/src/services/heartbeat.ts`
- Package deps: server, ui, cli `package.json`

### UI integration
- `QodoLogoIcon.tsx` — brand icon component
- Adapter cards in NewAgentDialog, OnboardingWizard
- Labels in agent-config-primitives
- isLocal checks in AgentConfigForm, AgentDetail

## Testing
- TypeScript compiles without errors
- `pnpm install` succeeds with workspace links
- Dynamic model discovery tested with `qodo models` output