### PR TITLE
docs: recommend global install in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Paperclip handles the hard orchestration details correctly.
 Open source. Self-hosted. No Paperclip account required.
 
 ```bash
-npx paperclipai onboard --yes
+npm install -g paperclipai
+paperclipai onboard --yes
 ```
 
 If you already have Paperclip configured, rerunning `onboard` keeps the existing config in place. Use `paperclipai configure` to edit settings.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - New users start with the README quickstart section
> - The quickstart used `npx paperclipai onboard --yes` as the first command
> - But npx runs from a temp cache and doesn't install globally
> - The next reference (`paperclipai configure`) appears without npx, so users get `command not found`
> - This PR changes the quickstart to recommend `npm install -g paperclipai` first
> - The benefit is that all subsequent commands (`paperclipai configure`, `paperclipai run`, etc.) work without prefix

## What Changed

- Replaced `npx paperclipai onboard --yes` with a two-line block: `npm install -g paperclipai` followed by `paperclipai onboard --yes`
- No other files changed

## Verification

- After `npm install -g paperclipai`, the `paperclipai` command is available globally
- The `paperclipai configure` reference on the next line now works as written
- The manual clone/pnpm path below is unchanged

## Risks

- Low. This is a docs-only change to README.md. No code changes.
- Users who prefer npx can still use it, but the quickstart now guides toward the path that makes subsequent commands work.

## Model Used

Claude Opus 4.6 (1M context) with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #2809

This contribution was developed with AI assistance (Claude Code).