### PR TITLE
Fix inbox badge after mark all as read

### DIFF
--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -299,6 +299,26 @@ describe("inbox helpers", () => {
     });
   });
 
+  it("excludes read mine issues from the badge count", () => {
+    const result = computeInboxBadgeData({
+      approvals: [],
+      joinRequests: [],
+      dashboard: undefined,
+      heartbeatRuns: [],
+      mineIssues: [makeIssue("1", true), makeIssue("2", false)],
+      dismissed: new Set<string>(),
+    });
+
+    expect(result).toEqual({
+      inbox: 1,
+      approvals: 0,
+      failedRuns: 0,
+      joinRequests: 0,
+      mineIssues: 1,
+      alerts: 0,
+    });
+  });
+
   it("drops dismissed runs and alerts from the computed badge", () => {
     const result = computeInboxBadgeData({
       approvals: [],

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -362,7 +362,7 @@ export function computeInboxBadgeData({
   const visibleJoinRequests = joinRequests.filter(
     (jr) => !dismissed.has(`join:${jr.id}`),
   ).length;
-  const visibleMineIssues = mineIssues.length;
+  const visibleMineIssues = getUnreadTouchedIssues(mineIssues).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;


### PR DESCRIPTION
## Summary
- count only unread Mine issues in the inbox badge
- keep the badge in sync after marking all issues as read
- add regression coverage for read Mine issues

## Testing
- pnpm test:run ui/src/lib/inbox.test.ts
- pnpm --filter @paperclipai/ui typecheck