### PR TITLE
fix: add browser-native first-admin bootstrap flow

### DIFF
--- a/server/src/__tests__/bootstrap-claim-routes.test.ts
+++ b/server/src/__tests__/bootstrap-claim-routes.test.ts
@@ -1,0 +1,188 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invites, instanceUserRoles } from "@paperclipai/db";
+import {
+  accessRoutes,
+  claimInitialInstanceAdmin,
+} from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+
+function createClaimTxStub(existingUserId: string | null = null) {
+  const execute = vi.fn().mockResolvedValue([]);
+  const returning = vi.fn().mockResolvedValue([
+    {
+      id: "role-1",
+      userId: "user-1",
+      role: "instance_admin",
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    },
+  ]);
+  const values = vi.fn().mockReturnValue({ returning });
+  const insert = vi.fn().mockReturnValue({ values });
+  const select = vi.fn(() => ({
+    from(table: unknown) {
+      return {
+        where: vi.fn().mockResolvedValue(
+          table === instanceUserRoles && existingUserId
+            ? [{ userId: existingUserId }]
+            : [],
+        ),
+      };
+    },
+  }));
+
+  return {
+    execute,
+    select,
+    insert,
+  } as any;
+}
+
+function createApp(
+  actor: Record<string, unknown>,
+  db: Record<string, unknown>,
+  deploymentMode: "local_trusted" | "authenticated" = "authenticated",
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes(db as any, {
+      deploymentMode,
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("claimInitialInstanceAdmin", () => {
+  it("locks instance admin roles before checking and inserting", async () => {
+    const tx = createClaimTxStub();
+
+    const result = await claimInitialInstanceAdmin(tx, "user-1");
+
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(tx.select).toHaveBeenCalledTimes(1);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      status: "claimed",
+      role: {
+        userId: "user-1",
+        role: "instance_admin",
+      },
+    });
+  });
+
+  it("returns already_claimed when another admin exists", async () => {
+    const tx = createClaimTxStub("user-existing");
+
+    const result = await claimInitialInstanceAdmin(tx, "user-1");
+
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "already_claimed",
+      existingUserId: "user-existing",
+    });
+  });
+});
+
+describe("bootstrap claim routes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("claims the first instance admin from the browser", async () => {
+    const tx = createClaimTxStub();
+    const db = {
+      transaction: vi.fn(async (callback) => callback(tx)),
+    };
+    const app = createApp(
+      {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        isInstanceAdmin: false,
+      },
+      db,
+    );
+
+    const res = await request(app).post("/api/bootstrap/claim").send({});
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ claimed: true, userId: "user-1" });
+  });
+
+  it("rejects bootstrap claim once another instance admin exists", async () => {
+    const tx = createClaimTxStub("user-existing");
+    const db = {
+      transaction: vi.fn(async (callback) => callback(tx)),
+    };
+    const app = createApp(
+      {
+        type: "board",
+        userId: "user-2",
+        source: "session",
+        isInstanceAdmin: false,
+      },
+      db,
+    );
+
+    const res = await request(app).post("/api/bootstrap/claim").send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Initial instance admin has already been claimed");
+  });
+
+  it("keeps bootstrap invite acceptance as fallback but rejects it after claim", async () => {
+    const invite = {
+      id: "invite-1",
+      companyId: null,
+      inviteType: "bootstrap_ceo",
+      allowedJoinTypes: "human",
+      defaultsPayload: null,
+      expiresAt: new Date("2099-04-06T00:10:00.000Z"),
+      invitedByUserId: null,
+      tokenHash: "hash",
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2099-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2099-04-06T00:00:00.000Z"),
+    };
+    const tx = createClaimTxStub("user-existing");
+    const db = {
+      select: vi.fn(() => ({
+        from(table: unknown) {
+          return {
+            where: vi.fn().mockResolvedValue(table === invites ? [invite] : []),
+          };
+        },
+      })),
+      transaction: vi.fn(async (callback) => callback(tx)),
+    };
+    const app = createApp(
+      {
+        type: "board",
+        userId: "user-2",
+        source: "session",
+        isInstanceAdmin: false,
+      },
+      db,
+    );
+
+    const res = await request(app)
+      .post("/api/invites/pcp_invite_test/accept")
+      .send({ requestType: "human" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Initial instance admin has already been claimed");
+  });
+});

