### PR TITLE
fix(http-adapter): block requests to private IPs and cloud metadata endpoints

### DIFF
--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -1,10 +1,46 @@
 import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
 import { asString, asNumber, parseObject } from "../utils.js";
 
+const BLOCKED_HOSTS = new Set([
+  "169.254.169.254",
+  "metadata.google.internal",
+  "metadata.azure.internal",
+]);
+
+function isBlockedUrl(urlStr: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    return true;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return true;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (BLOCKED_HOSTS.has(hostname)) return true;
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") return true;
+
+  // Block private IP ranges
+  const parts = hostname.split(".");
+  if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
+    const first = parseInt(parts[0], 10);
+    if (first === 10) return true;
+    if (first === 172 && parseInt(parts[1], 10) >= 16 && parseInt(parts[1], 10) <= 31) return true;
+    if (first === 192 && parseInt(parts[1], 10) === 168) return true;
+    if (first === 0 || first === 127) return true;
+  }
+
+  return false;
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { config, runId, agent, context } = ctx;
   const url = asString(config.url, "");
   if (!url) throw new Error("HTTP adapter missing url");
+  if (isBlockedUrl(url)) throw new Error(`HTTP adapter blocked request to ${url}: private or reserved address`);
 
   const method = asString(config.method, "POST");
   const timeoutMs = asNumber(config.timeoutMs, 0);

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -1,3 +1,4 @@
+import { lookup } from "node:dns/promises";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
 import { asString, asNumber, parseObject } from "../utils.js";
 
@@ -6,6 +7,39 @@ const BLOCKED_HOSTS = new Set([
   "metadata.google.internal",
   "metadata.azure.internal",
 ]);
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".");
+  if (parts.length !== 4 || !parts.every((p) => /^\d+$/.test(p))) return false;
+  const [a, b] = [parseInt(parts[0], 10), parseInt(parts[1], 10)];
+  if (a === 0 || a === 127) return true;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "::1") return true;
+  // fe80::/10 link-local
+  if (normalized.startsWith("fe80:") || normalized.startsWith("fe80")) return true;
+  // fc00::/7 unique-local (fc and fd prefixes)
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  // IPv4-mapped IPv6 (::ffff:x.x.x.x)
+  const v4mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4mapped && isPrivateIPv4(v4mapped[1])) return true;
+  // IPv4-mapped IPv6 hex form (::ffff:AABB:CCDD)
+  const v4hex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4hex) {
+    const hi = parseInt(v4hex[1], 16);
+    const lo = parseInt(v4hex[2], 16);
+    const mapped = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+    if (isPrivateIPv4(mapped)) return true;
+  }
+  return false;
+}
 
 function isBlockedUrl(urlStr: string): boolean {
   let parsed: URL;
@@ -21,19 +55,22 @@ function isBlockedUrl(urlStr: string): boolean {
 
   const hostname = parsed.hostname.toLowerCase();
   if (BLOCKED_HOSTS.has(hostname)) return true;
-  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") return true;
-
-  // Block private IP ranges
-  const parts = hostname.split(".");
-  if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
-    const first = parseInt(parts[0], 10);
-    if (first === 10) return true;
-    if (first === 172 && parseInt(parts[1], 10) >= 16 && parseInt(parts[1], 10) <= 31) return true;
-    if (first === 192 && parseInt(parts[1], 10) === 168) return true;
-    if (first === 0 || first === 127) return true;
-  }
+  if (hostname === "localhost") return true;
+  if (isPrivateIPv4(hostname)) return true;
+  if (isPrivateIPv6(hostname)) return true;
 
   return false;
+}
+
+async function isBlockedByDns(hostname: string): Promise<boolean> {
+  try {
+    const results = await lookup(hostname, { all: true });
+    return results.some((r) =>
+      r.family === 4 ? isPrivateIPv4(r.address) : isPrivateIPv6(r.address),
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
@@ -41,6 +78,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const url = asString(config.url, "");
   if (!url) throw new Error("HTTP adapter missing url");
   if (isBlockedUrl(url)) throw new Error(`HTTP adapter blocked request to ${url}: private or reserved address`);
+
+  const parsedUrl = new URL(url);
+  if (await isBlockedByDns(parsedUrl.hostname)) {
+    throw new Error(`HTTP adapter blocked request to ${url}: hostname resolves to private address`);
+  }
 
   const method = asString(config.method, "POST");
   const timeoutMs = asNumber(config.timeoutMs, 0);
@@ -59,6 +101,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         ...headers,
       },
       body: JSON.stringify(body),
+      redirect: "manual",
       ...(timer ? { signal: controller.signal } : {}),
     });
 


### PR DESCRIPTION
## What

Add URL validation to the HTTP adapter before calling fetch(). Rejects
requests to private IP ranges, localhost, and cloud metadata endpoints.

## Why

The HTTP adapter at server/src/adapters/http/execute.ts passes
user-configured URLs directly to fetch() without validation. In cloud
deployments this allows reaching metadata endpoints
(169.254.169.254) to obtain IAM credentials and accessing internal
services that should not be reachable from the application layer.

## Blocked destinations

- Cloud metadata: 169.254.169.254, metadata.google.internal, metadata.azure.internal
- Localhost: 127.0.0.1, localhost, [::1]
- Private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
- Non-HTTP(S) schemes

## Files

- server/src/adapters/http/execute.ts