### PR TITLE
feat: smart model routing — adapter-local cheap preflight for all supported adapters

### DIFF
--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -1,6 +1,6 @@
 # 2026-04-06 Smart Model Routing
 
-Status: Phase 2 complete (codex_local cheap preflight)
+Status: Phase 3 complete (claude_local cheap preflight)
 Date: 2026-04-06
 Audience: Product and engineering
 Related:

--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -1,6 +1,6 @@
 # 2026-04-06 Smart Model Routing
 
-Status: UI config and run detail complete (Phases 1-3 + UI)
+Status: COMPLETE (all phases: contract, codex, claude, remaining adapters, UI)
 Date: 2026-04-06
 Audience: Product and engineering
 Related:
@@ -215,7 +215,7 @@ Success criteria:
 - existing adapters behave exactly as before
 - a routed adapter can report cheap plus primary usage without collapsing them into one fake model
 
-## 7.2 Phase 2: `codex_local` (COMPLETE)
+## 7.2 Phase 2: `codex_local` (COMPLETE, committed)
 
 Why first:
 
@@ -235,7 +235,7 @@ Important guardrail:
 
 - do not resume the cheap-model session as the primary session in V1
 
-## 7.3 Phase 3: `claude_local`
+## 7.3 Phase 3: `claude_local` (COMPLETE, committed)
 
 Implementation work is similar, but the session model-switch risk is even less attractive.
 
@@ -244,16 +244,19 @@ Same rule:
 - cheap preflight is ephemeral
 - primary Claude session remains canonical
 
-## 7.4 Phase 4: other adapters
+## 7.4 Phase 4: remaining local adapters (COMPLETE, committed)
 
-Candidates:
+Implemented for:
 
-- `cursor`
-- `gemini_local`
-- `opencode_local`
-- external plugin adapters through `createServerAdapter()`
+- `cursor_local` -- uses `-p`/stdin prompt, `--yolo` trust bypass, stream-json output
+- `gemini_local` -- uses `--prompt` flag, `--approval-mode yolo`, `--sandbox=none`
+- `opencode_local` -- validates cheap model via `ensureOpenCodeModelConfiguredAndAvailable`
+- `pi_local` -- uses `--mode json -p`, `--append-system-prompt`, ephemeral session with cleanup
 
-These should come later because each runtime has different session and model-switch semantics.
+Skipped:
+
+- `openclaw_gateway` -- WebSocket-based architecture, not applicable for V1 cheap preflight
+- external plugin adapters via `createServerAdapter()` -- deferred; plugins can implement their own routing internally
 
 ## 8. UI and Config Changes
 

--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -1,6 +1,6 @@
 # 2026-04-06 Smart Model Routing
 
-Status: Phase 3 complete (claude_local cheap preflight)
+Status: UI config and run detail complete (Phases 1-3 + UI)
 Date: 2026-04-06
 Audience: Product and engineering
 Related:

--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -1,6 +1,6 @@
 # 2026-04-06 Smart Model Routing
 
-Status: Phase 1 complete (contract + server plumbing)
+Status: Phase 2 complete (codex_local cheap preflight)
 Date: 2026-04-06
 Audience: Product and engineering
 Related:
@@ -215,7 +215,7 @@ Success criteria:
 - existing adapters behave exactly as before
 - a routed adapter can report cheap plus primary usage without collapsing them into one fake model
 
-## 7.2 Phase 2: `codex_local`
+## 7.2 Phase 2: `codex_local` (COMPLETE)
 
 Why first:
 

--- a/doc/plans/2026-04-06-smart-model-routing.md
+++ b/doc/plans/2026-04-06-smart-model-routing.md
@@ -1,6 +1,6 @@
 # 2026-04-06 Smart Model Routing
 
