### PR TITLE
fix(heartbeat): inject wake comment body into adapter prompt

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -404,8 +404,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeCommentNote = asString(context.paperclipWakeCommentMarkdown, "").trim();
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
+    wakeCommentNote,
     sessionHandoffNote,
     renderedPrompt,
   ]);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -466,9 +466,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeCommentNote = asString(context.paperclipWakeCommentMarkdown, "").trim();
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    wakeCommentNote,
     sessionHandoffNote,
     renderedPrompt,
   ]);

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -358,10 +358,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeCommentNote = asString(context.paperclipWakeCommentMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    wakeCommentNote,
     sessionHandoffNote,
     paperclipEnvNote,
     renderedPrompt,

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -301,11 +301,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeCommentNote = asString(context.paperclipWakeCommentMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const apiAccessNote = renderApiAccessNote(env);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    wakeCommentNote,
     sessionHandoffNote,
     paperclipEnvNote,
     apiAccessNote,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -277,9 +277,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
         : "";
     const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+    const wakeCommentNote = asString(context.paperclipWakeCommentMarkdown, "").trim();
     const prompt = joinPromptSections([
       instructionsPrefix,
       renderedBootstrapPrompt,
+      wakeCommentNote,
       sessionHandoffNote,
       renderedPrompt,
     ]);

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -304,8 +304,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
       : "";
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const wakeCommentNote = asString(context.paperclipWakeCommentMarkdown, "").trim();
   const userPrompt = joinPromptSections([
     renderedBootstrapPrompt,
+    wakeCommentNote,
     sessionHandoffNote,
     renderedHeartbeatPrompt,
   ]);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2101,6 +2101,36 @@ export function heartbeatService(db: Db) {
           .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
           .then((rows) => rows[0] ?? null)
       : null;
+
+    // --- BEGIN: Inject wake comment body into adapter context (#799, #2249) ---
+    const wakeCommentId = readNonEmptyString(context.wakeCommentId);
+    if (wakeCommentId) {
+      try {
+        const wakeComment = await issuesSvc.getComment(wakeCommentId);
+        if (wakeComment?.body) {
+          const authorLabel = wakeComment.authorUserId
+            ? `board user`
+            : wakeComment.authorAgentId
+              ? `agent`
+              : `unknown`;
+          context.paperclipWakeCommentMarkdown = [
+            `## Triggering Comment (from ${authorLabel})`,
+            ``,
+            wakeComment.body,
+            ``,
+            `---`,
+            `*You were woken because of this comment. Read and respond to it before doing anything else.*`,
+          ].join("\n");
+        }
+      } catch (err) {
+        logger.warn(
+          { runId: run.id, wakeCommentId, err },
+          "failed to fetch wake comment body for context injection",
+        );
+      }
+    }
+    // --- END: Inject wake comment body ---
+
     const issueAssigneeOverrides =
       issueContext && issueContext.assigneeAgentId === agent.id
         ? parseIssueAssigneeAdapterOverrides(


### PR DESCRIPTION
## Summary

When an agent is woken by a comment (`wakeReason: issue_commented`), the heartbeat service passes `wakeCommentId` through the context snapshot, but the **comment body is never fetched or injected into the adapter prompt**. The agent wakes up and runs its default heartbeat routine without ever seeing the triggering comment.

This PR fixes the issue by:

1. **Heartbeat service** (`server/src/services/heartbeat.ts`): After fetching issue metadata, if `wakeCommentId` is present in the context, fetch the comment body via `issuesSvc.getComment()` and set `context.paperclipWakeCommentMarkdown` — a markdown-formatted section that includes the comment body, author type (board user vs agent), and an instruction to read and respond first.

2. **All 6 local adapters** (`claude-local`, `gemini-local`, `codex-local`, `cursor-local`, `opencode-local`, `pi-local`): Read `paperclipWakeCommentMarkdown` from context and include it in `joinPromptSections()`, placed **before** the session handoff note so the agent sees it as the first thing in its prompt.

## Behavior change

| Before | After |
|--------|-------|
| Agent receives `PAPERCLIP_WAKE_COMMENT_ID` as env var only | Agent receives the full comment body injected into the prompt |
| Agent must proactively call the API to read the comment | Comment is delivered automatically — agent sees it immediately |
| Board corrections and feedback are routinely ignored | Agent is instructed to "read and respond to this before doing anything else" |

## Error handling

If the comment fetch fails (deleted comment, DB error), a warning is logged and the agent continues without injection — identical to current behavior. No breaking change.

## Test plan

- [x] Deployed to local Paperclip instance (Docker)
- [x] Posted a board user comment on LOA-8 (in_review issue assigned to CEO agent)
- [x] Verified `contextSnapshot` contains `paperclipWakeCommentMarkdown` with full comment body
- [x] Agent woke up, read the comment, and responded directly to the feedback (replaced em-dashes in a Google Doc as instructed)
- [x] Compared to pre-fix behavior on LOA-3 where the same agent completely ignored a board comment

## Closes

- Closes #799 — Comment-triggered wakes resume prior session without passing the triggering comment body
- Closes #2249 — Mentioned agent wakes up but never reads or replies to the comment
- Related: #848 — Task-triggered runs ignore issue description