### PR TITLE
feat: add omp_local adapter for OMP (PI + enhancements)

### DIFF
--- a/packages/adapters/omp-local/README.md
+++ b/packages/adapters/omp-local/README.md
@@ -1,0 +1,71 @@
+# @paperclipai/adapter-omp-local
+
+OMP (PI + enhancements) local adapter for Paperclip.
+
+## Overview
+
+This adapter enables Paperclip to run OMP agents locally. OMP is built on PI (Pico Tools coding agent) with additional enhancements.
+
+## Features
+
+- Run OMP as a local child process
+- Session resumption across heartbeats
+- Support for multiple model providers via `--provider` and `--model` flags
+- Thinking level configuration
+- Skills injection support
+- JSONL output parsing
+
+## Installation
+
+```bash
+npm install @paperclipai/adapter-omp-local
+```
+
+## Configuration
+
+```json
+{
+  "adapterType": "omp_local",
+  "adapterConfig": {
+    "command": "omp",
+    "cwd": "/workspace/project",
+    "model": "minimax/MiniMax-M2.7",
+    "thinking": "medium",
+    "timeoutSec": 900,
+    "env": {
+      "MINIMAX_API_KEY": "your-api-key"
+    }
+  }
+}
+```
+
+## Adapter Options
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `command` | string | No | CLI command to run (default: "omp") |
+| `cwd` | string | No | Working directory |
+| `model` | string | Yes | Model in provider/model format |
+| `thinking` | string | No | Thinking level (minimal, low, medium, high, xhigh) |
+| `timeoutSec` | number | No | Run timeout in seconds (default: 900) |
+| `graceSec` | number | No | SIGTERM grace period (default: 15) |
+| `instructionsFilePath` | string | No | Path to instructions markdown file |
+| `promptTemplate` | string | No | Custom prompt template |
+| `env` | object | No | Environment variables |
+
+## Session Management
+
+Sessions are stored in `~/.omp/paperclips/` and can be resumed using the `--session` flag.
+
+## Contributing
+
+To build from source:
+
+```bash
+npm install
+npm run build
+```
+
+## License
+
+MIT

--- a/packages/adapters/omp-local/package.json
+++ b/packages/adapters/omp-local/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@paperclipai/adapter-omp-local",
+  "version": "2026.403.0",
+  "description": "OMP (PI + enhancements) local adapter for Paperclip",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/omp-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./cli": {
+      "types": "./dist/cli/index.d.ts",
+      "import": "./dist/cli/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@paperclipai/adapter-utils": "2026.403.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts"
+}

--- a/packages/adapters/omp-local/src/index.ts
+++ b/packages/adapters/omp-local/src/index.ts
@@ -1,0 +1,41 @@
+export const type = "omp_local";
+
+export const label = "OMP (local)";
+
+export const models = [];
+
+export const agentConfigurationDoc = `# omp_local agent configuration
+
+Adapter: omp_local
+
+Use when:
+- You want Paperclip to run OMP (PI + enhancements) locally as the agent runtime
+- You want provider/model routing in OMP format (--provider <name> --model <id>)
+- You need session resume across heartbeats via --session-dir
+- You need OMP's tool set (read, bash, edit, write, grep, find, ls)
+
+Don't use when:
+- You need webhook-style external invocation (use openclaw_gateway or http)
+- You only need one-shot shell commands (use process)
+- OMP CLI is not installed on the machine
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file appended to system prompt via --append-system-prompt
+- promptTemplate (string, optional): user prompt template passed via -p flag
+- model (string, required): OMP model id in provider/model format (for example minimax/MiniMax-M2.7)
+- thinking (string, optional): thinking level (minimal, low, medium, high, xhigh)
+- command (string, optional): defaults to "omp"
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- OMP supports multiple providers and models. Use \`omp --list-models\` to list available options.
+- Paperclip requires an explicit \`model\` value for \`omp_local\` agents.
+- Sessions are stored in ~/.omp/paperclips/ and resumed with --session.
+- All tools (read, bash, edit, write, grep, find, ls) are enabled by default.
+- Agent instructions are appended to OMP's system prompt via --append-system-prompt, while the user task is sent via -p.
+`;

