### PR TITLE
fix(opencode): handle read-only symlinked config files during runtime config preparation

### DIFF
--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -55,7 +55,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
       recursive: true,
       force: true,
       errorOnExist: false,
-      dereference: false,
+      dereference: true,
     });
   } catch (err) {
     if ((err as NodeJS.ErrnoException | null)?.code !== "ENOENT") {
@@ -74,6 +74,8 @@ export async function prepareOpenCodeRuntimeConfig(input: {
       external_directory: "allow",
     },
   };
+  // The copied file may be read-only (e.g. from Nix store), so remove it before writing.
+  await fs.rm(runtimeConfigPath, { force: true });
   await fs.writeFile(runtimeConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
 
   return {


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents for zero-human companies
> - Agents run on various local adapters, including the OpenCode adapter
> - The OpenCode adapter creates a temporary copy of the user's config directory to inject runtime permissions (e.g. permission.external_directory = "allow")
> - When the user manages dot files with tools like Nix Home Manager, GNU Stow, or chezmoi, ~/.config/opencode/opencode.json is a symlink to a read-only location (e.g. the Nix store)
> - fs.cp with dereference: false copies the symlink as-is, so the subsequent fs.writeFile tries to write to the immutable source and fails with EACCES
> - Even with dereference: true, the copied file inherits the source's read-only permissions, so fs.writeFile still fails
> - This pull request fixes both issues by dereferencing symlinks during copy and removing the read-only copy before writing the merged config
> -The benefit is that users with symlinked config directories can use the OpenCode adapter without hitting a 499 error

## What Changed
- Set dereference: true in fs.cp so symlinks are resolved and actual file contents are copied instead of symlink pointers
- Added fs.rm(runtimeConfigPath, { force: true }) before fs.writeFile to remove the potentially read-only copied file - fs.rm only requires write permission on the parent directory (which we own via mkdtemp), avoiding permission issues entirely.

Fixes #3026 


## Verification

- On a NixOS machine with Home Manager managing ~/.config/opencode/opencode.json as a symlink to /nix/store/..., confirmed POST /api/companies/:id/adapters/opencode_local/test-environment now returns 200 (previously 500 EACCES)
- No behavior change for users with regular (non-symlinked) config files — fs.rm on a writable file + fs.writeFile is functionally equivalent to the previous direct fs.writeFile

## Risks

  - Low risk. Changes are scoped to the temporary runtime config copy only — the user's actual config is never modified. Both dereference: true and the rm-before-write pattern are standard approaches for creating mutable copies from potentially immutable sources

## Model Used

- Anthropic Claude Opus 4.6 (claude-opus-4-6) via Claude Code CLI, with tool use capabilities

## Checklist

- [-] I have included a thinking path that traces from project context to this change
- [-] I have specified the model used (with version and capability details)
- [-] I have run tests locally and they pass
- [-] I have added or updated tests where applicable
- [-] If this change affects the UI, I have included before/after screenshots
- [-] I have updated relevant documentation to reflect my changes
- [-] I have considered and documented any risks above
- [-] I will address all Greptile and reviewer comments before requesting merge