### PR TITLE
test(server): lock local adapter issue context env propagation

### DIFF
--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -37,6 +37,9 @@ const payload = {
   instructionsContents: instructionsFilePath ? fs.readFileSync(instructionsFilePath, "utf8") : null,
   skillEntries: addDir ? fs.readdirSync(path.join(addDir, ".claude", "skills")).sort() : [],
   claudeConfigDir: process.env.CLAUDE_CONFIG_DIR || null,
+  paperclipRunId: process.env.PAPERCLIP_RUN_ID || null,
+  paperclipTaskId: process.env.PAPERCLIP_TASK_ID || null,
+  paperclipWakeReason: process.env.PAPERCLIP_WAKE_REASON || null,
 };
 if (capturePath) {
   fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
@@ -394,6 +397,67 @@ describe("claude execute", () => {
       else process.env.PATH = previousPath;
       if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
       else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects issue-scoped Paperclip run context into the child process env", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-context-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-context",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          issueId: "issue-only-2",
+          wakeReason: "issue_checked_out",
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as {
+        paperclipRunId: string | null;
+        paperclipTaskId: string | null;
+        paperclipWakeReason: string | null;
+      };
+      expect(capture.paperclipRunId).toBe("run-claude-context");
+      expect(capture.paperclipTaskId).toBe("issue-only-2");
+      expect(capture.paperclipWakeReason).toBe("issue_checked_out");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -14,6 +14,9 @@ const payload = {
   prompt: fs.readFileSync(0, "utf8"),
   codexHome: process.env.CODEX_HOME || null,
   paperclipWakePayloadJson: process.env.PAPERCLIP_WAKE_PAYLOAD_JSON || null,
+  paperclipRunId: process.env.PAPERCLIP_RUN_ID || null,
+  paperclipTaskId: process.env.PAPERCLIP_TASK_ID || null,
+  paperclipWakeReason: process.env.PAPERCLIP_WAKE_REASON || null,
   paperclipEnvKeys: Object.keys(process.env)
     .filter((key) => key.startsWith("PAPERCLIP_"))
     .sort(),
@@ -43,6 +46,9 @@ type CapturePayload = {
   prompt: string;
   codexHome: string | null;
   paperclipWakePayloadJson: string | null;
+  paperclipRunId: string | null;
+  paperclipTaskId: string | null;
+  paperclipWakeReason: string | null;
   paperclipEnvKeys: string[];
 };
 
@@ -356,6 +362,9 @@ describe("codex execute", () => {
       expect(result.errorMessage).toBeNull();
 
       const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.paperclipRunId).toBe("run-wake");
+      expect(capture.paperclipTaskId).toBe("issue-1");
+      expect(capture.paperclipWakeReason).toBe("issue_commented");
       expect(capture.paperclipEnvKeys).toContain("PAPERCLIP_WAKE_PAYLOAD_JSON");
       expect(capture.paperclipWakePayloadJson).not.toBeNull();
       expect(JSON.parse(capture.paperclipWakePayloadJson ?? "{}")).toMatchObject({
@@ -371,6 +380,63 @@ describe("codex execute", () => {
       );
       expect(capture.prompt).toContain("First comment");
       expect(capture.prompt).toContain("Second comment");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to issueId when injecting PAPERCLIP_TASK_ID", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-task-fallback-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-task-fallback",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          issueId: "issue-only-1",
+          wakeReason: "issue_checked_out",
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.paperclipRunId).toBe("run-task-fallback");
+      expect(capture.paperclipTaskId).toBe("issue-only-1");
+      expect(capture.paperclipWakeReason).toBe("issue_checked_out");
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates agent heartbeats around issue-scoped work, so local adapter runs need consistent run and task context.
> - The local adapter layer is responsible for translating server heartbeat context into child-process environment variables that agent runtimes consume.
> - A recent bugfix ensured local adapters inject `PAPERCLIP_RUN_ID`, `PAPERCLIP_TASK_ID`, and related wake context into subprocess env.
> - That fix is correct, but without direct regression coverage it would be easy to accidentally drop issue/task propagation in a future adapter refactor.
> - The highest-value follow-up is to lock the behavior at the adapter execution boundary, where the child process can prove which env vars it actually received.
> - This pull request adds direct regression tests for Codex local and Claude local execution.
> - The benefit is that issue-scoped local runs now have an explicit test guard for `context.issueId/taskId -> PAPERCLIP_TASK_ID` propagation.

## What Changed

- Extended the fake Codex local test command to capture `PAPERCLIP_RUN_ID`, `PAPERCLIP_TASK_ID`, and `PAPERCLIP_WAKE_REASON` from the child-process environment.
- Strengthened the existing Codex wake payload test to assert those env vars are present and correctly populated for an issue-scoped wake.
- Added a Codex regression test that verifies `issueId` falls back into `PAPERCLIP_TASK_ID` when `taskId` is absent.
- Extended the fake Claude local test command to capture the same Paperclip env vars.
- Added a Claude local regression test that verifies issue-scoped wake context is injected into the child-process environment.

## Verification

- `pnpm vitest run server/src/__tests__/codex-local-execute.test.ts server/src/__tests__/claude-local-execute.test.ts`

## Risks

- Low risk: test-only change.
- Main behavioral effect is stronger regression coverage around existing local adapter env propagation.

## Model Used

- OpenAI Codex via GPT-5-class coding model in Codex desktop with tool use and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
