### PR TITLE
fix: include issue description in wake payload and don't drop payload when no comments

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -197,6 +197,7 @@ type PaperclipWakeIssue = {
   id: string | null;
   identifier: string | null;
   title: string | null;
+  description: string | null;
   status: string | null;
   priority: string | null;
 };
@@ -230,12 +231,14 @@ function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null 
   const identifier = asString(issue.identifier, "").trim() || null;
   const title = asString(issue.title, "").trim() || null;
   const status = asString(issue.status, "").trim() || null;
+  const description = asString(issue.description, "").trim() || null;
   const priority = asString(issue.priority, "").trim() || null;
   if (!id && !identifier && !title) return null;
   return {
     id,
     identifier,
     title,
+    description,
     status,
     priority,
   };
@@ -332,6 +335,9 @@ export function renderPaperclipWakePrompt(
         `- fallback fetch needed: ${normalized.fallbackFetchNeeded ? "yes" : "no"}`,
       ];
 
+  if (normalized.issue?.description) {
+    lines.push(`- issue description: ${normalized.issue.description}`);
+  }
   if (normalized.issue?.status) {
     lines.push(`- issue status: ${normalized.issue.status}`);
   }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -317,7 +317,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const promptTemplate = asString(
     config.promptTemplate,
-    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.\n\nYour working directory is your current cwd. Always search within your working directory first. Never search broad paths like /Users or $HOME — use your cwd, project paths from context, or the Paperclip API to locate files.",
   );
   const model = asString(config.model, "");
   const effort = asString(config.effort, "");

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -832,13 +832,13 @@ async function buildPaperclipWakePayload(input: {
         id: string;
         identifier: string | null;
         title: string;
+        description: string | null;
         status: string;
         priority: string;
       }
     | null;
 }) {
   const commentIds = extractWakeCommentIds(input.contextSnapshot);
-  if (commentIds.length === 0) return null;
 
   const issueId = readNonEmptyString(input.contextSnapshot.issueId);
   const issueSummary =
@@ -849,6 +849,7 @@ async function buildPaperclipWakePayload(input: {
             id: issues.id,
             identifier: issues.identifier,
             title: issues.title,
+            description: issues.description,
             status: issues.status,
             priority: issues.priority,
           })
@@ -857,7 +858,9 @@ async function buildPaperclipWakePayload(input: {
           .then((rows) => rows[0] ?? null)
       : null);
 
-  const commentRows = await input.db
+  if (commentIds.length === 0 && !issueSummary) return null;
+
+  const commentRows = commentIds.length > 0 ? await input.db
     .select({
       id: issueComments.id,
       issueId: issueComments.issueId,
@@ -872,7 +875,7 @@ async function buildPaperclipWakePayload(input: {
         eq(issueComments.companyId, input.companyId),
         inArray(issueComments.id, commentIds),
       ),
-    );
+    ) : [];
 
   const commentsById = new Map(commentRows.map((comment) => [comment.id, comment]));
   const comments: Array<Record<string, unknown>> = [];
@@ -925,6 +928,7 @@ async function buildPaperclipWakePayload(input: {
           id: issueSummary.id,
           identifier: issueSummary.identifier,
           title: issueSummary.title,
+          description: issueSummary.description ?? null,
           status: issueSummary.status,
           priority: issueSummary.priority,
         }
@@ -2283,6 +2287,7 @@ export function heartbeatService(db: Db) {
             id: issues.id,
             identifier: issues.identifier,
             title: issues.title,
+            description: issues.description,
             status: issues.status,
             priority: issues.priority,
             projectId: issues.projectId,
@@ -2355,6 +2360,7 @@ export function heartbeatService(db: Db) {
           id: issueContext.id,
           identifier: issueContext.identifier,
           title: issueContext.title,
+          description: issueContext.description,
           status: issueContext.status,
           priority: issueContext.priority,
           projectId: issueContext.projectId,
@@ -2372,6 +2378,7 @@ export function heartbeatService(db: Db) {
             id: issueRef.id,
             identifier: issueRef.identifier,
             title: issueRef.title,
+            description: issueRef.description,
             status: issueRef.status,
             priority: issueRef.priority,
           }


### PR DESCRIPTION
## Summary

- **Fix empty wake payload when issue has no comments**: `buildPaperclipWakePayload` previously returned `null` when `commentIds.length === 0`, stripping all issue context from the agent prompt. Now only returns null when there are no comments AND no issue summary.
- **Add issue description to wake payload**: The `description` field was never fetched from the DB or included in the wake payload pipeline. Added it to the type definition, DB queries, normalizer, payload builder, and prompt renderer.
- **Add workspace guidance to default prompt template**: Agents were running expensive `find /Users/...` searches because the default prompt gave no workspace context. Added guidance to search within cwd first.

Fixes #2881, fixes #2882, fixes #2886

## Test plan

- [ ] Create an issue with a description, assign it to an agent with no comments — agent should receive the issue title and description
- [ ] Create an issue, add a comment, assign to agent — wake payload should include both the issue description and the comment
- [ ] Verify existing comment-based wakes still work correctly
- [ ] Verify agents search within their working directory instead of broad filesystem paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)