### PR TITLE
SUP-131: stop queued runs from blocking checkout

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -322,6 +322,48 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("cancelled");
   });
 
+  it("cancels a queued run when the issue lock was cleared by a later null-run checkout", async () => {
+    const { issueId, runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+    });
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+      })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    const queuedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(queuedRun?.status).toBe("cancelled");
+    expect(queuedRun?.errorCode).toBe("cancelled");
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+    expect(wakeup?.status).toBe("cancelled");
+  });
+
   it("clears the detached warning when the run reports activity again", async () => {
     const { runId } = await seedRunFixture({
       includeIssue: false,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -255,6 +255,73 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBe(runId);
   });
 
+  it("cancels a queued run when another running execution already owns the issue", async () => {
+    const { companyId, issueId, runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+    });
+    const otherAgentId = randomUUID();
+    const otherRunId = randomUUID();
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId,
+      agentId: otherAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-03-19T00:02:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:02:00.000Z"),
+    });
+
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: otherAgentId,
+        checkoutRunId: otherRunId,
+        executionRunId: otherRunId,
+      })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    const queuedRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(queuedRun?.status).toBe("cancelled");
+    expect(queuedRun?.errorCode).toBe("cancelled");
+    expect(issue?.executionRunId).toBe(otherRunId);
+    expect(issue?.checkoutRunId).toBe(otherRunId);
+    expect(wakeup?.status).toBe("cancelled");
+  });
+
   it("clears the detached warning when the run reports activity again", async () => {
     const { runId } = await seedRunFixture({
       includeIssue: false,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -662,6 +662,61 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     }));
   });
 
+  it("allows null-run checkout when executionRunId points to a queued run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const queuedRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: queuedRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Queued execution lock without actor run",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: queuedRunId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], null);
+
+    expect(checkedOut).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_progress",
+      checkoutRunId: null,
+      executionRunId: null,
+    }));
+  });
+
   it("still rejects checkout when executionRunId points to a running run", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -66,6 +67,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -603,6 +605,114 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       "2026-03-26T10:00:00.000Z",
     );
   });
+
+  it("allows checkout when executionRunId points to a queued run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const queuedRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: queuedRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: { issueId },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Queued execution lock",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: queuedRunId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], checkoutRunId);
+
+    expect(checkedOut).toEqual(expect.objectContaining({
+      id: issueId,
+      status: "in_progress",
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+    }));
+  });
+
+  it("still rejects checkout when executionRunId points to a running run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runningRunId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runningRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-06T16:00:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Running execution lock",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runningRunId,
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["todo"], checkoutRunId)).rejects.toMatchObject({
+      message: "Issue checkout conflict",
+    });
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
@@ -623,6 +733,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -900,6 +1011,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -642,6 +642,17 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       contextSnapshot: { issueId },
     });
 
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId },
+      startedAt: new Date("2026-04-06T16:05:00.000Z"),
+    });
+
     await db.insert(issues).values({
       id: issueId,
       companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1962,6 +1962,8 @@ export function heartbeatService(db: Db) {
         const issue = await tx
           .select({
             id: issues.id,
+            status: issues.status,
+            checkoutRunId: issues.checkoutRunId,
             executionRunId: issues.executionRunId,
           })
           .from(issues)
@@ -1979,8 +1981,17 @@ export function heartbeatService(db: Db) {
             .then((rows) => rows[0] ?? null)
           : null;
 
-        if (currentExecutionRun && currentExecutionRun.id !== run.id && currentExecutionRun.status === "running") {
-          return { claimed: null, cancelReason: "Cancelled because the issue is already owned by another running run" };
+        if (currentExecutionRun && currentExecutionRun.id !== run.id) {
+          return { claimed: null, cancelReason: "Cancelled because the issue is already owned by another execution run" };
+        }
+
+        if (
+          issue &&
+          issue.executionRunId == null &&
+          issue.status === "in_progress" &&
+          issue.checkoutRunId == null
+        ) {
+          return { claimed: null, cancelReason: "Cancelled because the issue execution lock was cleared before this queued run was claimed" };
         }
 
         const claimedRun = await tx

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1928,15 +1928,23 @@ export function heartbeatService(db: Db) {
     return Number(count ?? 0);
   }
 
-  async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect) {
+  async function claimQueuedRun(
+    run: typeof heartbeatRuns.$inferSelect,
+    opts?: { startNextQueuedRunOnCancel?: boolean },
+  ) {
     if (run.status !== "queued") return run;
+    const startNextQueuedRunOnCancel = opts?.startNextQueuedRunOnCancel ?? true;
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
+      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists", {
+        startNextQueuedRun: startNextQueuedRunOnCancel,
+      });
       return null;
     }
     if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
-      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable");
+      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable", {
+        startNextQueuedRun: startNextQueuedRunOnCancel,
+      });
       return null;
     }
 
