### PR TITLE
fix(api): require auth for GET /heartbeat-runs/:runId/issues

### DIFF
--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -17,15 +17,20 @@ const mockIssueService = vi.hoisted(() => ({
   getByIdentifier: vi.fn(),
 }));
 
+const mockHeartbeatService = vi.hoisted(() => ({
+  getRun: vi.fn(),
+}));
+
 vi.mock("../services/activity.js", () => ({
   activityService: () => mockActivityService,
 }));
 
 vi.mock("../services/index.js", () => ({
   issueService: () => mockIssueService,
+  heartbeatService: () => mockHeartbeatService,
 }));
 
-function createApp() {
+function createApp(actorOverrides?: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -35,6 +40,7 @@ function createApp() {
       companyIds: ["company-1"],
       source: "session",
       isInstanceAdmin: false,
+      ...actorOverrides,
     };
     next();
   });
@@ -66,5 +72,68 @@ describe("activity routes", () => {
     expect(mockIssueService.getById).not.toHaveBeenCalled();
     expect(mockActivityService.runsForIssue).toHaveBeenCalledWith("company-1", "issue-uuid-1");
     expect(res.body).toEqual([{ runId: "run-1" }]);
+  });
+
+  it("returns 401 for heartbeat run issues when unauthenticated", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId: "company-1",
+    });
+
+    const res = await request(createApp({ type: "none" })).get("/api/heartbeat-runs/run-1/issues");
+
+    expect(res.status).toBe(401);
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1");
+    expect(mockActivityService.issuesForRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for heartbeat run issues when board user lacks company access", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId: "company-a",
+    });
+
+    const res = await request(
+      createApp({
+        type: "board",
+        userId: "user-1",
+        companyIds: ["company-b"],
+        source: "session",
+        isInstanceAdmin: false,
+      }),
+    ).get("/api/heartbeat-runs/run-1/issues");
+
+    expect(res.status).toBe(403);
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1");
+    expect(mockActivityService.issuesForRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when heartbeat run does not exist", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+
+    const res = await request(createApp()).get("/api/heartbeat-runs/missing-run/issues");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Heartbeat run not found" });
+    expect(mockActivityService.issuesForRun).not.toHaveBeenCalled();
+  });
+
+  it("returns issues for a heartbeat run when caller has company access", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId: "company-1",
+    });
+    mockActivityService.issuesForRun.mockResolvedValue([
+      { issueId: "issue-1", identifier: "PAP-1", title: "T", status: "todo", priority: "medium" },
+    ]);
+
+    const res = await request(createApp()).get("/api/heartbeat-runs/run-1/issues");
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.getRun).toHaveBeenCalledWith("run-1");
+    expect(mockActivityService.issuesForRun).toHaveBeenCalledWith("run-1");
+    expect(res.body).toEqual([
+      { issueId: "issue-1", identifier: "PAP-1", title: "T", status: "todo", priority: "medium" },
+    ]);
   });
 });

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -4,7 +4,7 @@ import type { Db } from "@paperclipai/db";
 import { validate } from "../middleware/validate.js";
 import { activityService } from "../services/activity.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
-import { issueService } from "../services/index.js";
+import { heartbeatService, issueService } from "../services/index.js";
 import { sanitizeRecord } from "../redaction.js";
 
 const createActivitySchema = z.object({
@@ -21,6 +21,7 @@ export function activityRoutes(db: Db) {
   const router = Router();
   const svc = activityService(db);
   const issueSvc = issueService(db);
+  const heartbeat = heartbeatService(db);
 
   async function resolveIssueByRef(rawId: string) {
     if (/^[A-Z]+-\d+$/i.test(rawId)) {
@@ -80,6 +81,12 @@ export function activityRoutes(db: Db) {
 
   router.get("/heartbeat-runs/:runId/issues", async (req, res) => {
     const runId = req.params.runId as string;
+    const run = await heartbeat.getRun(runId);
+    if (!run) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    assertCompanyAccess(req, run.companyId);
     const result = await svc.issuesForRun(runId);
     res.json(result);
   });


### PR DESCRIPTION
Resolve #19 
## Thinking Path

Paperclip is a control plane for AI-agent companies: the API exposes company-scoped activity, issues, and heartbeat runs.
Board users and agents are supposed to see only data for companies they can access; routes typically call assertCompanyAccess (or equivalent) after resolving the resource.
GET /api/heartbeat-runs/:runId/issues listed issues linked to a run but never checked the caller’s identity or company membership.
That allowed unauthenticated requests to read issue summaries for any known run id, which breaks the same boundary as other /heartbeat-runs/:runId/* endpoints.
This PR loads the run via heartbeatService.getRun, returns 404 when the run is missing, then assertCompanyAccess(req, run.companyId) before calling issuesForRun, matching [server/src/routes/agents.ts](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/server/src/routes/agents.ts).
The benefit is consistent authorization with the rest of the heartbeat-run API and no leaked issue data to anonymous callers.

## What Changed

server/src/routes/activity.ts: For GET /api/heartbeat-runs/:runId/issues, resolve the run with heartbeat.getRun, respond with 404 + { error: "Heartbeat run not found" } if absent, then assertCompanyAccess(req, run.companyId) before activityService.issuesForRun(runId).
server/src/__tests__/activity-routes.test.ts: Mock heartbeatService; add coverage for 401 (unauthenticated), 403 (board user wrong company), 404 (missing run), and 200 (allowed access).

## Verification

pnpm --filter @paperclipai/server exec vitest run src/__tests__/activity-routes.test.ts
Optional manual: in authenticated deployment, curl without auth to /api/heartbeat-runs/<runId>/issues should return 401 (not issue JSON) when the run exists.

## Risks

Low. Callers who could already use GET /api/heartbeat-runs/:runId (same assertCompanyAccess on run.companyId) should behave the same for this sub-resource. Unauthenticated or cross-company access is now correctly rejected.

## Model Used

None — human-authored

## Checklist


 I have included a thinking path that traces from project context to this change

 I have specified the model used (with version and capability details)

 I have run tests locally and they pass

 I have added or updated tests where applicable

 If this change affects the UI, I have included before/after screenshots

 I have updated relevant documentation to reflect my changes

 I have considered and documented any risks above

 I will address all Greptile and reviewer comments before requesting merge
