### PR TITLE
fix(server): prevent identifier collision in issue creation

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1183,9 +1183,19 @@ export function issueService(db: Db) {
         if (executionWorkspaceId) {
           await assertValidExecutionWorkspace(companyId, issueData.projectId, executionWorkspaceId, tx);
         }
+        // Self-correcting counter: use MAX(issue_number) + 1 if the counter
+        // has drifted below the actual max, preventing identifier collisions.
+        const [maxRow] = await tx
+          .select({ maxNum: sql<number>`coalesce(max(${issues.issueNumber}), 0)` })
+          .from(issues)
+          .where(eq(issues.companyId, companyId));
+        const currentMax = maxRow?.maxNum ?? 0;
+
         const [company] = await tx
           .update(companies)
-          .set({ issueCounter: sql`${companies.issueCounter} + 1` })
+          .set({
+            issueCounter: sql`greatest(${companies.issueCounter}, ${currentMax}) + 1`,
+          })
           .where(eq(companies.id, companyId))
           .returning({ issueCounter: companies.issueCounter, issuePrefix: companies.issuePrefix });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Companies create issues via POST /api/companies/{id}/issues
> - Each issue gets a unique identifier like PREFIX-N based on a counter on the companies table
> - But the counter can drift out of sync with the actual max issue_number in the issues table
> - When that happens, the insert hits a duplicate key violation on the identifier unique index (error 23505) and the transaction rolls back
> - This PR adds a self-correcting counter that uses GREATEST(counter, MAX(issue_number)) + 1
> - The benefit is that counter desync is auto-corrected on the next issue creation, preventing silent failures

## What Changed

- Modified `server/src/services/issues.ts` in the `create` function's transaction block
- Before incrementing the counter, query `MAX(issue_number)` from the issues table for the company
- Use `GREATEST(counter, max_issue_number) + 1` instead of `counter + 1` so the counter self-corrects if it has drifted below the actual max
- This is a single additional query within the existing transaction, so it shares the same isolation level and adds no new failure modes

## Verification

- The fix is within the existing transaction block, so atomicity is preserved
- If `issue_counter` is already correct (the common case), `GREATEST` picks the counter and behavior is identical to before
- If `issue_counter` has drifted below `MAX(issue_number)`, the counter jumps to `max + 1`, skipping the collision
- Pre-existing test failures in UI (IssueDocumentsSection, Routines) are unrelated to this change (localStorage.clear issue on master)

## Risks

- Low risk. The `GREATEST` function is supported by PostgreSQL and adds one subquery to the transaction. The query plan should use the existing index on `issues.company_id`.
- No schema changes, no new columns, no migration needed.

## Model Used

Claude Opus 4.6 (1M context) with tool use. Implementation was guided by reading the existing `create` function in `server/src/services/issues.ts` and the Drizzle ORM patterns used throughout the codebase.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass (4 pre-existing UI failures unrelated to this change)
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #2705

This contribution was developed with AI assistance (Claude Code).