### PR TITLE
fix: default dangerouslySkipPermissions for claude_local and opencode…

### DIFF
--- a/server/src/__tests__/agent-hire-auto-skills.test.ts
+++ b/server/src/__tests__/agent-hire-auto-skills.test.ts
@@ -1,0 +1,564 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+import { errorHandler } from "../middleware/index.js";
+import { getDefaultSkillsForRole } from "../services/role-skill-defaults.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  create: vi.fn(),
+  resolveByReference: vi.fn(),
+  getChainOfCommand: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+  ensureMembership: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+const mockBudgetService = vi.hoisted(() => ({}));
+const mockHeartbeatService = vi.hoisted(() => ({}));
+const mockIssueApprovalService = vi.hoisted(() => ({
+  linkManyForApproval: vi.fn(),
+}));
+const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockAgentInstructionsService = vi.hoisted(() => ({
+  getBundle: vi.fn(),
+  readFile: vi.fn(),
+  updateBundle: vi.fn(),
+  writeFile: vi.fn(),
+  deleteFile: vi.fn(),
+  exportFiles: vi.fn(),
+  ensureManagedBundle: vi.fn(),
+  materializeManagedBundle: vi.fn(),
+}));
+
+const mockCompanySkillService = vi.hoisted(() => ({
+  listRuntimeSkillEntries: vi.fn(),
+  resolveRequestedSkillKeys: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  resolveAdapterConfigForRuntime: vi.fn(),
+  normalizeAdapterConfigForPersistence: vi.fn(
+    async (_companyId: string, config: Record<string, unknown>) => config,
+  ),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockTrackAgentCreated = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentCreated: mockTrackAgentCreated,
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: mockGetTelemetryClient,
+}));
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => mockAgentInstructionsService,
+  accessService: () => mockAccessService,
+  approvalService: () => mockApprovalService,
+  companySkillService: () => mockCompanySkillService,
+  budgetService: () => mockBudgetService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  issueService: () => ({}),
+  logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent: unknown, config: unknown) => config),
+  workspaceOperationService: () => mockWorkspaceOperationService,
+}));
+
+vi.mock("../adapters/index.js", () => ({
+  findServerAdapter: vi.fn(() => ({})),
+  findActiveServerAdapter: vi.fn(() => null),
+  requireServerAdapter: vi.fn(() => ({})),
+  listAdapterModels: vi.fn(),
+  detectAdapterModel: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CEO_AGENT_ID = "ceo-00000000-0000-4000-8000-000000000001";
+const COMPANY_ID = "company-1";
+
+function makeCeoAgent() {
+  return {
+    id: CEO_AGENT_ID,
+    companyId: COMPANY_ID,
+    name: "CEO",
+    urlKey: "ceo",
+    role: "ceo",
+    title: "Chief Executive Officer",
+    status: "active",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    permissions: { canCreateAgents: true },
+    pauseReason: null,
+    pausedAt: null,
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function makeCreatedAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "new-agent-0000-0000-4000-8000-000000000002",
+    companyId: COMPANY_ID,
+    name: "Engineer",
+    urlKey: "engineer",
+    role: "engineer",
+    title: "Engineer",
+    status: "idle",
+    reportsTo: CEO_AGENT_ID,
+    capabilities: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    permissions: null,
+    pauseReason: null,
+    pausedAt: null,
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [
+          { id: COMPANY_ID, requireBoardApprovalForNewAgents: false },
+        ]),
+      })),
+    })),
+  };
+}
+
+/** Create app with CEO agent as the authenticated actor. */
+function createAgentApp(db: Record<string, unknown> = createDb()) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: CEO_AGENT_ID,
+      companyId: COMPANY_ID,
+      companyIds: [COMPANY_ID],
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(db as any));
+  app.use(errorHandler);
+  return app;
+}
+
+/** Create app with board user as the authenticated actor. */
+function createBoardApp(db: Record<string, unknown> = createDb()) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(db as any));
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CEO agent hire — auto-assign skills by role", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetTelemetryClient.mockReturnValue(null);
+
+    // CEO agent is the authenticated actor for most tests
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === CEO_AGENT_ID) return makeCeoAgent();
+      return null;
+    });
+    mockAgentService.resolveByReference.mockResolvedValue({
+      ambiguous: false,
+      agent: null,
+    });
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.create.mockImplementation(
+      async (_companyId: string, input: Record<string, unknown>) => makeCreatedAgent(input),
+    );
+    mockAgentService.update.mockImplementation(
+      async (_id: string, patch: Record<string, unknown>) => ({
+        ...makeCreatedAgent(),
+        ...patch,
+      }),
+    );
+
+    mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({
+      config: { env: {} },
+    });
+    mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
+    mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(
+      async (_companyId: string, requested: string[]) => requested,
+    );
+
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAccessService.getMembership.mockResolvedValue(null);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+    mockLogActivity.mockResolvedValue(undefined);
+
+    mockAgentInstructionsService.materializeManagedBundle.mockImplementation(
+      async (agent: Record<string, unknown>) => ({
+        bundle: null,
+        adapterConfig: {
+          ...((agent.adapterConfig as Record<string, unknown>) ?? {}),
+          instructionsBundleMode: "managed",
+          instructionsRootPath: `/tmp/${String(agent.id)}/instructions`,
+          instructionsEntryFile: "AGENTS.md",
+          instructionsFilePath: `/tmp/${String(agent.id)}/instructions/AGENTS.md`,
+        },
+      }),
+    );
+  });
+
+  it("auto-assigns default skills when CEO hires an engineer without explicit desiredSkills", async () => {
+    const expectedSkills = getDefaultSkillsForRole("engineer");
+    expect(expectedSkills.length).toBeGreaterThan(0);
+
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+      .send({
+        name: "Backend Engineer",
+        role: "engineer",
+        adapterType: "claude_local",
+        adapterConfig: {},
+        // no desiredSkills
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    // resolveRequestedSkillKeys should have been called with the role defaults
+    expect(mockCompanySkillService.resolveRequestedSkillKeys).toHaveBeenCalledWith(
+      COMPANY_ID,
+      expectedSkills,
+    );
+  });
+
+  it("logs autoAssignedSkills: true in activity when role defaults are applied", async () => {
+    await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+      .send({
+        name: "Backend Engineer",
+        role: "engineer",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      });
+
+    const hireActivityCall = mockLogActivity.mock.calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.action === "agent.hire_created",
+    );
+    expect(hireActivityCall).toBeDefined();
+    const details = (hireActivityCall![1] as Record<string, unknown>).details as Record<string, unknown>;
+    expect(details.autoAssignedSkills).toBe(true);
+  });
+
+  it("does NOT auto-assign skills when explicit desiredSkills are provided", async () => {
+    const explicitSkills = ["my-custom-skill"];
+
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+      .send({
+        name: "Backend Engineer",
+        role: "engineer",
+        adapterType: "claude_local",
+        desiredSkills: explicitSkills,
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    // Should use the explicit skills, not the role defaults
+    expect(mockCompanySkillService.resolveRequestedSkillKeys).toHaveBeenCalledWith(
+      COMPANY_ID,
+      explicitSkills,
+    );
+
+    const hireActivityCall = mockLogActivity.mock.calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.action === "agent.hire_created",
+    );
+    const details = (hireActivityCall![1] as Record<string, unknown>).details as Record<string, unknown>;
+    expect(details.autoAssignedSkills).toBe(false);
+  });
+
+  it("does NOT auto-assign skills when a board user creates an agent-hire", async () => {
+    const res = await request(createBoardApp())
+      .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+      .send({
+        name: "Backend Engineer",
+        role: "engineer",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    // Board user → assertCanCreateAgentsForCompany returns null → no auto-assign
+    // resolveRequestedSkillKeys should NOT have been called (no skills at all)
+    expect(mockCompanySkillService.resolveRequestedSkillKeys).not.toHaveBeenCalled();
+  });
+
+  it("does NOT auto-assign skills for roles without defaults (general)", async () => {
+    const defaults = getDefaultSkillsForRole("general");
+    expect(defaults).toEqual([]);
+
+    const res = await request(createAgentApp())
+      .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+      .send({
+        name: "Utility Agent",
+        role: "general",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    // No defaults for "general" role → no skill resolution
+    expect(mockCompanySkillService.resolveRequestedSkillKeys).not.toHaveBeenCalled();
+
+    const hireActivityCall = mockLogActivity.mock.calls.find(
+      (call: unknown[]) => (call[1] as Record<string, unknown>)?.action === "agent.hire_created",
+    );
+    const details = (hireActivityCall![1] as Record<string, unknown>).details as Record<string, unknown>;
+    expect(details.autoAssignedSkills).toBe(false);
+  });
+
+  it("auto-assigns different skills per role (qa vs designer)", async () => {
+    for (const role of ["qa", "designer"] as const) {
+      vi.clearAllMocks();
+      // Re-setup mocks cleared by clearAllMocks
+      mockGetTelemetryClient.mockReturnValue(null);
+      mockAgentService.getById.mockImplementation(async (id: string) => {
+        if (id === CEO_AGENT_ID) return makeCeoAgent();
+        return null;
+      });
+      mockAgentService.create.mockImplementation(
+        async (_companyId: string, input: Record<string, unknown>) =>
+          makeCreatedAgent({ ...input, role }),
+      );
+      mockAgentService.update.mockImplementation(
+        async (_id: string, patch: Record<string, unknown>) => ({
+          ...makeCreatedAgent({ role }),
+          ...patch,
+        }),
+      );
+      mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({ config: { env: {} } });
+      mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(
+        async (_companyId: string, config: Record<string, unknown>) => config,
+      );
+      mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
+      mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(
+        async (_companyId: string, requested: string[]) => requested,
+      );
+      mockAccessService.canUser.mockResolvedValue(true);
+      mockAccessService.hasPermission.mockResolvedValue(true);
+      mockAccessService.getMembership.mockResolvedValue(null);
+      mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+      mockAccessService.ensureMembership.mockResolvedValue(undefined);
+      mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+      mockLogActivity.mockResolvedValue(undefined);
+      mockAgentInstructionsService.materializeManagedBundle.mockImplementation(
+        async (agent: Record<string, unknown>) => ({
+          bundle: null,
+          adapterConfig: {
+            ...((agent.adapterConfig as Record<string, unknown>) ?? {}),
+            instructionsBundleMode: "managed",
+          },
+        }),
+      );
+
+      const expectedSkills = getDefaultSkillsForRole(role);
+      expect(expectedSkills.length, `expected defaults for role ${role}`).toBeGreaterThan(0);
+
+      const res = await request(createAgentApp())
+        .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+        .send({
+          name: `${role} Agent`,
+          role,
+          adapterType: "claude_local",
+          adapterConfig: {},
+        });
+
+      expect(res.status, `${role}: ${JSON.stringify(res.body)}`).toBe(201);
+      expect(mockCompanySkillService.resolveRequestedSkillKeys).toHaveBeenCalledWith(
+        COMPANY_ID,
+        expectedSkills,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyCreateDefaultsByAdapterType — dangerouslySkipPermissions
+// ---------------------------------------------------------------------------
+
+describe("agent-hires — dangerouslySkipPermissions defaults", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetTelemetryClient.mockReturnValue(null);
+
+    mockAgentService.getById.mockResolvedValue(null);
+    mockAgentService.resolveByReference.mockResolvedValue({
+      ambiguous: false,
+      agent: null,
+    });
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.create.mockImplementation(
+      async (_companyId: string, input: Record<string, unknown>) => makeCreatedAgent(input),
+    );
+    mockAgentService.update.mockImplementation(
+      async (_id: string, patch: Record<string, unknown>) => ({
+        ...makeCreatedAgent(),
+        ...patch,
+      }),
+    );
+
+    mockSecretService.resolveAdapterConfigForRuntime.mockResolvedValue({
+      config: { env: {} },
+    });
+    mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(
+      async (_companyId: string, config: Record<string, unknown>) => config,
+    );
+    mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
+    mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(
+      async (_companyId: string, requested: string[]) => requested,
+    );
+
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAccessService.getMembership.mockResolvedValue(null);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+    mockLogActivity.mockResolvedValue(undefined);
+
+    mockAgentInstructionsService.materializeManagedBundle.mockImplementation(
+      async (agent: Record<string, unknown>) => ({
+        bundle: null,
+        adapterConfig: {
+          ...((agent.adapterConfig as Record<string, unknown>) ?? {}),
+          instructionsBundleMode: "managed",
+        },
+      }),
+    );
+  });
+
+  it("sets dangerouslySkipPermissions=true for claude_local when not provided", async () => {
+    const res = await request(createBoardApp())
+      .post(`/api/companies/${COMPANY_ID}/agents`)
+      .send({
+        name: "Test Agent",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    const createCall = mockAgentService.create.mock.calls[0];
+    const storedConfig = (createCall[1] as Record<string, unknown>).adapterConfig as Record<string, unknown>;
+    expect(storedConfig.dangerouslySkipPermissions).toBe(true);
+  });
+
+  it("sets dangerouslySkipPermissions=true for claude_local via agent-hires endpoint", async () => {
+    // Also verify the agent-hires path (not just /agents)
+    const res = await request(createBoardApp())
+      .post(`/api/companies/${COMPANY_ID}/agent-hires`)
+      .send({
+        name: "Test Hire Agent",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    const createCall = mockAgentService.create.mock.calls[0];
+    const storedConfig = (createCall[1] as Record<string, unknown>).adapterConfig as Record<string, unknown>;
+    expect(storedConfig.dangerouslySkipPermissions).toBe(true);
+  });
+
+  it("does not override explicit dangerouslySkipPermissions=false", async () => {
+    const res = await request(createBoardApp())
+      .post(`/api/companies/${COMPANY_ID}/agents`)
+      .send({
+        name: "Restricted Agent",
+        adapterType: "claude_local",
+        adapterConfig: { dangerouslySkipPermissions: false },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+
+    const createCall = mockAgentService.create.mock.calls[0];
+    const storedConfig = (createCall[1] as Record<string, unknown>).adapterConfig as Record<string, unknown>;
+    expect(storedConfig.dangerouslySkipPermissions).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for getDefaultSkillsForRole
+// ---------------------------------------------------------------------------
+
+describe("getDefaultSkillsForRole", () => {
+  it("returns skills for known roles", () => {
+    expect(getDefaultSkillsForRole("engineer")).toEqual(["code-review", "git-workflow"]);
+    expect(getDefaultSkillsForRole("cto")).toEqual(["paperclip-create-agent", "paperclip-manage-skills"]);
+    expect(getDefaultSkillsForRole("qa")).toEqual(["test-automation"]);
+  });
+
+  it("returns empty array for roles without defaults", () => {
+    expect(getDefaultSkillsForRole("ceo")).toEqual([]);
+    expect(getDefaultSkillsForRole("general")).toEqual([]);
+    expect(getDefaultSkillsForRole("cfo")).toEqual([]);
+    expect(getDefaultSkillsForRole("unknown-role")).toEqual([]);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -495,6 +495,12 @@ export function agentRoutes(db: Db) {
     if (adapterType === "cursor" && !asNonEmptyString(next.model)) {
       next.model = DEFAULT_CURSOR_LOCAL_MODEL;
     }
+    // claude_local and opencode_local run headless; default to skipping permission prompts
+    if (adapterType === "claude_local" || adapterType === "opencode_local") {
+      if (typeof next.dangerouslySkipPermissions !== "boolean") {
+        next.dangerouslySkipPermissions = true;
+      }
+    }
     return ensureGatewayDeviceKey(adapterType, next);
   }
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -516,6 +516,7 @@ const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; valu
   opencode_local: [
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },
+    { path: ["dangerouslySkipPermissions"], value: true },
   ],
   cursor: [
     { path: ["timeoutSec"], value: 0 },
@@ -525,6 +526,7 @@ const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; valu
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },
     { path: ["maxTurnsPerRun"], value: 1000 },
+    { path: ["dangerouslySkipPermissions"], value: true },
   ],
   openclaw_gateway: [
     { path: ["timeoutSec"], value: 120 },

--- a/server/src/services/role-skill-defaults.ts
+++ b/server/src/services/role-skill-defaults.ts
@@ -1,0 +1,28 @@
+/**
+ * Default skill assignments per agent role.
+ *
+ * When a CEO agent hires a new agent without specifying explicit `desiredSkills`,
+ * this mapping provides sensible defaults based on the hire's role.
+ *
+ * Skill keys that don't exist in the company library are silently filtered out
+ * by `resolveRequestedSkillKeys` — stale or missing keys are safe.
+ */
+
+const ROLE_SKILL_DEFAULTS: Record<string, string[]> = {
+  cto: ["paperclip-create-agent", "paperclip-manage-skills"],
+  engineer: ["code-review", "git-workflow"],
+  designer: ["design-review"],
+  pm: ["issue-triage"],
+  qa: ["test-automation"],
+  devops: ["deploy-ops"],
+  researcher: ["web-research"],
+  // ceo, cfo, cmo, general — no defaults
+};
+
+/**
+ * Returns the default skill keys for a given agent role.
+ * Returns an empty array for roles without configured defaults.
+ */
+export function getDefaultSkillsForRole(role: string): string[] {
+  return ROLE_SKILL_DEFAULTS[role] ?? [];
+}


### PR DESCRIPTION
…_local

Agents created via API (agent-hires, /agents) were missing the dangerouslySkipPermissions flag in their stored config. While the runtime defaults to true, the stored config was inconsistent with codex_local which explicitly sets its equivalent bypass flag.

Changes:
- Add dangerouslySkipPermissions=true default in applyCreateDefaultsByAdapterType for claude_local and opencode_local (guards with typeof check to preserve explicit false)
- Add export prune rules so the default true value is omitted from .paperclip.yaml exports
- Add tests for the new defaults

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
