### PR TITLE
fix(ui): truncate long agent names in kanban cards

### DIFF
--- a/ui/src/components/Identity.test.tsx
+++ b/ui/src/components/Identity.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Identity } from "./Identity";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("Identity", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("allows long names to shrink and exposes the full name on hover", () => {
+    const root = createRoot(container);
+    const longName = "QA and Repo Compliance Engineer";
+
+    act(() => {
+      root.render(<Identity name={longName} size="xs" />);
+    });
+
+    const wrapper = container.querySelector("span[title]") as HTMLSpanElement | null;
+    const name = wrapper?.querySelector("span.truncate") as HTMLSpanElement | null;
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.getAttribute("title")).toBe(longName);
+    expect(wrapper?.className).toContain("min-w-0");
+    expect(wrapper?.className).toContain("max-w-full");
+    expect(name).not.toBeNull();
+    expect(name?.className).toContain("min-w-0");
+    expect(name?.className).toContain("truncate");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/Identity.tsx
+++ b/ui/src/components/Identity.tsx
@@ -28,12 +28,20 @@ export function Identity({ name, avatarUrl, initials, size = "default", classNam
   const displayInitials = initials ?? deriveInitials(name);
 
   return (
-    <span className={cn("inline-flex gap-1.5 items-center", size === "xs" && "gap-1", size === "lg" && "gap-2", className)}>
-      <Avatar size={size}>
+    <span
+      title={name}
+      className={cn(
+        "inline-flex min-w-0 max-w-full gap-1.5",
+        size === "xs" ? "items-baseline gap-1" : "items-center",
+        size === "lg" && "gap-2",
+        className,
+      )}
+    >
+      <Avatar size={size} className={size === "xs" ? "relative -top-px" : undefined}>
         {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
         <AvatarFallback>{displayInitials}</AvatarFallback>
       </Avatar>
-      <span className={cn("truncate", textSize[size])}>{name}</span>
+      <span className={cn("min-w-0 truncate", textSize[size])}>{name}</span>
     </span>
   );
 }

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -167,7 +167,7 @@ function KanbanCard({
           )}
         </div>
         <p className="text-sm leading-snug line-clamp-2 mb-2">{issue.title}</p>
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <PriorityIcon priority={issue.priority} />
           {issue.assigneeAgentId && (() => {
             const name = agentName(issue.assigneeAgentId);


### PR DESCRIPTION
## Summary
- allow assignee identity rows in kanban cards to shrink inside the fixed-width card layout
- add hover titles for identities so the full agent name remains available
- add a focused UI test covering long-name truncation support

## Testing
- pnpm exec vitest run ui/src/components/Identity.test.tsx
- pnpm --filter @paperclipai/ui typecheck

Closes #2711