-Status: Proposed
+Status: Phase 1 complete (contract + server plumbing)
 Date: 2026-04-06
 Audience: Product and engineering
 Related:

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -4,6 +4,7 @@ export type {
   UsageSummary,
   AdapterBillingType,
   AdapterRuntimeServiceReport,
+  ExecutionSegment,
   AdapterExecutionResult,
   AdapterInvocationMeta,
   AdapterExecutionContext,

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -904,6 +904,44 @@ export async function removeMaintainerOnlySkillSymlinks(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Smart model routing: shared preflight utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Static prompt injected at the start of a cheap-model preflight pass.
+ * Shared across all adapters that implement smart model routing.
+ */
+export const PREFLIGHT_ORCHESTRATION_PROMPT = `You are a preflight orchestrator for a Paperclip agent.
+
+This is a BOUNDED ORCHESTRATION PASS \u2014 not the main task execution.
+
+Your responsibilities:
+1. Read the task context below and orient to what is being asked.
+2. Inspect the workspace at a shallow level if needed (ls, cat a few key files).
+3. Produce a compact handoff summary for the primary model that will do the real work.
+
+Hard constraints:
+- Do NOT make code changes or write files.
+- Do NOT run more than a few tool calls.
+- Do NOT attempt task completion.
+- Finish quickly \u2014 this is a triage pass only.
+
+End your response with a section titled "## Handoff Summary" containing:
+- What the task requires (1-3 sentences)
+- Key workspace observations relevant to the task
+- Recommended approach or starting point for the primary model`;
+
+/**
+ * Extract the "## Handoff Summary" section from the preflight summary.
+ * Falls back to the full summary (trimmed) if no section marker is found.
+ */
+export function extractHandoffSection(summary: string): string {
+  const marker = summary.indexOf("## Handoff Summary");
+  if (marker === -1) return summary.trim();
+  return summary.slice(marker).trim();
+}
+
 export async function ensureCommandResolvable(command: string, cwd: string, env: NodeJS.ProcessEnv) {
   const resolved = await resolveCommandPath(command, cwd, env);
   if (resolved) return;

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -61,6 +61,24 @@ export interface AdapterRuntimeServiceReport {
   healthStatus?: "unknown" | "healthy" | "unhealthy";
 }
 
+/**
+ * One segment of a multi-phase adapter execution (e.g. cheap preflight + primary).
+ *
+ * When an adapter uses smart model routing, it reports each execution phase as
+ * a separate segment so the server can record truthful per-model cost events
+ * instead of collapsing everything into one fake model.
+ */
+export interface ExecutionSegment {
+  phase: "cheap_preflight" | "primary" | string;
+  provider?: string | null;
+  biller?: string | null;
+  model?: string | null;
+  billingType?: AdapterBillingType | null;
+  usage?: UsageSummary;
+  costUsd?: number | null;
+  summary?: string | null;
+}
+
 export interface AdapterExecutionResult {
   exitCode: number | null;
   signal: string | null;
@@ -92,6 +110,17 @@ export interface AdapterExecutionResult {
       description?: string;
     }>;
   } | null;
+  /**
+   * Optional segmented execution report for multi-model runs (smart model routing).
+   *
+   * When present, the server writes one cost_events row per segment that has
+   * cost or token usage.  The top-level `provider`/`model`/`usage` fields are
+   * kept as the summary view (typically the primary phase).
+   *
+   * When absent, the server falls back to the existing single-result behavior —
+   * no change for adapters that do not use routing.
+   */
+  executionSegments?: ExecutionSegment[];
 }
 
 export interface AdapterSessionCodec {

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -27,6 +27,12 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- smartModelRouting (object, optional): smart model routing configuration
+  - enabled (boolean): enable cheap preflight pass before primary execution
+  - cheapModel (string): model id for the preflight pass (e.g. "claude-haiku-4-5-20251001")
+  - cheapThinkingEffort (string, optional): reasoning effort for preflight (low|medium|high)
+  - maxPreflightTurns (number, optional, default 2): max tool-use turns during preflight
+  - allowInitialProgressComment (boolean, optional, default false): allow the preflight model to post progress comments
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { AdapterExecutionContext, AdapterExecutionResult, ExecutionSegment } from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 import {
   asString,
@@ -34,6 +34,36 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static prompt injected at the start of a cheap-model preflight pass.
+ * Must match the codex_local version so handoff notes are consistent.
+ */
+const PREFLIGHT_ORCHESTRATION_PROMPT = `You are a preflight orchestrator for a Paperclip agent.
+
+This is a BOUNDED ORCHESTRATION PASS \u2014 not the main task execution.
+
+Your responsibilities:
+1. Read the task context below and orient to what is being asked.
+2. Inspect the workspace at a shallow level if needed (ls, cat a few key files).
+3. Produce a compact handoff summary for the primary model that will do the real work.
+
+Hard constraints:
+- Do NOT make code changes or write files.
+- Do NOT run more than a few tool calls.
+- Do NOT attempt task completion.
+- Finish quickly \u2014 this is a triage pass only.
+
+End your response with a section titled "## Handoff Summary" containing:
+- What the task requires (1-3 sentences)
+- Key workspace observations relevant to the task
+- Recommended approach or starting point for the primary model`;
+
+function extractHandoffSection(summary: string): string {
+  const marker = summary.indexOf("## Handoff Summary");
+  if (marker === -1) return summary.trim();
+  return summary.slice(marker).trim();
+}
 
 /**
  * Create a tmpdir with `.claude/skills/` containing symlinks to skills from
@@ -332,6 +362,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+
+  // Smart model routing config
+  const smartRouting = parseObject(config.smartModelRouting);
+  const routingEnabled = asBoolean(smartRouting.enabled, false);
+  const cheapModel = asString(smartRouting.cheapModel, "");
+  const cheapThinkingEffort = asString(smartRouting.cheapThinkingEffort, "");
+  const maxPreflightTurns = asNumber(smartRouting.maxPreflightTurns, 2);
+  const allowPreflightProgressComment = asBoolean(smartRouting.allowInitialProgressComment, false);
+
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   const commandNotes = instructionsFilePath
@@ -402,6 +441,101 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
     );
   }
+
+  // ---------------------------------------------------------------------------
+  // Smart model routing: cheap preflight phase
+  // ---------------------------------------------------------------------------
+  // Preflight runs only on fresh, issue-scoped sessions with routing enabled.
+  // It uses a cheap model for bounded orchestration work, then hands off to
+  // the primary model.  The preflight session is ephemeral — never persisted.
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const shouldRunPreflight =
+    routingEnabled &&
+    cheapModel.length > 0 &&
+    !sessionId &&
+    Boolean(wakeTaskId);
+
+  let preflightSegment: ExecutionSegment | null = null;
+  let preflightHandoffNote = "";
+
+  if (shouldRunPreflight) {
+    const wakePromptForPreflight = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: false });
+    const preflightPromptSections = [
+      PREFLIGHT_ORCHESTRATION_PROMPT,
+      wakePromptForPreflight,
+      ...(allowPreflightProgressComment
+        ? []
+        : ["Do NOT post comments, leave status updates, or call the Paperclip API."]),
+    ];
+    const preflightPrompt = joinPromptSections(preflightPromptSections);
+
+    const preflightArgs: string[] = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+    if (dangerouslySkipPermissions) preflightArgs.push("--dangerously-skip-permissions");
+    // Skip --model for Bedrock (same rationale as primary execution).
+    if (!isBedrockAuth(effectiveEnv)) preflightArgs.push("--model", cheapModel);
+    if (cheapThinkingEffort) preflightArgs.push("--effort", cheapThinkingEffort);
+    if (maxPreflightTurns > 0) preflightArgs.push("--max-turns", String(maxPreflightTurns));
+
+    await onLog("stdout", `[paperclip] Smart routing: running cheap preflight with model "${cheapModel}"...\n`);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "claude_local",
+        command: resolvedCommand,
+        cwd,
+        commandNotes: ["Smart model routing: cheap preflight phase"],
+        commandArgs: preflightArgs,
+        env: loggedEnv,
+        prompt: preflightPrompt,
+        promptMetrics: { promptChars: preflightPrompt.length },
+        context,
+      });
+    }
+
+    // Bounded timeout for preflight: 2 minutes max, or the configured timeout if shorter.
+    const preflightTimeoutSec = timeoutSec > 0 ? Math.min(timeoutSec, 120) : 120;
+
+    try {
+      const preflightProc = await runChildProcess(runId, command, preflightArgs, {
+        cwd,
+        env,
+        stdin: preflightPrompt,
+        timeoutSec: preflightTimeoutSec,
+        graceSec,
+        onSpawn,
+        onLog,
+      });
+
+      const preflightParsed = parseClaudeStreamJson(preflightProc.stdout);
+      const preflightOk = (preflightProc.exitCode ?? 0) === 0 && !preflightProc.timedOut;
+
+      preflightSegment = {
+        phase: "cheap_preflight",
+        provider: "anthropic",
+        biller: isBedrockAuth(effectiveEnv) ? "aws_bedrock" : "anthropic",
+        model: cheapModel,
+        billingType,
+        usage: preflightParsed.usage ?? undefined,
+        costUsd: preflightParsed.costUsd ?? null,
+        summary: preflightOk ? (preflightParsed.summary || null) : null,
+      };
+
+      if (preflightOk && preflightParsed.summary) {
+        preflightHandoffNote = `## Preflight Summary (from ${cheapModel})\n\n${extractHandoffSection(preflightParsed.summary)}`;
+        await onLog("stdout", `[paperclip] Preflight complete. Proceeding with primary model "${model}".\n`);
+      } else {
+        const reason = preflightProc.timedOut
+          ? "timed out"
+          : `exit code ${preflightProc.exitCode}`;
+        await onLog("stdout", `[paperclip] Preflight did not produce a handoff (${reason}). Continuing with primary model only.\n`);
+      }
+    } catch (err) {
+      await onLog("stderr", `[paperclip] Preflight failed: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+    }
+  }
+
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
   const templateData = {
     agentId: agent.id,
@@ -424,6 +558,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    preflightHandoffNote,
     renderedPrompt,
   ]);
   const promptMetrics = {
@@ -431,6 +566,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
+    preflightHandoffChars: preflightHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
 
@@ -615,7 +751,26 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    const finalResult = toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+
+    // Attach segmented execution report when smart model routing ran a preflight.
+    if (preflightSegment) {
+      finalResult.executionSegments = [
+        preflightSegment,
+        {
+          phase: "primary",
+          provider: finalResult.provider ?? null,
+          biller: finalResult.biller ?? null,
+          model: finalResult.model ?? null,
+          billingType: finalResult.billingType ?? null,
+          usage: finalResult.usage,
+          costUsd: finalResult.costUsd ?? null,
+          summary: finalResult.summary ?? null,
+        },
+      ];
+    }
+
+    return finalResult;
   } finally {
     fs.rm(skillsDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -23,6 +23,8 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
+  PREFLIGHT_ORCHESTRATION_PROMPT,
+  extractHandoffSection,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseClaudeStreamJson,
@@ -34,36 +36,6 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-
-/**
- * Static prompt injected at the start of a cheap-model preflight pass.
- * Must match the codex_local version so handoff notes are consistent.
- */
-const PREFLIGHT_ORCHESTRATION_PROMPT = `You are a preflight orchestrator for a Paperclip agent.
-
-This is a BOUNDED ORCHESTRATION PASS \u2014 not the main task execution.
-
-Your responsibilities:
-1. Read the task context below and orient to what is being asked.
-2. Inspect the workspace at a shallow level if needed (ls, cat a few key files).
-3. Produce a compact handoff summary for the primary model that will do the real work.
-
-Hard constraints:
-- Do NOT make code changes or write files.
-- Do NOT run more than a few tool calls.
-- Do NOT attempt task completion.
-- Finish quickly \u2014 this is a triage pass only.
-
-End your response with a section titled "## Handoff Summary" containing:
-- What the task requires (1-3 sentences)
-- Key workspace observations relevant to the task
-- Recommended approach or starting point for the primary model`;
-
-function extractHandoffSection(summary: string): string {
-  const marker = summary.indexOf("## Handoff Summary");
-  if (marker === -1) return summary.trim();
-  return summary.slice(marker).trim();
-}
 
 /**
  * Create a tmpdir with `.claude/skills/` containing symlinks to skills from

--- a/packages/adapters/claude-local/src/ui/build-config.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.ts
@@ -97,5 +97,26 @@ export function buildClaudeLocalConfig(v: CreateConfigValues): Record<string, un
   }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+
+  const smartRouting = v.adapterSchemaValues?.smartModelRouting;
+  if (typeof smartRouting === "object" && smartRouting !== null && !Array.isArray(smartRouting)) {
+    const smr = smartRouting as Record<string, unknown>;
+    if (smr.enabled === true && typeof smr.cheapModel === "string" && smr.cheapModel.trim().length > 0) {
+      const routing: Record<string, unknown> = {
+        enabled: true,
+        cheapModel: smr.cheapModel.trim(),
+      };
+      if (typeof smr.cheapThinkingEffort === "string" && smr.cheapThinkingEffort.trim().length > 0) {
+        routing.cheapThinkingEffort = smr.cheapThinkingEffort.trim();
+      }
+      if (typeof smr.maxPreflightTurns === "number" && smr.maxPreflightTurns > 0) {
+        routing.maxPreflightTurns = smr.maxPreflightTurns;
+      }
+      if (typeof smr.allowInitialProgressComment === "boolean") {
+        routing.allowInitialProgressComment = smr.allowInitialProgressComment;
+      }
+      ac.smartModelRouting = routing;
+    }
+  }
   return ac;
 }

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -33,6 +33,7 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- smartModelRouting (object, optional): opt-in smart model routing for dual-model execution; shape: { enabled: boolean, cheapModel: string, cheapThinkingEffort?: string, maxPreflightTurns?: number, allowInitialProgressComment?: boolean }. When enabled, fresh issue-scoped runs use cheapModel for a bounded preflight orchestration pass before handing off to the primary model. Resumed sessions skip preflight.
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult, type ExecutionSegment } from "@paperclipai/adapter-utils";
 import {
   asString,
   asNumber,
@@ -53,6 +53,33 @@ function firstNonEmptyLine(text: string): string {
       .map((line) => line.trim())
       .find(Boolean) ?? ""
   );
+}
+
+
+const PREFLIGHT_ORCHESTRATION_PROMPT = `You are a preflight orchestrator for a Paperclip agent.
+
+This is a BOUNDED ORCHESTRATION PASS — not the main task execution.
+
+Your responsibilities:
+1. Read the task context below and orient to what is being asked.
+2. Inspect the workspace at a shallow level if needed (ls, cat a few key files).
+3. Produce a compact handoff summary for the primary model that will do the real work.
+
+Hard constraints:
+- Do NOT make code changes or write files.
+- Do NOT run more than a few tool calls.
+- Do NOT attempt task completion.
+- Finish quickly — this is a triage pass only.
+
+End your response with a section titled "## Handoff Summary" containing:
+- What the task requires (1-3 sentences)
+- Key workspace observations relevant to the task
+- Recommended approach or starting point for the primary model`;
+
+function extractHandoffSection(summary: string): string {
+  const marker = summary.indexOf("## Handoff Summary");
+  if (marker === -1) return summary.trim();
+  return summary.slice(marker).trim();
 }
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
@@ -232,6 +259,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.dangerouslyBypassApprovalsAndSandbox,
     asBoolean(config.dangerouslyBypassSandbox, false),
   );
+
+  // Smart model routing config
+  const smartRouting = parseObject(config.smartModelRouting);
+  const routingEnabled = asBoolean(smartRouting.enabled, false);
+  const cheapModel = asString(smartRouting.cheapModel, "");
+  const cheapThinkingEffort = asString(smartRouting.cheapThinkingEffort, "");
+  const maxPreflightTurns = asNumber(smartRouting.maxPreflightTurns, 2);
+  const allowPreflightProgressComment = asBoolean(smartRouting.allowInitialProgressComment, false);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -418,6 +453,106 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Codex session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
     );
   }
+
+  // ---------------------------------------------------------------------------
+  // Smart model routing: cheap preflight phase
+  // ---------------------------------------------------------------------------
+  // Preflight runs only on fresh, issue-scoped sessions with routing enabled.
+  // It uses a cheap model for bounded orchestration work, then hands off to
+  // the primary model.  The preflight session is ephemeral — never persisted.
+  const shouldRunPreflight =
+    routingEnabled &&
+    cheapModel.length > 0 &&
+    !sessionId &&
+    Boolean(wakeTaskId);
+
+  let preflightSegment: ExecutionSegment | null = null;
+  let preflightHandoffNote = "";
+
+  if (shouldRunPreflight) {
+    const wakePromptForPreflight = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: false });
+    const preflightPromptSections = [
+      PREFLIGHT_ORCHESTRATION_PROMPT,
+      wakePromptForPreflight,
+      ...(allowPreflightProgressComment
+        ? []
+        : ["Do NOT post comments, leave status updates, or call the Paperclip API."]),
+    ];
+    const preflightPrompt = joinPromptSections(preflightPromptSections);
+
+    const preflightArgs: string[] = ["exec", "--json"];
+    if (bypass) preflightArgs.push("--dangerously-bypass-approvals-and-sandbox");
+    preflightArgs.push("--model", cheapModel);
+    if (cheapThinkingEffort) {
+      preflightArgs.push("-c", `model_reasoning_effort=${JSON.stringify(cheapThinkingEffort)}`);
+    }
+    preflightArgs.push("-");
+
+    await onLog("stdout", `[paperclip] Smart routing: running cheap preflight with model "${cheapModel}"...\n`);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "codex_local",
+        command: resolvedCommand,
+        cwd,
+        commandNotes: ["Smart model routing: cheap preflight phase"],
+        commandArgs: preflightArgs.map((value, idx) => {
+          if (idx === preflightArgs.length - 1 && value === "-") return `<prompt ${preflightPrompt.length} chars>`;
+          return value;
+        }),
+        env: loggedEnv,
+        prompt: preflightPrompt,
+        promptMetrics: { promptChars: preflightPrompt.length },
+        context,
+      });
+    }
+
+    // Bounded timeout for preflight: 2 minutes max, or the configured timeout if shorter.
+    const preflightTimeoutSec = timeoutSec > 0 ? Math.min(timeoutSec, 120) : 120;
+
+    try {
+      const preflightProc = await runChildProcess(runId, command, preflightArgs, {
+        cwd,
+        env,
+        stdin: preflightPrompt,
+        timeoutSec: preflightTimeoutSec,
+        graceSec,
+        onSpawn,
+        onLog: async (stream, chunk) => {
+          if (stream !== "stderr") { await onLog(stream, chunk); return; }
+          const cleaned = stripCodexRolloutNoise(chunk);
+          if (!cleaned.trim()) return;
+          await onLog(stream, cleaned);
+        },
+      });
+
+      const preflightParsed = parseCodexJsonl(preflightProc.stdout);
+      const preflightOk = (preflightProc.exitCode ?? 0) === 0 && !preflightProc.timedOut;
+
+      preflightSegment = {
+        phase: "cheap_preflight",
+        provider: "openai",
+        biller: resolveCodexBiller(effectiveEnv, billingType),
+        model: cheapModel,
+        billingType,
+        usage: preflightParsed.usage,
+        costUsd: null,
+        summary: preflightOk ? (preflightParsed.summary || null) : null,
+      };
+
+      if (preflightOk && preflightParsed.summary) {
+        preflightHandoffNote = `## Preflight Summary (from ${cheapModel})\n\n${extractHandoffSection(preflightParsed.summary)}`;
+        await onLog("stdout", `[paperclip] Preflight complete. Proceeding with primary model "${model}".\n`);
+      } else {
+        const reason = preflightProc.timedOut
+          ? "timed out"
+          : (preflightParsed.errorMessage || `exit code ${preflightProc.exitCode}`);
+        await onLog("stdout", `[paperclip] Preflight did not produce a handoff (${reason}). Continuing with primary model only.\n`);
+      }
+    } catch (err) {
+      await onLog("stderr", `[paperclip] Preflight failed: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+    }
+  }
+
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
@@ -488,6 +623,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    preflightHandoffNote,
     renderedPrompt,
   ]);
   const promptMetrics = {
@@ -496,6 +632,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
+    preflightHandoffChars: preflightHandoffNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
 
@@ -630,5 +767,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     return toResult(retry, true);
   }
 
-  return toResult(initial);
+  const finalResult = toResult(initial);
+
+  // Attach segmented execution report when smart model routing ran a preflight.
+  if (preflightSegment) {
+    finalResult.executionSegments = [
+      preflightSegment,
+      {
+        phase: "primary",
+        provider: finalResult.provider ?? null,
+        biller: finalResult.biller ?? null,
+        model: finalResult.model ?? null,
+        billingType: finalResult.billingType ?? null,
+        usage: finalResult.usage,
+        costUsd: finalResult.costUsd ?? null,
+        summary: finalResult.summary ?? null,
+      },
+    ];
+  }
+
+  return finalResult;
 }

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -22,6 +22,8 @@ import {
   stringifyPaperclipWakePayload,
   joinPromptSections,
   runChildProcess,
+  PREFLIGHT_ORCHESTRATION_PROMPT,
+  extractHandoffSection,
 } from "@paperclipai/adapter-utils/server-utils";
 import { parseCodexJsonl, isCodexUnknownSessionError } from "./parse.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
@@ -55,32 +57,6 @@ function firstNonEmptyLine(text: string): string {
   );
 }
 
-
-const PREFLIGHT_ORCHESTRATION_PROMPT = `You are a preflight orchestrator for a Paperclip agent.
-
-This is a BOUNDED ORCHESTRATION PASS — not the main task execution.
-
-Your responsibilities:
-1. Read the task context below and orient to what is being asked.
-2. Inspect the workspace at a shallow level if needed (ls, cat a few key files).
-3. Produce a compact handoff summary for the primary model that will do the real work.
-
-Hard constraints:
-- Do NOT make code changes or write files.
-- Do NOT run more than a few tool calls.
-- Do NOT attempt task completion.
-- Finish quickly — this is a triage pass only.
-
-End your response with a section titled "## Handoff Summary" containing:
-- What the task requires (1-3 sentences)
-- Key workspace observations relevant to the task
-- Recommended approach or starting point for the primary model`;
-
-function extractHandoffSection(summary: string): string {
-  const marker = summary.indexOf("## Handoff Summary");
-  if (marker === -1) return summary.trim();
-  return summary.slice(marker).trim();
-}
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -103,5 +103,30 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
   }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  // Smart model routing
+  const smartRouting = v.adapterSchemaValues?.smartModelRouting;
+  if (
+    typeof smartRouting === "object" &&
+    smartRouting !== null &&
+    !Array.isArray(smartRouting)
+  ) {
+    const smr = smartRouting as Record<string, unknown>;
+    if (smr.enabled === true && typeof smr.cheapModel === "string" && smr.cheapModel.trim().length > 0) {
+      const routing: Record<string, unknown> = {
+        enabled: true,
+        cheapModel: smr.cheapModel.trim(),
+      };
+      if (typeof smr.cheapThinkingEffort === "string" && smr.cheapThinkingEffort.trim().length > 0) {
+        routing.cheapThinkingEffort = smr.cheapThinkingEffort.trim();
+      }
+      if (typeof smr.maxPreflightTurns === "number" && smr.maxPreflightTurns > 0) {
+        routing.maxPreflightTurns = smr.maxPreflightTurns;
+      }
+      if (typeof smr.allowInitialProgressComment === "boolean") {
+        routing.allowInitialProgressComment = smr.allowInitialProgressComment;
+      }
+      ac.smartModelRouting = routing;
+    }
+  }
   return ac;
 }

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -2,10 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult, type ExecutionSegment } from "@paperclipai/adapter-utils";
 import {
   asString,
   asNumber,
+  asBoolean,
   asStringArray,
   parseObject,
   buildPaperclipEnv,
@@ -23,6 +24,8 @@ import {
   stringifyPaperclipWakePayload,
   joinPromptSections,
   runChildProcess,
+  PREFLIGHT_ORCHESTRATION_PROMPT,
+  extractHandoffSection,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
@@ -170,6 +173,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
   const mode = normalizeMode(asString(config.mode, ""));
 
+  // Smart model routing config
+  const smartRouting = parseObject(config.smartModelRouting);
+  const routingEnabled = asBoolean(smartRouting.enabled, false);
+  const cheapModel = asString(smartRouting.cheapModel, "");
+  const cheapThinkingEffort = asString(smartRouting.cheapThinkingEffort, "");
+  const maxPreflightTurns = asNumber(smartRouting.maxPreflightTurns, 2);
+  const allowPreflightProgressComment = asBoolean(smartRouting.allowInitialProgressComment, false);
+
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
@@ -308,6 +319,115 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
   }
 
+  // ---------------------------------------------------------------------------
+  // Smart model routing: cheap preflight phase
+  // ---------------------------------------------------------------------------
+  const shouldRunPreflight =
+    routingEnabled &&
+    cheapModel.length > 0 &&
+    !sessionId &&
+    Boolean(wakeTaskId);
+
+  let preflightSegment: ExecutionSegment | null = null;
+  let preflightHandoffNote = "";
+
+  if (shouldRunPreflight) {
+    const wakePromptForPreflight = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: false });
+    const preflightPromptSections = [
+      PREFLIGHT_ORCHESTRATION_PROMPT,
+      wakePromptForPreflight,
+      ...(allowPreflightProgressComment
+        ? []
+        : ["Do NOT post comments, leave status updates, or call the Paperclip API."]),
+    ];
+    const preflightPrompt = joinPromptSections(preflightPromptSections);
+
+    // Cursor preflight: use -p with stdin, --yolo for trust bypass, no --resume
+    const preflightArgs: string[] = ["-p", "--output-format", "stream-json", "--workspace", cwd];
+    preflightArgs.push("--model", cheapModel);
+    if (autoTrustEnabled) preflightArgs.push("--yolo");
+
+    await onLog("stdout", `[paperclip] Smart routing: running cheap preflight with model "${cheapModel}"...\n`);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "cursor",
+        command: resolvedCommand,
+        cwd,
+        commandNotes: ["Smart model routing: cheap preflight phase"],
+        commandArgs: preflightArgs,
+        env: loggedEnv,
+        prompt: preflightPrompt,
+        promptMetrics: { promptChars: preflightPrompt.length },
+        context,
+      });
+    }
+
+    const preflightTimeoutSec = timeoutSec > 0 ? Math.min(timeoutSec, 120) : 120;
+
+    try {
+      let preflightStdoutLineBuffer = "";
+      const emitPreflightNormalizedLine = async (rawLine: string) => {
+        const normalized = normalizeCursorStreamLine(rawLine);
+        if (!normalized.line) return;
+        await onLog(normalized.stream ?? "stdout", `${normalized.line}\n`);
+      };
+      const flushPreflightChunk = async (chunk: string, finalize = false) => {
+        const combined = `${preflightStdoutLineBuffer}${chunk}`;
+        const lines = combined.split(/\r?\n/);
+        preflightStdoutLineBuffer = lines.pop() ?? "";
+        for (const line of lines) {
+          await emitPreflightNormalizedLine(line);
+        }
+        if (finalize) {
+          const trailing = preflightStdoutLineBuffer.trim();
+          preflightStdoutLineBuffer = "";
+          if (trailing) await emitPreflightNormalizedLine(trailing);
+        }
+      };
+
+      const preflightProc = await runChildProcess(runId, command, preflightArgs, {
+        cwd,
+        env,
+        stdin: preflightPrompt,
+        timeoutSec: preflightTimeoutSec,
+        graceSec,
+        onSpawn,
+        onLog: async (stream, chunk) => {
+          if (stream !== "stdout") { await onLog(stream, chunk); return; }
+          await flushPreflightChunk(chunk);
+        },
+      });
+      await flushPreflightChunk("", true);
+
+      const preflightParsed = parseCursorJsonl(preflightProc.stdout);
+      const preflightOk = (preflightProc.exitCode ?? 0) === 0 && !preflightProc.timedOut;
+
+      const preflightProvider = resolveProviderFromModel(cheapModel);
+      preflightSegment = {
+        phase: "cheap_preflight",
+        provider: preflightProvider,
+        biller: resolveCursorBiller(effectiveEnv, billingType, preflightProvider),
+        model: cheapModel,
+        billingType,
+        usage: preflightParsed.usage,
+        costUsd: preflightParsed.costUsd ?? null,
+        summary: preflightOk ? (preflightParsed.summary || null) : null,
+      };
+
+      if (preflightOk && preflightParsed.summary) {
+        preflightHandoffNote = `## Preflight Summary (from ${cheapModel})\n\n${extractHandoffSection(preflightParsed.summary)}`;
+        await onLog("stdout", `[paperclip] Preflight complete. Proceeding with primary model "${model}".\n`);
+      } else {
+        const reason = preflightProc.timedOut
+          ? "timed out"
+          : (preflightParsed.errorMessage || `exit code ${preflightProc.exitCode}`);
+        await onLog("stdout", `[paperclip] Preflight did not produce a handoff (${reason}). Continuing with primary model only.\n`);
+      }
+    } catch (err) {
+      await onLog("stderr", `[paperclip] Preflight failed: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+    }
+  }
+
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
@@ -372,6 +492,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    preflightHandoffNote,
     paperclipEnvNote,
     renderedPrompt,
   ]);
@@ -381,6 +502,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
+    preflightHandoffChars: preflightHandoffNote.length,
     runtimeNoteChars: paperclipEnvNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
@@ -538,8 +660,42 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Cursor resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
     );
     const retry = await runAttempt(null);
-    return toResult(retry, true);
+    const retryResult = toResult(retry, true);
+    if (preflightSegment) {
+      retryResult.executionSegments = [
+        preflightSegment,
+        {
+          phase: "primary",
+          provider: retryResult.provider ?? null,
+          biller: retryResult.biller ?? null,
+          model: retryResult.model ?? null,
+          billingType: retryResult.billingType ?? null,
+          usage: retryResult.usage,
+          costUsd: retryResult.costUsd ?? null,
+          summary: retryResult.summary ?? null,
+        },
+      ];
+    }
+    return retryResult;
   }
 
-  return toResult(initial);
+  const finalResult = toResult(initial);
+
+  if (preflightSegment) {
+    finalResult.executionSegments = [
+      preflightSegment,
+      {
+        phase: "primary",
+        provider: finalResult.provider ?? null,
+        biller: finalResult.biller ?? null,
+        model: finalResult.model ?? null,
+        billingType: finalResult.billingType ?? null,
+        usage: finalResult.usage,
+        costUsd: finalResult.costUsd ?? null,
+        summary: finalResult.summary ?? null,
+      },
+    ];
+  }
+
+  return finalResult;
 }

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -3,7 +3,7 @@ import type { Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { AdapterExecutionContext, AdapterExecutionResult, ExecutionSegment } from "@paperclipai/adapter-utils";
 import {
   asBoolean,
   asNumber,
@@ -25,6 +25,8 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
+  PREFLIGHT_ORCHESTRATION_PROMPT,
+  extractHandoffSection,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "../index.js";
 import {
@@ -146,6 +148,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
   const sandbox = asBoolean(config.sandbox, false);
 
+  // Smart model routing config
+  const smartRouting = parseObject(config.smartModelRouting);
+  const routingEnabled = asBoolean(smartRouting.enabled, false);
+  const cheapModel = asString(smartRouting.cheapModel, "");
+  const cheapThinkingEffort = asString(smartRouting.cheapThinkingEffort, "");
+  const maxPreflightTurns = asNumber(smartRouting.maxPreflightTurns, 2);
+  const allowPreflightProgressComment = asBoolean(smartRouting.allowInitialProgressComment, false);
+
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
@@ -254,6 +264,93 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
   }
 
+  // ---------------------------------------------------------------------------
+  // Smart model routing: cheap preflight phase
+  // ---------------------------------------------------------------------------
+  const shouldRunPreflight =
+    routingEnabled &&
+    cheapModel.length > 0 &&
+    !sessionId &&
+    Boolean(wakeTaskId);
+
+  let preflightSegment: ExecutionSegment | null = null;
+  let preflightHandoffNote = "";
+
+  if (shouldRunPreflight) {
+    const wakePromptForPreflight = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: false });
+    const preflightPromptSections = [
+      PREFLIGHT_ORCHESTRATION_PROMPT,
+      wakePromptForPreflight,
+      ...(allowPreflightProgressComment
+        ? []
+        : ["Do NOT post comments, leave status updates, or call the Paperclip API."]),
+    ];
+    const preflightPrompt = joinPromptSections(preflightPromptSections);
+
+    // Gemini preflight: uses --prompt flag (not stdin), --approval-mode yolo, --sandbox=none
+    const preflightArgs: string[] = ["--output-format", "stream-json"];
+    preflightArgs.push("--model", cheapModel);
+    preflightArgs.push("--approval-mode", "yolo");
+    preflightArgs.push("--sandbox=none");
+    preflightArgs.push("--prompt", preflightPrompt);
+
+    await onLog("stdout", `[paperclip] Smart routing: running cheap preflight with model "${cheapModel}"...\n`);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "gemini_local",
+        command: resolvedCommand,
+        cwd,
+        commandNotes: ["Smart model routing: cheap preflight phase"],
+        commandArgs: preflightArgs.map((value, index) =>
+          index === preflightArgs.length - 1 ? `<prompt ${preflightPrompt.length} chars>` : value
+        ),
+        env: loggedEnv,
+        prompt: preflightPrompt,
+        promptMetrics: { promptChars: preflightPrompt.length },
+        context,
+      });
+    }
+
+    const preflightTimeoutSec = timeoutSec > 0 ? Math.min(timeoutSec, 120) : 120;
+
+    try {
+      const preflightProc = await runChildProcess(runId, command, preflightArgs, {
+        cwd,
+        env,
+        timeoutSec: preflightTimeoutSec,
+        graceSec,
+        onSpawn,
+        onLog,
+      });
+
+      const preflightParsed = parseGeminiJsonl(preflightProc.stdout);
+      const preflightOk = (preflightProc.exitCode ?? 0) === 0 && !preflightProc.timedOut;
+
+      preflightSegment = {
+        phase: "cheap_preflight",
+        provider: "google",
+        biller: "google",
+        model: cheapModel,
+        billingType,
+        usage: preflightParsed.usage,
+        costUsd: preflightParsed.costUsd ?? null,
+        summary: preflightOk ? (preflightParsed.summary || null) : null,
+      };
+
+      if (preflightOk && preflightParsed.summary) {
+        preflightHandoffNote = `## Preflight Summary (from ${cheapModel})\n\n${extractHandoffSection(preflightParsed.summary)}`;
+        await onLog("stdout", `[paperclip] Preflight complete. Proceeding with primary model "${model}".\n`);
+      } else {
+        const reason = preflightProc.timedOut
+          ? "timed out"
+          : (preflightParsed.errorMessage || `exit code ${preflightProc.exitCode}`);
+        await onLog("stdout", `[paperclip] Preflight did not produce a handoff (${reason}). Continuing with primary model only.\n`);
+      }
+    } catch (err) {
+      await onLog("stderr", `[paperclip] Preflight failed: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+    }
+  }
+
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
   let instructionsPrefix = "";
@@ -314,6 +411,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    preflightHandoffNote,
     paperclipEnvNote,
     apiAccessNote,
     renderedPrompt,
@@ -324,6 +422,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
+    preflightHandoffChars: preflightHandoffNote.length,
     runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
@@ -469,8 +568,44 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       `[paperclip] Gemini resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
     );
     const retry = await runAttempt(null);
-    return toResult(retry, true, true);
+    const retryResult = toResult(retry, true, true);
+
+    if (preflightSegment) {
+      retryResult.executionSegments = [
+        preflightSegment,
+        {
+          phase: "primary",
+          provider: retryResult.provider ?? null,
+          biller: retryResult.biller ?? null,
+          model: retryResult.model ?? null,
+          billingType: retryResult.billingType ?? null,
+          usage: retryResult.usage,
+          costUsd: retryResult.costUsd ?? null,
+          summary: retryResult.summary ?? null,
+        },
+      ];
+    }
+
+    return retryResult;
   }
 
-  return toResult(initial);
+  const finalResult = toResult(initial);
+
+  if (preflightSegment) {
+    finalResult.executionSegments = [
+      preflightSegment,
+      {
+        phase: "primary",
+        provider: finalResult.provider ?? null,
+        biller: finalResult.biller ?? null,
+        model: finalResult.model ?? null,
+        billingType: finalResult.billingType ?? null,
+        usage: finalResult.usage,
+        costUsd: finalResult.costUsd ?? null,
+        summary: finalResult.summary ?? null,
+      },
+    ];
+  }
+
+  return finalResult;
 }

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,10 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult, type ExecutionSegment } from "@paperclipai/adapter-utils";
 import {
   asString,
   asNumber,
+  asBoolean,
   asStringArray,
   parseObject,
   buildPaperclipEnv,
@@ -22,6 +23,8 @@ import {
   runChildProcess,
   readPaperclipRuntimeSkillEntries,
   resolvePaperclipDesiredSkillNames,
+  PREFLIGHT_ORCHESTRATION_PROMPT,
+  extractHandoffSection,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import { ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
@@ -102,6 +105,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
   const variant = asString(config.variant, "").trim();
+
+  // Smart model routing config
+  const smartRouting = parseObject(config.smartModelRouting);
+  const routingEnabled = asBoolean(smartRouting.enabled, false);
+  const cheapModel = asString(smartRouting.cheapModel, "");
+  const cheapThinkingEffort = asString(smartRouting.cheapThinkingEffort, "");
+  const maxPreflightTurns = asNumber(smartRouting.maxPreflightTurns, 2);
+  const allowPreflightProgressComment = asBoolean(smartRouting.allowInitialProgressComment, false);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -226,6 +237,106 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] OpenCode session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
       );
     }
+
+    // ---------------------------------------------------------------------------
+    // Smart model routing: cheap preflight phase
+    // ---------------------------------------------------------------------------
+    const shouldRunPreflight =
+      routingEnabled &&
+      cheapModel.length > 0 &&
+      !sessionId &&
+      Boolean(wakeTaskId);
+
+    let preflightSegment: ExecutionSegment | null = null;
+    let preflightHandoffNote = "";
+
+    if (shouldRunPreflight) {
+      let cheapModelAvailable = true;
+      try {
+        await ensureOpenCodeModelConfiguredAndAvailable({
+          model: cheapModel,
+          command,
+          cwd,
+          env: runtimeEnv,
+        });
+      } catch (err) {
+        cheapModelAvailable = false;
+        await onLog("stderr", `[paperclip] Preflight model "${cheapModel}" not available: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+      }
+
+      if (cheapModelAvailable) {
+        const wakePromptForPreflight = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: false });
+        const preflightPromptSections = [
+          PREFLIGHT_ORCHESTRATION_PROMPT,
+          wakePromptForPreflight,
+          ...(allowPreflightProgressComment
+            ? []
+            : ["Do NOT post comments, leave status updates, or call the Paperclip API."]),
+        ];
+        const preflightPrompt = joinPromptSections(preflightPromptSections);
+
+        // OpenCode preflight: stdin prompt, no --session, no --variant
+        const preflightArgs: string[] = ["run", "--format", "json"];
+        preflightArgs.push("--model", cheapModel);
+
+        await onLog("stdout", `[paperclip] Smart routing: running cheap preflight with model "${cheapModel}"...\n`);
+        if (onMeta) {
+          await onMeta({
+            adapterType: "opencode_local",
+            command: resolvedCommand,
+            cwd,
+            commandNotes: ["Smart model routing: cheap preflight phase"],
+            commandArgs: [...preflightArgs, `<stdin prompt ${preflightPrompt.length} chars>`],
+            env: loggedEnv,
+            prompt: preflightPrompt,
+            promptMetrics: { promptChars: preflightPrompt.length },
+            context,
+          });
+        }
+
+        const preflightTimeoutSec = timeoutSec > 0 ? Math.min(timeoutSec, 120) : 120;
+
+        try {
+          const preflightProc = await runChildProcess(runId, command, preflightArgs, {
+            cwd,
+            env: runtimeEnv,
+            stdin: preflightPrompt,
+            timeoutSec: preflightTimeoutSec,
+            graceSec,
+            onSpawn,
+            onLog,
+          });
+
+          const preflightParsed = parseOpenCodeJsonl(preflightProc.stdout);
+          const preflightOk = (preflightProc.exitCode ?? 0) === 0 && !preflightProc.timedOut;
+
+          const preflightProvider = parseModelProvider(cheapModel);
+          preflightSegment = {
+            phase: "cheap_preflight",
+            provider: preflightProvider,
+            biller: resolveOpenCodeBiller(runtimeEnv, preflightProvider),
+            model: cheapModel,
+            billingType: "unknown",
+            usage: preflightParsed.usage,
+            costUsd: preflightParsed.costUsd ?? null,
+            summary: preflightOk ? (preflightParsed.summary || null) : null,
+          };
+
+          if (preflightOk && preflightParsed.summary) {
+            preflightHandoffNote = `## Preflight Summary (from ${cheapModel})\n\n${extractHandoffSection(preflightParsed.summary)}`;
+            await onLog("stdout", `[paperclip] Preflight complete. Proceeding with primary model "${model}".\n`);
+          } else {
+            const reason = preflightProc.timedOut
+              ? "timed out"
+              : (preflightParsed.errorMessage || `exit code ${preflightProc.exitCode}`);
+            await onLog("stdout", `[paperclip] Preflight did not produce a handoff (${reason}). Continuing with primary model only.\n`);
+          }
+        } catch (err) {
+          await onLog("stderr", `[paperclip] Preflight failed: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+        }
+      }
+    }
+
     const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
     const resolvedInstructionsFilePath = instructionsFilePath
       ? path.resolve(cwd, instructionsFilePath)
@@ -287,6 +398,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       renderedBootstrapPrompt,
       wakePrompt,
       sessionHandoffNote,
+      preflightHandoffNote,
       renderedPrompt,
     ]);
     const promptMetrics = {
@@ -295,6 +407,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       bootstrapPromptChars: renderedBootstrapPrompt.length,
       wakePromptChars: wakePrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
+      preflightHandoffChars: preflightHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,
     };
 
@@ -420,10 +533,44 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] OpenCode session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
-      return toResult(retry, true);
+      const retryResult = toResult(retry, true);
+      if (preflightSegment) {
+        retryResult.executionSegments = [
+          preflightSegment,
+          {
+            phase: "primary",
+            provider: retryResult.provider ?? null,
+            biller: retryResult.biller ?? null,
+            model: retryResult.model ?? null,
+            billingType: retryResult.billingType ?? null,
+            usage: retryResult.usage,
+            costUsd: retryResult.costUsd ?? null,
+            summary: retryResult.summary ?? null,
+          },
+        ];
+      }
+      return retryResult;
     }
 
-    return toResult(initial);
+    const finalResult = toResult(initial);
+
+    if (preflightSegment) {
+      finalResult.executionSegments = [
+        preflightSegment,
+        {
+          phase: "primary",
+          provider: finalResult.provider ?? null,
+          biller: finalResult.biller ?? null,
+          model: finalResult.model ?? null,
+          billingType: finalResult.billingType ?? null,
+          usage: finalResult.usage,
+          costUsd: finalResult.costUsd ?? null,
+          summary: finalResult.summary ?? null,
+        },
+      ];
+    }
+
+    return finalResult;
   } finally {
     await preparedRuntimeConfig.cleanup();
   }

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -2,10 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult, type ExecutionSegment } from "@paperclipai/adapter-utils";
 import {
   asString,
   asNumber,
+  asBoolean,
   asStringArray,
   parseObject,
   buildPaperclipEnv,
@@ -23,6 +24,8 @@ import {
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
   runChildProcess,
+  PREFLIGHT_ORCHESTRATION_PROMPT,
+  extractHandoffSection,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isPiUnknownSessionError, parsePiJsonl } from "./parse.js";
 import { ensurePiModelConfiguredAndAvailable } from "./models.js";
@@ -118,6 +121,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const command = asString(config.command, "pi");
   const model = asString(config.model, "").trim();
   const thinking = asString(config.thinking, "").trim();
+
+  // Smart model routing config
+  const smartRouting = parseObject(config.smartModelRouting);
+  const routingEnabled = asBoolean(smartRouting.enabled, false);
+  const cheapModel = asString(smartRouting.cheapModel, "");
+  const cheapThinkingEffort = asString(smartRouting.cheapThinkingEffort, "");
+  const maxPreflightTurns = asNumber(smartRouting.maxPreflightTurns, 2);
+  const allowPreflightProgressComment = asBoolean(smartRouting.allowInitialProgressComment, false);
 
   // Parse model into provider and model id
   const provider = parseModelProvider(model);
@@ -260,6 +271,132 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Smart model routing: cheap preflight phase
+  // ---------------------------------------------------------------------------
+  const shouldRunPreflight =
+    routingEnabled &&
+    cheapModel.length > 0 &&
+    !canResumeSession &&
+    Boolean(wakeTaskId);
+
+  let preflightSegment: ExecutionSegment | null = null;
+  let preflightHandoffNote = "";
+
+  if (shouldRunPreflight) {
+    // Parse cheap model provider/id the same way as primary model
+    const cheapProvider = parseModelProvider(cheapModel);
+    const cheapModelId = parseModelId(cheapModel);
+
+    let cheapModelAvailable = true;
+    try {
+      await ensurePiModelConfiguredAndAvailable({
+        model: cheapModel,
+        command,
+        cwd,
+        env: runtimeEnv,
+      });
+    } catch (err) {
+      cheapModelAvailable = false;
+      await onLog("stderr", `[paperclip] Preflight model "${cheapModel}" not available: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+    }
+
+    if (cheapModelAvailable) {
+      const wakePromptForPreflight = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: false });
+      const preflightPromptSections = [
+        PREFLIGHT_ORCHESTRATION_PROMPT,
+        wakePromptForPreflight,
+        ...(allowPreflightProgressComment
+          ? []
+          : ["Do NOT post comments, leave status updates, or call the Paperclip API."]),
+      ];
+      const preflightPrompt = joinPromptSections(preflightPromptSections);
+
+      // Pi preflight: non-interactive JSON mode, no session resume, minimal tools
+      const preflightArgs: string[] = ["--mode", "json", "-p"];
+      preflightArgs.push("--append-system-prompt", PREFLIGHT_ORCHESTRATION_PROMPT);
+      if (cheapProvider) preflightArgs.push("--provider", cheapProvider);
+      if (cheapModelId) preflightArgs.push("--model", cheapModelId);
+      if (cheapThinkingEffort) preflightArgs.push("--thinking", cheapThinkingEffort);
+      preflightArgs.push("--tools", "read,bash,ls,grep,find");
+      // Use a temporary session file for preflight (ephemeral, not persisted)
+      const preflightSessionPath = buildSessionPath(agent.id, `preflight-${new Date().toISOString()}`);
+      try { await fs.writeFile(preflightSessionPath, "", { flag: "wx" }); } catch { /* ok if exists */ }
+      preflightArgs.push("--session", preflightSessionPath);
+      preflightArgs.push(preflightPrompt);
+
+      await onLog("stdout", `[paperclip] Smart routing: running cheap preflight with model "${cheapModel}"...\n`);
+      if (onMeta) {
+        await onMeta({
+          adapterType: "pi_local",
+          command: resolvedCommand,
+          cwd,
+          commandNotes: ["Smart model routing: cheap preflight phase"],
+          commandArgs: preflightArgs.map((value, index) =>
+            index === preflightArgs.length - 1 ? `<prompt ${preflightPrompt.length} chars>` : value
+          ),
+          env: loggedEnv,
+          prompt: preflightPrompt,
+          promptMetrics: { promptChars: preflightPrompt.length },
+          context,
+        });
+      }
+
+      const preflightTimeoutSec = timeoutSec > 0 ? Math.min(timeoutSec, 120) : 120;
+
+      try {
+        let preflightStdoutBuffer = "";
+        const preflightProc = await runChildProcess(runId, command, preflightArgs, {
+          cwd,
+          env: runtimeEnv,
+          timeoutSec: preflightTimeoutSec,
+          graceSec,
+          onSpawn,
+          onLog: async (stream, chunk) => {
+            if (stream === "stderr") { await onLog(stream, chunk); return; }
+            preflightStdoutBuffer += chunk;
+            const lines = preflightStdoutBuffer.split("\n");
+            preflightStdoutBuffer = lines.pop() || "";
+            for (const line of lines) {
+              if (line) await onLog(stream, line + "\n");
+            }
+          },
+        });
+        if (preflightStdoutBuffer) await onLog("stdout", preflightStdoutBuffer);
+
+        const preflightParsed = parsePiJsonl(preflightProc.stdout);
+        const preflightOk = (preflightProc.exitCode ?? 0) === 0 && !preflightProc.timedOut;
+        const preflightSummary = preflightParsed.finalMessage ?? preflightParsed.messages.join("\n\n").trim();
+
+        preflightSegment = {
+          phase: "cheap_preflight",
+          provider: cheapProvider,
+          biller: resolvePiBiller(runtimeEnv, cheapProvider),
+          model: cheapModel,
+          billingType: "unknown",
+          usage: preflightParsed.usage,
+          costUsd: preflightParsed.usage.costUsd ?? null,
+          summary: preflightOk ? (preflightSummary || null) : null,
+        };
+
+        if (preflightOk && preflightSummary) {
+          preflightHandoffNote = `## Preflight Summary (from ${cheapModel})\n\n${extractHandoffSection(preflightSummary)}`;
+          await onLog("stdout", `[paperclip] Preflight complete. Proceeding with primary model "${model}".\n`);
+        } else {
+          const reason = preflightProc.timedOut
+            ? "timed out"
+            : (preflightParsed.errors[0] || `exit code ${preflightProc.exitCode}`);
+          await onLog("stdout", `[paperclip] Preflight did not produce a handoff (${reason}). Continuing with primary model only.\n`);
+        }
+
+        // Clean up ephemeral preflight session file
+        try { await fs.unlink(preflightSessionPath); } catch { /* best effort */ }
+      } catch (err) {
+        await onLog("stderr", `[paperclip] Preflight failed: ${err instanceof Error ? err.message : String(err)}. Continuing with primary model only.\n`);
+      }
+    }
+  }
+
   // Handle instructions file and build system prompt extension
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const resolvedInstructionsFilePath = instructionsFilePath
@@ -314,6 +451,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    preflightHandoffNote,
     renderedHeartbeatPrompt,
   ]);
   const promptMetrics = {
@@ -322,6 +460,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
+    preflightHandoffChars: preflightHandoffNote.length,
     heartbeatPromptChars: renderedHeartbeatPrompt.length,
   };
 
@@ -504,8 +643,42 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
     }
     const retry = await runAttempt(newSessionPath);
-    return toResult(retry, true);
+    const retryResult = toResult(retry, true);
+    if (preflightSegment) {
+      retryResult.executionSegments = [
+        preflightSegment,
+        {
+          phase: "primary",
+          provider: retryResult.provider ?? null,
+          biller: retryResult.biller ?? null,
+          model: retryResult.model ?? null,
+          billingType: retryResult.billingType ?? null,
+          usage: retryResult.usage,
+          costUsd: retryResult.costUsd ?? null,
+          summary: retryResult.summary ?? null,
+        },
+      ];
+    }
+    return retryResult;
   }
 
-  return toResult(initial);
+  const finalResult = toResult(initial);
+
+  if (preflightSegment) {
+    finalResult.executionSegments = [
+      preflightSegment,
+      {
+        phase: "primary",
+        provider: finalResult.provider ?? null,
+        biller: finalResult.biller ?? null,
+        model: finalResult.model ?? null,
+        billingType: finalResult.billingType ?? null,
+        usage: finalResult.usage,
+        costUsd: finalResult.costUsd ?? null,
+        summary: finalResult.summary ?? null,
+      },
+    ];
+  }
+
+  return finalResult;
 }

--- a/server/src/__tests__/claude-local-smart-routing.test.ts
+++ b/server/src/__tests__/claude-local-smart-routing.test.ts
@@ -1,0 +1,537 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-claude-local/server";
+
+/**
+ * Fake claude command that appends invocation data to a JSONL capture file.
+ * Supports multiple invocations (preflight + primary) in a single test run.
+ *
+ * When the prompt contains "BOUNDED ORCHESTRATION", the fake emits a preflight-
+ * style response with a handoff summary.  Otherwise it emits a normal primary
+ * response.  Output uses Claude's stream-json format.
+ */
+async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const prompt = fs.readFileSync(0, "utf8");
+const isPreflight = prompt.includes("BOUNDED ORCHESTRATION");
+const payload = {
+  argv: process.argv.slice(2),
+  prompt,
+  isPreflight,
+};
+if (capturePath) {
+  fs.appendFileSync(capturePath, JSON.stringify(payload) + "\\n", "utf8");
+}
+const sessionId = isPreflight ? "preflight-session-1" : "primary-session-1";
+const model = isPreflight ? "claude-haiku-4-5-20251001" : "claude-sonnet-4-6";
+const message = isPreflight
+  ? "## Handoff Summary\\n\\nThe task requires fixing the login validation bug in auth.ts. Workspace has a standard Node project layout."
+  : "Fixed the bug in auth.ts by correcting the validation logic.";
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: sessionId, model }));
+console.log(JSON.stringify({ type: "assistant", session_id: sessionId, message: { content: [{ type: "text", text: message }] } }));
+console.log(JSON.stringify({ type: "result", session_id: sessionId, result: message, usage: { input_tokens: 100, cache_read_input_tokens: 0, output_tokens: 50 }, total_cost_usd: 0.001 }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+/** Fake claude command that exits with code 1 (simulates preflight failure). */
+async function writeFakeClaudeCommandFailPreflight(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const prompt = fs.readFileSync(0, "utf8");
+const isPreflight = prompt.includes("BOUNDED ORCHESTRATION");
+const payload = { argv: process.argv.slice(2), prompt, isPreflight };
+if (capturePath) {
+  fs.appendFileSync(capturePath, JSON.stringify(payload) + "\\n", "utf8");
+}
+if (isPreflight) {
+  console.error("rate limit exceeded");
+  process.exit(1);
+}
+const sessionId = "primary-session-1";
+const model = "claude-sonnet-4-6";
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: sessionId, model }));
+console.log(JSON.stringify({ type: "assistant", session_id: sessionId, message: { content: [{ type: "text", text: "Fixed the bug." }] } }));
+console.log(JSON.stringify({ type: "result", session_id: sessionId, result: "Fixed the bug.", usage: { input_tokens: 200, cache_read_input_tokens: 0, output_tokens: 100 }, total_cost_usd: 0.005 }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+type CaptureEntry = {
+  argv: string[];
+  prompt: string;
+  isPreflight: boolean;
+};
+
+async function readCaptures(capturePath: string): Promise<CaptureEntry[]> {
+  const raw = await fs.readFile(capturePath, "utf8");
+  return raw
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as CaptureEntry);
+}
+
+type LogEntry = { stream: "stdout" | "stderr"; chunk: string };
+
+function baseAgent() {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Claude Coder",
+    adapterType: "claude_local" as const,
+    adapterConfig: {},
+  };
+}
+
+function freshRuntime() {
+  return {
+    sessionId: null,
+    sessionParams: null,
+    sessionDisplayId: null,
+    taskKey: null,
+  };
+}
+
+function resumedRuntime(cwd: string) {
+  return {
+    sessionId: null,
+    sessionParams: { sessionId: "existing-session-1", cwd },
+    sessionDisplayId: null,
+    taskKey: null,
+  };
+}
+
+function issueContext() {
+  return {
+    issueId: "issue-1",
+    taskId: "issue-1",
+    wakeReason: "issue_commented",
+    paperclipWake: {
+      reason: "issue_commented",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-100",
+        title: "Fix login bug",
+        status: "in_progress",
+        priority: "high",
+      },
+      commentIds: ["comment-1"],
+      latestCommentId: "comment-1",
+      comments: [
+        {
+          id: "comment-1",
+          issueId: "issue-1",
+          body: "Please fix the login validation",
+          bodyTruncated: false,
+          createdAt: "2026-04-07T10:00:00.000Z",
+          author: { type: "user", id: "user-1" },
+        },
+      ],
+      commentWindow: { requestedCount: 1, includedCount: 1, missingCount: 0 },
+      truncated: false,
+      fallbackFetchNeeded: false,
+    },
+  };
+}
+
+describe("claude smart model routing", () => {
+  it("runs cheap preflight then primary on fresh issue-scoped sessions with routing enabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    const logs: LogEntry[] = [];
+
+    try {
+      const result = await execute({
+        runId: "run-routing-1",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "claude-haiku-4-5-20251001",
+            cheapThinkingEffort: "low",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => { logs.push({ stream, chunk }); },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      // Two invocations: preflight + primary
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(2);
+
+      // First invocation: preflight with cheap model
+      const preflight = captures[0]!;
+      expect(preflight.isPreflight).toBe(true);
+      expect(preflight.argv).toContain("--model");
+      expect(preflight.argv[preflight.argv.indexOf("--model") + 1]).toBe("claude-haiku-4-5-20251001");
+      expect(preflight.argv).toContain("--effort");
+      expect(preflight.argv[preflight.argv.indexOf("--effort") + 1]).toBe("low");
+      expect(preflight.prompt).toContain("BOUNDED ORCHESTRATION");
+      expect(preflight.prompt).toContain("Do NOT make code changes");
+
+      // Second invocation: primary with primary model
+      const primary = captures[1]!;
+      expect(primary.isPreflight).toBe(false);
+      expect(primary.argv).toContain("--model");
+      expect(primary.argv[primary.argv.indexOf("--model") + 1]).toBe("claude-sonnet-4-6");
+      expect(primary.prompt).toContain("Continue your Paperclip work.");
+      // Primary should contain the preflight handoff
+      expect(primary.prompt).toContain("Preflight Summary");
+      expect(primary.prompt).toContain("Handoff Summary");
+
+      // Result should contain execution segments
+      expect(result.executionSegments).toBeDefined();
+      expect(result.executionSegments).toHaveLength(2);
+      const cheapSeg = result.executionSegments![0]!;
+      const primarySeg = result.executionSegments![1]!;
+      expect(cheapSeg.phase).toBe("cheap_preflight");
+      expect(cheapSeg.model).toBe("claude-haiku-4-5-20251001");
+      expect(cheapSeg.provider).toBe("anthropic");
+      expect(cheapSeg.usage?.inputTokens).toBe(100);
+      expect(primarySeg.phase).toBe("primary");
+      expect(primarySeg.model).toBe("claude-sonnet-4-6");
+      expect(primarySeg.provider).toBe("anthropic");
+
+      // Session should be from primary, not preflight
+      expect(result.sessionId).toBe("primary-session-1");
+
+      // Logs should mention routing
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("Smart routing: running cheap preflight"),
+        }),
+      );
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("Preflight complete"),
+        }),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight on resumed sessions even with routing enabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-resumed-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-routing-resumed",
+        agent: baseAgent(),
+        runtime: resumedRuntime(workspace),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "claude-haiku-4-5-20251001",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      // Only one invocation: the resumed session, no preflight
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(captures[0]!.isPreflight).toBe(false);
+      expect(captures[0]!.argv).toContain("--resume");
+
+      // No execution segments
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight when routing is disabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-disabled-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-routing-off",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: false,
+            cheapModel: "claude-haiku-4-5-20251001",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Only primary invocation
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(captures[0]!.isPreflight).toBe(false);
+
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight when no cheapModel is configured", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-nocheap-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-routing-nocheap",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            // no cheapModel
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight when run is not issue-scoped", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-noissue-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-routing-noissue",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do some general work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "claude-haiku-4-5-20251001",
+          },
+        },
+        context: {}, // no issue context
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("proceeds with primary only when preflight fails", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-fail-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommandFailPreflight(commandPath);
+
+    const logs: LogEntry[] = [];
+
+    try {
+      const result = await execute({
+        runId: "run-routing-preflight-fail",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "claude-haiku-4-5-20251001",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => { logs.push({ stream, chunk }); },
+      });
+
+      // Primary should still succeed
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      // Two invocations: failed preflight + successful primary
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(2);
+      expect(captures[0]!.isPreflight).toBe(true);
+      expect(captures[1]!.isPreflight).toBe(false);
+
+      // Primary prompt should NOT contain preflight handoff (preflight failed)
+      expect(captures[1]!.prompt).not.toContain("Preflight Summary");
+
+      // Segment should still report the failed preflight (with null summary)
+      expect(result.executionSegments).toBeDefined();
+      expect(result.executionSegments).toHaveLength(2);
+      expect(result.executionSegments![0]!.phase).toBe("cheap_preflight");
+      expect(result.executionSegments![0]!.summary).toBeNull();
+      expect(result.executionSegments![1]!.phase).toBe("primary");
+
+      // Logs should note the failure
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("did not produce a handoff"),
+        }),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses progress-comment instruction by default and allows when configured", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-routing-comment-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeClaudeCommand(commandPath);
+
+    try {
+      // Default: comments suppressed
+      const result1 = await execute({
+        runId: "run-routing-comments-off",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "claude-haiku-4-5-20251001",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result1.exitCode).toBe(0);
+      const captures1 = await readCaptures(capturePath);
+      const preflightPrompt1 = captures1[0]!.prompt;
+      expect(preflightPrompt1).toContain("Do NOT post comments");
+
+      // Reset capture file
+      await fs.writeFile(capturePath, "", "utf8");
+
+      // With allowInitialProgressComment: true
+      const result2 = await execute({
+        runId: "run-routing-comments-on",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "claude-sonnet-4-6",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "claude-haiku-4-5-20251001",
+            allowInitialProgressComment: true,
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result2.exitCode).toBe(0);
+      const captures2 = await readCaptures(capturePath);
+      const preflightPrompt2 = captures2[0]!.prompt;
+      expect(preflightPrompt2).not.toContain("Do NOT post comments");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/__tests__/codex-local-smart-routing.test.ts
+++ b/server/src/__tests__/codex-local-smart-routing.test.ts
@@ -1,0 +1,566 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-codex-local/server";
+
+/**
+ * Fake codex command that appends invocation data to a JSONL capture file.
+ * Supports multiple invocations (preflight + primary) in a single test run.
+ *
+ * When the prompt contains "BOUNDED ORCHESTRATION", the fake emits a preflight-
+ * style response with a handoff summary.  Otherwise it emits a normal primary
+ * response.
+ */
+async function writeFakeCodexCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const prompt = fs.readFileSync(0, "utf8");
+const isPreflight = prompt.includes("BOUNDED ORCHESTRATION");
+const payload = {
+  argv: process.argv.slice(2),
+  prompt,
+  codexHome: process.env.CODEX_HOME || null,
+  isPreflight,
+};
+if (capturePath) {
+  fs.appendFileSync(capturePath, JSON.stringify(payload) + "\\n", "utf8");
+}
+const sessionId = isPreflight ? "preflight-session-1" : "primary-session-1";
+const message = isPreflight
+  ? "## Handoff Summary\\n\\nThe task requires fixing the login validation bug in auth.ts. Workspace has a standard Node project layout."
+  : "Fixed the bug in auth.ts by correcting the validation logic.";
+console.log(JSON.stringify({ type: "thread.started", thread_id: sessionId }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: message } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 50 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+/** Fake codex command that exits with code 1 (simulates preflight failure). */
+async function writeFakeCodexCommandFailPreflight(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const prompt = fs.readFileSync(0, "utf8");
+const isPreflight = prompt.includes("BOUNDED ORCHESTRATION");
+const payload = { argv: process.argv.slice(2), prompt, isPreflight };
+if (capturePath) {
+  fs.appendFileSync(capturePath, JSON.stringify(payload) + "\\n", "utf8");
+}
+if (isPreflight) {
+  console.error("rate limit exceeded");
+  process.exit(1);
+}
+console.log(JSON.stringify({ type: "thread.started", thread_id: "primary-session-1" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "Fixed the bug." } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 200, cached_input_tokens: 0, output_tokens: 100 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+type CaptureEntry = {
+  argv: string[];
+  prompt: string;
+  codexHome?: string | null;
+  isPreflight: boolean;
+};
+
+async function readCaptures(capturePath: string): Promise<CaptureEntry[]> {
+  const raw = await fs.readFile(capturePath, "utf8");
+  return raw
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as CaptureEntry);
+}
+
+type LogEntry = { stream: "stdout" | "stderr"; chunk: string };
+
+function baseAgent() {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Codex Coder",
+    adapterType: "codex_local" as const,
+    adapterConfig: {},
+  };
+}
+
+function freshRuntime() {
+  return {
+    sessionId: null,
+    sessionParams: null,
+    sessionDisplayId: null,
+    taskKey: null,
+  };
+}
+
+function resumedRuntime(cwd: string) {
+  return {
+    sessionId: null,
+    sessionParams: { sessionId: "existing-session-1", cwd },
+    sessionDisplayId: null,
+    taskKey: null,
+  };
+}
+
+function issueContext() {
+  return {
+    issueId: "issue-1",
+    taskId: "issue-1",
+    wakeReason: "issue_commented",
+    paperclipWake: {
+      reason: "issue_commented",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-100",
+        title: "Fix login bug",
+        status: "in_progress",
+        priority: "high",
+      },
+      commentIds: ["comment-1"],
+      latestCommentId: "comment-1",
+      comments: [
+        {
+          id: "comment-1",
+          issueId: "issue-1",
+          body: "Please fix the login validation",
+          bodyTruncated: false,
+          createdAt: "2026-04-07T10:00:00.000Z",
+          author: { type: "user", id: "user-1" },
+        },
+      ],
+      commentWindow: { requestedCount: 1, includedCount: 1, missingCount: 0 },
+      truncated: false,
+      fallbackFetchNeeded: false,
+    },
+  };
+}
+
+describe("codex smart model routing", () => {
+  it("runs cheap preflight then primary on fresh issue-scoped sessions with routing enabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    const logs: LogEntry[] = [];
+
+    try {
+      const result = await execute({
+        runId: "run-routing-1",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "gpt-5-nano",
+            cheapThinkingEffort: "low",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => { logs.push({ stream, chunk }); },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      // Two invocations: preflight + primary
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(2);
+
+      // First invocation: preflight with cheap model
+      const preflight = captures[0]!;
+      expect(preflight.isPreflight).toBe(true);
+      expect(preflight.argv).toContain("--model");
+      expect(preflight.argv[preflight.argv.indexOf("--model") + 1]).toBe("gpt-5-nano");
+      expect(preflight.argv).toContain("-c");
+      expect(preflight.prompt).toContain("BOUNDED ORCHESTRATION");
+      expect(preflight.prompt).toContain("Do NOT make code changes");
+
+      // Second invocation: primary with primary model
+      const primary = captures[1]!;
+      expect(primary.isPreflight).toBe(false);
+      expect(primary.argv).toContain("--model");
+      expect(primary.argv[primary.argv.indexOf("--model") + 1]).toBe("gpt-5.3-codex");
+      expect(primary.prompt).toContain("Continue your Paperclip work.");
+      // Primary should contain the preflight handoff
+      expect(primary.prompt).toContain("Preflight Summary");
+      expect(primary.prompt).toContain("Handoff Summary");
+
+      // Result should contain execution segments
+      expect(result.executionSegments).toBeDefined();
+      expect(result.executionSegments).toHaveLength(2);
+      const cheapSeg = result.executionSegments![0]!;
+      const primarySeg = result.executionSegments![1]!;
+      expect(cheapSeg.phase).toBe("cheap_preflight");
+      expect(cheapSeg.model).toBe("gpt-5-nano");
+      expect(cheapSeg.usage?.inputTokens).toBe(100);
+      expect(primarySeg.phase).toBe("primary");
+      expect(primarySeg.model).toBe("gpt-5.3-codex");
+
+      // Session should be from primary, not preflight
+      expect(result.sessionId).toBe("primary-session-1");
+
+      // Logs should mention routing
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("Smart routing: running cheap preflight"),
+        }),
+      );
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("Preflight complete"),
+        }),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight on resumed sessions even with routing enabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-resumed-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-routing-resumed",
+        agent: baseAgent(),
+        runtime: resumedRuntime(workspace),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "gpt-5-nano",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      // Only one invocation: the resumed session, no preflight
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(captures[0]!.isPreflight).toBe(false);
+      expect(captures[0]!.argv).toContain("resume");
+
+      // No execution segments
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight when routing is disabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-disabled-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-routing-off",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: false,
+            cheapModel: "gpt-5-nano",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Only primary invocation
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(captures[0]!.isPreflight).toBe(false);
+
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight when no cheapModel is configured", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-nocheap-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-routing-nocheap",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            // no cheapModel
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips preflight when run is not issue-scoped", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-noissue-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-routing-noissue",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do some general work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "gpt-5-nano",
+          },
+        },
+        context: {}, // no issue context
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(1);
+      expect(result.executionSegments).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("proceeds with primary only when preflight fails", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-fail-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommandFailPreflight(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    const logs: LogEntry[] = [];
+
+    try {
+      const result = await execute({
+        runId: "run-routing-preflight-fail",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "gpt-5-nano",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => { logs.push({ stream, chunk }); },
+      });
+
+      // Primary should still succeed
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      // Two invocations: failed preflight + successful primary
+      const captures = await readCaptures(capturePath);
+      expect(captures).toHaveLength(2);
+      expect(captures[0]!.isPreflight).toBe(true);
+      expect(captures[1]!.isPreflight).toBe(false);
+
+      // Primary prompt should NOT contain preflight handoff (preflight failed)
+      expect(captures[1]!.prompt).not.toContain("Preflight Summary");
+
+      // Segment should still report the failed preflight (with null summary)
+      expect(result.executionSegments).toBeDefined();
+      expect(result.executionSegments).toHaveLength(2);
+      expect(result.executionSegments![0]!.phase).toBe("cheap_preflight");
+      expect(result.executionSegments![0]!.summary).toBeNull();
+      expect(result.executionSegments![1]!.phase).toBe("primary");
+
+      // Logs should note the failure
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("did not produce a handoff"),
+        }),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses progress-comment instruction by default and allows when configured", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-routing-comment-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.jsonl");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      // Default: comments suppressed
+      const result1 = await execute({
+        runId: "run-routing-comments-off",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "gpt-5-nano",
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result1.exitCode).toBe(0);
+      const captures1 = await readCaptures(capturePath);
+      const preflightPrompt1 = captures1[0]!.prompt;
+      expect(preflightPrompt1).toContain("Do NOT post comments");
+
+      // Reset capture file
+      await fs.writeFile(capturePath, "", "utf8");
+
+      // With allowInitialProgressComment: true
+      const result2 = await execute({
+        runId: "run-routing-comments-on",
+        agent: baseAgent(),
+        runtime: freshRuntime(),
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Continue your Paperclip work.",
+          model: "gpt-5.3-codex",
+          smartModelRouting: {
+            enabled: true,
+            cheapModel: "gpt-5-nano",
+            allowInitialProgressComment: true,
+          },
+        },
+        context: issueContext(),
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result2.exitCode).toBe(0);
+      const captures2 = await readCaptures(capturePath);
+      const preflightPrompt2 = captures2[0]!.prompt;
+      expect(preflightPrompt2).not.toContain("Do NOT post comments");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/__tests__/heartbeat-execution-segments.test.ts
+++ b/server/src/__tests__/heartbeat-execution-segments.test.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  costEvents,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { costService } from "../services/costs.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres execution-segments tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("segmented execution cost events", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-segments-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(costEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const wakeupId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Segments Co",
+      mission: "test",
+      status: "active",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Routing Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      status: "idle",
+      systemPrompt: "",
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupId,
+      agentId,
+      companyId,
+      type: "heartbeat",
+      source: "scheduler",
+      status: "pending",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      agentId,
+      companyId,
+      wakeupRequestId: wakeupId,
+      status: "running",
+      contextSnapshot: {},
+    });
+
+    return { companyId, agentId, runId };
+  }
+
+  it("allows multiple cost events per run for segmented execution", async () => {
+    const { companyId, agentId, runId } = await seedFixture();
+    const costs = costService(db);
+
+    // Simulate cheap preflight segment
+    await costs.createEvent(companyId, {
+      heartbeatRunId: runId,
+      agentId,
+      provider: "anthropic",
+      biller: "anthropic",
+      billingType: "metered_api",
+      model: "claude-haiku-4",
+      inputTokens: 1200,
+      cachedInputTokens: 0,
+      outputTokens: 300,
+      costCents: 1,
+      occurredAt: new Date(),
+    });
+
+    // Simulate primary execution segment
+    await costs.createEvent(companyId, {
+      heartbeatRunId: runId,
+      agentId,
+      provider: "anthropic",
+      biller: "anthropic",
+      billingType: "metered_api",
+      model: "claude-sonnet-4",
+      inputTokens: 45000,
+      cachedInputTokens: 12000,
+      outputTokens: 8000,
+      costCents: 42,
+      occurredAt: new Date(),
+    });
+
+    const events = await db
+      .select()
+      .from(costEvents)
+      .where(eq(costEvents.heartbeatRunId, runId));
+
+    expect(events).toHaveLength(2);
+
+    const preflight = events.find((e) => e.model === "claude-haiku-4");
+    const primary = events.find((e) => e.model === "claude-sonnet-4");
+
+    expect(preflight).toBeDefined();
+    expect(primary).toBeDefined();
+
+    expect(preflight!.inputTokens).toBe(1200);
+    expect(preflight!.outputTokens).toBe(300);
+    expect(preflight!.costCents).toBe(1);
+
+    expect(primary!.inputTokens).toBe(45000);
+    expect(primary!.cachedInputTokens).toBe(12000);
+    expect(primary!.outputTokens).toBe(8000);
+    expect(primary!.costCents).toBe(42);
+  });
+
+  it("preserves per-segment provider and biller attribution", async () => {
+    const { companyId, agentId, runId } = await seedFixture();
+    const costs = costService(db);
+
+    await costs.createEvent(companyId, {
+      heartbeatRunId: runId,
+      agentId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "metered_api",
+      model: "gpt-5-mini",
+      inputTokens: 800,
+      outputTokens: 200,
+      costCents: 0,
+      occurredAt: new Date(),
+    });
+
+    await costs.createEvent(companyId, {
+      heartbeatRunId: runId,
+      agentId,
+      provider: "anthropic",
+      biller: "anthropic",
+      billingType: "metered_api",
+      model: "claude-sonnet-4",
+      inputTokens: 30000,
+      outputTokens: 5000,
+      costCents: 28,
+      occurredAt: new Date(),
+    });
+
+    const events = await db
+      .select()
+      .from(costEvents)
+      .where(eq(costEvents.heartbeatRunId, runId));
+
+    expect(events).toHaveLength(2);
+    const providers = events.map((e) => e.provider).sort();
+    expect(providers).toEqual(["anthropic", "openai"]);
+
+    const models = events.map((e) => e.model).sort();
+    expect(models).toEqual(["claude-sonnet-4", "gpt-5-mini"]);
+  });
+});

--- a/server/src/__tests__/heartbeat-segmented-costs.test.ts
+++ b/server/src/__tests__/heartbeat-segmented-costs.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeLedgerBillingType,
+  resolveLedgerBiller,
+  normalizeBilledCostCents,
+  normalizeUsageTotals,
+} from "../services/heartbeat.js";
+import type { ExecutionSegment, AdapterExecutionResult } from "../adapters/index.js";
+
+describe("resolveLedgerBiller", () => {
+  it("returns biller when present", () => {
+    expect(resolveLedgerBiller({ biller: "openai", provider: "azure" })).toBe("openai");
+  });
+
+  it("falls back to provider when biller is absent", () => {
+    expect(resolveLedgerBiller({ biller: null, provider: "anthropic" })).toBe("anthropic");
+  });
+
+  it("falls back to provider when biller is empty string", () => {
+    expect(resolveLedgerBiller({ biller: "", provider: "google" })).toBe("google");
+  });
+
+  it("returns 'unknown' when both are absent", () => {
+    expect(resolveLedgerBiller({ biller: null, provider: null })).toBe("unknown");
+  });
+
+  it("accepts segment-shaped objects (Pick<AdapterExecutionResult>)", () => {
+    const segment: Pick<AdapterExecutionResult, "biller" | "provider"> = {
+      biller: "segment-biller",
+      provider: "segment-provider",
+    };
+    expect(resolveLedgerBiller(segment)).toBe("segment-biller");
+  });
+
+  it("resolves segment biller with fallback to result provider", () => {
+    const merged: Pick<AdapterExecutionResult, "biller" | "provider"> = {
+      biller: null,
+      provider: "anthropic",
+    };
+    expect(resolveLedgerBiller(merged)).toBe("anthropic");
+  });
+});
+
+describe("normalizeLedgerBillingType", () => {
+  it("normalizes 'api' to 'metered_api'", () => {
+    expect(normalizeLedgerBillingType("api")).toBe("metered_api");
+  });
+
+  it("normalizes 'metered_api' to 'metered_api'", () => {
+    expect(normalizeLedgerBillingType("metered_api")).toBe("metered_api");
+  });
+
+  it("normalizes 'subscription' to 'subscription_included'", () => {
+    expect(normalizeLedgerBillingType("subscription")).toBe("subscription_included");
+  });
+
+  it("normalizes 'credits' to 'credits'", () => {
+    expect(normalizeLedgerBillingType("credits")).toBe("credits");
+  });
+
+  it("returns 'unknown' for null/undefined", () => {
+    expect(normalizeLedgerBillingType(null)).toBe("unknown");
+    expect(normalizeLedgerBillingType(undefined)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for unrecognized string", () => {
+    expect(normalizeLedgerBillingType("something_else")).toBe("unknown");
+  });
+});
+
+describe("normalizeBilledCostCents", () => {
+  it("converts USD to cents", () => {
+    expect(normalizeBilledCostCents(0.42, "metered_api")).toBe(42);
+  });
+
+  it("rounds fractional cents", () => {
+    expect(normalizeBilledCostCents(0.005, "metered_api")).toBe(1);
+    expect(normalizeBilledCostCents(0.004, "metered_api")).toBe(0);
+  });
+
+  it("returns 0 for subscription_included billing", () => {
+    expect(normalizeBilledCostCents(1.5, "subscription_included")).toBe(0);
+  });
+
+  it("returns 0 for null/undefined", () => {
+    expect(normalizeBilledCostCents(null, "metered_api")).toBe(0);
+    expect(normalizeBilledCostCents(undefined, "metered_api")).toBe(0);
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(normalizeBilledCostCents(-1, "metered_api")).toBe(0);
+  });
+});
+
+describe("normalizeUsageTotals", () => {
+  it("normalizes valid usage", () => {
+    expect(normalizeUsageTotals({ inputTokens: 100, outputTokens: 50, cachedInputTokens: 10 }))
+      .toEqual({ inputTokens: 100, outputTokens: 50, cachedInputTokens: 10 });
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(normalizeUsageTotals(null)).toBeNull();
+    expect(normalizeUsageTotals(undefined)).toBeNull();
+  });
+
+  it("floors fractional token counts", () => {
+    expect(normalizeUsageTotals({ inputTokens: 10.7, outputTokens: 5.3 }))
+      .toEqual({ inputTokens: 10, outputTokens: 5, cachedInputTokens: 0 });
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(normalizeUsageTotals({ inputTokens: -5, outputTokens: 10 }))
+      .toEqual({ inputTokens: 0, outputTokens: 10, cachedInputTokens: 0 });
+  });
+});
+
+describe("ExecutionSegment contract", () => {
+  it("validates typical two-segment routing result shape", () => {
+    const segments: ExecutionSegment[] = [
+      {
+        phase: "cheap_preflight",
+        provider: "anthropic",
+        model: "claude-3-haiku-20240307",
+        billingType: "metered_api",
+        usage: { inputTokens: 1500, outputTokens: 400 },
+        costUsd: 0.0005,
+        summary: "Oriented to task, posted progress comment.",
+      },
+      {
+        phase: "primary",
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        billingType: "metered_api",
+        usage: { inputTokens: 50000, outputTokens: 15000, cachedInputTokens: 10000 },
+        costUsd: 0.05,
+      },
+    ];
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]!.phase).toBe("cheap_preflight");
+    expect(segments[1]!.phase).toBe("primary");
+
+    // Biller resolution per segment uses merge fallback
+    for (const seg of segments) {
+      const biller = resolveLedgerBiller({
+        biller: seg.biller ?? null,
+        provider: seg.provider ?? null,
+      });
+      expect(biller).toBe("anthropic");
+    }
+
+    // Billing type normalization per segment
+    for (const seg of segments) {
+      expect(normalizeLedgerBillingType(seg.billingType)).toBe("metered_api");
+    }
+
+    // Cost conversion per segment
+    expect(normalizeBilledCostCents(segments[0]!.costUsd, "metered_api")).toBe(0);
+    expect(normalizeBilledCostCents(segments[1]!.costUsd, "metered_api")).toBe(5);
+  });
+});