--- a/packages/adapters/omp-local/src/server/execute.ts
+++ b/packages/adapters/omp-local/src/server/execute.ts
@@ -1,0 +1,358 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  asStringArray,
+  parseObject,
+  buildPaperclipEnv,
+  joinPromptSections,
+  buildInvocationEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePaperclipSkillSymlink,
+  ensurePathInEnv,
+  readPaperclipRuntimeSkillEntries,
+  resolveCommandForLogs,
+  resolvePaperclipDesiredSkillNames,
+  removeMaintainerOnlySkillSymlinks,
+  renderTemplate,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { isOmpUnknownSessionError, parseOmpJsonl } from "./parse.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const OMP_SESSIONS_DIR = path.join(os.homedir(), ".omp", "paperclips");
+const OMP_AGENT_SKILLS_DIR = path.join(os.homedir(), ".omp", "agent", "skills");
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function parseModelProvider(model: string | null): string | null {
+  if (!model) return null;
+  const trimmed = model.trim();
+  if (!trimmed.includes("/")) return null;
+  return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
+}
+
+function parseModelId(model: string | null): string | null {
+  if (!model) return null;
+  const trimmed = model.trim();
+  if (!trimmed.includes("/")) return trimmed || null;
+  return trimmed.slice(trimmed.indexOf("/") + 1).trim() || null;
+}
+
+async function ensureOmpSkillsInjected(
+  onLog: (type: "stdout" | "stderr", data: string) => void,
+  skillsEntries: Array<{ key: string; source: string; runtimeName: string }>,
+  desiredSkillNames: string[] | null
+): Promise<void> {
+  const desiredSet = new Set(desiredSkillNames ?? skillsEntries.map((entry) => entry.key));
+  const selectedEntries = skillsEntries.filter((entry) => desiredSet.has(entry.key));
+  if (selectedEntries.length === 0) return;
+
+  await fs.mkdir(OMP_AGENT_SKILLS_DIR, { recursive: true });
+
+  const removedSkills = await removeMaintainerOnlySkillSymlinks(
+    OMP_AGENT_SKILLS_DIR,
+    selectedEntries.map((entry) => entry.runtimeName)
+  );
+
+  for (const skillName of removedSkills) {
+    await onLog("stderr", `[paperclip] Removed maintainer-only OMP skill "${skillName}" from ${OMP_AGENT_SKILLS_DIR}\n`);
+  }
+
+  for (const entry of selectedEntries) {
+    const target = path.join(OMP_AGENT_SKILLS_DIR, entry.runtimeName);
+    try {
+      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      if (result === "skipped") continue;
+      await onLog(
+        "stderr",
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Injected"} OMP skill "${entry.runtimeName}" into ${OMP_AGENT_SKILLS_DIR}\n`
+      );
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to inject OMP skill "${entry.runtimeName}" into ${OMP_AGENT_SKILLS_DIR}: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
+  }
+}
+
+function resolveOmpBiller(env: Record<string, string | undefined>, provider: string | null): string {
+  return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
+}
+
+async function ensureSessionsDir(): Promise<string> {
+  await fs.mkdir(OMP_SESSIONS_DIR, { recursive: true });
+  return OMP_SESSIONS_DIR;
+}
+
+function buildSessionPath(agentId: string, timestamp: string): string {
+  const safeTimestamp = timestamp.replace(/[:.]/g, "-");
+  return path.join(OMP_SESSIONS_DIR, `${safeTimestamp}-${agentId}.jsonl`);
+}
+
+interface ExecuteContext {
+  runId: string;
+  agent: { id: string; name: string; companyId: string };
+  runtime: unknown;
+  config: Record<string, unknown>;
+  context: {
+    paperclipWorkspace?: Record<string, unknown>;
+    paperclipWorkspaces?: Array<Record<string, unknown>>;
+    taskId?: string;
+    issueId?: string;
+    wakeReason?: string;
+    wakeCommentId?: string;
+    commentId?: string;
+    approvalId?: string;
+    approvalStatus?: string;
+    issueIds?: string[];
+    session?: { sessionId: string; cwd?: string } | null;
+  };
+  onLog: (type: "stdout" | "stderr", data: string) => void;
+  onMeta: (meta: Record<string, unknown>) => void;
+  onSpawn: (info: { pid: number; command: string }) => void;
+  authToken: string | null;
+}
+
+export async function execute(ctx: ExecuteContext): Promise<{
+  sessionId?: string | null;
+  result?: string;
+  error?: string;
+  errorResponse?: string | null;
+  unknownSession?: boolean;
+  resultMeta?: { usage?: unknown };
+  debugOutput?: string;
+}> {
+  const { runId, agent, config, context, onLog, onSpawn } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work."
+  );
+  const command = asString(config.command, "omp");
+  const model = asString(config.model, "").trim();
+  const thinking = asString(config.thinking, "").trim();
+
+  // Parse model into provider and model id
+  const provider = parseModelProvider(model);
+  const modelId = parseModelId(model);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext?.cwd, "");
+  const workspaceSource = asString(workspaceContext?.source, "");
+  const workspaceId = asString(workspaceContext?.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext?.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext?.repoRef, "");
+  const agentHome = asString(workspaceContext?.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter((value): value is Record<string, unknown> =>
+        typeof value === "object" && value !== null
+      )
+    : [];
+
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  // Ensure sessions directory exists
+  await ensureSessionsDir();
+
+  // Inject skills
+  const ompSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredOmpSkillNames = resolvePaperclipDesiredSkillNames(config, ompSkillEntries);
+  await ensureOmpSkillsInjected(onLog, ompSkillEntries, desiredOmpSkillNames);
+
+  // Build environment
+  const envConfig = parseObject(config.env);
+
+  const env: Record<string, string | undefined> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 &&
+      context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string =>
+        typeof value === "string" && value.trim().length > 0
+      )
+    : [];
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
+  if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (agentHome) env.AGENT_HOME = agentHome;
+  if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  // Build command arguments
+  const args: string[] = [];
+
+  // Model specification
+  if (provider && modelId) {
+    args.push("--provider", provider);
+    args.push("--model", modelId);
+  } else if (model) {
+    // Try to parse as provider/model or use as direct model id
+    if (provider) {
+      args.push("--provider", provider);
+      args.push("--model", modelId || model);
+    } else {
+      args.push("--model", model);
+    }
+  }
+
+  // Thinking level
+  if (thinking) {
+    args.push("--thinking", thinking);
+  }
+
+  // Session management - use session from context if available
+  const sessionData = context.session;
+  if (sessionData?.sessionId) {
+    args.push("--resume", sessionData.sessionId);
+  } else {
+    // Create a new session file for this run
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const sessionFile = buildSessionPath(agent.id, timestamp);
+    await fs.writeFile(sessionFile, "", "utf-8");
+    args.push("--session-dir", OMP_SESSIONS_DIR);
+  }
+
+  // Instructions file
+  const instructionsFilePath = asString(config.instructionsFilePath, "");
+  if (instructionsFilePath) {
+    args.push("--append-system-prompt", `@${instructionsFilePath}`);
+  }
+
+  // Append system prompt with template
+  const instructions = renderTemplate(promptTemplate, {
+    agent,
+    company: { id: agent.companyId },
+    runId,
+    context,
+  });
+  args.push("--append-system-prompt", instructions);
+
+  // CWD
+  if (cwd) {
+    args.push("--allow-home");
+  }
+
+  // Output mode for JSONL parsing
+  args.push("--output-format", "jsonl");
+
+  // Print mode for non-interactive
+  args.push("--print");
+
+  // Additional args
+  const extraArgs = asStringArray(config.extraArgs, []);
+  args.push(...extraArgs);
+
+  // Timeout
+  const timeoutSec = asNumber(config.timeoutSec, 900);
+  const graceSec = asNumber(config.graceSec, 15);
+
+  // Build final env with PATH
+  const finalEnv = ensurePathInEnv(env, command);
+
+  await onLog("stderr", `[paperclip] Running OMP: ${command} ${args.join(" ")}\n`);
+  await onLog("stderr", `[paperclip] CWD: ${cwd}\n`);
+
+  const result = await runChildProcess({
+    command,
+    args,
+    cwd,
+    env: finalEnv,
+    timeoutSec,
+    graceSec,
+    onLog,
+    onSpawn,
+  });
+
+  // Parse JSONL output
+  const parsed = parseOmpJsonl(result.stdout);
+
+  if (parsed.error) {
+    return {
+      error: parsed.error,
+      errorResponse: parsed.errorResponse,
+    };
+  }
+
+  // Extract session ID from output if present
+  let savedSessionId = sessionData?.sessionId ?? null;
+  if (parsed.sessionId && !savedSessionId) {
+    savedSessionId = parsed.sessionId;
+  }
+
+  // Check for unknown session error
+  if (
+    parsed.hasUnknownSessionError ||
+    isOmpUnknownSessionError(result.stderr)
+  ) {
+    return {
+      sessionId: savedSessionId,
+      error: "unknown_session",
+      errorResponse: parsed.hasUnknownSessionError
+        ? parsed.errorResponse
+        : result.stderr
+            .split("\n")
+            .find((l) =>
+              l.includes("unknown session") || l.includes("session not found")
+            ) ?? null,
+      unknownSession: true,
+    };
+  }
+
+  return {
+    sessionId: savedSessionId,
+    result: parsed.result,
+    resultMeta: parsed.usage ? { usage: parsed.usage } : undefined,
+    debugOutput: result.stderr,
+  };
+}

