### PR TITLE
feat(ui): add plugin detail tab support to AgentDetail

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
+import { PluginSlotMount, usePluginSlots } from "@/plugins/slots";
 import { useParams, useNavigate, Link, Navigate, useBeforeUnload } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -223,9 +224,16 @@ function scrollToContainerBottom(container: ScrollContainer, behavior: ScrollBeh
   container.scrollTo({ top: container.scrollHeight, behavior });
 }
 
-type AgentDetailView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget";
+type AgentBaseView = "dashboard" | "instructions" | "configuration" | "skills" | "runs" | "budget";
+type AgentPluginTab = `plugin:${string}`;
+type AgentDetailView = AgentBaseView | AgentPluginTab;
+
+function isAgentPluginTab(value: string | null): value is AgentPluginTab {
+  return typeof value === "string" && value.startsWith("plugin:");
+}
 
 function parseAgentDetailView(value: string | null): AgentDetailView {
+  if (isAgentPluginTab(value)) return value;
   if (value === "instructions" || value === "prompts") return "instructions";
   if (value === "configure" || value === "configuration") return "configuration";
   if (value === "skills") return "skills";
@@ -657,6 +665,24 @@ export function AgentDetail() {
   const agentLookupRef = agent?.id ?? routeAgentRef;
   const resolvedAgentId = agent?.id ?? null;
 
+  const {
+    slots: pluginDetailSlots,
+  } = usePluginSlots({
+    slotTypes: ["detailTab"],
+    entityType: "agent",
+    companyId: resolvedCompanyId,
+    enabled: !!resolvedCompanyId,
+  });
+  const pluginTabItems = useMemo(
+    () => pluginDetailSlots.map((slot) => ({
+      value: `plugin:${slot.pluginKey}:${slot.id}` as AgentPluginTab,
+      label: slot.displayName,
+      slot,
+    })),
+    [pluginDetailSlots],
+  );
+  const activePluginTab = pluginTabItems.find((item) => item.value === activeView) ?? null;
+
   const { data: runtimeState } = useQuery({
     queryKey: queryKeys.agents.runtimeState(resolvedAgentId ?? routeAgentRef),
     queryFn: () => agentsApi.runtimeState(resolvedAgentId!, resolvedCompanyId ?? undefined),
@@ -738,17 +764,19 @@ export function AgentDetail() {
       return;
     }
     const canonicalTab =
-      activeView === "instructions"
-        ? "instructions"
-        : activeView === "configuration"
-          ? "configuration"
-          : activeView === "skills"
-            ? "skills"
-            : activeView === "runs"
-              ? "runs"
-              : activeView === "budget"
-                ? "budget"
-              : "dashboard";
+      isAgentPluginTab(activeView)
+        ? activeView
+        : activeView === "instructions"
+          ? "instructions"
+          : activeView === "configuration"
+            ? "configuration"
+            : activeView === "skills"
+              ? "skills"
+              : activeView === "runs"
+                ? "runs"
+                : activeView === "budget"
+                  ? "budget"
+                : "dashboard";
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
       navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
       return;
@@ -1011,6 +1039,10 @@ export function AgentDetail() {
               { value: "configuration", label: "Configuration" },
               { value: "runs", label: "Runs" },
               { value: "budget", label: "Budget" },
+              ...pluginTabItems.map((item) => ({
+                value: item.value,
+                label: item.label,
+              })),
             ]}
             value={activeView}
             onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
@@ -1146,6 +1178,19 @@ export function AgentDetail() {
           />
         </div>
       ) : null}
+
+      {activePluginTab && (
+        <PluginSlotMount
+          slot={activePluginTab.slot}
+          context={{
+            companyId: resolvedCompanyId,
+            companyPrefix: companyPrefix ?? null,
+            entityId: agent.id,
+            entityType: "agent",
+          }}
+          missingBehavior="placeholder"
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -899,12 +899,15 @@ export function AgentDetail() {
         crumbs.push({ label: "Runs" });
       } else if (activeView === "budget") {
         crumbs.push({ label: "Budget" });
+      } else if (isAgentPluginTab(activeView)) {
+        const pluginTab = pluginTabItems.find((item) => item.value === activeView);
+        crumbs.push({ label: pluginTab?.label ?? "Plugin" });
       } else {
         crumbs.push({ label: "Dashboard" });
       }
     }
     setBreadcrumbs(crumbs);
-  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId]);
+  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId, pluginTabItems]);
 
   useEffect(() => {
     closePanel();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The plugin SDK allows plugins to register custom UI slots, including `detailTab` slots that appear as tabs on entity detail pages
> - `ProjectDetail.tsx` and `IssueDetail.tsx` both integrate `usePluginSlots` to render plugin-registered detail tabs for their respective entity types
> - `AgentDetail.tsx` does **not** have this integration — plugin detail tabs with `entityType: "agent"` are silently ignored by the UI despite being accepted by the backend and SDK
> - This is an omission, not a design decision: the backend validates and stores `entityType: "agent"` slot registrations correctly, and the SDK documents it as a supported entity type
> - This pull request adds the `usePluginSlots` integration to `AgentDetail.tsx`, following the identical pattern already established in `ProjectDetail.tsx` and `IssueDetail.tsx`
> - The benefit is that plugins can now surface custom tabs on agent detail pages, enabling richer agent-level tooling (memory viewers, session inspectors, MCP managers, performance dashboards, etc.)

## What Changed

- Imported `PluginSlotMount` and `usePluginSlots` from `@/plugins/slots`
- Introduced `AgentPluginTab` template literal type (`plugin:${string}`) and `isAgentPluginTab` type guard to extend the existing `AgentDetailView` union
- Wired `usePluginSlots` hook with `slotTypes: ["detailTab"]` and `entityType: "agent"`, gated by `resolvedCompanyId`
- Built `pluginTabItems` memo that maps plugin slots to tab bar entries
- Spread plugin tabs into the `PageTabBar` items array after the "Budget" tab
- Added conditional `<PluginSlotMount>` rendering when a plugin tab is active, passing `companyId`, `companyPrefix`, `entityId`, and `entityType` as context
- Extended the `canonicalTab` resolution logic to preserve plugin tab routes

## Verification

- Install any plugin that declares a `detailTab` slot with `entityType: ["agent"]` in its manifest
- Navigate to an agent detail page
- Confirm the plugin tab appears in the tab bar after "Budget"
- Click the plugin tab and verify the plugin component renders with correct context (`entityId`, `entityType: "agent"`, `companyId`)
- Verify deep-linking works: navigate directly to `/agents/{id}/plugin:{pluginKey}:{slotId}` and confirm the correct tab is active
- Confirm all existing tabs (Dashboard, Instructions, Skills, Configuration, Runs, Budget) remain functional
- Confirm no regressions on `ProjectDetail` and `IssueDetail` plugin tabs

## Risks

- **Low risk.** This change is additive — it introduces no modifications to existing tab behavior. The `usePluginSlots` hook returns an empty array when no plugins register agent detail tabs, so the tab bar remains unchanged for users without such plugins. The implementation is a direct copy of the pattern already battle-tested in `ProjectDetail.tsx` and `IssueDetail.tsx`.

## Model Used

- **Claude Opus 4** (claude-opus-4-20250514) via Claude Code CLI, with extended thinking enabled and tool use (file search, code analysis, git operations)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
