### PR TITLE
fix(ci): refresh lockfile in verify/e2e when manifests change

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -107,6 +109,14 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Refresh lockfile for new workspace packages
+        run: |
+          changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          manifest_pattern='(^|/)package\.json$|^pnpm-workspace\.yaml$|^\.npmrc$|^pnpmfile\.(cjs|js|mjs)$'
+          if printf '%s\n' "$changed" | grep -Eq "$manifest_pattern"; then
+            pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -134,6 +144,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -145,6 +157,14 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Refresh lockfile for new workspace packages
+        run: |
+          changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          manifest_pattern='(^|/)package\.json$|^pnpm-workspace\.yaml$|^\.npmrc$|^pnpmfile\.(cjs|js|mjs)$'
+          if printf '%s\n' "$changed" | grep -Eq "$manifest_pattern"; then
+            pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Contributors add new adapters as workspace packages under `packages/adapters/`
- New workspace packages require `pnpm-lock.yaml` to be updated
- The `policy` job correctly blocks manual lockfile edits (CI owns the lockfile)
- The `policy` job already runs `pnpm install --lockfile-only` to validate dependency resolution when manifests change
- But `verify` and `e2e` jobs use `pnpm install --frozen-lockfile` without refreshing first
- This creates a chicken-and-egg problem: PRs adding new workspace packages can never pass CI
- This PR adds the same lockfile refresh step (already in `policy`) to `verify` and `e2e`

## What Changed

Added a "Refresh lockfile for new workspace packages" step to both `verify` and `e2e` jobs in `.github/workflows/pr.yml`. This step:
1. Checks if any package manifests changed in the PR
2. If so, runs `pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile` to update the lockfile
3. Then the existing `pnpm install --frozen-lockfile` succeeds

This mirrors the existing "Validate dependency resolution when manifests change" step already present in the `policy` job.

## Verification

- PRs that don't change manifests: no behavior change (the refresh step is skipped)
- PRs that change manifests (e.g. adding new adapters): lockfile is refreshed before `--frozen-lockfile` install
- The `policy` job still blocks manual lockfile commits, maintaining CI ownership of the lockfile

## Risks

- Low risk: the refresh step only runs when manifests change, and uses the same command the policy job already runs
- No impact on PRs that don't add new packages

## Model Used

Claude Sonnet 4 via Kiro CLI

## Checklist

- [x] PR follows the template
- [x] Change is minimal and focused
- [x] No tests affected (CI workflow change only)