### PR TITLE
docs: add missing npx prefix to CLI commands across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Open source. Self-hosted. No Paperclip account required.
 npx paperclipai onboard --yes
 ```
 
-If you already have Paperclip configured, rerunning `onboard` keeps the existing config in place. Use `paperclipai configure` to edit settings.
+If you already have Paperclip configured, rerunning `onboard` keeps the existing config in place. Use `npx paperclipai configure` to edit settings.
 
 Or manually:
 

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -16,7 +16,7 @@ pnpm paperclipai run
 Does:
 
 1. Auto-onboards if config is missing
-2. Runs `paperclipai doctor` with repair enabled
+2. Runs `npx paperclipai doctor` with repair enabled
 3. Starts the server when checks pass
 
 Choose a specific instance:
@@ -33,7 +33,7 @@ Interactive first-time setup:
 pnpm paperclipai onboard
 ```
 
-If Paperclip is already configured, rerunning `onboard` keeps the existing config in place. Use `paperclipai configure` to change settings on an existing install.
+If Paperclip is already configured, rerunning `onboard` keeps the existing config in place. Use `npx paperclipai configure` to change settings on an existing install.
 
 First prompt:
 

--- a/docs/deploy/local-development.md
+++ b/docs/deploy/local-development.md
@@ -35,7 +35,7 @@ pnpm paperclipai run
 This does:
 
 1. Auto-onboards if config is missing
-2. Runs `paperclipai doctor` with repair enabled
+2. Runs `npx paperclipai doctor` with repair enabled
 3. Starts the server when checks pass
 
 ## Tailscale/Private Auth Dev Mode

--- a/docs/deploy/tailscale-private-access.md
+++ b/docs/deploy/tailscale-private-access.md
@@ -72,6 +72,6 @@ Expected result:
 
 ## Troubleshooting
 
-- Login or redirect errors on a private hostname: add it with `paperclipai allowed-hostname`.
+- Login or redirect errors on a private hostname: add it with `npx paperclipai allowed-hostname`.
 - App only works on `localhost`: make sure you started with `--tailscale-auth` (or set `HOST=0.0.0.0` in private mode).
 - Can connect locally but not remotely: verify both devices are on the same Tailscale network and port `3100` is reachable.

--- a/docs/feedback-voting.md
+++ b/docs/feedback-voting.md
@@ -33,7 +33,7 @@ Shows a color-coded summary: vote counts, per-trace details with reasons, and ex
 
 ```bash
 # Installed CLI
-paperclipai feedback report
+npx paperclipai feedback report
 
 # Point to a different server or company
 pnpm paperclipai feedback report --api-base http://127.0.0.1:3000 --company-id <company-id>

--- a/docs/guides/board-operator/importing-and-exporting.md
+++ b/docs/guides/board-operator/importing-and-exporting.md
@@ -34,7 +34,7 @@ my-company/
 Export a company into a portable folder:
 
 ```sh
-paperclipai company export <company-id> --out ./my-export
+npx paperclipai company export <company-id> --out ./my-export
 ```
 
 ### Options
@@ -53,13 +53,13 @@ paperclipai company export <company-id> --out ./my-export
 
 ```sh
 # Export company with agents and projects
-paperclipai company export abc123 --out ./backup --include company,agents,projects
+npx paperclipai company export abc123 --out ./backup --include company,agents,projects
 
 # Export everything including tasks and skills
-paperclipai company export abc123 --out ./full-export --include company,agents,projects,tasks,skills
+npx paperclipai company export abc123 --out ./full-export --include company,agents,projects,tasks,skills
 
 # Export only specific skills
-paperclipai company export abc123 --out ./skills-only --include skills --skills review,deploy
+npx paperclipai company export abc123 --out ./skills-only --include skills --skills review,deploy
 ```
 
 ### What Gets Exported
@@ -79,17 +79,17 @@ Import from a local directory, GitHub URL, or GitHub shorthand:
 
 ```sh
 # From a local folder
-paperclipai company import ./my-export
+npx paperclipai company import ./my-export
 
 # From a GitHub URL
