### PR TITLE
fix(issues): release execution lock when assignee changes mid-run

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -7,6 +7,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -857,5 +858,179 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     expect(followUp.executionWorkspaceSettings).toEqual({
       mode: "operator_branch",
     });
+  });
+});
+
+describeEmbeddedPostgres("issueService.update assignee change releases execution lock", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-assignee-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("clears executionRunId and related lock fields when the agent assignee changes", async () => {
+    const companyId = randomUUID();
+    const outgoingAgentId = randomUUID();
+    const incomingAgentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const lockedAt = new Date("2026-04-05T19:30:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: outgoingAgentId,
+        companyId,
+        name: "TechLead",
+        role: "tech_lead",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: incomingAgentId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: outgoingAgentId,
+      invocationSource: "heartbeat",
+      status: "running",
+      startedAt: lockedAt,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cross-partition Cosmos query fix",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: outgoingAgentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "tech_lead",
+      executionLockedAt: lockedAt,
+    });
+
+    const updated = await svc.update(issueId, {
+      status: "in_review",
+      assigneeAgentId: incomingAgentId,
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.assigneeAgentId).toBe(incomingAgentId);
+    expect(updated!.status).toBe("in_review");
+    expect(updated!.checkoutRunId).toBeNull();
+    expect(updated!.executionRunId).toBeNull();
+    expect(updated!.executionAgentNameKey).toBeNull();
+    expect(updated!.executionLockedAt).toBeNull();
+
+    // The outgoing run itself must stay intact — only the issue-level lock is released.
+    const persistedRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(persistedRun?.status).toBe("running");
+  });
+
+  it("keeps the execution lock intact when assignee fields are untouched", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const lockedAt = new Date("2026-04-05T19:30:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TechLead",
+      role: "tech_lead",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "heartbeat",
+      status: "running",
+      startedAt: lockedAt,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Still mine",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "tech_lead",
+      executionLockedAt: lockedAt,
+    });
+
+    const updated = await svc.update(issueId, {
+      title: "Still mine, updated title",
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.assigneeAgentId).toBe(agentId);
+    expect(updated!.checkoutRunId).toBe(runId);
+    expect(updated!.executionRunId).toBe(runId);
+    expect(updated!.executionAgentNameKey).toBe("tech_lead");
+    expect(updated!.executionLockedAt).toEqual(lockedAt);
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1297,6 +1297,15 @@ export function issueService(db: Db) {
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
       ) {
         patch.checkoutRunId = null;
+        // Voluntary handoff: the outgoing assignee's run (if any) no longer owns this
+        // issue's execution lock. Releasing these fields lets the new assignee's wakeup
+        // proceed instead of being deferred behind a run that will never reach a
+        // terminal state (e.g. agent naturally exhausted its turn without signalling
+        // completion). The outgoing run keeps running; its eventual
+        // releaseIssueExecutionAndPromote no-ops when the lock is already released.
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
       }
 
       return db.transaction(async (tx) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue checkout & execution locking is how one agent claims an issue for work without another agent (or a re-triggered wakeup) racing on it
> - When an agent hands an issue off mid-run by changing `assigneeAgentId`, `checkoutRunId` is cleared but `executionRunId` / `executionAgentNameKey` / `executionLockedAt` stay pointing at the outgoing agent's still-`running` heartbeat run
> - PR #2537 only clears these fields when the holding run is terminal or missing, so a "naturally handed off" run (agent exhausted its turn without signalling completion) keeps the lock forever and the new assignee's wakeup sits in `deferred_issue_execution` until someone manually presses Stop
> - This pull request treats a voluntary assignee change as an implicit release of the issue-level execution lock, mirroring the existing `checkoutRunId` reset that is already in the same branch
> - The benefit is that agent-to-agent handoffs stop getting stuck: the incoming agent's wakeup transitions straight to `queued` and the outgoing run continues running until it exits on its own (its eventual `releaseIssueExecutionAndPromote` no-ops safely)

## What Changed

- `server/src/services/issues.ts`: inside `issueService.update`, when `assigneeAgentId` or `assigneeUserId` changes, also null out `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` alongside the existing `checkoutRunId` reset
- `server/src/__tests__/issues-service.test.ts`: add two embedded-Postgres tests — (1) agent-to-agent handoff clears all four lock fields while the outgoing heartbeat run stays `running`, (2) an update that does not touch assignee fields preserves all lock fields (regression guard)

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passes
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts` — 13/13 pass including the two new cases
- Ran adjacent suites to confirm no regressions: `issues-checkout-wakeup`, `issue-comment-reopen-routes`, `issue-closed-workspace-routes`, `heartbeat-process-recovery`, `heartbeat-comment-wake-batching`, `routines-service`, `routines-e2e`, `routine-run-telemetry`, `workspace-runtime` — 76/76 pass overall
- Manual repro before the fix: Tech Lead agent PATCHes `assigneeAgentId: cto`, writes a summary comment, run stays `running`; CTO's enqueued wakeup lands in `deferred_issue_execution` and stays there until the stuck run is manually stopped. After applying the patch locally to a live `npx paperclipai@2026.403.0` install, the same flow releases the lock synchronously and CTO's wakeup goes straight to `queued`

## Risks

- Low risk. The change is a 3-line addition that mirrors the existing `checkoutRunId` behaviour on the exact same code path — there is no new branch, no new query, and no schema change
- Behavioural shift: an outgoing agent that loses the assignee also loses its execution lock on that issue. This is intentional — its `releaseIssueExecutionAndPromote` becomes a safe no-op because the issue no longer matches `execution_run_id = run.id`. The run itself is untouched and continues until it finishes on its own
- Edge case considered: an update that changes assignee back and forth within a single PATCH is not possible (one PATCH, one final value); if a separate future PATCH reassigns back to the original agent, they simply re-checkout via the normal flow

## Model Used

- Provider / model: Anthropic Claude, model ID `claude-opus-4-6` (1M context window), used via Claude Code CLI with tool use + code execution
- Human author reviewed the diagnosis, fix, and tests before opening the PR

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (n/a — server-only change)
- [x] I have updated relevant documentation to reflect my changes (n/a — behaviour is covered by the new test cases and in-code comment)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Refs #2533