### PR TITLE
fix(backups): compress DB backups with gzip

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -129,7 +129,7 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
           filenamePrefix: "paperclip-test",
         });
 
-        expect(result.backupFile).toMatch(/paperclip-test-.*\.sql$/);
+        expect(result.backupFile).toMatch(/paperclip-test-.*\.sql\.gz$/);
         expect(result.sizeBytes).toBeGreaterThan(1024 * 1024);
         expect(fs.existsSync(result.backupFile)).toBe(true);
 

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -1,6 +1,8 @@
-import { createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, resolve } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGzip, gunzipSync } from "node:zlib";
 import postgres from "postgres";
 
 export type RunDatabaseBackupOptions = {
@@ -77,7 +79,7 @@ function pruneOldBackups(backupDir: string, retentionDays: number, filenamePrefi
   let pruned = 0;
 
   for (const name of readdirSync(backupDir)) {
-    if (!name.startsWith(`${filenamePrefix}-`) || !name.endsWith(".sql")) continue;
+    if (!name.startsWith(`${filenamePrefix}-`) || !(name.endsWith(".sql") || name.endsWith(".sql.gz"))) continue;
     const fullPath = resolve(backupDir, name);
     const stat = statSync(fullPath);
     if (stat.mtimeMs < cutoff) {
@@ -604,11 +606,20 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
 
     await writer.close();
 
-    const sizeBytes = statSync(backupFile).size;
+    // Compress the SQL dump with gzip
+    const gzipFile = `${backupFile}.gz`;
+    await pipeline(
+      createReadStream(backupFile),
+      createGzip(),
+      createWriteStream(gzipFile),
+    );
+    unlinkSync(backupFile);
+
+    const sizeBytes = statSync(gzipFile).size;
     const prunedCount = pruneOldBackups(opts.backupDir, retentionDays, filenamePrefix);
 
     return {
-      backupFile,
+      backupFile: gzipFile,
       sizeBytes,
       prunedCount,
     };
@@ -626,7 +637,10 @@ export async function runDatabaseRestore(opts: RunDatabaseRestoreOptions): Promi
 
   try {
     await sql`SELECT 1`;
-    const contents = await readFile(opts.backupFile, "utf8");
+    const raw = await readFile(opts.backupFile);
+    const contents = opts.backupFile.endsWith(".gz")
+      ? gunzipSync(raw).toString("utf8")
+      : raw.toString("utf8");
     const statements = contents
       .split(STATEMENT_BREAKPOINT)
       .map((statement) => statement.trim())


### PR DESCRIPTION
## Summary

- Compress database backups with gzip (`.sql` → `.sql.gz`), achieving ~83% size reduction (~675MB → ~120MB per backup)
- Update cleanup logic to handle both `.sql` and `.sql.gz` files (backward compatible with existing uncompressed backups)
- Update restore to auto-detect and decompress `.gz` files via `gunzipSync`

## Context

Uncompressed hourly backups (675MB each, 30-day retention) can consume ~470GB/month of disk space. In our production deployment, 275 backup files totaling 126GB filled a 700GB drive and crashed the server.

Gzip compression uses Node.js native `zlib` (`createGzip`/`gunzipSync`) with streaming `pipeline()` — no new dependencies.

## Changes (2 files, +20/-6)

- `packages/db/src/backup-lib.ts`: Stream SQL dump through `createGzip()`, auto-decompress on restore, backward-compatible cleanup for both extensions
- `packages/db/src/backup-lib.test.ts`: Update expected file extension to `.sql.gz`

## Verification

- [x] 33+ hours of production gzip backups (38 consecutive `.sql.gz` files, all ~118-120MB)
- [x] Compression ratio verified: 83% reduction
- [x] Backup restore path handles `.gz` decompression
- [x] Pruning handles both `.sql` and `.sql.gz` extensions
- [x] `packages/db` typecheck passes
- [x] `backup-lib.test.ts` passes

## Test plan

- [x] Verify `.sql.gz` output from `runDatabaseBackup`
- [x] Verify `runDatabaseRestore` handles both `.sql` and `.sql.gz` inputs
- [x] Verify `pruneOldBackups` cleans both extensions
- [x] Run typecheck and unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)