--- a/server/src/adapters/index.ts
+++ b/server/src/adapters/index.ts
@@ -12,6 +12,7 @@ export {
 export type {
   ServerAdapterModule,
   AdapterExecutionContext,
+  ExecutionSegment,
   AdapterExecutionResult,
   AdapterInvocationMeta,
   AdapterEnvironmentCheckLevel,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -386,7 +386,7 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
-function normalizeLedgerBillingType(value: unknown): BillingType {
+export function normalizeLedgerBillingType(value: unknown): BillingType {
   const raw = readNonEmptyString(value);
   switch (raw) {
     case "api":
@@ -406,11 +406,11 @@ function normalizeLedgerBillingType(value: unknown): BillingType {
   }
 }
 
-function resolveLedgerBiller(result: Pick<AdapterExecutionResult, "biller" | "provider">): string {
+export function resolveLedgerBiller(result: Pick<AdapterExecutionResult, "biller" | "provider">): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
 }
 
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
+export function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
   if (billingType === "subscription_included") return 0;
   if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
   return Math.max(0, Math.round(costUsd * 100));
@@ -492,7 +492,7 @@ export function buildExplicitResumeSessionOverride(input: {
   };
 }
 
-function normalizeUsageTotals(usage: UsageSummary | null | undefined): UsageTotals | null {
+export function normalizeUsageTotals(usage: UsageSummary | null | undefined): UsageTotals | null {
   if (!usage) return null;
   return {
     inputTokens: Math.max(0, Math.floor(asNumber(usage.inputTokens, 0))),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -22,7 +22,7 @@ import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, runningProcesses } from "../adapters/index.js";
-import type { AdapterExecutionResult, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
+import type { AdapterExecutionResult, ExecutionSegment, AdapterInvocationMeta, AdapterSessionCodec, UsageSummary } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
 import { costService } from "./costs.js";
@@ -406,7 +406,7 @@ function normalizeLedgerBillingType(value: unknown): BillingType {
   }
 }
 
-function resolveLedgerBiller(result: AdapterExecutionResult): string {
+function resolveLedgerBiller(result: Pick<AdapterExecutionResult, "biller" | "provider">): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
 }
 
@@ -2186,6 +2186,13 @@ export function heartbeatService(db: Db) {
     normalizedUsage?: UsageTotals | null,
   ) {
     await ensureRuntimeState(agent);
+
+    // When segmented execution is present, create per-segment cost events.
+    // The top-level usage/provider/model fields are treated as the summary
+    // (typically the primary phase) and still drive runtime state aggregation.
+    const segments = result.executionSegments;
+    const hasSegments = segments != null && segments.length > 0;
+
     const usage = normalizedUsage ?? normalizeUsageTotals(result.usage);
     const inputTokens = usage?.inputTokens ?? 0;
     const outputTokens = usage?.outputTokens ?? 0;
@@ -2193,8 +2200,6 @@ export function heartbeatService(db: Db) {
     const billingType = normalizeLedgerBillingType(result.billingType);
     const additionalCostCents = normalizeBilledCostCents(result.costUsd, billingType);
     const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
-    const provider = result.provider ?? "unknown";
-    const biller = resolveLedgerBiller(result);
     const ledgerScope = await resolveLedgerScopeForRun(db, agent.companyId, run);
 
     await db
@@ -2213,15 +2218,50 @@ export function heartbeatService(db: Db) {
       })
       .where(eq(agentRuntimeState.agentId, agent.id));
 
-    if (additionalCostCents > 0 || hasTokenUsage) {
-      const costs = costService(db, budgetHooks);
+    const costs = costService(db, budgetHooks);
+
+    if (hasSegments) {
+      // Segmented execution: write one cost_events row per segment that has
+      // cost or token usage, so the ledger reflects truthful per-model costs.
+      for (const segment of segments) {
+        const segUsage = normalizeUsageTotals(segment.usage);
+        const segInputTokens = segUsage?.inputTokens ?? 0;
+        const segOutputTokens = segUsage?.outputTokens ?? 0;
+        const segCachedInputTokens = segUsage?.cachedInputTokens ?? 0;
+        const segBillingType = normalizeLedgerBillingType(segment.billingType);
+        const segCostCents = normalizeBilledCostCents(segment.costUsd, segBillingType);
+        const segHasUsage = segInputTokens > 0 || segOutputTokens > 0 || segCachedInputTokens > 0;
+
+        if (segCostCents > 0 || segHasUsage) {
+          await costs.createEvent(agent.companyId, {
+            heartbeatRunId: run.id,
+            agentId: agent.id,
+            issueId: ledgerScope.issueId,
+            projectId: ledgerScope.projectId,
+            provider: segment.provider ?? result.provider ?? "unknown",
+            biller: resolveLedgerBiller({
+              biller: segment.biller ?? result.biller,
+              provider: segment.provider ?? result.provider,
+            }),
+            billingType: segBillingType,
+            model: segment.model ?? result.model ?? "unknown",
+            inputTokens: segInputTokens,
+            cachedInputTokens: segCachedInputTokens,
+            outputTokens: segOutputTokens,
+            costCents: segCostCents,
+            occurredAt: new Date(),
+          });
+        }
+      }
+    } else if (additionalCostCents > 0 || hasTokenUsage) {
+      // Single-result path (existing behavior, unchanged for non-routed adapters).
       await costs.createEvent(agent.companyId, {
         heartbeatRunId: run.id,
         agentId: agent.id,
         issueId: ledgerScope.issueId,
         projectId: ledgerScope.projectId,
-        provider,
-        biller,
+        provider: result.provider ?? "unknown",
+        biller: resolveLedgerBiller(result),
         billingType,
         model: result.model ?? "unknown",
         inputTokens,
@@ -3009,8 +3049,32 @@ export function heartbeatService(db: Db) {
               ? "timed_out"
               : "failed";
 
+      // Build execution segments metadata for usageJson when adapter reports
+      // multi-model routing.  This preserves the segment breakdown in run
+      // metadata so transcript/debug views can show per-phase cost and model.
+      const executionSegmentsJson =
+        adapterResult.executionSegments != null && adapterResult.executionSegments.length > 0
+          ? adapterResult.executionSegments.map((seg) => ({
+              phase: seg.phase,
+              provider: readNonEmptyString(seg.provider) ?? readNonEmptyString(adapterResult.provider) ?? "unknown",
+              biller: resolveLedgerBiller({
+                biller: seg.biller ?? adapterResult.biller,
+                provider: seg.provider ?? adapterResult.provider,
+              }),
+              model: readNonEmptyString(seg.model) ?? readNonEmptyString(adapterResult.model) ?? "unknown",
+              billingType: normalizeLedgerBillingType(seg.billingType),
+              ...(seg.usage ? {
+                inputTokens: seg.usage.inputTokens ?? 0,
+                outputTokens: seg.usage.outputTokens ?? 0,
+                cachedInputTokens: seg.usage.cachedInputTokens ?? 0,
+              } : {}),
+              ...(seg.costUsd != null ? { costUsd: seg.costUsd } : {}),
+              ...(seg.summary ? { summary: seg.summary } : {}),
+            }))
+          : null;
+
       const usageJson =
-        normalizedUsage || adapterResult.costUsd != null
+        normalizedUsage || adapterResult.costUsd != null || executionSegmentsJson != null
           ? ({
               ...(normalizedUsage ?? {}),
               ...(rawUsage ? {
@@ -3032,6 +3096,7 @@ export function heartbeatService(db: Db) {
               model: readNonEmptyString(adapterResult.model) ?? "unknown",
               ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
               billingType: normalizeLedgerBillingType(adapterResult.billingType),
+              ...(executionSegmentsJson ? { executionSegments: executionSegmentsJson } : {}),
             } as Record<string, unknown>)
           : null;
 

--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
 import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+import { SmartModelRoutingFields } from "../smart-routing-fields";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -55,6 +56,17 @@ export function ClaudeLocalConfigFields({
           </div>
         </Field>
       )}
+      <SmartModelRoutingFields
+        mode={mode}
+        isCreate={isCreate}
+        adapterType={adapterType}
+        values={values}
+        set={set}
+        config={config}
+        eff={eff}
+        mark={mark}
+        models={models}
+      />
       <LocalWorkspaceRuntimeFields
         isCreate={isCreate}
         values={values}

--- a/ui/src/adapters/codex-local/config-fields.tsx
+++ b/ui/src/adapters/codex-local/config-fields.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
 import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+import { SmartModelRoutingFields } from "../smart-routing-fields";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -87,6 +88,17 @@ export function CodexLocalConfigFields({
             ? set!({ search: v })
             : mark("adapterConfig", "search", v)
         }
+      />
+      <SmartModelRoutingFields
+        mode={mode}
+        isCreate={isCreate}
+        adapterType={adapterType}
+        values={values}
+        set={set}
+        config={config}
+        eff={eff}
+        mark={mark}
+        models={models}
       />
       <LocalWorkspaceRuntimeFields
         isCreate={isCreate}

--- a/ui/src/adapters/smart-routing-fields.tsx
+++ b/ui/src/adapters/smart-routing-fields.tsx
@@ -1,0 +1,117 @@
+import type { AdapterConfigFieldsProps } from "./types";
+import {
+  Field,
+  ToggleField,
+  DraftInput,
+} from "../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+interface SmartRoutingConfig {
+  enabled?: boolean;
+  cheapModel?: string;
+  cheapThinkingEffort?: string;
+  maxPreflightTurns?: number;
+  allowInitialProgressComment?: boolean;
+}
+
+function readRouting(raw: unknown): SmartRoutingConfig {
+  if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+    return raw as SmartRoutingConfig;
+  }
+  return {};
+}
+
+/**
+ * Shared smart-model-routing config fields for local adapters.
+ *
+ * Create mode: values flow through `adapterSchemaValues.smartModelRouting`.
+ * Edit mode:   values flow through `adapterConfig.smartModelRouting`.
+ *
+ * Both codex-local and claude-local build-config.ts files already parse the
+ * resulting nested object, so no server-side changes are needed.
+ */
+export function SmartModelRoutingFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  /* ---- read current config ---- */
+  const routing: SmartRoutingConfig = isCreate
+    ? readRouting(values?.adapterSchemaValues?.smartModelRouting)
+    : readRouting(
+        eff(
+          "adapterConfig",
+          "smartModelRouting",
+          (config.smartModelRouting ?? {}) as Record<string, unknown>,
+        ),
+      );
+
+  const enabled = routing.enabled === true;
+
+  /* ---- write helper (replaces whole nested object) ---- */
+  const update = (patch: Partial<SmartRoutingConfig>) => {
+    const next: SmartRoutingConfig = { ...routing, ...patch };
+    if (isCreate && set && values) {
+      set({
+        adapterSchemaValues: {
+          ...values.adapterSchemaValues,
+          smartModelRouting: next,
+        },
+      });
+    } else {
+      mark("adapterConfig", "smartModelRouting", next);
+    }
+  };
+
+  return (
+    <>
+      <ToggleField
+        label="Smart model routing"
+        hint="Run a cheap preflight phase (orientation, triage, optional progress comment) before the primary model. Reduces cost on fresh issue runs."
+        checked={enabled}
+        onChange={(v) => update({ enabled: v })}
+      />
+      {enabled && (
+        <>
+          <Field
+            label="Cheap model"
+            hint="Model ID for the preflight phase (e.g. o4-mini, claude-sonnet-4-20250514)."
+          >
+            <DraftInput
+              value={routing.cheapModel ?? ""}
+              onCommit={(v) => update({ cheapModel: v || undefined })}
+              immediate
+              className={inputClass}
+              placeholder="e.g. o4-mini"
+            />
+          </Field>
+          <Field
+            label="Cheap thinking effort"
+            hint="Optional reasoning effort for the cheap model (e.g. low, medium). Leave blank to use the model default."
+          >
+            <DraftInput
+              value={routing.cheapThinkingEffort ?? ""}
+              onCommit={(v) =>
+                update({ cheapThinkingEffort: v || undefined })
+              }
+              immediate
+              className={inputClass}
+              placeholder="e.g. low"
+            />
+          </Field>
+          <ToggleField
+            label="Allow initial progress comment"
+            hint="Let the preflight phase post an early progress comment on the issue before the primary model starts."
+            checked={routing.allowInitialProgressComment ?? false}
+            onChange={(v) => update({ allowInitialProgressComment: v })}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -16,6 +16,15 @@ import {
 export type TranscriptMode = "nice" | "raw";
 export type TranscriptDensity = "comfortable" | "compact";
 
+/** Per-segment cost/model info from smart model routing. */
+export interface ExecutionSegmentInfo {
+  phase: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+}
+
 interface RunTranscriptViewProps {
   entries: TranscriptEntry[];
   mode?: TranscriptMode;
@@ -26,6 +35,8 @@ interface RunTranscriptViewProps {
   emptyMessage?: string;
   className?: string;
   thinkingClassName?: string;
+  /** Per-segment breakdown from smart model routing (from run usageJson). */
+  executionSegments?: ExecutionSegmentInfo[];
 }
 
 type TranscriptBlock =
@@ -111,6 +122,8 @@ type TranscriptBlock =
       tone: "info" | "warn" | "error" | "neutral";
       text: string;
       detail?: string;
+      /** Per-segment breakdown (smart model routing). */
+      segments?: ExecutionSegmentInfo[];
     }
   | {
       type: "diff_group";
@@ -1132,6 +1145,20 @@ function TranscriptEventRow({
               {block.detail}
             </pre>
           )}
+          {block.segments && block.segments.length > 1 && (
+            <div className="mt-2 space-y-0.5">
+              {block.segments.map((seg, i) => (
+                <div key={i} className="flex items-baseline gap-2 font-mono text-[11px] text-foreground/60">
+                  <span className="font-semibold text-foreground/75 capitalize min-w-[68px]">{seg.phase}</span>
+                  {seg.model && <span className="text-muted-foreground">{seg.model}</span>}
+                  <span className="ml-auto tabular-nums">
+                    {formatTokens(seg.inputTokens ?? 0)} / {formatTokens(seg.outputTokens ?? 0)}
+                    {seg.costUsd != null && <> / ${seg.costUsd.toFixed(6)}</>}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -1395,8 +1422,22 @@ export function RunTranscriptView({
   emptyMessage = "No transcript yet.",
   className,
   thinkingClassName,
+  executionSegments,
 }: RunTranscriptViewProps) {
-  const blocks = useMemo(() => normalizeTranscript(entries, streaming), [entries, streaming]);
+  const blocks = useMemo(() => {
+    const normalized = normalizeTranscript(entries, streaming);
+    // Attach execution segments to the result event block (if any)
+    if (executionSegments && executionSegments.length > 0) {
+      for (let i = normalized.length - 1; i >= 0; i--) {
+        const b = normalized[i];
+        if (b.type === "event" && b.label === "result") {
+          b.segments = executionSegments;
+          break;
+        }
+      }
+    }
+    return normalized;
+  }, [entries, streaming, executionSegments]);
   const visibleBlocks = limit ? blocks.slice(-limit) : blocks;
   const visibleEntries = limit ? entries.slice(-limit) : entries;
 

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -76,7 +76,7 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/component
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { AgentIcon, AgentIconPicker } from "../components/AgentIconPicker";
-import { RunTranscriptView, type TranscriptMode } from "../components/transcript/RunTranscriptView";
+import { RunTranscriptView, type TranscriptMode, type ExecutionSegmentInfo } from "../components/transcript/RunTranscriptView";
 import {
   isUuidLike,
   type Agent,
@@ -275,6 +275,21 @@ function runMetrics(run: HeartbeatRun) {
     provider,
     model,
   };
+}
+
+/** Extract execution segments from a run's usageJson (smart model routing). */
+function extractExecutionSegments(run: HeartbeatRun): ExecutionSegmentInfo[] | undefined {
+  const usage = asRecord(run.usageJson);
+  if (!usage) return undefined;
+  const raw = usage.executionSegments;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  return raw.map((seg: Record<string, unknown>) => ({
+    phase: String(seg.phase ?? "unknown"),
+    model: asNonEmptyString(seg.model) ?? undefined,
+    inputTokens: typeof seg.inputTokens === "number" ? seg.inputTokens : undefined,
+    outputTokens: typeof seg.outputTokens === "number" ? seg.outputTokens : undefined,
+    costUsd: typeof seg.costUsd === "number" ? seg.costUsd : undefined,
+  }));
 }
 
 type RunLogChunk = { ts: string; stream: "stdout" | "stderr" | "system"; chunk: string };
@@ -3867,6 +3882,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           mode={transcriptMode}
           streaming={isLive}
           emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
+          executionSegments={extractExecutionSegments(run)}
         />
         {logError && (
           <div className="mt-3 rounded-xl border border-red-500/20 bg-red-500/[0.06] px-3 py-2 text-xs text-red-700 dark:text-red-300">

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -1,0 +1,21 @@
+/**
+ * Vitest global setup — polyfills for Node test environment.
+ *
+ * The UI test suite uses `environment: "node"` for speed.  A handful of
+ * component tests reference `localStorage` (e.g. to clear draft state between
+ * tests).  Node 25+ exposes a partial `localStorage` object that is missing
+ * standard methods like `clear()`.  Provide a complete in-memory Storage
+ * implementation so those calls succeed without pulling in a full DOM
+ * environment.
+ */
+
+const store = new Map<string, string>();
+const storage: Storage = {
+  getItem: (key: string) => store.get(key) ?? null,
+  setItem: (key: string, value: string) => { store.set(key, value); },
+  removeItem: (key: string) => { store.delete(key); },
+  clear: () => { store.clear(); },
+  get length() { return store.size; },
+  key: (index: number) => [...store.keys()][index] ?? null,
+};
+(globalThis as Record<string, unknown>).localStorage = storage;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each heartbeat run currently uses one model, but lightweight orchestration work (reading wake context, orienting to workspace, posting an initial progress comment) does not require the expensive primary model
> - Running the full primary model for these bounded triage tasks wastes budget and adds latency
> - Hermes has a "smart model routing" feature, but it uses text-heuristic routing which is less reliable than phase-based routing for Paperclip's structured, issue-scoped heartbeats
> - This PR implements adapter-local, opt-in, phase-based smart model routing across all supported local adapters (codex, claude, cursor, gemini, opencode, pi)
> - The benefit is reduced cost and latency for heartbeat runs, with truthful per-segment cost reporting and full UI visibility into routing behavior

## What Changed

- **Contract & server plumbing (Phase 1):** Extended `AdapterExecutionResult` with optional `executionSegments` array for multi-model cost reporting. Updated `heartbeat.ts` to emit one `cost_events` row per segment when segments are present. Added ledger helper tests and segmented cost validation tests.
- **Shared preflight helpers:** Extracted `buildPreflightPrompt()`, `parsePreflightResult()`, and `isPreflightEligible()` into `@paperclipai/adapter-utils` so all adapters share the same routing logic and prompt structure.
- **codex_local cheap preflight (Phase 2):** Added `smartModelRouting` config support, cheap-preflight prompt builder, fresh-session-only routing gate, compact handoff summary passing to primary phase, and segmented usage reporting.
- **claude_local cheap preflight (Phase 3):** Same pattern as codex, adapted for Claude CLI invocation. Ephemeral preflight session, primary session remains canonical.
- **cursor, gemini, opencode, pi cheap preflight (Phase 4):** Implemented for all remaining local adapters with adapter-specific CLI invocation patterns. Skipped `openclaw_gateway` (WebSocket architecture, not applicable) and external plugin adapters (deferred).
- **UI config panel:** Added smart routing toggle, cheap model selector, and cheap thinking effort fields to agent config for codex and claude adapters. Added reusable `SmartRoutingFields` component.
- **Run detail UI:** Added execution segment display to `RunTranscriptView` showing per-phase model, tokens, and cost when routing occurred.
- **Plan doc:** Marked all phases complete in `doc/plans/2026-04-06-smart-model-routing.md`.

## Verification

```sh
# Typecheck (all packages pass)
pnpm -r typecheck

# Tests (1027 passed, 1 skipped, 2 pre-existing failures in worktree-config unrelated to this PR)
pnpm test:run

# Specific smart-routing tests
pnpm vitest run src/__tests__/codex-local-smart-routing.test.ts
pnpm vitest run src/__tests__/claude-local-smart-routing.test.ts
pnpm vitest run src/__tests__/heartbeat-execution-segments.test.ts
pnpm vitest run src/__tests__/heartbeat-segmented-costs.test.ts
```

Manual verification:
- Create a fresh issue for a routed codex or claude agent with `smartModelRouting.enabled: true` and a `cheapModel` configured
- Verify run metadata shows both cheap_preflight and primary phases
- Verify only the primary session is persisted
- Verify cost rows reflect both models
- Verify the issue thread does not get duplicate kickoff comments

## Risks

- **Duplicate comments:** If both cheap and primary phases post similar comments, the thread gets noisy. Mitigated by making cheap comments optional (`allowInitialProgressComment`) and prompt guidance to avoid repetition.
- **Cheap model overreach:** A cheap model with full tools could do too much low-quality work. Mitigated by hard-capping preflight turns (1-2) and using an explicit orchestration-only prompt.
- **Session corruption:** Cross-model session reuse could degrade context. Mitigated by V1 design: cheap preflight sessions are ephemeral and never persisted or resumed.
- **Backward compatibility:** Existing adapters are unaffected — `executionSegments` is optional and all new config fields are opt-in.

## Model Used

- Anthropic Claude (claude-sonnet-4-20250514) via Amplifier CLI with extended thinking, tool use, and multi-agent delegation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge