### PR TITLE
fix(ui): backport approval detail improvements

### DIFF
--- a/releases/v2026.405.0.md
+++ b/releases/v2026.405.0.md
@@ -1,0 +1,29 @@
+# v2026.405.0
+
+> Released: 2026-04-05
+
+## Highlights
+
+- **Approval payload clarity** — `approve_ceo_strategy` approvals now render a schema-aware summary section with action details, scope, scheduling, and rationale for faster human review.
+- **Safer approval decisions** — Reject and Request Revision flows now require a decision note and include `decisionNote` in the mutation payload.
+- **Readable approval headers** — Approval detail pages now show a human-readable title and include a `Copy UUID` action.
+- **Linked issue context** — Linked issues now include status, priority, and assignee metadata in approval detail.
+
+## Improvements
+
+- **Technical details disclosure** — JSON payload technical details are collapsed by default behind a `View technical details` disclosure.
+- **Server package artifact refresh** — Regenerated `@paperclipai/server` `ui-dist` to include the updated approval experience in published package artifacts.
+
+## Fixes
+
+- **Approval UI parity** — Backported approval UI behavior from runtime patch into source (`ui/src/components/ApprovalPayload.tsx`, `ui/src/pages/ApprovalDetail.tsx`) to ensure consistency across fresh installs.
+
+## Upgrade Guide
+
+No migration changes are required for this release. Upgrade `@paperclipai/server` and restart running Paperclip services to pick up the refreshed UI bundle.
+
+## Contributors
+
+Thank you to everyone who contributed to this release!
+
+@lucasproko

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -89,9 +89,84 @@ export function HireAgentPayload({ payload }: { payload: Record<string, unknown>
 }
 
 export function CeoStrategyPayload({ payload }: { payload: Record<string, unknown> }) {
+  const asTrimmedString = (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  const asStringList = (value: unknown): string[] => {
+    if (!Array.isArray(value)) return [];
+    return value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  };
+
+  const actionKind =
+    asTrimmedString(payload.actionKind) ??
+    asTrimmedString(payload.action) ??
+    asTrimmedString(payload.kind);
+  const behaviorSummary = asStringList(payload.behaviorSummary).join(" | ");
+  const changeSummary =
+    behaviorSummary ||
+    asTrimmedString(payload.changeSummary) ||
+    asTrimmedString(payload.changes) ||
+    asTrimmedString(payload.summary);
+  const routineProject = [
+    asTrimmedString(payload.routineTitle),
+    asTrimmedString(payload.projectTitle),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" | ");
+  const scheduleRecord =
+    payload.schedule && typeof payload.schedule === "object"
+      ? (payload.schedule as Record<string, unknown>)
+      : null;
+  const scheduleLabel = [scheduleRecord && asTrimmedString(scheduleRecord.label), scheduleRecord && asTrimmedString(scheduleRecord.timezone)]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+  const schedule =
+    scheduleLabel ||
+    (scheduleRecord && asTrimmedString(scheduleRecord.cron)) ||
+    asTrimmedString(payload.schedule);
+  const impacts = [
+    ...asStringList(payload.impactedFiles),
+    ...asStringList(payload.ticketIds),
+  ].join(" | ");
+  const rationale =
+    asTrimmedString(payload.recommendationRationale) ??
+    asTrimmedString(payload.rationale) ??
+    asTrimmedString(payload.notes) ??
+    asTrimmedString(payload.reason);
+  const sourceArtifact =
+    asTrimmedString(payload.sourceArtifactUrl) ??
+    (payload.sourceArtifact &&
+    typeof payload.sourceArtifact === "object"
+      ? asTrimmedString((payload.sourceArtifact as Record<string, unknown>).url)
+      : null);
   const plan = payload.plan ?? payload.description ?? payload.strategy ?? payload.text;
   return (
     <div className="mt-3 space-y-1.5 text-sm">
+      <PayloadField label="Action kind" value={actionKind} />
+      <PayloadField label="What changes" value={changeSummary || null} />
+      <PayloadField label="Routine/project" value={routineProject || null} />
+      <PayloadField label="Schedule" value={schedule} />
+      <PayloadField label="Files/tickets" value={impacts || null} />
+      <PayloadField label="Why" value={rationale} />
+      {!!sourceArtifact && (
+        <div className="flex items-start gap-2">
+          <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs pt-0.5">Source</span>
+          <a
+            href={sourceArtifact}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs underline underline-offset-2 break-all"
+          >
+            {sourceArtifact}
+          </a>
+        </div>
+      )}
       <PayloadField label="Title" value={payload.title} />
       {!!plan && (
         <div className="mt-2 rounded-md bg-muted/40 px-3 py-2 text-sm text-muted-foreground whitespace-pre-wrap font-mono text-xs max-h-48 overflow-y-auto">

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -12,7 +12,7 @@ import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer } fro
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { CheckCircle2, ChevronRight, Sparkles } from "lucide-react";
+import { CheckCircle2, ChevronRight, Copy, Sparkles } from "lucide-react";
 import type { ApprovalComment } from "@paperclipai/shared";
 import { MarkdownBody } from "../components/MarkdownBody";
 
@@ -24,8 +24,10 @@ export function ApprovalDetail() {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [commentBody, setCommentBody] = useState("");
+  const [decisionNote, setDecisionNote] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [showRawPayload, setShowRawPayload] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const { data: approval, isLoading } = useQuery({
     queryKey: queryKeys.approvals.detail(approvalId!),
@@ -66,7 +68,11 @@ export function ApprovalDetail() {
   useEffect(() => {
     setBreadcrumbs([
       { label: "Approvals", href: "/approvals" },
-      { label: approval?.id?.slice(0, 8) ?? approvalId ?? "Approval" },
+      {
+        label: approval
+          ? approvalLabel(approval.type, approval.payload as Record<string, unknown> | null)
+          : approvalId ?? "Approval",
+      },
     ]);
   }, [setBreadcrumbs, approval, approvalId]);
 
@@ -95,7 +101,7 @@ export function ApprovalDetail() {
   });
 
   const rejectMutation = useMutation({
-    mutationFn: () => approvalsApi.reject(approvalId!),
+    mutationFn: () => approvalsApi.reject(approvalId!, decisionNote.trim()),
     onSuccess: () => {
       setError(null);
       refresh();
@@ -104,7 +110,7 @@ export function ApprovalDetail() {
   });
 
   const revisionMutation = useMutation({
-    mutationFn: () => approvalsApi.requestRevision(approvalId!),
+    mutationFn: () => approvalsApi.requestRevision(approvalId!, decisionNote.trim()),
     onSuccess: () => {
       setError(null);
       refresh();
@@ -149,6 +155,7 @@ export function ApprovalDetail() {
   const isActionable = approval.status === "pending" || approval.status === "revision_requested";
   const isBudgetApproval = approval.type === "budget_override_required";
   const TypeIcon = typeIcon[approval.type] ?? defaultTypeIcon;
+  const headerLabel = approvalLabel(approval.type, approval.payload as Record<string, unknown> | null);
   const showApprovedBanner = searchParams.get("resolved") === "approved" && approval.status === "approved";
   const primaryLinkedIssue = linkedIssues?.[0] ?? null;
   const resolvedCta =
@@ -203,8 +210,26 @@ export function ApprovalDetail() {
           <div className="flex items-center gap-2">
             <TypeIcon className="h-5 w-5 text-muted-foreground shrink-0" />
             <div>
-              <h2 className="text-lg font-semibold">{approvalLabel(approval.type, approval.payload as Record<string, unknown> | null)}</h2>
-              <p className="text-xs text-muted-foreground font-mono">{approval.id}</p>
+              <h2 className="text-lg font-semibold">{headerLabel}</h2>
+              <div className="flex items-center gap-2 mt-0.5">
+                <p className="text-xs text-muted-foreground font-mono">{approval.id}</p>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(approval.id);
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 1200);
+                    } catch {
+                      setError("Could not copy UUID.");
+                    }
+                  }}
+                >
+                  <Copy className="h-3 w-3" />
+                  {copied ? "Copied" : "Copy UUID"}
+                </button>
+              </div>
             </div>
           </div>
           <StatusBadge status={approval.status} />
@@ -226,7 +251,7 @@ export function ApprovalDetail() {
             onClick={() => setShowRawPayload((v) => !v)}
           >
             <ChevronRight className={`h-3 w-3 transition-transform ${showRawPayload ? "rotate-90" : ""}`} />
-            See full request
+            View technical details
           </button>
           {showRawPayload && (
             <pre className="text-xs bg-muted/40 rounded-md p-3 overflow-x-auto">
@@ -246,12 +271,22 @@ export function ApprovalDetail() {
                 <Link
                   key={issue.id}
                   to={`/issues/${issue.identifier ?? issue.id}`}
-                  className="block text-xs rounded border border-border/70 px-2 py-1.5 hover:bg-accent/20"
+                  className="block text-xs rounded border border-border/70 px-2 py-1.5 hover:bg-accent/20 space-y-1"
                 >
-                  <span className="font-mono text-muted-foreground mr-2">
-                    {issue.identifier ?? issue.id.slice(0, 8)}
-                  </span>
-                  <span>{issue.title}</span>
+                  <div>
+                    <span className="font-mono text-muted-foreground mr-2">
+                      {issue.identifier ?? issue.id.slice(0, 8)}
+                    </span>
+                    <span>{issue.title}</span>
+                  </div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Status: {issue.status} · Priority: {issue.priority} · Assignee:{" "}
+                    {issue.assigneeAgentId
+                      ? (agentNameById.get(issue.assigneeAgentId) ?? issue.assigneeAgentId.slice(0, 8))
+                      : issue.assigneeUserId
+                        ? "Board"
+                        : "Unassigned"}
+                  </div>
                 </Link>
               ))}
             </div>
@@ -263,6 +298,13 @@ export function ApprovalDetail() {
         <div className="flex flex-wrap items-center gap-2">
           {isActionable && !isBudgetApproval && (
             <>
+              <Textarea
+                value={decisionNote}
+                onChange={(e) => setDecisionNote(e.target.value)}
+                placeholder="Decision note (required for Reject / Request revision)"
+                rows={2}
+                className="w-full"
+              />
               <Button
                 size="sm"
                 className="bg-green-700 hover:bg-green-600 text-white"
@@ -272,29 +314,41 @@ export function ApprovalDetail() {
                 Approve
               </Button>
               <Button
-                variant="destructive"
                 size="sm"
-                onClick={() => rejectMutation.mutate()}
+                variant="outline"
+                onClick={() => {
+                  if (!decisionNote.trim()) {
+                    setError("Decision note is required to reject.");
+                    return;
+                  }
+                  rejectMutation.mutate();
+                }}
                 disabled={rejectMutation.isPending}
               >
                 Reject
               </Button>
+              {approval.status === "pending" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    if (!decisionNote.trim()) {
+                      setError("Decision note is required to request revision.");
+                      return;
+                    }
+                    revisionMutation.mutate();
+                  }}
+                  disabled={revisionMutation.isPending}
+                >
+                  Request revision
+                </Button>
+              )}
             </>
           )}
           {isBudgetApproval && approval.status === "pending" && (
             <p className="text-sm text-muted-foreground">
               Resolve this budget stop from the budget controls on <Link to="/costs" className="underline underline-offset-2">/costs</Link>.
             </p>
-          )}
-          {approval.status === "pending" && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => revisionMutation.mutate()}
-              disabled={revisionMutation.isPending}
-            >
-              Request revision
-            </Button>
           )}
           {approval.status === "revision_requested" && (
             <Button


### PR DESCRIPTION
## Summary
- backport Approval payload/detail UI improvements into source
- require decision notes for reject/request-revision flows
- add stable release notes file for v2026.405.0

## Testing
- pnpm --filter @paperclipai/ui build

Follow-up from [LUK-250](/LUK/issues/LUK-250) and [LUK-253](/LUK/issues/LUK-253).