### PR TITLE
fix(ci): scope lockfile refresh PR lookup to repo owner

### DIFF
--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -54,10 +54,11 @@ jobs:
         id: upsert-pr
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           if git diff --quiet -- pnpm-lock.yaml; then
             echo "Lockfile unchanged, nothing to do."
-            echo "pr_created=false" >> "$GITHUB_OUTPUT"
+            echo "pr_url=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -70,28 +71,26 @@ jobs:
           git commit -m "chore(lockfile): refresh pnpm-lock.yaml"
           git push --force origin "$BRANCH"
 
-          # Create PR if one doesn't already exist
-          existing=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
-          if [ -z "$existing" ]; then
-            gh pr create \
+          # Only reuse an open PR from this repository owner, not a fork with the same branch name.
+          pr_url="$(
+            gh pr list --state open --head "$BRANCH" --json url,headRepositoryOwner \
+              --jq ".[] | select(.headRepositoryOwner.login == \"$REPO_OWNER\") | .url" |
+            head -n 1
+          )"
+          if [ -z "$pr_url" ]; then
+            pr_url="$(gh pr create \
               --head "$BRANCH" \
               --title "chore(lockfile): refresh pnpm-lock.yaml" \
-              --body "Auto-generated lockfile refresh after dependencies changed on master. This PR only updates pnpm-lock.yaml."
-            echo "Created new PR."
+              --body "Auto-generated lockfile refresh after dependencies changed on master. This PR only updates pnpm-lock.yaml.")"
+            echo "Created new PR: $pr_url"
           else
-            echo "PR #$existing already exists, branch updated via force push."
+            echo "PR already exists: $pr_url"
           fi
-          echo "pr_created=true" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge for lockfile PR
-        if: steps.upsert-pr.outputs.pr_created == 'true'
+        if: steps.upsert-pr.outputs.pr_url != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          pr_url="$(gh pr list --head chore/refresh-lockfile --json url --jq '.[0].url')"
-          if [ -z "$pr_url" ]; then
-            echo "Error: lockfile PR was not found." >&2
-            exit 1
-          fi
-
-          gh pr merge --auto --squash --delete-branch "$pr_url"
+          gh pr merge --auto --squash --delete-branch "${{ steps.upsert-pr.outputs.pr_url }}"


### PR DESCRIPTION
## Thinking Path

> - Paperclip relies on GitHub Actions to keep repository automation, including dependency hygiene, working without manual cleanup.
> - The `Refresh Lockfile` workflow is the subsystem responsible for regenerating `pnpm-lock.yaml` and opening a follow-up PR when `master` changes dependencies.
> - After `packages/mcp-server` landed, the lockfile refresh path needed to create or reuse the correct PR so the stale lockfile could be merged back.
> - The workflow was using `gh pr list --head chore/refresh-lockfile`, which is not owner-scoped and therefore matches fork PRs that happen to use the same branch name.
> - That made the automation think a valid lockfile PR already existed even when the main repository had no repo-owned `chore/refresh-lockfile` PR to update or auto-merge.
> - This pull request scopes PR reuse to `github.repository_owner` and passes the resolved PR URL through the rest of the workflow so only a repo-owned lockfile PR is accepted.
> - The benefit is that future lockfile refreshes will either reuse the correct upstream PR or create a new one instead of silently treating fork PRs as valid.

## What Changed

- Added `REPO_OWNER: ${{ github.repository_owner }}` to the lockfile PR upsert step.
- Replaced the old boolean output with a `pr_url` output so the workflow carries the exact resolved PR forward.
- Filtered `gh pr list` results by `headRepositoryOwner.login == $REPO_OWNER` before deciding whether an existing lockfile PR can be reused.
- Switched the auto-merge step to consume the exact `pr_url` emitted by the upsert step instead of doing another unscoped PR lookup.

## Verification

- `gh pr list --repo paperclipai/paperclip --state open --head chore/refresh-lockfile --json number,url,headRepositoryOwner`
- `gh pr list --repo paperclipai/paperclip --state open --head chore/refresh-lockfile --json url,headRepositoryOwner --jq '.[] | select(.headRepositoryOwner.login == "paperclipai") | .url'`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` currently fails in unrelated existing test `server/src/__tests__/agent-skills-routes.test.ts:283` with `expected "spy" to be called`, and this PR does not touch that area.

## Risks

- Low risk: this only changes GitHub Actions control flow in `.github/workflows/refresh-lockfile.yml` and narrows PR reuse behavior to the repository owner.
- If the repository intentionally wanted to reuse a fork-owned lockfile PR, that behavior will no longer happen; this is the intended fix for the current failure mode.

## Model Used

- OpenAI Codex on GPT-5.4 via the local Codex adapter, with tool use, shell execution, and repository editing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
