### PR TITLE
Bust local plugin manifest cache during upgrade

### DIFF
--- a/server/src/__tests__/plugin-fresh-manifest-loader.test.ts
+++ b/server/src/__tests__/plugin-fresh-manifest-loader.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadFreshManifestModule } from "../services/plugin-loader.js";
+
+describe("loadFreshManifestModule", () => {
+  const cleanupPaths = new Set<string>();
+
+  afterEach(async () => {
+    for (const cleanupPath of cleanupPaths) {
+      await rm(cleanupPath, { recursive: true, force: true });
+    }
+    cleanupPaths.clear();
+  });
+
+  it("ignores stdout written during manifest evaluation", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-fresh-manifest-"));
+    cleanupPaths.add(tempRoot);
+
+    const manifestPath = path.join(tempRoot, "manifest.js");
+    const expected = {
+      id: "paperclip.fresh_manifest_stdout",
+      apiVersion: 1,
+      version: "1.2.3",
+      displayName: "Fresh Manifest Stdout Fixture",
+      description: "Writes to stdout during evaluation to exercise JSON transport isolation.",
+      author: "Paperclip",
+      categories: ["automation"],
+      capabilities: ["companies.read"],
+      entrypoints: {
+        worker: "./worker.js",
+      },
+    };
+
+    await writeFile(
+      manifestPath,
+      [
+        `console.log("noise-before");`,
+        `process.stdout.write("noise-write\\n");`,
+        `console.log(${JSON.stringify({ polluted: true })});`,
+        `export default ${JSON.stringify(expected)};`,
+        `console.log("noise-after");`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(loadFreshManifestModule(manifestPath)).resolves.toEqual(expected);
+  });
+
+  it("still fails when the manifest module itself throws", async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-fresh-manifest-throw-"));
+    cleanupPaths.add(tempRoot);
+
+    const manifestPath = path.join(tempRoot, "manifest.js");
+    await writeFile(
+      manifestPath,
+      `throw new Error("boom-from-manifest");\n`,
+      "utf8",
+    );
+
+    await expect(loadFreshManifestModule(manifestPath)).rejects.toThrow(
+      /Failed to load fresh manifest module/,
+    );
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -29,7 +29,7 @@ import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { Db } from "@paperclipai/db";
 import { PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
@@ -59,6 +59,15 @@ export const BUNDLED_LOCAL_PLUGIN_ROOT = path.join(REPO_ROOT, "packages", "plugi
 export const STANDALONE_BUNDLED_PLUGIN_ROOT = path.join(BUNDLED_LOCAL_PLUGIN_ROOT, "sandbox-providers");
 export const LOCAL_PLUGIN_AUTOBUILD_TIMEOUT_MS = 120_000;
 const STANDALONE_BUNDLED_PLUGIN_SDK_PACKAGE = "@paperclipai/plugin-sdk";
+
+const FRESH_MANIFEST_LOADER_SCRIPT = `
+import { pathToFileURL } from "node:url";
+
+const manifestPath = process.argv[1];
+const mod = await import(pathToFileURL(manifestPath).href);
+const raw = mod.default ?? mod;
+process.stdout.write(JSON.stringify(raw));
+`;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1193,8 +1202,12 @@ export function pluginLoader(
    */
   async function fetchAndValidate(
     installOptions: PluginInstallOptions,
+    options: {
+      freshManifest?: boolean;
+    } = {},
   ): Promise<DiscoveredPlugin> {
     const { packageName, localPath, version, installDir } = installOptions;
+    const { freshManifest = false } = options;
 
     if (!packageName && !localPath) {
       throw new Error("Either packageName or localPath must be provided");
@@ -1283,7 +1296,7 @@ export function pluginLoader(
       );
     }
 
-    const manifest = await loadManifestFromPath(manifestPath);
+    const manifest = await loadManifestFromPath(manifestPath, { fresh: freshManifest });
 
     // Step 4: Reject incompatible plugin API versions
     if (!manifestValidator.getSupportedVersions().includes(manifest.apiVersion)) {
@@ -1333,15 +1346,33 @@ export function pluginLoader(
    */
   async function loadManifestFromPath(
     manifestPath: string,
+    options: {
+      fresh?: boolean;
+    } = {},
   ): Promise<PaperclipPluginManifestV1> {
+    const { fresh = false } = options;
     let raw: unknown;
 
+    if (fresh) {
+      try {
+        const { stdout } = await execFileAsync(
+          process.execPath,
+          ["--input-type=module", "-e", FRESH_MANIFEST_LOADER_SCRIPT, manifestPath],
+          { timeout: 15_000, maxBuffer: 1024 * 1024 },
+        );
+        raw = JSON.parse(stdout);
+      } catch (err) {
+        throw new Error(
+          `Failed to load fresh manifest module at ${manifestPath}: ${String(err)}`,
+        );
+      }
+
+      return manifestValidator.parseOrThrow(raw);
+    }
+
     try {
-      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const manifestUrl = pathToFileURL(manifestPath);
-      const manifestStat = await stat(manifestPath);
-      manifestUrl.searchParams.set("mtime", String(Math.trunc(manifestStat.mtimeMs)));
-      const mod = await import(manifestUrl.href) as Record<string, unknown>;
+      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests.
+      const mod = await import(manifestPath) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {
@@ -1808,6 +1839,8 @@ export function pluginLoader(
         localPath,
         version,
         installDir: localPluginDir,
+      }, {
+        freshManifest: Boolean(localPath),
       });
 
       const newManifest = discovered.manifest!;

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -60,14 +60,54 @@ export const STANDALONE_BUNDLED_PLUGIN_ROOT = path.join(BUNDLED_LOCAL_PLUGIN_ROO
 export const LOCAL_PLUGIN_AUTOBUILD_TIMEOUT_MS = 120_000;
 const STANDALONE_BUNDLED_PLUGIN_SDK_PACKAGE = "@paperclipai/plugin-sdk";
 
-const FRESH_MANIFEST_LOADER_SCRIPT = `
+/**
+ * Short-lived Node script used by {@link loadFreshManifestModule}.
+ *
+ * Writes the imported manifest to an output file path (argv[2]) instead of
+ * stdout. That keeps the JSON transport isolated from incidental
+ * `console.log` / `process.stdout.write` output during module evaluation.
+ */
+export const FRESH_MANIFEST_LOADER_SCRIPT = `
 import { pathToFileURL } from "node:url";
+import { writeFileSync } from "node:fs";
 
 const manifestPath = process.argv[1];
+const outputPath = process.argv[2];
 const mod = await import(pathToFileURL(manifestPath).href);
 const raw = mod.default ?? mod;
-process.stdout.write(JSON.stringify(raw));
+writeFileSync(outputPath, JSON.stringify(raw), "utf8");
 `;
+
+/**
+ * Import a plugin manifest module in an isolated Node subprocess and return
+ * the raw export. Used for local-path upgrades so rebuilt ESM/CJS manifests
+ * are re-read without host process module-cache reuse.
+ *
+ * The child writes JSON to a temp file rather than stdout so evaluation-time
+ * stdout noise cannot corrupt the transport.
+ */
+export async function loadFreshManifestModule(manifestPath: string): Promise<unknown> {
+  const outputPath = path.join(
+    os.tmpdir(),
+    `paperclip-fresh-manifest-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+  );
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "-e", FRESH_MANIFEST_LOADER_SCRIPT, manifestPath, outputPath],
+      { timeout: 15_000, maxBuffer: 1024 * 1024 },
+    );
+    const payload = await readFile(outputPath, "utf8");
+    return JSON.parse(payload) as unknown;
+  } catch (err) {
+    throw new Error(
+      `Failed to load fresh manifest module at ${manifestPath}: ${String(err)}`,
+    );
+  } finally {
+    await rm(outputPath, { force: true }).catch(() => undefined);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1354,19 +1394,7 @@ export function pluginLoader(
     let raw: unknown;
 
     if (fresh) {
-      try {
-        const { stdout } = await execFileAsync(
-          process.execPath,
-          ["--input-type=module", "-e", FRESH_MANIFEST_LOADER_SCRIPT, manifestPath],
-          { timeout: 15_000, maxBuffer: 1024 * 1024 },
-        );
-        raw = JSON.parse(stdout);
-      } catch (err) {
-        throw new Error(
-          `Failed to load fresh manifest module at ${manifestPath}: ${String(err)}`,
-        );
-      }
-
+      raw = await loadFreshManifestModule(manifestPath);
       return manifestValidator.parseOrThrow(raw);
     }
 


### PR DESCRIPTION
## Thinking Path
- Paperclip loads plugins from npm packages and local filesystem paths
- Local filesystem plugins are important for fast iteration while developing Paperclip plugins
- Plugin upgrades are supposed to let operators rebuild a local plugin and refresh it in place
- But the manifest loader was reusing the same imported module, so rebuilt manifests could still report stale metadata
- My first fix only addressed ESM-path caching and was too broad
- This PR narrows the fix to local upgrade flows and fresh-loads the manifest in an isolated Node process
- That makes rebuilt local plugin manifests observable immediately for both ESM and CJS manifests without growing the host process module cache

## Summary
- fresh-load local plugin manifests out of process during local-path upgrades
- keep normal in-process manifest loading for install/discovery paths
- avoid stale local upgrade metadata without requiring a full server restart

## Why
`POST /api/plugins/:pluginId/upgrade` could keep returning the previous manifest version for local plugins after a rebuild. The stale result came from module caching in the host process. The revised approach avoids that cache entirely for the local-upgrade case.

Fixes #2774

## Verification
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm build`
- manual child-process CommonJS reload repro (`value: 1` then `value: 2`)
- manual local plugin upgrade verification against a running Paperclip instance

## Not run
- no new automated test was added for this cache invalidation path
- `pnpm test:run` currently has unrelated pre-existing failures/timeouts in the repo
