### PR TITLE
Fix stale SPA fallback shell after UI dist refresh

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -256,10 +256,22 @@ export async function createApp(
     ];
     const uiDist = candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
     if (uiDist) {
-      const indexHtml = applyUiBranding(fs.readFileSync(path.join(uiDist, "index.html"), "utf-8"));
+      const indexHtmlPath = path.join(uiDist, "index.html");
+      let indexHtml = "";
+      let indexHtmlMtimeMs = 0;
+
+      const getIndexHtml = () => {
+        const nextMtimeMs = fs.statSync(indexHtmlPath).mtimeMs;
+        if (!indexHtml || nextMtimeMs !== indexHtmlMtimeMs) {
+          indexHtml = applyUiBranding(fs.readFileSync(indexHtmlPath, "utf-8"));
+          indexHtmlMtimeMs = nextMtimeMs;
+        }
+        return indexHtml;
+      };
+
       app.use(express.static(uiDist));
       app.get(/.*/, (_req, res) => {
-        res.status(200).set("Content-Type", "text/html").end(indexHtml);
+        res.status(200).set("Content-Type", "text/html").end(getIndexHtml());
       });
     } else {
       console.warn("[paperclip] UI dist not found; running in API-only mode");


### PR DESCRIPTION
## Summary
- refresh the static SPA fallback `index.html` when `ui-dist/index.html` changes on disk
- keep the current in-memory cache, but invalidate it on mtime changes so deep links do not serve a stale bundle hash after a UI dist refresh

## Why
`express.static(uiDist)` serves `/` from disk, but deep links use the process-cached fallback HTML. If `ui-dist/index.html` is updated without a process restart, `/` can point at the new hashed bundle while deep links still point at a deleted old bundle. The old bundle request then falls through to the HTML fallback and the browser rejects it as `text/html`, yielding a blank page on direct routes.

Fixes #2869

## Verification
- `corepack pnpm --filter @paperclipai/server typecheck`
- `corepack pnpm --filter @paperclipai/server build`
- manually hotpatched the same logic into a local `paperclipai` runtime and verified `/LUK/issues/LUK-267` loads directly with no browser console errors after a fresh browser navigation
