### PR TITLE
feat: add mobile properties panel via Sheet

### DIFF
--- a/ui/src/components/PropertiesPanel.tsx
+++ b/ui/src/components/PropertiesPanel.tsx
@@ -1,12 +1,38 @@
 import { X } from "lucide-react";
 import { usePanel } from "../context/PanelContext";
+import { useSidebar } from "../context/SidebarContext";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 
 export function PropertiesPanel() {
-  const { panelContent, panelVisible, setPanelVisible } = usePanel();
+  const { panelContent, panelVisible, setPanelVisible, closePanel } = usePanel();
+  const { isMobile } = useSidebar();
 
   if (!panelContent) return null;
+
+  if (isMobile) {
+    return (
+      <Sheet
+        open={panelVisible}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPanelVisible(false);
+            closePanel();
+          }
+        }}
+      >
+        <SheetContent side="right" showCloseButton={false}>
+          <SheetHeader>
+            <SheetTitle>Properties</SheetTitle>
+          </SheetHeader>
+          <ScrollArea className="flex-1 overflow-auto">
+            <div className="px-4 pb-4">{panelContent}</div>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+    );
+  }
 
   return (
     <aside


### PR DESCRIPTION
## Summary
- The `PropertiesPanel` was completely hidden on mobile (`hidden md:flex`), making issue/goal properties inaccessible on small screens
- On mobile, the panel content now renders inside the existing `Sheet` component (side="right") instead of the hidden `<aside>`
- Zero new dependencies — reuses the existing Sheet component and PanelContext

## Changes
- `ui/src/components/PropertiesPanel.tsx` — detect mobile via `useSidebar().isMobile`, render `Sheet` on mobile, keep existing `<aside>` on desktop

## Test plan
- [ ] Open any issue detail page on a mobile viewport (< 768px) — properties sheet should slide in from the right
- [ ] Tap overlay or swipe to dismiss the sheet
- [ ] Verify desktop behavior is unchanged (320px aside panel)
- [ ] Test on goal detail pages as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)