### PR TITLE
fix: clear checkoutRunId when releasing issue execution lock

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -252,7 +252,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
-    expect(issue?.checkoutRunId).toBe(runId);
+    expect(issue?.checkoutRunId).toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3246,6 +3246,7 @@ export function heartbeatService(db: Db) {
           executionRunId: null,
           executionAgentNameKey: null,
           executionLockedAt: null,
+          checkoutRunId: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, issue.id));
@@ -3535,6 +3536,7 @@ export function heartbeatService(db: Db) {
               executionRunId: null,
               executionAgentNameKey: null,
               executionLockedAt: null,
+              checkoutRunId: null,
               updatedAt: new Date(),
             })
             .where(eq(issues.id, issue.id));


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses an execution lock (executionRunId, executionAgentNameKey, executionLockedAt) to prevent concurrent runs on the same issue
> - A separate checkoutRunId field is set when an agent checks out an issue, linking the checkout to the run that performed it
> - When a run ends in any terminal state (cancelled, failed, process-lost), releaseIssueExecutionAndPromote clears the execution lock fields
> - But it did NOT clear checkoutRunId, leaving a stale checkout lock on the issue
> - This stale lock prevents any future checkout from succeeding — the issue appears locked to a dead run and cannot be assigned to a new one without a manual DB fix
> - The same gap existed in the enqueueWakeup stale-lock cleanup path

## Problem

`releaseIssueExecutionAndPromote` cleared `executionRunId`, `executionAgentNameKey`, and `executionLockedAt` but not `checkoutRunId`. After a run ends, the issue retains a stale checkout lock pointing to the terminated run, blocking all future checkouts.

The same gap existed in `enqueueWakeup`'s stale-lock detection: when it found a non-live `executionRunId` and cleared the execution fields, it also left `checkoutRunId` set.

Fixes #2912

## What Changed

- `server/src/services/heartbeat.ts`: Added `checkoutRunId: null` to the update set in:
  1. `releaseIssueExecutionAndPromote` (called on all terminal run states)
  2. `enqueueWakeup` stale-lock cleanup (detects and clears non-live execution locks)
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: Updated assertion to expect `checkoutRunId` to be `null` after a non-retried process-loss failure (was incorrectly asserting it retained the old run ID)

## Verification

```bash
pnpm --filter "@paperclipai/server" exec vitest run src/__tests__/heartbeat-process-recovery.test.ts
# All 5 tests pass
```

The existing `heartbeat-process-recovery` test suite covers the process-lost path. The updated assertion in that test confirms `checkoutRunId` is properly cleared after the run terminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)