### PR TITLE
feat(ui): add Approvals nav item to sidebar with pending count badge

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Boxes,
   Repeat,
   Settings,
+  ShieldCheck,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -20,6 +21,7 @@ import { SidebarAgents } from "./SidebarAgents";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { heartbeatsApi } from "../api/heartbeats";
+import { approvalsApi } from "../api/approvals";
 import { queryKeys } from "../lib/queryKeys";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Button } from "@/components/ui/button";
@@ -36,6 +38,13 @@ export function Sidebar() {
     refetchInterval: 10_000,
   });
   const liveRunCount = liveRuns?.length ?? 0;
+  const { data: pendingApprovals } = useQuery({
+    queryKey: queryKeys.approvals.list(selectedCompanyId!, "pending"),
+    queryFn: () => approvalsApi.list(selectedCompanyId!, "pending"),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 15_000,
+  });
+  const pendingApprovalCount = pendingApprovals?.length ?? 0;
 
   function openSearch() {
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }));
@@ -101,6 +110,13 @@ export function Sidebar() {
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
           <SidebarNavItem to="/routines" label="Routines" icon={Repeat} textBadge="Beta" textBadgeTone="amber" />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          <SidebarNavItem
+            to="/approvals"
+            label="Approvals"
+            icon={ShieldCheck}
+            badge={pendingApprovalCount || undefined}
+            badgeTone={pendingApprovalCount > 0 ? "danger" : "default"}
+          />
         </SidebarSection>
 
         <SidebarProjects />


### PR DESCRIPTION
## Summary

Adds an **Approvals** navigation item to the sidebar so board operators can quickly see and access pending approval requests without navigating away from their current view.

**Problem:** Currently, pending approvals (agent hire requests, budget approvals, etc.) are only visible by navigating to the Approvals page directly. Board operators managing multiple agent companies have no passive visibility into approvals that need their attention. This creates delays — agents sit idle waiting for approval while the board doesn't realize anything is pending.

**Solution:** 
- Added `Approvals` nav item to the sidebar between Goals and the Projects section
- Shows a **red badge with pending count** when approvals are waiting (polls every 15s)
- Badge disappears when no approvals are pending
- Uses the existing `ShieldCheck` icon from lucide-react and the existing `approvalsApi.list()` endpoint

## Changes

- `ui/src/components/Sidebar.tsx` — Added approval count query + nav item with badge

## Test plan

- [ ] Verify "Approvals" appears in sidebar between Goals and Projects
- [ ] Create a pending approval (e.g., agent hire request) and confirm badge shows count
- [ ] Approve/reject all pending approvals and confirm badge disappears
- [ ] Verify badge updates within 15 seconds of new approval being created
- [ ] Check no layout shift or visual regression in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)