### PR TITLE
fix(server): add role and name fallback to agent reference resolver

### DIFF
--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -678,15 +678,44 @@ export function agentService(db: Db) {
       }
 
       const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
-      const matches = rows
-        .map(normalizeAgentRow)
-        .filter((agent) => agent.urlKey === urlKey && agent.status !== "terminated");
-      if (matches.length === 1) {
-        return { agent: matches[0] ?? null, ambiguous: false } as const;
+      const active = rows.map(normalizeAgentRow).filter((a) => a.status !== "terminated");
+
+      // 1. Exact urlKey match (existing behavior)
+      const urlKeyMatches = active.filter((agent) => agent.urlKey === urlKey);
+      if (urlKeyMatches.length === 1) {
+        return { agent: urlKeyMatches[0] ?? null, ambiguous: false } as const;
       }
-      if (matches.length > 1) {
+      if (urlKeyMatches.length > 1) {
         return { agent: null, ambiguous: true } as const;
       }
+
+      // 2. Fallback: match by role (company-scoped, must be unique)
+      const lowerRef = raw.toLowerCase();
+      const roleMatches = active.filter((agent) => agent.role === lowerRef);
+      if (roleMatches.length === 1) {
+        return { agent: roleMatches[0] ?? null, ambiguous: false } as const;
+      }
+      if (roleMatches.length > 1) {
+        return { agent: null, ambiguous: true } as const;
+      }
+
+      // 3. Fallback: match by normalized name slug prefix
+      const nameMatches = active.filter((agent) => {
+        const nameSlug = agent.name
+          ? agent.name
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, "-")
+              .replace(/^-|-$/g, "")
+          : "";
+        return nameSlug === urlKey || nameSlug.startsWith(`${urlKey}-`);
+      });
+      if (nameMatches.length === 1) {
+        return { agent: nameMatches[0] ?? null, ambiguous: false } as const;
+      }
+      if (nameMatches.length > 1) {
+        return { agent: null, ambiguous: true } as const;
+      }
+
       return { agent: null, ambiguous: false } as const;
     },
   };


### PR DESCRIPTION
## Summary

When resolving agent references by short name (e.g. `"ceo"`, `"cto"`), the `resolveByReference()` function in `server/src/services/agents.ts` only matches against `urlKey`. If the urlKey is a compound slug like `"ceo-minion"`, passing just `"ceo"` returns 404 — even though the agent exists and has `role: "ceo"`.

This PR adds a 3-tier fallback chain:

1. **Exact urlKey match** — existing behavior, unchanged
2. **Role match** — `"ceo"` resolves via `agent.role === "ceo"`, scoped to company, must be unique
3. **Name slug prefix match** — `"cto"` resolves if the agent's normalized name starts with `"cto-"` (e.g. "CTO Coding Helper" → slug `"cto-coding-helper"`)

### Behavior

- Ambiguous matches at any tier return 409/`ambiguous: true` instead of guessing
- All tiers are scoped to `companyId` and exclude terminated agents
- Canonical urlKey lookups are completely unaffected
- No new DB queries — reuses the existing `SELECT * FROM agents WHERE companyId = ?` result

### Reproducer

```bash
# Before: 404
curl /api/agents/ceo?companyId=<id>
# {"error": "Agent not found"}

# After: resolves via role fallback
curl /api/agents/ceo?companyId=<id>
# {"id": "...", "name": "CEO(Minion)", "urlKey": "ceo-minion", "role": "ceo", ...}
```

## Test plan

- [ ] `"ceo"` resolves to the CEO agent via role match when urlKey is `"ceo-minion"`
- [ ] `"cto"` resolves to the CTO agent via name slug when role is `"general"` but name is `"CTO (Coding Helper)"`
- [ ] Canonical urlKey `"ceo-minion"` still resolves correctly
- [ ] Ambiguous role (e.g. multiple `"engineer"` agents) returns 409
- [ ] Non-existent ref returns 404
- [ ] UUID lookup unaffected