--- a/packages/adapters/omp-local/src/server/index.ts
+++ b/packages/adapters/omp-local/src/server/index.ts
@@ -1,0 +1,53 @@
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec = {
+  deserialize(raw: unknown): { sessionId: string; cwd?: string } | null {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.session);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+
+  serialize(params: { sessionId?: string; session_id?: string; session?: string; cwd?: string; workdir?: string; folder?: string } | null): { sessionId: string; cwd?: string } | null {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.session);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+    };
+  },
+
+  getDisplayId(params: { sessionId?: string; session_id?: string; session?: string } | null): string | null {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.session)
+    );
+  },
+};
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { parseOmpJsonl, isOmpUnknownSessionError } from "./parse.js";

--- a/packages/adapters/omp-local/src/server/parse.ts
+++ b/packages/adapters/omp-local/src/server/parse.ts
@@ -1,0 +1,121 @@
+/**
+ * Parse OMP JSONL output
+ * OMP outputs JSONL format similar to PI, with each line being a JSON object
+ */
+export function parseOmpJsonl(stdout: string): {
+  result: string;
+  usage: unknown;
+  sessionId: string | null;
+  error?: string;
+  errorResponse?: string;
+  hasUnknownSessionError?: boolean;
+} {
+  if (!stdout || !stdout.trim()) {
+    return { result: "", usage: null, sessionId: null };
+  }
+
+  const lines = stdout.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) {
+    return { result: "", usage: null, sessionId: null };
+  }
+
+  const lastLine = lines[lines.length - 1];
+  let parsed: Record<string, unknown>;
+
+  try {
+    parsed = JSON.parse(lastLine);
+  } catch {
+    // If last line isn't valid JSON, try to reconstruct from all lines
+    const allText = lines
+      .map((l) => {
+        try {
+          const obj = JSON.parse(l);
+          return (obj.content as string) || (obj.text as string) || (obj.message as string) || "";
+        } catch {
+          return l;
+        }
+      })
+      .join("\n");
+    return { result: allText, usage: null, sessionId: null };
+  }
+
+  // Extract result from various possible formats
+  let result = "";
+  let usage: unknown = null;
+  let sessionId: string | null = null;
+  let error: string | undefined;
+  let errorResponse: string | undefined;
+  let hasUnknownSessionError = false;
+
+  // OMP might use different field names
+  if (typeof parsed === "string") {
+    result = parsed;
+  } else if (parsed.content) {
+    result = parsed.content as string;
+  } else if (parsed.text) {
+    result = parsed.text as string;
+  } else if (parsed.message) {
+    result = parsed.message as string;
+  } else if (parsed.output) {
+    result = parsed.output as string;
+  } else if (parsed.result) {
+    result = parsed.result as string;
+  } else if (parsed.response) {
+    result = parsed.response as string;
+  }
+
+  // Extract usage if present
+  if (parsed.usage || (parsed.meta as Record<string, unknown>)?.usage) {
+    usage = (parsed.usage as Record<string, unknown>) || ((parsed.meta as Record<string, unknown>)?.usage as Record<string, unknown>);
+  }
+
+  // Extract session ID if present
+  if (parsed.sessionId || parsed.session_id || parsed.session) {
+    sessionId = (parsed.sessionId as string) || (parsed.session_id as string) || (parsed.session as string);
+  }
+
+  // Check for errors
+  if (parsed.error) {
+    error = String(parsed.error);
+    errorResponse = (parsed.errorMessage as string) || (parsed.message as string) || JSON.stringify(parsed.error);
+  }
+
+  // Check for unknown session errors
+  const errorText = (parsed.error || "").toString().toLowerCase();
+  const messageText = (parsed.message || "").toString().toLowerCase();
+  if (
+    errorText.includes("unknown session") ||
+    errorText.includes("session not found") ||
+    errorText.includes("invalid session") ||
+    messageText.includes("unknown session") ||
+    messageText.includes("session not found")
+  ) {
+    hasUnknownSessionError = true;
+  }
+
+  return {
+    result,
+    usage,
+    sessionId,
+    error,
+    errorResponse,
+    hasUnknownSessionError,
+  };
+}
+
+/**
+ * Check if stderr contains an unknown session error
+ */
+export function isOmpUnknownSessionError(stderr: string | null): boolean {
+  if (!stderr) return false;
+  const lines = stderr.split("\n");
+  return lines.some((line) => {
+    const lower = line.toLowerCase();
+    return (
+      lower.includes("unknown session") ||
+      lower.includes("session not found") ||
+      lower.includes("invalid session") ||
+      lower.includes("no such session")
+    );
+  });
+}

