### PR TITLE
fix: clear execution state when resetting issue to todo

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   createDb,
   executionWorkspaces,
+  heartbeatRuns,
   instanceSettings,
   issueComments,
   issueInboxArchives,
@@ -1086,5 +1087,100 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       assigneeAgentId,
       childIssueIds: [childA, childB],
     });
+  });
+});
+
+describeEmbeddedPostgres("issueService.release clears execution state", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-release-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("clears executionRunId, executionLockedAt, and executionAgentNameKey on release", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "running",
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue with stale execution state",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      executionLockedAt: new Date(),
+      executionAgentNameKey: "TestAgent",
+    });
+
+    const released = await svc.release(issueId, agentId, runId);
+
+    expect(released).not.toBeNull();
+    expect(released!.status).toBe("todo");
+    expect(released!.assigneeAgentId).toBeNull();
+    expect(released!.checkoutRunId).toBeNull();
+    expect(released!.executionRunId).toBeNull();
+    expect(released!.executionLockedAt).toBeNull();
+    expect(released!.executionAgentNameKey).toBeNull();
+
+    // Verify in DB directly
+    const [row] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(row.executionRunId).toBeNull();
+    expect(row.executionLockedAt).toBeNull();
+    expect(row.executionAgentNameKey).toBeNull();
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1920,6 +1920,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          executionRunId: null,
+          executionLockedAt: null,
+          executionAgentNameKey: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents pick up issues by checking them out, which sets execution locks on the issue (`executionRunId`, `executionLockedAt`, `executionAgentNameKey`)
> - When something goes wrong or a user wants to retry, they can reset an issue back to "todo" status
> - The reset path was already clearing `assigneeAgentId` and `checkoutRunId` but not the execution state fields
> - This meant stale execution locks remained on the issue after reset
> - Other agents seeing the stale lock would skip the issue, thinking it was still being worked on
> - This pull request adds clears for `executionRunId`, `executionLockedAt`, and `executionAgentNameKey` to the reset path
> - The benefit is that reset issues are fully clean and can be picked up by agents again without manual database intervention

## What Changed

- Clear `executionRunId`, `executionLockedAt`, and `executionAgentNameKey` alongside the existing `assigneeAgentId` and `checkoutRunId` clears when resetting an issue to "todo" in `server/src/services/issues.ts`
- Added integration test in `server/src/__tests__/issues-service.test.ts` verifying all execution state fields are nulled on release

## Verification

- Run the new test: `npx vitest run server/src/__tests__/issues-service.test.ts`
- Reset an in-progress issue to "todo" and verify all three execution fields are null in the database
- Confirm the reset issue can be checked out and picked up by an agent again

## Risks

Low risk — additive null-setting on an existing reset path. No schema changes, no new queries, no behavioral change for issues that aren't being reset.

## Model Used

Claude Opus 4.6 (1M context) — `claude-opus-4-6`, tool use mode via Claude Code CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge