### PR TITLE
Fix collapsed issue document markdown rendering

### DIFF
--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -14,6 +14,7 @@ import { ApiError } from "../api/client";
 import { issuesApi } from "../api/issues";
 import { useAutosaveIndicator } from "../hooks/useAutosaveIndicator";
 import { deriveDocumentRevisionState } from "../lib/document-revisions";
+import { repairCollapsedMarkdown } from "../lib/repair-collapsed-markdown";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, relativeTime } from "../lib/utils";
 import { FoldCurtain } from "./FoldCurtain";
@@ -74,7 +75,7 @@ function saveFoldedDocumentKeys(issueId: string, keys: string[]) {
 function renderFoldableBody(body: string, className?: string) {
   return (
     <FoldCurtain>
-      <MarkdownBody className={className} softBreaks={false}>{body}</MarkdownBody>
+      <MarkdownBody className={className} softBreaks={false}>{repairCollapsedMarkdown(body)}</MarkdownBody>
     </FoldCurtain>
   );
 }

--- a/ui/src/lib/repair-collapsed-markdown.test.ts
+++ b/ui/src/lib/repair-collapsed-markdown.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isCollapsedMarkdown, repairCollapsedMarkdown } from "./repair-collapsed-markdown";
+
+describe("repairCollapsedMarkdown", () => {
+  it("restores headings, blockquotes, and bullet lists from collapsed issue documents", () => {
+    const input = "# 研究任务 Brief：面向Agent的软件设计趋势与数据资产化商业模式  > 状态：draft > 版本：0.1.0 > owner：Research & Knowledge Lead  ## 1. 基本信息  - 任务名称：面向Agent的软件设计趋势与数据资产化商业模式研究 - 发起时间：2026-04-05 - 发起人：CEO";
+
+    expect(isCollapsedMarkdown(input)).toBe(true);
+    expect(repairCollapsedMarkdown(input)).toBe([
+      "# 研究任务 Brief：面向Agent的软件设计趋势与数据资产化商业模式",
+      "> 状态：draft",
+      "> 版本：0.1.0",
+      "> owner：Research & Knowledge Lead",
+      "",
+      "## 1. 基本信息",
+      "- 任务名称：面向Agent的软件设计趋势与数据资产化商业模式研究",
+      "- 发起时间：2026-04-05",
+      "- 发起人：CEO",
+    ].join("\n"));
+  });
+
+  it("restores numbered lists and thematic separators from collapsed synthesis documents", () => {
+    const input = "# 研究综合结论：面向Agent的软件设计趋势与数据资产化商业模式 > 状态：完成 > 版本：1.0.0 > owner：Research & Knowledge Lead  ## 2. 核心事实 ### 行业发展现状事实 1. **标准层面**：MCP已经成为事实标准 2. **产品层面**：主流平台都已支持Skill封装 ---  ## 3. 模式抽象";
+    const repaired = repairCollapsedMarkdown(input);
+
+    expect(repaired).toContain("## 2. 核心事实");
+    expect(repaired).toContain("### 行业发展现状事实\n1. **标准层面**：MCP已经成为事实标准\n2. **产品层面**：主流平台都已支持Skill封装");
+    expect(repaired).toContain("\n\n---\n\n## 3. 模式抽象");
+  });
+
+  it("leaves already structured markdown untouched", () => {
+    const input = "# Title\n\n## Section\n- item one\n- item two";
+    expect(isCollapsedMarkdown(input)).toBe(false);
+    expect(repairCollapsedMarkdown(input)).toBe(input);
+  });
+});

--- a/ui/src/lib/repair-collapsed-markdown.ts
+++ b/ui/src/lib/repair-collapsed-markdown.ts
@@ -1,0 +1,34 @@
+import { normalizeMarkdown } from "./normalize-markdown";
+
+const BLOCK_MARKER_AT_LINE_START = /^\s*(?:>\s|#{1,6}\s|[-*]\s|\d+\.\s|---(?:\s|$))/;
+
+function countInlineBlockMarkers(text: string) {
+  const matches = text.match(/(?:^|[^\n])[ \t]+(?=(?:>\s|#{1,6}\s|[-*]\s|\d+\.\s|---(?:\s|$)))/g);
+  return matches?.length ?? 0;
+}
+
+function looksLikeCollapsedMarkdown(text: string) {
+  const normalized = normalizeMarkdown(text);
+  const lines = normalized.split("\n");
+  const lineCount = lines.length;
+  if (lineCount > 8) return false;
+  const structuredLineCount = lines.filter((line) => BLOCK_MARKER_AT_LINE_START.test(line)).length;
+  const inlineMarkerCount = countInlineBlockMarkers(normalized);
+  return inlineMarkerCount >= 3 && inlineMarkerCount > structuredLineCount;
+}
+
+export function repairCollapsedMarkdown(text: string): string {
+  const normalized = normalizeMarkdown(text);
+  if (!looksLikeCollapsedMarkdown(normalized)) return normalized;
+
+  return normalized
+    .replace(/[ \t]+(?=>\s)/g, "\n")
+    .replace(/[ \t]+(?=(?:#{1,6}\s|---(?:\s|$)))/g, "\n\n")
+    .replace(/(?<!#)[ \t]+(?=(?:[-*]\s|\d+\.\s))/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function isCollapsedMarkdown(text: string): boolean {
+  return looksLikeCollapsedMarkdown(text);
+}


### PR DESCRIPTION
## Summary
- repair collapsed issue document bodies before rendering in the issue documents panel
- preserve existing markdown rendering for already-structured documents
- add targeted tests for collapsed research brief and synthesis content

## Testing
- pnpm --filter @paperclipai/ui typecheck
- pnpm --filter @paperclipai/ui exec vitest run src/lib/repair-collapsed-markdown.test.ts src/components/IssueDocumentsSection.test.ts src/components/MarkdownBody.test.ts