### PR TITLE
fix(worktree): prevent repair function from poisoning default instance config

### DIFF
--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -480,6 +480,10 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_IN_WORKTREE = "true";
     process.env.PAPERCLIP_WORKTREE_NAME = "PAP-884-ai-commits-component";
     process.env.PAPERCLIP_WORKTREES_DIR = isolatedHome;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_CONFIG;
+    delete process.env.PAPERCLIP_CONTEXT;
 
     const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
     const repairedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));
@@ -655,6 +659,60 @@ describe("worktree config repair", () => {
     expect(writtenConfig.server.port).toBe(3103);
     expect(writtenConfig.database.embeddedPostgresPort).toBe(54335);
     expect(writtenConfig.auth.publicBaseUrl).toBe("https://paperclip.example");
+  });
+
+  it("refuses to repair when config resolves to default home instance (no worktree-local config)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-poison-"));
+    const worktreeRoot = path.join(tempRoot, "worktrees", "PAP-999-feature");
+    const defaultInstanceRoot = path.join(tempRoot, "home", ".paperclip", "instances", "default");
+    const defaultConfigPath = path.join(defaultInstanceRoot, "config.json");
+    const defaultEnvPath = path.join(defaultInstanceRoot, ".env");
+
+    // Create a worktree directory WITHOUT .paperclip/config.json
+    await fs.mkdir(worktreeRoot, { recursive: true });
+
+    // Create the default instance config (the one that should NOT be rewritten)
+    await fs.mkdir(defaultInstanceRoot, { recursive: true });
+    const originalConfig = buildLegacyConfig(defaultInstanceRoot);
+    await fs.writeFile(defaultConfigPath, JSON.stringify(originalConfig, null, 2) + "\n", "utf8");
+    await fs.writeFile(defaultEnvPath, "# Default instance env\n", "utf8");
+
+    // Simulate worktree context: PAPERCLIP_IN_WORKTREE=true, but no local config
+    // so resolvePaperclipConfigPath falls back to the default instance config
+    process.chdir(worktreeRoot);
+    process.env.PAPERCLIP_IN_WORKTREE = "true";
+    process.env.PAPERCLIP_WORKTREE_NAME = "PAP-999-feature";
+    process.env.PAPERCLIP_HOME = path.join(tempRoot, "home", ".paperclip");
+    process.env.PAPERCLIP_CONFIG = defaultConfigPath;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_WORKTREES_DIR;
+
+    const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
+
+    // Should bail — not repair
+    expect(result).toEqual({ repairedConfig: false, repairedEnv: false });
+
+    // Default config should be untouched
+    const configAfter = JSON.parse(await fs.readFile(defaultConfigPath, "utf8"));
+    expect(configAfter).toEqual(originalConfig);
+
+    // Default .env should be untouched
+    const envAfter = await fs.readFile(defaultEnvPath, "utf8");
+    expect(envAfter).toBe("# Default instance env\n");
+  });
+
+  it("can update the in-memory config without rewriting env-driven ports", () => {
+    const { config, changed } = applyRuntimePortSelectionToConfig(buildLegacyConfig("/tmp/shared"), {
+      serverPort: 3104,
+      databasePort: 54340,
+      allowServerPortWrite: false,
+      allowDatabasePortWrite: true,
+    });
+
+    expect(changed).toBe(true);
+    expect(config.server.port).toBe(3100);
+    expect(config.database.embeddedPostgresPort).toBe(54340);
+    expect(config.auth.publicBaseUrl).toBe("http://127.0.0.1:3104/");
   });
 
   it("can update the in-memory config when auth URL already includes a port", () => {

--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -430,6 +430,10 @@ describe("worktree config repair", () => {
     process.env.PAPERCLIP_IN_WORKTREE = "true";
     process.env.PAPERCLIP_WORKTREE_NAME = "PAP-884-ai-commits-component";
     process.env.PAPERCLIP_WORKTREES_DIR = isolatedHome;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_CONFIG;
+    delete process.env.PAPERCLIP_CONTEXT;
 
     const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
     const repairedConfig = JSON.parse(await fs.readFile(configPath, "utf8"));

--- a/server/src/__tests__/worktree-config.test.ts
+++ b/server/src/__tests__/worktree-config.test.ts
@@ -521,6 +521,46 @@ describe("worktree config repair", () => {
     expect(writtenConfig.auth.publicBaseUrl).toBe("http://my-host.ts.net:3103/");
   });
 
+  it("refuses to repair when config resolves to default home instance (no worktree-local config)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-poison-"));
+    const worktreeRoot = path.join(tempRoot, "worktrees", "PAP-999-feature");
+    const defaultInstanceRoot = path.join(tempRoot, "home", ".paperclip", "instances", "default");
+    const defaultConfigPath = path.join(defaultInstanceRoot, "config.json");
+    const defaultEnvPath = path.join(defaultInstanceRoot, ".env");
+
+    // Create a worktree directory WITHOUT .paperclip/config.json
+    await fs.mkdir(worktreeRoot, { recursive: true });
+
+    // Create the default instance config (the one that should NOT be rewritten)
+    await fs.mkdir(defaultInstanceRoot, { recursive: true });
+    const originalConfig = buildLegacyConfig(defaultInstanceRoot);
+    await fs.writeFile(defaultConfigPath, JSON.stringify(originalConfig, null, 2) + "\n", "utf8");
+    await fs.writeFile(defaultEnvPath, "# Default instance env\n", "utf8");
+
+    // Simulate worktree context: PAPERCLIP_IN_WORKTREE=true, but no local config
+    // so resolvePaperclipConfigPath falls back to the default instance config
+    process.chdir(worktreeRoot);
+    process.env.PAPERCLIP_IN_WORKTREE = "true";
+    process.env.PAPERCLIP_WORKTREE_NAME = "PAP-999-feature";
+    process.env.PAPERCLIP_HOME = path.join(tempRoot, "home", ".paperclip");
+    process.env.PAPERCLIP_CONFIG = defaultConfigPath;
+    delete process.env.PAPERCLIP_INSTANCE_ID;
+    delete process.env.PAPERCLIP_WORKTREES_DIR;
+
+    const result = maybeRepairLegacyWorktreeConfigAndEnvFiles();
+
+    // Should bail — not repair
+    expect(result).toEqual({ repairedConfig: false, repairedEnv: false });
+
+    // Default config should be untouched
+    const configAfter = JSON.parse(await fs.readFile(defaultConfigPath, "utf8"));
+    expect(configAfter).toEqual(originalConfig);
+
+    // Default .env should be untouched
+    const envAfter = await fs.readFile(defaultEnvPath, "utf8");
+    expect(envAfter).toBe("# Default instance env\n");
+  });
+
   it("does not rewrite no-port public auth URLs when persisting runtime-selected ports", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-public-ports-"));
     const worktreeRoot = path.join(tempRoot, "PAP-125-public-base-url");

--- a/server/src/worktree-config.ts
+++ b/server/src/worktree-config.ts
@@ -113,6 +113,23 @@ function resolveWorktreeRuntimeContext(
   if (env.PAPERCLIP_IN_WORKTREE !== "true") return null;
 
   const configPath = resolvePaperclipConfigPath(overrideConfigPath);
+
+  // Guard: if the config path resolved to the paperclip home directory (either
+  // the env-overridden one or the hardcoded default), the worktree is
+  // misconfigured (no worktree-local .paperclip/config.json was found).
+  // Bail to prevent rewriting a shared instance config with worktree-isolated
+  // paths, which would poison it for all other consumers.
+  const envHome = resolveHomeAwarePath(
+    nonEmpty(env.PAPERCLIP_HOME) ?? "~/.paperclip",
+  );
+  if (isPathInside(configPath, envHome)) {
+    return null;
+  }
+  const defaultHome = path.resolve(os.homedir(), ".paperclip");
+  if (defaultHome !== envHome && isPathInside(configPath, defaultHome)) {
+    return null;
+  }
+
   const envPath = resolvePaperclipEnvPath(configPath);
   const persistedEnv = readEnvEntries(envPath);
   const persistedConfigPath = nonEmpty(persistedEnv.PAPERCLIP_CONFIG);

--- a/server/src/worktree-config.ts
+++ b/server/src/worktree-config.ts
@@ -113,6 +113,23 @@ function resolveWorktreeRuntimeContext(
   if (env.PAPERCLIP_IN_WORKTREE !== "true") return null;
 
   const configPath = resolvePaperclipConfigPath(overrideConfigPath);
+
+  // Guard: if the config path resolved to the paperclip home directory (either
+  // the env-overridden one or the hardcoded default), the worktree is
+  // misconfigured (no worktree-local .paperclip/config.json was found).
+  // Bail to prevent rewriting a shared instance config with worktree-isolated
+  // paths, which would poison it for all other consumers.
+  const envHome = resolveHomeAwarePath(
+    nonEmpty(env.PAPERCLIP_HOME) ?? "~/.paperclip",
+  );
+  if (isPathInside(configPath, envHome)) {
+    return null;
+  }
+  const defaultHome = path.resolve(os.homedir(), ".paperclip");
+  if (defaultHome !== envHome && isPathInside(configPath, defaultHome)) {
+    return null;
+  }
+
   const envPath = resolvePaperclipEnvPath(configPath);
   const persistedEnv = readEnvEntries(envPath);
   const worktreeRoot = path.resolve(path.dirname(configPath), "..");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents run in git worktrees for workspace isolation, each with their own config and ports
> - The worktree config repair function (`maybeRepairLegacyWorktreeConfigAndEnvFiles`) ensures worktree configs have isolated paths and non-colliding ports
> - But when a worktree lacks its own `.paperclip/config.json`, config resolution falls back to the default instance at `~/.paperclip/instances/default/config.json`
> - The repair function then rewrites that shared config with worktree-isolated paths (temp dirs, bumped ports) and writes `PAPERCLIP_IN_WORKTREE=true` into the default `.env`
> - This creates a self-perpetuating poisoning loop: on next server start, dotenv loads the poisoned `.env`, triggering the repair again on the wrong config
> - This pull request adds a guard that detects when the resolved config path is inside the paperclip home directory and bails instead of rewriting shared state
> - The benefit is the default instance config is never corrupted by worktree repair, preventing wrong-port starts, fresh-setup prompts, and cross-database agent confusion

## What Changed

- **Guard in `resolveWorktreeRuntimeContext`** (`server/src/worktree-config.ts`): After resolving configPath, checks if it's inside the paperclip home directory (env-overridden or hardcoded default `~/.paperclip`). If so, returns `null` to prevent the repair function from targeting shared state.
- **Regression test** (`server/src/__tests__/worktree-config.test.ts`): New test case simulating a worktree without local config, verifying the repair function bails and leaves the default instance config and `.env` untouched.
- **Test env cleanup**: Two existing tests ("avoids sibling worktree ports" and "rebalances duplicate ports") were missing `delete process.env.PAPERCLIP_CONFIG` / `PAPERCLIP_INSTANCE_ID` / `PAPERCLIP_HOME` / `PAPERCLIP_CONTEXT`, causing failures on machines with Paperclip installed (ambient env vars leaked into tests). Added matching cleanup to both.

## Verification

- All 6 worktree-config tests pass locally (previously 2 were failing due to env leakage):
  ```
  pnpm vitest run server/src/__tests__/worktree-config.test.ts
  ```
- No new typecheck errors introduced (pre-existing `TS2774` in `routes/issues.ts:1389` is unrelated)

## Risks

- Low risk. The guard is a strict bail-out that only activates when `PAPERCLIP_IN_WORKTREE=true` AND the config path resolves inside the home directory — a scenario that was always a misconfiguration. Normal worktree flows (with local `.paperclip/config.json`) are unaffected.

## Model Used

- **Provider:** Anthropic Claude
- **Model:** Claude Opus 4.6 (`claude-opus-4-6`)
- **Context:** 1M tokens
- **Capabilities:** Tool use, code execution, systematic debugging
- **Environment:** Claude Code CLI on Windows 11

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge