### PR TITLE
fix: gemini-local adapter compatibility with Gemini CLI v0.36.0 on Windows

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -492,7 +492,7 @@ async function resolveSpawnTarget(
     const commandLine = [quoteForCmd(executable), ...args.map(quoteForCmd)].join(" ");
     return {
       command: shell,
-      args: ["/d", "/s", "/c", commandLine],
+      args: ["/d", "/c", commandLine],
     };
   }
 
@@ -956,6 +956,7 @@ export async function runChildProcess(
           cwd: opts.cwd,
           env: mergedEnv,
           shell: false,
+          windowsHide: false,
           stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
         }) as ChildProcessWithEvents;
         const startedAt = new Date().toISOString();

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -492,7 +492,7 @@ async function resolveSpawnTarget(
     const commandLine = [quoteForCmd(executable), ...args.map(quoteForCmd)].join(" ");
     return {
       command: shell,
-      args: ["/d", "/c", commandLine],
+      args: ["/d", "/s", "/c", commandLine],
     };
   }
 

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -144,7 +144,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "gemini");
   const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
-  const sandbox = asBoolean(config.sandbox, false);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -346,9 +345,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         command: resolvedCommand,
         cwd,
         commandNotes,
-        commandArgs: args.map((value, index) => (
-          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
-        )),
+        commandArgs: args,
         env: loggedEnv,
         prompt,
         promptMetrics,
@@ -369,10 +366,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // Gemini CLI v0.35.3+ may print before the actual JSON output.
     const jsonStart = proc.stdout.indexOf('{');
     const cleanStdout = jsonStart !== -1 ? proc.stdout.slice(jsonStart) : proc.stdout;
-    return {
-      proc,
-      parsed: parseGeminiJsonl(cleanStdout),
-    };
+    let parsed = parseGeminiJsonl(cleanStdout);
+    if (!parsed.summary.trim()) {
+      try {
+        const raw = JSON.parse(cleanStdout);
+        if (raw.response) {
+          parsed = { ...parsed, summary: String(raw.response).trim() };
+        }
+      } catch {
+        // ignore
+      }
+    }
+    return { proc, parsed };
   };
 
   const toResult = (

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -329,17 +329,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const buildArgs = (resumeSessionId: string | null) => {
-    const args = ["--output-format", "stream-json"];
+    const args = ["--output-format", "json"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
     args.push("--approval-mode", "yolo");
-    if (sandbox) {
-      args.push("--sandbox");
-    } else {
-      args.push("--sandbox=none");
-    }
+
     if (extraArgs.length > 0) args.push(...extraArgs);
-    args.push("--prompt", prompt);
     return args;
   };
 
@@ -368,10 +363,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       graceSec,
       onSpawn,
       onLog,
+      stdin: prompt,
     });
+    // Strip non-JSON noise lines (e.g. "Loaded cached credentials.") that
+    // Gemini CLI v0.35.3+ may print before the actual JSON output.
+    const jsonStart = proc.stdout.indexOf('{');
+    const cleanStdout = jsonStart !== -1 ? proc.stdout.slice(jsonStart) : proc.stdout;
     return {
       proc,
-      parsed: parseGeminiJsonl(proc.stdout),
+      parsed: parseGeminiJsonl(cleanStdout),
     };
   };
 

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -272,7 +272,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
+    const notes: string[] = ["Prompt is passed to Gemini via stdin for non-interactive execution."];
     notes.push("Added --approval-mode yolo for unattended execution.");
     if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -134,7 +134,6 @@ export async function testEnvironment(
     } else {
       const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
       const approvalMode = asString(config.approvalMode, asBoolean(config.yolo, false) ? "yolo" : "default");
-      const sandbox = asBoolean(config.sandbox, false);
       const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 30));
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -135,21 +135,17 @@ export async function testEnvironment(
       const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
       const approvalMode = asString(config.approvalMode, asBoolean(config.yolo, false) ? "yolo" : "default");
       const sandbox = asBoolean(config.sandbox, false);
-      const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 10));
+      const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 30));
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
         if (fromExtraArgs.length > 0) return fromExtraArgs;
         return asStringArray(config.args);
       })();
 
-      const args = ["--output-format", "stream-json", "--prompt", "Respond with hello."];
+      const args = ["--output-format", "json"];
       if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
       if (approvalMode !== "default") args.push("--approval-mode", approvalMode);
-      if (sandbox) {
-        args.push("--sandbox");
-      } else {
-        args.push("--sandbox=none");
-      }
+
       if (extraArgs.length > 0) args.push(...extraArgs);
 
       const probe = await runChildProcess(
@@ -162,9 +158,24 @@ export async function testEnvironment(
           timeoutSec: helloProbeTimeoutSec,
           graceSec: 5,
           onLog: async () => { },
+          stdin: "Respond with hello.",
         },
       );
-      const parsed = parseGeminiJsonl(probe.stdout);
+      // Strip non-JSON noise lines (e.g. "Loaded cached credentials.") that
+      // Gemini CLI v0.35.3+ may print before the actual JSON output.
+      const jsonStart = probe.stdout.indexOf('{');
+      const cleanStdout = jsonStart !== -1 ? probe.stdout.slice(jsonStart) : probe.stdout;
+      const parsed = parseGeminiJsonl(cleanStdout);
+      // Fallback for Gemini CLI v0.36.0 which returns plain JSON instead of JSONL
+      let summary = parsed.summary.trim();
+      if (!summary) {
+        try {
+          const raw = JSON.parse(cleanStdout);
+          if (raw.response) summary = String(raw.response).trim();
+        } catch {
+          // ignore parse errors
+        }
+      }
       const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
       const authMeta = detectGeminiAuthRequired({
         parsed: parsed.resultEvent,
@@ -195,15 +206,15 @@ export async function testEnvironment(
           hint: "Retry the probe. If this persists, verify Gemini can run `Respond with hello.` from this directory manually.",
         });
       } else if ((probe.exitCode ?? 1) === 0) {
-        const summary = parsed.summary.trim();
-        const hasHello = /\bhello\b/i.test(summary);
+        const finalSummary = summary;
+        const hasHello = /\bhello\b/i.test(finalSummary);
         checks.push({
           code: hasHello ? "gemini_hello_probe_passed" : "gemini_hello_probe_unexpected_output",
           level: hasHello ? "info" : "warn",
           message: hasHello
             ? "Gemini hello probe succeeded."
             : "Gemini probe ran but did not return `hello` as expected.",
-          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+          ...(finalSummary ? { detail: finalSummary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
           ...(hasHello
             ? {}
             : {

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -134,6 +134,14 @@ export async function testEnvironment(
     } else {
       const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
       const approvalMode = asString(config.approvalMode, asBoolean(config.yolo, false) ? "yolo" : "default");
+      if (asBoolean(config.sandbox, false)) {
+        checks.push({
+          code: "gemini_sandbox_unsupported",
+          level: "warn",
+          message: "The sandbox setting is not supported by Gemini CLI v0.36.0 and will be ignored.",
+          hint: "Remove sandbox from adapter config, or use extraArgs if equivalent behavior becomes available.",
+        });
+      }
       const helloProbeTimeoutSec = Math.max(1, asNumber(config.helloProbeTimeoutSec, 30));
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);

--- a/server/src/__tests__/gemini-local-adapter-environment.test.ts
+++ b/server/src/__tests__/gemini-local-adapter-environment.test.ts
@@ -26,6 +26,10 @@ console.log(JSON.stringify({
   await fs.writeFile(scriptPath, script, "utf8");
   const cmd = `@"${process.execPath.replace(/\\/g, "\\\\")}" "%~dp0gemini.js" %*\r\n`;
   await fs.writeFile(cmdPath, cmd, "utf8");
+  if (process.platform !== "win32") {
+    await fs.chmod(scriptPath, 0o755);
+    return scriptPath;
+  }
   return cmdPath;
 }
 
@@ -42,6 +46,10 @@ process.exit(1);
   await fs.writeFile(scriptPath, script, "utf8");
   const cmd = `@"${process.execPath.replace(/\\/g, "\\\\")}" "%~dp0gemini.js" %*\r\n`;
   await fs.writeFile(cmdPath, cmd, "utf8");
+  if (process.platform !== "win32") {
+    await fs.chmod(scriptPath, 0o755);
+    return scriptPath;
+  }
   return cmdPath;
 }
 

--- a/server/src/__tests__/gemini-local-adapter-environment.test.ts
+++ b/server/src/__tests__/gemini-local-adapter-environment.test.ts
@@ -30,6 +30,7 @@ console.log(JSON.stringify({
     await fs.chmod(scriptPath, 0o755);
     return scriptPath;
   }
+  await fs.chmod(cmdPath, 0o755);
   return cmdPath;
 }
 
@@ -50,6 +51,7 @@ process.exit(1);
     await fs.chmod(scriptPath, 0o755);
     return scriptPath;
   }
+  await fs.chmod(cmdPath, 0o755);
   return cmdPath;
 }
 

--- a/server/src/__tests__/gemini-local-adapter-environment.test.ts
+++ b/server/src/__tests__/gemini-local-adapter-environment.test.ts
@@ -5,8 +5,9 @@ import path from "node:path";
 import { testEnvironment } from "@paperclipai/adapter-gemini-local/server";
 
 async function writeFakeGeminiCommand(binDir: string, argsCapturePath: string): Promise<string> {
-  const commandPath = path.join(binDir, "gemini");
-  const script = `#!/usr/bin/env node
+  const scriptPath = path.join(binDir, "gemini.js");
+  const cmdPath = path.join(binDir, "gemini.cmd");
+  const script = `
 const fs = require("node:fs");
 const outPath = process.env.PAPERCLIP_TEST_ARGS_PATH;
 if (outPath) {
@@ -22,23 +23,26 @@ console.log(JSON.stringify({
   result: "hello",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
-  return commandPath;
+  await fs.writeFile(scriptPath, script, "utf8");
+  const cmd = `@"${process.execPath.replace(/\\/g, "\\\\")}" "%~dp0gemini.js" %*\r\n`;
+  await fs.writeFile(cmdPath, cmd, "utf8");
+  return cmdPath;
 }
 
 async function writeQuotaGeminiCommand(binDir: string): Promise<string> {
-  const commandPath = path.join(binDir, "gemini");
-  const script = `#!/usr/bin/env node
+  const scriptPath = path.join(binDir, "gemini.js");
+  const cmdPath = path.join(binDir, "gemini.cmd");
+  const script = `
 if (process.argv.includes("--help")) {
   process.exit(0);
 }
 console.error("429 RESOURCE_EXHAUSTED: You exceeded your current quota and billing details.");
 process.exit(1);
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
-  return commandPath;
+  await fs.writeFile(scriptPath, script, "utf8");
+  const cmd = `@"${process.execPath.replace(/\\/g, "\\\\")}" "%~dp0gemini.js" %*\r\n`;
+  await fs.writeFile(cmdPath, cmd, "utf8");
+  return cmdPath;
 }
 
 describe("gemini_local environment diagnostics", () => {
@@ -100,7 +104,6 @@ describe("gemini_local environment diagnostics", () => {
     expect(args).toContain("gemini-2.5-pro");
     expect(args).toContain("--approval-mode");
     expect(args).toContain("yolo");
-    expect(args).toContain("--prompt");
     await fs.rm(root, { recursive: true, force: true });
   });
 

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-gemini-local/server";
 
-async function writeFakeGeminiCommand(commandPath: string): Promise<void> {
+async function writeFakeGeminiCommand(commandPath: string): Promise<string> {
   const scriptPath = commandPath + ".js";
   const cmdPath = commandPath + ".cmd";
   const script = `
@@ -45,6 +45,11 @@ process.stdin.on("end", () => {
   await fs.writeFile(scriptPath, script, "utf8");
   const cmd = `@"${process.execPath.replace(/\\/g, "\\\\")}" "%~dp0gemini.js" %*\r\n`;
   await fs.writeFile(cmdPath, cmd, "utf8");
+  if (process.platform !== "win32") {
+    await fs.chmod(scriptPath, 0o755);
+    return scriptPath;
+  }
+  return cmdPath;
 }
 
 type CapturePayload = {
@@ -57,10 +62,10 @@ describe("gemini execute", () => {
   it("passes prompt via --prompt and injects paperclip env vars", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-execute-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "gemini");
+    let commandPath = path.join(root, "gemini");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeGeminiCommand(commandPath);
+    commandPath = await writeFakeGeminiCommand(commandPath);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -83,7 +88,7 @@ describe("gemini execute", () => {
           taskKey: null,
         },
         config: {
-          command: commandPath + ".cmd",
+          command: commandPath,
           cwd: workspace,
           model: "gemini-2.5-pro",
           env: {
@@ -137,10 +142,10 @@ describe("gemini execute", () => {
   it("always passes --approval-mode yolo", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-yolo-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "gemini");
+    let commandPath = path.join(root, "gemini");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeGeminiCommand(commandPath);
+    commandPath = await writeFakeGeminiCommand(commandPath);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -151,7 +156,7 @@ describe("gemini execute", () => {
         agent: { id: "a1", companyId: "c1", name: "G", adapterType: "gemini_local", adapterConfig: {} },
         runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
         config: {
-          command: commandPath + ".cmd",
+          command: commandPath,
           cwd: workspace,
           env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
         },
@@ -179,10 +184,10 @@ describe("gemini execute", () => {
   it("uses a compact wake delta instead of the full heartbeat prompt when resuming a session", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-resume-wake-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "gemini");
+    let commandPath = path.join(root, "gemini");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeGeminiCommand(commandPath);
+    commandPath = await writeFakeGeminiCommand(commandPath);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -204,7 +209,7 @@ describe("gemini execute", () => {
           taskKey: null,
         },
         config: {
-          command: commandPath + ".cmd",
+          command: commandPath,
           cwd: workspace,
           model: "gemini-2.5-pro",
           env: {

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -5,42 +5,51 @@ import path from "node:path";
 import { execute } from "@paperclipai/adapter-gemini-local/server";
 
 async function writeFakeGeminiCommand(commandPath: string): Promise<void> {
-  const script = `#!/usr/bin/env node
+  const scriptPath = commandPath + ".js";
+  const cmdPath = commandPath + ".cmd";
+  const script = `
 const fs = require("node:fs");
-
 const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
-const payload = {
-  argv: process.argv.slice(2),
-  paperclipEnvKeys: Object.keys(process.env)
-    .filter((key) => key.startsWith("PAPERCLIP_"))
-    .sort(),
-};
-if (capturePath) {
-  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
-}
-console.log(JSON.stringify({
-  type: "system",
-  subtype: "init",
-  session_id: "gemini-session-1",
-  model: "gemini-2.5-pro",
-}));
-console.log(JSON.stringify({
-  type: "assistant",
-  message: { content: [{ type: "output_text", text: "hello" }] },
-}));
-console.log(JSON.stringify({
-  type: "result",
-  subtype: "success",
-  session_id: "gemini-session-1",
-  result: "ok",
-}));
+let stdinData = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { stdinData += chunk; });
+process.stdin.on("end", () => {
+  const payload = {
+    argv: process.argv.slice(2),
+    stdin: stdinData,
+    paperclipEnvKeys: Object.keys(process.env)
+      .filter((key) => key.startsWith("PAPERCLIP_"))
+      .sort(),
+  };
+  if (capturePath) {
+    fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+  }
+  console.log(JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "gemini-session-1",
+    model: "gemini-2.5-pro",
+  }));
+  console.log(JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "output_text", text: "hello" }] },
+  }));
+  console.log(JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: "gemini-session-1",
+    result: "ok",
+  }));
+});
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await fs.writeFile(scriptPath, script, "utf8");
+  const cmd = `@"${process.execPath.replace(/\\/g, "\\\\")}" "%~dp0gemini.js" %*\r\n`;
+  await fs.writeFile(cmdPath, cmd, "utf8");
 }
 
 type CapturePayload = {
   argv: string[];
+  stdin: string;
   paperclipEnvKeys: string[];
 };
 
@@ -74,7 +83,7 @@ describe("gemini execute", () => {
           taskKey: null,
         },
         config: {
-          command: commandPath,
+          command: commandPath + ".cmd",
           cwd: workspace,
           model: "gemini-2.5-pro",
           env: {
@@ -95,12 +104,10 @@ describe("gemini execute", () => {
 
       const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
       expect(capture.argv).toContain("--output-format");
-      expect(capture.argv).toContain("stream-json");
-      expect(capture.argv).toContain("--prompt");
+      expect(capture.argv).toContain("json");
       expect(capture.argv).toContain("--approval-mode");
       expect(capture.argv).toContain("yolo");
-      const promptFlagIndex = capture.argv.indexOf("--prompt");
-      const promptArg = promptFlagIndex >= 0 ? capture.argv[promptFlagIndex + 1] : "";
+      const promptArg = capture.stdin ?? "";
       expect(promptArg).toContain("Follow the paperclip heartbeat.");
       expect(promptArg).toContain("Paperclip runtime note:");
       expect(capture.paperclipEnvKeys).toEqual(
@@ -144,7 +151,7 @@ describe("gemini execute", () => {
         agent: { id: "a1", companyId: "c1", name: "G", adapterType: "gemini_local", adapterConfig: {} },
         runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
         config: {
-          command: commandPath,
+          command: commandPath + ".cmd",
           cwd: workspace,
           env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
         },
@@ -197,7 +204,7 @@ describe("gemini execute", () => {
           taskKey: null,
         },
         config: {
-          command: commandPath,
+          command: commandPath + ".cmd",
           cwd: workspace,
           model: "gemini-2.5-pro",
           env: {
@@ -248,8 +255,7 @@ describe("gemini execute", () => {
       expect(result.errorMessage).toBeNull();
 
       const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
-      const promptFlagIndex = capture.argv.indexOf("--prompt");
-      const promptArg = promptFlagIndex >= 0 ? capture.argv[promptFlagIndex + 1] : "";
+      const promptArg = capture.stdin ?? "";
       expect(capture.argv).toContain("--resume");
       expect(capture.argv).toContain("gemini-session-1");
       expect(promptArg).toContain("## Paperclip Resume Delta");


### PR DESCRIPTION
Fixes #2852

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The gemini-local adapter spawns Gemini CLI as a subprocess to execute agent tasks
> - Gemini CLI v0.36.0 introduced breaking changes on Windows — removed `-p` flag support, dropped sandbox Docker image, and changed JSON output format
> - Without this fix, the adapter fails immediately on any Windows machine running v0.36.0
> - This PR updates the adapter to work with Gemini CLI v0.36.0 on Windows
> - The benefit is Windows users can run Paperclip with the latest Gemini CLI without downgrading

## What Changed

- Switched prompt delivery from `-p` flag to stdin in both `execute.ts` and `test.ts`
- Removed `--sandbox` flag — v0.36.0 tries to pull a Docker image that doesn't exist, causing a fatal crash
- Increased hello probe timeout from 10s to 30s to account for MCP initialization overhead on Windows
- Fixed JSON noise filter to use `indexOf('{')` instead of line-based filter — old filter broke multi-line JSON
- Added fallback parser for v0.36.0 plain JSON format (`raw.response`) since it no longer returns JSONL
- Added `windowsHide: false` to spawn options in `server-utils.ts` to preserve Windows console handle

## Verification

- Tested on Windows 11, Gemini CLI v0.36.0
- Adapter environment probe passes cleanly
- Agents run end to end and produce real output across multiple agent types (CEO, CTO, CMO, UXDesigner)

## Risks

- `--sandbox` removal means sandbox mode is fully disabled. Low risk — sandbox was already broken in v0.36.0 and caused crashes
- `windowsHide: false` only affects Windows behavior, no impact on Linux/Mac
- Timeout increase from 10s to 30s is conservative and configurable via `helloProbeTimeoutSec`

## Known Remaining Issue

`AttachConsole failed` errors appear in transcripts on Windows when agents run shell commands. Non-fatal — agents complete tasks successfully despite them. Root cause is node-pty inside Gemini CLI attempting PTY initialization without a real console. Requires a fix inside Gemini CLI itself.

## Model Used

- Provider: Google Gemini via Gemini CLI
- Models: gemini-2.5-flash-lite (router), gemini-3-flash-preview (main)
- Used for agent task execution during testing only. Code changes were authored manually with debugging assistance from Claude (Anthropic, claude-sonnet-4-6).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge