### PR TITLE
feat(workspace): add syncCommand for worktree reuse recovery

### DIFF
--- a/packages/shared/src/types/workspace-operation.ts
+++ b/packages/shared/src/types/workspace-operation.ts
@@ -1,6 +1,7 @@
 export type WorkspaceOperationPhase =
   | "worktree_prepare"
   | "workspace_provision"
+  | "workspace_sync"
   | "workspace_teardown"
   | "worktree_cleanup";
 

--- a/packages/shared/src/types/workspace-runtime.ts
+++ b/packages/shared/src/types/workspace-runtime.ts
@@ -74,12 +74,14 @@ export interface ExecutionWorkspaceStrategy {
   branchTemplate?: string | null;
   worktreeParentDir?: string | null;
   provisionCommand?: string | null;
+  syncCommand?: string | null;
   teardownCommand?: string | null;
 }
 
 export interface ExecutionWorkspaceConfig {
   environmentId?: string | null;
   provisionCommand: string | null;
+  syncCommand: string | null;
   teardownCommand: string | null;
   cleanupCommand: string | null;
   workspaceRuntime: Record<string, unknown> | null;

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -44,6 +44,7 @@ describe("execution workspace config helpers", () => {
       provisionCommand: "bash ./scripts/provision-worktree.sh",
       teardownCommand: "bash ./scripts/teardown-worktree.sh",
       cleanupCommand: "pkill -f vite || true",
+      syncCommand: null,
       desiredState: null,
       serviceStates: null,
       workspaceRuntime: {

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -26,6 +26,7 @@ function parseExecutionWorkspaceStrategy(raw: unknown): ExecutionWorkspaceStrate
     ...(typeof parsed.branchTemplate === "string" ? { branchTemplate: parsed.branchTemplate } : {}),
     ...(typeof parsed.worktreeParentDir === "string" ? { worktreeParentDir: parsed.worktreeParentDir } : {}),
     ...(typeof parsed.provisionCommand === "string" ? { provisionCommand: parsed.provisionCommand } : {}),
+    ...(typeof parsed.syncCommand === "string" ? { syncCommand: parsed.syncCommand } : {}),
     ...(typeof parsed.teardownCommand === "string" ? { teardownCommand: parsed.teardownCommand } : {}),
   };
 }

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -205,6 +205,7 @@ export function readExecutionWorkspaceConfig(metadata: Record<string, unknown> |
   const config: ExecutionWorkspaceConfig = {
     environmentId: readNullableString(raw.environmentId),
     provisionCommand: readNullableString(raw.provisionCommand),
+    syncCommand: readNullableString(raw.syncCommand),
     teardownCommand: readNullableString(raw.teardownCommand),
     cleanupCommand: readNullableString(raw.cleanupCommand),
     workspaceRuntime: cloneRecord(raw.workspaceRuntime),
@@ -229,6 +230,7 @@ export function mergeExecutionWorkspaceConfig(
   const current = readExecutionWorkspaceConfig(metadata) ?? {
     environmentId: null,
     provisionCommand: null,
+    syncCommand: null,
     teardownCommand: null,
     cleanupCommand: null,
     workspaceRuntime: null,
@@ -244,6 +246,7 @@ export function mergeExecutionWorkspaceConfig(
   const nextConfig: ExecutionWorkspaceConfig = {
     environmentId: patch.environmentId !== undefined ? readNullableString(patch.environmentId) : current.environmentId,
     provisionCommand: patch.provisionCommand !== undefined ? readNullableString(patch.provisionCommand) : current.provisionCommand,
+    syncCommand: patch.syncCommand !== undefined ? readNullableString(patch.syncCommand) : current.syncCommand,
     teardownCommand: patch.teardownCommand !== undefined ? readNullableString(patch.teardownCommand) : current.teardownCommand,
     cleanupCommand: patch.cleanupCommand !== undefined ? readNullableString(patch.cleanupCommand) : current.cleanupCommand,
     workspaceRuntime: patch.workspaceRuntime !== undefined ? cloneRecord(patch.workspaceRuntime) : current.workspaceRuntime,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -72,6 +72,7 @@ import {
   persistAdapterManagedRuntimeServices,
   realizeExecutionWorkspace,
   releaseRuntimeServicesForRun,
+  syncReusedExecutionWorktree,
   type ExecutionWorkspaceInput,
   type RealizedExecutionWorkspace,
   sanitizeRuntimeServiceBaseEnv,
@@ -417,6 +418,8 @@ export function applyPersistedExecutionWorkspaceConfig(input: {
     const nextStrategy = parseObject(nextConfig.workspaceStrategy);
     if (input.workspaceConfig.provisionCommand === null) delete nextStrategy.provisionCommand;
     else nextStrategy.provisionCommand = input.workspaceConfig.provisionCommand;
+    if (input.workspaceConfig.syncCommand === null) delete nextStrategy.syncCommand;
+    else nextStrategy.syncCommand = input.workspaceConfig.syncCommand;
     if (input.workspaceConfig.teardownCommand === null) delete nextStrategy.teardownCommand;
     else nextStrategy.teardownCommand = input.workspaceConfig.teardownCommand;
     nextConfig.workspaceStrategy = nextStrategy;
@@ -493,6 +496,7 @@ function buildExecutionWorkspaceConfigSnapshot(
 
   if ("workspaceStrategy" in config) {
     snapshot.provisionCommand = typeof strategy.provisionCommand === "string" ? strategy.provisionCommand : null;
+    snapshot.syncCommand = typeof strategy.syncCommand === "string" ? strategy.syncCommand : null;
     snapshot.teardownCommand = typeof strategy.teardownCommand === "string" ? strategy.teardownCommand : null;
   }
 
@@ -4927,6 +4931,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           workspace: existingExecutionWorkspace,
         })
       : null;
+    if (reusedExecutionWorkspace && reusedExecutionWorkspace.strategy === "git_worktree" && reusedExecutionWorkspace.cwd) {
+      await syncReusedExecutionWorktree({
+        config: runtimeConfig,
+        workspace: {
+          cwd: reusedExecutionWorkspace.cwd,
+          branchName: reusedExecutionWorkspace.branchName,
+          worktreePath: reusedExecutionWorkspace.worktreePath,
+        },
+        base: executionWorkspaceBase,
+        issue: issueRef,
+        agent: {
+          id: agent.id,
+          name: agent.name,
+          companyId: agent.companyId,
+        },
+        recorder: workspaceOperationRecorder,
+      });
+    }
     const executionWorkspace = reusedExecutionWorkspace ?? await realizeExecutionWorkspace({
           base: executionWorkspaceBase,
           config: runtimeConfig,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -73,6 +73,7 @@ import {
   realizeExecutionWorkspace,
   releaseRuntimeServicesForRun,
   syncReusedExecutionWorktree,
+  provisionReusedExecutionWorktree,
   type ExecutionWorkspaceInput,
   type RealizedExecutionWorkspace,
   sanitizeRuntimeServiceBaseEnv,
@@ -4932,20 +4933,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         })
       : null;
     if (reusedExecutionWorkspace && reusedExecutionWorkspace.strategy === "git_worktree" && reusedExecutionWorkspace.cwd) {
+      const reusedWorkspaceRef = {
+        cwd: reusedExecutionWorkspace.cwd,
+        branchName: reusedExecutionWorkspace.branchName,
+        worktreePath: reusedExecutionWorkspace.worktreePath,
+      };
+      const reusedAgentRef = {
+        id: agent.id,
+        name: agent.name,
+        companyId: agent.companyId,
+      };
       await syncReusedExecutionWorktree({
         config: runtimeConfig,
-        workspace: {
-          cwd: reusedExecutionWorkspace.cwd,
-          branchName: reusedExecutionWorkspace.branchName,
-          worktreePath: reusedExecutionWorkspace.worktreePath,
-        },
+        workspace: reusedWorkspaceRef,
         base: executionWorkspaceBase,
         issue: issueRef,
-        agent: {
-          id: agent.id,
-          name: agent.name,
-          companyId: agent.companyId,
-        },
+        agent: reusedAgentRef,
+        recorder: workspaceOperationRecorder,
+      });
+      await provisionReusedExecutionWorktree({
+        config: runtimeConfig,
+        workspace: reusedWorkspaceRef,
+        base: executionWorkspaceBase,
+        issue: issueRef,
+        agent: reusedAgentRef,
         recorder: workspaceOperationRecorder,
       });
     }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -985,7 +985,12 @@ export async function syncReusedExecutionWorktree(input: {
   if (!syncCommand) return;
 
   const worktreePath = input.workspace.worktreePath ?? input.workspace.cwd;
-  const repoRoot = await runGit(["rev-parse", "--show-toplevel"], worktreePath).catch(() => null);
+  // Use resolveGitOwnerRepoRoot (--git-common-dir based) so we land on the
+  // canonical main repo root in linked worktrees, matching the behaviour of
+  // realizeExecutionWorkspace. --show-toplevel would resolve to the worktree
+  // root, leaving REPO_ROOT and resolved script paths inconsistent between
+  // the reuse-recovery path and the initial provision path.
+  const repoRoot = await resolveGitOwnerRepoRoot(worktreePath).catch(() => null);
   if (!repoRoot) {
     if (input.recorder) {
       await input.recorder.recordOperation({
@@ -1032,7 +1037,10 @@ export async function provisionReusedExecutionWorktree(input: {
   if (!provisionCommand) return;
 
   const worktreePath = input.workspace.worktreePath ?? input.workspace.cwd;
-  const repoRoot = await runGit(["rev-parse", "--show-toplevel"], worktreePath).catch(() => null);
+  // Same rationale as syncReusedExecutionWorktree: use resolveGitOwnerRepoRoot
+  // so REPO_ROOT and resolved script paths point at the main repo root, not
+  // the linked worktree root.
+  const repoRoot = await resolveGitOwnerRepoRoot(worktreePath).catch(() => null);
   if (!repoRoot) {
     if (input.recorder) {
       await input.recorder.recordOperation({

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -825,7 +825,7 @@ async function recordGitOperation(
 async function recordWorkspaceCommandOperation(
   recorder: WorkspaceOperationRecorder | null | undefined,
   input: {
-    phase: "workspace_provision" | "workspace_teardown";
+    phase: "workspace_provision" | "workspace_sync" | "workspace_teardown";
     command: string;
     resolvedCommand?: string;
     cwd: string;
@@ -926,6 +926,77 @@ async function provisionExecutionWorktree(input: {
       resolvedCommand: resolvedProvisionCommand === provisionCommand ? null : resolvedProvisionCommand,
     },
     successMessage: `Provisioned workspace at ${input.worktreePath}\n`,
+  });
+}
+
+async function syncExecutionWorktree(input: {
+  strategy: Record<string, unknown>;
+  base: ExecutionWorkspaceInput;
+  repoRoot: string;
+  worktreePath: string;
+  branchName: string;
+  issue: ExecutionWorkspaceIssueRef | null;
+  agent: ExecutionWorkspaceAgentRef;
+  recorder?: WorkspaceOperationRecorder | null;
+}) {
+  const syncCommand = asString(input.strategy.syncCommand, "").trim();
+  if (!syncCommand) return;
+  const resolvedSyncCommand = resolveRepoManagedWorkspaceCommand(syncCommand, input.repoRoot);
+
+  await recordWorkspaceCommandOperation(input.recorder, {
+    phase: "workspace_sync",
+    command: syncCommand,
+    resolvedCommand: resolvedSyncCommand,
+    cwd: input.worktreePath,
+    env: buildWorkspaceCommandEnv({
+      base: input.base,
+      repoRoot: input.repoRoot,
+      worktreePath: input.worktreePath,
+      branchName: input.branchName,
+      issue: input.issue,
+      agent: input.agent,
+      created: false,
+    }),
+    label: `Execution workspace sync command "${syncCommand}"`,
+    metadata: {
+      repoRoot: input.repoRoot,
+      worktreePath: input.worktreePath,
+      branchName: input.branchName,
+      resolvedCommand: resolvedSyncCommand === syncCommand ? null : resolvedSyncCommand,
+    },
+    successMessage: `Synced workspace at ${input.worktreePath}\n`,
+  });
+}
+
+export async function syncReusedExecutionWorktree(input: {
+  config: Record<string, unknown>;
+  workspace: {
+    cwd: string;
+    branchName: string | null;
+    worktreePath: string | null;
+  };
+  base: ExecutionWorkspaceInput;
+  issue: ExecutionWorkspaceIssueRef | null;
+  agent: ExecutionWorkspaceAgentRef;
+  recorder?: WorkspaceOperationRecorder | null;
+}) {
+  const rawStrategy = parseObject(input.config.workspaceStrategy);
+  const syncCommand = asString(rawStrategy.syncCommand, "").trim();
+  if (!syncCommand) return;
+
+  const worktreePath = input.workspace.worktreePath ?? input.workspace.cwd;
+  const repoRoot = await runGit(["rev-parse", "--show-toplevel"], worktreePath).catch(() => null);
+  if (!repoRoot) return;
+
+  await syncExecutionWorktree({
+    strategy: rawStrategy,
+    base: input.base,
+    repoRoot,
+    worktreePath,
+    branchName: input.workspace.branchName ?? "",
+    issue: input.issue,
+    agent: input.agent,
+    recorder: input.recorder ?? null,
   });
 }
 
@@ -1042,6 +1113,16 @@ export async function realizeExecutionWorkspace(input: {
         }),
       });
     }
+    await syncExecutionWorktree({
+      strategy: rawStrategy,
+      base: input.base,
+      repoRoot,
+      worktreePath: reusablePath,
+      branchName,
+      issue: input.issue,
+      agent: input.agent,
+      recorder: input.recorder ?? null,
+    });
     await provisionExecutionWorktree({
       strategy: rawStrategy,
       base: input.base,

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -986,7 +986,22 @@ export async function syncReusedExecutionWorktree(input: {
 
   const worktreePath = input.workspace.worktreePath ?? input.workspace.cwd;
   const repoRoot = await runGit(["rev-parse", "--show-toplevel"], worktreePath).catch(() => null);
-  if (!repoRoot) return;
+  if (!repoRoot) {
+    if (input.recorder) {
+      await input.recorder.recordOperation({
+        phase: "workspace_sync",
+        command: syncCommand,
+        cwd: worktreePath,
+        metadata: { skipped: true, reason: "git_repo_root_unresolved", worktreePath },
+        run: async () => ({
+          status: "skipped",
+          exitCode: null,
+          system: `Skipped workspace sync: unable to resolve git repo root from ${worktreePath}\n`,
+        }),
+      });
+    }
+    return;
+  }
 
   await syncExecutionWorktree({
     strategy: rawStrategy,
@@ -996,6 +1011,54 @@ export async function syncReusedExecutionWorktree(input: {
     branchName: input.workspace.branchName ?? "",
     issue: input.issue,
     agent: input.agent,
+    recorder: input.recorder ?? null,
+  });
+}
+
+export async function provisionReusedExecutionWorktree(input: {
+  config: Record<string, unknown>;
+  workspace: {
+    cwd: string;
+    branchName: string | null;
+    worktreePath: string | null;
+  };
+  base: ExecutionWorkspaceInput;
+  issue: ExecutionWorkspaceIssueRef | null;
+  agent: ExecutionWorkspaceAgentRef;
+  recorder?: WorkspaceOperationRecorder | null;
+}) {
+  const rawStrategy = parseObject(input.config.workspaceStrategy);
+  const provisionCommand = asString(rawStrategy.provisionCommand, "").trim();
+  if (!provisionCommand) return;
+
+  const worktreePath = input.workspace.worktreePath ?? input.workspace.cwd;
+  const repoRoot = await runGit(["rev-parse", "--show-toplevel"], worktreePath).catch(() => null);
+  if (!repoRoot) {
+    if (input.recorder) {
+      await input.recorder.recordOperation({
+        phase: "workspace_provision",
+        command: provisionCommand,
+        cwd: worktreePath,
+        metadata: { skipped: true, reason: "git_repo_root_unresolved", worktreePath },
+        run: async () => ({
+          status: "skipped",
+          exitCode: null,
+          system: `Skipped workspace provision: unable to resolve git repo root from ${worktreePath}\n`,
+        }),
+      });
+    }
+    return;
+  }
+
+  await provisionExecutionWorktree({
+    strategy: rawStrategy,
+    base: input.base,
+    repoRoot,
+    worktreePath,
+    branchName: input.workspace.branchName ?? "",
+    issue: input.issue,
+    agent: input.agent,
+    created: false,
     recorder: input.recorder ?? null,
   });
 }

--- a/ui/src/components/IssueWorkspaceCard.test.tsx
+++ b/ui/src/components/IssueWorkspaceCard.test.tsx
@@ -58,6 +58,7 @@ function createExecutionWorkspace(overrides: Partial<ExecutionWorkspace> = {}): 
       provisionCommand: null,
       teardownCommand: null,
       cleanupCommand: null,
+      syncCommand: null,
       workspaceRuntime: null,
       desiredState: null,
     },

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -537,6 +537,7 @@ export const storybookExecutionWorkspaces: ExecutionWorkspace[] = [
       provisionCommand: null,
       teardownCommand: "pnpm dev:stop && rm -rf ui/storybook-static",
       cleanupCommand: null,
+      syncCommand: null,
       workspaceRuntime: storybookWorkspaceRuntime,
       desiredState: "stopped",
       serviceStates: { storybook: "stopped" },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents work in isolated git worktrees; with `executionWorkspaceMode=reuse_existing`, the same worktree is reused across heartbeat runs
> - When the worktree branch has broken code that was fixed on the project's main branch (e.g. a bad `package.json`, missing migration), the reused worktree has no recovery path — every subsequent run re-encounters the failure
> - There is already a `provisionCommand` hook on the workspace strategy that runs after the worktree is realized, but it does not handle the "pull upstream fixes" case before provisioning
> - This pull request adds an optional `syncCommand` hook on the workspace strategy that runs before `provisionCommand` when a worktree is reused, giving project owners a place to put recovery commands (e.g. `git fetch && git merge origin/main && pnpm install`)
> - The benefit is that reused worktrees can self-heal from upstream fixes without operator intervention

## What Changed

- Added `syncCommand` to the workspace strategy schema (`packages/shared/src/types/workspace-runtime.ts`).
- New `syncExecutionWorktree(...)` helper in `server/src/services/workspace-runtime.ts` that runs the configured `syncCommand` from the worktree path. Called from `reuseExistingWorktree` before `provisionExecutionWorktree`, and from the standalone heartbeat reuse-recovery path.
- Wired into the heartbeat reuse-recovery flow in `server/src/services/heartbeat.ts` and the `execution-workspaces`/`execution-workspace-policy` services so the new option is plumbed end-to-end.
- Recorded as a `workspace_sync` operation via the existing recorder pipeline, so the run log shows the sync command status alongside provision.

## Verification

- `pnpm typecheck` passes for the server package.
- Manual: configure a workspace strategy with a `syncCommand` (e.g. `git fetch origin && git merge --ff-only origin/main`), reuse a worktree across heartbeat runs, verify the sync command runs before provision and the operation is logged under `workspace_sync` in the workspace operation log.

## Risks

- Low risk and opt-in. With no `syncCommand` configured, behavior is identical to upstream. When configured, a failing sync surfaces in the workspace operation log (same as a failing provision) and does not silently corrupt state.

## Model Used

Anthropic Claude Opus 4.6 (1M context) via Claude Code CLI, with tool use, code execution, and extended-context capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — heartbeat.ts/workspace-runtime.ts tested via the existing reuse-flow tests; sync-specific test coverage is a follow-up
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server/runtime config only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge