### PR TITLE
fix(codex-local): detect stale rollout path and missing thread errors for session auto-recovery

### DIFF
--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -67,7 +67,7 @@ export function isCodexUnknownSessionError(stdout: string, stderr: string): bool
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
-  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path/i.test(
+  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path|state db returned stale rollout path|no rollout found for thread/i.test(
     haystack,
   );
 }


### PR DESCRIPTION
## Summary

- `isCodexUnknownSessionError()` was missing two error patterns that Codex emits when a session file is deleted or becomes stale
- Without these patterns, the adapter never triggered the fresh-session retry path, leaving the agent permanently stuck in `error` status
- Adds detection for `state db returned stale rollout path` and `no rollout found for thread`

## Root Cause

When a Codex session history exceeds the model's context window (`context_length_exceeded`), the compact operation fails and the session file becomes corrupted/deleted. On the next heartbeat, Codex tries to resume the old session and emits these errors — but the existing regex only matched `state db **missing** rollout path` (not `stale`) and had no pattern for `no rollout found for thread`.

## Test plan

- [x] Trigger a heartbeat with a deleted/stale Codex session file
- [x] Verify the agent logs `"Codex resume session … is unavailable; retrying with a fresh session."` and recovers automatically
- [x] Confirm agent status returns to `running` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)