### PR TITLE
fix(encoding): use StringDecoder to prevent UTF-8 corruption in UI

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
@@ -1969,6 +1970,11 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        // StringDecoder buffers incomplete multi-byte UTF-8 sequences across
+        // stream chunks, preventing replacement-character (U+FFFD) corruption
+        // when a chunk boundary falls inside a multi-byte character.
+        const stdoutDecoder = new StringDecoder("utf8");
+        const stderrDecoder = new StringDecoder("utf8");
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -2024,11 +2030,15 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
-        child.stdout?.on("data", (chunk: unknown) => {
+        child.stdout?.on("data", (chunk: Buffer) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
-          const text = String(chunk);
+          const text = stdoutDecoder.write(chunk);
+          if (!text) {
+            resumeReadable(readable);
+            return;
+          }
           stdout = appendWithCap(stdout, text);
           maybeArmTerminalResultCleanup();
           logChain = logChain
@@ -2040,11 +2050,15 @@ export async function runChildProcess(
             });
         });
 
-        child.stderr?.on("data", (chunk: unknown) => {
+        child.stderr?.on("data", (chunk: Buffer) => {
           const readable = child.stderr;
           if (!readable) return;
           readable.pause();
-          const text = String(chunk);
+          const text = stderrDecoder.write(chunk);
+          if (!text) {
+            resumeReadable(readable);
+            return;
+          }
           stderr = appendWithCap(stderr, text);
           maybeArmTerminalResultCleanup();
           logChain = logChain
@@ -2087,6 +2101,21 @@ export async function runChildProcess(
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
+          // Flush any remaining bytes buffered by the StringDecoders
+          const stdoutTail = stdoutDecoder.end();
+          const stderrTail = stderrDecoder.end();
+          if (stdoutTail) {
+            stdout = appendWithCap(stdout, stdoutTail);
+            logChain = logChain
+              .then(() => opts.onLog("stdout", stdoutTail))
+              .catch((err) => onLogError(err, runId, "failed to append stdout log tail"));
+          }
+          if (stderrTail) {
+            stderr = appendWithCap(stderr, stderrTail);
+            logChain = logChain
+              .then(() => opts.onLog("stderr", stderrTail))
+              .catch((err) => onLogError(err, runId, "failed to append stderr log tail"));
+          }
           void logChain.finally(() => {
             void Promise.resolve()
               .then(() => target.cleanup?.())

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import type {
   AdapterSkillEntry,
@@ -1529,6 +1530,11 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        // StringDecoder buffers incomplete multi-byte UTF-8 sequences across
+        // stream chunks, preventing replacement-character (U+FFFD) corruption
+        // when a chunk boundary falls inside a multi-byte character.
+        const stdoutDecoder = new StringDecoder("utf8");
+        const stderrDecoder = new StringDecoder("utf8");
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -1584,36 +1590,44 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
-        child.stdout?.on("data", (chunk: unknown) => {
+        child.stdout?.on("data", (chunk: Buffer) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
-          const text = String(chunk);
-          stdout = appendWithCap(stdout, text);
-          maybeArmTerminalResultCleanup();
-          logChain = logChain
-            .then(() => opts.onLog("stdout", text))
-            .catch((err) => onLogError(err, runId, "failed to append stdout log chunk"))
-            .finally(() => {
-              maybeArmTerminalResultCleanup();
-              resumeReadable(readable);
-            });
+          const text = stdoutDecoder.write(chunk);
+          if (text) {
+            stdout = appendWithCap(stdout, text);
+            maybeArmTerminalResultCleanup();
+            logChain = logChain
+              .then(() => opts.onLog("stdout", text))
+              .catch((err) => onLogError(err, runId, "failed to append stdout log chunk"))
+              .finally(() => {
+                maybeArmTerminalResultCleanup();
+                resumeReadable(readable);
+              });
+          } else {
+            resumeReadable(readable);
+          }
         });
 
-        child.stderr?.on("data", (chunk: unknown) => {
+        child.stderr?.on("data", (chunk: Buffer) => {
           const readable = child.stderr;
           if (!readable) return;
           readable.pause();
-          const text = String(chunk);
-          stderr = appendWithCap(stderr, text);
-          maybeArmTerminalResultCleanup();
-          logChain = logChain
-            .then(() => opts.onLog("stderr", text))
-            .catch((err) => onLogError(err, runId, "failed to append stderr log chunk"))
-            .finally(() => {
-              maybeArmTerminalResultCleanup();
-              resumeReadable(readable);
-            });
+          const text = stderrDecoder.write(chunk);
+          if (text) {
+            stderr = appendWithCap(stderr, text);
+            maybeArmTerminalResultCleanup();
+            logChain = logChain
+              .then(() => opts.onLog("stderr", text))
+              .catch((err) => onLogError(err, runId, "failed to append stderr log chunk"))
+              .finally(() => {
+                maybeArmTerminalResultCleanup();
+                resumeReadable(readable);
+              });
+          } else {
+            resumeReadable(readable);
+          }
         });
 
         const stdin = child.stdin;
@@ -1647,6 +1661,21 @@ export async function runChildProcess(
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
+          // Flush any remaining bytes buffered by the StringDecoders
+          const stdoutTail = stdoutDecoder.end();
+          const stderrTail = stderrDecoder.end();
+          if (stdoutTail) {
+            stdout = appendWithCap(stdout, stdoutTail);
+            logChain = logChain
+              .then(() => opts.onLog("stdout", stdoutTail))
+              .catch((err) => onLogError(err, runId, "failed to append stdout log tail"));
+          }
+          if (stderrTail) {
+            stderr = appendWithCap(stderr, stderrTail);
+            logChain = logChain
+              .then(() => opts.onLog("stderr", stderrTail))
+              .catch((err) => onLogError(err, runId, "failed to append stderr log tail"));
+          }
           void logChain.finally(() => {
             void Promise.resolve()
               .then(() => target.cleanup?.())

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -368,7 +368,7 @@ export async function createApp(
         }
         res
           .status(200)
-          .set("Content-Type", "text/html")
+          .set("Content-Type", "text/html; charset=utf-8")
           .set("Cache-Control", "no-cache")
           .end(readBrandedStaticIndexHtml(uiDist));
       });
@@ -413,7 +413,7 @@ export async function createApp(
       }
       try {
         const html = await renderViteHtml.render(req.originalUrl);
-        res.status(200).set({ "Content-Type": "text/html" }).end(html);
+        res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).end(html);
       } catch (err) {
         next(err);
       }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -345,7 +345,7 @@ export async function createApp(
         }
         res
           .status(200)
-          .set("Content-Type", "text/html")
+          .set("Content-Type", "text/html; charset=utf-8")
           .set("Cache-Control", "no-cache")
           .end(indexHtml);
       });
@@ -389,7 +389,7 @@ export async function createApp(
       }
       try {
         const html = await renderViteHtml.render(req.originalUrl);
-        res.status(200).set({ "Content-Type": "text/html" }).end(html);
+        res.status(200).set({ "Content-Type": "text/html; charset=utf-8" }).end(html);
       } catch (err) {
         next(err);
       }

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1515,7 +1515,7 @@ export function pluginRoutes(
 
     // Set SSE headers
     res.writeHead(200, {
-      "Content-Type": "text/event-stream",
+      "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache",
       "Connection": "keep-alive",
       "X-Accel-Buffering": "no",

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1389,7 +1389,7 @@ export function pluginRoutes(
 
     // Set SSE headers
     res.writeHead(200, {
-      "Content-Type": "text/event-stream",
+      "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache",
       "Connection": "keep-alive",
       "X-Accel-Buffering": "no",

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -4,6 +4,29 @@ import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 
+/**
+ * Find the byte length of valid UTF-8 ending at or before `buf.length`.
+ * Trims any incomplete multi-byte sequence at the tail so that
+ * `buf.subarray(0, n).toString("utf8")` never produces U+FFFD.
+ */
+function findUtf8SafeEnd(buf: Buffer): number {
+  const len = buf.length;
+  if (len === 0) return 0;
+  // If last byte is ASCII, the buffer ends on a complete character
+  if (buf[len - 1]! < 0x80) return len;
+  // Walk backwards through continuation bytes (10xxxxxx)
+  let i = len - 1;
+  while (i >= 0 && (buf[i]! & 0xc0) === 0x80) i--;
+  if (i < 0) return 0;
+  // i is now at a lead byte — determine expected sequence length
+  const lead = buf[i]!;
+  const seqLen = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+  // If the sequence is complete within the buffer, keep everything
+  if (len - i >= seqLen) return len;
+  // Incomplete sequence — trim to before the lead byte
+  return i;
+}
+
 export type RunLogStoreType = "local_file";
 
 export interface RunLogHandle {
@@ -77,8 +100,12 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       stream.on("end", () => resolve());
     });
 
-    const content = Buffer.concat(chunks).toString("utf8");
-    const nextOffset = end + 1 < stat.size ? end + 1 : undefined;
+    const raw = Buffer.concat(chunks);
+    const safeEnd = findUtf8SafeEnd(raw);
+    const content = raw.subarray(0, safeEnd).toString("utf8");
+    // Advance nextOffset only past the safely decoded bytes
+    const bytesConsumed = start + safeEnd;
+    const nextOffset = bytesConsumed < stat.size ? bytesConsumed : undefined;
     return { content, nextOffset };
   }
 

--- a/server/src/services/workspace-operation-log-store.ts
+++ b/server/src/services/workspace-operation-log-store.ts
@@ -4,6 +4,24 @@ import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 
+/**
+ * Find the byte length of valid UTF-8 ending at or before `buf.length`.
+ * Trims any incomplete multi-byte sequence at the tail so that
+ * `buf.subarray(0, n).toString("utf8")` never produces U+FFFD.
+ */
+function findUtf8SafeEnd(buf: Buffer): number {
+  const len = buf.length;
+  if (len === 0) return 0;
+  if (buf[len - 1]! < 0x80) return len;
+  let i = len - 1;
+  while (i >= 0 && (buf[i]! & 0xc0) === 0x80) i--;
+  if (i < 0) return 0;
+  const lead = buf[i]!;
+  const seqLen = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+  if (len - i >= seqLen) return len;
+  return i;
+}
+
 export type WorkspaceOperationLogStoreType = "local_file";
 
 export interface WorkspaceOperationLogHandle {
@@ -77,8 +95,11 @@ function createLocalFileWorkspaceOperationLogStore(basePath: string): WorkspaceO
       stream.on("end", () => resolve());
     });
 
-    const content = Buffer.concat(chunks).toString("utf8");
-    const nextOffset = end + 1 < stat.size ? end + 1 : undefined;
+    const raw = Buffer.concat(chunks);
+    const safeEnd = findUtf8SafeEnd(raw);
+    const content = raw.subarray(0, safeEnd).toString("utf8");
+    const bytesConsumed = start + safeEnd;
+    const nextOffset = bytesConsumed < stat.size ? bytesConsumed : undefined;
     return { content, nextOffset };
   }
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { setTimeout as delay } from "node:timers/promises";
 import type { AdapterRuntimeServiceReport } from "@paperclipai/adapter-utils";
 import type { Db } from "@paperclipai/db";
@@ -490,14 +491,24 @@ async function executeProcess(input: {
     });
     const stdout = createProcessOutputCapture(input.maxStdoutBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
     const stderr = createProcessOutputCapture(input.maxStderrBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
+    const stdoutDec = new StringDecoder("utf8");
+    const stderrDec = new StringDecoder("utf8");
     child.stdout?.on("data", (chunk) => {
-      stdout.append(String(chunk));
+      const text = stdoutDec.write(chunk);
+      if (text) stdout.append(text);
     });
     child.stderr?.on("data", (chunk) => {
-      stderr.append(String(chunk));
+      const text = stderrDec.write(chunk);
+      if (text) stderr.append(text);
     });
     child.on("error", reject);
-    child.on("close", (code) => resolve({ stdout, stderr, code }));
+    child.on("close", (code) => {
+      const stdoutTail = stdoutDec.end();
+      const stderrTail = stderrDec.end();
+      if (stdoutTail) stdout.append(stdoutTail);
+      if (stderrTail) stderr.append(stderrTail);
+      resolve({ stdout, stderr, code });
+    });
   });
   const stdout = proc.stdout.finish();
   const stderr = proc.stderr.finish();
@@ -2094,13 +2105,17 @@ async function startLocalRuntimeService(input: {
   });
   let stderrExcerpt = "";
   let stdoutExcerpt = "";
+  const svcStdoutDec = new StringDecoder("utf8");
+  const svcStderrDec = new StringDecoder("utf8");
   child.stdout?.on("data", async (chunk) => {
-    const text = String(chunk);
+    const text = svcStdoutDec.write(chunk);
+    if (!text) return;
     stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
     if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
   });
   child.stderr?.on("data", async (chunk) => {
-    const text = String(chunk);
+    const text = svcStderrDec.write(chunk);
+    if (!text) return;
     stderrExcerpt = (stderrExcerpt + text).slice(-4096);
     if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
   });

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { setTimeout as delay } from "node:timers/promises";
 import type { AdapterRuntimeServiceReport } from "@paperclipai/adapter-utils";
 import type { Db } from "@paperclipai/db";
@@ -484,14 +485,24 @@ async function executeProcess(input: {
     });
     const stdout = createProcessOutputCapture(input.maxStdoutBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
     const stderr = createProcessOutputCapture(input.maxStderrBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
+    const stdoutDec = new StringDecoder("utf8");
+    const stderrDec = new StringDecoder("utf8");
     child.stdout?.on("data", (chunk) => {
-      stdout.append(String(chunk));
+      const text = stdoutDec.write(chunk);
+      if (text) stdout.append(text);
     });
     child.stderr?.on("data", (chunk) => {
-      stderr.append(String(chunk));
+      const text = stderrDec.write(chunk);
+      if (text) stderr.append(text);
     });
     child.on("error", reject);
-    child.on("close", (code) => resolve({ stdout, stderr, code }));
+    child.on("close", (code) => {
+      const stdoutTail = stdoutDec.end();
+      const stderrTail = stderrDec.end();
+      if (stdoutTail) stdout.append(stdoutTail);
+      if (stderrTail) stderr.append(stderrTail);
+      resolve({ stdout, stderr, code });
+    });
   });
   const stdout = proc.stdout.finish();
   const stderr = proc.stderr.finish();
@@ -2049,13 +2060,17 @@ async function startLocalRuntimeService(input: {
   });
   let stderrExcerpt = "";
   let stdoutExcerpt = "";
+  const svcStdoutDec = new StringDecoder("utf8");
+  const svcStderrDec = new StringDecoder("utf8");
   child.stdout?.on("data", async (chunk) => {
-    const text = String(chunk);
+    const text = svcStdoutDec.write(chunk);
+    if (!text) return;
     stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
     if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
   });
   child.stderr?.on("data", async (chunk) => {
-    const text = String(chunk);
+    const text = svcStderrDec.write(chunk);
+    if (!text) return;
     stderrExcerpt = (stderrExcerpt + text).slice(-4096);
     if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents via child processes (Claude Code, Codex, etc.) and displays their output in a web UI
> - The adapter-utils package provides `runChildProcess` which captures stdout/stderr from agent processes
> - Users reported widespread U+FFFD replacement characters in the UI, specifically with Claude-based agents (every em dash, smart quote, emoji, etc.)
> - The Codex agent did not exhibit the same issue, suggesting the corruption happens during output capture
> - Node.js child process stdio streams emit raw Buffer chunks at arbitrary boundaries — multi-byte UTF-8 characters can be split across chunks
> - `String(chunk)` decodes each chunk independently, producing replacement characters for split multi-byte sequences
> - On Windows, pipe buffer sizes are ~4KB (vs ~64KB Linux), creating many more chunk boundaries and multiplying the corruption
> - Additionally, the NDJSON log file reader (`readFileRange`) reads arbitrary byte ranges that can split multi-byte characters at read boundaries
> - `StringDecoder` from `node:string_decoder` is the canonical Node.js solution for stream chunk boundaries
> - For byte-range reads, a `findUtf8SafeEnd()` helper trims incomplete trailing sequences and adjusts the byte offset
> - This PR fixes all identified corruption sites across 5 files

## What Changed

- **`packages/adapter-utils/src/server-utils.ts`**: Replaced `String(chunk)` with `StringDecoder.write(chunk)` for both stdout and stderr handlers in `runChildProcess`. Added `StringDecoder.end()` flush in the `close` handler to capture remaining buffered bytes.
- **`server/src/services/workspace-runtime.ts`**: Applied the same `StringDecoder` fix to 4 additional `String(chunk)` instances in `executeProcess` and service startup functions.
- **`server/src/services/run-log-store.ts`**: Added `findUtf8SafeEnd()` helper to prevent byte-range reads from splitting multi-byte UTF-8 characters. Adjusts `nextOffset` to the last complete character boundary.
- **`server/src/services/workspace-operation-log-store.ts`**: Same `findUtf8SafeEnd()` fix for workspace operation log reads.
- **`server/src/app.ts`**: Added `charset=utf-8` to `Content-Type: text/html` headers for both static and Vite dev mode HTML responses.
- **`server/src/routes/plugins.ts`**: Added `charset=utf-8` to `Content-Type: text/event-stream` header for SSE endpoint.

## Verification

- `pnpm typecheck` passes clean, no new errors
- `pnpm test:run` no new test failures (pre-existing failures are unrelated: worktree port tests, EPERM symlink issues, missing binaries)
- Manual verification: ran a Claude agent heartbeat and posted a comment containing em dashes, smart quotes, arrows, emoji, CJK characters, and other multi-byte UTF-8. All rendered correctly in the UI without replacement characters.
- Confirmed the fix working in live use

## Risks

Low risk. `StringDecoder` is a stable Node.js core module (available since v0.1.99). The `findUtf8SafeEnd()` helper is a pure function that only trims 1-3 bytes at most from the end of a read buffer. The behavioral change is strictly correctness — previously corrupted multi-byte characters now decode properly. The `if (text)` guard ensures empty decoder output does not trigger unnecessary log writes. The `charset=utf-8` header additions are redundant-but-harmless per HTTP specs.

## Model Used

Claude Opus 4.6 (1M context) via Claude Code CLI, with tool use capabilities (file read/write, bash, grep, glob)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