--- a/server/src/__tests__/bootstrap-claim-routes.test.ts
+++ b/server/src/__tests__/bootstrap-claim-routes.test.ts
@@ -100,6 +100,27 @@ describe("bootstrap claim routes", () => {
     vi.restoreAllMocks();
   });
 
+  it("rejects an unauthenticated bootstrap claim attempt", async () => {
+    const db = {
+      transaction: vi.fn(),
+    };
+    const app = createApp(
+      {
+        type: "board",
+        userId: null,
+        source: "api_key",
+        isInstanceAdmin: false,
+      },
+      db,
+    );
+
+    const res = await request(app).post("/api/bootstrap/claim").send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Sign in before claiming instance admin");
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
   it("claims the first instance admin from the browser", async () => {
     const tx = createClaimTxStub();
     const db = {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -9,12 +9,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Router } from "express";
 import type { Request } from "express";
-import { and, eq, isNull, desc } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agentApiKeys,
   authUsers,
   companies,
+  instanceUserRoles,
   invites,
   joinRequests
 } from "@paperclipai/db";
@@ -77,6 +78,16 @@ function createClaimSecret() {
   return `pcp_claim_${randomBytes(24).toString("hex")}`;
 }
 
+type InitialInstanceAdminClaimResult =
+  | {
+      status: "claimed";
+      role: typeof instanceUserRoles.$inferSelect;
+    }
+  | {
+      status: "already_claimed";
+      existingUserId: string | null;
+    };
+
 export function companyInviteExpiresAt(nowMs: number = Date.now()) {
   return new Date(nowMs + COMPANY_INVITE_TTL_MS);
 }
@@ -88,6 +99,41 @@ function tokenHashesMatch(left: string, right: string) {
     leftBytes.length === rightBytes.length &&
     timingSafeEqual(leftBytes, rightBytes)
   );
+}
+
+export async function claimInitialInstanceAdmin(
+  tx: Db,
+  userId: string
+): Promise<InitialInstanceAdminClaimResult> {
+  await tx.execute(
+    sql`lock table ${instanceUserRoles} in share row exclusive mode`
+  );
+
+  const existingAdmin = await tx
+    .select({ userId: instanceUserRoles.userId })
+    .from(instanceUserRoles)
+    .where(eq(instanceUserRoles.role, "instance_admin"))
+    .then((rows) => rows[0] ?? null);
+  if (existingAdmin) {
+    return {
+      status: "already_claimed",
+      existingUserId: existingAdmin.userId
+    };
+  }
+
+  const role = await tx
+    .insert(instanceUserRoles)
+    .values({
+      userId,
+      role: "instance_admin"
+    })
+    .returning()
+    .then((rows) => rows[0]);
+
+  return {
+    status: "claimed",
+    role
+  };
 }
 
 function requestBaseUrl(req: Request) {
@@ -1635,6 +1681,31 @@ export function accessRoutes(
     throw conflict("Board claim challenge is no longer available");
   });
 
+  router.post("/bootstrap/claim", async (req, res) => {
+    if (opts.deploymentMode !== "authenticated") {
+      throw notFound("Bootstrap claim is only available in authenticated mode");
+    }
+    if (
+      req.actor.type !== "board" ||
+      req.actor.source !== "session" ||
+      !req.actor.userId
+    ) {
+      throw unauthorized("Sign in before claiming instance admin");
+    }
+
+    const result = await db.transaction((tx) =>
+      claimInitialInstanceAdmin(tx as unknown as Db, req.actor.userId as string)
+    );
+    if (result.status === "already_claimed") {
+      throw conflict("Initial instance admin has already been claimed");
+    }
+
+    res.status(201).json({
+      claimed: true,
+      userId: req.actor.userId
+    });
+  });
+
   router.post(
     "/cli-auth/challenges",
     validate(createCliAuthChallengeSchema),
@@ -2180,19 +2251,35 @@ export function accessRoutes(
           );
         }
         const userId = req.actor.userId ?? "local-board";
-        const existingAdmin = await access.isInstanceAdmin(userId);
-        if (!existingAdmin) {
-          await access.promoteInstanceAdmin(userId);
+        const bootstrapClaim = await db.transaction(async (tx) => {
+          const claimed = await claimInitialInstanceAdmin(tx as unknown as Db, userId);
+          if (claimed.status === "already_claimed") return claimed;
+          const updatedInvite = await tx
+            .update(invites)
+            .set({ acceptedAt: new Date(), updatedAt: new Date() })
+            .where(
+              and(
+                eq(invites.id, invite.id),
+                isNull(invites.acceptedAt),
+                isNull(invites.revokedAt)
+              )
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (!updatedInvite) {
+            throw conflict("Bootstrap invite has already been used");
+          }
+          return {
+            status: "claimed" as const,
+            updatedInvite
+          };
+        });
+        if (bootstrapClaim.status === "already_claimed") {
+          throw conflict("Initial instance admin has already been claimed");
         }
-        const updatedInvite = await db
-          .update(invites)
-          .set({ acceptedAt: new Date(), updatedAt: new Date() })
-          .where(eq(invites.id, invite.id))
-          .returning()
-          .then((rows) => rows[0] ?? invite);
         res.status(202).json({
-          inviteId: updatedInvite.id,
-          inviteType: updatedInvite.inviteType,
+          inviteId: bootstrapClaim.updatedInvite.id,
+          inviteType: bootstrapClaim.updatedInvite.inviteType,
           bootstrapAccepted: true,
           userId
         });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BootstrapPendingPage } from "./components/BootstrapPendingPage";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: ComponentProps<"a"> & { to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+  Navigate: () => null,
+  Outlet: () => null,
+  Route: () => null,
+  Routes: ({ children }: { children?: unknown }) => <>{children}</>,
+  useLocation: () => ({ pathname: "/", search: "", hash: "" }),
+  useParams: () => ({}),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    asChild,
+    children,
+    ...props
+  }: ComponentProps<"button"> & { asChild?: boolean }) => {
+    if (asChild) return children;
+    return <button {...props}>{children}</button>;
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("BootstrapPendingPage", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("renders a claim action for signed-in users", () => {
+    const root = createRoot(container);
+    const onClaim = vi.fn();
+
+    act(() => {
+      root.render(
+        <BootstrapPendingPage
+          session={{
+            session: { id: "session-1", userId: "user-1" },
+            user: { id: "user-1", email: "founder@example.com", name: "Founder" },
+          }}
+          onClaim={onClaim}
+        />,
+      );
+    });
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("Claim instance admin");
+    expect(container.textContent).toContain("Signed in as Founder");
+
+    act(() => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClaim).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("renders a sign-in link and bootstrap invite fallback for signed-out users", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <BootstrapPendingPage
+          hasActiveInvite
+          signInPath="/auth?next=%2F"
+        />,
+      );
+    });
+
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("/auth?next=%2F");
+    expect(link?.textContent).toBe("Sign in / Create account");
+    expect(container.textContent).toContain("A bootstrap invite is already active.");
+    expect(container.textContent).toContain("pnpm paperclipai onboard");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,9 +1,11 @@
 import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Layout } from "./components/Layout";
 import { OnboardingWizard } from "./components/OnboardingWizard";
+import { BootstrapPendingPage } from "./components/BootstrapPendingPage";
 import { authApi } from "./api/auth";
+import { accessApi } from "./api/access";
 import { healthApi } from "./api/health";
 import { Dashboard } from "./pages/Dashboard";
 import { Companies } from "./pages/Companies";
@@ -50,26 +52,9 @@ import { useDialog } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
 import { shouldRedirectCompanylessRouteToOnboarding } from "./lib/onboarding-route";
 
-function BootstrapPendingPage({ hasActiveInvite = false }: { hasActiveInvite?: boolean }) {
-  return (
-    <div className="mx-auto max-w-xl py-10">
-      <div className="rounded-lg border border-border bg-card p-6">
-        <h1 className="text-xl font-semibold">Instance setup required</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {hasActiveInvite
-            ? "No instance admin exists yet. A bootstrap invite is already active. Check your Paperclip startup logs for the first admin invite URL, or run this command to rotate it:"
-            : "No instance admin exists yet. Run this command in your Paperclip environment to generate the first admin invite URL:"}
-        </p>
-        <pre className="mt-4 overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
-{`pnpm paperclipai auth bootstrap-ceo`}
-        </pre>
-      </div>
-    </div>
-  );
-}
-
 function CloudAccessGate() {
   const location = useLocation();
+  const queryClient = useQueryClient();
   const healthQuery = useQuery({
     queryKey: queryKeys.health,
     queryFn: () => healthApi.get(),
@@ -92,6 +77,14 @@ function CloudAccessGate() {
     enabled: isAuthenticatedMode,
     retry: false,
   });
+  const claimMutation = useMutation({
+    mutationFn: () => accessApi.claimBootstrapAdmin(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.health });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    },
+  });
 
   if (healthQuery.isLoading || (isAuthenticatedMode && sessionQuery.isLoading)) {
     return <div className="mx-auto max-w-xl py-10 text-sm text-muted-foreground">Loading...</div>;
@@ -106,7 +99,21 @@ function CloudAccessGate() {
   }
 
   if (isAuthenticatedMode && healthQuery.data?.bootstrapStatus === "bootstrap_pending") {
-    return <BootstrapPendingPage hasActiveInvite={healthQuery.data.bootstrapInviteActive} />;
+    const next = encodeURIComponent(`${location.pathname}${location.search}`);
+    return (
+      <BootstrapPendingPage
+        hasActiveInvite={healthQuery.data.bootstrapInviteActive}
+        session={sessionQuery.data}
+        onClaim={() => claimMutation.mutate()}
+        isClaiming={claimMutation.isPending}
+        claimError={
+          claimMutation.error instanceof Error
+            ? claimMutation.error.message
+            : null
+        }
+        signInPath={`/auth?next=${next}`}
+      />
+    );
   }
 
   if (isAuthenticatedMode && !sessionQuery.data) {

--- a/ui/src/api/access.ts
+++ b/ui/src/api/access.ts
@@ -95,6 +95,9 @@ type CompanyInviteCreated = {
 };
 
 export const accessApi = {
+  claimBootstrapAdmin: () =>
+    api.post<{ claimed: true; userId: string }>("/bootstrap/claim", {}),
+
   createCompanyInvite: (
     companyId: string,
     input: {

--- a/ui/src/components/BootstrapPendingPage.tsx
+++ b/ui/src/components/BootstrapPendingPage.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import type { AuthSession } from "../api/auth";
+
+export function BootstrapPendingPage({
+  hasActiveInvite = false,
+  session = null,
+  onClaim,
+  isClaiming = false,
+  claimError = null,
+  signInPath = "/auth",
+}: {
+  hasActiveInvite?: boolean;
+  session?: AuthSession | null;
+  onClaim?: () => void;
+  isClaiming?: boolean;
+  claimError?: string | null;
+  signInPath?: string;
+}) {
+  return (
+    <div className="mx-auto max-w-xl py-10">
+      <div className="rounded-lg border border-border bg-card p-6">
+        <h1 className="text-xl font-semibold">Instance setup required</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          No instance admin exists yet.
+          {session
+            ? " Claim this instance from the browser, or use the bootstrap invite flow if you want to complete setup from another device."
+            : " Sign in to claim it from the browser, or use the bootstrap invite flow if you want to complete setup from another device."}
+        </p>
+        {session ? (
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <Button onClick={onClaim} disabled={isClaiming}>
+              {isClaiming ? "Claiming…" : "Claim instance admin"}
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Signed in as {session.user.name?.trim() || session.user.email || session.user.id}
+            </span>
+          </div>
+        ) : (
+          <div className="mt-4">
+            <Button asChild>
+              <Link to={signInPath}>Sign in / Create account</Link>
+            </Button>
+          </div>
+        )}
+        {claimError ? <p className="mt-3 text-sm text-destructive">{claimError}</p> : null}
+        <p className="mt-4 text-sm text-muted-foreground">
+          {hasActiveInvite
+            ? "A bootstrap invite is already active. Check your Paperclip startup logs for the first admin invite URL, or run this command to rotate it:"
+            : "Run this command in your Paperclip environment to generate the first admin invite URL:"}
+        </p>
+        <pre className="mt-4 overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs">
+{`pnpm paperclipai onboard`}
+        </pre>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - In authenticated deployments, the first human user has to bootstrap the board/admin layer before the company can be used normally
> - The current fresh-install flow blocks on a CLI-generated bootstrap invite, which assumes the operator has shell or log access to the host
> - That is a poor fit for appliance-style/browser-first installs like Umbrel, where users expect to finish setup entirely from the UI
> - This pull request adds a browser-native path for the signed-in first user to claim the initial `instance_admin` role while bootstrap is still pending
> - It also keeps the invite flow working as a fallback and routes both paths through the same locking helper so only one first admin can ever win
> - The benefit is a much smoother first-run experience without breaking existing operator-driven bootstrap workflows

## What Changed

- Added `POST /api/bootstrap/claim` so a signed-in browser user can claim the initial `instance_admin` role during bootstrap
- Added a shared `claimInitialInstanceAdmin()` helper that locks `instance_user_roles` before checking/inserting, and reused it from bootstrap invite acceptance so the browser and invite paths cannot race each other
- Replaced the CLI-only bootstrap blocker UI with a `BootstrapPendingPage` that shows `Sign in / Create account` when signed out and `Claim instance admin` when signed in, while keeping the CLI fallback visible
- Added/updated tests for the happy path, already-claimed path, invite fallback path, signed-out browser path, and the main app bootstrap UI states

## Verification

- `pnpm vitest --run server/src/__tests__/bootstrap-claim-routes.test.ts ui/src/App.test.tsx`
- `pnpm -r typecheck`
- Manual browser verification in `authenticated/private` mode:
  1. Fresh instance shows the new bootstrap page instead of only CLI instructions
  2. Signed-out user can go to `Sign in / Create account`
  3. After signing in, the page shows `Claim instance admin`
  4. Clicking it enters the normal onboarding flow without requiring a bootstrap invite URL

### Before
![Before: CLI-only bootstrap screen](https://github.com/aidencole98/paperclip/blob/fake/assets/assets/pr-bootstrap-flow/00-before-cli-only-bootstrap.png?raw=1)

### After
![After: signed-out bootstrap page](https://github.com/aidencole98/paperclip/blob/fake/assets/assets/pr-bootstrap-flow/01-signed-out-bootstrap.png?raw=1)

![After: signed-in claim page](https://github.com/aidencole98/paperclip/blob/fake/assets/assets/pr-bootstrap-flow/02-signed-in-claim.png?raw=1)

![After: onboarding after claim](https://github.com/aidencole98/paperclip/blob/fake/assets/assets/pr-bootstrap-flow/03-onboarding-after-claim.png?raw=1)

## Risks

- Low risk: the new route only applies while bootstrap is pending and still requires a real signed-in board session
- The main behavioral change is that fresh authenticated installs no longer require a CLI-generated invite for the first admin; existing bootstrap-invite workflows remain available as a fallback
- The concurrency-sensitive part is first-admin creation, which is why both claim paths now share the same table-locking helper

## Model Used

- OpenAI Codex CLI agent for implementation/review passes (provider/model family: `gpt-5.4`; used with full repo access and code editing)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
