### PR TITLE
fix: allow agents to execute plugin-registered tools

### DIFF
--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -15,6 +15,12 @@ export function assertInstanceAdmin(req: Request) {
   throw forbidden("Instance admin access required");
 }
 
+export function assertAuthenticated(req: Request) {
+  if (req.actor.type === "none") {
+    throw unauthorized();
+  }
+}
+
 export function assertCompanyAccess(req: Request, companyId: string) {
   if (req.actor.type === "none") {
     throw unauthorized();

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -47,7 +47,7 @@ import type { PluginStreamBus } from "../services/plugin-stream-bus.js";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 import type { ToolRunContext } from "@paperclipai/plugin-sdk";
 import { JsonRpcCallError, PLUGIN_RPC_ERROR_CODES } from "@paperclipai/plugin-sdk";
-import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { assertAuthenticated, assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { validateInstanceConfig } from "../services/plugin-config-validator.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -483,7 +483,7 @@ export function pluginRoutes(
    * Errors: 501 if tool dispatcher is not configured
    */
   router.get("/plugins/tools", async (req, res) => {
-    assertBoard(req);
+    assertAuthenticated(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -517,7 +517,7 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoard(req);
+    assertAuthenticated(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1812,7 +1812,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,14 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (key)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin's database UUID, used for worker routing
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +431,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins can register tools (like `escalate_to_human`) that agents should be able to call
> - The tool registry and worker system correctly register and host these tools
> - But the HTTP endpoints that expose them (`/api/plugins/tools` and `/api/plugins/tools/execute`) require board-level auth, blocking agent JWTs
> - Additionally, the plugin activation path passes `pluginKey` instead of the database UUID to the tool registry, causing a worker lookup mismatch at execution time
> - This PR fixes both bugs so agents can discover and execute plugin tools
> - The benefit is that plugin tools like `escalate_to_human` work as designed — agents can call them directly without workarounds

## What Changed

- **`server/src/routes/authz.ts`**: Added `assertAuthenticated()` helper that allows both board users and agent JWTs (rejects only unauthenticated requests)
- **`server/src/routes/plugins.ts`**: Changed `GET /plugins/tools` and `POST /plugins/tools/execute` from `assertBoard()` to `assertAuthenticated()`. The execute handler already calls `assertCompanyAccess(req, runContext.companyId)` downstream, which properly scopes agents to their own company's tools.
- **`server/src/services/plugin-tool-dispatcher.ts`**: Added optional `pluginDbId` parameter to `registerPluginTools()` and forwards it to `registry.registerPlugin()`
- **`server/src/services/plugin-loader.ts`**: Passes `pluginId` (DB UUID) as the third argument to `toolDispatcher.registerPluginTools()` during plugin activation. This matches what `initialize()` already does correctly.

## Verification

1. Install a plugin with tools (e.g., `paperclip-plugin-discord` which registers `escalate_to_human`)
2. Generate an agent JWT for any agent in the company
3. **Before fix**: `POST /api/plugins/tools/execute` with agent JWT returns `403 Board access required`
4. **After fix**: Same call returns `200` with the tool execution result

Manual test confirmed working: generated a test JWT for an agent, called `escalate_to_human`, received `200` with `{"escalationId":"esc_...","status":"pending","message":"Escalation posted to Discord for human review."}` and the message appeared in Discord with interactive buttons.

The `initialize()` path (server startup) was already correct — this fix aligns the `activatePlugin()` path (runtime activation) to match.

## Risks

- **Low risk.** The auth change is minimal: `assertAuthenticated` is strictly less restrictive than `assertBoard`, and agent scope is already enforced by `assertCompanyAccess` downstream. No new attack surface — agents could already call every other company-scoped API endpoint.
- The `pluginDbId` parameter is optional and defaults to the existing behavior when not provided, so no backward compatibility concerns.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Opus 4.6 (`claude-opus-4-6`)
- **Context:** 1M tokens
- **Capabilities:** Extended thinking, tool use, code execution
- **Usage:** Root cause analysis of the bug chain (auth → registry → worker lookup), fix design, and implementation. Human (Chad) directed the investigation and verified the fix in production.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge