### PR TITLE
fix: auto-discover .mcp.json for agent sessions in git worktree mode

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -264,12 +264,27 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
 
   // Resolve MCP config paths: explicit adapter config takes precedence,
   // otherwise auto-discover .mcp.json from the project base directory.
-  const mcpConfigPaths: string[] = (() => {
+  const mcpConfigPaths: string[] = await (async () => {
     const explicit = asStringArray(config.mcpConfig);
     if (explicit.length > 0) return explicit;
     // Auto-discover: prefer baseCwd (original project root) over the effective cwd,
     // since .mcp.json is typically untracked and absent from git worktrees.
-    const discoveryRoot = workspaceBaseCwd || configuredCwd;
+    // When falling back to configuredCwd, walk up to the git root because
+    // configuredCwd may be a subdirectory (e.g. packages/my-app).
+    let discoveryRoot = workspaceBaseCwd;
+    if (!discoveryRoot && configuredCwd) {
+      let dir = configuredCwd;
+      while (dir !== path.dirname(dir)) {
+        try {
+          await fs.access(path.join(dir, ".git"));
+          discoveryRoot = dir;
+          break;
+        } catch {
+          dir = path.dirname(dir);
+        }
+      }
+      if (!discoveryRoot) discoveryRoot = configuredCwd;
+    }
     if (discoveryRoot) return [path.join(discoveryRoot, ".mcp.json")];
     return [];
   })();

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -479,7 +479,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", effectiveInstructionsFilePath);
     }
     args.push("--add-dir", skillsDir);
-    if (mcpConfigPaths.length > 0) args.push("--mcp-config", ...mcpConfigPaths);
+    for (const p of mcpConfigPaths) args.push("--mcp-config", p);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -81,6 +81,7 @@ interface ClaudeRuntimeConfig {
   timeoutSec: number;
   graceSec: number;
   extraArgs: string[];
+  mcpConfigPaths: string[];
 }
 
 function buildLoginResult(input: {
@@ -113,6 +114,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const command = asString(config.command, "claude");
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceBaseCwd = asString(workspaceContext.baseCwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
   const workspaceStrategy = asString(workspaceContext.strategy, "");
   const workspaceId = asString(workspaceContext.workspaceId, "") || null;
@@ -260,6 +262,28 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     return asStringArray(config.args);
   })();
 
+  // Resolve MCP config paths: explicit adapter config takes precedence,
+  // otherwise auto-discover .mcp.json from the project base directory.
+  const mcpConfigPaths: string[] = (() => {
+    const explicit = asStringArray(config.mcpConfig);
+    if (explicit.length > 0) return explicit;
+    // Auto-discover: prefer baseCwd (original project root) over the effective cwd,
+    // since .mcp.json is typically untracked and absent from git worktrees.
+    const discoveryRoot = workspaceBaseCwd || configuredCwd;
+    if (discoveryRoot) return [path.join(discoveryRoot, ".mcp.json")];
+    return [];
+  })();
+  // Filter to only paths that actually exist on disk.
+  const resolvedMcpConfigPaths: string[] = [];
+  for (const p of mcpConfigPaths) {
+    try {
+      await fs.access(p);
+      resolvedMcpConfigPaths.push(p);
+    } catch {
+      // File does not exist — skip.
+    }
+  }
+
   return {
     command,
     resolvedCommand,
@@ -272,6 +296,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     timeoutSec,
     graceSec,
     extraArgs,
+    mcpConfigPaths: resolvedMcpConfigPaths,
   };
 }
 
@@ -351,6 +376,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     timeoutSec,
     graceSec,
     extraArgs,
+    mcpConfigPaths,
   } = runtimeConfig;
   const effectiveEnv = Object.fromEntries(
     Object.entries({ ...process.env, ...env }).filter(
@@ -438,6 +464,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", effectiveInstructionsFilePath);
     }
     args.push("--add-dir", skillsDir);
+    if (mcpConfigPaths.length > 0) args.push("--mcp-config", ...mcpConfigPaths);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2620,6 +2620,7 @@ export function heartbeatService(db: Db) {
     ];
     context.paperclipWorkspace = {
       cwd: executionWorkspace.cwd,
+      baseCwd: executionWorkspace.baseCwd,
       source: executionWorkspace.source,
       mode: effectiveExecutionWorkspaceMode,
       strategy: executionWorkspace.strategy,


### PR DESCRIPTION
## Summary

- Auto-discovers `.mcp.json` from the original project root (`baseCwd`) and passes it to Claude CLI via `--mcp-config` flag, fixing MCP servers not loading in git worktree execution mode
- Exposes `baseCwd` in the workspace context so the adapter knows the original project root even when running in a worktree
- Supports explicit `mcpConfig` adapter config field as an override for custom setups

Closes #2940

## Test plan

- [ ] Verify `.mcp.json` is discovered and passed via `--mcp-config` when running in `git_worktree` mode
- [ ] Verify `shared_workspace` / `project_primary` mode still works (`.mcp.json` exists in cwd)
- [ ] Verify explicit `mcpConfig` adapter config overrides auto-discovery
- [ ] Verify no `--mcp-config` flag is added when `.mcp.json` doesn't exist
- [ ] Verify `extraArgs` with manual `--mcp-config` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)