-paperclipai company import https://github.com/org/repo
+npx paperclipai company import https://github.com/org/repo
 
 # From a GitHub subfolder
-paperclipai company import https://github.com/org/repo/tree/main/companies/acme
+npx paperclipai company import https://github.com/org/repo/tree/main/companies/acme
 
 # From GitHub shorthand
-paperclipai company import org/repo
-paperclipai company import org/repo/companies/acme
+npx paperclipai company import org/repo
+npx paperclipai company import org/repo/companies/acme
 ```
 
 ### Options
@@ -131,7 +131,7 @@ When running interactively (no `--yes` or `--json` flags), the import command sh
 Always preview first with `--dry-run`:
 
 ```sh
-paperclipai company import org/repo --target existing --company-id abc123 --dry-run
+npx paperclipai company import org/repo --target existing --company-id abc123 --dry-run
 ```
 
 The preview shows:
@@ -147,7 +147,7 @@ Imported agents always land with timer heartbeats disabled. Assignment/on-demand
 **Clone a company template from GitHub:**
 
 ```sh
-paperclipai company import org/company-templates/engineering-team \
+npx paperclipai company import org/company-templates/engineering-team \
   --target new \
   --new-company-name "My Engineering Team"
 ```
@@ -155,7 +155,7 @@ paperclipai company import org/company-templates/engineering-team \
 **Add agents from a package into your existing company:**
 
 ```sh
-paperclipai company import ./shared-agents \
+npx paperclipai company import ./shared-agents \
   --target existing \
   --company-id abc123 \
   --include agents \
@@ -165,13 +165,13 @@ paperclipai company import ./shared-agents \
 **Import a specific branch or tag:**
 
 ```sh
-paperclipai company import org/repo --ref v2.0.0 --dry-run
+npx paperclipai company import org/repo --ref v2.0.0 --dry-run
 ```
 
 **Non-interactive import (CI/scripts):**
 
 ```sh
-paperclipai company import ./package \
+npx paperclipai company import ./package \
   --target new \
   --yes \
   --json

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -13,7 +13,7 @@ npx paperclipai onboard --yes
 
 This walks you through setup, configures your environment, and gets Paperclip running.
 
-If you already have a Paperclip install, rerunning `onboard` keeps your current config and data paths intact. Use `paperclipai configure` if you want to edit settings.
+If you already have a Paperclip install, rerunning `onboard` keeps your current config and data paths intact. Use `npx paperclipai configure` if you want to edit settings.
 
 To start Paperclip again later:
 


### PR DESCRIPTION
## Thinking Path

README.md quickstart → user runs `npx paperclipai onboard --yes` → subsequent commands in docs drop the `npx` prefix → user gets "command not found" because `npx` does not install globally.

Traced all occurrences of bare `paperclipai` commands across README and docs/. Classified each as either a runnable command (needs `npx`) or a reference/heading (leave as-is).

## What Changed

Added `npx ` prefix to **21 bare `paperclipai` commands** across 7 files:

| File | Fixes | Example |
|------|-------|---------|
| README.md | 1 | `Use npx paperclipai configure` |
| docs/start/quickstart.md | 1 | Same pattern |
| docs/cli/setup-commands.md | 3 | Inline running instructions |
| docs/deploy/local-development.md | 1 | `Runs npx paperclipai doctor` |
| docs/deploy/tailscale-private-access.md | 1 | `npx paperclipai allowed-hostname` |
| docs/feedback-voting.md | 1 | Code block |
| docs/guides/board-operator/importing-and-exporting.md | 14 | All `paperclipai company` code blocks |

**Intentionally unchanged:**
- Section headings (`## paperclipai run`) — command names, not instructions
- Architecture descriptions ("CLI module — terminal formatter")
- File name references in adapter docs

## Verification

- Searched all `.md` files for bare `paperclipai` with a script
- Verified remaining occurrences are headings/descriptions (not runnable)
- No code changes, docs only

## Risks

None — text-only changes in documentation files.

## Checklist

- [x] PR title follows conventional commits
- [x] Greptile: N/A (docs only)
- [x] Tests: N/A (docs only)

Fixes #2809

## Model Used
Claude Opus 4.6 (via Claude Code)
