### PR TITLE
fix(plugins): clean orphan plugin_jobs on soft uninstall

### DIFF
--- a/server/src/services/plugin-registry.ts
+++ b/server/src/services/plugin-registry.ts
@@ -264,16 +264,26 @@ export function pluginRegistryService(db: Db) {
           .then((rows) => rows[0] ?? null);
       }
 
-      // Soft delete – mark as uninstalled
-      return db
-        .update(plugins)
-        .set({
-          status: "uninstalled" as PluginStatus,
-          updatedAt: new Date(),
-        })
-        .where(eq(plugins.id, id))
-        .returning()
-        .then((rows) => rows[0] ?? null);
+      // Soft delete – mark as uninstalled.
+      // Clean runtime job state — plugin_jobs are re-created from the manifest
+      // on reinstall, and stale rows cause the scheduler to spam
+      // "skipping job — worker not running" every tick. Wrap in a transaction
+      // so the status flip and the job-state cleanup are atomic. plugin_config
+      // is intentionally preserved so user settings survive uninstall/reinstall
+      // cycles.
+      return db.transaction(async (tx) => {
+        await tx.delete(pluginJobRuns).where(eq(pluginJobRuns.pluginId, id));
+        await tx.delete(pluginJobs).where(eq(pluginJobs.pluginId, id));
+        return tx
+          .update(plugins)
+          .set({
+            status: "uninstalled" as PluginStatus,
+            updatedAt: new Date(),
+          })
+          .where(eq(plugins.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+      });
     },
 
     // ----- Config ---------------------------------------------------------

--- a/server/src/services/plugin-registry.ts
+++ b/server/src/services/plugin-registry.ts
@@ -264,16 +264,36 @@ export function pluginRegistryService(db: Db) {
           .then((rows) => rows[0] ?? null);
       }
 
-      // Soft delete – mark as uninstalled.
-      // Clean runtime job state — plugin_jobs are re-created from the manifest
-      // on reinstall, and stale rows cause the scheduler to spam
-      // "skipping job — worker not running" every tick. Wrap in a transaction
-      // so the status flip and the job-state cleanup are atomic. plugin_config
-      // is intentionally preserved so user settings survive uninstall/reinstall
-      // cycles.
+      // Soft delete – mark plugin as uninstalled and pause its jobs.
+      //
+      // PLUGIN_SPEC §25.1 lists `plugin_jobs` as plugin-owned data with a
+      // 30-day grace period; deleting on soft uninstall would violate that.
+      // Pausing instead:
+      //   - Honors the spec (data retained for the grace period and recoverable
+      //     on reinstall).
+      //   - Stops the scheduler tick from picking these jobs up — the tick
+      //     query is `WHERE status = 'active'`, so paused rows are silently
+      //     skipped at the SQL layer rather than at the runtime "worker not
+      //     running" debug log.
+      //   - Mirrors the existing pattern in plugin-job-store.ts
+      //     `syncJobDeclarations()`, which pauses jobs when a manifest no
+      //     longer declares them and reactivates them on reinstall.
+      //   - Leaves plugin_job_runs untouched: in-flight runs are cancelled by
+      //     `onPluginUnloaded` → `unregisterPlugin()` → `completeRun(...,
+      //     status: "cancelled")`, and historical runs are preserved per spec.
+      //
+      // The host's grace-period purge (§25.1, point 5) is the path that
+      // eventually deletes plugin_jobs / plugin_job_runs after 30 days.
       return db.transaction(async (tx) => {
-        await tx.delete(pluginJobRuns).where(eq(pluginJobRuns.pluginId, id));
-        await tx.delete(pluginJobs).where(eq(pluginJobs.pluginId, id));
+        await tx
+          .update(pluginJobs)
+          .set({ status: "paused" as const, updatedAt: new Date() })
+          .where(
+            and(
+              eq(pluginJobs.pluginId, id),
+              ne(pluginJobs.status, "paused"),
+            ),
+          );
         return tx
           .update(plugins)
           .set({


### PR DESCRIPTION

# Soft-delete plugin uninstall leaves orphan `plugin_jobs` + `plugin_job_runs` rows, causing scheduler log spam forever

## TL;DR

`DELETE /api/plugins/:pluginId` (without `removeData=true`) does a soft-delete that sets `plugins.status = 'uninstalled'` but leaves `plugin_jobs`, `plugin_job_runs`, and `plugin_config` rows behind. The plugin-job-scheduler continues to dispatch the orphaned jobs every tick, finds no worker, and logs `skipping job — worker not running` indefinitely (~8,640 lines/day for a plugin with 3 jobs on `* * * * *`/`*/15 * * * *`/`0 * * * *` schedules).

I reproduced this **twice in one day** with `paperclip-plugin-telegram` installs. Both times the orphan job rows persisted across server restart and silently filled the log.

## Reproduction

```bash
# 1. Install a plugin with scheduled jobs (paperclip-plugin-telegram has 3)
curl -X POST http://127.0.0.1:3100/api/plugins/install \
  -H "Content-Type: application/json" \
  -d '{"packageName":"paperclip-plugin-telegram"}'
# → 200, plugin installed, 3 jobs registered with scheduler

# 2. Uninstall (soft, the default)
curl -X DELETE http://127.0.0.1:3100/api/plugins/<pluginId>
# → 200, plugin row updated to status='uninstalled'

# 3. Check the DB
psql ... -c "SELECT COUNT(*) FROM plugin_jobs WHERE plugin_id = '<pluginId>';"
# → 3   (orphaned)
psql ... -c "SELECT COUNT(*) FROM plugin_job_runs WHERE plugin_id = '<pluginId>';"
# → 141 (orphaned, grows over time)
psql ... -c "SELECT COUNT(*) FROM plugin_config WHERE plugin_id = '<pluginId>';"
# → 1   (orphaned)

# 4. Tail the server log
tail -f /var/paperclip/instances/default/logs/server.log | grep "skipping job"
# → DEBUG: skipping job — worker not running {"pluginId":"<orphan>"}
#   firing every 30s, forever
```

## Root cause

**[`server/src/services/plugin-registry.ts:254-277`](https://github.com/paperclipai/paperclip/blob/master/server/src/services/plugin-registry.ts#L254)**

```ts
uninstall: async (id: string, removeData = false) => {
  const plugin = await getById(id);
  if (!plugin) throw notFound("Plugin not found");

  if (removeData) {
    // Hard delete – plugin_config cascades via FK onDelete
    return db
      .delete(plugins)
      .where(eq(plugins.id, id))
      .returning()
      .then((rows) => rows[0] ?? null);
  }

  // Soft delete – mark as uninstalled
  return db
    .update(plugins)
    .set({
      status: "uninstalled" as PluginStatus,
      updatedAt: new Date(),
    })
    .where(eq(plugins.id, id))
    .returning()
    .then((rows) => rows[0] ?? null);
},
```

The hard-delete branch correctly relies on FK `onDelete CASCADE` to clean `plugin_config` (and presumably the other plugin_* tables). The soft-delete branch only updates `plugins.status` and **does not touch any of the dependent tables**, leaving orphaned rows behind.

The plugin-job-scheduler then queries `plugin_jobs` without joining `plugins` to filter on `status != 'uninstalled'`, so it happily dispatches the orphan jobs forever. Each tick, the worker manager reports "worker not running" (because the plugin is uninstalled), and the scheduler logs it.

## Why this matters

- **Log spam**: A plugin like `paperclip-plugin-telegram` with 3 jobs at `* * * * *`, `*/15 * * * *`, and `0 * * * *` produces ~3 skipped-job log lines every 30 seconds = **~8,640 lines/day**. Multiply by every plugin a user has ever uninstalled.
- **Wasted scheduler cycles**: every tick, the scheduler queries the DB for due jobs, finds the orphans, attempts to dispatch them, fails. Small per-tick cost but it's pure waste.
- **Confusing reinstall behavior**: when the plugin is reinstalled, it gets a new UUID and a new set of `plugin_jobs` rows. The old orphan jobs still fire. If the plugin uses singleton state (e.g. a Telegram bot polling token lock), the old + new can interact in surprising ways.
- **DB bloat**: `plugin_job_runs` accumulates one row per job execution forever — at 1/min for a single orphan, that's ~525K rows/year per orphaned job.
- **Hard to diagnose**: the only signal is DEBUG-level log spam that most operators won't notice.

## Suggested fix

Two options. Either is acceptable; option B is more conservative.

### Option A — clean orphan job state on soft delete (recommended)

Plugin jobs are runtime state derived from the plugin manifest's `jobs[]` array. They're re-created on every install via `plugin-loader: job declarations synced and plugin registered with scheduler`. They have no value across uninstall — the user's `plugin_config` is the only thing worth preserving for reinstall convenience.

```diff
   // Soft delete – mark as uninstalled
+  // Clean runtime job state — plugin_jobs are re-created from manifest on
+  // reinstall, and stale rows cause the scheduler to spam "worker not running"
+  // every tick. Preserve plugin_config so the user's settings survive
+  // uninstall/reinstall cycles.
+  await db.delete(pluginJobRuns).where(eq(pluginJobRuns.pluginId, id));
+  await db.delete(pluginJobs).where(eq(pluginJobs.pluginId, id));
   return db
     .update(plugins)
     .set({
       status: "uninstalled" as PluginStatus,
       updatedAt: new Date(),
     })
     .where(eq(plugins.id, id))
     .returning()
     .then((rows) => rows[0] ?? null);
```

Wrap in a transaction (`db.transaction(...)`) to ensure atomicity.

### Option B — filter orphan jobs at the scheduler query level

If you'd rather not touch the uninstall path (e.g. to preserve a future "undelete" capability), the scheduler can join `plugin_jobs` against `plugins` and exclude rows where `plugins.status = 'uninstalled'`:

```diff
- SELECT * FROM plugin_jobs WHERE next_run_at <= now() AND status = 'active'
+ SELECT pj.* FROM plugin_jobs pj
+ JOIN plugins p ON p.id = pj.plugin_id
+ WHERE pj.next_run_at <= now()
+   AND pj.status = 'active'
+   AND p.status != 'uninstalled'
```

This stops the log spam but doesn't address DB bloat. Combine with a periodic GC job if you go this route.

**I recommend Option A** — it's a 2-line transactional addition to the existing handler, removes the bloat at the source, and matches the principle of least surprise (when a plugin is uninstalled, its scheduled work goes away).

## Related — separate plugin bug also reproduced today

While debugging this, I also hit a silent-fail bug in `paperclip-plugin-telegram` where the polling loop dispatches but never produces outbound HTTP. Filed separately at github.com/mvanhorn/paperclip-plugin-telegram (issue link to be added). Mentioning here because the orphan-job log spam made that debug session significantly noisier than it needed to be.

## Environment

- Paperclip server: `paperclipai/paperclip@6c856915` (master, 1 commit behind upstream)
- Node v24.13.0, macOS 15.3 / Apple Silicon
- Embedded Postgres 18.1.0-beta.16 on :54329
- Plugin used to reproduce: `paperclip-plugin-telegram@0.2.6` (manifest stale, npm dist-tag latest is 0.2.8)

## Workaround (for anyone else hitting this)

Until fixed upstream, after a soft uninstall run:

```sql
BEGIN;
DELETE FROM plugin_job_runs WHERE plugin_id = '<orphan-uuid>';
DELETE FROM plugin_jobs     WHERE plugin_id = '<orphan-uuid>';
DELETE FROM plugin_config   WHERE plugin_id = '<orphan-uuid>';
DELETE FROM plugins         WHERE id        = '<orphan-uuid>' AND status = 'uninstalled';
COMMIT;
```

Then restart the paperclip server (`launchctl kickstart -k gui/$UID/com.paperclip` or equivalent) to clear the in-memory scheduler cache.

Happy to open this as a PR with the Option A fix if you'd like — let me know.
