### PR TITLE
fix: scan symlinked skill directories and resolve symlinks for conflict detection

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { promises as fs, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,9 +26,10 @@ import type {
   CompanySkillUsageAgent,
 } from "@paperclipai/shared";
 import { normalizeAgentUrlKey } from "@paperclipai/shared";
-import { findServerAdapter } from "../adapters/index.js";
+import { findActiveServerAdapter } from "../adapters/index.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { notFound, unprocessable } from "../errors.js";
+import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import { agentService } from "./agents.js";
 import { projectService } from "./projects.js";
 import { secretService } from "./secrets.js";
@@ -73,6 +73,7 @@ type ParsedSkillImportSource = {
 type SkillSourceMeta = {
   skillKey?: string;
   sourceKind?: string;
+  hostname?: string;
   owner?: string;
   repo?: string;
   ref?: string;
@@ -470,7 +471,7 @@ function parseFrontmatterMarkdown(raw: string): { frontmatter: Record<string, un
 }
 
 async function fetchText(url: string) {
-  const response = await fetch(url);
+  const response = await ghFetch(url);
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
@@ -478,7 +479,7 @@ async function fetchText(url: string) {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
+  const response = await ghFetch(url, {
     headers: {
       accept: "application/vnd.github+json",
     },
@@ -489,16 +490,17 @@ async function fetchJson<T>(url: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-async function resolveGitHubDefaultBranch(owner: string, repo: string) {
+
+async function resolveGitHubDefaultBranch(owner: string, repo: string, apiBase: string) {
   const response = await fetchJson<{ default_branch?: string }>(
-    `https://api.github.com/repos/${owner}/${repo}`,
+    `${apiBase}/repos/${owner}/${repo}`,
   );
   return asString(response.default_branch) ?? "main";
 }
 
-async function resolveGitHubCommitSha(owner: string, repo: string, ref: string) {
+async function resolveGitHubCommitSha(owner: string, repo: string, ref: string, apiBase: string) {
   const response = await fetchJson<{ sha?: string }>(
-    `https://api.github.com/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
+    `${apiBase}/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
   );
   const sha = asString(response.sha);
   if (!sha) {
@@ -509,8 +511,8 @@ async function resolveGitHubCommitSha(owner: string, repo: string, ref: string) 
 
 function parseGitHubSourceUrl(rawUrl: string) {
   const url = new URL(rawUrl);
-  if (url.hostname !== "github.com") {
-    throw unprocessable("GitHub source must use github.com URL");
+  if (url.protocol !== "https:") {
+    throw unprocessable("GitHub source URL must use HTTPS");
   }
   const parts = url.pathname.split("/").filter(Boolean);
   if (parts.length < 2) {
@@ -532,10 +534,11 @@ function parseGitHubSourceUrl(rawUrl: string) {
     basePath = filePath ? path.posix.dirname(filePath) : "";
     explicitRef = true;
   }
-  return { owner, repo, ref, basePath, filePath, explicitRef };
+  return { hostname: url.hostname, owner, repo, ref, basePath, filePath, explicitRef };
 }
 
 async function resolveGitHubPinnedRef(parsed: ReturnType<typeof parseGitHubSourceUrl>) {
+  const apiBase = gitHubApiBase(parsed.hostname);
   if (/^[0-9a-f]{40}$/i.test(parsed.ref.trim())) {
     return {
       pinnedRef: parsed.ref,
@@ -545,14 +548,11 @@ async function resolveGitHubPinnedRef(parsed: ReturnType<typeof parseGitHubSourc
 
   const trackingRef = parsed.explicitRef
     ? parsed.ref
-    : await resolveGitHubDefaultBranch(parsed.owner, parsed.repo);
-  const pinnedRef = await resolveGitHubCommitSha(parsed.owner, parsed.repo, trackingRef);
+    : await resolveGitHubDefaultBranch(parsed.owner, parsed.repo, apiBase);
+  const pinnedRef = await resolveGitHubCommitSha(parsed.owner, parsed.repo, trackingRef, apiBase);
   return { pinnedRef, trackingRef };
 }
 
-function resolveRawGitHubUrl(owner: string, repo: string, ref: string, filePath: string) {
-  return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${filePath.replace(/^\/+/, "")}`;
-}
 
 function extractCommandTokens(raw: string) {
   const matches = raw.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
@@ -675,9 +675,10 @@ function deriveImportedSkillSource(
     const repoPath = asString(sourceEntry?.path);
     const commit = asString(sourceEntry?.commit);
     const trackingRef = asString(sourceEntry?.trackingRef);
+    const sourceHostname = asString(sourceEntry?.hostname) || "github.com";
     const url = asString(sourceEntry?.url)
       ?? (repo
-        ? `https://github.com/${repo}${repoPath ? `/tree/${trackingRef ?? commit ?? "main"}/${repoPath}` : ""}`
+        ? `https://${sourceHostname}/${repo}${repoPath ? `/tree/${trackingRef ?? commit ?? "main"}/${repoPath}` : ""}`
         : null);
     const [owner, repoName] = (repo ?? "").split("/");
     if (repo && owner && repoName) {
@@ -688,6 +689,7 @@ function deriveImportedSkillSource(
         metadata: {
           ...(canonicalKey ? { skillKey: canonicalKey } : {}),
           sourceKind: "github",
+          ...(sourceHostname !== "github.com" ? { hostname: sourceHostname } : {}),
           owner,
           repo: repoName,
           ref: commit,
@@ -891,8 +893,9 @@ export async function discoverProjectWorkspaceSkillDirectories(target: ProjectSk
     for (const entry of entries) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
       const absoluteSkillDir = path.resolve(absoluteRoot, entry.name);
+      const realSkillDir = resolveRealPath(absoluteSkillDir);
       if (!(await statPath(path.join(absoluteSkillDir, "SKILL.md")))?.isFile()) continue;
-      discovered.set(absoluteSkillDir, "full");
+      discovered.set(realSkillDir, "full");
     }
   }
 
@@ -981,12 +984,21 @@ async function readUrlSkillImports(
 ): Promise<{ skills: ImportedSkill[]; warnings: string[] }> {
   const url = sourceUrl.trim();
   const warnings: string[] = [];
-  if (url.includes("github.com/")) {
+  const looksLikeRepoUrl = (() => { try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    const h = parsed.hostname.toLowerCase();
+    if (h.endsWith(".githubusercontent.com") || h === "gist.github.com") return false;
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    return segments.length >= 2 && !parsed.pathname.endsWith(".md");
+  } catch { return false; } })();
+  if (looksLikeRepoUrl) {
     const parsed = parseGitHubSourceUrl(url);
+    const apiBase = gitHubApiBase(parsed.hostname);
     const { pinnedRef, trackingRef } = await resolveGitHubPinnedRef(parsed);
     let ref = pinnedRef;
     const tree = await fetchJson<{ tree?: Array<{ path: string; type: string }> }>(
-      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/git/trees/${ref}?recursive=1`,
+      `${apiBase}/repos/${parsed.owner}/${parsed.repo}/git/trees/${ref}?recursive=1`,
     ).catch(() => {
       throw unprocessable(`Failed to read GitHub tree for ${url}`);
     });
@@ -1013,7 +1025,7 @@ async function readUrlSkillImports(
     const skills: ImportedSkill[] = [];
     for (const relativeSkillPath of skillPaths) {
       const repoSkillPath = basePrefix ? `${basePrefix}${relativeSkillPath}` : relativeSkillPath;
-      const markdown = await fetchText(resolveRawGitHubUrl(parsed.owner, parsed.repo, ref, repoSkillPath));
+      const markdown = await fetchText(resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, repoSkillPath));
       const parsedMarkdown = parseFrontmatterMarkdown(markdown);
       const skillDir = path.posix.dirname(relativeSkillPath);
       const slug = deriveImportedSkillSlug(parsedMarkdown.frontmatter, path.posix.basename(skillDir));
@@ -1027,9 +1039,10 @@ async function readUrlSkillImports(
       const metadata = {
         ...(skillKey ? { skillKey } : {}),
         sourceKind: "github",
+        ...(parsed.hostname !== "github.com" ? { hostname: parsed.hostname } : {}),
         owner: parsed.owner,
         repo: parsed.repo,
-        ref: ref,
+        ref,
         trackingRef,
         repoSkillDir: normalizeGitHubSkillDirectory(
           basePrefix ? `${basePrefix}${skillDir}` : skillDir,
@@ -1240,6 +1253,10 @@ function resolveDesiredSkillKeys(
   ));
 }
 
+/** Resolves symlinks to their real path. Falls back to the original path if
+ * resolution fails (e.g. the path no longer exists on disk). Uses synchronous
+ * I/O; acceptable because this is called once per skill entry during infrequent
+ * scan operations — event-loop blocking is negligible. */
 function resolveRealPath(p: string): string {
   try {
     return realpathSync(p);
@@ -1570,7 +1587,7 @@ export function companySkillService(db: Db) {
 
     return Promise.all(
       desiredAgents.map(async (agent) => {
-        const adapter = findServerAdapter(agent.adapterType);
+        const adapter = findActiveServerAdapter(agent.adapterType);
         let actualState: string | null = null;
 
         if (!adapter?.listSkills) {
@@ -1649,7 +1666,9 @@ export function companySkillService(db: Db) {
       };
     }
 
-    const latestRef = await resolveGitHubCommitSha(owner, repo, trackingRef);
+    const hostname = asString(metadata.hostname) || "github.com";
+    const apiBase = gitHubApiBase(hostname);
+    const latestRef = await resolveGitHubCommitSha(owner, repo, trackingRef, apiBase);
     return {
       supported: true,
       reason: null,
@@ -1687,13 +1706,14 @@ export function companySkillService(db: Db) {
       const metadata = getSkillMeta(skill);
       const owner = asString(metadata.owner);
       const repo = asString(metadata.repo);
+      const hostname = asString(metadata.hostname) || "github.com";
       const ref = skill.sourceRef ?? asString(metadata.ref) ?? "main";
       const repoSkillDir = normalizeGitHubSkillDirectory(asString(metadata.repoSkillDir), skill.slug);
       if (!owner || !repo) {
         throw unprocessable("Skill source metadata is incomplete.");
       }
       const repoPath = normalizePortablePath(path.posix.join(repoSkillDir, normalizedPath));
-      content = await fetchText(resolveRawGitHubUrl(owner, repo, ref, repoPath));
+      content = await fetchText(resolveRawGitHubUrl(hostname, owner, repo, ref, repoPath));
     } else if (skill.sourceType === "url") {
       if (normalizedPath !== "SKILL.md") {
         throw notFound("This skill source only exposes SKILL.md");

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { promises as fs } from "node:fs";
+import { promises as fs, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { and, asc, eq } from "drizzle-orm";
@@ -889,7 +889,7 @@ export async function discoverProjectWorkspaceSkillDirectories(target: ProjectSk
 
     const entries = await fs.readdir(absoluteRoot, { withFileTypes: true }).catch(() => []);
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
       const absoluteSkillDir = path.resolve(absoluteRoot, entry.name);
       if (!(await statPath(path.join(absoluteSkillDir, "SKILL.md")))?.isFile()) continue;
       discovered.set(absoluteSkillDir, "full");
@@ -1240,9 +1240,17 @@ function resolveDesiredSkillKeys(
   ));
 }
 
+function resolveRealPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
 function normalizeSkillDirectory(skill: CompanySkill) {
   if ((skill.sourceType !== "local_path" && skill.sourceType !== "catalog") || !skill.sourceLocator) return null;
-  const resolved = path.resolve(skill.sourceLocator);
+  const resolved = resolveRealPath(path.resolve(skill.sourceLocator));
   if (path.basename(resolved).toLowerCase() === "skill.md") {
     return path.dirname(resolved);
   }
@@ -1251,7 +1259,7 @@ function normalizeSkillDirectory(skill: CompanySkill) {
 
 function normalizeSourceLocatorDirectory(sourceLocator: string | null) {
   if (!sourceLocator) return null;
-  const resolved = path.resolve(sourceLocator);
+  const resolved = resolveRealPath(path.resolve(sourceLocator));
   return path.basename(resolved).toLowerCase() === "skill.md" ? path.dirname(resolved) : resolved;
 }
 


### PR DESCRIPTION
## Problem

Skills directories managed via symlinks were silently skipped during project workspace scans, and symlinked skills that pointed to an already-registered source caused false slug conflicts.

### Issue 1 — Symlinked skill directories not scanned

`discoverProjectWorkspaceSkillDirectories` iterates directory entries with `withFileTypes: true` and skips anything where `entry.isDirectory()` is false. In Node.js, symlink dirents return `isSymbolicLink() = true` and `isDirectory() = false`, so symlinked skill directories were never picked up.

A common real-world pattern: a shared agent skills repo symlinked into `.claude/skills/`, `.agents/skills/`, or similar tool directories. All those skills were invisible to `scan-projects`.

Note: `listAvailableSkills()` in `access.ts` already handles this correctly with `entry.isDirectory() || entry.isSymbolicLink()` — this fix brings `scan-projects` in line with that behaviour.

### Issue 2 — False slug conflicts for symlinked sources

`normalizeSkillDirectory` and `normalizeSourceLocatorDirectory` used `path.resolve()` to normalise paths before comparison. `path.resolve` is purely lexical — it does not follow symlinks. So two paths that point to the same physical directory (one being a symlink of the other) compared as different strings and triggered a conflict instead of an update.

## Thinking Path

**Context:** Paperclip's `scan-projects` feature discovers skill directories in a workspace by scanning `PROJECT_SCAN_DIRECTORY_ROOTS` entries. Skills can live in real directories or be managed via symlinks (e.g. a shared agent skills repo symlinked into `.claude/skills/`). The scan result feeds slug conflict detection which compares skill source paths to decide whether an incoming skill is a new import or an update to an existing one.

**Root cause — Issue 1:** `fs.readdir` with `withFileTypes: true` returns `Dirent` objects. A symlink to a directory has `isSymbolicLink() === true` and `isDirectory() === false`, so the existing `if (!entry.isDirectory()) continue` guard unconditionally skips symlinked directories. The `listAvailableSkills()` function in `access.ts` already gets this right with `entry.isDirectory() || entry.isSymbolicLink()`.

**Root cause — Issue 2:** `path.resolve()` is a purely lexical operation — it normalises `..` segments and resolves relative paths, but never touches the filesystem or follows symlinks. When a skill is stored under a symlinked path (e.g. `/Users/tom/.claude/skills/my-skill`) and the same physical directory is already registered under its real path (e.g. `/Users/tom/agents/skills/my-skill`), the two strings compare as unequal and a conflict is raised instead of recognising them as the same source. `fs.realpathSync` resolves symlinks to their canonical filesystem path, making the comparison physical rather than lexical.

**Fix sequence:**
1. Add `!entry.isSymbolicLink()` to the dirent guard in `discoverProjectWorkspaceSkillDirectories` — mirrors the existing pattern in `access.ts`.
2. Introduce `resolveRealPath(p)` — a thin `realpathSync` wrapper with a fallback for paths that no longer exist (e.g. a dangling symlink during an in-progress deletion).
3. Key the `discovered` map by `resolveRealPath(absoluteSkillDir)` so that two symlinks pointing to the same physical directory are deduplicated at scan time and can't produce a double-import.
4. Apply `resolveRealPath` in `normalizeSkillDirectory` and `normalizeSourceLocatorDirectory` so all downstream conflict and slug dedup checks compare real paths.

**Verification:**
- Run `scan-projects` against a workspace with a symlinked skill directory; skills should now appear in the discovered list.
- Confirm that a symlinked skill and its real-path counterpart produce a single entry, not a conflict.
- Check that the before/after numbers below reproduce (or improve) locally.
- Dangling symlink edge case: a symlinked path that no longer exists should not crash the scan; `resolveRealPath` falls back to the original string.

**Risks:**
- `realpathSync` is synchronous. It is called once per skill entry during an already-infrequent scan operation, so event-loop blocking is negligible. A JSDoc comment on `resolveRealPath` documents this decision.
- Deduplicating `discovered` by real path means that if two distinct symlinks in `PROJECT_SCAN_DIRECTORY_ROOTS` both point to the same physical skill, only one entry (with one `sourceLocator`) wins. This is the correct behaviour — importing the same skill twice would create a conflict anyway.

## Fix

**Change 1** — accept symlink dirents as skill directory candidates:
```ts
// before
if (!entry.isDirectory()) continue;
// after
if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
```

**Change 2** — deduplicate the `discovered` map by real path:
```ts
const absoluteSkillDir = path.resolve(absoluteRoot, entry.name);
const realSkillDir = resolveRealPath(absoluteSkillDir);
if (!(await statPath(path.join(absoluteSkillDir, "SKILL.md")))?.isFile()) continue;
discovered.set(realSkillDir, "full");
```

**Change 3** — resolve symlinks before path comparison via a `resolveRealPath` helper that wraps `realpathSync` with a fallback (gracefully handles paths that no longer exist on disk):
```ts
/** Resolves symlinks to their real path. Falls back to the original path if
 * resolution fails (e.g. the path no longer exists on disk). Uses synchronous
 * I/O; acceptable because this is called once per skill entry during infrequent
 * scan operations — event-loop blocking is negligible. */
function resolveRealPath(p: string): string {
  try { return realpathSync(p); }
  catch { return p; }
}
```
Applied to both `normalizeSkillDirectory` and `normalizeSourceLocatorDirectory`.

## Result

| | Before | After |
|---|---|---|
| Discovered | 23 | 119 |
| Imported | 0 | 92 |
| Conflicts (symlink aliases) | 4 | 0 |