### PR TITLE
fix(workspace): reuse worktree when branch is at different directory path

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -35,6 +35,7 @@ import {
   sanitizeRuntimeServiceBaseEnv,
   startRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace,
+  truncateWorktreeDirName,
   type RealizedExecutionWorkspace,
 } from "../services/workspace-runtime.ts";
 import { writeLocalServiceRegistryRecord } from "../services/local-service-supervisor.ts";
@@ -170,6 +171,36 @@ afterEach(async () => {
   delete process.env.PAPERCLIP_WORKTREES_DIR;
   delete process.env.DATABASE_URL;
   await resetRuntimeServicesForTests();
+});
+
+describe("truncateWorktreeDirName", () => {
+  it("returns the branch name unchanged when it fits in maxDirNameLen", () => {
+    const parentDirLen = 60;
+    expect(truncateWorktreeDirName("short-branch", parentDirLen)).toBe("short-branch");
+  });
+
+  it("truncates and appends a hash when the branch is too long", () => {
+    const parentDirLen = 180; // leaves only 20 chars for the dir name
+    const longBranch = "a".repeat(80);
+    const result = truncateWorktreeDirName(longBranch, parentDirLen);
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result).toMatch(/-[0-9a-f]{7}$/);
+  });
+
+  it("produces distinct dir names for branches sharing a long common prefix", () => {
+    const parentDirLen = 180; // forces aggressive truncation
+    const branchA = `${"x".repeat(80)}-part-a`;
+    const branchB = `${"x".repeat(80)}-part-b`;
+    const dirA = truncateWorktreeDirName(branchA, parentDirLen);
+    const dirB = truncateWorktreeDirName(branchB, parentDirLen);
+    expect(dirA).not.toBe(dirB);
+  });
+
+  it("never produces a dir name longer than the configured cap", () => {
+    const parentDirLen = 195; // worst case: max is clamped to 20
+    const result = truncateWorktreeDirName("z".repeat(120), parentDirLen);
+    expect(result.length).toBeLessThanOrEqual(20);
+  });
 });
 
 describe("sanitizeRuntimeServiceBaseEnv", () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -563,6 +563,61 @@ describe("realizeExecutionWorkspace", () => {
     });
   });
 
+  it("reuses a worktree when the branch is checked out at a different directory path", async () => {
+    const repoRoot = await createTempRepo();
+    const branchName = "PAP-999-branch-in-different-dir";
+
+    // Create a worktree at a path that does NOT match the sanitized branch name.
+    // This simulates a worktree created by an older version with different
+    // directory naming, which is the root cause of OCT-412's failure.
+    const shortWorktreeDir = path.join(repoRoot, ".paperclip", "worktrees", "PAP-999-short-name");
+    await fs.mkdir(path.dirname(shortWorktreeDir), { recursive: true });
+    await runGit(repoRoot, ["worktree", "add", "-b", branchName, shortWorktreeDir, "HEAD"]);
+
+    // Add a commit on the branch inside the worktree so we can verify it's preserved.
+    await fs.writeFile(path.join(shortWorktreeDir, "work.txt"), "keep this\n", "utf8");
+    await runGit(shortWorktreeDir, ["add", "work.txt"]);
+    await runGit(shortWorktreeDir, ["commit", "-m", "Work in progress"]);
+    const expectedHead = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: shortWorktreeDir })).stdout.trim();
+
+    // Now realize the workspace — it will try to create a worktree at the
+    // canonical path (PAP-999-branch-in-different-dir) but the branch is
+    // already checked out at the shorter path. It should find and reuse it.
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-999",
+        title: "Branch in different dir",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(workspace.branchName).toBe(branchName);
+    await expect(fs.realpath(workspace.cwd)).resolves.toBe(await fs.realpath(shortWorktreeDir));
+    expect(workspace.created).toBe(false);
+    await expect(fs.readFile(path.join(workspace.cwd, "work.txt"), "utf8")).resolves.toBe("keep this\n");
+    const actualHead = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: workspace.cwd })).stdout.trim();
+    expect(actualHead).toBe(expectedHead);
+  });
+
   it("slugifies unsafe issue titles for branch names and worktree folders", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -396,6 +396,18 @@ function sanitizeBranchName(value: string): string {
     .slice(0, 120) || "paperclip-work";
 }
 
+// Windows long parent paths can push the worktree path past MAX_PATH (260),
+// causing git to fail. We truncate the directory name (not the branch) to keep
+// the total under 200 chars and append a short hash so two branches sharing a
+// long common prefix still resolve to distinct directories.
+export function truncateWorktreeDirName(branchName: string, parentDirLenWithSeparator: number): string {
+  const maxDirNameLen = Math.max(20, 200 - parentDirLenWithSeparator);
+  if (branchName.length <= maxDirNameLen) return branchName;
+  const hashSuffix = createHash("sha1").update(branchName).digest("hex").slice(0, 7);
+  const trimLen = Math.max(8, maxDirNameLen - 1 - hashSuffix.length);
+  return `${branchName.slice(0, trimLen).replace(/-+$/, "")}-${hashSuffix}`;
+}
+
 function isAbsolutePath(value: string) {
   return path.isAbsolute(value) || value.startsWith("~");
 }
@@ -1017,14 +1029,9 @@ export async function realizeExecutionWorkspace(input: {
   // git to fail with "$GIT_DIR too big". Truncate the directory name (not the
   // branch) to keep the worktree path under 200 chars, leaving room for
   // nested files.
-  let worktreeDirName = branchName;
-  if (process.platform === "win32") {
-    const parentDirLen = worktreeParentDir.length + 1; // +1 for separator
-    const maxDirNameLen = Math.max(20, 200 - parentDirLen);
-    if (worktreeDirName.length > maxDirNameLen) {
-      worktreeDirName = worktreeDirName.slice(0, maxDirNameLen).replace(/-+$/, "");
-    }
-  }
+  const worktreeDirName = process.platform === "win32"
+    ? truncateWorktreeDirName(branchName, worktreeParentDir.length + 1)
+    : branchName;
   const worktreePath = path.join(worktreeParentDir, worktreeDirName);
   const configuredBaseRef = typeof rawStrategy.baseRef === "string" && rawStrategy.baseRef.length > 0
     ? rawStrategy.baseRef

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1012,7 +1012,20 @@ export async function realizeExecutionWorkspace(input: {
   const worktreeParentDir = configuredParentDir
     ? resolveConfiguredPath(configuredParentDir, repoRoot)
     : path.join(repoRoot, ".paperclip", "worktrees");
-  const worktreePath = path.join(worktreeParentDir, branchName);
+  // The worktree directory name defaults to the full branch name, but on
+  // Windows long parent paths can push the total past MAX_PATH (260), causing
+  // git to fail with "$GIT_DIR too big". Truncate the directory name (not the
+  // branch) to keep the worktree path under 200 chars, leaving room for
+  // nested files.
+  let worktreeDirName = branchName;
+  if (process.platform === "win32") {
+    const parentDirLen = worktreeParentDir.length + 1; // +1 for separator
+    const maxDirNameLen = Math.max(20, 200 - parentDirLen);
+    if (worktreeDirName.length > maxDirNameLen) {
+      worktreeDirName = worktreeDirName.slice(0, maxDirNameLen).replace(/-+$/, "");
+    }
+  }
+  const worktreePath = path.join(worktreeParentDir, worktreeDirName);
   const configuredBaseRef = typeof rawStrategy.baseRef === "string" && rawStrategy.baseRef.length > 0
     ? rawStrategy.baseRef
     : input.base.repoRef ?? null;
@@ -1128,7 +1141,10 @@ export async function realizeExecutionWorkspace(input: {
         failureLabel: `git worktree add ${worktreePath}`,
       });
     } catch (attachError) {
-      if (!gitErrorIncludes(attachError, "already checked out")) {
+      // Branch is checked out in a different worktree (e.g. directory name
+      // changed between runs, or attach failed because the branch is already
+      // attached). Find and reuse that existing worktree.
+      if (!gitErrorIncludes(attachError, "already checked out") && !gitErrorIncludes(attachError, "already used by worktree")) {
         throw attachError;
       }
       const reusablePath = await findRegisteredGitWorktreeByBranch(repoRoot, branchName);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that need an isolated workspace per task
> - The execution-workspace subsystem materialises that isolation via git worktrees rooted under each project workspace
> - Two failure modes block worktree creation in real installations: (a) when a branch is already checked out in a worktree at a different directory name, `git worktree add` returns `"already used by worktree"`; (b) on Windows, deeply nested project workspace paths push the worktree path past MAX_PATH (260), causing `fatal: $GIT_DIR too big`
> - Without this fix, agents can't recover from a worktree they themselves created earlier, and Windows users with long project paths can't get a worktree at all — both surface as opaque heartbeat failures
> - This pull request catches the `"already used by worktree"` error and reuses the existing registered worktree, and adds a Windows path-length guard that truncates the worktree directory name (with a hash suffix to preserve uniqueness) to keep total paths under 200 chars
> - The benefit is two real-world failure modes silently disappear: previously-aborted agents resume against the same worktree, and Windows installations stop hitting MAX_PATH

## What Changed

- `server/src/services/workspace-runtime.ts`: extend the existing `attachError` catch on `git worktree add` to also handle `"already used by worktree"`, then reuse the existing registered worktree via `findRegisteredGitWorktreeByBranch`
- `server/src/services/workspace-runtime.ts`: add `truncateWorktreeDirName(branchName, parentDirLenWithSeparator)` which, on Windows, caps the worktree directory name to fit under 200 chars and appends a 7-char SHA1 hash of the full branch name so two branches sharing a long common prefix still resolve to distinct directories
- `server/src/__tests__/workspace-runtime.test.ts`: 4 unit tests for `truncateWorktreeDirName` (passthrough, truncation, collision avoidance, length cap) plus an end-to-end regression test creating a mismatched-path worktree and verifying it's reused

## Verification

- `pnpm test:run server/src/__tests__/workspace-runtime.test.ts` — passes locally and in CI
- `pnpm typecheck` — passes
- Manual: with `worktreeParentDir` set to a 180-char path, `git worktree add` previously returned `fatal: $GIT_DIR too big`; with this PR the worktree dir is truncated and the path stays under 200 chars
- Manual: when the same branch is reused for a second issue, the worktree is now reused at its original directory path instead of failing

## Risks

- Low risk. The new error-catch path only fires on the specific `"already used by worktree"` git output and falls back to the existing reuse-by-branch helper that already powered other failure modes.
- The Windows truncation only fires on `process.platform === "win32"` AND when `branchName.length > maxDirNameLen`, so non-Windows and short-name branches are unaffected.
- The hash suffix changes the directory name format for very long branches on Windows. Worktrees provisioned before this PR will be re-resolved via `findRegisteredGitWorktreeByBranch` on next reuse, so the rename is invisible to callers.

## Model Used

Claude Opus 4.7 (1M context), extended thinking enabled, with full repo tooling (Read/Edit/Bash/Grep). Authored by an AI agent (paperclipai engineer) running on Anthropic's Claude API; all decisions reviewed via Greptile and human oversight before merge.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes OCT-443 / unblocks OCT-412 and OCT-314
