### PR TITLE
Fix stale issue execution ownership handoffs

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -515,7 +515,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
-    expect(issue?.checkoutRunId).toBe(runId);
+    expect(issue?.checkoutRunId).toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -6,6 +6,8 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   assertCheckoutOwner: vi.fn(),
   update: vi.fn(),
+  checkout: vi.fn(),
+  release: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
@@ -172,6 +174,8 @@ describe("issue comment reopen routes", () => {
     mockIssueService.getById.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
     mockIssueService.update.mockReset();
+    mockIssueService.checkout.mockReset();
+    mockIssueService.release.mockReset();
     mockIssueService.addComment.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
     mockIssueService.listWakeableBlockedDependents.mockReset();
@@ -375,6 +379,10 @@ describe("issue comment reopen routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      {
+        actorAgentId: null,
+        actorRunId: null,
+      },
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
@@ -526,6 +534,10 @@ describe("issue comment reopen routes", () => {
           lastDecisionOutcome: "approved",
         }),
       }),
+      {
+        actorAgentId: null,
+        actorRunId: null,
+      },
       mockTx,
     );
     const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, any>;
@@ -599,6 +611,10 @@ describe("issue comment reopen routes", () => {
           }),
         }),
       }),
+      {
+        actorAgentId: "22222222-2222-4222-8222-222222222222",
+        actorRunId: "run-1",
+      },
     );
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "33333333-3333-4333-8333-333333333333",
@@ -678,6 +694,122 @@ describe("issue comment reopen routes", () => {
             allowedActions: ["address_changes", "resubmit"],
           }),
         }),
+      }),
+    );
+  });
+
+  it("keeps authenticated board run headers audit-only on comment reopen", async () => {
+    const closedIssue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(closedIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...closedIssue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "board",
+        userId: "board-user",
+        companyIds: ["company-1"],
+        source: "session",
+        isInstanceAdmin: true,
+        runId: "untrusted-board-run",
+      }),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Reopening", reopen: true });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "todo",
+        actorUserId: "board-user",
+      }),
+      {
+        actorAgentId: null,
+        actorRunId: null,
+      },
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "Reopening",
+      expect.objectContaining({ runId: null }),
+    );
+    expect(mockHeartbeatService.reportRunActivity).not.toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.updated",
+        runId: null,
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.comment_added",
+        runId: null,
+      }),
+    );
+  });
+
+  it("keeps authenticated board run headers audit-only on checkout and release activity", async () => {
+    const issue = makeIssue("todo");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.checkout.mockResolvedValue({
+      ...issue,
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+    });
+    mockIssueService.release.mockResolvedValue({
+      ...issue,
+      status: "todo",
+      assigneeAgentId: null,
+    });
+
+    const actor = {
+      type: "board",
+      userId: "board-user",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: true,
+      runId: "untrusted-board-run",
+    };
+    const app = await installActor(createApp(), actor);
+
+    const checkoutRes = await request(app)
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/checkout")
+      .send({
+        agentId: "22222222-2222-4222-8222-222222222222",
+        expectedStatuses: ["todo"],
+      });
+
+    expect(checkoutRes.status).toBe(200);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.checked_out",
+        runId: null,
+      }),
+    );
+
+    const releaseRes = await request(app).post("/api/issues/11111111-1111-4111-8111-111111111111/release").send({});
+
+    expect(releaseRes.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        actorAgentId: null,
+        actorRunId: null,
+        actorUserId: "board-user",
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.released",
+        runId: null,
       }),
     );
   });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -203,7 +203,25 @@ describe("issue comment reopen routes", () => {
     mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx));
     mockHeartbeatService.wakeup.mockResolvedValue(undefined);
     mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
-    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.getRun.mockImplementation(async (runId: string) => {
+      if (runId === "run-1") {
+        return {
+          id: "run-1",
+          companyId: "company-1",
+          agentId: "22222222-2222-4222-8222-222222222222",
+          status: "running",
+        };
+      }
+      if (runId === "run-2") {
+        return {
+          id: "run-2",
+          companyId: "company-1",
+          agentId: "33333333-3333-4333-8333-333333333333",
+          status: "running",
+        };
+      }
+      return null;
+    });
     mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
     mockHeartbeatService.cancelRun.mockResolvedValue(null);
     mockLogActivity.mockResolvedValue(undefined);

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -25,6 +25,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getRun: vi.fn(async () => null),
   getActiveRunForAgent: vi.fn(async () => null),
   cancelRun: vi.fn(async () => null),
+  promoteDeferredIssueWakeupForIssue: vi.fn(async () => null),
 }));
 
 const mockAgentService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -308,6 +308,10 @@ describe("issue comment reopen routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      expect.objectContaining({
+        actorAgentId: null,
+        actorRunId: null,
+      }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
@@ -342,7 +346,13 @@ describe("issue comment reopen routes", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
+        actorAgentId: null,
+        actorUserId: "local-board",
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      }),
+      expect.objectContaining({
+        actorAgentId: null,
+        actorRunId: null,
       }),
     );
   });
@@ -430,7 +440,15 @@ describe("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({
+        actorAgentId: null,
+        actorUserId: "local-board",
+        status: "todo",
+      }),
+      expect.objectContaining({
+        actorAgentId: null,
+        actorRunId: null,
+      }),
     );
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -630,10 +630,11 @@ describe("issue comment reopen routes", () => {
           }),
         }),
       }),
-      {
+      expect.objectContaining({
         actorAgentId: "22222222-2222-4222-8222-222222222222",
         actorRunId: "run-1",
-      },
+        requireCheckoutOwnership: true,
+      }),
     );
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "33333333-3333-4333-8333-333333333333",

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -138,6 +138,10 @@ describe("issue execution policy routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      {
+        actorAgentId: null,
+        actorRunId: null,
+      },
     );
     const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(updatePatch.status).toBeUndefined();

--- a/server/src/__tests__/issue-release-routes.test.ts
+++ b/server/src/__tests__/issue-release-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockPromoteDeferredIssueWakeupForIssue = vi.hoisted(() => vi.fn(async () => null));
 
 vi.mock("../services/index.js", () => ({
   accessService: () => ({
@@ -37,7 +38,7 @@ vi.mock("../services/index.js", () => ({
         }
         : null),
     reportRunActivity: vi.fn(async () => undefined),
-    promoteDeferredIssueWakeupForIssue: vi.fn(async () => null),
+    promoteDeferredIssueWakeupForIssue: mockPromoteDeferredIssueWakeupForIssue,
   }),
   instanceSettingsService: () => ({}),
   issueApprovalService: () => ({}),
@@ -66,6 +67,7 @@ describe("issue release routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockPromoteDeferredIssueWakeupForIssue.mockResolvedValue(null);
   });
 
   it("preserves board identity across reroute then release", async () => {
@@ -142,6 +144,10 @@ describe("issue release routes", () => {
       actorRunId: null,
       actorUserId: "local-board",
     });
+    expect(mockPromoteDeferredIssueWakeupForIssue).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "company-1",
+    );
   });
 
   it("passes board user identity into release", async () => {
@@ -176,6 +182,10 @@ describe("issue release routes", () => {
       actorRunId: null,
       actorUserId: "local-board",
     });
+    expect(mockPromoteDeferredIssueWakeupForIssue).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "company-1",
+    );
   });
 
   it("passes agent run identity into release", async () => {
@@ -214,6 +224,10 @@ describe("issue release routes", () => {
       actorRunId: "run-1",
       actorUserId: null,
     });
+    expect(mockPromoteDeferredIssueWakeupForIssue).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "company-1",
+    );
   });
 
   it("does not log issue.released when release conflicts", async () => {
@@ -238,5 +252,6 @@ describe("issue release routes", () => {
     expect(res.status).toBe(409);
     expect(res.body).toEqual({ error: "Issue still owned by active run" });
     expect(mockLogActivity).not.toHaveBeenCalled();
+    expect(mockPromoteDeferredIssueWakeupForIssue).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issue-release-routes.test.ts
+++ b/server/src/__tests__/issue-release-routes.test.ts
@@ -27,6 +27,15 @@ vi.mock("../services/index.js", () => ({
   feedbackService: () => ({}),
   goalService: () => ({}),
   heartbeatService: () => ({
+    getRun: vi.fn(async (runId: string) =>
+      runId === "run-1"
+        ? {
+          id: "run-1",
+          companyId: "company-1",
+          agentId: "agent-1",
+          status: "running",
+        }
+        : null),
     reportRunActivity: vi.fn(async () => undefined),
   }),
   instanceSettingsService: () => ({}),

--- a/server/src/__tests__/issue-release-routes.test.ts
+++ b/server/src/__tests__/issue-release-routes.test.ts
@@ -37,6 +37,7 @@ vi.mock("../services/index.js", () => ({
         }
         : null),
     reportRunActivity: vi.fn(async () => undefined),
+    promoteDeferredIssueWakeupForIssue: vi.fn(async () => null),
   }),
   instanceSettingsService: () => ({}),
   issueApprovalService: () => ({}),

--- a/server/src/__tests__/issue-release-routes.test.ts
+++ b/server/src/__tests__/issue-release-routes.test.ts
@@ -1,0 +1,232 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { conflict } from "../errors.js";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  update: vi.fn(),
+  release: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  instanceSettingsService: () => ({}),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+}));
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue release routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+  });
+
+  it("preserves board identity across reroute then release", async () => {
+    mockIssueService.getById
+      .mockResolvedValueOnce({
+        id: "11111111-1111-4111-8111-111111111111",
+        companyId: "company-1",
+        status: "in_progress",
+        assigneeAgentId: "agent-1",
+        assigneeUserId: null,
+        createdByUserId: "local-board",
+      })
+      .mockResolvedValueOnce({
+        id: "11111111-1111-4111-8111-111111111111",
+        companyId: "company-1",
+        status: "in_progress",
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        createdByUserId: "local-board",
+      });
+    mockIssueService.update.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      checkoutRunId: "run-1",
+      executionRunId: "run-1",
+    });
+    mockIssueService.release.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      checkoutRunId: "run-1",
+      executionRunId: "run-1",
+    });
+
+    const app = createApp({
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    });
+
+    const patchRes = await request(app)
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ assigneeAgentId: null, assigneeUserId: "local-board" });
+
+    expect(patchRes.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        actorAgentId: null,
+        actorUserId: "local-board",
+      }),
+      {
+        actorAgentId: null,
+        actorRunId: null,
+      },
+    );
+
+    const releaseRes = await request(app)
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/release")
+      .send({});
+
+    expect(releaseRes.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
+      actorAgentId: null,
+      actorRunId: null,
+      actorUserId: "local-board",
+    });
+  });
+
+  it("passes board user identity into release", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+    });
+    mockIssueService.release.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createApp({
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/release")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.release).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
+      actorAgentId: null,
+      actorRunId: null,
+      actorUserId: "local-board",
+    });
+  });
+
+  it("passes agent run identity into release", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+    });
+    mockIssueService.release.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/release")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "agent-1",
+      "run-1",
+    );
+    expect(mockIssueService.release).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111", {
+      actorAgentId: "agent-1",
+      actorRunId: "run-1",
+      actorUserId: null,
+    });
+  });
+
+  it("does not log issue.released when release conflicts", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+    });
+    mockIssueService.release.mockRejectedValue(conflict("Issue still owned by active run"));
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/release")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: "Issue still owned by active run" });
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -1,0 +1,871 @@
+import { createHash, randomUUID } from "node:crypto";
+import express from "express";
+import { eq, sql } from "drizzle-orm";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentApiKeys,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  instanceUserRoles,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { actorMiddleware } from "../middleware/auth.js";
+import { boardMutationGuard } from "../middleware/board-mutation-guard.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+
+const mockHeartbeatWakeup = vi.hoisted(() => vi.fn(async () => null));
+const mockReportRunActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/index.js")>("../services/index.js");
+  return {
+    ...actual,
+    heartbeatService: (db: any) => ({
+      ...actual.heartbeatService(db),
+      reportRunActivity: mockReportRunActivity,
+      wakeup: mockHeartbeatWakeup,
+    }),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue update route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue update handoff routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-update-handoff-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`set local client_min_messages = warning`);
+      await tx.execute(sql`
+        TRUNCATE TABLE
+          activity_log,
+          issue_comments,
+          issue_inbox_archives,
+          issues,
+          heartbeat_run_events,
+          heartbeat_runs,
+          agent_wakeup_requests,
+          agent_runtime_state,
+          execution_workspaces,
+          project_workspaces,
+          projects,
+          agents,
+          instance_user_roles,
+          companies,
+          instance_settings
+        RESTART IDENTITY CASCADE
+      `);
+    });
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createRouteApp(opts?: {
+    deploymentMode?: "local_trusted" | "authenticated";
+    resolveSession?: Parameters<typeof actorMiddleware>[1]["resolveSession"];
+  }) {
+    const app = express();
+    app.use(express.json());
+    app.use(actorMiddleware(db, {
+      deploymentMode: opts?.deploymentMode ?? "local_trusted",
+      resolveSession: opts?.resolveSession,
+    }));
+    app.use(boardMutationGuard());
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedHandoffFixture(input?: { executionAgentId?: string }) {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const builderAgentId = input?.executionAgentId ?? randomUUID();
+    const issueId = randomUUID();
+    const qaRunId = randomUUID();
+    const builderRunId = randomUUID();
+    const executionAgentId = input?.executionAgentId ?? qaAgentId;
+    const executionRunId = executionAgentId === qaAgentId ? qaRunId : builderRunId;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: qaRunId,
+        companyId,
+        agentId: qaAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T14:30:00.000Z"),
+      },
+      {
+        id: builderRunId,
+        companyId,
+        agentId: builderAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T14:31:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "QA handoff to Staff review",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: qaAgentId,
+      checkoutRunId: executionRunId,
+      executionRunId,
+      executionAgentNameKey: executionAgentId === qaAgentId ? "qa-engineer" : "builder",
+      executionLockedAt: new Date("2026-04-11T14:30:00.000Z"),
+      startedAt: new Date("2026-04-11T14:30:00.000Z"),
+    });
+
+    return {
+      companyId,
+      issueId,
+      qaAgentId,
+      staffAgentId,
+      builderAgentId,
+      qaRunId,
+      builderRunId,
+      executionRunId,
+    };
+  }
+
+  async function seedForeignExecutionFixture(input?: {
+    status?: "todo" | "in_progress" | "in_review";
+    checkoutRunId?: string | null | "foreign";
+  }) {
+    const companyId = randomUUID();
+    const assignedAgentId = randomUUID();
+    const foreignAgentId = randomUUID();
+    const issueId = randomUUID();
+    const staleRunId = randomUUID();
+    const foreignRunId = randomUUID();
+    const agentToken = `agent-token-${assignedAgentId}`;
+    const lockedAt = new Date("2026-04-11T15:40:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: assignedAgentId,
+        companyId,
+        name: "Assigned Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: foreignAgentId,
+        companyId,
+        name: "Foreign Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(agentApiKeys).values({
+      agentId: assignedAgentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId: assignedAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T15:30:00.000Z"),
+        finishedAt: new Date("2026-04-11T15:35:00.000Z"),
+      },
+      {
+        id: foreignRunId,
+        companyId,
+        agentId: foreignAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: lockedAt,
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Forged run id must not clear foreign execution",
+      status: input?.status ?? "in_progress",
+      priority: "high",
+      assigneeAgentId: assignedAgentId,
+      checkoutRunId:
+        input?.checkoutRunId === undefined
+          ? staleRunId
+          : input.checkoutRunId === "foreign"
+            ? foreignRunId
+            : input.checkoutRunId,
+      executionRunId: foreignRunId,
+      executionAgentNameKey: "foreign-builder",
+      executionLockedAt: lockedAt,
+      startedAt: new Date("2026-04-11T15:30:00.000Z"),
+    });
+
+    return {
+      issueId,
+      assignedAgentId,
+      staleRunId,
+      foreignRunId,
+      agentToken,
+      lockedAt,
+    };
+  }
+
+  async function seedSameAgentSplitLockFixture() {
+    const companyId = randomUUID();
+    const assignedAgentId = randomUUID();
+    const issueId = randomUUID();
+    const oldRunId = randomUUID();
+    const retryRunId = randomUUID();
+    const lockedAt = new Date("2026-04-11T16:10:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: assignedAgentId,
+      companyId,
+      name: "Assigned Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: oldRunId,
+        companyId,
+        agentId: assignedAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T16:00:00.000Z"),
+      },
+      {
+        id: retryRunId,
+        companyId,
+        agentId: assignedAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: lockedAt,
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Same-agent split lock must preserve retry execution",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: assignedAgentId,
+      checkoutRunId: oldRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "assigned-builder",
+      executionLockedAt: lockedAt,
+      startedAt: new Date("2026-04-11T16:00:00.000Z"),
+    });
+
+    return {
+      companyId,
+      issueId,
+      assignedAgentId,
+      oldRunId,
+      retryRunId,
+      lockedAt,
+    };
+  }
+
+  async function seedBoardActivityFixture(userId: string) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const checkoutIssueId = randomUUID();
+    const releaseIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(instanceUserRoles).values({
+      userId,
+      role: "instance_admin",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values([
+      {
+        id: checkoutIssueId,
+        companyId,
+        title: "Board checkout activity",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: releaseIssueId,
+        companyId,
+        title: "Board release activity",
+        status: "todo",
+        priority: "high",
+        assigneeUserId: userId,
+      },
+    ]);
+
+    return {
+      agentId,
+      checkoutIssueId,
+      releaseIssueId,
+    };
+  }
+
+  function hashToken(token: string) {
+    return createHash("sha256").update(token).digest("hex");
+  }
+
+  function setLocalAgentJwtSecret(secret: string) {
+    const previous = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = secret;
+    return () => {
+      if (previous === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+      else process.env.PAPERCLIP_AGENT_JWT_SECRET = previous;
+    };
+  }
+
+  async function getPersistedIssue(issueId: string) {
+    return db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  it("clears execution ownership for a local-board PATCH carrying the owning run id", async () => {
+    const { issueId, staffAgentId, qaRunId } = await seedHandoffFixture();
+
+    const res = await request(createRouteApp())
+      .patch(`/api/issues/${issueId}`)
+      .set("X-Paperclip-Run-Id", qaRunId)
+      .send({
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    }));
+  });
+
+  it("preserves execution ownership when the local-board run header belongs to a different live agent", async () => {
+    const builderAgentId = randomUUID();
+    const { issueId, staffAgentId, builderRunId } = await seedHandoffFixture({
+      executionAgentId: builderAgentId,
+    });
+
+    const res = await request(createRouteApp())
+      .patch(`/api/issues/${issueId}`)
+      .set("X-Paperclip-Run-Id", builderRunId)
+      .send({
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: builderRunId,
+      executionRunId: builderRunId,
+      executionAgentNameKey: "builder",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: builderRunId,
+      executionRunId: builderRunId,
+      executionAgentNameKey: "builder",
+    }));
+  });
+
+  it("treats authenticated board run headers as audit context only", async () => {
+    const { issueId, staffAgentId, qaRunId } = await seedHandoffFixture();
+    const userId = "board-user";
+    await db.insert(instanceUserRoles).values({
+      userId,
+      role: "instance_admin",
+    });
+
+    const res = await request(createRouteApp({
+      deploymentMode: "authenticated",
+      resolveSession: async () => ({
+        session: { id: "session-1", userId },
+        user: { id: userId },
+      }),
+    }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Origin", "http://localhost:3100")
+      .set("X-Paperclip-Run-Id", qaRunId)
+      .send({
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: qaRunId,
+      executionAgentNameKey: "qa-engineer",
+    }));
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: qaRunId,
+      executionAgentNameKey: "qa-engineer",
+    }));
+
+    const commentRes = await request(createRouteApp({
+      deploymentMode: "authenticated",
+      resolveSession: async () => ({
+        session: { id: "session-1", userId },
+        user: { id: userId },
+      }),
+    }))
+      .post(`/api/issues/${issueId}/comments`)
+      .set("Origin", "http://localhost:3100")
+      .set("X-Paperclip-Run-Id", qaRunId)
+      .send({ body: "Audit-only board comment" });
+
+    expect(commentRes.status).toBe(201);
+    expect(commentRes.body).toEqual(expect.objectContaining({
+      body: "Audit-only board comment",
+      createdByRunId: null,
+    }));
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    const updateActivity = activityRows.find((row) => row.action === "issue.updated");
+    const commentActivity = activityRows.find((row) => row.action === "issue.comment_added");
+    expect(updateActivity?.runId).toBeNull();
+    expect(commentActivity?.runId).toBeNull();
+  });
+
+  it("keeps authenticated board run headers audit-only when reopening from a comment", async () => {
+    const { issueId, qaRunId } = await seedHandoffFixture();
+    const userId = "board-user";
+    await db.insert(instanceUserRoles).values({
+      userId,
+      role: "instance_admin",
+    });
+    await db
+      .update(issues)
+      .set({ status: "done" })
+      .where(eq(issues.id, issueId));
+
+    const res = await request(createRouteApp({
+      deploymentMode: "authenticated",
+      resolveSession: async () => ({
+        session: { id: "session-1", userId },
+        user: { id: userId },
+      }),
+    }))
+      .post(`/api/issues/${issueId}/comments`)
+      .set("Origin", "http://localhost:3100")
+      .set("X-Paperclip-Run-Id", qaRunId)
+      .send({ body: "Reopen without trusting board run header", reopen: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(expect.objectContaining({
+      body: "Reopen without trusting board run header",
+      createdByRunId: null,
+    }));
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    const reopenedUpdate = activityRows.find((row) =>
+      row.action === "issue.updated" && (row.details as { reopened?: boolean } | null)?.reopened === true);
+    const commentActivity = activityRows.find((row) => row.action === "issue.comment_added");
+    expect(reopenedUpdate?.runId).toBeNull();
+    expect(commentActivity?.runId).toBeNull();
+  });
+
+  it("keeps authenticated board run headers audit-only for checkout and release activity", async () => {
+    const userId = "board-user";
+    const { agentId, checkoutIssueId, releaseIssueId } = await seedBoardActivityFixture(userId);
+    const untrustedRunId = randomUUID();
+    const app = createRouteApp({
+      deploymentMode: "authenticated",
+      resolveSession: async () => ({
+        session: { id: "session-1", userId },
+        user: { id: userId },
+      }),
+    });
+
+    const checkoutRes = await request(app)
+      .post(`/api/issues/${checkoutIssueId}/checkout`)
+      .set("Origin", "http://localhost:3100")
+      .set("X-Paperclip-Run-Id", untrustedRunId)
+      .send({
+        agentId,
+        expectedStatuses: ["todo"],
+      });
+
+    expect(checkoutRes.status).toBe(200);
+
+    const releaseRes = await request(app)
+      .post(`/api/issues/${releaseIssueId}/release`)
+      .set("Origin", "http://localhost:3100")
+      .set("X-Paperclip-Run-Id", untrustedRunId)
+      .send({});
+
+    expect(releaseRes.status).toBe(200);
+
+    const activityRows = await db.select().from(activityLog);
+    const checkoutActivity = activityRows.find((row) =>
+      row.entityId === checkoutIssueId && row.action === "issue.checked_out");
+    const releaseActivity = activityRows.find((row) =>
+      row.entityId === releaseIssueId && row.action === "issue.released");
+    expect(checkoutActivity?.runId).toBeNull();
+    expect(releaseActivity?.runId).toBeNull();
+  });
+
+  it("rejects an agent PATCH when the run header belongs to a foreign live execution owner", async () => {
+    const builderAgentId = randomUUID();
+    const { companyId, issueId, qaAgentId, builderRunId } = await seedHandoffFixture({
+      executionAgentId: builderAgentId,
+    });
+    const agentToken = "qa-agent-token";
+    const lockedAt = new Date("2026-04-11T14:30:00.000Z");
+
+    await db.insert(agentApiKeys).values({
+      agentId: qaAgentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", builderRunId)
+      .send({
+        status: "done",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue run ownership conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_progress",
+      assigneeAgentId: qaAgentId,
+      checkoutRunId: builderRunId,
+      executionRunId: builderRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: lockedAt,
+    }));
+  });
+
+  it("rejects agent checkout adoption when the run header belongs to a foreign live execution owner", async () => {
+    const { issueId, assignedAgentId, staleRunId, foreignRunId, agentToken, lockedAt } =
+      await seedForeignExecutionFixture();
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .post(`/api/issues/${issueId}/checkout`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", foreignRunId)
+      .send({
+        agentId: assignedAgentId,
+        expectedStatuses: ["in_progress"],
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue checkout conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_progress",
+      assigneeAgentId: assignedAgentId,
+      checkoutRunId: staleRunId,
+      executionRunId: foreignRunId,
+      executionAgentNameKey: "foreign-builder",
+      executionLockedAt: lockedAt,
+    }));
+  });
+
+  it("rejects direct agent checkout when checkout is unlocked but execution belongs to a foreign live run", async () => {
+    const { issueId, assignedAgentId, foreignRunId, agentToken, lockedAt } =
+      await seedForeignExecutionFixture({
+        status: "todo",
+        checkoutRunId: null,
+      });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .post(`/api/issues/${issueId}/checkout`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", foreignRunId)
+      .send({
+        agentId: assignedAgentId,
+        expectedStatuses: ["todo"],
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue checkout conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "todo",
+      assigneeAgentId: assignedAgentId,
+      checkoutRunId: null,
+      executionRunId: foreignRunId,
+      executionAgentNameKey: "foreign-builder",
+      executionLockedAt: lockedAt,
+    }));
+  });
+
+  it("rejects direct agent checkout when checkout and execution both belong to a foreign live run", async () => {
+    const { issueId, assignedAgentId, foreignRunId, agentToken, lockedAt } =
+      await seedForeignExecutionFixture({
+        checkoutRunId: "foreign",
+      });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .post(`/api/issues/${issueId}/checkout`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", foreignRunId)
+      .send({
+        agentId: assignedAgentId,
+        expectedStatuses: ["in_progress"],
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue checkout conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_progress",
+      assigneeAgentId: assignedAgentId,
+      checkoutRunId: foreignRunId,
+      executionRunId: foreignRunId,
+      executionAgentNameKey: "foreign-builder",
+      executionLockedAt: lockedAt,
+    }));
+  });
+
+  it("rejects same-agent split-lock checkout when a local JWT run is overridden by header", async () => {
+    const { companyId, issueId, assignedAgentId, oldRunId, retryRunId, lockedAt } =
+      await seedSameAgentSplitLockFixture();
+    const restoreJwtSecret = setLocalAgentJwtSecret("test-secret");
+
+    try {
+      const token = createLocalAgentJwt(assignedAgentId, companyId, "codex_local", oldRunId);
+      expect(token).toBeTypeOf("string");
+
+      const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+        .post(`/api/issues/${issueId}/checkout`)
+        .set("Authorization", `Bearer ${token}`)
+        .set("X-Paperclip-Run-Id", retryRunId)
+        .send({
+          agentId: assignedAgentId,
+          expectedStatuses: ["in_progress"],
+        });
+
+      expect(res.status).toBe(409);
+      expect(res.body).toEqual(expect.objectContaining({
+        error: "Issue checkout conflict",
+      }));
+
+      await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+        status: "in_progress",
+        assigneeAgentId: assignedAgentId,
+        checkoutRunId: oldRunId,
+        executionRunId: retryRunId,
+        executionAgentNameKey: "assigned-builder",
+        executionLockedAt: lockedAt,
+      }));
+    } finally {
+      restoreJwtSecret();
+    }
+  });
+
+  it("rejects agent release when the run header belongs to a foreign live execution owner", async () => {
+    const { issueId, assignedAgentId, foreignRunId, agentToken, lockedAt } =
+      await seedForeignExecutionFixture({
+        status: "in_review",
+        checkoutRunId: null,
+      });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .post(`/api/issues/${issueId}/release`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", foreignRunId)
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue still owned by active run",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_review",
+      assigneeAgentId: assignedAgentId,
+      checkoutRunId: null,
+      executionRunId: foreignRunId,
+      executionAgentNameKey: "foreign-builder",
+      executionLockedAt: lockedAt,
+    }));
+  });
+});

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -822,6 +822,98 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     }));
   });
 
+  it("rejects an agent PATCH when a terminal run header would adopt a stale checkout", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleRunId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+    const agentToken = "terminal-patch-agent-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T13:00:00.000Z"),
+        finishedAt: new Date("2026-04-13T13:05:00.000Z"),
+      },
+      {
+        id: terminalRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T13:06:00.000Z"),
+        finishedAt: new Date("2026-04-13T13:07:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal run patch should not adopt stale checkout",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: staleRunId,
+      executionRunId: null,
+      startedAt: new Date("2026-04-13T13:00:00.000Z"),
+    });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", terminalRunId)
+      .send({
+        status: "done",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue run ownership conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: staleRunId,
+      executionRunId: null,
+    }));
+  });
+
   it("keeps forged agent API-key run headers out of execution decision provenance", async () => {
     const companyId = randomUUID();
     const reviewerAgentId = randomUUID();

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -497,6 +497,89 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     }));
   });
 
+  it("wakes the assignee when same-assignee status changes into actionable work", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const todoIssueId = randomUUID();
+    const reviewIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Staff Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values([
+      {
+        id: todoIssueId,
+        companyId,
+        title: "Same assignee todo wake",
+        status: "in_review",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: reviewIssueId,
+        companyId,
+        title: "Same assignee review wake",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const app = createRouteApp();
+
+    const todoRes = await request(app)
+      .patch(`/api/issues/${todoIssueId}`)
+      .send({ status: "todo" });
+    const reviewRes = await request(app)
+      .patch(`/api/issues/${reviewIssueId}`)
+      .send({ status: "in_review" });
+
+    expect(todoRes.status).toBe(200);
+    expect(reviewRes.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(mockHeartbeatWakeup).toHaveBeenCalledTimes(2);
+    });
+    expect(mockHeartbeatWakeup).toHaveBeenCalledWith(agentId, expect.objectContaining({
+      reason: "issue_status_changed",
+      payload: expect.objectContaining({
+        issueId: todoIssueId,
+        mutation: "update",
+      }),
+      contextSnapshot: expect.objectContaining({
+        issueId: todoIssueId,
+        source: "issue.status_change",
+      }),
+    }));
+    expect(mockHeartbeatWakeup).toHaveBeenCalledWith(agentId, expect.objectContaining({
+      reason: "issue_status_changed",
+      payload: expect.objectContaining({
+        issueId: reviewIssueId,
+        mutation: "update",
+      }),
+      contextSnapshot: expect.objectContaining({
+        issueId: reviewIssueId,
+        source: "issue.status_change",
+      }),
+    }));
+  });
+
   it("preserves execution ownership when the local-board run header belongs to a different live agent", async () => {
     const builderAgentId = randomUUID();
     const { issueId, staffAgentId, builderRunId } = await seedHandoffFixture({

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -94,15 +94,17 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
   function createRouteApp(opts?: {
     deploymentMode?: "local_trusted" | "authenticated";
     resolveSession?: Parameters<typeof actorMiddleware>[1]["resolveSession"];
+    dbOverride?: typeof db;
   }) {
+    const routeDb = opts?.dbOverride ?? db;
     const app = express();
     app.use(express.json());
-    app.use(actorMiddleware(db, {
+    app.use(actorMiddleware(routeDb, {
       deploymentMode: opts?.deploymentMode ?? "local_trusted",
       resolveSession: opts?.resolveSession,
     }));
     app.use(boardMutationGuard());
-    app.use("/api", issueRoutes(db, {} as any));
+    app.use("/api", issueRoutes(routeDb, {} as any));
     app.use(errorHandler);
     return app;
   }
@@ -911,6 +913,204 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
       assigneeAgentId: agentId,
       checkoutRunId: staleRunId,
       executionRunId: null,
+    }));
+  });
+
+  it("rejects an agent PATCH when a terminal run header already matches checkout ownership", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+    const agentToken = "terminal-same-run-patch-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-13T14:00:00.000Z"),
+      finishedAt: new Date("2026-04-13T14:05:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal run patch should not satisfy checkout ownership",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: terminalRunId,
+      executionRunId: null,
+      startedAt: new Date("2026-04-13T14:00:00.000Z"),
+    });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", terminalRunId)
+      .send({
+        status: "done",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue run ownership conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: terminalRunId,
+      executionRunId: null,
+    }));
+  });
+
+  it("rejects an agent PATCH when checkout ownership changes before the locked update", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const originalRunId = randomUUID();
+    const freshRunId = randomUUID();
+    const issueId = randomUUID();
+    const agentToken = "stale-precheck-patch-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:10:00.000Z"),
+      },
+      {
+        id: freshRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "queued",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:11:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale precheck patch should not mutate fresh checkout owner",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: originalRunId,
+      executionRunId: originalRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-13T14:10:00.000Z"),
+      startedAt: new Date("2026-04-13T14:10:00.000Z"),
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  checkoutRunId: freshRunId,
+                  executionRunId: freshRunId,
+                  executionLockedAt: new Date("2026-04-13T14:11:00.000Z"),
+                  updatedAt: new Date("2026-04-13T14:11:00.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+
+    const res = await request(createRouteApp({
+      deploymentMode: "authenticated",
+      dbOverride: delayedDb,
+    }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", originalRunId)
+      .send({
+        status: "done",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue run ownership conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: freshRunId,
+      executionRunId: freshRunId,
     }));
   });
 

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -9,8 +9,10 @@ import {
   agents,
   companies,
   createDb,
+  documentRevisions,
   heartbeatRuns,
   instanceUserRoles,
+  issueExecutionDecisions,
   issues,
 } from "@paperclipai/db";
 import {
@@ -63,6 +65,9 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
       await tx.execute(sql`
         TRUNCATE TABLE
           activity_log,
+          document_revisions,
+          issue_documents,
+          documents,
           issue_comments,
           issue_inbox_archives,
           issues,
@@ -507,14 +512,6 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(expect.objectContaining({
-      id: issueId,
-      status: "in_review",
-      assigneeAgentId: staffAgentId,
-      checkoutRunId: builderRunId,
-      executionRunId: builderRunId,
-      executionAgentNameKey: "builder",
-    }));
 
     await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
       status: "in_review",
@@ -586,14 +583,40 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     }));
     expect(mockReportRunActivity).not.toHaveBeenCalled();
 
+    const documentRes = await request(createRouteApp({
+      deploymentMode: "authenticated",
+      resolveSession: async () => ({
+        session: { id: "session-1", userId },
+        user: { id: userId },
+      }),
+    }))
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .set("Origin", "http://localhost:3100")
+      .set("X-Paperclip-Run-Id", qaRunId)
+      .send({
+        title: "Plan",
+        format: "markdown",
+        body: "Audit-only board document",
+        baseRevisionId: null,
+      });
+
+    expect(documentRes.status).toBe(201);
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    const revisionRows = await db.select().from(documentRevisions);
+    expect(revisionRows).toHaveLength(1);
+    expect(revisionRows[0]?.createdByRunId).toBeNull();
+
     const activityRows = await db
       .select()
       .from(activityLog)
       .where(eq(activityLog.entityId, issueId));
     const updateActivity = activityRows.find((row) => row.action === "issue.updated");
     const commentActivity = activityRows.find((row) => row.action === "issue.comment_added");
+    const documentActivity = activityRows.find((row) => row.action === "issue.document_created");
     expect(updateActivity?.runId).toBeNull();
     expect(commentActivity?.runId).toBeNull();
+    expect(documentActivity?.runId).toBeNull();
   });
 
   it("keeps authenticated board run headers audit-only when reopening from a comment", async () => {
@@ -714,6 +737,140 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
       executionAgentNameKey: "builder",
       executionLockedAt: lockedAt,
     }));
+  });
+
+  it("keeps forged agent API-key run headers out of execution decision provenance", async () => {
+    const companyId = randomUUID();
+    const reviewerAgentId = randomUUID();
+    const builderAgentId = randomUUID();
+    const issueId = randomUUID();
+    const stageId = randomUUID();
+    const participantId = randomUUID();
+    const foreignRunId = randomUUID();
+    const agentToken = "reviewer-agent-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: reviewerAgentId,
+        companyId,
+        name: "Reviewer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(agentApiKeys).values({
+      agentId: reviewerAgentId,
+      companyId,
+      name: "reviewer key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: foreignRunId,
+      companyId,
+      agentId: builderAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-11T20:50:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review decision provenance",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: reviewerAgentId,
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [
+          {
+            id: stageId,
+            type: "review",
+            approvalsNeeded: 1,
+            participants: [
+              {
+                id: participantId,
+                type: "agent",
+                agentId: reviewerAgentId,
+                userId: null,
+              },
+            ],
+          },
+        ],
+      },
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: {
+          type: "agent",
+          agentId: reviewerAgentId,
+          userId: null,
+        },
+        returnAssignee: {
+          type: "agent",
+          agentId: builderAgentId,
+          userId: null,
+        },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", foreignRunId)
+      .send({
+        status: "done",
+        comment: "Approved.",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    const decisions = await db
+      .select()
+      .from(issueExecutionDecisions)
+      .where(eq(issueExecutionDecisions.issueId, issueId));
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.createdByRunId).toBeNull();
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activityRows.find((row) => row.action === "issue.updated")?.runId).toBeNull();
+    expect(activityRows.find((row) => row.action === "issue.comment_added")?.runId).toBeNull();
   });
 
   it("rejects agent checkout adoption when the run header belongs to a foreign live execution owner", async () => {

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -984,6 +984,84 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     }));
   });
 
+  it("rejects agent checkout when the run header is a terminal same-agent run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+    const agentToken = "terminal-agent-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-13T13:00:00.000Z"),
+      finishedAt: new Date("2026-04-13T13:05:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal run checkout should fail",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .post(`/api/issues/${issueId}/checkout`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", terminalRunId)
+      .send({
+        agentId,
+        expectedStatuses: ["todo"],
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue checkout conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      status: "todo",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    }));
+  });
+
   it("rejects direct agent checkout when checkout is unlocked but execution belongs to a foreign live run", async () => {
     const { issueId, assignedAgentId, foreignRunId, agentToken, lockedAt } =
       await seedForeignExecutionFixture({

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -12,6 +12,7 @@ import {
   documentRevisions,
   heartbeatRuns,
   instanceUserRoles,
+  issueComments,
   issueExecutionDecisions,
   issues,
 } from "@paperclipai/db";
@@ -582,6 +583,75 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     }));
   });
 
+  it("wakes the assignee when a same-assignee comment reopen makes closed work actionable", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Staff Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Same assignee reopen wake",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      completedAt: new Date("2026-04-13T14:20:00.000Z"),
+    });
+
+    const res = await request(createRouteApp())
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        comment: "Please take another pass.",
+        reopen: true,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: agentId,
+    }));
+
+    await vi.waitFor(() => {
+      expect(mockHeartbeatWakeup).toHaveBeenCalledTimes(1);
+    });
+    expect(mockHeartbeatWakeup).toHaveBeenCalledWith(agentId, expect.objectContaining({
+      reason: "issue_reopened_via_comment",
+      payload: expect.objectContaining({
+        issueId,
+        mutation: "comment",
+        reopenedFrom: "done",
+        commentId: expect.any(String),
+      }),
+      contextSnapshot: expect.objectContaining({
+        issueId,
+        wakeCommentId: expect.any(String),
+        source: "issue.comment.reopen",
+        wakeReason: "issue_reopened_via_comment",
+        reopenedFrom: "done",
+      }),
+    }));
+  });
+
   it("preserves execution ownership when the local-board run header belongs to a different live agent", async () => {
     const builderAgentId = randomUUID();
     const { issueId, staffAgentId, builderRunId } = await seedHandoffFixture({
@@ -605,6 +675,42 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
       executionRunId: builderRunId,
       executionAgentNameKey: "builder",
     }));
+  });
+
+  it("keeps local-board terminal run headers out of update provenance", async () => {
+    const { issueId, staffAgentId, qaRunId } = await seedHandoffFixture();
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "succeeded",
+        finishedAt: new Date("2026-04-13T14:17:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, qaRunId));
+
+    const res = await request(createRouteApp())
+      .patch(`/api/issues/${issueId}`)
+      .set("X-Paperclip-Run-Id", qaRunId)
+      .send({
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    }));
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activityRows.find((row) => row.action === "issue.updated")?.runId).toBeNull();
   });
 
   it("treats authenticated board run headers as audit context only", async () => {
@@ -1114,6 +1220,124 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     }));
   });
 
+  it("rejects an agent PATCH when an unlocked issue becomes checkout-owned before the locked update", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleActorRunId = randomUUID();
+    const freshRunId = randomUUID();
+    const issueId = randomUUID();
+    const agentToken = "todo-precheck-patch-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "test key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleActorRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:12:00.000Z"),
+      },
+      {
+        id: freshRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "queued",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:13:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Unlocked precheck patch should not mutate fresh checkout owner",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  status: "in_progress",
+                  checkoutRunId: freshRunId,
+                  executionRunId: freshRunId,
+                  executionLockedAt: new Date("2026-04-13T14:13:00.000Z"),
+                  startedAt: new Date("2026-04-13T14:13:00.000Z"),
+                  updatedAt: new Date("2026-04-13T14:13:00.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+
+    const res = await request(createRouteApp({
+      deploymentMode: "authenticated",
+      dbOverride: delayedDb,
+    }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", staleActorRunId)
+      .send({
+        title: "Stale write attempt",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Issue run ownership conflict",
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      title: "Unlocked precheck patch should not mutate fresh checkout owner",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: freshRunId,
+      executionRunId: freshRunId,
+    }));
+  });
+
   it("keeps forged agent API-key run headers out of execution decision provenance", async () => {
     const companyId = randomUUID();
     const reviewerAgentId = randomUUID();
@@ -1239,6 +1463,87 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
       .where(eq(issueExecutionDecisions.issueId, issueId));
     expect(decisions).toHaveLength(1);
     expect(decisions[0]?.createdByRunId).toBeNull();
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activityRows.find((row) => row.action === "issue.updated")?.runId).toBeNull();
+    expect(activityRows.find((row) => row.action === "issue.comment_added")?.runId).toBeNull();
+  });
+
+  it("keeps terminal same-agent run headers out of non-checkout PATCH provenance", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+    const agentToken = "terminal-provenance-agent-token";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Staff Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "staff key",
+      keyHash: hashToken(agentToken),
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-13T14:15:00.000Z"),
+      finishedAt: new Date("2026-04-13T14:16:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal provenance should be ignored",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const res = await request(createRouteApp({ deploymentMode: "authenticated" }))
+      .patch(`/api/issues/${issueId}`)
+      .set("Authorization", `Bearer ${agentToken}`)
+      .set("X-Paperclip-Run-Id", terminalRunId)
+      .send({
+        comment: "Reviewed from a stale run.",
+        priority: "medium",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockReportRunActivity).not.toHaveBeenCalled();
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.createdByRunId).toBeNull();
 
     const activityRows = await db
       .select()

--- a/server/src/__tests__/issue-update-handoff-routes.test.ts
+++ b/server/src/__tests__/issue-update-handoff-routes.test.ts
@@ -892,6 +892,81 @@ describeEmbeddedPostgres("issue update handoff routes", () => {
     expect(releaseActivity?.runId).toBeNull();
   });
 
+  it("allows local board release to clear terminal stale locks on an agent-assigned issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-14T20:00:00.000Z"),
+      finishedAt: new Date("2026-04-14T20:01:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Local board release should clear stale agent lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-14T20:00:00.000Z"),
+      startedAt: new Date("2026-04-14T20:00:00.000Z"),
+    });
+
+    const res = await request(createRouteApp())
+      .post(`/api/issues/${issueId}/release`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+    }));
+
+    await expect(getPersistedIssue(issueId)).resolves.toEqual(expect.objectContaining({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+    }));
+  });
+
   it("rejects an agent PATCH when the run header belongs to a foreign live execution owner", async () => {
     const builderAgentId = randomUUID();
     const { companyId, issueId, qaAgentId, builderRunId } = await seedHandoffFixture({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2232,6 +2232,75 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     );
   });
 
+  it("rejects terminal same-agent run ids that already match checkout ownership", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-13T14:00:00.000Z"),
+      finishedAt: new Date("2026-04-13T14:05:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal run must not satisfy current checkout ownership",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: terminalRunId,
+      executionRunId: null,
+      startedAt: new Date("2026-04-13T14:00:00.000Z"),
+    });
+
+    await expect(
+      svc.assertCheckoutOwner(issueId, agentId, terminalRunId),
+    ).rejects.toThrow("Issue run ownership conflict");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        checkoutRunId: terminalRunId,
+        executionRunId: null,
+      }),
+    );
+  });
+
   it("promotes deferred wakeups after clearing terminal checkout ownership", async () => {
     const companyId = randomUUID();
     const qaAgentId = randomUUID();
@@ -2641,6 +2710,124 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
       .then((rows) => rows[0] ?? null);
 
     expect(issue?.executionRunId).toBe(freshRunId);
+  });
+
+  it("rejects an agent update when checkout ownership changes before the locked write", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const originalRunId = randomUUID();
+    const freshRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:10:00.000Z"),
+      },
+      {
+        id: freshRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "queued",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:11:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale actor update should not mutate fresh checkout owner",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: originalRunId,
+      executionRunId: originalRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-13T14:10:00.000Z"),
+      startedAt: new Date("2026-04-13T14:10:00.000Z"),
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  checkoutRunId: freshRunId,
+                  executionRunId: freshRunId,
+                  executionLockedAt: new Date("2026-04-13T14:11:00.000Z"),
+                  updatedAt: new Date("2026-04-13T14:11:00.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+    const delayedSvc = issueService(delayedDb);
+
+    await expect(
+      delayedSvc.update(
+        issueId,
+        { status: "done" },
+        {
+          actorAgentId: agentId,
+          actorRunId: originalRunId,
+          requireCheckoutOwnership: true,
+        },
+      ),
+    ).rejects.toThrow("Issue run ownership conflict");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: freshRunId,
+        executionRunId: freshRunId,
+      }),
+    );
   });
 
   it("clears execution ownership on release so another run can pick the issue up", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2830,6 +2830,121 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     );
   });
 
+  it("rejects an agent update when an unlocked issue becomes checkout-owned before the locked write", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleActorRunId = randomUUID();
+    const freshRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleActorRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:12:00.000Z"),
+      },
+      {
+        id: freshRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "queued",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T14:13:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Unlocked actor update should not mutate fresh checkout owner",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  status: "in_progress",
+                  checkoutRunId: freshRunId,
+                  executionRunId: freshRunId,
+                  executionLockedAt: new Date("2026-04-13T14:13:00.000Z"),
+                  startedAt: new Date("2026-04-13T14:13:00.000Z"),
+                  updatedAt: new Date("2026-04-13T14:13:00.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+    const delayedSvc = issueService(delayedDb);
+
+    await expect(
+      delayedSvc.update(
+        issueId,
+        { title: "Stale write attempt" },
+        {
+          actorAgentId: agentId,
+          actorRunId: staleActorRunId,
+        },
+      ),
+    ).rejects.toThrow("Issue run ownership conflict");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        title: "Unlocked actor update should not mutate fresh checkout owner",
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: freshRunId,
+        executionRunId: freshRunId,
+      }),
+    );
+  });
+
   it("clears execution ownership on release so another run can pick the issue up", async () => {
     const companyId = randomUUID();
     const originalAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2429,8 +2429,8 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
         status: "in_review",
         assigneeAgentId: staffAgentId,
         checkoutRunId: null,
-        executionRunId: promotedRunId,
-        executionAgentNameKey: "staff engineer",
+        executionRunId: null,
+        executionAgentNameKey: null,
       }),
     );
 
@@ -2443,6 +2443,255 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
         assigneeAgentId: staffAgentId,
         checkoutRunId: promotedRunId,
         executionRunId: promotedRunId,
+      }),
+    );
+  });
+
+  it("re-defers a queued issue wake when another checkout claims the issue before start", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const staffBlockerRunId = randomUUID();
+    const issueId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: qaRunId,
+        companyId,
+        agentId: qaAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: {},
+        startedAt: new Date("2026-04-14T20:40:00.000Z"),
+      },
+      {
+        id: staffBlockerRunId,
+        companyId,
+        agentId: staffAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId: blockerIssueId },
+        startedAt: new Date("2026-04-14T20:40:30.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Queued wake should lose to live checkout",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+
+    const queuedRun = await heartbeat.wakeup(staffAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId },
+    });
+
+    expect(queuedRun).toEqual(
+      expect.objectContaining({
+        agentId: staffAgentId,
+        status: "queued",
+      }),
+    );
+
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: qaRunId,
+        executionRunId: qaRunId,
+        executionAgentNameKey: "qa-engineer",
+        executionLockedAt: new Date("2026-04-14T20:41:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "succeeded",
+        finishedAt: new Date("2026-04-14T20:41:30.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, staffBlockerRunId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    const queuedAfterRace = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, queuedRun?.id as string))
+      .then((rows) => rows[0] ?? null);
+
+    expect(queuedAfterRace).toEqual(
+      expect.objectContaining({
+        id: queuedRun?.id,
+        status: "cancelled",
+        errorCode: "issue_execution_deferred",
+      }),
+    );
+
+    const [deferredWake] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, staffAgentId));
+
+    expect(deferredWake).toEqual(
+      expect.objectContaining({
+        status: "deferred_issue_execution",
+        reason: "issue_execution_deferred",
+        runId: null,
+      }),
+    );
+
+    const claimedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(claimedIssue).toEqual(
+      expect.objectContaining({
+        checkoutRunId: qaRunId,
+        executionRunId: qaRunId,
+        executionAgentNameKey: "qa-engineer",
+      }),
+    );
+  });
+
+  it("promotes deferred wakeups after clearing missing checkout ownership", async () => {
+    const companyId = randomUUID();
+    const staffAgentId = randomUUID();
+    const missingRunId = randomUUID();
+    const staffBlockerRunId = randomUUID();
+    const issueId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: staffAgentId,
+      companyId,
+      name: "Staff Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: staffBlockerRunId,
+      companyId,
+      agentId: staffAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: blockerIssueId },
+      startedAt: new Date("2026-04-14T20:42:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Missing stale lock should clear",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+    });
+
+    await db.execute(sql`alter table issues disable trigger all`);
+    try {
+      await db.execute(sql`
+        update issues
+        set checkout_run_id = ${missingRunId},
+            execution_run_id = ${missingRunId},
+            execution_agent_name_key = 'qa-engineer',
+            execution_locked_at = ${"2026-04-14T20:41:00.000Z"}::timestamptz
+        where id = ${issueId}
+      `);
+    } finally {
+      await db.execute(sql`alter table issues enable trigger all`);
+    }
+
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId: staffAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      payload: { issueId },
+      status: "deferred_issue_execution",
+    });
+
+    const promotedRun = await heartbeat.promoteDeferredIssueWakeupForIssue(issueId, companyId);
+
+    expect(promotedRun).toEqual(
+      expect.objectContaining({
+        agentId: staffAgentId,
+        status: "queued",
+      }),
+    );
+
+    const promotedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(promotedIssue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
       }),
     );
   });
@@ -2582,8 +2831,8 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
         status: "in_review",
         assigneeAgentId: staffAgentId,
         checkoutRunId: null,
-        executionRunId: promotedRun?.id,
-        executionAgentNameKey: "staff engineer",
+        executionRunId: null,
+        executionAgentNameKey: null,
       }),
     );
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3090,6 +3090,76 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     );
   });
 
+  it("allows a board operator to release stale terminal locks on agent-assigned issues", async () => {
+    const companyId = randomUUID();
+    const boardUserId = "local-board";
+    const agentId = randomUUID();
+    const terminalRunId = randomUUID();
+    const terminalIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId: terminalIssueId },
+      startedAt: new Date("2026-04-14T20:00:00.000Z"),
+      finishedAt: new Date("2026-04-14T20:01:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: terminalIssueId,
+      companyId,
+      title: "Board release clears terminal agent lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: terminalRunId,
+      executionRunId: terminalRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-14T20:00:00.000Z"),
+      startedAt: new Date("2026-04-14T20:00:00.000Z"),
+    });
+
+    const released = await svc.release(terminalIssueId, {
+      actorUserId: boardUserId,
+    });
+
+    expect(released).toEqual(
+      expect.objectContaining({
+        id: terminalIssueId,
+        status: "todo",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      }),
+    );
+  });
+
   it("does not overwrite a newer reroute when the prior run releases late", async () => {
     const companyId = randomUUID();
     const originalAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1507,6 +1507,103 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     );
   });
 
+  it("preserves live checkout-only ownership when update has no owning run authority", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const staffRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: qaRunId,
+        companyId,
+        agentId: qaAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T21:00:00.000Z"),
+      },
+      {
+        id: staffRunId,
+        companyId,
+        agentId: staffAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T21:01:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Checkout-only live owner",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: qaAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: null,
+      executionAgentNameKey: "qa-engineer",
+      executionLockedAt: new Date("2026-04-11T21:00:00.000Z"),
+    });
+
+    const rerouted = await svc.update(issueId, {
+      status: "in_review",
+      assigneeAgentId: staffAgentId,
+    });
+
+    expect(rerouted).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: qaRunId,
+        executionRunId: null,
+        executionAgentNameKey: "qa-engineer",
+      }),
+    );
+
+    await expect(svc.checkout(issueId, staffAgentId, ["in_review"], staffRunId)).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
   it("preserves execution ownership when a local board run id belongs to a different live agent", async () => {
     const companyId = randomUUID();
     const qaAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2149,6 +2149,89 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     );
   });
 
+  it("rejects terminal same-agent run ids during stale checkout adoption", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const staleRunId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staleRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T13:00:00.000Z"),
+        finishedAt: new Date("2026-04-13T13:05:00.000Z"),
+      },
+      {
+        id: terminalRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-13T13:06:00.000Z"),
+        finishedAt: new Date("2026-04-13T13:07:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal run must not adopt stale checkout",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: staleRunId,
+      executionRunId: null,
+      startedAt: new Date("2026-04-13T13:00:00.000Z"),
+    });
+
+    await expect(
+      svc.assertCheckoutOwner(issueId, agentId, terminalRunId),
+    ).rejects.toThrow("Issue run ownership conflict");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        checkoutRunId: staleRunId,
+        executionRunId: null,
+      }),
+    );
+  });
+
   it("promotes deferred wakeups after clearing terminal checkout ownership", async () => {
     const companyId = randomUUID();
     const qaAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1905,7 +1905,7 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     expect(builderRuns).toHaveLength(0);
   });
 
-  it("defers assignment wakeups while prior checkout-only ownership is still live", async () => {
+  it("defers assignment wakeups while prior checkout-only ownership is still live despite stale agent key", async () => {
     const companyId = randomUUID();
     const qaAgentId = randomUUID();
     const staffAgentId = randomUUID();
@@ -1965,7 +1965,7 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
       assigneeAgentId: staffAgentId,
       checkoutRunId: qaRunId,
       executionRunId: null,
-      executionAgentNameKey: "qa-engineer",
+      executionAgentNameKey: "staff-engineer",
       executionLockedAt: new Date("2026-04-11T21:00:00.000Z"),
     });
 
@@ -2000,6 +2000,153 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
       .where(eq(heartbeatRuns.agentId, staffAgentId));
 
     expect(staffRuns).toHaveLength(0);
+  });
+
+  it("coalesces checkout-only wakeups onto the actual run owner despite stale agent key", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const issueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: qaAgentId,
+      companyId,
+      name: "QA Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: qaRunId,
+      companyId,
+      agentId: qaAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, existing: true },
+      startedAt: new Date("2026-04-11T21:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Checkout-only wake should coalesce onto actual owner",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: qaAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: null,
+      executionAgentNameKey: "staff-engineer",
+      executionLockedAt: new Date("2026-04-11T21:00:00.000Z"),
+    });
+
+    const wake = await heartbeat.wakeup(qaAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, fresh: true },
+    });
+
+    expect(wake).toEqual(expect.objectContaining({
+      id: qaRunId,
+      agentId: qaAgentId,
+    }));
+
+    const [coalesced] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, qaAgentId));
+
+    expect(coalesced).toEqual(
+      expect.objectContaining({
+        agentId: qaAgentId,
+        companyId,
+        status: "coalesced",
+        reason: "issue_execution_same_name",
+        runId: qaRunId,
+      }),
+    );
+  });
+
+  it("rejects terminal same-agent run ids at checkout", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const terminalRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-13T13:00:00.000Z"),
+      finishedAt: new Date("2026-04-13T13:05:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal run must not checkout",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+
+    await expect(
+      svc.checkout(issueId, agentId, ["todo"], terminalRunId),
+    ).rejects.toThrow("Issue checkout conflict");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        checkoutRunId: null,
+        executionRunId: null,
+      }),
+    );
   });
 
   it("promotes deferred wakeups after clearing terminal checkout ownership", async () => {
@@ -2144,6 +2291,147 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
         assigneeAgentId: staffAgentId,
         checkoutRunId: promotedRunId,
         executionRunId: promotedRunId,
+      }),
+    );
+  });
+
+  it("promotes deferred wakeups after an owning run explicitly releases before finishing", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const staffBlockerRunId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const issueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: qaRunId,
+        companyId,
+        agentId: qaAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: {},
+        startedAt: new Date("2026-04-13T13:10:00.000Z"),
+      },
+      {
+        id: staffBlockerRunId,
+        companyId,
+        agentId: staffAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId: blockerIssueId },
+        startedAt: new Date("2026-04-13T13:10:30.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Deferred wakeup should promote after explicit release",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: qaRunId,
+      executionAgentNameKey: "qa-engineer",
+      executionLockedAt: new Date("2026-04-13T13:10:00.000Z"),
+    });
+
+    await expect(heartbeat.wakeup(staffAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId },
+    })).resolves.toBeNull();
+
+    const released = await svc.release(issueId, {
+      actorAgentId: qaAgentId,
+      actorRunId: qaRunId,
+    });
+
+    expect(released).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+      }),
+    );
+
+    const promotedRun = await heartbeat.promoteDeferredIssueWakeupForIssue(issueId, companyId);
+
+    expect(promotedRun).toEqual(
+      expect.objectContaining({
+        agentId: staffAgentId,
+        status: "queued",
+      }),
+    );
+
+    const [promotedWake] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, staffAgentId));
+
+    expect(promotedWake).toEqual(
+      expect.objectContaining({
+        status: "queued",
+        reason: "issue_execution_promoted",
+        runId: promotedRun?.id,
+      }),
+    );
+
+    const promotedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(promotedIssue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: null,
+        executionRunId: promotedRun?.id,
+        executionAgentNameKey: "staff engineer",
       }),
     );
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1905,6 +1905,249 @@ describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
     expect(builderRuns).toHaveLength(0);
   });
 
+  it("defers assignment wakeups while prior checkout-only ownership is still live", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const issueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: qaRunId,
+      companyId,
+      agentId: qaAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {},
+      startedAt: new Date("2026-04-11T21:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Checkout-only reroute should defer",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: null,
+      executionAgentNameKey: "qa-engineer",
+      executionLockedAt: new Date("2026-04-11T21:00:00.000Z"),
+    });
+
+    const wake = await heartbeat.wakeup(staffAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId },
+    });
+
+    expect(wake).toBeNull();
+
+    const [deferred] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, staffAgentId));
+
+    expect(deferred).toEqual(
+      expect.objectContaining({
+        agentId: staffAgentId,
+        companyId,
+        status: "deferred_issue_execution",
+        reason: "issue_execution_deferred",
+        runId: null,
+      }),
+    );
+
+    const staffRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, staffAgentId));
+
+    expect(staffRuns).toHaveLength(0);
+  });
+
+  it("promotes deferred wakeups after clearing terminal checkout ownership", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const staffBlockerRunId = randomUUID();
+    const issueId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: qaRunId,
+        companyId,
+        agentId: qaAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T21:00:00.000Z"),
+      },
+      {
+        id: staffBlockerRunId,
+        companyId,
+        agentId: staffAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId: blockerIssueId },
+        startedAt: new Date("2026-04-11T21:00:30.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Deferred wakeup should promote after QA release",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: qaRunId,
+      executionAgentNameKey: "qa-engineer",
+      executionLockedAt: new Date("2026-04-11T21:00:00.000Z"),
+    });
+
+    await expect(heartbeat.wakeup(staffAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId },
+    })).resolves.toBeNull();
+
+    await heartbeat.cancelRun(qaRunId);
+
+    const [promotedWake] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, staffAgentId));
+
+    expect(promotedWake).toEqual(
+      expect.objectContaining({
+        status: "queued",
+        reason: "issue_execution_promoted",
+      }),
+    );
+    expect(promotedWake?.runId).toEqual(expect.any(String));
+
+    const promotedRunId = promotedWake?.runId as string;
+    const promotedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, promotedRunId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(promotedRun).toEqual(
+      expect.objectContaining({
+        id: promotedRunId,
+        agentId: staffAgentId,
+        status: "queued",
+      }),
+    );
+
+    const promotedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(promotedIssue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: null,
+        executionRunId: promotedRunId,
+        executionAgentNameKey: "staff engineer",
+      }),
+    );
+
+    const checkedOut = await svc.checkout(issueId, staffAgentId, ["in_review"], promotedRunId);
+
+    expect(checkedOut).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: promotedRunId,
+        executionRunId: promotedRunId,
+      }),
+    );
+  });
+
   it("does not clear a fresh execution owner queued between update read and write", async () => {
     const companyId = randomUUID();
     const staffAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,9 +5,11 @@ import { sql } from "drizzle-orm";
 import {
   activityLog,
   agents,
+  agentWakeupRequests,
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -20,6 +22,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
 import { instanceSettingsService } from "../services/instance-settings.ts";
 import { issueService } from "../services/issues.ts";
 
@@ -1180,5 +1183,1688 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       assigneeAgentId,
       childIssueIds: [childA, childB],
     });
+  });
+});
+describeEmbeddedPostgres("issueService execution ownership handoffs", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-execution-locks-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`set local client_min_messages = warning`);
+      await tx.execute(sql`
+        TRUNCATE TABLE
+          activity_log,
+          issue_comments,
+          issue_inbox_archives,
+          issues,
+          heartbeat_run_events,
+          heartbeat_runs,
+          agent_wakeup_requests,
+          agent_runtime_state,
+          execution_workspaces,
+          project_workspaces,
+          projects,
+          agents,
+          companies,
+          instance_settings
+        RESTART IDENTITY CASCADE
+      `);
+    });
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("clears stale execution ownership when review routes back to builder", async () => {
+    const companyId = randomUUID();
+    const staffAgentId = randomUUID();
+    const builderAgentId = randomUUID();
+    const staffRunId = randomUUID();
+    const builderRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staffRunId,
+        companyId,
+        agentId: staffAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "cancelled",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:24:00.000Z"),
+        finishedAt: new Date("2026-04-05T15:24:30.000Z"),
+      },
+      {
+        id: builderRunId,
+        companyId,
+        agentId: builderAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:25:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Route failed review back to Builder",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: staffRunId,
+      executionAgentNameKey: "staff-engineer",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    const rerouted = await svc.update(issueId, {
+      status: "todo",
+      assigneeAgentId: builderAgentId,
+    });
+
+    expect(rerouted).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: builderAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      }),
+    );
+
+    const checkedOut = await svc.checkout(issueId, builderAgentId, ["todo"], builderRunId);
+
+    expect(checkedOut).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: builderAgentId,
+        checkoutRunId: builderRunId,
+        executionRunId: builderRunId,
+      }),
+    );
+  });
+
+  it("clears execution ownership when the owning run performs the handoff itself", async () => {
+    const companyId = randomUUID();
+    const staffAgentId = randomUUID();
+    const builderAgentId = randomUUID();
+    const staffRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: staffRunId,
+      companyId,
+      agentId: staffAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Safe handoff from reviewer to builder",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: staffRunId,
+      executionAgentNameKey: "staff-engineer",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    const rerouted = await svc.update(
+      issueId,
+      {
+        status: "todo",
+        assigneeAgentId: builderAgentId,
+      },
+      {
+        actorAgentId: staffAgentId,
+        actorRunId: staffRunId,
+      },
+    );
+
+    expect(rerouted).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: builderAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      }),
+    );
+  });
+
+  it("clears execution ownership when a local board request carries the owning run id", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const qaRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: qaRunId,
+      companyId,
+      agentId: qaAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-11T14:30:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "QA handoff to Staff review",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: qaAgentId,
+      checkoutRunId: qaRunId,
+      executionRunId: qaRunId,
+      executionAgentNameKey: "qa-engineer",
+      executionLockedAt: new Date("2026-04-11T14:30:00.000Z"),
+    });
+
+    const rerouted = await svc.update(
+      issueId,
+      {
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+      },
+      {
+        actorAgentId: null,
+        actorRunId: qaRunId,
+      },
+    );
+
+    expect(rerouted).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      }),
+    );
+  });
+
+  it("preserves execution ownership when a local board run id belongs to a different live agent", async () => {
+    const companyId = randomUUID();
+    const qaAgentId = randomUUID();
+    const staffAgentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const otherRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: qaAgentId,
+        companyId,
+        name: "QA Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId,
+      agentId: otherAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-11T14:30:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Mismatched live run should stay locked",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: qaAgentId,
+      checkoutRunId: otherRunId,
+      executionRunId: otherRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-11T14:30:00.000Z"),
+    });
+
+    const rerouted = await svc.update(
+      issueId,
+      {
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+      },
+      {
+        actorAgentId: null,
+        actorRunId: otherRunId,
+      },
+    );
+
+    expect(rerouted).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_review",
+        assigneeAgentId: staffAgentId,
+        checkoutRunId: otherRunId,
+        executionRunId: otherRunId,
+        executionAgentNameKey: "builder",
+      }),
+    );
+  });
+
+  it("preserves live execution ownership on reassignment without interrupt", async () => {
+    const companyId = randomUUID();
+    const staffAgentId = randomUUID();
+    const builderAgentId = randomUUID();
+    const staffRunId = randomUUID();
+    const builderRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: staffRunId,
+        companyId,
+        agentId: staffAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:24:00.000Z"),
+      },
+      {
+        id: builderRunId,
+        companyId,
+        agentId: builderAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:25:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Live reassignment should keep execution lock",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: staffRunId,
+      executionAgentNameKey: "staff-engineer",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    const reassigned = await svc.update(issueId, {
+      status: "todo",
+      assigneeAgentId: builderAgentId,
+    });
+
+    expect(reassigned).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: builderAgentId,
+        checkoutRunId: null,
+        executionRunId: staffRunId,
+        executionAgentNameKey: "staff-engineer",
+      }),
+    );
+
+    await expect(svc.checkout(issueId, builderAgentId, ["todo"], builderRunId)).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
+  it("defers assignment wakeups while prior execution ownership is still live", async () => {
+    const companyId = randomUUID();
+    const staffAgentId = randomUUID();
+    const builderAgentId = randomUUID();
+    const staffRunId = randomUUID();
+    const issueId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: staffRunId,
+      companyId,
+      agentId: staffAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Deferred wakeup on reassignment",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: builderAgentId,
+      checkoutRunId: null,
+      executionRunId: staffRunId,
+      executionAgentNameKey: "staff-engineer",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    const wake = await heartbeat.wakeup(builderAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId },
+    });
+
+    expect(wake).toBeNull();
+
+    const [deferred] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, builderAgentId));
+
+    expect(deferred).toEqual(
+      expect.objectContaining({
+        agentId: builderAgentId,
+        companyId,
+        status: "deferred_issue_execution",
+        reason: "issue_execution_deferred",
+        runId: null,
+      }),
+    );
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue?.executionRunId).toBe(staffRunId);
+
+    const builderRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, builderAgentId));
+
+    expect(builderRuns).toHaveLength(0);
+  });
+
+  it("does not clear a fresh execution owner queued between update read and write", async () => {
+    const companyId = randomUUID();
+    const staffAgentId = randomUUID();
+    const builderAgentId = randomUUID();
+    const staleStaffRunId = randomUUID();
+    const freshRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: staffAgentId,
+        companyId,
+        name: "Staff Engineer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: builderAgentId,
+        companyId,
+        name: "Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values({
+      id: staleStaffRunId,
+      companyId,
+      agentId: staffAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "cancelled",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-05T15:24:00.000Z"),
+      finishedAt: new Date("2026-04-05T15:24:30.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Update should not clear a fresh execution owner",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: staffAgentId,
+      checkoutRunId: null,
+      executionRunId: staleStaffRunId,
+      executionAgentNameKey: "staff-engineer",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target.insert(heartbeatRuns).values({
+                id: freshRunId,
+                companyId,
+                agentId: staffAgentId,
+                invocationSource: "assignment",
+                triggerDetail: "system",
+                status: "queued",
+                contextSnapshot: { issueId },
+              });
+              await target
+                .update(issues)
+                .set({
+                  executionRunId: freshRunId,
+                  executionAgentNameKey: "staff engineer",
+                  executionLockedAt: new Date("2026-04-05T15:24:05.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+    const delayedSvc = issueService(delayedDb);
+
+    const updated = await delayedSvc.update(issueId, {
+      status: "todo",
+      assigneeAgentId: builderAgentId,
+    });
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: builderAgentId,
+        checkoutRunId: null,
+        executionRunId: freshRunId,
+        executionAgentNameKey: "staff engineer",
+      }),
+    );
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue?.executionRunId).toBe(freshRunId);
+  });
+
+  it("clears execution ownership on release so another run can pick the issue up", async () => {
+    const companyId = randomUUID();
+    const originalAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const originalRunId = randomUUID();
+    const nextRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: originalAgentId,
+        companyId,
+        name: "Original Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "Next Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId: originalAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:24:00.000Z"),
+      },
+      {
+        id: nextRunId,
+        companyId,
+        agentId: nextAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:25:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Released issue should not keep stale execution ownership",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: originalAgentId,
+      checkoutRunId: originalRunId,
+      executionRunId: originalRunId,
+      executionAgentNameKey: "original-builder",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+      startedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    const released = await svc.release(issueId, {
+      actorAgentId: originalAgentId,
+      actorRunId: originalRunId,
+    });
+
+    expect(released).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: null,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      }),
+    );
+
+    const reclaimed = await svc.checkout(issueId, nextAgentId, ["todo"], nextRunId);
+
+    expect(reclaimed).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: nextRunId,
+        executionRunId: nextRunId,
+      }),
+    );
+  });
+
+  it("allows a board user to release their own user-assigned issue", async () => {
+    const companyId = randomUUID();
+    const boardUserId = "local-board";
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board-owned issue can be released",
+      status: "in_progress",
+      priority: "medium",
+      assigneeUserId: boardUserId,
+      startedAt: new Date("2026-04-06T13:00:00.000Z"),
+    });
+
+    const released = await svc.release(issueId, {
+      actorUserId: boardUserId,
+    });
+
+    expect(released).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        checkoutRunId: null,
+        executionRunId: null,
+      }),
+    );
+  });
+
+  it("does not overwrite a newer reroute when the prior run releases late", async () => {
+    const companyId = randomUUID();
+    const originalAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const originalRunId = randomUUID();
+    const nextRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: originalAgentId,
+        companyId,
+        name: "Original Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "Next Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId: originalAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:24:00.000Z"),
+      },
+      {
+        id: nextRunId,
+        companyId,
+        agentId: nextAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:25:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Late release should preserve rerouted assignee",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: originalAgentId,
+      checkoutRunId: originalRunId,
+      executionRunId: originalRunId,
+      executionAgentNameKey: "original-builder",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+      startedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  status: "todo",
+                  assigneeAgentId: nextAgentId,
+                  updatedAt: new Date("2026-04-05T15:24:05.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+    const delayedSvc = issueService(delayedDb);
+
+    const released = await delayedSvc.release(issueId, {
+      actorAgentId: originalAgentId,
+      actorRunId: originalRunId,
+    });
+
+    expect(released).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+      }),
+    );
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: null,
+        executionRunId: null,
+      }),
+    );
+
+    const reclaimed = await svc.checkout(issueId, nextAgentId, ["todo"], nextRunId);
+
+    expect(reclaimed).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: nextRunId,
+        executionRunId: nextRunId,
+      }),
+    );
+  });
+
+  it("does not overwrite a newer reroute when a board user releases late", async () => {
+    const companyId = randomUUID();
+    const boardUserId = "local-board";
+    const nextAgentId = randomUUID();
+    const nextRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: nextAgentId,
+      companyId,
+      name: "Next Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: nextRunId,
+      companyId,
+      agentId: nextAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-06T13:00:10.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Late board release should preserve rerouted assignee",
+      status: "todo",
+      priority: "high",
+      assigneeUserId: boardUserId,
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  assigneeAgentId: nextAgentId,
+                  assigneeUserId: null,
+                  updatedAt: new Date("2026-04-06T13:00:05.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+    const delayedSvc = issueService(delayedDb);
+
+    await expect(
+      delayedSvc.release(issueId, {
+        actorUserId: boardUserId,
+      }),
+    ).rejects.toThrow("Only assignee can release issue");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: nextAgentId,
+        assigneeUserId: null,
+        checkoutRunId: null,
+        executionRunId: null,
+      }),
+    );
+
+    const reclaimed = await svc.checkout(issueId, nextAgentId, ["todo"], nextRunId);
+
+    expect(reclaimed).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: nextAgentId,
+        assigneeUserId: null,
+        checkoutRunId: nextRunId,
+        executionRunId: nextRunId,
+      }),
+    );
+  });
+
+  it("blocks board release while a foreign live run still owns checkout and execution", async () => {
+    const companyId = randomUUID();
+    const boardUserId = "local-board";
+    const originalAgentId = randomUUID();
+    const originalRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: originalAgentId,
+      companyId,
+      name: "Original Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: originalRunId,
+      companyId,
+      agentId: originalAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-06T18:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board release must not clear a foreign live run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: null,
+      assigneeUserId: boardUserId,
+      checkoutRunId: originalRunId,
+      executionRunId: originalRunId,
+      executionAgentNameKey: "original-builder",
+      executionLockedAt: new Date("2026-04-06T18:00:00.000Z"),
+      startedAt: new Date("2026-04-06T18:00:00.000Z"),
+    });
+
+    await expect(
+      svc.release(issueId, {
+        actorUserId: boardUserId,
+      }),
+    ).rejects.toThrow("Issue still owned by active run");
+
+    const blockedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(blockedIssue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: null,
+        assigneeUserId: boardUserId,
+        checkoutRunId: originalRunId,
+        executionRunId: originalRunId,
+      }),
+    );
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "succeeded",
+        finishedAt: new Date("2026-04-06T18:00:30.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, originalRunId));
+
+    const released = await svc.release(issueId, {
+      actorUserId: boardUserId,
+    });
+
+    expect(released).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "todo",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        checkoutRunId: null,
+        executionRunId: null,
+      }),
+    );
+  });
+
+  it("blocks a stale checkout holder from releasing while retry execution is owned by a newer live run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const originalRunId = randomUUID();
+    const retryRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Original Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-06T18:20:00.000Z"),
+      },
+      {
+        id: retryRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "queued",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-06T18:20:10.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Retry promotion must keep replacement execution owner",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: originalRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "original-builder",
+      executionLockedAt: new Date("2026-04-06T18:20:10.000Z"),
+      startedAt: new Date("2026-04-06T18:20:00.000Z"),
+    });
+
+    await expect(
+      svc.release(issueId, {
+        actorAgentId: agentId,
+        actorRunId: originalRunId,
+      }),
+    ).rejects.toThrow("Issue still owned by active run");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: originalRunId,
+        executionRunId: retryRunId,
+      }),
+    );
+  });
+
+  it("rejects stale late release on an in-progress reroute until the old run is terminal", async () => {
+    const companyId = randomUUID();
+    const originalAgentId = randomUUID();
+    const nextAgentId = randomUUID();
+    const originalRunId = randomUUID();
+    const nextRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: originalAgentId,
+        companyId,
+        name: "Original Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: nextAgentId,
+        companyId,
+        name: "Next Builder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId: originalAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:24:00.000Z"),
+      },
+      {
+        id: nextRunId,
+        companyId,
+        agentId: nextAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "queued",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-05T15:25:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Late release should preserve in-progress reroute checkout ownership",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: originalAgentId,
+      checkoutRunId: originalRunId,
+      executionRunId: originalRunId,
+      executionAgentNameKey: "original-builder",
+      executionLockedAt: new Date("2026-04-05T15:24:00.000Z"),
+      startedAt: new Date("2026-04-05T15:24:00.000Z"),
+    });
+
+    let hookInjected = false;
+    const delayedDb = new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "transaction") {
+          return async (callback: Parameters<typeof db.transaction>[0]) => {
+            if (!hookInjected) {
+              hookInjected = true;
+              await target
+                .update(issues)
+                .set({
+                  assigneeAgentId: nextAgentId,
+                  updatedAt: new Date("2026-04-05T15:24:05.000Z"),
+                })
+                .where(eq(issues.id, issueId));
+            }
+            return target.transaction(callback);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof db;
+    const delayedSvc = issueService(delayedDb);
+
+    await expect(
+      delayedSvc.release(issueId, {
+        actorAgentId: originalAgentId,
+        actorRunId: originalRunId,
+      }),
+    ).rejects.toThrow("Only assignee can release issue");
+
+    const blockedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(blockedIssue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: originalRunId,
+        executionRunId: originalRunId,
+      }),
+    );
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "succeeded",
+        finishedAt: new Date("2026-04-05T15:24:30.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, originalRunId));
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date("2026-04-05T15:24:30.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+
+    const ownership = await svc.assertCheckoutOwner(issueId, nextAgentId, nextRunId);
+
+    expect(ownership).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: nextRunId,
+        adoptedFromRunId: originalRunId,
+      }),
+    );
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: nextAgentId,
+        checkoutRunId: nextRunId,
+        executionRunId: nextRunId,
+      }),
+    );
+  });
+
+  it("prefers the live execution owner over a stale checkout holder during retry promotion", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const originalRunId = randomUUID();
+    const retryRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-06T18:20:00.000Z"),
+      },
+      {
+        id: retryRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-06T18:20:10.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Retry run should own split execution",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: originalRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-06T18:20:10.000Z"),
+      startedAt: new Date("2026-04-06T18:20:00.000Z"),
+    });
+
+    await expect(svc.assertCheckoutOwner(issueId, agentId, originalRunId)).rejects.toThrow(
+      "Issue run ownership conflict",
+    );
+
+    const ownership = await svc.assertCheckoutOwner(issueId, agentId, retryRunId);
+
+    expect(ownership).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: originalRunId,
+        executionRunId: retryRunId,
+        adoptedFromRunId: null,
+      }),
+    );
+  });
+
+  it("does not adopt a stale checkout when a newer live execution owner exists", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const originalRunId = randomUUID();
+    const retryRunId = randomUUID();
+    const nextRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: originalRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T15:00:00.000Z"),
+        finishedAt: new Date("2026-04-11T15:05:00.000Z"),
+      },
+      {
+        id: retryRunId,
+        companyId,
+        agentId,
+        invocationSource: "retry",
+        triggerDetail: "process_loss",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T15:05:10.000Z"),
+      },
+      {
+        id: nextRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "manual",
+        status: "running",
+        contextSnapshot: { issueId },
+        startedAt: new Date("2026-04-11T15:06:00.000Z"),
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Retry execution should not be overwritten",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: originalRunId,
+      executionRunId: retryRunId,
+      executionAgentNameKey: "builder",
+      executionLockedAt: new Date("2026-04-11T15:05:10.000Z"),
+      startedAt: new Date("2026-04-11T15:00:00.000Z"),
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["in_progress"], nextRunId)).rejects.toThrow(
+      "Issue checkout conflict",
+    );
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issue).toEqual(
+      expect.objectContaining({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: originalRunId,
+        executionRunId: retryRunId,
+        executionAgentNameKey: "builder",
+      }),
+    );
   });
 });

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -136,7 +136,9 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         agentId: claims.sub,
         companyId: claims.company_id,
         keyId: undefined,
-        runId: runIdHeader || claims.run_id || undefined,
+        // Local agent JWTs carry a signed run id. Do not let an unsigned
+        // request header replace it.
+        runId: claims.run_id || undefined,
         source: "agent_jwt",
       };
       next();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1513,6 +1513,11 @@ export function issueRoutes(
       updateFields.assigneeUserId === undefined ? existing.assigneeUserId : (updateFields.assigneeUserId as string | null);
     const assigneeWillChange =
       nextAssigneeAgentId !== existing.assigneeAgentId || nextAssigneeUserId !== existing.assigneeUserId;
+    const requireLockedCheckoutOwnership =
+      req.actor.type === "agent" &&
+      !!actor.agentId &&
+      existing.status === "in_progress" &&
+      existing.assigneeAgentId === actor.agentId;
     const isAgentReturningIssueToCreator =
       req.actor.type === "agent" &&
       !!req.actor.agentId &&
@@ -1533,6 +1538,7 @@ export function issueRoutes(
       const updateActor = {
         actorAgentId: actor.agentId ?? null,
         actorRunId: trustedActorRunId,
+        ...(requireLockedCheckoutOwnership ? { requireCheckoutOwnership: true } : {}),
       };
       if (transition.decision && decisionId) {
         const decision = transition.decision;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -398,6 +398,12 @@ export function issueRoutes(
     return null;
   }
 
+  function trustedRunIdForUpdateClearance(req: Request, runId: string | null) {
+    if (req.actor.type === "agent") return runId;
+    if (req.actor.type === "board" && req.actor.source === "local_implicit") return runId;
+    return null;
+  }
+
   async function assertAgentRunCheckoutOwnership(
     req: Request,
     res: Response,
@@ -1376,6 +1382,7 @@ export function issueRoutes(
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
 
     const actor = getActorInfo(req);
+    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
     const isClosed = isClosedIssueStatus(existing.status);
     const normalizedAssigneeAgentId = await normalizeIssueAssigneeAgentReference(
       existing.companyId,
@@ -1432,7 +1439,7 @@ export function issueRoutes(
             actorType: actor.actorType,
             actorId: actor.actorId,
             agentId: actor.agentId,
-            runId: actor.runId,
+            runId: trustedActorRunId,
             action: "heartbeat.cancelled",
             entityType: "heartbeat_run",
             entityId: cancelled.id,
@@ -1511,6 +1518,10 @@ export function issueRoutes(
 
     let issue;
     try {
+      const updateActor = {
+        actorAgentId: actor.agentId ?? null,
+        actorRunId: trustedActorRunId,
+      };
       if (transition.decision && decisionId) {
         const decision = transition.decision;
         issue = await db.transaction(async (tx) => {
@@ -1521,6 +1532,7 @@ export function issueRoutes(
               actorAgentId: actor.agentId ?? null,
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
             },
+            updateActor,
             tx,
           );
           if (!updated) return null;
@@ -1535,7 +1547,7 @@ export function issueRoutes(
             actorUserId: actor.actorType === "user" ? actor.actorId : null,
             outcome: decision.outcome,
             body: decision.body,
-            createdByRunId: actor.runId ?? null,
+            createdByRunId: trustedActorRunId,
           });
 
           return updated;
@@ -1545,7 +1557,7 @@ export function issueRoutes(
           ...updateFields,
           actorAgentId: actor.agentId ?? null,
           actorUserId: actor.actorType === "user" ? actor.actorId : null,
-        });
+        }, updateActor);
       }
     } catch (err) {
       if (err instanceof HttpError && err.status === 422) {
@@ -1586,9 +1598,9 @@ export function issueRoutes(
     }
     await routinesSvc.syncRunStatusForIssue(issue.id);
 
-    if (actor.runId) {
-      await heartbeat.reportRunActivity(actor.runId).catch((err) =>
-        logger.warn({ err, runId: actor.runId }, "failed to clear detached run warning after issue activity"));
+    if (trustedActorRunId) {
+      await heartbeat.reportRunActivity(trustedActorRunId).catch((err) =>
+        logger.warn({ err, runId: trustedActorRunId }, "failed to clear detached run warning after issue activity"));
     }
 
     // Build activity details with previous values for changed fields
@@ -1615,7 +1627,7 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
-      runId: actor.runId,
+      runId: trustedActorRunId,
       action: "issue.updated",
       entityType: "issue",
       entityId: issue.id,
@@ -1642,7 +1654,7 @@ export function issueRoutes(
           actorType: actor.actorType,
           actorId: actor.actorId,
           agentId: actor.agentId,
-          runId: actor.runId,
+          runId: trustedActorRunId,
           action: "issue.blockers_updated",
           entityType: "issue",
           entityId: issue.id,
@@ -1670,7 +1682,7 @@ export function issueRoutes(
         actorType: actor.actorType,
         actorId: actor.actorId,
         agentId: actor.agentId,
-        runId: actor.runId,
+        runId: trustedActorRunId,
         action: "issue.reviewers_updated",
         entityType: "issue",
         entityId: issue.id,
@@ -1690,7 +1702,7 @@ export function issueRoutes(
         actorType: actor.actorType,
         actorId: actor.actorId,
         agentId: actor.agentId,
-        runId: actor.runId,
+        runId: trustedActorRunId,
         action: "issue.approvers_updated",
         entityType: "issue",
         entityId: issue.id,
@@ -1724,7 +1736,7 @@ export function issueRoutes(
       comment = await svc.addComment(id, commentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
+        runId: trustedActorRunId,
       });
 
       await logActivity(db, {
@@ -1732,7 +1744,7 @@ export function issueRoutes(
         actorType: actor.actorType,
         actorId: actor.actorId,
         agentId: actor.agentId,
-        runId: actor.runId,
+        runId: trustedActorRunId,
         action: "issue.comment_added",
         entityType: "issue",
         entityId: issue.id,
@@ -2033,13 +2045,14 @@ export function issueRoutes(
     if (req.actor.type === "agent" && !checkoutRunId) return;
     const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
     const actor = getActorInfo(req);
+    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
 
     await logActivity(db, {
       companyId: issue.companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
-      runId: actor.runId,
+      runId: trustedActorRunId,
       action: "issue.checked_out",
       entityType: "issue",
       entityId: issue.id,
@@ -2082,23 +2095,24 @@ export function issueRoutes(
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;
 
-    const released = await svc.release(
-      id,
-      req.actor.type === "agent" ? req.actor.agentId : undefined,
+    const released = await svc.release(id, {
+      actorAgentId: req.actor.type === "agent" ? req.actor.agentId : null,
       actorRunId,
-    );
+      actorUserId: req.actor.type === "board" ? req.actor.userId : null,
+    });
     if (!released) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
 
     const actor = getActorInfo(req);
+    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
     await logActivity(db, {
       companyId: released.companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
-      runId: actor.runId,
+      runId: trustedActorRunId,
       action: "issue.released",
       entityType: "issue",
       entityId: released.id,
@@ -2320,6 +2334,7 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
     const reopenRequested = req.body.reopen === true;
     const interruptRequested = req.body.interrupt === true;
     const isClosed = isClosedIssueStatus(issue.status);
@@ -2337,7 +2352,18 @@ export function issueRoutes(
     let currentIssue = issue;
 
     if (effectiveReopenRequested && isClosed) {
-      const reopenedIssue = await svc.update(id, { status: "todo" });
+      const reopenedIssue = await svc.update(
+        id,
+        {
+          status: "todo",
+          actorAgentId: actor.agentId ?? null,
+          actorUserId: actor.actorType === "user" ? actor.actorId : null,
+        },
+        {
+          actorAgentId: actor.agentId ?? null,
+          actorRunId: trustedActorRunId,
+        },
+      );
       if (!reopenedIssue) {
         res.status(404).json({ error: "Issue not found" });
         return;
@@ -2351,7 +2377,7 @@ export function issueRoutes(
         actorType: actor.actorType,
         actorId: actor.actorId,
         agentId: actor.agentId,
-        runId: actor.runId,
+        runId: trustedActorRunId,
         action: "issue.updated",
         entityType: "issue",
         entityId: currentIssue.id,
@@ -2381,7 +2407,7 @@ export function issueRoutes(
             actorType: actor.actorType,
             actorId: actor.actorId,
             agentId: actor.agentId,
-            runId: actor.runId,
+            runId: trustedActorRunId,
             action: "heartbeat.cancelled",
             entityType: "heartbeat_run",
             entityId: cancelled.id,
@@ -2394,12 +2420,12 @@ export function issueRoutes(
     const comment = await svc.addComment(id, req.body.body, {
       agentId: actor.agentId ?? undefined,
       userId: actor.actorType === "user" ? actor.actorId : undefined,
-      runId: actor.runId,
+      runId: trustedActorRunId,
     });
 
-    if (actor.runId) {
-      await heartbeat.reportRunActivity(actor.runId).catch((err) =>
-        logger.warn({ err, runId: actor.runId }, "failed to clear detached run warning after issue comment"));
+    if (trustedActorRunId) {
+      await heartbeat.reportRunActivity(trustedActorRunId).catch((err) =>
+        logger.warn({ err, runId: trustedActorRunId }, "failed to clear detached run warning after issue comment"));
     }
 
     await logActivity(db, {
@@ -2407,7 +2433,7 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
-      runId: actor.runId,
+      runId: trustedActorRunId,
       action: "issue.comment_added",
       entityType: "issue",
       entityId: currentIssue.id,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1774,14 +1774,13 @@ export function issueRoutes(
     }
     const assigneeChanged =
       issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
-    const statusChangedFromBacklog =
-      existing.status === "backlog" &&
+    const statusChangedToWakeableAssignedWork =
+      !assigneeChanged &&
+      !!issue.assigneeAgentId &&
+      req.body.status !== undefined &&
+      existing.status !== issue.status &&
       issue.status !== "backlog" &&
-      req.body.status !== undefined;
-    const statusChangedFromBlockedToTodo =
-      existing.status === "blocked" &&
-      issue.status === "todo" &&
-      req.body.status !== undefined;
+      (existing.status === "backlog" || issue.status === "todo" || issue.status === "in_review");
     const previousExecutionState = parseIssueExecutionState(existing.executionState);
     const nextExecutionState = parseIssueExecutionState(issue.executionState);
     const executionStageWakeup = buildExecutionStageWakeup({
@@ -1835,7 +1834,7 @@ export function issueRoutes(
         });
       }
 
-      if (!assigneeChanged && (statusChangedFromBacklog || statusChangedFromBlockedToTodo) && issue.assigneeAgentId) {
+      if (statusChangedToWakeableAssignedWork && issue.assigneeAgentId) {
         addWakeup(issue.assigneeAgentId, {
           source: "automation",
           triggerDetail: "system",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -398,9 +398,20 @@ export function issueRoutes(
     return null;
   }
 
-  function trustedRunIdForUpdateClearance(req: Request, runId: string | null) {
-    if (req.actor.type === "agent") return runId;
-    if (req.actor.type === "board" && req.actor.source === "local_implicit") return runId;
+  async function trustedRunIdForUpdateClearance(req: Request, runId: string | null, companyId?: string | null) {
+    if (!runId) return null;
+    if (req.actor.type === "agent") {
+      if (!req.actor.agentId) return null;
+      const run = await heartbeat.getRun(runId);
+      if (!run || run.agentId !== req.actor.agentId) return null;
+      if (companyId && run.companyId !== companyId) return null;
+      return runId;
+    }
+    if (req.actor.type === "board" && req.actor.source === "local_implicit") {
+      if (!companyId) return runId;
+      const run = await heartbeat.getRun(runId);
+      return run?.companyId === companyId ? runId : null;
+    }
     return null;
   }
 
@@ -896,6 +907,7 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const trustedActorRunId = await trustedRunIdForUpdateClearance(req, actor.runId ?? null, issue.companyId);
     const result = await documentsSvc.upsertIssueDocument({
       issueId: issue.id,
       key: keyParsed.data,
@@ -906,7 +918,7 @@ export function issueRoutes(
       baseRevisionId: req.body.baseRevisionId ?? null,
       createdByAgentId: actor.agentId ?? null,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
-      createdByRunId: actor.runId ?? null,
+      createdByRunId: trustedActorRunId,
     });
     const doc = result.document;
 
@@ -915,7 +927,7 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
       agentId: actor.agentId,
-      runId: actor.runId,
+      runId: trustedActorRunId,
       action: result.created ? "issue.document_created" : "issue.document_updated",
       entityType: "issue",
       entityId: issue.id,
@@ -1382,7 +1394,7 @@ export function issueRoutes(
     if (!(await assertAgentRunCheckoutOwnership(req, res, existing))) return;
 
     const actor = getActorInfo(req);
-    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
+    const trustedActorRunId = await trustedRunIdForUpdateClearance(req, actor.runId ?? null, existing.companyId);
     const isClosed = isClosedIssueStatus(existing.status);
     const normalizedAssigneeAgentId = await normalizeIssueAssigneeAgentReference(
       existing.companyId,
@@ -2045,7 +2057,7 @@ export function issueRoutes(
     if (req.actor.type === "agent" && !checkoutRunId) return;
     const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
     const actor = getActorInfo(req);
-    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
+    const trustedActorRunId = await trustedRunIdForUpdateClearance(req, actor.runId ?? null, issue.companyId);
 
     await logActivity(db, {
       companyId: issue.companyId,
@@ -2106,7 +2118,7 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
-    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
+    const trustedActorRunId = await trustedRunIdForUpdateClearance(req, actor.runId ?? null, released.companyId);
     await logActivity(db, {
       companyId: released.companyId,
       actorType: actor.actorType,
@@ -2334,7 +2346,7 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
-    const trustedActorRunId = trustedRunIdForUpdateClearance(req, actor.runId ?? null);
+    const trustedActorRunId = await trustedRunIdForUpdateClearance(req, actor.runId ?? null, issue.companyId);
     const reopenRequested = req.body.reopen === true;
     const interruptRequested = req.body.interrupt === true;
     const isClosed = isClosedIssueStatus(issue.status);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2129,6 +2129,10 @@ export function issueRoutes(
       entityId: released.id,
     });
 
+    await heartbeat
+      .promoteDeferredIssueWakeupForIssue(released.id, released.companyId)
+      .catch((err) => logger.warn({ err, issueId: released.id }, "failed to promote deferred wakeup on issue release"));
+
     res.json(released);
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -66,6 +66,7 @@ const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
+const LIVE_HEARTBEAT_RUN_STATUSES = new Set(["queued", "running"]);
 
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
@@ -405,12 +406,14 @@ export function issueRoutes(
       const run = await heartbeat.getRun(runId);
       if (!run || run.agentId !== req.actor.agentId) return null;
       if (companyId && run.companyId !== companyId) return null;
+      if (!LIVE_HEARTBEAT_RUN_STATUSES.has(run.status)) return null;
       return runId;
     }
     if (req.actor.type === "board" && req.actor.source === "local_implicit") {
-      if (!companyId) return runId;
       const run = await heartbeat.getRun(runId);
-      return run?.companyId === companyId ? runId : null;
+      if (!run || !LIVE_HEARTBEAT_RUN_STATUSES.has(run.status)) return null;
+      if (companyId && run.companyId !== companyId) return null;
+      return runId;
     }
     return null;
   }
@@ -1783,7 +1786,7 @@ export function issueRoutes(
     const statusChangedToWakeableAssignedWork =
       !assigneeChanged &&
       !!issue.assigneeAgentId &&
-      req.body.status !== undefined &&
+      updateFields.status !== undefined &&
       existing.status !== issue.status &&
       issue.status !== "backlog" &&
       (existing.status === "backlog" || issue.status === "todo" || issue.status === "in_review");
@@ -1864,7 +1867,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || (isClosed && !reopened);
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4144,6 +4144,7 @@ export function heartbeatService(db: Db) {
               status: "todo",
               executionState: null,
             },
+            undefined,
             tx,
           );
           if (reopenedIssue) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2194,16 +2194,6 @@ export function heartbeatService(db: Db) {
         .where(eq(agentWakeupRequests.id, wakeupRequest.id));
 
       await tx
-        .update(issues)
-        .set({
-          executionRunId: queuedRun.id,
-          executionAgentNameKey: normalizeAgentNameKey(agent.name),
-          executionLockedAt: now,
-          updatedAt: now,
-        })
-        .where(eq(issues.id, issue.id));
-
-      await tx
         .update(heartbeatRuns)
         .set({
           issueCommentStatus: "retry_queued",
@@ -2448,16 +2438,147 @@ export function heartbeatService(db: Db) {
     }
 
     const claimedAt = new Date();
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+    const claimedIssueId = readNonEmptyString(context.issueId);
+    const claimResult = await db.transaction(async (tx) => {
+      let claimIssueId: string | null = null;
+      let claimIssuePatch: Partial<typeof issues.$inferInsert> | null = null;
+
+      if (claimedIssueId) {
+        await tx.execute(
+          sql`
+            select id
+            from issues
+            where id = ${claimedIssueId}
+              and company_id = ${run.companyId}
+            for update
+          `,
+        );
+
+        const issue = await tx
+          .select({
+            id: issues.id,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(and(eq(issues.id, claimedIssueId), eq(issues.companyId, run.companyId)))
+          .then((rows) => rows[0] ?? null);
+
+        if (issue) {
+          const lockRunIds = [...new Set([issue.checkoutRunId, issue.executionRunId].filter(Boolean) as string[])];
+          const lockRuns = lockRunIds.length > 0
+            ? await tx
+              .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+              .from(heartbeatRuns)
+              .where(inArray(heartbeatRuns.id, lockRunIds))
+            : [];
+          const liveLockRunIds = new Set(
+            lockRuns
+              .filter((lockRun) => lockRun.status === "queued" || lockRun.status === "running")
+              .map((lockRun) => lockRun.id),
+          );
+          const hasForeignLiveLock = lockRunIds.some((runId) => runId !== run.id && liveLockRunIds.has(runId));
+
+          if (hasForeignLiveLock) {
+            const cancelled = await tx
+              .update(heartbeatRuns)
+              .set({
+                status: "cancelled",
+                startedAt: run.startedAt ?? claimedAt,
+                finishedAt: claimedAt,
+                error: "Deferred because issue is owned by another active run",
+                errorCode: "issue_execution_deferred",
+                updatedAt: claimedAt,
+              })
+              .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+              .returning()
+              .then((rows) => rows[0] ?? null);
+
+            if (cancelled?.wakeupRequestId) {
+              const wakeup = await tx
+                .select()
+                .from(agentWakeupRequests)
+                .where(eq(agentWakeupRequests.id, cancelled.wakeupRequestId))
+                .then((rows) => rows[0] ?? null);
+              const wakePayload = parseObject(wakeup?.payload);
+              await tx
+                .update(agentWakeupRequests)
+                .set({
+                  status: "deferred_issue_execution",
+                  reason: "issue_execution_deferred",
+                  payload: {
+                    ...wakePayload,
+                    issueId: issue.id,
+                    [DEFERRED_WAKE_CONTEXT_KEY]: {
+                      ...parseObject(wakePayload[DEFERRED_WAKE_CONTEXT_KEY]),
+                      ...context,
+                      issueId: issue.id,
+                    },
+                  },
+                  runId: null,
+                  claimedAt: null,
+                  finishedAt: null,
+                  error: null,
+                  updatedAt: claimedAt,
+                })
+                .where(eq(agentWakeupRequests.id, cancelled.wakeupRequestId));
+            }
+
+            return { claimed: null, cancelled };
+          }
+
+          claimIssueId = issue.id;
+          claimIssuePatch = {
+            executionRunId: run.id,
+            executionAgentNameKey: normalizeAgentNameKey(agent.name),
+            executionLockedAt: claimedAt,
+            updatedAt: claimedAt,
+          };
+          if (issue.checkoutRunId && !liveLockRunIds.has(issue.checkoutRunId)) {
+            claimIssuePatch.checkoutRunId = null;
+          }
+        }
+      }
+
+      const claimed = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          startedAt: run.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+
+      if (claimed && claimIssueId && claimIssuePatch) {
+        await tx
+          .update(issues)
+          .set(claimIssuePatch)
+          .where(eq(issues.id, claimIssueId));
+      }
+
+      return { claimed, cancelled: null };
+    });
+    if (claimResult.cancelled) {
+      publishLiveEvent({
+        companyId: claimResult.cancelled.companyId,
+        type: "heartbeat.run.status",
+        payload: {
+          runId: claimResult.cancelled.id,
+          agentId: claimResult.cancelled.agentId,
+          status: claimResult.cancelled.status,
+          invocationSource: claimResult.cancelled.invocationSource,
+          triggerDetail: claimResult.cancelled.triggerDetail,
+          error: claimResult.cancelled.error ?? null,
+          errorCode: claimResult.cancelled.errorCode ?? null,
+          startedAt: claimResult.cancelled.startedAt ? new Date(claimResult.cancelled.startedAt).toISOString() : null,
+          finishedAt: claimResult.cancelled.finishedAt ? new Date(claimResult.cancelled.finishedAt).toISOString() : null,
+        },
+      });
+    }
+
+    const claimed = claimResult.claimed;
     if (!claimed) return null;
 
     publishLiveEvent({
@@ -2477,28 +2598,6 @@ export function heartbeatService(db: Db) {
     });
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
-
-    // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedIssueId = readNonEmptyString(parseObject(claimed.contextSnapshot).issueId);
-    if (claimedIssueId) {
-      const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, claimedIssueId),
-            eq(issues.companyId, claimed.companyId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
-        );
-    }
 
     return claimed;
   }
@@ -4228,16 +4327,6 @@ export function heartbeatService(db: Db) {
           })
           .where(eq(agentWakeupRequests.id, deferred.id));
 
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: newRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
-            executionLockedAt: now,
-            updatedAt: now,
-          })
-          .where(eq(issues.id, issue.id));
-
         return {
           run: newRun,
           reopenedActivity,
@@ -4486,14 +4575,11 @@ export function heartbeatService(db: Db) {
             .where(
               and(
                 eq(heartbeatRuns.companyId, issue.companyId),
-                inArray(heartbeatRuns.status, ["queued", "running"]),
+                eq(heartbeatRuns.status, "running"),
                 sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
               ),
             )
-            .orderBy(
-              sql`case when ${heartbeatRuns.status} = 'running' then 0 else 1 end`,
-              asc(heartbeatRuns.createdAt),
-            )
+            .orderBy(asc(heartbeatRuns.createdAt))
             .limit(1)
             .then((rows) => rows[0] ?? null);
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4022,7 +4022,13 @@ export function heartbeatService(db: Db) {
         );
       } else {
         await tx.execute(
-          sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
+          sql`
+            select id
+            from issues
+            where company_id = ${run.companyId}
+              and (execution_run_id = ${run.id} or checkout_run_id = ${run.id})
+            for update
+          `,
         );
       }
 
@@ -4032,13 +4038,16 @@ export function heartbeatService(db: Db) {
           companyId: issues.companyId,
           identifier: issues.identifier,
           status: issues.status,
+          checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(
           and(
             eq(issues.companyId, run.companyId),
-            contextIssueId ? eq(issues.id, contextIssueId) : eq(issues.executionRunId, run.id),
+            contextIssueId
+              ? eq(issues.id, contextIssueId)
+              : or(eq(issues.executionRunId, run.id), eq(issues.checkoutRunId, run.id)),
           ),
         )
         .then((rows) => rows[0] ?? null);
@@ -4046,17 +4055,35 @@ export function heartbeatService(db: Db) {
       if (!issue) return null;
       if (issue.executionRunId && issue.executionRunId !== run.id) return null;
 
-      if (issue.executionRunId === run.id) {
-        await tx
-          .update(issues)
-          .set({
-            executionRunId: null,
-            executionAgentNameKey: null,
-            executionLockedAt: null,
-            updatedAt: new Date(),
-          })
-          .where(eq(issues.id, issue.id));
+      let checkoutClearable = issue.checkoutRunId === run.id;
+      if (issue.checkoutRunId && issue.checkoutRunId !== run.id) {
+        const checkoutRun = await tx
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, issue.checkoutRunId))
+          .then((rows) => rows[0] ?? null);
+        checkoutClearable = !checkoutRun || (checkoutRun.status !== "queued" && checkoutRun.status !== "running");
       }
+
+      const issuePatch: Partial<typeof issues.$inferInsert> = {
+        updatedAt: new Date(),
+      };
+      if (checkoutClearable) {
+        issuePatch.checkoutRunId = null;
+      }
+      if (issue.executionRunId === run.id) {
+        issuePatch.executionRunId = null;
+        issuePatch.executionAgentNameKey = null;
+        issuePatch.executionLockedAt = null;
+      }
+
+      await tx
+        .update(issues)
+        .set(issuePatch)
+        .where(eq(issues.id, issue.id));
+
+      if (issue.checkoutRunId && !checkoutClearable) return null;
+      if (issue.executionRunId && issue.executionRunId !== run.id) return null;
 
       while (true) {
         const deferred = await tx
@@ -4352,6 +4379,7 @@ export function heartbeatService(db: Db) {
           .select({
             id: issues.id,
             companyId: issues.companyId,
+            checkoutRunId: issues.checkoutRunId,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
           })
@@ -4376,13 +4404,16 @@ export function heartbeatService(db: Db) {
           return { kind: "skipped" as const };
         }
 
-        let activeExecutionRun = issue.executionRunId
-          ? await tx
-            .select()
-            .from(heartbeatRuns)
-            .where(eq(heartbeatRuns.id, issue.executionRunId))
-            .then((rows) => rows[0] ?? null)
-          : null;
+        const getActiveIssueRun = (runId: string | null) =>
+          runId
+            ? tx
+              .select()
+              .from(heartbeatRuns)
+              .where(eq(heartbeatRuns.id, runId))
+              .then((rows) => rows[0] ?? null)
+            : Promise.resolve(null);
+
+        let activeExecutionRun = await getActiveIssueRun(issue.executionRunId);
 
         if (activeExecutionRun && activeExecutionRun.status !== "queued" && activeExecutionRun.status !== "running") {
           activeExecutionRun = null;
@@ -4398,6 +4429,25 @@ export function heartbeatService(db: Db) {
               updatedAt: new Date(),
             })
             .where(eq(issues.id, issue.id));
+        }
+
+        if (!activeExecutionRun) {
+          let activeCheckoutRun = await getActiveIssueRun(issue.checkoutRunId);
+          if (activeCheckoutRun && activeCheckoutRun.status !== "queued" && activeCheckoutRun.status !== "running") {
+            activeCheckoutRun = null;
+          }
+
+          if (activeCheckoutRun) {
+            activeExecutionRun = activeCheckoutRun;
+          } else if (issue.checkoutRunId) {
+            await tx
+              .update(issues)
+              .set({
+                checkoutRunId: null,
+                updatedAt: new Date(),
+              })
+              .where(and(eq(issues.id, issue.id), eq(issues.checkoutRunId, issue.checkoutRunId)));
+          }
         }
 
         if (!activeExecutionRun) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4012,25 +4012,21 @@ export function heartbeatService(db: Db) {
         }
   }
 
-  async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
-    const runContext = parseObject(run.contextSnapshot);
-    const contextIssueId = readNonEmptyString(runContext.issueId);
+  async function promoteDeferredIssueWakeupForIssue(
+    issueId: string,
+    companyId?: string | null,
+    promotedByRunId?: string | null,
+  ) {
     const promotionResult = await db.transaction(async (tx) => {
-      if (contextIssueId) {
-        await tx.execute(
-          sql`select id from issues where company_id = ${run.companyId} and id = ${contextIssueId} for update`,
-        );
-      } else {
-        await tx.execute(
-          sql`
-            select id
-            from issues
-            where company_id = ${run.companyId}
-              and (execution_run_id = ${run.id} or checkout_run_id = ${run.id})
-            for update
-          `,
-        );
-      }
+      await tx.execute(
+        sql`
+          select id
+          from issues
+          where id = ${issueId}
+            ${companyId ? sql`and company_id = ${companyId}` : sql``}
+          for update
+        `,
+      );
 
       let issue = await tx
         .select({
@@ -4042,21 +4038,13 @@ export function heartbeatService(db: Db) {
           executionRunId: issues.executionRunId,
         })
         .from(issues)
-        .where(
-          and(
-            eq(issues.companyId, run.companyId),
-            contextIssueId
-              ? eq(issues.id, contextIssueId)
-              : or(eq(issues.executionRunId, run.id), eq(issues.checkoutRunId, run.id)),
-          ),
-        )
+        .where(companyId ? and(eq(issues.id, issueId), eq(issues.companyId, companyId)) : eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
       if (!issue) return null;
-      if (issue.executionRunId && issue.executionRunId !== run.id) return null;
 
-      let checkoutClearable = issue.checkoutRunId === run.id;
-      if (issue.checkoutRunId && issue.checkoutRunId !== run.id) {
+      let checkoutClearable = true;
+      if (issue.checkoutRunId) {
         const checkoutRun = await tx
           .select({ status: heartbeatRuns.status })
           .from(heartbeatRuns)
@@ -4065,25 +4053,38 @@ export function heartbeatService(db: Db) {
         checkoutClearable = !checkoutRun || (checkoutRun.status !== "queued" && checkoutRun.status !== "running");
       }
 
+      let executionClearable = true;
+      if (issue.executionRunId) {
+        const executionRun = await tx
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, issue.executionRunId))
+          .then((rows) => rows[0] ?? null);
+        executionClearable =
+          !executionRun || (executionRun.status !== "queued" && executionRun.status !== "running");
+      }
+
       const issuePatch: Partial<typeof issues.$inferInsert> = {
         updatedAt: new Date(),
       };
-      if (checkoutClearable) {
+      if (issue.checkoutRunId && checkoutClearable) {
         issuePatch.checkoutRunId = null;
       }
-      if (issue.executionRunId === run.id) {
+      if (issue.executionRunId && executionClearable) {
         issuePatch.executionRunId = null;
         issuePatch.executionAgentNameKey = null;
         issuePatch.executionLockedAt = null;
       }
 
-      await tx
-        .update(issues)
-        .set(issuePatch)
-        .where(eq(issues.id, issue.id));
+      if (issue.checkoutRunId || issue.executionRunId) {
+        await tx
+          .update(issues)
+          .set(issuePatch)
+          .where(eq(issues.id, issue.id));
+      }
 
       if (issue.checkoutRunId && !checkoutClearable) return null;
-      if (issue.executionRunId && issue.executionRunId !== run.id) return null;
+      if (issue.executionRunId && !executionClearable) return null;
 
       while (true) {
         const deferred = await tx
@@ -4160,7 +4161,7 @@ export function heartbeatService(db: Db) {
               actorType: "system",
               actorId: "heartbeat",
               agentId: deferred.agentId,
-              runId: run.id,
+              runId: promotedByRunId ?? null,
               action: "issue.updated",
               entityType: "issue",
               entityId: issue.id,
@@ -4263,6 +4264,33 @@ export function heartbeatService(db: Db) {
     });
 
     await startNextQueuedRunForAgent(promotedRun.agentId);
+    return promotedRun;
+  }
+
+  async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
+    const issueIds = new Set<string>();
+
+    const lockedIssueIds = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, run.companyId),
+          or(eq(issues.executionRunId, run.id), eq(issues.checkoutRunId, run.id)),
+        ),
+      );
+    for (const issue of lockedIssueIds) {
+      issueIds.add(issue.id);
+    }
+
+    const contextIssueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+    if (contextIssueId) {
+      issueIds.add(contextIssueId);
+    }
+
+    for (const issueId of issueIds) {
+      await promoteDeferredIssueWakeupForIssue(issueId, run.companyId, run.id);
+    }
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
@@ -4494,8 +4522,8 @@ export function heartbeatService(db: Db) {
             .where(eq(agents.id, activeExecutionRun.agentId))
             .then((rows) => rows[0] ?? null);
           const executionAgentNameKey =
-            normalizeAgentNameKey(issue.executionAgentNameKey) ??
-            normalizeAgentNameKey(executionAgent?.name);
+            normalizeAgentNameKey(executionAgent?.name) ??
+            normalizeAgentNameKey(issue.executionAgentNameKey);
           const isSameExecutionAgent =
             Boolean(executionAgentNameKey) && executionAgentNameKey === agentNameKey;
           const shouldQueueFollowupForCommentWake =
@@ -5119,6 +5147,8 @@ export function heartbeatService(db: Db) {
       }),
 
     wakeup: enqueueWakeup,
+
+    promoteDeferredIssueWakeupForIssue,
 
     reportRunActivity: clearDetachedRunWarning,
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2180,6 +2180,13 @@ export function issueService(db: Db) {
         const actorStillOwnsIssue =
           (actorAgentId != null && current.assigneeAgentId === actorAgentId) ||
           (actorUserId != null && current.assigneeUserId === actorUserId);
+        const actorIsBoardOperator = actorAgentId == null && actorUserId != null;
+        const issueHasTrackedRunLock = current.checkoutRunId != null || current.executionRunId != null;
+        const canBoardOperatorReleaseStaleAgentLocks =
+          actorIsBoardOperator &&
+          current.assigneeAgentId != null &&
+          current.assigneeUserId == null &&
+          issueHasTrackedRunLock;
         const {
           actorOwnsCheckout,
           actorOwnsExecution,
@@ -2192,7 +2199,8 @@ export function issueService(db: Db) {
           (actorAgentId != null || actorUserId != null) &&
           !actorStillOwnsIssue &&
           !actorOwnsCheckout &&
-          !actorOwnsExecution
+          !actorOwnsExecution &&
+          !canBoardOperatorReleaseStaleAgentLocks
         ) {
           throw conflict("Only assignee can release issue");
         }
@@ -2201,7 +2209,7 @@ export function issueService(db: Db) {
           updatedAt: new Date(),
         };
 
-        if (actorStillOwnsIssue) {
+        if (actorStillOwnsIssue || canBoardOperatorReleaseStaleAgentLocks) {
           if (!canClearAllTrackedLocks) {
             throw conflict("Issue still owned by active run", {
               issueId: current.id,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -981,13 +981,15 @@ export function issueService(db: Db) {
     expectedCheckoutRunId: string;
     expectedExecutionRunId: string | null;
   }) {
+    const actorRunState = await getRunLockState(db, input.actorRunId, input.actorAgentId);
+    if (!actorRunState.liveBelongsToActor) return null;
+
     const stale = await isTerminalOrMissingHeartbeatRun(db, input.expectedCheckoutRunId);
     if (!stale) return null;
 
     let executionClearable = input.expectedExecutionRunId === null;
     if (!executionClearable && input.expectedExecutionRunId === input.actorRunId) {
-      const actorRunState = await getRunLockState(db, input.actorRunId, input.actorAgentId);
-      executionClearable = actorRunState.liveBelongsToActor || actorRunState.terminalOrMissing;
+      executionClearable = true;
     }
     if (!executionClearable && input.expectedExecutionRunId) {
       executionClearable = await isTerminalOrMissingHeartbeatRun(db, input.expectedExecutionRunId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1859,8 +1859,9 @@ export function issueService(db: Db) {
       await assertAssignableAgent(issueCompany.companyId, agentId);
 
       if (checkoutRunId) {
-        const checkoutRunState = await getRunLockState(db, checkoutRunId, agentId);
-        if (!checkoutRunState.terminalOrMissing && !checkoutRunState.liveBelongsToActor) {
+        const checkoutRun = await getHeartbeatRun(db, checkoutRunId);
+        const checkoutRunIsLive = checkoutRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(checkoutRun.status);
+        if (!checkoutRunIsLive || checkoutRun.agentId !== agentId) {
           throw conflict("Issue checkout conflict", {
             issueId: id,
             assigneeAgentId: agentId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -64,6 +64,13 @@ function applyStatusSideEffects(
   return patch;
 }
 
+function clearExecutionOwnership(patch: Partial<typeof issues.$inferInsert>) {
+  patch.checkoutRunId = null;
+  patch.executionRunId = null;
+  patch.executionAgentNameKey = null;
+  patch.executionLockedAt = null;
+}
+
 export interface IssueFilters {
   status?: string;
   assigneeAgentId?: string;
@@ -124,6 +131,16 @@ type IssueRelationSummaryMap = {
   blockedBy: IssueRelationIssueSummary[];
   blocks: IssueRelationIssueSummary[];
 };
+type IssueUpdateActor = {
+  actorAgentId?: string | null;
+  actorRunId?: string | null;
+};
+type IssueReleaseActor = {
+  actorAgentId?: string | null;
+  actorRunId?: string | null;
+  actorUserId?: string | null;
+};
+type HeartbeatRunReader = Pick<Db, "select">;
 
 function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
   if (actorRunId) return checkoutRunId === actorRunId;
@@ -861,14 +878,85 @@ export function issueService(db: Db) {
     );
   }
 
-  async function isTerminalOrMissingHeartbeatRun(runId: string) {
-    const run = await db
-      .select({ status: heartbeatRuns.status })
+  async function getHeartbeatRun(reader: HeartbeatRunReader, runId: string) {
+    return reader
+      .select({ agentId: heartbeatRuns.agentId, status: heartbeatRuns.status })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
-    if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+  }
+
+  async function getRunLockState(
+    reader: HeartbeatRunReader,
+    runId: string,
+    actorAgentId: string | null | undefined,
+  ) {
+    const run = await getHeartbeatRun(reader, runId);
+    const terminalOrMissing = !run || TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    return {
+      terminalOrMissing,
+      liveBelongsToActor: Boolean(run && !terminalOrMissing && actorAgentId && run.agentId === actorAgentId),
+    };
+  }
+
+  async function isTerminalOrMissingHeartbeatRun(reader: HeartbeatRunReader, runId: string) {
+    const run = await getHeartbeatRun(reader, runId);
+    return !run || TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+  }
+
+  async function canClearExecutionOwnershipOnUpdate(
+    reader: HeartbeatRunReader,
+    existing: typeof issues.$inferSelect,
+    actor?: IssueUpdateActor,
+  ) {
+    if (!existing.executionRunId) return true;
+
+    if (actor?.actorRunId && existing.executionRunId === actor.actorRunId) {
+      const run = await getHeartbeatRun(reader, actor.actorRunId);
+      if (!run || TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+      if (run.agentId !== existing.assigneeAgentId) return false;
+      if (actor.actorAgentId && run.agentId !== actor.actorAgentId) return false;
+      return true;
+    }
+
+    return isTerminalOrMissingHeartbeatRun(reader, existing.executionRunId);
+  }
+
+  async function getReleaseLockClearance(
+    reader: HeartbeatRunReader,
+    existing: typeof issues.$inferSelect,
+    actor?: IssueReleaseActor,
+  ) {
+    const actorAgentId = actor?.actorAgentId ?? null;
+    const actorRunId = actor?.actorRunId ?? null;
+    const checkoutRunState =
+      existing.checkoutRunId && actorRunId && existing.checkoutRunId === actorRunId
+        ? await getRunLockState(reader, existing.checkoutRunId, actorAgentId)
+        : null;
+    const executionRunState =
+      existing.executionRunId && actorRunId && existing.executionRunId === actorRunId
+        ? existing.checkoutRunId === existing.executionRunId
+          ? checkoutRunState
+          : await getRunLockState(reader, existing.executionRunId, actorAgentId)
+        : null;
+    const actorOwnsCheckout = Boolean(checkoutRunState?.liveBelongsToActor);
+    const actorOwnsExecution = Boolean(executionRunState?.liveBelongsToActor);
+
+    const [checkoutClearable, executionClearable] = await Promise.all([
+      existing.checkoutRunId && !actorOwnsCheckout
+        ? isTerminalOrMissingHeartbeatRun(reader, existing.checkoutRunId)
+        : true,
+      existing.executionRunId && !actorOwnsExecution
+        ? isTerminalOrMissingHeartbeatRun(reader, existing.executionRunId)
+        : true,
+    ]);
+
+    return {
+      actorOwnsCheckout,
+      actorOwnsExecution,
+      checkoutClearable,
+      executionClearable,
+    };
   }
 
   async function adoptStaleCheckoutRun(input: {
@@ -876,9 +964,20 @@ export function issueService(db: Db) {
     actorAgentId: string;
     actorRunId: string;
     expectedCheckoutRunId: string;
+    expectedExecutionRunId: string | null;
   }) {
-    const stale = await isTerminalOrMissingHeartbeatRun(input.expectedCheckoutRunId);
+    const stale = await isTerminalOrMissingHeartbeatRun(db, input.expectedCheckoutRunId);
     if (!stale) return null;
+
+    let executionClearable = input.expectedExecutionRunId === null;
+    if (!executionClearable && input.expectedExecutionRunId === input.actorRunId) {
+      const actorRunState = await getRunLockState(db, input.actorRunId, input.actorAgentId);
+      executionClearable = actorRunState.liveBelongsToActor || actorRunState.terminalOrMissing;
+    }
+    if (!executionClearable && input.expectedExecutionRunId) {
+      executionClearable = await isTerminalOrMissingHeartbeatRun(db, input.expectedExecutionRunId);
+    }
+    if (!executionClearable) return null;
 
     const now = new Date();
     const adopted = await db
@@ -895,6 +994,9 @@ export function issueService(db: Db) {
           eq(issues.status, "in_progress"),
           eq(issues.assigneeAgentId, input.actorAgentId),
           eq(issues.checkoutRunId, input.expectedCheckoutRunId),
+          input.expectedExecutionRunId === null
+            ? isNull(issues.executionRunId)
+            : eq(issues.executionRunId, input.expectedExecutionRunId),
         ),
       )
       .returning({
@@ -1562,6 +1664,7 @@ export function issueService(db: Db) {
         actorAgentId?: string | null;
         actorUserId?: string | null;
       },
+      actor?: IssueUpdateActor,
       dbOrTx: any = db,
     ) => {
       const existing = await dbOrTx
@@ -1630,37 +1733,38 @@ export function issueService(db: Db) {
       if (issueData.status && issueData.status !== "cancelled") {
         patch.cancelledAt = null;
       }
-      if (issueData.status && issueData.status !== "in_progress") {
-        patch.checkoutRunId = null;
-        // Fix B: also clear the execution lock when leaving in_progress
-        patch.executionRunId = null;
-        patch.executionAgentNameKey = null;
-        patch.executionLockedAt = null;
-      }
-      if (
-        (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
-        (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
-      ) {
-        patch.checkoutRunId = null;
-        // Fix B: clear execution lock on reassignment, matching checkoutRunId clear
-        patch.executionRunId = null;
-        patch.executionAgentNameKey = null;
-        patch.executionLockedAt = null;
-      }
+      const leavesActiveExecutionStage = issueData.status !== undefined && issueData.status !== "in_progress";
 
       const runUpdate = async (tx: any) => {
-        const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
+        await tx.execute(sql`select id from issues where id = ${id} for update`);
+        const lockedExisting = await tx
+          .select()
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
+        if (!lockedExisting) return null;
+        const lockedAssigneeChanged =
+          (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== lockedExisting.assigneeAgentId) ||
+          (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== lockedExisting.assigneeUserId);
+        if (
+          (leavesActiveExecutionStage || lockedAssigneeChanged) &&
+          await canClearExecutionOwnershipOnUpdate(tx, lockedExisting, actor)
+        ) {
+          clearExecutionOwnership(patch);
+        }
+
+        const defaultCompanyGoal = await getDefaultCompanyGoal(tx, lockedExisting.companyId);
         const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
-          getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),
+          getProjectDefaultGoalId(tx, lockedExisting.companyId, lockedExisting.projectId),
           getProjectDefaultGoalId(
             tx,
-            existing.companyId,
-            issueData.projectId !== undefined ? issueData.projectId : existing.projectId,
+            lockedExisting.companyId,
+            issueData.projectId !== undefined ? issueData.projectId : lockedExisting.projectId,
           ),
         ]);
         patch.goalId = resolveNextIssueGoalId({
-          currentProjectId: existing.projectId,
-          currentGoalId: existing.goalId,
+          currentProjectId: lockedExisting.projectId,
+          currentGoalId: lockedExisting.goalId,
           currentProjectGoalId,
           projectId: issueData.projectId,
           goalId: issueData.goalId,
@@ -1738,6 +1842,17 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!issueCompany) throw notFound("Issue not found");
       await assertAssignableAgent(issueCompany.companyId, agentId);
+
+      if (checkoutRunId) {
+        const checkoutRunState = await getRunLockState(db, checkoutRunId, agentId);
+        if (!checkoutRunState.terminalOrMissing && !checkoutRunState.liveBelongsToActor) {
+          throw conflict("Issue checkout conflict", {
+            issueId: id,
+            assigneeAgentId: agentId,
+            checkoutRunId,
+          });
+        }
+      }
 
       const now = new Date();
 
@@ -1824,6 +1939,16 @@ export function issueService(db: Db) {
 
       if (!current) throw notFound("Issue not found");
 
+      const executionRun = current.executionRunId ? await getHeartbeatRun(db, current.executionRunId) : null;
+      const actorOwnsExecution =
+        checkoutRunId != null &&
+        current.executionRunId === checkoutRunId &&
+        executionRun?.agentId === agentId;
+      const foreignExecutionClearable =
+        current.executionRunId && !actorOwnsExecution
+          ? !executionRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)
+          : true;
+
       if (
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
@@ -1864,6 +1989,7 @@ export function issueService(db: Db) {
           actorAgentId: agentId,
           actorRunId: checkoutRunId,
           expectedCheckoutRunId: current.checkoutRunId,
+          expectedExecutionRunId: current.executionRunId,
         });
         if (adopted) {
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
@@ -1877,7 +2003,8 @@ export function issueService(db: Db) {
       if (
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
-        sameRunLock(current.checkoutRunId, checkoutRunId)
+        (actorOwnsExecution || sameRunLock(current.checkoutRunId, checkoutRunId)) &&
+        foreignExecutionClearable
       ) {
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
         if (!row) throw notFound("Issue not found");
@@ -1901,6 +2028,7 @@ export function issueService(db: Db) {
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, id))
@@ -1908,26 +2036,38 @@ export function issueService(db: Db) {
 
       if (!current) throw notFound("Issue not found");
 
+      const actorStillAssigned = current.status === "in_progress" && current.assigneeAgentId === actorAgentId;
+      const executionRun = current.executionRunId ? await getHeartbeatRun(db, current.executionRunId) : null;
+      const actorOwnsExecution =
+        actorRunId != null &&
+        current.executionRunId === actorRunId &&
+        executionRun?.agentId === actorAgentId;
+      const foreignExecutionClearable =
+        current.executionRunId && !actorOwnsExecution
+          ? !executionRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)
+          : true;
+
       if (
-        current.status === "in_progress" &&
-        current.assigneeAgentId === actorAgentId &&
-        sameRunLock(current.checkoutRunId, actorRunId)
+        actorStillAssigned &&
+        (actorOwnsExecution || sameRunLock(current.checkoutRunId, actorRunId)) &&
+        foreignExecutionClearable
       ) {
         return { ...current, adoptedFromRunId: null as string | null };
       }
 
       if (
         actorRunId &&
-        current.status === "in_progress" &&
-        current.assigneeAgentId === actorAgentId &&
+        actorStillAssigned &&
         current.checkoutRunId &&
-        current.checkoutRunId !== actorRunId
+        current.checkoutRunId !== actorRunId &&
+        foreignExecutionClearable
       ) {
         const adopted = await adoptStaleCheckoutRun({
           issueId: id,
           actorAgentId,
           actorRunId,
           expectedCheckoutRunId: current.checkoutRunId,
+          expectedExecutionRunId: current.executionRunId,
         });
 
         if (adopted) {
@@ -1943,52 +2083,108 @@ export function issueService(db: Db) {
         status: current.status,
         assigneeAgentId: current.assigneeAgentId,
         checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
         actorAgentId,
         actorRunId,
       });
     },
 
-    release: async (id: string, actorAgentId?: string, actorRunId?: string | null) => {
-      const existing = await db
-        .select()
-        .from(issues)
-        .where(eq(issues.id, id))
-        .then((rows) => rows[0] ?? null);
+    release: async (id: string, actor?: IssueReleaseActor) =>
+      db.transaction(async (tx) => {
+        await tx.execute(sql`select id from issues where id = ${id} for update`);
 
-      if (!existing) return null;
-      if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
-        throw conflict("Only assignee can release issue");
-      }
-      if (
-        actorAgentId &&
-        existing.status === "in_progress" &&
-        existing.assigneeAgentId === actorAgentId &&
-        existing.checkoutRunId &&
-        !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
-      ) {
-        throw conflict("Only checkout run can release issue", {
-          issueId: existing.id,
-          assigneeAgentId: existing.assigneeAgentId,
-          checkoutRunId: existing.checkoutRunId,
-          actorRunId: actorRunId ?? null,
-        });
-      }
+        const current = await tx
+          .select()
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
 
-      const updated = await db
-        .update(issues)
-        .set({
-          status: "todo",
-          assigneeAgentId: null,
-          checkoutRunId: null,
+        if (!current) return null;
+
+        const actorAgentId = actor?.actorAgentId ?? null;
+        const actorRunId = actor?.actorRunId ?? null;
+        const actorUserId = actor?.actorUserId ?? null;
+        const actorStillOwnsIssue =
+          (actorAgentId != null && current.assigneeAgentId === actorAgentId) ||
+          (actorUserId != null && current.assigneeUserId === actorUserId);
+        const {
+          actorOwnsCheckout,
+          actorOwnsExecution,
+          checkoutClearable,
+          executionClearable,
+        } = await getReleaseLockClearance(tx, current, actor);
+        const canClearAllTrackedLocks = checkoutClearable && executionClearable;
+
+        if (
+          (actorAgentId != null || actorUserId != null) &&
+          !actorStillOwnsIssue &&
+          !actorOwnsCheckout &&
+          !actorOwnsExecution
+        ) {
+          throw conflict("Only assignee can release issue");
+        }
+
+        const patch: Partial<typeof issues.$inferInsert> = {
           updatedAt: new Date(),
-        })
-        .where(eq(issues.id, id))
-        .returning()
-        .then((rows) => rows[0] ?? null);
-      if (!updated) return null;
-      const [enriched] = await withIssueLabels(db, [updated]);
-      return enriched;
-    },
+        };
+
+        if (actorStillOwnsIssue) {
+          if (!canClearAllTrackedLocks) {
+            throw conflict("Issue still owned by active run", {
+              issueId: current.id,
+              assigneeAgentId: current.assigneeAgentId,
+              assigneeUserId: current.assigneeUserId,
+              checkoutRunId: current.checkoutRunId,
+              executionRunId: current.executionRunId,
+              actorAgentId,
+              actorRunId,
+              actorUserId,
+            });
+          }
+          patch.status = "todo";
+          patch.assigneeAgentId = null;
+          patch.assigneeUserId = null;
+          clearExecutionOwnership(patch);
+        } else if (actorOwnsCheckout || actorOwnsExecution) {
+          if (!canClearAllTrackedLocks) {
+            throw conflict("Issue still owned by active run", {
+              issueId: current.id,
+              assigneeAgentId: current.assigneeAgentId,
+              assigneeUserId: current.assigneeUserId,
+              checkoutRunId: current.checkoutRunId,
+              executionRunId: current.executionRunId,
+              actorAgentId,
+              actorRunId,
+              actorUserId,
+            });
+          }
+          if (current.status === "in_progress" && (current.assigneeAgentId || current.assigneeUserId)) {
+            throw conflict("Only assignee can release issue", {
+              issueId: current.id,
+              assigneeAgentId: current.assigneeAgentId,
+              assigneeUserId: current.assigneeUserId,
+              checkoutRunId: current.checkoutRunId,
+              executionRunId: current.executionRunId,
+              actorAgentId,
+              actorRunId,
+              actorUserId,
+            });
+          }
+          clearExecutionOwnership(patch);
+        } else {
+          return (await withIssueLabels(tx, [current]))[0] ?? null;
+        }
+
+        const updated = await tx
+          .update(issues)
+          .set(patch)
+          .where(eq(issues.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+        const [enriched] = await withIssueLabels(tx, [updated]);
+        return enriched;
+      }),
 
     listLabels: (companyId: string) =>
       db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -134,6 +134,7 @@ type IssueRelationSummaryMap = {
 type IssueUpdateActor = {
   actorAgentId?: string | null;
   actorRunId?: string | null;
+  requireCheckoutOwnership?: boolean;
 };
 type IssueReleaseActor = {
   actorAgentId?: string | null;
@@ -935,6 +936,45 @@ export function issueService(db: Db) {
       canClearRun(existing.executionRunId),
     ]);
     return checkoutClearable && executionClearable;
+  }
+
+  async function assertLiveActorRunOwnsIssue(
+    reader: HeartbeatRunReader,
+    current: Pick<
+      typeof issues.$inferSelect,
+      "id" | "status" | "assigneeAgentId" | "checkoutRunId" | "executionRunId"
+    >,
+    actorAgentId: string | null | undefined,
+    actorRunId: string | null | undefined,
+  ) {
+    const actorRunState = actorRunId ? await getRunLockState(reader, actorRunId, actorAgentId) : null;
+    const actorRunIsLiveOwner = Boolean(actorRunState?.liveBelongsToActor);
+    const actorStillAssigned =
+      current.status === "in_progress" &&
+      actorAgentId != null &&
+      current.assigneeAgentId === actorAgentId;
+    const actorOwnsCheckout = actorRunIsLiveOwner && current.checkoutRunId === actorRunId;
+    const actorOwnsExecution = actorRunIsLiveOwner && current.executionRunId === actorRunId;
+    const executionRun =
+      current.executionRunId && !actorOwnsExecution ? await getHeartbeatRun(reader, current.executionRunId) : null;
+    const foreignExecutionClearable =
+      current.executionRunId && !actorOwnsExecution
+        ? !executionRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)
+        : true;
+
+    if (actorStillAssigned && (actorOwnsCheckout || actorOwnsExecution) && foreignExecutionClearable) {
+      return;
+    }
+
+    throw conflict("Issue run ownership conflict", {
+      issueId: current.id,
+      status: current.status,
+      assigneeAgentId: current.assigneeAgentId,
+      checkoutRunId: current.checkoutRunId,
+      executionRunId: current.executionRunId,
+      actorAgentId,
+      actorRunId,
+    });
   }
 
   async function getReleaseLockClearance(
@@ -1760,6 +1800,14 @@ export function issueService(db: Db) {
           .where(eq(issues.id, id))
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!lockedExisting) return null;
+        if (actor?.requireCheckoutOwnership) {
+          await assertLiveActorRunOwnsIssue(
+            tx,
+            lockedExisting,
+            actor.actorAgentId ?? null,
+            actor.actorRunId ?? null,
+          );
+        }
         const lockedAssigneeChanged =
           (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== lockedExisting.assigneeAgentId) ||
           (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== lockedExisting.assigneeUserId);
@@ -2055,11 +2103,12 @@ export function issueService(db: Db) {
       if (!current) throw notFound("Issue not found");
 
       const actorStillAssigned = current.status === "in_progress" && current.assigneeAgentId === actorAgentId;
-      const executionRun = current.executionRunId ? await getHeartbeatRun(db, current.executionRunId) : null;
-      const actorOwnsExecution =
-        actorRunId != null &&
-        current.executionRunId === actorRunId &&
-        executionRun?.agentId === actorAgentId;
+      const actorRunState = actorRunId ? await getRunLockState(db, actorRunId, actorAgentId) : null;
+      const actorRunIsLiveOwner = Boolean(actorRunState?.liveBelongsToActor);
+      const actorOwnsCheckout = actorRunIsLiveOwner && current.checkoutRunId === actorRunId;
+      const actorOwnsExecution = actorRunIsLiveOwner && current.executionRunId === actorRunId;
+      const executionRun =
+        current.executionRunId && !actorOwnsExecution ? await getHeartbeatRun(db, current.executionRunId) : null;
       const foreignExecutionClearable =
         current.executionRunId && !actorOwnsExecution
           ? !executionRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)
@@ -2067,7 +2116,7 @@ export function issueService(db: Db) {
 
       if (
         actorStillAssigned &&
-        (actorOwnsExecution || sameRunLock(current.checkoutRunId, actorRunId)) &&
+        (actorOwnsExecution || actorOwnsCheckout) &&
         foreignExecutionClearable
       ) {
         return { ...current, adoptedFromRunId: null as string | null };

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1800,7 +1800,13 @@ export function issueService(db: Db) {
           .where(eq(issues.id, id))
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!lockedExisting) return null;
-        if (actor?.requireCheckoutOwnership) {
+        const lockedRequiresCheckoutOwnership =
+          actor?.actorAgentId != null &&
+          lockedExisting.status === "in_progress" &&
+          (lockedExisting.checkoutRunId != null ||
+            lockedExisting.executionRunId != null ||
+            (actor.requireCheckoutOwnership === true && lockedExisting.assigneeAgentId === actor.actorAgentId));
+        if (lockedRequiresCheckoutOwnership) {
           await assertLiveActorRunOwnsIssue(
             tx,
             lockedExisting,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -909,17 +909,32 @@ export function issueService(db: Db) {
     existing: typeof issues.$inferSelect,
     actor?: IssueUpdateActor,
   ) {
-    if (!existing.executionRunId) return true;
+    const actorRunId = actor?.actorRunId ?? null;
+    const actorAgentId = actor?.actorAgentId ?? null;
+    const checkedRuns = new Map<string, Awaited<ReturnType<typeof getHeartbeatRun>>>();
 
-    if (actor?.actorRunId && existing.executionRunId === actor.actorRunId) {
-      const run = await getHeartbeatRun(reader, actor.actorRunId);
+    const getCheckedRun = async (runId: string) => {
+      if (!checkedRuns.has(runId)) {
+        checkedRuns.set(runId, await getHeartbeatRun(reader, runId));
+      }
+      return checkedRuns.get(runId) ?? null;
+    };
+
+    const canClearRun = async (runId: string | null) => {
+      if (!runId) return true;
+      const run = await getCheckedRun(runId);
       if (!run || TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+      if (actorRunId !== runId) return false;
       if (run.agentId !== existing.assigneeAgentId) return false;
-      if (actor.actorAgentId && run.agentId !== actor.actorAgentId) return false;
+      if (actorAgentId && run.agentId !== actorAgentId) return false;
       return true;
-    }
+    };
 
-    return isTerminalOrMissingHeartbeatRun(reader, existing.executionRunId);
+    const [checkoutClearable, executionClearable] = await Promise.all([
+      canClearRun(existing.checkoutRunId),
+      canClearRun(existing.executionRunId),
+    ]);
+    return checkoutClearable && executionClearable;
   }
 
   async function getReleaseLockClearance(

--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -128,6 +128,19 @@ async function agentCheckoutAndPatch(
   expectedStatuses: string[],
   patchData: Record<string, unknown>,
 ) {
+  async function boardCheckoutAndPatch() {
+    const boardCheckout = await board.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
+      data: { agentId: agent.agentId, expectedStatuses },
+    });
+    if (!boardCheckout.ok()) {
+      throw new Error(`Board checkout failed: ${await boardCheckout.text()}`);
+    }
+    // Board PATCH (executor mark-done triggers signoff regardless of actor)
+    return board.patch(`${BASE_URL}/api/issues/${issueId}`, {
+      data: patchData,
+    });
+  }
+
   let checkoutRunId = await resolveCheckoutRunId(board, agent, issueId);
   // Checkout (sets executionRunId so PATCH is allowed)
   let checkoutRes = await agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
@@ -156,23 +169,19 @@ async function agentCheckoutAndPatch(
 
     // If no run owns execution anymore, fall back to board checkout then PATCH.
     // Board checkout must not bypass a live execution lock.
-    const boardCheckout = await board.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
-      data: { agentId: agent.agentId, expectedStatuses },
-    });
-    if (!boardCheckout.ok()) {
-      throw new Error(`Board checkout failed: ${await boardCheckout.text()}`);
-    }
-    // Board PATCH (executor mark-done triggers signoff regardless of actor)
-    const res = await board.patch(`${BASE_URL}/api/issues/${issueId}`, {
-      data: patchData,
-    });
-    return res;
+    return boardCheckoutAndPatch();
   }
   // PATCH with agent identity
   const res = await agent.request.patch(`${BASE_URL}/api/issues/${issueId}`, {
     headers: { "X-Paperclip-Run-Id": checkoutRunId },
     data: patchData,
   });
+  if (res.status() === 409) {
+    const latestIssue = await getIssueForCheckout(board, issueId);
+    if (!latestIssue.executionRunId) {
+      return boardCheckoutAndPatch();
+    }
+  }
   return res;
 }
 

--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -49,6 +49,18 @@ function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
 }
 
+function readConflictLockIds(body: string) {
+  try {
+    const parsed = JSON.parse(body) as { details?: Record<string, unknown> };
+    return {
+      checkoutRunId: readString(parsed.details?.checkoutRunId),
+      executionRunId: readString(parsed.details?.executionRunId),
+    };
+  } catch {
+    return { checkoutRunId: null, executionRunId: null };
+  }
+}
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -152,7 +164,13 @@ async function agentCheckoutAndPatch(
       data: { agentId: agent.agentId, expectedStatuses },
     });
     if (!boardCheckout.ok()) {
-      throw new Error(`Board checkout failed: ${await boardCheckout.text()}`);
+      const body = await boardCheckout.text();
+      const lockIds = readConflictLockIds(body);
+      if ((lockIds.checkoutRunId || lockIds.executionRunId) && retryDepth < 10) {
+        await sleep(150);
+        return agentCheckoutAndPatch(board, agent, issueId, expectedStatuses, patchData, retryDepth + 1);
+      }
+      throw new Error(`Board checkout failed: ${body}`);
     }
     // Board PATCH (executor mark-done triggers signoff regardless of actor)
     return board.patch(`${BASE_URL}/api/issues/${issueId}`, {
@@ -178,6 +196,11 @@ async function agentCheckoutAndPatch(
     const activeRun = await getActiveRunForCheckout(board, issueId);
     const activeRunAgentId = readString(activeRun?.agentId);
     if (activeRun && activeRunAgentId !== agent.agentId && retryDepth < 5) {
+      await sleep(150);
+      return agentCheckoutAndPatch(board, agent, issueId, expectedStatuses, patchData, retryDepth + 1);
+    }
+    const lockIds = readConflictLockIds(checkoutBody);
+    if ((lockIds.checkoutRunId || lockIds.executionRunId) && retryDepth < 10) {
       await sleep(150);
       return agentCheckoutAndPatch(board, agent, issueId, expectedStatuses, patchData, retryDepth + 1);
     }

--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -128,6 +128,20 @@ async function agentCheckoutAndPatch(
   expectedStatuses: string[],
   patchData: Record<string, unknown>,
 ) {
+  async function agentCheckout(runId: string) {
+    return agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
+      headers: { "X-Paperclip-Run-Id": runId },
+      data: { agentId: agent.agentId, expectedStatuses },
+    });
+  }
+
+  async function agentPatchWithRun(runId: string) {
+    return agent.request.patch(`${BASE_URL}/api/issues/${issueId}`, {
+      headers: { "X-Paperclip-Run-Id": runId },
+      data: patchData,
+    });
+  }
+
   async function boardCheckoutAndPatch() {
     const boardCheckout = await board.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
       data: { agentId: agent.agentId, expectedStatuses },
@@ -143,10 +157,7 @@ async function agentCheckoutAndPatch(
 
   let checkoutRunId = await resolveCheckoutRunId(board, agent, issueId);
   // Checkout (sets executionRunId so PATCH is allowed)
-  let checkoutRes = await agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
-    headers: { "X-Paperclip-Run-Id": checkoutRunId },
-    data: { agentId: agent.agentId, expectedStatuses },
-  });
+  let checkoutRes = await agentCheckout(checkoutRunId);
   let checkoutBody = checkoutRes.ok() ? "" : await checkoutRes.text();
   if (!checkoutRes.ok()) {
     const activeRun = await getActiveRunForCheckout(board, issueId);
@@ -154,16 +165,13 @@ async function agentCheckoutAndPatch(
     const activeRunAgentId = readString(activeRun?.agentId);
     if (activeRunId && activeRunAgentId === agent.agentId && activeRunId !== checkoutRunId) {
       checkoutRunId = activeRunId;
-      checkoutRes = await agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
-        headers: { "X-Paperclip-Run-Id": checkoutRunId },
-        data: { agentId: agent.agentId, expectedStatuses },
-      });
+      checkoutRes = await agentCheckout(checkoutRunId);
       checkoutBody = checkoutRes.ok() ? "" : await checkoutRes.text();
     }
   }
   if (!checkoutRes.ok()) {
-    const latestIssue = await getIssueForCheckout(board, issueId);
-    if (latestIssue.executionRunId) {
+    const activeRun = await getActiveRunForCheckout(board, issueId);
+    if (activeRun) {
       throw new Error(`Agent checkout failed: ${checkoutBody}`);
     }
 
@@ -172,13 +180,18 @@ async function agentCheckoutAndPatch(
     return boardCheckoutAndPatch();
   }
   // PATCH with agent identity
-  const res = await agent.request.patch(`${BASE_URL}/api/issues/${issueId}`, {
-    headers: { "X-Paperclip-Run-Id": checkoutRunId },
-    data: patchData,
-  });
+  let res = await agentPatchWithRun(checkoutRunId);
   if (res.status() === 409) {
-    const latestIssue = await getIssueForCheckout(board, issueId);
-    if (!latestIssue.executionRunId) {
+    const activeRun = await getActiveRunForCheckout(board, issueId);
+    const activeRunId = readString(activeRun?.id);
+    const activeRunAgentId = readString(activeRun?.agentId);
+    if (activeRunId && activeRunAgentId === agent.agentId) {
+      checkoutRunId = activeRunId;
+      checkoutRes = await agentCheckout(checkoutRunId);
+      if (checkoutRes.ok()) {
+        res = await agentPatchWithRun(checkoutRunId);
+      }
+    } else if (!activeRunId) {
       return boardCheckoutAndPatch();
     }
   }
@@ -414,10 +427,12 @@ test.describe("Signoff execution policy", () => {
     const issueId = issue.id;
 
     // Executor marks done → routes to reviewer
-    await agentCheckoutAndPatch(
+    const doneRes = await agentCheckoutAndPatch(
       ctx.boardRequest, ctx.executor, issueId, ["in_progress"],
       { status: "done", comment: "Done." },
     );
+    expect(doneRes.ok()).toBe(true);
+    expect((await doneRes.json()).status).toBe("in_review");
 
     // Reviewer tries to approve without comment → should fail
     const noCommentRes = await agentPatch(

--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -49,6 +49,10 @@ function readString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /** Create an authenticated APIRequestContext for an agent (token set, no run ID yet). */
 async function createAgentRequest(token: string): Promise<APIRequestContext> {
   return pwRequest.newContext({
@@ -127,6 +131,7 @@ async function agentCheckoutAndPatch(
   issueId: string,
   expectedStatuses: string[],
   patchData: Record<string, unknown>,
+  retryDepth = 0,
 ) {
   async function agentCheckout(runId: string) {
     return agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
@@ -171,6 +176,11 @@ async function agentCheckoutAndPatch(
   }
   if (!checkoutRes.ok()) {
     const activeRun = await getActiveRunForCheckout(board, issueId);
+    const activeRunAgentId = readString(activeRun?.agentId);
+    if (activeRun && activeRunAgentId !== agent.agentId && retryDepth < 5) {
+      await sleep(150);
+      return agentCheckoutAndPatch(board, agent, issueId, expectedStatuses, patchData, retryDepth + 1);
+    }
     if (activeRun) {
       throw new Error(`Agent checkout failed: ${checkoutBody}`);
     }
@@ -191,6 +201,9 @@ async function agentCheckoutAndPatch(
       if (checkoutRes.ok()) {
         res = await agentPatchWithRun(checkoutRunId);
       }
+    } else if (activeRunId && retryDepth < 5) {
+      await sleep(150);
+      return agentCheckoutAndPatch(board, agent, issueId, expectedStatuses, patchData, retryDepth + 1);
     } else if (!activeRunId) {
       return boardCheckoutAndPatch();
     }

--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -16,6 +16,9 @@ import { test, expect, request as pwRequest, type APIRequestContext } from "@pla
  * Agent auth flow:
  *   - Board request (local_trusted auto-auth) handles setup/teardown.
  *   - Agent-specific actions use API keys + heartbeat run IDs.
+ *   - Executor checkout reuses the assignment/change-request run when one
+ *     already owns issue execution; invoking a second run would correctly
+ *     conflict with the live execution lock.
  *   - Reviewers/approvers invoke heartbeat runs (gets run IDs) then PATCH
  *     directly without checkout (checkout would force in_progress, breaking
  *     the in_review state the signoff policy requires).
@@ -42,10 +45,8 @@ interface TestContext {
   issueIds: string[];
 }
 
-interface IssueRunLockState {
-  assigneeAgentId: string | null;
-  checkoutRunId: string | null;
-  executionRunId: string | null;
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
 }
 
 /** Create an authenticated APIRequestContext for an agent (token set, no run ID yet). */
@@ -64,15 +65,44 @@ async function invokeHeartbeat(board: APIRequestContext, agentId: string): Promi
   return run.id;
 }
 
-async function getIssueRunLockState(board: APIRequestContext, issueId: string): Promise<IssueRunLockState> {
+async function getIssueForCheckout(board: APIRequestContext, issueId: string): Promise<Record<string, unknown>> {
   const res = await board.get(`${BASE_URL}/api/issues/${issueId}`);
   expect(res.ok()).toBe(true);
-  const issue = await res.json();
-  return {
-    assigneeAgentId: issue.assigneeAgentId ?? null,
-    checkoutRunId: issue.checkoutRunId ?? null,
-    executionRunId: issue.executionRunId ?? null,
-  };
+  return await res.json();
+}
+
+async function getActiveRunForCheckout(
+  board: APIRequestContext,
+  issueId: string,
+): Promise<Record<string, unknown> | null> {
+  const res = await board.get(`${BASE_URL}/api/issues/${issueId}/active-run`);
+  expect(res.ok()).toBe(true);
+  return await res.json();
+}
+
+async function resolveCheckoutRunId(board: APIRequestContext, agent: AgentAuth, issueId: string): Promise<string> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const [issue, activeRun] = await Promise.all([
+      getIssueForCheckout(board, issueId),
+      getActiveRunForCheckout(board, issueId),
+    ]);
+    const activeRunId = readString(activeRun?.id);
+    const activeRunAgentId = readString(activeRun?.agentId);
+    if (
+      issue.status === "in_progress" &&
+      issue.assigneeAgentId === agent.agentId &&
+      activeRunId &&
+      activeRunAgentId === agent.agentId
+    ) {
+      return activeRunId;
+    }
+
+    if (attempt < 9) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  return invokeHeartbeat(board, agent.agentId);
 }
 
 /** PATCH an issue as an agent with a fresh heartbeat run ID. */
@@ -98,26 +128,34 @@ async function agentCheckoutAndPatch(
   expectedStatuses: string[],
   patchData: Record<string, unknown>,
 ) {
-  const runId = await invokeHeartbeat(board, agent.agentId);
+  let checkoutRunId = await resolveCheckoutRunId(board, agent, issueId);
   // Checkout (sets executionRunId so PATCH is allowed)
-  const checkoutRes = await agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
-    headers: { "X-Paperclip-Run-Id": runId },
+  let checkoutRes = await agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
+    headers: { "X-Paperclip-Run-Id": checkoutRunId },
     data: { agentId: agent.agentId, expectedStatuses },
   });
+  let checkoutBody = checkoutRes.ok() ? "" : await checkoutRes.text();
   if (!checkoutRes.ok()) {
-    if (checkoutRes.status() === 409) {
-      const issueRunLock = await getIssueRunLockState(board, issueId);
-      const lockedRunId = issueRunLock.checkoutRunId ?? issueRunLock.executionRunId;
-      const res = await agent.request.patch(`${BASE_URL}/api/issues/${issueId}`, {
-        headers: { "X-Paperclip-Run-Id": lockedRunId ?? runId },
-        data: patchData,
+    const activeRun = await getActiveRunForCheckout(board, issueId);
+    const activeRunId = readString(activeRun?.id);
+    const activeRunAgentId = readString(activeRun?.agentId);
+    if (activeRunId && activeRunAgentId === agent.agentId && activeRunId !== checkoutRunId) {
+      checkoutRunId = activeRunId;
+      checkoutRes = await agent.request.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
+        headers: { "X-Paperclip-Run-Id": checkoutRunId },
+        data: { agentId: agent.agentId, expectedStatuses },
       });
-      if (res.ok() && issueRunLock.assigneeAgentId === agent.agentId) {
-        return res;
-      }
+      checkoutBody = checkoutRes.ok() ? "" : await checkoutRes.text();
     }
-    // If agent checkout fails (e.g. run expired), fall back to board checkout
-    // then PATCH with the agent's identity
+  }
+  if (!checkoutRes.ok()) {
+    const latestIssue = await getIssueForCheckout(board, issueId);
+    if (latestIssue.executionRunId) {
+      throw new Error(`Agent checkout failed: ${checkoutBody}`);
+    }
+
+    // If no run owns execution anymore, fall back to board checkout then PATCH.
+    // Board checkout must not bypass a live execution lock.
     const boardCheckout = await board.post(`${BASE_URL}/api/issues/${issueId}/checkout`, {
       data: { agentId: agent.agentId, expectedStatuses },
     });
@@ -132,7 +170,7 @@ async function agentCheckoutAndPatch(
   }
   // PATCH with agent identity
   const res = await agent.request.patch(`${BASE_URL}/api/issues/${issueId}`, {
-    headers: { "X-Paperclip-Run-Id": runId },
+    headers: { "X-Paperclip-Run-Id": checkoutRunId },
     data: patchData,
   });
   return res;


### PR DESCRIPTION
## Summary
- preserves live execution ownership while adding route-level coverage for local-trusted same-run handoffs
- treats authenticated board run headers as audit context only for update clearance
- adds regressions for stale release, split checkout/execution locks, agent mutation conflicts, and the local-board PATCH path from VEN-114

## Verification
- pnpm --dir /Users/fabiannitka/code/paperclip-v2026.403.0/server exec vitest run src/__tests__/issues-service.test.ts src/__tests__/issue-comment-reopen-routes.test.ts src/__tests__/issue-telemetry-routes.test.ts src/__tests__/issue-release-routes.test.ts src/__tests__/issue-update-handoff-routes.test.ts
- pnpm --dir /Users/fabiannitka/code/paperclip-v2026.403.0/server typecheck
- pnpm --dir /Users/fabiannitka/code/paperclip-v2026.403.0 typecheck
- env -u DATABASE_URL pnpm --dir /Users/fabiannitka/code/paperclip-v2026.403.0 test:run
- pnpm --dir /Users/fabiannitka/code/paperclip-v2026.403.0 build

Note: root has no lint script; `pnpm run lint --if-present` reports missing script.