--- a/packages/adapters/omp-local/src/server/test.ts
+++ b/packages/adapters/omp-local/src/server/test.ts
@@ -1,0 +1,17 @@
+import { ensureCommandResolvable } from "@paperclipai/adapter-utils/server-utils";
+
+export async function testEnvironment(config: Record<string, unknown> | null): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  const command = (typeof config === "object" && config !== null && config.command) || "omp";
+  try {
+    await ensureCommandResolvable(command as string);
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `OMP command "${command}" is not installed or not in PATH. Install via: npm install -g omp`,
+    };
+  }
+}

--- a/packages/adapters/omp-local/tsconfig.json
+++ b/packages/adapters/omp-local/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -29,6 +29,7 @@ export const AGENT_ADAPTER_TYPES = [
   "gemini_local",
   "opencode_local",
   "pi_local",
+  "omp_local",
   "cursor",
   "openclaw_gateway",
 ] as const;


### PR DESCRIPTION
## Summary

This PR adds support for OMP (PI + enhancements) as a local adapter type in Paperclip. OMP is a coding agent built on PI with additional enhancements.

## Changes

### New Package: `packages/adapters/omp-local`

Added the `omp_local` adapter package with:
- Session resumption across heartbeats
- Support for multiple model providers via `--provider` and `--model` flags
- Thinking level configuration
- Skills injection support
- JSONL output parsing

### Updated: `packages/shared/src/constants.ts`

Added `"omp_local"` to `AGENT_ADAPTER_TYPES` array.

## Why OMP?

OMP (PI + enhancements) provides:
- Seamless integration with multiple model providers (MiniMax, OpenAI, Anthropic, etc.)
- Enhanced session management
- Improved tool calling capabilities
- Better JSONL output for Paperclip integration

## Testing

```bash
cd packages/adapters/omp-local
npm install
npm run build
npm run typecheck
```

## Checklist

- [x] Package structure created
- [x] TypeScript compilation verified
- [x] Session codec implemented
- [x] JSONL parsing implemented
- [x] Added to AGENT_ADAPTER_TYPES
- [ ] Adapter registered in core (if needed)
- [ ] Tests added
- [ ] Documentation reviewed

## Related

Based on the existing PI Local Adapter implementation.
