### PR TITLE
fix: auto-restart dev server in watch mode after unexpected SIGTERM

### DIFF
--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -543,6 +543,10 @@ async function startServerChild() {
       if (restartInFlight || expected || shuttingDown) {
         return;
       }
+      // In watch mode, the outer restart loop handles unexpected deaths.
+      if (mode === "watch") {
+        return;
+      }
       if (signal) {
         exitForSignal(signal);
         return;
@@ -650,10 +654,53 @@ await startServerChild();
 installDevIntervals();
 
 if (mode === "watch") {
-  const exit = await waitForChildExit();
-  await removeLocalServiceRegistryRecord(devService.serviceKey);
-  if (exit.signal) {
-    exitForSignal(exit.signal);
+  const maxWatchRestarts = 5;
+  const watchRestartBackoffMs = 2000;
+  let watchRestartCount = 0;
+
+  while (true) {
+    const exit = await waitForChildExit();
+
+    // SIGINT (Ctrl+C) is always intentional — exit immediately.
+    if (exit.signal === "SIGINT") {
+      await removeLocalServiceRegistryRecord(devService.serviceKey);
+      exitForSignal(exit.signal);
+      break;
+    }
+
+    // Clean exit (code 0) means the child decided to stop — honour it.
+    if (!exit.signal && exit.code === 0) {
+      await removeLocalServiceRegistryRecord(devService.serviceKey);
+      process.exit(0);
+      break;
+    }
+
+    // Unexpected death (SIGTERM or non-zero exit) — attempt auto-restart.
+    watchRestartCount++;
+    if (watchRestartCount > maxWatchRestarts) {
+      console.error(
+        `[paperclip] watch mode child died ${watchRestartCount} times — giving up (last signal: ${exit.signal ?? "none"}, code: ${exit.code})`,
+      );
+      await removeLocalServiceRegistryRecord(devService.serviceKey);
+      if (exit.signal) {
+        exitForSignal(exit.signal);
+      }
+      process.exit(exit.code ?? 1);
+      break;
+    }
+
+    const backoff = watchRestartBackoffMs * watchRestartCount;
+    console.log(
+      `[paperclip] watch mode child exited unexpectedly (signal: ${exit.signal ?? "none"}, code: ${exit.code}) — restarting in ${backoff}ms (attempt ${watchRestartCount}/${maxWatchRestarts})`,
+    );
+    await new Promise((r) => setTimeout(r, backoff));
+
+    if (shuttingDown) {
+      await removeLocalServiceRegistryRecord(devService.serviceKey);
+      process.exit(0);
+      break;
+    }
+
+    await startServerChild();
   }
-  process.exit(exit.code ?? 0);
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -742,6 +742,14 @@ export async function startServer(): Promise<StartedServer> {
         await telemetryClient.flush();
       }
 
+      // Close HTTP server first so in-flight requests drain before
+      // the database becomes unavailable.
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        // If connections linger, force-close after a short grace period.
+        setTimeout(() => resolve(), 5000);
+      });
+
       if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
         logger.info({ signal }, "Stopping embedded PostgreSQL");
         try {


### PR DESCRIPTION
## Summary

- Adds auto-restart with linear backoff (up to 5 retries) in watch mode when the child process dies from an unexpected SIGTERM or non-zero exit
- SIGINT (Ctrl+C) and clean exits (code 0) still terminate immediately as before
- Child exit handler in `startServerChild()` defers to the restart loop in watch mode instead of racing with `exitForSignal()`

**Problem:** When the `dev:watch` process received an external SIGTERM (terminal disruption, macOS sleep/wake), the entire process tree died permanently with no recovery, causing extended server downtime.

## Test plan

- [ ] Run `pnpm run dev` in watch mode, verify normal file-change restarts still work
- [ ] Send SIGTERM to the child process (`kill <pid>`), verify auto-restart kicks in with backoff logging
- [ ] Send SIGINT (Ctrl+C), verify clean immediate exit
- [ ] Send SIGTERM 6+ times rapidly, verify it gives up after max retries

## Model Used

Claude Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)