### PR TITLE
docs: add auth/onboarding validation matrix and anchor authz tests

### DIFF
--- a/doc/AUTH-ONBOARDING-VALIDATION-MATRIX.md
+++ b/doc/AUTH-ONBOARDING-VALIDATION-MATRIX.md
@@ -1,0 +1,87 @@
+# Auth and onboarding validation matrix
+
+This document is the **canonical** map from deployment mode + actor + surface to **expected behavior** (fail closed) and **evidence** in code or tests.
+
+**Handoff note:** An external handoff packet `paperclips/handoffs/2026-03-19-auth-onboarding-validation-matrix.md` was not present in this repository clone, and fetching additional remotes was not possible in this environment. This matrix was derived from the current codebase (`server/src/middleware/auth.ts`, `server/src/routes/authz.ts`, `server/src/routes/access.ts`, CLI bootstrap, UI and tests). If upstream adds that handoff file, link it here as supplementary context.
+
+## Deployment modes (product intent)
+
+| Mode | Board identity without browser session | Typical use |
+|------|----------------------------------------|-------------|
+| `local_trusted` | Every request is treated as the **implicit local board** (`userId: local-board`, `source: local_implicit`, `isInstanceAdmin: true`). No login UI required. | Single-operator local machine; **not** a failure to deny HTTP “anonymous” access to the API—there is no separate anonymous principal. |
+| `authenticated` | Without `Authorization: Bearer …` or a valid session cookie, `req.actor.type` stays **`none`** until resolved. | Login-required deployments; unauthenticated callers should get **401** on protected routes. |
+
+**Fail closed:** In `authenticated` mode, missing or invalid credentials do not silently grant board or agent access. In `local_trusted`, the implicit board is **explicit** in code (see [`server/src/middleware/auth.ts`](../server/src/middleware/auth.ts)); there is no hidden upgrade to a different company.
+
+## Actor resolution order (`authenticated` mode)
+
+For each request, [`actorMiddleware`](../server/src/middleware/auth.ts):
+
+1. Initializes actor: `local_trusted` → board implicit; `authenticated` → `none`.
+2. If **no** `Authorization: Bearer` header: tries **Better Auth session** → board with `companyIds` from memberships and `isInstanceAdmin` from `instance_user_roles`.
+3. If Bearer present: resolves **board API key** → board with resolved company access; else **agent API key** (hash) → agent; else **agent JWT** (`verifyLocalAgentJwt`) with DB check that the agent exists, matches `company_id` claim, and is not `terminated` / `pending_approval`.
+
+Invalid JWT, wrong company vs agent row, terminated agent: actor remains **`none`** (JWT path) or stays unset → **`none`** for protected resources.
+
+## Company scoping ([`assertCompanyAccess`](../server/src/routes/authz.ts))
+
+| `req.actor` | `companyId` in route | Result |
+|-------------|----------------------|--------|
+| `none` | any | **401** `Unauthorized` |
+| `agent`, `companyId` mismatch | target company | **403** `Agent key cannot access another company` |
+| `board`, `source` not `local_implicit`, not instance admin | target not in `companyIds` | **403** `User does not have access to this company` |
+| `board`, `local_implicit` or instance admin | any company | Allowed (still subject to route-specific rules) |
+| `board`, session, membership includes company | that company | Allowed |
+
+Instance admins (`isInstanceAdmin`) are not restricted by the `companyIds` list for `assertCompanyAccess` (see implementation).
+
+## Matrix: Board access
+
+| # | Scenario | Mode | Expectation | Evidence |
+|---|----------|------|-------------|----------|
+| B1 | No `Authorization`, no session cookie | `authenticated` | `actor.type === none` for API; protected routes using `assertBoard` / `assertCompanyAccess` → **401** | [`auth.ts`](../server/src/middleware/auth.ts), [`activity-routes.test.ts`](../server/src/__tests__/activity-routes.test.ts) (heartbeat run issues) |
+| B2 | Valid session cookie | `authenticated` | `actor.type === board`, `companyIds` populated | [`auth.ts`](../server/src/middleware/auth.ts) |
+| B3 | Bearer board API key | either | `actor.type === board`, access from `boardAuth.resolveBoardAccess` | [`auth.ts`](../server/src/middleware/auth.ts) |
+| B4 | No credentials | `local_trusted` | **Implicit board** (not `none`) | [`auth.ts`](../server/src/middleware/auth.ts) |
+| B5 | Session board mutates (POST/PATCH/DELETE) from untrusted origin | `authenticated` | **403** `Board mutation requires trusted browser origin` | [`board-mutation-guard.ts`](../server/src/middleware/board-mutation-guard.ts) |
+| B6 | Create company | either | `assertBoard` + instance admin (non–local-trusted) | [`companies.ts`](../server/src/routes/companies.ts) |
+
+## Matrix: Agent access (API key and run JWT)
+
+| # | Scenario | Expectation | Evidence |
+|---|----------|-------------|----------|
+| A1 | Valid agent API key | `actor.type === agent`, `companyId` from key | [`auth.ts`](../server/src/middleware/auth.ts) |
+| A2 | Valid run JWT; JWT `company_id` ≠ agent row `companyId` | Actor not set as agent (stays `none`) | [`auth.ts`](../server/src/middleware/auth.ts) |
+| A3 | Agent token, resource in **another** company | **403** via `assertCompanyAccess` | [`authz.ts`](../server/src/routes/authz.ts), [`auth-onboarding-validation-matrix.test.ts`](../server/src/__tests__/auth-onboarding-validation-matrix.test.ts) |
+| A4 | JWT claims: `sub`, `company_id`, `run_id` binding | Documented + unit tests | [`agent-auth-jwt.ts`](../server/src/agent-auth-jwt.ts), [`agent-auth-jwt.test.ts`](../server/src/__tests__/agent-auth-jwt.test.ts) |
+
+## Matrix: Bootstrap CEO invite
+
+| # | Step | Expectation | Evidence |
+|---|------|-------------|----------|
+| S1 | CLI creates bootstrap invite | Only when `deploymentMode === authenticated`; revokes prior active bootstrap invites (unless `--force`); inserts `inviteType: bootstrap_ceo`, `invitedByUserId: system` | [`cli/src/commands/auth-bootstrap-ceo.ts`](../cli/src/commands/auth-bootstrap-ceo.ts) |
+| S2 | Health endpoint exposes bootstrap state | `bootstrapStatus`, `bootstrapInviteActive` when no instance admin | [`health.ts`](../server/src/routes/health.ts) |
+| S3 | Accept bootstrap invite | `inviteType === bootstrap_ceo` requires **human** `requestType`, **authenticated** board user (`req.actor.type === board` with user or local implicit), promotes instance admin, marks accepted | [`access.ts`](../server/src/routes/access.ts) (`POST /invites/:token/accept`) |
+| S4 | UI gate while bootstrap pending | `CloudAccessGate` in [`ui/src/App.tsx`](../ui/src/App.tsx) uses `/api/health` | — |
+
+## Matrix: Company join invites and onboarding
+
+| # | Surface | Expectation | Evidence |
+|---|---------|-------------|----------|
+| I1 | `GET /api/invites/:token` (summary) | Unauthenticated access to token metadata as designed for landing | [`access.ts`](../server/src/routes/access.ts) |
+| I2 | `GET …/onboarding.txt` | Plain-text onboarding handoff with registration and claim URLs | [`invite-onboarding-text.test.ts`](../server/src/__tests__/invite-onboarding-text.test.ts), [`access.ts`](../server/src/routes/access.ts) |
+| I3 | `POST …/accept` | Validates invite, creates join request / acceptance paths per `inviteType` | [`invite-accept-replay.test.ts`](../server/src/__tests__/invite-accept-replay.test.ts), [`invite-join-grants.test.ts`](../server/src/__tests__/invite-join-grants.test.ts) |
+| I4 | Agent join grants | Defaults include `tasks:assign` | [`invite-join-grants.test.ts`](../server/src/__tests__/invite-join-grants.test.ts) |
+
+## Matrix: End-to-end / smoke (optional CI)
+
+| Suite | Scope |
+|-------|--------|
+| [`tests/release-smoke/docker-auth-onboarding.spec.ts`](../tests/release-smoke/docker-auth-onboarding.spec.ts) | Authenticated Docker onboarding flow (Playwright) |
+
+## Maintenance
+
+When changing auth or onboarding:
+
+1. Update this matrix or the linked tests in the same PR.
+2. Run `pnpm --filter @paperclipai/server exec vitest run src/__tests__/auth-onboarding-validation-matrix.test.ts` plus affected route tests.

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -54,3 +54,9 @@ All entities belong to a company. The API enforces company boundaries:
 - Agents can only access entities in their own company
 - Board operators can access all companies they're members of
 - Cross-company access is denied with `403`
+
+## Validation matrix (canonical reference)
+
+Deployment modes (`local_trusted` vs `authenticated`), actor resolution (session, board API key, agent key, run JWT), bootstrap CEO invite, invite onboarding, and mapped test evidence are documented in **`doc/AUTH-ONBOARDING-VALIDATION-MATRIX.md`** in the repository root (source-of-truth for audits; not duplicated here).
+
+Server-side anchor tests: `server/src/__tests__/auth-onboarding-validation-matrix.test.ts`.

--- a/server/src/__tests__/auth-onboarding-validation-matrix.test.ts
+++ b/server/src/__tests__/auth-onboarding-validation-matrix.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Anchor tests for doc/AUTH-ONBOARDING-VALIDATION-MATRIX.md (company scoping rows).
+ */
+import type { Request } from "express";
+import { describe, expect, it } from "vitest";
+import { HttpError } from "../errors.js";
+import { assertBoard, assertCompanyAccess } from "../routes/authz.js";
+
+function expectHttpError(fn: () => void, status: number) {
+  try {
+    fn();
+    expect.fail("expected HttpError");
+  } catch (err) {
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(status);
+  }
+}
+
+function boardReq(overrides: Partial<Request["actor"]> = {}): Request {
+  return {
+    actor: {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+      ...overrides,
+    },
+  } as unknown as Request;
+}
+
+describe("auth validation matrix (authz helpers)", () => {
+  it("assertCompanyAccess: none → 401 (matrix B1 / company gate)", () => {
+    const req = { actor: { type: "none", source: "none" } } as unknown as Request;
+    expectHttpError(() => assertCompanyAccess(req, "company-1"), 401);
+  });
+
+  it("assertCompanyAccess: agent wrong company → 403 (matrix A3)", () => {
+    const req = {
+      actor: {
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-a",
+        source: "agent_key",
+      },
+    } as unknown as Request;
+    expectHttpError(() => assertCompanyAccess(req, "company-b"), 403);
+  });
+
+  it("assertCompanyAccess: session board missing membership → 403", () => {
+    const req = boardReq({ companyIds: ["company-other"] });
+    expectHttpError(() => assertCompanyAccess(req, "company-1"), 403);
+  });
+
+  it("assertCompanyAccess: session board with membership → ok", () => {
+    const req = boardReq({ companyIds: ["company-1"] });
+    expect(() => assertCompanyAccess(req, "company-1")).not.toThrow();
+  });
+
+  it("assertCompanyAccess: local_implicit board → ok for any companyId (matrix B4)", () => {
+    const req = {
+      actor: {
+        type: "board",
+        userId: "local-board",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+      },
+    } as unknown as Request;
+    expect(() => assertCompanyAccess(req, "any-company-id")).not.toThrow();
+  });
+
+  it("assertBoard: agent → 403", () => {
+    const req = {
+      actor: { type: "agent", agentId: "a1", companyId: "c1", source: "agent_key" },
+    } as unknown as Request;
+    expectHttpError(() => assertBoard(req), 403);
+  });
+});


### PR DESCRIPTION
Resolve #693 
## Thinking Path

Paperclip is a control plane for AI-agent companies; production behavior depends on clear rules for board sessions, agent keys/JWTs, company boundaries, and invite/bootstrap flows.
Auth logic is spread across middleware (actorMiddleware), route guards (assertCompanyAccess, assertBoard), access routes (invites, join), CLI bootstrap, and the UI gate for authenticated bootstrap.
Without a single map, reviewers and auditors cannot verify that unauthenticated callers, cross-company agents, and bootstrap/onboarding paths all fail closed in the intended way.
This PR adds a canonical validation matrix document at the repo root, links it from the public API authentication page, and adds focused unit tests on authz helpers that anchor the “company scoping” rows of that matrix.
The benefit is explicit, test-backed evidence for auth and onboarding behavior, with local_trusted vs authenticated called out so implicit local board access is not mistaken for a security gap.

## What Changed

Added [doc/AUTH-ONBOARDING-VALIDATION-MATRIX.md](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/doc/AUTH-ONBOARDING-VALIDATION-MATRIX.md): deployment modes, actor resolution summary, assertCompanyAccess table, board/agent/bootstrap/invite matrices, pointers to code and existing tests (including invite and release-smoke specs). Notes that the external handoff file was not present in this clone/remotes and was not retrieved.
Updated [docs/api/authentication.md](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/api/authentication.md): new “Validation matrix” section pointing to the repo-root matrix and the anchor test file.
Added [server/src/__tests__/auth-onboarding-validation-matrix.test.ts](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/server/src/__tests__/auth-onboarding-validation-matrix.test.ts): tests for assertCompanyAccess (none → 401, agent wrong company → 403, session board membership, local_implicit board) and assertBoard rejecting agents.

## Verification

pnpm --filter @paperclipai/server exec vitest run src/__tests__/auth-onboarding-validation-matrix.test.ts
Optional: pnpm -r typecheck (recommended before merge per repo norms)

## Risks

Low. Documentation and additive tests only; no change to runtime auth middleware behavior.
Docs drift: If auth middleware semantics change, update the matrix and anchor tests in the same PR.

## Model Used

None — human-authored

## Checklist


 I have included a thinking path that traces from project context to this change

 I have specified the model used (with version and capability details)

 I have run tests locally and they pass

 I have added or updated tests where applicable

 If this change affects the UI, I have included before/after screenshots (N/A — docs + server unit tests)

 I have updated relevant documentation to reflect my changes

 I have considered and documented any risks above
