### PR TITLE
fix: recognize missing-rollout Codex resume error as stale session

### DIFF
--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isCodexUnknownSessionError, parseCodexJsonl } from "./parse.js";
+
+describe("parseCodexJsonl", () => {
+  it("captures session id, assistant summary, usage, and error message", () => {
+    const stdout = [
+      JSON.stringify({ type: "thread.started", thread_id: "thread_123" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "Recovered response" },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 4 },
+      }),
+      JSON.stringify({ type: "turn.failed", error: { message: "resume failed" } }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(stdout)).toEqual({
+      sessionId: "thread_123",
+      summary: "Recovered response",
+      usage: {
+        inputTokens: 10,
+        cachedInputTokens: 2,
+        outputTokens: 4,
+      },
+      errorMessage: "resume failed",
+    });
+  });
+});
+
+describe("isCodexUnknownSessionError", () => {
+  it("detects the current missing-rollout thread error", () => {
+    expect(
+      isCodexUnknownSessionError(
+        "",
+        "Error: thread/resume: thread/resume failed: no rollout found for thread id d448e715-7607-4bcc-91fc-7a3c0c5a9632",
+      ),
+    ).toBe(true);
+  });
+
+  it("still detects existing stale-session wordings", () => {
+    expect(isCodexUnknownSessionError("unknown thread id", "")).toBe(true);
+    expect(isCodexUnknownSessionError("", "state db missing rollout path for thread abc")).toBe(true);
+  });
+
+  it("does not classify unrelated Codex failures as stale sessions", () => {
+    expect(isCodexUnknownSessionError("", "model overloaded")).toBe(false);
+  });
+});

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -67,7 +67,7 @@ export function isCodexUnknownSessionError(stdout: string, stderr: string): bool
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
-  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path/i.test(
+  return /unknown (session|thread)|session .* not found|thread .* not found|conversation .* not found|missing rollout path for thread|state db missing rollout path|no rollout found for thread id/i.test(
     haystack,
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Codex adapter (`packages/adapters/codex-local`) bridges Paperclip task execution to the Codex CLI
> - Codex CLI garbage-collects thread rollouts after inactivity, producing a `no rollout found for thread id` error on resume
> - `isCodexUnknownSessionError()` in `parse.ts` controls whether the existing single-retry path in `execute.ts` activates; it did not recognise this new error wording
> - This PR extends the regex in `parse.ts` to match the `no rollout found for thread id` error pattern
> - The benefit is that GC'd-rollout failures now automatically trigger the existing retry mechanism, recovering sessions transparently without any new retry logic

## What Changed

- Extended `isCodexUnknownSessionError()` in `packages/adapters/codex-local/src/server/parse.ts` to match the `no rollout found for thread id` Codex CLI error
- Added `packages/adapters/codex-local/src/server/parse.test.ts` with regression tests covering the new pattern, existing stale-session wordings, `parseCodexJsonl`, and a negative case

## Verification

- `parseCodexJsonl` captures session id, summary, usage, and error message
- `isCodexUnknownSessionError` detects `no rollout found for thread id` (new pattern)
- `isCodexUnknownSessionError` still detects existing stale-session wordings
- `isCodexUnknownSessionError` does not classify unrelated failures as stale sessions
- All focused Codex adapter Vitest tests pass (`parse.test.ts` + `quota-spawn-error.test.ts`)

## Risks

- Low risk — regex-only change in `parse.ts`, no new retry logic; the existing single-retry path in `execute.ts` is already battle-tested. No breaking behaviour.

## Model Used

claude-opus-4-6

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge