### PR TITLE
feat: wake assignee when issue status becomes actionable (blocked/in_review→todo/in_progress)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @paperclipai/server
 
+## [Unreleased]
+
+### Features
+
+- Wake assignee agent when issue status transitions from `blocked` or `in_review` to an actionable state (`todo` or `in_progress`)
+
+### Bug Fixes
+
+- Fix `statusBecameActionable` condition to compare committed DB state (`issue.status`) rather than raw request body, preventing spurious wakeups when the service layer normalises status values
+
 ## 0.3.1
 
 ### Patch Changes

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -153,6 +153,87 @@ describe("issue dependency wakeups in issue routes", () => {
     );
   });
 
+  describe("statusBecameActionable wakeups", () => {
+    const makeIssue = (status: string, assigneeAgentId: string | null = "agent-1") => ({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-100",
+      title: "Test issue",
+      description: null,
+      status,
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId,
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+
+    it.each([
+      ["blocked", "todo"],
+      ["blocked", "in_progress"],
+      ["in_review", "todo"],
+      ["in_review", "in_progress"],
+    ])("wakes assignee when status changes from %s to %s", async (fromStatus, toStatus) => {
+      mockIssueService.getById.mockResolvedValue(makeIssue(fromStatus));
+      mockIssueService.update.mockResolvedValue(makeIssue(toStatus));
+
+      const res = await request(createApp()).patch("/api/issues/issue-1").send({ status: toStatus });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(res.status).toBe(200);
+      expect(mockWakeup).toHaveBeenCalledWith(
+        "agent-1",
+        expect.objectContaining({
+          reason: "issue_status_changed",
+          payload: expect.objectContaining({ issueId: "issue-1", mutation: "update" }),
+        }),
+      );
+    });
+
+    it("does not wake assignee when blocked transitions to done (not actionable)", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+      mockIssueService.update.mockResolvedValue(makeIssue("done"));
+
+      const res = await request(createApp()).patch("/api/issues/issue-1").send({ status: "done" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(res.status).toBe(200);
+      expect(mockWakeup).not.toHaveBeenCalledWith(
+        "agent-1",
+        expect.objectContaining({ reason: "issue_status_changed" }),
+      );
+    });
+
+    it("does not wake assignee when issue has no assigneeAgentId", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue("blocked", null));
+      mockIssueService.update.mockResolvedValue(makeIssue("todo", null));
+
+      const res = await request(createApp()).patch("/api/issues/issue-1").send({ status: "todo" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(res.status).toBe(200);
+      expect(mockWakeup).not.toHaveBeenCalled();
+    });
+
+    it("does not fire status wakeup when status is unchanged (no-op update)", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+      mockIssueService.update.mockResolvedValue(makeIssue("blocked"));
+
+      const res = await request(createApp()).patch("/api/issues/issue-1").send({ status: "blocked" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(res.status).toBe(200);
+      expect(mockWakeup).not.toHaveBeenCalledWith(
+        "agent-1",
+        expect.objectContaining({ reason: "issue_status_changed" }),
+      );
+    });
+  });
+
   it("wakes the parent when all direct children become terminal", async () => {
     mockIssueService.getById.mockResolvedValue({
       id: "child-1",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1333,7 +1333,7 @@ export function issueRoutes(
     const statusBecameActionable =
       req.body.status !== undefined &&
       existing.status !== req.body.status &&
-      ["blocked", "backlog"].includes(existing.status) &&
+      ["blocked", "in_review"].includes(existing.status) &&
       ["todo", "in_progress"].includes(issue.status);
 
     // Merge all wakeups from this update into one enqueue per agent to avoid duplicate runs.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1332,7 +1332,7 @@ export function issueRoutes(
       req.body.status !== undefined;
     const statusBecameActionable =
       req.body.status !== undefined &&
-      existing.status !== req.body.status &&
+      existing.status !== issue.status &&
       ["blocked", "in_review"].includes(existing.status) &&
       ["todo", "in_progress"].includes(issue.status);
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1330,6 +1330,11 @@ export function issueRoutes(
       existing.status === "backlog" &&
       issue.status !== "backlog" &&
       req.body.status !== undefined;
+    const statusBecameActionable =
+      req.body.status !== undefined &&
+      existing.status !== req.body.status &&
+      ["blocked", "backlog"].includes(existing.status) &&
+      ["todo", "in_progress"].includes(issue.status);
 
     // Merge all wakeups from this update into one enqueue per agent to avoid duplicate runs.
     void (async () => {
@@ -1363,7 +1368,7 @@ export function issueRoutes(
         });
       }
 
-      if (!assigneeChanged && statusChangedFromBacklog && issue.assigneeAgentId) {
+      if (!assigneeChanged && (statusChangedFromBacklog || statusBecameActionable) && issue.assigneeAgentId) {
         addWakeup(issue.assigneeAgentId, {
           source: "automation",
           triggerDetail: "system",


### PR DESCRIPTION
## Summary

- Wake the assigned agent when an issue transitions from `blocked` or `in_review` to an actionable state (`todo` or `in_progress`), complementing the existing backlog→active wakeup
- Fix `statusBecameActionable` to compare committed DB state (`issue.status`) instead of raw `req.body.status`, preventing spurious/missed wakeups when the service layer normalises values
- Add 7 route-level tests covering all 4 happy-path transitions, a non-actionable target (→done), missing assignee, and no-op update

## Test plan

- [ ] All 9 tests in `server/src/__tests__/issue-dependency-wakeups-routes.test.ts` pass (`npx vitest run` in `server/`)
- [ ] Build passes (`pnpm run build` in `server/`)
- [ ] Manually verify: assign an agent to a blocked issue, transition it to `todo` — agent receives `issue_status_changed` wakeup
- [ ] Verify: transitioning `blocked` → `done` does NOT trigger the status-change wakeup for the assignee

🤖 Generated with [Claude Code](https://claude.com/claude-code)