### PR TITLE
fix(ui): batch persisted live transcript updates

### DIFF
--- a/ui/src/components/transcript/useLiveRunTranscripts.strictmode.test.tsx
+++ b/ui/src/components/transcript/useLiveRunTranscripts.strictmode.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { StrictMode, useEffect } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { LiveRunForIssue } from "@/api/heartbeats";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLiveRunTranscripts } from "./useLiveRunTranscripts";
+
+const getGeneralMock = vi.fn(async () => ({ censorUsernameInLogs: false }));
+const logMock = vi.fn();
+
+vi.mock("../../api/instanceSettings", () => ({
+  instanceSettingsApi: {
+    getGeneral: () => getGeneralMock(),
+  },
+}));
+
+vi.mock("../../api/heartbeats", () => ({
+  heartbeatsApi: {
+    log: (runId: string, offset = 0, limitBytes = 256000) => logMock(runId, offset, limitBytes),
+  },
+}));
+
+vi.mock("../../adapters", async () => {
+  const actual = await vi.importActual<typeof import("../../adapters")>("../../adapters");
+  return {
+    ...actual,
+    onAdapterChange: () => () => {},
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createRun(id: string): LiveRunForIssue {
+  return {
+    id,
+    status: "succeeded",
+    invocationSource: "assignment",
+    triggerDetail: null,
+    startedAt: "2026-04-04T00:00:00.000Z",
+    finishedAt: "2026-04-04T00:01:00.000Z",
+    createdAt: "2026-04-04T00:00:00.000Z",
+    agentId: `agent-${id}`,
+    agentName: `Agent ${id}`,
+    adapterType: "process",
+    issueId: `issue-${id}`,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function HookProbe({
+  runs,
+  onSnapshot,
+}: {
+  runs: LiveRunForIssue[];
+  onSnapshot: (value: Record<string, boolean>) => void;
+}) {
+  const { hasOutputForRun } = useLiveRunTranscripts({
+    runs,
+    companyId: "company-1",
+  });
+
+  useEffect(() => {
+    onSnapshot(
+      Object.fromEntries(runs.map((run) => [run.id, hasOutputForRun(run.id)])),
+    );
+  }, [hasOutputForRun, onSnapshot, runs]);
+
+  return null;
+}
+
+describe("useLiveRunTranscripts strict mode", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    getGeneralMock.mockClear();
+    logMock.mockReset();
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("retains persisted transcript output for multiple runs after StrictMode remounts", async () => {
+    const runA = createRun("run-a");
+    const runB = createRun("run-b");
+    const runAFirst = deferred<{ runId: string; store: string; logRef: string; content: string; nextOffset?: number }>();
+    const runBFirst = deferred<{ runId: string; store: string; logRef: string; content: string; nextOffset?: number }>();
+    const snapshots: Array<Record<string, boolean>> = [];
+
+    logMock.mockImplementation((runId: string) => {
+      if (runId === runA.id) return runAFirst.promise;
+      if (runId === runB.id) return runBFirst.promise;
+      return Promise.resolve({
+        runId,
+        store: "inline",
+        logRef: `${runId}-log`,
+        content: "",
+      });
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <QueryClientProvider client={queryClient}>
+            <HookProbe runs={[runA, runB]} onSnapshot={(value) => snapshots.push(value)} />
+          </QueryClientProvider>
+        </StrictMode>,
+      );
+    });
+
+    await act(async () => {
+      runBFirst.resolve({
+        runId: runB.id,
+        store: "inline",
+        logRef: "log-b",
+        content: `${JSON.stringify({ ts: "2026-04-04T00:00:02.000Z", stream: "stdout", chunk: "second run line\\n" })}\n`,
+      });
+      runAFirst.resolve({
+        runId: runA.id,
+        store: "inline",
+        logRef: "log-a",
+        content: `${JSON.stringify({ ts: "2026-04-04T00:00:01.000Z", stream: "stdout", chunk: "first run line\\n" })}\n`,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(logMock).toHaveBeenCalledWith(runA.id, 0, 256000);
+    expect(logMock).toHaveBeenCalledWith(runB.id, 0, 256000);
+    expect(snapshots.some((snapshot) => snapshot[runA.id] && snapshot[runB.id])).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/transcript/useLiveRunTranscripts.ts
+++ b/ui/src/components/transcript/useLiveRunTranscripts.ts
@@ -210,51 +210,103 @@ export function useLiveRunTranscripts({
   useEffect(() => {
     if (normalizedRuns.length === 0) return;
 
+    seenChunkKeysRef.current.clear();
+    pendingLogRowsByRunRef.current.clear();
+    logOffsetByRunRef.current.clear();
+
     let cancelled = false;
 
-    const readRunLog = async (run: RunTranscriptSource) => {
-      if (missingTerminalLogRunIdsRef.current.has(run.id)) {
-        return;
-      }
-      const offset = logOffsetByRunRef.current.get(run.id) ?? resolveInitialLogOffset(run, logReadLimitBytes);
-      try {
-        const result = await heartbeatsApi.log(run.id, offset, logReadLimitBytes);
-        if (cancelled) return;
-
-        appendChunks(run.id, parsePersistedLogContent(run.id, result.content, pendingLogRowsByRunRef.current));
-
-        if (result.nextOffset !== undefined) {
-          logOffsetByRunRef.current.set(run.id, result.nextOffset);
-          return;
-        }
-        if (result.content.length > 0) {
-          logOffsetByRunRef.current.set(run.id, offset + result.content.length);
-        }
-      } catch (error) {
-        if (error instanceof ApiError && error.status === 404 && isTerminalStatus(run.status)) {
-          missingTerminalLogRunIdsRef.current.add(run.id);
-        }
-      } finally {
-        if (!cancelled) {
-          setHydratedRunIds((prev) => {
-            if (prev.has(run.id)) return prev;
-            const next = new Set(prev);
-            next.add(run.id);
-            return next;
-          });
-        }
-      }
-    };
-
     const readAll = async () => {
-      await Promise.all(normalizedRuns.map((run) => readRunLog(run)));
+      const results = await Promise.allSettled(
+        normalizedRuns.map(async (run) => {
+          if (missingTerminalLogRunIdsRef.current.has(run.id)) {
+            return { run, skipped: true as const };
+          }
+          const offset = logOffsetByRunRef.current.get(run.id) ?? resolveInitialLogOffset(run, logReadLimitBytes);
+          try {
+            const result = await heartbeatsApi.log(run.id, offset, logReadLimitBytes);
+            return { run, result, offset, skipped: false as const };
+          } catch (error) {
+            return { run, error, offset, skipped: false as const };
+          }
+        }),
+      );
+      if (cancelled) return;
+
+      const parsedByRun = new Map<string, Array<RunLogChunk & { dedupeKey: string }>>();
+      const hydratedRunIds = new Set<string>();
+
+      for (const settled of results) {
+        if (settled.status !== "fulfilled") continue;
+        const entry = settled.value;
+        hydratedRunIds.add(entry.run.id);
+
+        if (entry.skipped) continue;
+
+        if ("error" in entry) {
+          if (entry.error instanceof ApiError && entry.error.status === 404 && isTerminalStatus(entry.run.status)) {
+            missingTerminalLogRunIdsRef.current.add(entry.run.id);
+          }
+          continue;
+        }
+
+        const parsed = parsePersistedLogContent(entry.run.id, entry.result.content, pendingLogRowsByRunRef.current);
+        if (parsed.length > 0) {
+          parsedByRun.set(entry.run.id, parsed);
+        }
+
+        if (entry.result.nextOffset !== undefined) {
+          logOffsetByRunRef.current.set(entry.run.id, entry.result.nextOffset);
+        } else if (entry.result.content.length > 0) {
+          logOffsetByRunRef.current.set(entry.run.id, entry.offset + entry.result.content.length);
+        }
+      }
+
+      if (parsedByRun.size > 0) {
+        setChunksByRun((prev) => {
+          const next = new Map(prev);
+          let changed = false;
+
+          for (const [runId, chunks] of parsedByRun) {
+            const existing = [...(next.get(runId) ?? [])];
+            for (const chunk of chunks) {
+              if (seenChunkKeysRef.current.has(chunk.dedupeKey)) continue;
+              seenChunkKeysRef.current.add(chunk.dedupeKey);
+              existing.push({ ts: chunk.ts, stream: chunk.stream, chunk: chunk.chunk });
+              changed = true;
+            }
+            if (existing.length > 0) {
+              next.set(runId, existing.slice(-maxChunksPerRun));
+            }
+          }
+
+          if (!changed) return prev;
+          if (seenChunkKeysRef.current.size > 12000) {
+            seenChunkKeysRef.current.clear();
+          }
+          return next;
+        });
+      }
+
+      if (hydratedRunIds.size > 0) {
+        setHydratedRunIds((prev) => {
+          const next = new Set(prev);
+          let changed = false;
+          for (const runId of hydratedRunIds) {
+            if (next.has(runId)) continue;
+            next.add(runId);
+            changed = true;
+          }
+          return changed ? next : prev;
+        });
+      }
     };
 
     void readAll();
     const activeRuns = normalizedRuns.filter((run) => !isTerminalStatus(run.status));
     const interval = activeRuns.length > 0 && logPollIntervalMs > 0
       ? window.setInterval(() => {
-          void Promise.all(activeRuns.map((run) => readRunLog(run)));
+          void readAll();
         }, logPollIntervalMs)
       : null;
 
@@ -262,7 +314,7 @@ export function useLiveRunTranscripts({
       cancelled = true;
       if (interval !== null) window.clearInterval(interval);
     };
-  }, [logPollIntervalMs, logReadLimitBytes, normalizedRuns, runIdsKey]);
+  }, [logPollIntervalMs, logReadLimitBytes, maxChunksPerRun, normalizedRuns, runIdsKey]);
 
   useEffect(() => {
     if (!enableRealtimeUpdates) return;


### PR DESCRIPTION
## Summary
- batch persisted run-log reads into a single transcript state update per poll
- clear transcript dedupe and offset refs when the persisted log effect restarts
- add a focused hook test covering multiple finished runs under StrictMode

## Testing
- pnpm exec vitest run ui/src/components/transcript/useLiveRunTranscripts.test.tsx
- pnpm --filter @paperclipai/ui typecheck

Closes #2736