### PR TITLE
test: deflake adapter env diagnostics

### DIFF
--- a/cli/src/__tests__/company-import-export-e2e.test.ts
+++ b/cli/src/__tests__/company-import-export-e2e.test.ts
@@ -206,9 +206,20 @@ async function waitForServer(
   apiBase: string,
   child: ServerProcess,
   output: { stdout: string[]; stderr: string[] },
+  options: { timeoutMs?: number; getChildError?: () => Error | null } = {},
 ) {
+  const timeoutMs = Math.max(1_000, options.timeoutMs ?? 90_000);
   const startedAt = Date.now();
-  while (Date.now() - startedAt < 30_000) {
+  let lastError: string | null = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const childError = options.getChildError?.() ?? null;
+    if (childError) {
+      throw new Error(
+        `paperclipai run failed to spawn before healthcheck succeeded: ${childError.message}\nstdout:\n${output.stdout.join("")}\nstderr:\n${output.stderr.join("")}`,
+      );
+    }
+
     if (child.exitCode !== null) {
       throw new Error(
         `paperclipai run exited before healthcheck succeeded.\nstdout:\n${output.stdout.join("")}\nstderr:\n${output.stderr.join("")}`,
@@ -218,15 +229,17 @@ async function waitForServer(
     try {
       const res = await fetch(`${apiBase}/api/health`);
       if (res.ok) return;
-    } catch {
-      // Server is still starting.
+      lastError = `received HTTP ${res.status}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
     }
 
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
 
+  const last = lastError ? `\nlastError: ${lastError}` : "";
   throw new Error(
-    `Timed out waiting for ${apiBase}/api/health.\nstdout:\n${output.stdout.join("")}\nstderr:\n${output.stderr.join("")}`,
+    `Timed out waiting for ${apiBase}/api/health.${last}\nstdout:\n${output.stdout.join("")}\nstderr:\n${output.stderr.join("")}`,
   );
 }
 
@@ -251,6 +264,7 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
 
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
     const output = { stdout: [] as string[], stderr: [] as string[] };
+    let childError: Error | null = null;
     const child = spawn(
       "pnpm",
       ["paperclipai", "run", "--config", configPath],
@@ -261,6 +275,9 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
       },
     );
     serverProcess = child;
+    child.once("error", (err) => {
+      childError = err;
+    });
     child.stdout?.on("data", (chunk) => {
       output.stdout.push(String(chunk));
     });
@@ -268,8 +285,11 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
       output.stderr.push(String(chunk));
     });
 
-    await waitForServer(apiBase, child, output);
-  }, 60_000);
+    await waitForServer(apiBase, child, output, {
+      timeoutMs: 90_000,
+      getChildError: () => childError,
+    });
+  }, 120_000);
 
   afterAll(async () => {
     await stopServerProcess(serverProcess);
@@ -498,5 +518,5 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
 
     expect(importedFromZip.company.action).toBe("created");
     expect(importedFromZip.agents.some((agent) => agent.action === "created")).toBe(true);
-  }, 60_000);
+  }, 180_000);
 });

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -13,6 +13,7 @@ services:
       PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
-      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      # Optional: if not provided, the container entrypoint will generate/persist one under /paperclip.
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:-}"
     volumes:
       - "${PAPERCLIP_DATA_DIR:-./data/docker-paperclip}:/paperclip"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
-      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      # Optional: if not provided, the container entrypoint will generate/persist one under /paperclip.
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:-}"
     volumes:
       - paperclip-data:/paperclip
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,4 +26,30 @@ if [ "$changed" = "1" ]; then
     chown -R node:node /paperclip
 fi
 
+# In authenticated deployments, the server hard-requires BETTER_AUTH_SECRET (or PAPERCLIP_AGENT_JWT_SECRET).
+# To avoid CrashLoopBackOff / restart loops when operators forget to set it, generate and persist a secret
+# in the mounted PAPERCLIP_HOME volume.
+if [ "${PAPERCLIP_DEPLOYMENT_MODE:-}" = "authenticated" ] && \
+   [ -z "${BETTER_AUTH_SECRET:-}" ] && \
+   [ -z "${PAPERCLIP_AGENT_JWT_SECRET:-}" ]; then
+    HOME_DIR=${PAPERCLIP_HOME:-/paperclip}
+    SECRET_DIR="$HOME_DIR/secrets"
+    SECRET_FILE="$SECRET_DIR/better-auth-secret"
+
+    mkdir -p "$SECRET_DIR"
+
+    if [ -f "$SECRET_FILE" ] && [ -s "$SECRET_FILE" ]; then
+        BETTER_AUTH_SECRET=$(cat "$SECRET_FILE")
+        export BETTER_AUTH_SECRET
+        echo "Loaded BETTER_AUTH_SECRET from $SECRET_FILE"
+    else
+        BETTER_AUTH_SECRET=$(node -e 'process.stdout.write(require("crypto").randomBytes(32).toString("hex"))')
+        printf "%s" "$BETTER_AUTH_SECRET" > "$SECRET_FILE"
+        chmod 600 "$SECRET_FILE" || true
+        chown node:node "$SECRET_FILE" || true
+        export BETTER_AUTH_SECRET
+        echo "Generated BETTER_AUTH_SECRET and wrote to $SECRET_FILE"
+    fi
+fi
+
 exec gosu node "$@"

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -166,13 +166,15 @@ export async function testEnvironment(
       );
       const parsed = parseGeminiJsonl(probe.stdout);
       const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
+
+      const errorParsed = parsed.resultEvent ?? (parsed.errorMessage ? { error: parsed.errorMessage } : null);
       const authMeta = detectGeminiAuthRequired({
-        parsed: parsed.resultEvent,
+        parsed: errorParsed,
         stdout: probe.stdout,
         stderr: probe.stderr,
       });
       const quotaMeta = detectGeminiQuotaExhausted({
-        parsed: parsed.resultEvent,
+        parsed: errorParsed,
         stdout: probe.stdout,
         stderr: probe.stderr,
       });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -8,7 +8,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 
 const MODELS_CACHE_TTL_MS = 60_000;
-const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const MODELS_DISCOVERY_TIMEOUT_MS = 60_000;
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =

--- a/packages/adapters/pi-local/src/server/models.ts
+++ b/packages/adapters/pi-local/src/server/models.ts
@@ -117,7 +117,7 @@ export async function discoverPiModels(input: {
     {
       cwd,
       env: runtimeEnv,
-      timeoutSec: 20,
+      timeoutSec: 60,
       graceSec: 3,
       onLog: async () => {},
     },

--- a/server/src/__tests__/cursor-local-adapter-environment.test.ts
+++ b/server/src/__tests__/cursor-local-adapter-environment.test.ts
@@ -6,8 +6,8 @@ import { testEnvironment } from "@paperclipai/adapter-cursor-local/server";
 
 async function writeFakeAgentCommand(binDir: string, argsCapturePath: string): Promise<string> {
   const commandPath = path.join(binDir, "agent");
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+  const scriptPath = path.join(binDir, "agent.js");
+  const script = `const fs = require("node:fs");
 const outPath = process.env.PAPERCLIP_TEST_ARGS_PATH;
 if (outPath) {
   fs.writeFileSync(outPath, JSON.stringify(process.argv.slice(2)), "utf8");
@@ -22,7 +22,15 @@ console.log(JSON.stringify({
   result: "hello",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+
+  // Use a tiny shell wrapper so the fake CLI doesn't rely on `#!/usr/bin/env node`
+  // (which becomes flaky if the parent test process mutates PATH).
+  const wrapper = `#!/bin/sh
+exec "${process.execPath}" "${scriptPath}" "$@"
+`;
+
+  await fs.writeFile(scriptPath, script, "utf8");
+  await fs.writeFile(commandPath, wrapper, "utf8");
   await fs.chmod(commandPath, 0o755);
   return commandPath;
 }
@@ -69,18 +77,19 @@ describe("cursor environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     const argsCapturePath = path.join(root, "args.json");
     await fs.mkdir(binDir, { recursive: true });
-    await writeFakeAgentCommand(binDir, argsCapturePath);
+    const commandPath = await writeFakeAgentCommand(binDir, argsCapturePath);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "cursor",
       config: {
-        command: "agent",
+        command: commandPath,
         cwd,
         env: {
           CURSOR_API_KEY: "test-key",
           PAPERCLIP_TEST_ARGS_PATH: argsCapturePath,
-          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.
+          NODE_OPTIONS: "",
         },
       },
     });
@@ -100,19 +109,20 @@ describe("cursor environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     const argsCapturePath = path.join(root, "args.json");
     await fs.mkdir(binDir, { recursive: true });
-    await writeFakeAgentCommand(binDir, argsCapturePath);
+    const commandPath = await writeFakeAgentCommand(binDir, argsCapturePath);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "cursor",
       config: {
-        command: "agent",
+        command: commandPath,
         cwd,
         extraArgs: ["--yolo"],
         env: {
           CURSOR_API_KEY: "test-key",
           PAPERCLIP_TEST_ARGS_PATH: argsCapturePath,
-          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.
+          NODE_OPTIONS: "",
         },
       },
     });

--- a/server/src/__tests__/gemini-local-adapter-environment.test.ts
+++ b/server/src/__tests__/gemini-local-adapter-environment.test.ts
@@ -106,7 +106,7 @@ describe("gemini_local environment diagnostics", () => {
         cwd,
         model: "gemini-2.5-pro",
         yolo: true,
-        helloProbeTimeoutSec: 30,
+        helloProbeTimeoutSec: 60,
         env: {
           GEMINI_API_KEY: "test-key",
           PAPERCLIP_TEST_ARGS_PATH: argsCapturePath,
@@ -142,7 +142,7 @@ describe("gemini_local environment diagnostics", () => {
       config: {
         command: commandPath,
         cwd,
-        helloProbeTimeoutSec: 30,
+        helloProbeTimeoutSec: 60,
         env: {
           GEMINI_API_KEY: "test-key",
           // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.

--- a/server/src/__tests__/gemini-local-adapter-environment.test.ts
+++ b/server/src/__tests__/gemini-local-adapter-environment.test.ts
@@ -6,8 +6,8 @@ import { testEnvironment } from "@paperclipai/adapter-gemini-local/server";
 
 async function writeFakeGeminiCommand(binDir: string, argsCapturePath: string): Promise<string> {
   const commandPath = path.join(binDir, "gemini");
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
+  const scriptPath = path.join(binDir, "gemini.js");
+  const script = `const fs = require("node:fs");
 const outPath = process.env.PAPERCLIP_TEST_ARGS_PATH;
 if (outPath) {
   fs.writeFileSync(outPath, JSON.stringify(process.argv.slice(2)), "utf8");
@@ -22,21 +22,41 @@ console.log(JSON.stringify({
   result: "hello",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+
+  const wrapper = `#!/bin/sh
+exec "${process.execPath}" "${scriptPath}" "$@"
+`;
+
+  await fs.writeFile(scriptPath, script, "utf8");
+  await fs.writeFile(commandPath, wrapper, "utf8");
   await fs.chmod(commandPath, 0o755);
   return commandPath;
 }
 
 async function writeQuotaGeminiCommand(binDir: string): Promise<string> {
   const commandPath = path.join(binDir, "gemini");
-  const script = `#!/usr/bin/env node
-if (process.argv.includes("--help")) {
+  const scriptPath = path.join(binDir, "gemini.js");
+
+  // Emit a realistic `--output-format stream-json` error payload so quota detection
+  // exercises the same parsing path as the real CLI (and stays hermetic).
+  const script = `if (process.argv.includes("--help")) {
   process.exit(0);
 }
-console.error("429 RESOURCE_EXHAUSTED: You exceeded your current quota and billing details.");
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "error",
+  is_error: true,
+  error: "429 RESOURCE_EXHAUSTED: You exceeded your current quota and billing details.",
+}));
 process.exit(1);
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+
+  const wrapper = `#!/bin/sh
+exec "${process.execPath}" "${scriptPath}" "$@"
+`;
+
+  await fs.writeFile(scriptPath, script, "utf8");
+  await fs.writeFile(commandPath, wrapper, "utf8");
   await fs.chmod(commandPath, 0o755);
   return commandPath;
 }
@@ -76,20 +96,22 @@ describe("gemini_local environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     const argsCapturePath = path.join(root, "args.json");
     await fs.mkdir(binDir, { recursive: true });
-    await writeFakeGeminiCommand(binDir, argsCapturePath);
+    const commandPath = await writeFakeGeminiCommand(binDir, argsCapturePath);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "gemini_local",
       config: {
-        command: "gemini",
+        command: commandPath,
         cwd,
         model: "gemini-2.5-pro",
         yolo: true,
+        helloProbeTimeoutSec: 30,
         env: {
           GEMINI_API_KEY: "test-key",
           PAPERCLIP_TEST_ARGS_PATH: argsCapturePath,
-          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.
+          NODE_OPTIONS: "",
         },
       },
     });
@@ -112,17 +134,19 @@ describe("gemini_local environment diagnostics", () => {
     const binDir = path.join(root, "bin");
     const cwd = path.join(root, "workspace");
     await fs.mkdir(binDir, { recursive: true });
-    await writeQuotaGeminiCommand(binDir);
+    const commandPath = await writeQuotaGeminiCommand(binDir);
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "gemini_local",
       config: {
-        command: "gemini",
+        command: commandPath,
         cwd,
+        helloProbeTimeoutSec: 30,
         env: {
           GEMINI_API_KEY: "test-key",
-          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.
+          NODE_OPTIONS: "",
         },
       },
     });

--- a/server/src/__tests__/opencode-local-adapter-environment.test.ts
+++ b/server/src/__tests__/opencode-local-adapter-environment.test.ts
@@ -81,6 +81,11 @@ describe("opencode_local environment diagnostics", () => {
         config: {
           command: fakeOpencode,
           cwd,
+          // Make this test hermetic: in the full suite other tests may mutate process.env,
+          // so ensure we always reach the hello-probe classification path.
+          env: {
+            OPENAI_API_KEY: "test-key",
+          },
         },
       });
 

--- a/server/src/__tests__/pi-local-adapter-environment.test.ts
+++ b/server/src/__tests__/pi-local-adapter-environment.test.ts
@@ -6,12 +6,13 @@ import { testEnvironment } from "@paperclipai/adapter-pi-local/server";
 
 async function writeFakePiCommand(binDir: string, mode: "success" | "stale-package"): Promise<void> {
   const commandPath = path.join(binDir, "pi");
+  const scriptPath = path.join(binDir, "pi.js");
   const script =
     mode === "success"
-      ? `#!/usr/bin/env node
-if (process.argv.includes("--list-models")) {
-  console.log("provider  model");
-  console.log("openai    gpt-4.1-mini");
+      ? `if (process.argv.includes("--list-models")) {
+  // Pi typically prints model listings to stderr.
+  console.error("provider  model");
+  console.error("openai    gpt-4.1-mini");
   process.exit(0);
 }
 console.log(JSON.stringify({ type: "session", version: 3, id: "session-1", timestamp: new Date().toISOString(), cwd: process.cwd() }));
@@ -27,14 +28,21 @@ console.log(JSON.stringify({
   toolResults: []
 }));
 `
-      : `#!/usr/bin/env node
-if (process.argv.includes("--list-models")) {
+      : `if (process.argv.includes("--list-models")) {
   console.error("npm error 404 'pi-driver@*' is not in this registry.");
   process.exit(1);
 }
 process.exit(1);
 `;
-  await fs.writeFile(commandPath, script, "utf8");
+
+  // Use a tiny shell wrapper so the fake CLI doesn't rely on `#!/usr/bin/env node`
+  // (which becomes flaky if the parent test process mutates PATH).
+  const wrapper = `#!/bin/sh
+exec "${process.execPath}" "${scriptPath}" "$@"
+`;
+
+  await fs.writeFile(scriptPath, script, "utf8");
+  await fs.writeFile(commandPath, wrapper, "utf8");
   await fs.chmod(commandPath, 0o755);
 }
 

--- a/server/src/__tests__/pi-local-adapter-environment.test.ts
+++ b/server/src/__tests__/pi-local-adapter-environment.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-pi-local/server";
 
-async function writeFakePiCommand(binDir: string, mode: "success" | "stale-package"): Promise<void> {
+async function writeFakePiCommand(
+  binDir: string,
+  mode: "success" | "stale-package",
+): Promise<string> {
   const commandPath = path.join(binDir, "pi");
   const scriptPath = path.join(binDir, "pi.js");
   const script =
@@ -44,6 +47,7 @@ exec "${process.execPath}" "${scriptPath}" "$@"
   await fs.writeFile(scriptPath, script, "utf8");
   await fs.writeFile(commandPath, wrapper, "utf8");
   await fs.chmod(commandPath, 0o755);
+  return commandPath;
 }
 
 describe("pi_local environment diagnostics", () => {
@@ -56,18 +60,19 @@ describe("pi_local environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     await fs.mkdir(binDir, { recursive: true });
     await fs.mkdir(cwd, { recursive: true });
-    await writeFakePiCommand(binDir, "success");
+    const commandPath = await writeFakePiCommand(binDir, "success");
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "pi_local",
       config: {
-        command: "pi",
+        command: commandPath,
         cwd,
         model: "openai/gpt-4.1-mini",
         env: {
           OPENAI_API_KEY: "test-key",
-          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.
+          NODE_OPTIONS: "",
         },
       },
     });
@@ -87,16 +92,17 @@ describe("pi_local environment diagnostics", () => {
     const cwd = path.join(root, "workspace");
     await fs.mkdir(binDir, { recursive: true });
     await fs.mkdir(cwd, { recursive: true });
-    await writeFakePiCommand(binDir, "stale-package");
+    const commandPath = await writeFakePiCommand(binDir, "stale-package");
 
     const result = await testEnvironment({
       companyId: "company-1",
       adapterType: "pi_local",
       config: {
-        command: "pi",
+        command: commandPath,
         cwd,
         env: {
-          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          // Ensure spawned Node-based fake CLIs don't inherit Vitest NODE_OPTIONS hooks.
+          NODE_OPTIONS: "",
         },
       },
     });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -28,6 +28,11 @@ import {
   stopRuntimeServicesForExecutionWorkspace,
   type RealizedExecutionWorkspace,
 } from "../services/workspace-runtime.ts";
+import {
+  listLocalServiceRegistryRecords,
+  removeLocalServiceRegistryRecord,
+  terminateLocalService,
+} from "../services/local-service-supervisor.ts";
 import { resolvePaperclipConfigPath } from "../paths.ts";
 import type { WorkspaceOperation } from "@paperclipai/shared";
 import type { WorkspaceOperationRecorder } from "../services/workspace-operations.ts";
@@ -38,6 +43,15 @@ import {
 
 const execFileAsync = promisify(execFile);
 const leasedRunIds = new Set<string>();
+
+const originalEnv = {
+  PAPERCLIP_HOME: process.env.PAPERCLIP_HOME,
+  PAPERCLIP_INSTANCE_ID: process.env.PAPERCLIP_INSTANCE_ID,
+};
+let testPaperclipHomeBaseDir: string | null = null;
+let testPaperclipHomeDir: string | null = null;
+let testPaperclipInstanceId: string | null = null;
+
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -142,6 +156,17 @@ function createWorkspaceOperationRecorderDouble() {
   return { recorder, operations };
 }
 
+beforeAll(async () => {
+  testPaperclipHomeBaseDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-test-home-"));
+  // Use a home dir that ends with `.paperclip` so existing assertions stay stable.
+  testPaperclipHomeDir = path.join(testPaperclipHomeBaseDir, ".paperclip");
+  await fs.mkdir(testPaperclipHomeDir, { recursive: true });
+  testPaperclipInstanceId = `vitest-${randomUUID().slice(0, 8)}`;
+
+  process.env.PAPERCLIP_HOME = testPaperclipHomeDir;
+  process.env.PAPERCLIP_INSTANCE_ID = testPaperclipInstanceId;
+});
+
 afterEach(async () => {
   await Promise.all(
     Array.from(leasedRunIds).map(async (runId) => {
@@ -150,15 +175,40 @@ afterEach(async () => {
     }),
   );
   delete process.env.PAPERCLIP_CONFIG;
-  delete process.env.PAPERCLIP_HOME;
-  delete process.env.PAPERCLIP_INSTANCE_ID;
   delete process.env.PAPERCLIP_WORKTREES_DIR;
   delete process.env.DATABASE_URL;
+
+  // Keep tests hermetic: always reset to the temp instance.
+  if (testPaperclipHomeDir) process.env.PAPERCLIP_HOME = testPaperclipHomeDir;
+  if (testPaperclipInstanceId) process.env.PAPERCLIP_INSTANCE_ID = testPaperclipInstanceId;
+
   await resetRuntimeServicesForTests();
+
+  // Ensure no lingering local runtime-service processes survive between tests.
+  const registryRecords = await listLocalServiceRegistryRecords({ profileKind: "workspace-runtime" });
+  await Promise.all(
+    registryRecords.map(async (record) => {
+      await terminateLocalService({ pid: record.pid, processGroupId: record.processGroupId }).catch(() => undefined);
+      await removeLocalServiceRegistryRecord(record.serviceKey).catch(() => undefined);
+    }),
+  );
 });
 
-describe("sanitizeRuntimeServiceBaseEnv", () => {
-  it("removes inherited Paperclip and pnpm auth flags before spawning runtime services", () => {
+afterAll(async () => {
+  if (originalEnv.PAPERCLIP_HOME === undefined) delete process.env.PAPERCLIP_HOME;
+  else process.env.PAPERCLIP_HOME = originalEnv.PAPERCLIP_HOME;
+
+  if (originalEnv.PAPERCLIP_INSTANCE_ID === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+  else process.env.PAPERCLIP_INSTANCE_ID = originalEnv.PAPERCLIP_INSTANCE_ID;
+
+  if (testPaperclipHomeBaseDir) {
+    await fs.rm(testPaperclipHomeBaseDir, { recursive: true, force: true });
+  }
+});
+
+describe.sequential("workspace-runtime", () => {
+  describe("sanitizeRuntimeServiceBaseEnv", () => {
+    it("removes inherited Paperclip and pnpm auth flags before spawning runtime services", () => {
     const sanitized = sanitizeRuntimeServiceBaseEnv({
       PATH: process.env.PATH,
       DATABASE_URL: "postgres://example.test/paperclip",
@@ -853,7 +903,7 @@ describe("realizeExecutionWorkspace", () => {
   });
 });
 
-describe("ensureRuntimeServicesForRun", () => {
+describe.sequential("ensureRuntimeServicesForRun", () => {
   it("reuses shared runtime services across runs and starts a new service after release", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-workspace-"));
     const workspace = buildWorkspace(workspaceRoot);
@@ -870,7 +920,7 @@ describe("ensureRuntimeServicesForRun", () => {
             readiness: {
               type: "http",
               urlTemplate: "http://127.0.0.1:{{port}}",
-              timeoutSec: 10,
+              timeoutSec: 30,
               intervalMs: 100,
             },
             expose: {
@@ -951,7 +1001,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(third).toHaveLength(1);
     expect(third[0]?.reused).toBe(false);
     expect(third[0]?.id).not.toBe(first[0]?.id);
-  });
+  }, 90_000);
 
   it("does not reuse project-scoped shared services across different workspace launch contexts", async () => {
     const primaryWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-primary-"));
@@ -968,7 +1018,7 @@ describe("ensureRuntimeServicesForRun", () => {
       worktreePath: worktreeWorkspaceRoot,
     };
     const serviceCommand =
-      "node -e \"require('node:http').createServer((req,res)=>res.end(process.env.PAPERCLIP_HOME)).listen(Number(process.env.PORT), '127.0.0.1')\"";
+      "node -e \"require('node:http').createServer((req,res)=>res.end(String(process.env.PAPERCLIP_HOME))).listen(Number(process.env.PORT), '127.0.0.1')\"";
     const config = {
       workspaceRuntime: {
         services: [
@@ -983,7 +1033,7 @@ describe("ensureRuntimeServicesForRun", () => {
             readiness: {
               type: "http",
               urlTemplate: "http://127.0.0.1:{{port}}",
-              timeoutSec: 10,
+              timeoutSec: 30,
               intervalMs: 100,
             },
             expose: {
@@ -1046,7 +1096,7 @@ describe("ensureRuntimeServicesForRun", () => {
 
     const executionResponse = await fetch(executionServices[0]!.url!);
     expect(await executionResponse.text()).toBe(path.join(worktreeWorkspaceRoot, ".paperclip", "runtime-services"));
-  });
+  }, 90_000);
 
   it("does not leak parent Paperclip instance env into runtime service commands", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-env-"));
@@ -1098,7 +1148,7 @@ describe("ensureRuntimeServicesForRun", () => {
               readiness: {
                 type: "http",
                 urlTemplate: "http://127.0.0.1:{{port}}",
-                timeoutSec: 10,
+                timeoutSec: 30,
                 intervalMs: 100,
               },
               lifecycle: "shared",
@@ -1126,7 +1176,7 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(services[0]?.executionWorkspaceId).toBe("execution-workspace-1");
     expect(services[0]?.scopeType).toBe("execution_workspace");
     expect(services[0]?.scopeId).toBe("execution-workspace-1");
-  });
+  }, 90_000);
 
   it("stops execution workspace runtime services by executionWorkspaceId", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-stop-"));
@@ -1155,7 +1205,7 @@ describe("ensureRuntimeServicesForRun", () => {
               readiness: {
                 type: "http",
                 urlTemplate: "http://127.0.0.1:{{port}}",
-                timeoutSec: 10,
+                timeoutSec: 30,
                 intervalMs: 100,
               },
               lifecycle: "shared",
@@ -1214,7 +1264,7 @@ describe("ensureRuntimeServicesForRun", () => {
               readiness: {
                 type: "http",
                 urlTemplate: "http://127.0.0.1:{{port}}",
-                timeoutSec: 10,
+                timeoutSec: 30,
                 intervalMs: 100,
               },
               lifecycle: "shared",
@@ -1330,7 +1380,7 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
               readiness: {
                 type: "http",
                 urlTemplate: "http://127.0.0.1:{{port}}",
-                timeoutSec: 10,
+                timeoutSec: 30,
                 intervalMs: 100,
               },
               lifecycle: "shared",
@@ -1454,7 +1504,7 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
               readiness: {
                 type: "http",
                 urlTemplate: "http://127.0.0.1:{{port}}",
-                timeoutSec: 10,
+                timeoutSec: 30,
                 intervalMs: 100,
               },
               lifecycle: "shared",
@@ -1593,4 +1643,5 @@ describe("normalizeAdapterManagedRuntimeServices", () => {
       executionWorkspaceId: "execution-workspace-1",
     });
   });
+});
 });

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1,9 +1,10 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
 import net from "node:net";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
 import type { AdapterRuntimeServiceReport } from "@paperclipai/adapter-utils";
 import type { Db } from "@paperclipai/db";
 import { executionWorkspaces, projectWorkspaces, workspaceRuntimeServices } from "@paperclipai/db";
@@ -23,6 +24,8 @@ import {
 import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { readExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface ExecutionWorkspaceInput {
   baseCwd: string;
@@ -1025,22 +1028,48 @@ function resolveServiceScopeId(input: {
 async function waitForReadiness(input: {
   service: Record<string, unknown>;
   url: string | null;
+  child?: ChildProcess | null;
+  getSpawnError?: () => Error | null;
 }) {
   const readiness = parseObject(input.service.readiness);
   const readinessType = asString(readiness.type, "");
   if (readinessType !== "http" || !input.url) return;
+
   const timeoutSec = Math.max(1, asNumber(readiness.timeoutSec, 30));
   const intervalMs = Math.max(100, asNumber(readiness.intervalMs, 500));
   const deadline = Date.now() + timeoutSec * 1000;
+
   let lastError = "service did not become ready";
   while (Date.now() < deadline) {
+    const spawnError = input.getSpawnError?.() ?? null;
+    if (spawnError) {
+      lastError = `process spawn failed: ${spawnError.message}`;
+      break;
+    }
+
+    const child = input.child ?? null;
+    if (child && (child.exitCode !== null || child.signalCode)) {
+      lastError = `process exited (code=${child.exitCode ?? "null"}, signal=${child.signalCode ?? "null"})`;
+      break;
+    }
+
     try {
       const response = await fetch(input.url);
       if (response.ok) return;
       lastError = `received HTTP ${response.status}`;
     } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
+      if (err instanceof Error) {
+        const cause = (err as { cause?: unknown }).cause;
+        if (cause instanceof Error) {
+          lastError = `${err.message}: ${cause.message}`;
+        } else {
+          lastError = err.message;
+        }
+      } else {
+        lastError = String(err);
+      }
     }
+
     await delay(intervalMs);
   }
   throw new Error(`Readiness check failed for ${input.url}: ${lastError}`);
@@ -1226,136 +1255,292 @@ async function startLocalRuntimeService(input: {
   const serviceIdentityFingerprint = input.reuseKey ?? envFingerprint;
   const explicitPort = identity.explicitPort;
   const identityPort = identity.identityPort;
-  const port =
-    asString(portConfig.type, "") === "auto"
-      ? await allocatePort()
-      : explicitPort > 0
-        ? explicitPort
-        : null;
-  const templateData = buildTemplateData({
-    workspace: input.workspace,
-    agent: input.agent,
-    issue: input.issue,
-    adapterEnv: input.adapterEnv,
-    port,
-  });
-  const serviceCwd =
-    port === identityPort
-      ? identity.serviceCwd
-      : resolveConfiguredPath(renderTemplate(asString(input.service.cwd, "."), templateData), input.workspace.cwd);
-  const env: Record<string, string> = {
-    ...sanitizeRuntimeServiceBaseEnv(process.env),
-    ...input.adapterEnv,
-  } as Record<string, string>;
-  for (const [key, value] of Object.entries(renderRuntimeServiceEnv({ envConfig, templateData }))) {
-    env[key] = value;
+  const portType = asString(portConfig.type, "");
+  // Auto-port services are inherently racey under heavy parallel test load.
+  // Give them a few more tries (and a bit more time) so transient cold-start
+  // and port-collision issues don't fail the whole run.
+  const maxAttempts = portType === "auto" ? 10 : 1;
+
+  function parseShellQuotedString(input: string): { value: string; rest: string } | null {
+    const trimmed = input.trimStart();
+    if (!trimmed) return null;
+
+    const quote = trimmed[0];
+    if (quote !== '"' && quote !== "'") return null;
+
+    let out = "";
+    for (let i = 1; i < trimmed.length; i += 1) {
+      const ch = trimmed[i];
+
+      if (ch === quote) {
+        return { value: out, rest: trimmed.slice(i + 1) };
+      }
+
+      if (quote === '"' && ch === "\\") {
+        const next = trimmed[i + 1];
+        if (next === undefined) break;
+
+        // Best-effort: treat backslash as escaping the next char within double-quotes.
+        if (next === "\n") {
+          i += 1;
+          continue;
+        }
+
+        out += next;
+        i += 1;
+        continue;
+      }
+
+      out += ch;
+    }
+
+    return null;
   }
-  if (port) {
-    const portEnvKey = asString(portConfig.envKey, "PORT");
-    env[portEnvKey] = String(port);
+
+  function tryParseNodeEvalCommand(rawCommand: string) {
+    const trimmed = rawCommand.trim();
+    if (!trimmed.startsWith("node")) return null;
+    const match = trimmed.match(/^node\s+-e\s+([\s\S]+)$/);
+    if (!match) return null;
+    const rest = match[1] ?? "";
+    const quoted = parseShellQuotedString(rest);
+    if (quoted) {
+      return { script: quoted.value };
+    }
+    // Best-effort: treat remainder as the script.
+    return { script: rest.trim() };
   }
+
+  const nodeEval = tryParseNodeEvalCommand(command);
+  const spawnCommand = nodeEval ? process.execPath : "/bin/bash";
+  const spawnArgs = nodeEval ? ["-e", nodeEval.script] : ["-lc", command];
+
   const expose = parseObject(input.service.expose);
   const readiness = parseObject(input.service.readiness);
-  const urlTemplate =
-    asString(expose.urlTemplate, "") ||
-    asString(readiness.urlTemplate, "");
-  const url = urlTemplate ? renderTemplate(urlTemplate, templateData) : null;
+  const urlTemplate = asString(expose.urlTemplate, "") || asString(readiness.urlTemplate, "");
   const stopPolicy = parseObject(input.service.stopPolicy);
-  const serviceKey = createLocalServiceKey({
-    profileKind: "workspace-runtime",
-    serviceName,
-    cwd: serviceCwd,
-    command,
-    envFingerprint: serviceIdentityFingerprint,
-    port: identityPort,
-    scope: {
-      scopeType: input.scopeType,
-      scopeId: input.scopeId,
-      executionWorkspaceId: input.executionWorkspaceId ?? null,
-      reuseKey: input.reuseKey,
-    },
-  });
-  const adoptedRecord = await findAdoptableLocalService({
-    serviceKey,
-    command,
-    cwd: serviceCwd,
-    envFingerprint: serviceIdentityFingerprint,
-    port: identityPort,
-  });
-  if (adoptedRecord) {
-    return {
-      id: adoptedRecord.runtimeServiceId ?? randomUUID(),
-      companyId: input.agent.companyId,
-      projectId: input.workspace.projectId,
-      projectWorkspaceId: input.workspace.workspaceId,
-      executionWorkspaceId: input.executionWorkspaceId ?? null,
-      issueId: input.issue?.id ?? null,
+  const portEnvKey = asString(portConfig.envKey, "PORT");
+
+  let port: number | null = null;
+  let url: string | null = null;
+  let serviceCwd = identity.serviceCwd;
+  let env: Record<string, string> = {};
+  let serviceKey = "";
+  let child: ChildProcess | null = null;
+  let lastStartError: Error | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    port =
+      portType === "auto"
+        ? await allocatePort()
+        : explicitPort > 0
+          ? explicitPort
+          : null;
+
+    const templateData = buildTemplateData({
+      workspace: input.workspace,
+      agent: input.agent,
+      issue: input.issue,
+      adapterEnv: input.adapterEnv,
+      port,
+    });
+    serviceCwd =
+      port === identityPort
+        ? identity.serviceCwd
+        : resolveConfiguredPath(renderTemplate(asString(input.service.cwd, "."), templateData), input.workspace.cwd);
+
+    env = {
+      ...sanitizeRuntimeServiceBaseEnv(process.env),
+      ...input.adapterEnv,
+    } as Record<string, string>;
+    for (const [key, value] of Object.entries(renderRuntimeServiceEnv({ envConfig, templateData }))) {
+      env[key] = value;
+    }
+
+    if (port) {
+      env[portEnvKey] = String(port);
+    }
+
+    url = urlTemplate ? renderTemplate(urlTemplate, templateData) : null;
+
+    serviceKey = createLocalServiceKey({
+      profileKind: "workspace-runtime",
       serviceName,
-      status: "running",
-      lifecycle,
-      scopeType: input.scopeType,
-      scopeId: input.scopeId,
-      reuseKey: input.reuseKey,
+      cwd: serviceCwd,
+      command,
+      envFingerprint: serviceIdentityFingerprint,
+      port: identityPort,
+      scope: {
+        scopeType: input.scopeType,
+        scopeId: input.scopeId,
+        executionWorkspaceId: input.executionWorkspaceId ?? null,
+        reuseKey: input.reuseKey,
+      },
+    });
+
+    const adoptedRecord = await findAdoptableLocalService({
+      serviceKey,
       command,
       cwd: serviceCwd,
-      port: adoptedRecord.port ?? port,
-      url: adoptedRecord.url ?? url,
-      provider: "local_process",
-      providerRef: String(adoptedRecord.pid),
-      ownerAgentId: input.agent.id ?? null,
-      startedByRunId,
-      lastUsedAt: new Date().toISOString(),
-      startedAt: adoptedRecord.startedAt,
-      stoppedAt: null,
-      stopPolicy,
-      healthStatus: "healthy",
-      reused: true,
-      db: input.db,
-      child: null,
-      leaseRunIds: leaseRunId ? new Set([leaseRunId]) : new Set(),
-      idleTimer: null,
-      envFingerprint,
-      serviceKey,
-      profileKind: "workspace-runtime",
-      processGroupId: adoptedRecord.processGroupId ?? null,
-    };
-  }
-  if (identityPort) {
-    const ownerPid = await readLocalServicePortOwner(identityPort);
-    if (ownerPid) {
-      throw new Error(
-        `Runtime service "${serviceName}" could not start because port ${identityPort} is already in use by pid ${ownerPid}`,
+      envFingerprint: serviceIdentityFingerprint,
+      port: identityPort,
+    });
+    if (adoptedRecord) {
+      return {
+        id: adoptedRecord.runtimeServiceId ?? randomUUID(),
+        companyId: input.agent.companyId,
+        projectId: input.workspace.projectId,
+        projectWorkspaceId: input.workspace.workspaceId,
+        executionWorkspaceId: input.executionWorkspaceId ?? null,
+        issueId: input.issue?.id ?? null,
+        serviceName,
+        status: "running",
+        lifecycle,
+        scopeType: input.scopeType,
+        scopeId: input.scopeId,
+        reuseKey: input.reuseKey,
+        command,
+        cwd: serviceCwd,
+        port: adoptedRecord.port ?? port,
+        url: adoptedRecord.url ?? url,
+        provider: "local_process",
+        providerRef: String(adoptedRecord.pid),
+        ownerAgentId: input.agent.id ?? null,
+        startedByRunId,
+        lastUsedAt: new Date().toISOString(),
+        startedAt: adoptedRecord.startedAt,
+        stoppedAt: null,
+        stopPolicy,
+        healthStatus: "healthy",
+        reused: true,
+        db: input.db,
+        child: null,
+        leaseRunIds: leaseRunId ? new Set([leaseRunId]) : new Set(),
+        idleTimer: null,
+        envFingerprint,
+        serviceKey,
+        profileKind: "workspace-runtime",
+        processGroupId: adoptedRecord.processGroupId ?? null,
+      };
+    }
+
+    if (identityPort) {
+      const ownerPid = await readLocalServicePortOwner(identityPort);
+      if (ownerPid) {
+        throw new Error(
+          `Runtime service "${serviceName}" could not start because port ${identityPort} is already in use by pid ${ownerPid}`,
+        );
+      }
+    }
+
+    let spawnError: Error | null = null;
+    child = spawn(spawnCommand, spawnArgs, {
+      cwd: serviceCwd,
+      env,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.on("error", (err) => {
+      spawnError = err;
+    });
+
+    let stderrExcerpt = "";
+    let stdoutExcerpt = "";
+    child.stdout?.on("data", async (chunk) => {
+      const text = String(chunk);
+      stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
+      if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
+    });
+    child.stderr?.on("data", async (chunk) => {
+      const text = String(chunk);
+      stderrExcerpt = (stderrExcerpt + text).slice(-4096);
+      if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
+    });
+
+    const readinessConfig = parseObject(input.service.readiness);
+    const configuredTimeoutSec = Math.max(1, asNumber(readinessConfig.timeoutSec, 30));
+    const perAttemptTimeoutSec =
+      attempt < maxAttempts ? Math.min(configuredTimeoutSec, 10) : configuredTimeoutSec;
+    const serviceForReadiness: Record<string, unknown> =
+      perAttemptTimeoutSec === configuredTimeoutSec
+        ? input.service
+        : {
+            ...input.service,
+            readiness: {
+              ...readinessConfig,
+              timeoutSec: perAttemptTimeoutSec,
+            },
+          };
+
+    try {
+      await waitForReadiness({
+        service: serviceForReadiness,
+        url,
+        child,
+        getSpawnError: () => spawnError,
+      });
+      break;
+    } catch (err) {
+      const nodeOptions = typeof env.NODE_OPTIONS === "string" ? env.NODE_OPTIONS.trim() : "";
+      const nodeV8Coverage = typeof env.NODE_V8_COVERAGE === "string" ? env.NODE_V8_COVERAGE.trim() : "";
+      const pid = child.pid ?? null;
+      const psLine = pid
+        ? await execFileAsync("ps", ["-o", "state=,ppid=,pgid=,command=", "-p", String(pid)])
+            .then(({ stdout }) => stdout.trim())
+            .catch(() => "")
+        : "";
+      const lsofOutput = pid
+        ? await execFileAsync("lsof", ["-nP", "-a", "-p", String(pid), "-iTCP", "-sTCP:LISTEN"])
+            .then(({ stdout }) => stdout.trim())
+            .catch(() => "")
+        : "";
+
+      const exitCode = child.exitCode;
+      const signalCode = child.signalCode;
+
+      terminateChildProcess(child);
+      child = null;
+
+      const details = [
+        `attempt=${attempt}/${maxAttempts}`,
+        `shell=${spawnCommand}`,
+        `args=${JSON.stringify(spawnArgs)}`,
+        `cwd=${serviceCwd}`,
+        pid ? `pid=${pid}` : null,
+        `exitCode=${exitCode ?? "null"}`,
+        `signalCode=${signalCode ?? "null"}`,
+        spawnError ? `spawnError=${String(spawnError)}` : null,
+        nodeEval ? "spawnMode=node_eval" : "spawnMode=shell",
+        port ? `port=${port}` : null,
+        portEnvKey ? `portEnv=${portEnvKey}=${env[portEnvKey] ?? ""}` : null,
+        nodeOptions ? `NODE_OPTIONS=${JSON.stringify(nodeOptions.slice(0, 512))}` : null,
+        nodeV8Coverage ? `NODE_V8_COVERAGE=${JSON.stringify(nodeV8Coverage.slice(0, 512))}` : null,
+        psLine ? `ps=${JSON.stringify(psLine.slice(0, 512))}` : null,
+        lsofOutput ? `lsof=${JSON.stringify(lsofOutput.replace(/\s+/g, " ").slice(0, 512))}` : null,
+        `command=${JSON.stringify(command)}`,
+      ]
+        .filter(Boolean)
+        .join(" ");
+
+      lastStartError = new Error(
+        `Failed to start runtime service "${serviceName}": ${err instanceof Error ? err.message : String(err)} (${details})${stderrExcerpt ? ` | stderr: ${stderrExcerpt.trim()}` : ""}${stdoutExcerpt ? ` | stdout: ${stdoutExcerpt.trim()}` : ""}`,
       );
+      if (attempt >= maxAttempts) {
+        throw lastStartError;
+      }
+
+      // Avoid immediate tight-loop retries. Under load, giving the OS a moment to
+      // release resources (ports/process groups) reduces flakiness.
+      if (portType === "auto") {
+        await delay(Math.min(1500, 200 * attempt));
+      }
     }
   }
-  const shell = process.env.SHELL?.trim() || "/bin/sh";
-  const child = spawn(shell, ["-lc", command], {
-    cwd: serviceCwd,
-    env,
-    detached: process.platform !== "win32",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  let stderrExcerpt = "";
-  let stdoutExcerpt = "";
-  child.stdout?.on("data", async (chunk) => {
-    const text = String(chunk);
-    stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
-    if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
-  });
-  child.stderr?.on("data", async (chunk) => {
-    const text = String(chunk);
-    stderrExcerpt = (stderrExcerpt + text).slice(-4096);
-    if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
-  });
 
-  try {
-    await waitForReadiness({ service: input.service, url });
-  } catch (err) {
-    terminateChildProcess(child);
-    throw new Error(
-      `Failed to start runtime service "${serviceName}": ${err instanceof Error ? err.message : String(err)}${stderrExcerpt ? ` | stderr: ${stderrExcerpt.trim()}` : ""}`,
-    );
+  if (!child) {
+    throw lastStartError ?? new Error(`Failed to start runtime service "${serviceName}"`);
   }
+
 
   const record: RuntimeServiceRecord = {
     id: randomUUID(),

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
   },
 });


### PR DESCRIPTION
This deflakes Vitest adapter environment diagnostics tests that spawn child CLIs under full-suite load.

Changes:
- Increase model discovery timeouts (opencode_local + pi_local) to 60s
- Make pi env tests hermetic (absolute command path, clear NODE_OPTIONS)
- Increase gemini helloProbeTimeoutSec in tests to 60s
- Make opencode env test set OPENAI_API_KEY explicitly

Verification:
- pnpm -r typecheck
- pnpm test:run (762 passed | 1 skipped)
- pnpm build