@@ -1946,7 +1954,9 @@ export function heartbeatService(db: Db) {
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
-      await cancelRunInternal(run.id, budgetBlock.reason);
+      await cancelRunInternal(run.id, budgetBlock.reason, {
+        startNextQueuedRun: startNextQueuedRunOnCancel,
+      });
       return null;
     }
 
@@ -2024,7 +2034,9 @@ export function heartbeatService(db: Db) {
         return { claimed: claimedRun, cancelReason: null };
       }).then(async (result) => {
         if (result.cancelReason) {
-          await cancelRunInternal(run.id, result.cancelReason);
+          await cancelRunInternal(run.id, result.cancelReason, {
+            startNextQueuedRun: startNextQueuedRunOnCancel,
+          });
           return null;
         }
         return result.claimed;
@@ -2303,7 +2315,9 @@ export function heartbeatService(db: Db) {
 
       const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
       for (const queuedRun of queuedRuns) {
-        const claimed = await claimQueuedRun(queuedRun);
+        const claimed = await claimQueuedRun(queuedRun, {
+          startNextQueuedRunOnCancel: false,
+        });
         if (claimed) claimedRuns.push(claimed);
       }
       if (claimedRuns.length === 0) return [];
@@ -4014,7 +4028,11 @@ export function heartbeatService(db: Db) {
     return wakeupIds.length;
   }
 
-  async function cancelRunInternal(runId: string, reason = "Cancelled by control plane") {
+  async function cancelRunInternal(
+    runId: string,
+    reason = "Cancelled by control plane",
+    opts?: { startNextQueuedRun?: boolean },
+  ) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
     if (run.status !== "running" && run.status !== "queued") return run;
@@ -4053,7 +4071,9 @@ export function heartbeatService(db: Db) {
 
     runningProcesses.delete(run.id);
     await finalizeAgentStatus(run.agentId, "cancelled");
-    await startNextQueuedRunForAgent(run.agentId);
+    if (opts?.startNextQueuedRun ?? true) {
+      await startNextQueuedRunForAgent(run.agentId);
+    }
     return cancelled;
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1951,16 +1951,83 @@ export function heartbeatService(db: Db) {
     }
 
     const claimedAt = new Date();
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
+    const issueId = readNonEmptyString(context.issueId);
+    const agentNameKey = normalizeAgentNameKey(agent.name);
+    const claimed = issueId
+      ? await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select id from issues where id = ${issueId} and company_id = ${run.companyId} for update`,
+        );
+
+        const issue = await tx
+          .select({
+            id: issues.id,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+          .then((rows) => rows[0] ?? null);
+
+        const currentExecutionRun = issue?.executionRunId
+          ? await tx
+            .select({
+              id: heartbeatRuns.id,
+              status: heartbeatRuns.status,
+            })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, issue.executionRunId))
+            .then((rows) => rows[0] ?? null)
+          : null;
+
+        if (currentExecutionRun && currentExecutionRun.id !== run.id && currentExecutionRun.status === "running") {
+          return { claimed: null, cancelReason: "Cancelled because the issue is already owned by another running run" };
+        }
+
+        const claimedRun = await tx
+          .update(heartbeatRuns)
+          .set({
+            status: "running",
+            startedAt: run.startedAt ?? claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (!claimedRun) {
+          return { claimed: null, cancelReason: null };
+        }
+
+        if (issue) {
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: claimedRun.id,
+              executionAgentNameKey: agentNameKey,
+              executionLockedAt: claimedAt,
+              updatedAt: claimedAt,
+            })
+            .where(eq(issues.id, issue.id));
+        }
+
+        return { claimed: claimedRun, cancelReason: null };
+      }).then(async (result) => {
+        if (result.cancelReason) {
+          await cancelRunInternal(run.id, result.cancelReason);
+          return null;
+        }
+        return result.claimed;
       })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+      : await db
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          startedAt: run.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
     if (!claimed) return null;
 
     publishLiveEvent({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1769,12 +1769,20 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
+      const currentExecutionRunStatus = current.executionRunId
+        ? await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, current.executionRunId))
+          .then((rows) => rows[0]?.status ?? null)
+        : null;
+      const currentExecutionRunIsQueued = currentExecutionRunStatus === "queued";
 
       if (
         current.assigneeAgentId === agentId &&
         current.status === "in_progress" &&
         current.checkoutRunId == null &&
-        (current.executionRunId == null || current.executionRunId === checkoutRunId) &&
+        (current.executionRunId == null || current.executionRunId === checkoutRunId || currentExecutionRunIsQueued) &&
         checkoutRunId
       ) {
         const adopted = await db
@@ -1790,7 +1798,7 @@ export function issueService(db: Db) {
               eq(issues.status, "in_progress"),
               eq(issues.assigneeAgentId, agentId),
               isNull(issues.checkoutRunId),
-              or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId)),
+              or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId), queuedExecutionRunCondition),
             ),
           )
           .returning()

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1720,9 +1720,15 @@ export function issueService(db: Db) {
           or(isNull(issues.checkoutRunId), eq(issues.checkoutRunId, checkoutRunId)),
         )
         : and(eq(issues.assigneeAgentId, agentId), isNull(issues.checkoutRunId));
+      const queuedExecutionRunCondition = sql<boolean>`exists (
+        select 1
+        from ${heartbeatRuns}
+        where ${heartbeatRuns.id} = ${issues.executionRunId}
+          and ${heartbeatRuns.status} = 'queued'
+      )`;
       const executionLockCondition = checkoutRunId
-        ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
-        : isNull(issues.executionRunId);
+        ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId), queuedExecutionRunCondition)
+        : or(isNull(issues.executionRunId), queuedExecutionRunCondition);
       const updated = await db
         .update(issues)
         .set({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents by assigning issues to heartbeat runs and persisting that ownership state in the server data layer.
> - Issue checkout and queued-run recovery both live in the backend services that coordinate `issues` and `heartbeat_runs`.
> - [SUP-131] exposed a lock-handling gap where a queued `executionRunId` could block a later checkout even though no run had actually claimed execution yet.
> - The first backend fix allowed queued-lock overrides on the primary checkout path, but review surfaced two remaining consistency gaps: the null-run adoption path and the case where a queued run wakes up after a later checkout already cleared the lock.
> - Those gaps matter because they can strand queued runs or let a stale queued run reclaim an issue after ownership has moved on.
> - This pull request aligns checkout and queued-run recovery around the same ownership rule: queued execution locks are overridable, and stale queued runs cancel instead of reclaiming work.
> - The benefit is that issue ownership stays consistent across checkout, recovery, and delayed queued-run claims.

## What Changed

- Allowed `issueService.checkout` to treat queued `executionRunId` values as overridable in both the direct checkout update and the in-progress adoption fallback, including null-run checkout.
- Added issue-service coverage for null-run checkout against a queued execution lock.
- Tightened queued-run claiming in `heartbeatService` so a queued run cancels if the issue is now owned by any other execution run.
- Added a second queued-run cancellation guard for issues that were later checked out without a run and therefore no longer have an execution lock to claim.
- Added heartbeat recovery coverage for the cleared-lock cancellation path.

## Verification

- `pnpm -C /tmp/paperclip-sup131 test:run server/src/__tests__/issues-service.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts`
  - On this host, both suites skip because embedded Postgres init exits with code `127`.
- `pnpm -C /tmp/paperclip-sup131 --filter @paperclipai/server exec tsx -e "(async () => { await import('./src/services/heartbeat.ts'); await import('./src/services/issues.ts'); console.log('module-load-ok'); })().catch((err) => { console.error(err); process.exit(1); });"`
  - Prints `module-load-ok`.

## Risks

- Low risk. The change stays inside backend checkout/recovery paths, but those paths are concurrency-sensitive and still need a host with working embedded Postgres to fully execute the added integration coverage.

## Model Used

- OpenAI Codex, GPT-5-class coding agent in Codex CLI with tool use and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
