### PR TITLE
fix(gemini-local): update model list to Gemini 3.x (CLI-verified, no Claude models)

### DIFF
--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,11 +4,12 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
-  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-  { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
-  { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
-  { id: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
+  { id: "gemini-3.1-pro-preview-customtools", label: "Gemini 3.1 Pro Preview (Custom Tools)" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
+  { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite Preview" },
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6 (via Vertex AI)" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6 (via Vertex AI)" },
 ];
 
 export const agentConfigurationDoc = `# gemini_local agent configuration
@@ -29,7 +30,7 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - promptTemplate (string, optional): run prompt template
-- model (string, optional): Gemini model id. Defaults to auto.
+- model (string, optional): Gemini model id, or a Claude model id (claude-opus-4-6, claude-sonnet-4-6) routed via Vertex AI. Defaults to auto.
 - sandbox (boolean, optional): run in sandbox mode (default: false, passes --sandbox=none)
 - command (string, optional): defaults to "gemini"
 - extraArgs (string[], optional): additional CLI args
@@ -44,4 +45,5 @@ Notes:
 - Sessions resume with --resume when stored session cwd matches the current cwd.
 - Paperclip auto-injects local skills into \`~/.gemini/skills/\` via symlinks, so the CLI can discover both credentials and skills in their natural location.
 - Authentication can use GEMINI_API_KEY / GOOGLE_API_KEY or local Gemini CLI login.
+- Claude models (claude-opus-4-6, claude-sonnet-4-6) are routed through Vertex AI and require GOOGLE_CLOUD_PROJECT and appropriate Vertex AI permissions; no separate Anthropic API key is needed.
 `;

--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -8,8 +8,6 @@ export const models = [
   { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
   { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
   { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite Preview" },
-  { id: "claude-opus-4-6", label: "Claude Opus 4.6 (via Vertex AI)" },
-  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6 (via Vertex AI)" },
 ];
 
 export const agentConfigurationDoc = `# gemini_local agent configuration
@@ -30,7 +28,7 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - promptTemplate (string, optional): run prompt template
-- model (string, optional): Gemini model id, or a Claude model id (claude-opus-4-6, claude-sonnet-4-6) routed via Vertex AI. Defaults to auto.
+- model (string, optional): Gemini model id. Defaults to auto.
 - sandbox (boolean, optional): run in sandbox mode (default: false, passes --sandbox=none)
 - command (string, optional): defaults to "gemini"
 - extraArgs (string[], optional): additional CLI args
@@ -45,5 +43,4 @@ Notes:
 - Sessions resume with --resume when stored session cwd matches the current cwd.
 - Paperclip auto-injects local skills into \`~/.gemini/skills/\` via symlinks, so the CLI can discover both credentials and skills in their natural location.
 - Authentication can use GEMINI_API_KEY / GOOGLE_API_KEY or local Gemini CLI login.
-- Claude models (claude-opus-4-6, claude-sonnet-4-6) are routed through Vertex AI and require GOOGLE_CLOUD_PROJECT and appropriate Vertex AI permissions; no separate Anthropic API key is needed.
 `;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; each agent adapter exposes a model selector so operators can choose which underlying model to use
> - The `gemini-local` adapter runs agents via the `@google/gemini-cli` tool — it is not a Vertex AI adapter
> - The model list was using Gemini 2.x IDs (`gemini-2.5-pro`, etc.) which are Vertex AI / API identifiers, not valid Gemini CLI model names
> - The Gemini CLI only accepts models from its internal `VALID_GEMINI_MODELS` set; passing an unrecognised model ID causes a runtime error
> - A previous commit attempted to add Claude 4.x models to this adapter, which is wrong — the Gemini CLI cannot invoke Claude models at all
> - This PR replaces all model IDs with the four Gemini 3.x preview IDs verified against `@google/gemini-cli` v0.36.0 source, and removes the Claude entries entirely
> - The benefit is that the model dropdown in the Paperclip UI will only show models the Gemini CLI actually accepts, eliminating runtime failures from bad model IDs

## What Changed

- Replaced five Gemini 2.x model entries (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`) with four Gemini 3.x CLI-verified model IDs
- Removed Claude 4.x model entries (`claude-opus-4-6`, `claude-sonnet-4-6`) — the `gemini-local` adapter uses `@google/gemini-cli`, which cannot invoke Claude models
- File changed: `packages/adapters/gemini-local/src/index.ts` (4 insertions, 5 deletions)

**Verified model IDs against `@google/gemini-cli` v0.36.0 `VALID_GEMINI_MODELS` set:**

| Model ID | CLI constant |
|---|---|
| `gemini-3.1-pro-preview-customtools` | `PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL` |
| `gemini-3.1-pro-preview` | `PREVIEW_GEMINI_3_1_MODEL` |
| `gemini-3-flash-preview` | `PREVIEW_GEMINI_FLASH_MODEL` |
| `gemini-3.1-flash-lite-preview` | `PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL` |

## Verification

- Inspect `@google/gemini-cli` v0.36.0 bundle and confirm the four model IDs appear in `VALID_GEMINI_MODELS`
- Create a `gemini-local` agent in Paperclip and confirm the model dropdown shows the four new entries and no legacy/Claude entries
- Assign a task to the agent with each model variant selected and confirm no "invalid model" runtime errors

## Risks

Low risk. This is a pure configuration change — it replaces string constants in a static array. No logic, no migration, no API surface change. The only risk is if the Gemini CLI v0.36.0 model IDs diverge from what a given deployment has installed; in that case the Gemini CLI will surface its own error message, and the operator can fall back to `auto`.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- **Context window:** 200K tokens
- **Reasoning mode:** Standard (no extended thinking)
- **Tool use:** Yes — shell, file read, grep, and GitHub CLI used to verify model IDs against `@google/gemini-cli` bundle source

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (no tests needed — config-only change)
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (none required)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge