### PR TITLE
feat: add since filter to comments + context-digest endpoint (#683)

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -552,6 +552,17 @@ export function issueRoutes(
     });
   });
 
+  router.get("/issues/:id/context-digest", async (req, res) => {
+    const id = req.params.id as string;
+    const digest = await svc.getContextDigest(id);
+    if (!digest) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, digest.companyId);
+    res.json(digest);
+  });
+
   router.get("/issues/:id/work-products", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);
@@ -1653,10 +1664,14 @@ export function issueRoutes(
       limitRaw && Number.isFinite(limitRaw) && limitRaw > 0
         ? Math.min(Math.floor(limitRaw), MAX_ISSUE_COMMENT_LIMIT)
         : null;
+    const sinceRaw = typeof req.query.since === "string" ? req.query.since.trim() : null;
+    const since = sinceRaw ? new Date(sinceRaw) : null;
+    const validSince = since && !isNaN(since.getTime()) ? since : null;
     const comments = await svc.listComments(id, {
       afterCommentId,
       order,
       limit,
+      since: validSince,
     });
     res.json(comments);
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -1965,6 +1965,7 @@ export function issueService(db: Db) {
         afterCommentId?: string | null;
         order?: "asc" | "desc";
         limit?: number | null;
+        since?: Date | null;
       },
     ) => {
       const order = opts?.order === "asc" ? "asc" : "desc";
@@ -1975,6 +1976,9 @@ export function issueService(db: Db) {
           : null;
 
       const conditions = [eq(issueComments.issueId, issueId)];
+      if (opts?.since) {
+        conditions.push(gt(issueComments.createdAt, opts.since));
+      }
       if (afterCommentId) {
         const anchor = await db
           .select({
@@ -2038,6 +2042,44 @@ export function issueService(db: Db) {
         totalComments: Number(countRow?.totalComments ?? 0),
         latestCommentId: latest?.latestCommentId ?? null,
         latestCommentAt: latest?.latestCommentAt ?? null,
+      };
+    },
+
+    getContextDigest: async (issueId: string) => {
+      const issue = await db
+        .select({
+          id: issues.id,
+          identifier: issues.identifier,
+          title: issues.title,
+          description: issues.description,
+          status: issues.status,
+          priority: issues.priority,
+          companyId: issues.companyId,
+          assigneeAgentId: issues.assigneeAgentId,
+          projectId: issues.projectId,
+          parentId: issues.parentId,
+          executionRunId: issues.executionRunId,
+          updatedAt: issues.updatedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      if (!issue) return null;
+
+      const commentStats = await db
+        .select({
+          count: sql<number>`count(*)::int`,
+          lastAt: sql<Date | null>`max(${issueComments.createdAt})`,
+        })
+        .from(issueComments)
+        .where(eq(issueComments.issueId, issueId))
+        .then((rows) => rows[0]);
+
+      return {
+        ...issue,
+        commentCount: commentStats?.count ?? 0,
+        lastCommentAt: commentStats?.lastAt ?? null,
       };
     },
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents need to fetch context about their assigned issues via the API on every heartbeat wake
> - The comments endpoint only supports cursor-based pagination (`after=<commentId>`), with no timestamp filtering
> - This forces agents to re-read entire comment threads or track comment IDs statelessly, wasting tokens
> - There is also no lightweight endpoint to get a quick status summary without fetching full issue details
> - This pull request adds a `since` timestamp filter to `GET /issues/:id/comments` and a new `GET /issues/:id/context-digest` endpoint
> - The benefit is agents can poll efficiently: check the digest for changes, then fetch only new comments since their last wake

## What Changed

- Added `since` (ISO timestamp) query parameter to `GET /issues/:id/comments` — returns only comments created after the given timestamp
- Added `since?: Date | null` to `listComments` opts in `server/src/services/issues.ts`
- New `GET /issues/:id/context-digest` endpoint returning compact issue summary (id, identifier, title, description, status, priority, assignee, project, parent, executionRunId, updatedAt) plus `commentCount` and `lastCommentAt` from aggregate query
- New `getContextDigest()` method in the issues service

## Verification

```bash
pnpm -r typecheck   # passes
pnpm test:run        # passes
```

- `GET /issues/:id/comments?since=2026-04-01T00:00:00Z` returns only comments after that timestamp
- `GET /issues/:id/comments?since=2026-04-01T00:00:00Z&limit=5&order=asc` combines with existing params
- `GET /issues/:id/context-digest` returns compact JSON with comment stats
- Invalid `since` values are silently ignored (treated as no filter)

## Risks

- Low risk. The `since` filter is additive — existing callers without `since` see no change.
- The `context-digest` endpoint is a new read-only route with standard company access checks.
- No database schema changes or migrations required.

## Model Used

Claude Opus 4.6 (1M context) via Claude Code CLI. Tool use and code execution capabilities. Model ID: `claude-opus-4-6`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge