### PR TITLE
fix(security): sanitize Mermaid SVG output and restore URL scheme filtering

### DIFF
--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -71,6 +71,23 @@ function extractMermaidSource(children: ReactNode): string | null {
   return flattenText(childProps.children).replace(/\n$/, "");
 }
 
+/** Strip scripts, foreignObject, and event handlers from SVG using the browser's built-in DOMParser. */
+function sanitizeSvg(svgString: string): string {
+  const doc = new DOMParser().parseFromString(svgString, "image/svg+xml");
+  for (const tag of ["script", "foreignObject"]) {
+    doc.querySelectorAll(tag).forEach((el) => el.remove());
+  }
+  for (const el of doc.querySelectorAll("*")) {
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.startsWith("on")) el.removeAttribute(attr.name);
+      if (["href", "xlink:href"].includes(attr.name) && attr.value.replace(/\s/g, "").toLowerCase().startsWith("javascript:")) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+  return new XMLSerializer().serializeToString(doc.documentElement);
+}
+
 function MermaidDiagramBlock({ source, darkMode }: { source: string; darkMode: boolean }) {
   const renderId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   const [svg, setSvg] = useState<string | null>(null);
@@ -111,7 +128,7 @@ function MermaidDiagramBlock({ source, darkMode }: { source: string; darkMode: b
   return (
     <div className="paperclip-mermaid">
       {svg ? (
-        <div dangerouslySetInnerHTML={{ __html: svg }} />
+        <div dangerouslySetInnerHTML={{ __html: sanitizeSvg(svg) }} />
       ) : (
         <>
           <p className={cn("paperclip-mermaid-status", error && "paperclip-mermaid-status-error")}>
@@ -215,7 +232,13 @@ export function MarkdownBody({
       )}
       style={style}
     >
-      <Markdown remarkPlugins={remarkPlugins} components={components} urlTransform={(url) => url}>
+      <Markdown remarkPlugins={remarkPlugins} components={components} urlTransform={(url) => {
+          const trimmed = url.replace(/\s/g, "").toLowerCase();
+          if (trimmed.startsWith("javascript:") || trimmed.startsWith("vbscript:") || trimmed.startsWith("data:text/html")) {
+            return "";
+          }
+          return url;
+        }}>
         {children}
       </Markdown>
     </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents produce markdown output (issue descriptions, summaries, comments) that gets rendered in the board UI
> - The MarkdownBody component renders this markdown including Mermaid diagrams via `dangerouslySetInnerHTML`
> - The Mermaid SVG output was injected into the DOM without sanitization, relying solely on Mermaid's `securityLevel: "strict"` — if Mermaid ever has a sanitization bypass, XSS is possible
> - Additionally, `urlTransform={(url) => url}` bypassed react-markdown's built-in `javascript:` URL filtering
> - This pull request adds browser-native DOMParser sanitization for Mermaid SVG and restores URL scheme filtering
> - The benefit is defense-in-depth against XSS without adding any new dependencies

## What Changed

- Added `sanitizeSvg()` function using browser-native `DOMParser`/`XMLSerializer` that strips `<script>`, `<foreignObject>`, `on*` event handlers, and `javascript:` hrefs from SVG
- Wrapped `dangerouslySetInnerHTML` through `sanitizeSvg(svg)` instead of raw injection
- Replaced the identity `urlTransform` with a filter blocking `javascript:`, `vbscript:`, and `data:text/html` URL schemes (handles case variations, whitespace, and tab injection)
- Zero new dependencies — uses browser built-in APIs only

## Verification

- `pnpm test:run` passes locally
- CI green (policy, verify, e2e, snyk all pass)
- Manual test: Mermaid flowcharts, sequence diagrams, and gantt charts render correctly after sanitization
- Manual test: markdown links with http/https/mailto still work, `data:image/png` inline images still render

## Risks

- Low risk. The `sanitizeSvg` function only strips dangerous elements — all standard SVG elements Mermaid produces (paths, rects, text, g, defs, markers) pass through unchanged.
- The URL filter is a blocklist rather than an allowlist, which means unknown schemes pass through. This is intentional to avoid breaking `data:image/*` URLs used for inline images.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #2754
