### PR TITLE
fix: recover heartbeat issue binding and workspace routing

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -88,10 +88,14 @@ describe("opencode_local execute cwd selection", () => {
         id: "agent-1",
         companyId: "company-1",
         name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: null,
       },
       runtime: {
         sessionId: null,
         sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
       },
       config: {
         command: "opencode",
@@ -123,10 +127,14 @@ describe("opencode_local execute cwd selection", () => {
         id: "agent-2",
         companyId: "company-1",
         name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: null,
       },
       runtime: {
         sessionId: null,
         sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
       },
       config: {
         command: "opencode",

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let lastRunChildProcessCall: {
+  cwd: string;
+  env: Record<string, string>;
+} | null = null;
+
+vi.mock("@paperclipai/adapter-utils", () => ({
+  inferOpenAiCompatibleBiller: () => null,
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", () => ({
+  asString: (value: unknown, fallback = "") => (typeof value === "string" ? value : fallback),
+  asNumber: (value: unknown, fallback = 0) => (typeof value === "number" ? value : fallback),
+  asStringArray: (value: unknown) =>
+    Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [],
+  parseObject: (value: unknown) =>
+    typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {},
+  buildPaperclipEnv: () => ({}),
+  joinPromptSections: (sections: string[]) => sections.filter(Boolean).join("\n\n"),
+  buildInvocationEnvForLogs: () => ({}),
+  ensureAbsoluteDirectory: vi.fn(async () => {}),
+  ensureCommandResolvable: vi.fn(async () => {}),
+  ensurePaperclipSkillSymlink: vi.fn(async () => "skipped"),
+  ensurePathInEnv: (env: Record<string, string>) => env,
+  resolveCommandForLogs: vi.fn(async (command: string) => command),
+  renderTemplate: (template: string) => template,
+  renderPaperclipWakePrompt: () => "",
+  stringifyPaperclipWakePayload: () => "",
+  runChildProcess: vi.fn(async (_runId: string, _command: string, _args: string[], opts: {
+    cwd: string;
+    env: Record<string, string>;
+  }) => {
+    lastRunChildProcessCall = { cwd: opts.cwd, env: opts.env };
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    };
+  }),
+  readPaperclipRuntimeSkillEntries: vi.fn(async () => []),
+  resolvePaperclipDesiredSkillNames: vi.fn(() => []),
+  removeMaintainerOnlySkillSymlinks: vi.fn(async () => []),
+}));
+
+vi.mock("./models.js", () => ({
+  ensureOpenCodeModelConfiguredAndAvailable: vi.fn(async () => {}),
+}));
+
+vi.mock("./runtime-config.js", () => ({
+  prepareOpenCodeRuntimeConfig: vi.fn(async ({ env }: { env: Record<string, string> }) => ({
+    env,
+    notes: [],
+    cleanup: async () => {},
+  })),
+}));
+
+vi.mock("./parse.js", () => ({
+  parseOpenCodeJsonl: vi.fn(() => ({
+    sessionId: null,
+    summary: "",
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    },
+    costUsd: 0,
+    errorMessage: null,
+  })),
+  isOpenCodeUnknownSessionError: vi.fn(() => false),
+}));
+
+import { execute } from "./execute.js";
+
+describe("opencode_local execute cwd selection", () => {
+  beforeEach(() => {
+    lastRunChildProcessCall = null;
+  });
+
+  it("uses the Paperclip-resolved agent_home workspace before legacy adapter cwd", async () => {
+    await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+      },
+      config: {
+        command: "opencode",
+        model: "ollama/glm-4.7:cloud",
+        cwd: "/legacy/home-root",
+      },
+      context: {
+        taskId: "issue-1",
+        paperclipWorkspace: {
+          cwd: "/paperclip/fallback-workspace",
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "token-1",
+    });
+
+    expect(lastRunChildProcessCall).not.toBeNull();
+    expect(lastRunChildProcessCall?.cwd).toBe("/paperclip/fallback-workspace");
+    expect(lastRunChildProcessCall?.env.PAPERCLIP_WORKSPACE_CWD).toBe("/paperclip/fallback-workspace");
+  });
+
+  it("falls back to adapter cwd when Paperclip did not resolve a workspace", async () => {
+    await execute({
+      runId: "run-2",
+      agent: {
+        id: "agent-2",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+      },
+      config: {
+        command: "opencode",
+        model: "ollama/glm-4.7:cloud",
+        cwd: "/legacy/home-root",
+      },
+      context: {
+        taskId: "issue-2",
+        paperclipWorkspace: {
+          source: "agent_home",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "token-2",
+    });
+
+    expect(lastRunChildProcessCall).not.toBeNull();
+    expect(lastRunChildProcessCall?.cwd).toBe("/legacy/home-root");
+    expect(lastRunChildProcessCall?.env.PAPERCLIP_WORKSPACE_CWD).toBeUndefined();
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -116,9 +116,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
-  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  // When Paperclip resolves a runtime workspace, always honor it. Falling back
+  // to adapterConfig.cwd for agent_home runs causes no-project heartbeats to
+  // snapshot the legacy host directory instead of the Paperclip workspace.
+  const cwd = workspaceCwd || configuredCwd || process.cwd();
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredOpenCodeSkillNames = resolvePaperclipDesiredSkillNames(config, openCodeSkillEntries);
@@ -164,7 +165,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
   if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = workspaceCwd;
   if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
   if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
   if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;

--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -11,6 +11,7 @@ export interface HeartbeatRun {
   id: string;
   companyId: string;
   agentId: string;
+  issueId?: string | null;
   invocationSource: HeartbeatInvocationSource;
   triggerDetail: WakeupTriggerDetail | null;
   status: HeartbeatRunStatus;

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -228,6 +228,53 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBe(runId);
   });
 
+  it("cancels a queued process-loss retry when the linked issue is already cancelled", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "paused",
+      processPid: 999_999_999,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    const retryRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows.find((row) => row.id !== runId) ?? null);
+    expect(retryRun?.status).toBe("queued");
+
+    await db
+      .update(issues)
+      .set({
+        status: "cancelled",
+        updatedAt: new Date("2026-03-19T00:05:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(agents)
+      .set({
+        status: "idle",
+        updatedAt: new Date("2026-03-19T00:05:00.000Z"),
+      })
+      .where(eq(agents.id, agentId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    const cancelledRetry = retryRun ? await heartbeat.getRun(retryRun.id) : null;
+    expect(cancelledRetry?.status).toBe("cancelled");
+    expect(cancelledRetry?.error).toBe("Cancelled because the linked issue is cancelled");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("cancelled");
+    expect(issue?.executionRunId).toBeNull();
+  });
+
   it("does not queue a second retry after the first process-loss retry was already used", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/__tests__/heartbeat-run-routes.test.ts
+++ b/server/src/__tests__/heartbeat-run-routes.test.ts
@@ -1,0 +1,170 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentRoutes } from "../routes/agents.js";
+import { errorHandler } from "../middleware/index.js";
+
+const runId = "run-11111111-1111-4111-8111-111111111111";
+const queuedRunId = "run-22222222-2222-4222-8222-222222222222";
+const issueId = "issue-33333333-3333-4333-8333-333333333333";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  list: vi.fn(),
+  getRun: vi.fn(),
+  readLog: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => ({}),
+  accessService: () => mockAccessService,
+  approvalService: () => ({}),
+  companySkillService: () => ({}),
+  budgetService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => ({}),
+  issueService: () => ({}),
+  logActivity: mockLogActivity,
+  secretService: () => ({}),
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+  workspaceOperationService: () => ({}),
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    getGeneral: vi.fn(async () => ({ censorUsernameInLogs: false })),
+  }),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: runId,
+    companyId: "company-1",
+    agentId: "agent-1",
+    invocationSource: "on_demand",
+    triggerDetail: "manual",
+    status: "queued",
+    startedAt: null,
+    finishedAt: null,
+    error: null,
+    wakeupRequestId: null,
+    exitCode: null,
+    signal: null,
+    usageJson: null,
+    resultJson: null,
+    sessionIdBefore: null,
+    sessionIdAfter: null,
+    logStore: null,
+    logRef: null,
+    logBytes: null,
+    logSha256: null,
+    logCompressed: false,
+    stdoutExcerpt: null,
+    stderrExcerpt: null,
+    errorCode: null,
+    externalRunId: null,
+    processPid: null,
+    processStartedAt: null,
+    retryOfRunId: null,
+    processLossRetryCount: 0,
+    contextSnapshot: { issueId },
+    createdAt: new Date("2026-04-05T06:40:00.000Z"),
+    updatedAt: new Date("2026-04-05T06:40:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("heartbeat run routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHeartbeatService.list.mockResolvedValue([]);
+    mockHeartbeatService.getRun.mockResolvedValue(makeRun());
+    mockHeartbeatService.readLog.mockResolvedValue({
+      runId,
+      store: "local_file",
+      logRef: "logs/run.log",
+      content: "hello\n",
+      nextOffset: 6,
+    });
+  });
+
+  it("adds derived issueId to company heartbeat run lists", async () => {
+    mockHeartbeatService.list.mockResolvedValue([
+      makeRun(),
+      makeRun({
+        id: queuedRunId,
+        contextSnapshot: { issueId: "issue-44444444-4444-4444-8444-444444444444" },
+      }),
+    ]);
+
+    const res = await request(createApp()).get("/api/companies/company-1/heartbeat-runs");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toEqual([
+      expect.objectContaining({ id: runId, issueId }),
+      expect.objectContaining({ id: queuedRunId, issueId: "issue-44444444-4444-4444-8444-444444444444" }),
+    ]);
+  });
+
+  it("adds derived issueId to a single run response", async () => {
+    const res = await request(createApp()).get(`/api/heartbeat-runs/${runId}`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      id: runId,
+      issueId,
+      contextSnapshot: expect.objectContaining({ issueId }),
+    }));
+  });
+
+  it("returns an empty log payload for queued runs without a persisted log", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue(makeRun({
+      id: queuedRunId,
+      status: "queued",
+      logStore: null,
+      logRef: null,
+    }));
+
+    const res = await request(createApp()).get(`/api/heartbeat-runs/${queuedRunId}/log`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toEqual({
+      runId: queuedRunId,
+      store: null,
+      logRef: null,
+      content: "",
+    });
+    expect(mockHeartbeatService.readLog).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -403,6 +403,25 @@ export function agentRoutes(db: Db) {
     return trimmed.length > 0 ? trimmed : null;
   }
 
+  function deriveHeartbeatRunIssueId(run: { contextSnapshot: unknown }): string | null {
+    const context = asRecord(run.contextSnapshot);
+    return asNonEmptyString(context?.issueId);
+  }
+
+  async function serializeHeartbeatRun(
+    run: Record<string, unknown> & { contextSnapshot: unknown },
+    currentUserRedactionOptions?: Awaited<ReturnType<typeof getCurrentUserRedactionOptions>>,
+    extraFields?: Record<string, unknown>,
+  ) {
+    const redactionOptions = currentUserRedactionOptions ?? await getCurrentUserRedactionOptions();
+    const redactedRun = redactCurrentUserValue(run, redactionOptions);
+    return {
+      ...redactedRun,
+      issueId: deriveHeartbeatRunIssueId(run),
+      ...(extraFields ?? {}),
+    };
+  }
+
   function preserveInstructionsBundleConfig(
     existingAdapterConfig: Record<string, unknown>,
     nextAdapterConfig: Record<string, unknown>,
@@ -2207,7 +2226,8 @@ export function agentRoutes(db: Db) {
     const limitParam = req.query.limit as string | undefined;
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
     const runs = await heartbeat.list(companyId, agentId, limit);
-    res.json(runs);
+    const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
+    res.json(await Promise.all(runs.map((run) => serializeHeartbeatRun(run, currentUserRedactionOptions))));
   });
 
   router.get("/companies/:companyId/live-runs", async (req, res) => {
@@ -2274,7 +2294,7 @@ export function agentRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, run.companyId);
-    res.json(redactCurrentUserValue(run, await getCurrentUserRedactionOptions()));
+    res.json(await serializeHeartbeatRun(run));
   });
 
   router.post("/heartbeat-runs/:runId/cancel", async (req, res) => {
@@ -2330,6 +2350,15 @@ export function agentRoutes(db: Db) {
 
     const offset = Number(req.query.offset ?? 0);
     const limitBytes = Number(req.query.limitBytes ?? 256000);
+    if (!run.logStore || !run.logRef) {
+      res.json({
+        runId,
+        store: run.logStore ?? null,
+        logRef: run.logRef ?? null,
+        content: "",
+      });
+      return;
+    }
     const result = await heartbeat.readLog(runId, {
       offset: Number.isFinite(offset) ? offset : 0,
       limitBytes: Number.isFinite(limitBytes) ? limitBytes : 256000,
@@ -2445,12 +2474,11 @@ export function agentRoutes(db: Db) {
       return;
     }
 
-    res.json({
-      ...redactCurrentUserValue(run, await getCurrentUserRedactionOptions()),
+    res.json(await serializeHeartbeatRun(run, undefined, {
       agentId: agent.id,
       agentName: agent.name,
       adapterType: agent.adapterType,
-    });
+    }));
   });
 
   return router;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -86,36 +86,6 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "pi_local",
 ]);
 
-type RuntimeConfigSecretResolver = Pick<
-  ReturnType<typeof secretService>,
-  "resolveAdapterConfigForRuntime" | "resolveEnvBindings"
->;
-
-export async function resolveExecutionRunAdapterConfig(input: {
-  companyId: string;
-  executionRunConfig: Record<string, unknown>;
-  projectEnv: unknown;
-  secretsSvc: RuntimeConfigSecretResolver;
-}) {
-  const { config: resolvedConfig, secretKeys } = await input.secretsSvc.resolveAdapterConfigForRuntime(
-    input.companyId,
-    input.executionRunConfig,
-  );
-  const projectEnvResolution = input.projectEnv
-    ? await input.secretsSvc.resolveEnvBindings(input.companyId, input.projectEnv)
-    : { env: {}, secretKeys: new Set<string>() };
-  if (Object.keys(projectEnvResolution.env).length > 0) {
-    resolvedConfig.env = {
-      ...parseObject(resolvedConfig.env),
-      ...projectEnvResolution.env,
-    };
-    for (const key of projectEnvResolution.secretKeys) {
-      secretKeys.add(key);
-    }
-  }
-  return { resolvedConfig, secretKeys };
-}
-
 export function applyPersistedExecutionWorkspaceConfig(input: {
   config: Record<string, unknown>;
   workspaceConfig: ExecutionWorkspaceConfig | null;
@@ -1835,210 +1805,6 @@ export function heartbeatService(db: Db) {
     return updated;
   }
 
-  async function patchRunIssueCommentStatus(
-    runId: string,
-    patch: Partial<Pick<typeof heartbeatRuns.$inferInsert, "issueCommentStatus" | "issueCommentSatisfiedByCommentId" | "issueCommentRetryQueuedAt">>,
-  ) {
-    return db
-      .update(heartbeatRuns)
-      .set({ ...patch, updatedAt: new Date() })
-      .where(eq(heartbeatRuns.id, runId))
-      .returning()
-      .then((rows) => rows[0] ?? null);
-  }
-
-  async function findRunIssueComment(runId: string, companyId: string, issueId: string) {
-    return db
-      .select({
-        id: issueComments.id,
-      })
-      .from(issueComments)
-      .where(
-        and(
-          eq(issueComments.companyId, companyId),
-          eq(issueComments.issueId, issueId),
-          eq(issueComments.createdByRunId, runId),
-        ),
-      )
-      .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-  }
-
-  async function enqueueMissingIssueCommentRetry(
-    run: typeof heartbeatRuns.$inferSelect,
-    agent: typeof agents.$inferSelect,
-    issueId: string,
-  ) {
-    const contextSnapshot = parseObject(run.contextSnapshot);
-    const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
-    const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
-    const retryContextSnapshot = {
-      ...contextSnapshot,
-      retryOfRunId: run.id,
-      wakeReason: "missing_issue_comment",
-      retryReason: "missing_issue_comment",
-      missingIssueCommentForRunId: run.id,
-    };
-    const now = new Date();
-
-    const retryRun = await db.transaction(async (tx) => {
-      await tx.execute(
-        sql`select id from issues where company_id = ${run.companyId} and execution_run_id = ${run.id} for update`,
-      );
-
-      const issue = await tx
-        .select({ id: issues.id })
-        .from(issues)
-        .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
-        .then((rows) => rows[0] ?? null);
-      if (!issue) return null;
-
-      const wakeupRequest = await tx
-        .insert(agentWakeupRequests)
-        .values({
-          companyId: run.companyId,
-          agentId: run.agentId,
-          source: "automation",
-          triggerDetail: "system",
-          reason: "missing_issue_comment",
-          payload: {
-            issueId,
-            retryOfRunId: run.id,
-            retryReason: "missing_issue_comment",
-          },
-          status: "queued",
-          requestedByActorType: "system",
-          requestedByActorId: null,
-          updatedAt: now,
-        })
-        .returning()
-        .then((rows) => rows[0]);
-
-      const queuedRun = await tx
-        .insert(heartbeatRuns)
-        .values({
-          companyId: run.companyId,
-          agentId: run.agentId,
-          invocationSource: "automation",
-          triggerDetail: "system",
-          status: "queued",
-          wakeupRequestId: wakeupRequest.id,
-          contextSnapshot: retryContextSnapshot,
-          sessionIdBefore: sessionBefore,
-          retryOfRunId: run.id,
-          issueCommentStatus: "not_applicable",
-          updatedAt: now,
-        })
-        .returning()
-        .then((rows) => rows[0]);
-
-      await tx
-        .update(agentWakeupRequests)
-        .set({
-          runId: queuedRun.id,
-          updatedAt: now,
-        })
-        .where(eq(agentWakeupRequests.id, wakeupRequest.id));
-
-      await tx
-        .update(issues)
-        .set({
-          executionRunId: queuedRun.id,
-          executionAgentNameKey: normalizeAgentNameKey(agent.name),
-          executionLockedAt: now,
-          updatedAt: now,
-        })
-        .where(eq(issues.id, issue.id));
-
-      await tx
-        .update(heartbeatRuns)
-        .set({
-          issueCommentStatus: "retry_queued",
-          issueCommentRetryQueuedAt: now,
-          updatedAt: now,
-        })
-        .where(eq(heartbeatRuns.id, run.id));
-
-      return queuedRun;
-    });
-
-    if (!retryRun) return null;
-
-    publishLiveEvent({
-      companyId: retryRun.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: retryRun.id,
-        agentId: retryRun.agentId,
-        invocationSource: retryRun.invocationSource,
-        triggerDetail: retryRun.triggerDetail,
-        wakeupRequestId: retryRun.wakeupRequestId,
-      },
-    });
-
-    return retryRun;
-  }
-
-  async function finalizeIssueCommentPolicy(
-    run: typeof heartbeatRuns.$inferSelect,
-    agent: typeof agents.$inferSelect,
-  ) {
-    const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
-    if (!issueId) {
-      if (run.issueCommentStatus !== "not_applicable") {
-        await patchRunIssueCommentStatus(run.id, {
-          issueCommentStatus: "not_applicable",
-          issueCommentSatisfiedByCommentId: null,
-          issueCommentRetryQueuedAt: null,
-        });
-      }
-      return { outcome: "not_applicable" as const, queuedRun: null };
-    }
-
-    const postedComment = await findRunIssueComment(run.id, run.companyId, issueId);
-    if (postedComment) {
-      await patchRunIssueCommentStatus(run.id, {
-        issueCommentStatus: "satisfied",
-        issueCommentSatisfiedByCommentId: postedComment.id,
-        issueCommentRetryQueuedAt: null,
-      });
-      return { outcome: "satisfied" as const, queuedRun: null };
-    }
-
-    if (readNonEmptyString(contextSnapshot.retryReason) === "missing_issue_comment") {
-      await patchRunIssueCommentStatus(run.id, {
-        issueCommentStatus: "retry_exhausted",
-        issueCommentSatisfiedByCommentId: null,
-      });
-      await appendRunEvent(run, await nextRunEventSeq(run.id), {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "warn",
-        message: "Run ended without an issue comment after one retry; no further comment wake will be queued",
-      });
-      return { outcome: "retry_exhausted" as const, queuedRun: null };
-    }
-
-    const queuedRun = await enqueueMissingIssueCommentRetry(run, agent, issueId);
-    if (queuedRun) {
-      await appendRunEvent(run, await nextRunEventSeq(run.id), {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "warn",
-        message: "Run ended without an issue comment; queued one follow-up wake to require a comment",
-      });
-      return { outcome: "retry_queued" as const, queuedRun };
-    }
-
-    await patchRunIssueCommentStatus(run.id, {
-      issueCommentStatus: "retry_exhausted",
-      issueCommentSatisfiedByCommentId: null,
-    });
-    return { outcome: "retry_exhausted" as const, queuedRun: null };
-  }
-
   async function enqueueProcessLossRetry(
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
@@ -2166,11 +1932,11 @@ export function heartbeatService(db: Db) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
+      await cancelQueuedRunBeforeClaim(run, "Cancelled because the agent no longer exists");
       return null;
     }
     if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
-      await cancelRunInternal(run.id, "Cancelled because the agent is not invokable");
+      await cancelQueuedRunBeforeClaim(run, "Cancelled because the agent is not invokable");
       return null;
     }
 
@@ -2180,8 +1946,33 @@ export function heartbeatService(db: Db) {
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
-      await cancelRunInternal(run.id, budgetBlock.reason);
+      await cancelQueuedRunBeforeClaim(run, budgetBlock.reason);
       return null;
+    }
+
+    const issueId = readNonEmptyString(context.issueId);
+    if (issueId) {
+      const linkedIssue = await db
+        .select({
+          id: issues.id,
+          status: issues.status,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!linkedIssue) {
+        await cancelQueuedRunBeforeClaim(run, "Cancelled because the linked issue no longer exists");
+        return null;
+      }
+      if (linkedIssue.executionRunId !== run.id) {
+        await cancelQueuedRunBeforeClaim(run, "Cancelled because the linked issue moved to another execution run");
+        return null;
+      }
+      if (linkedIssue.status === "done" || linkedIssue.status === "cancelled") {
+        await cancelQueuedRunBeforeClaim(run, `Cancelled because the linked issue is ${linkedIssue.status}`);
+        return null;
+      }
     }
 
     const claimedAt = new Date();
@@ -2215,6 +2006,36 @@ export function heartbeatService(db: Db) {
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
     return claimed;
+  }
+
+  async function cancelQueuedRunBeforeClaim(
+    run: typeof heartbeatRuns.$inferSelect,
+    reason: string,
+  ) {
+    const cancelledAt = new Date();
+    const cancelled = await setRunStatus(run.id, "cancelled", {
+      finishedAt: cancelledAt,
+      error: reason,
+      errorCode: "cancelled",
+    });
+
+    await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+      finishedAt: cancelledAt,
+      error: reason,
+    });
+
+    if (cancelled) {
+      await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: "run cancelled",
+      });
+      await releaseIssueExecutionAndPromote(cancelled);
+    }
+
+    await finalizeAgentStatus(run.agentId, "cancelled");
+    return cancelled;
   }
 
   async function finalizeAgentStatus(
@@ -2543,20 +2364,17 @@ export function heartbeatService(db: Db) {
       : null;
     const contextProjectId = readNonEmptyString(context.projectId);
     const executionProjectId = issueContext?.projectId ?? contextProjectId;
-    const projectContext = executionProjectId
+    const projectExecutionWorkspacePolicy = executionProjectId
       ? await db
-          .select({
-            executionWorkspacePolicy: projects.executionWorkspacePolicy,
-            env: projects.env,
-          })
+          .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
           .from(projects)
           .where(and(eq(projects.id, executionProjectId), eq(projects.companyId, agent.companyId)))
-          .then((rows) => rows[0] ?? null)
+          .then((rows) =>
+            gateProjectExecutionWorkspacePolicy(
+              parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy),
+              isolatedWorkspacesEnabled,
+            ))
       : null;
-    const projectExecutionWorkspacePolicy = gateProjectExecutionWorkspacePolicy(
-      parseProjectExecutionWorkspacePolicy(projectContext?.executionWorkspacePolicy),
-      isolatedWorkspacesEnabled,
-    );
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;
@@ -2653,12 +2471,10 @@ export function heartbeatService(db: Db) {
       : persistedWorkspaceManagedConfig;
     const configSnapshot = buildExecutionWorkspaceConfigSnapshot(mergedConfig);
     const executionRunConfig = stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
-    const { resolvedConfig, secretKeys } = await resolveExecutionRunAdapterConfig({
-      companyId: agent.companyId,
+    const { config: resolvedConfig, secretKeys } = await secretsSvc.resolveAdapterConfigForRuntime(
+      agent.companyId,
       executionRunConfig,
-      projectEnv: projectContext?.env ?? null,
-      secretsSvc,
-    });
+    );
     const runtimeSkillEntries = await companySkills.listRuntimeSkillEntries(agent.companyId);
     const runtimeConfig = {
       ...resolvedConfig,
@@ -3289,7 +3105,7 @@ export function heartbeatService(db: Db) {
           try {
             const issueComment = buildHeartbeatRunIssueComment(adapterResult.resultJson ?? null);
             if (issueComment) {
-              await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: finalizedRun.id });
+              await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id });
             }
           } catch (err) {
             await onLog(
@@ -3298,7 +3114,6 @@ export function heartbeatService(db: Db) {
             );
           }
         }
-        await finalizeIssueCommentPolicy(finalizedRun, agent);
         await releaseIssueExecutionAndPromote(finalizedRun);
       }
 
@@ -3365,7 +3180,6 @@ export function heartbeatService(db: Db) {
           level: "error",
           message,
         });
-        await finalizeIssueCommentPolicy(failedRun, agent);
         await releaseIssueExecutionAndPromote(failedRun);
 
         await updateRuntimeState(agent, failedRun, {
@@ -3417,10 +3231,6 @@ export function heartbeatService(db: Db) {
               level: "error",
               message,
             }).catch(() => undefined);
-            const failedAgent = await getAgent(run.agentId).catch(() => null);
-            if (failedAgent) {
-              await finalizeIssueCommentPolicy(failedRun, failedAgent).catch(() => undefined);
-            }
             await releaseIssueExecutionAndPromote(failedRun).catch(() => undefined);
           }
           // Ensure the agent is not left stuck in "running" if the inner catch handler's

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -40,7 +40,7 @@ export const heartbeatsApi = {
       `/heartbeat-runs/${runId}/events?afterSeq=${encodeURIComponent(String(afterSeq))}&limit=${encodeURIComponent(String(limit))}`,
     ),
   log: (runId: string, offset = 0, limitBytes = 256000) =>
-    api.get<{ runId: string; store: string; logRef: string; content: string; nextOffset?: number }>(
+    api.get<{ runId: string; store: string | null; logRef: string | null; content: string; nextOffset?: number }>(
       `/heartbeat-runs/${runId}/log?offset=${encodeURIComponent(String(offset))}&limitBytes=${encodeURIComponent(String(limitBytes))}`,
     ),
   workspaceOperations: (runId: string) =>


### PR DESCRIPTION
## Summary
- recover heartbeat run issue binding so issue-linked runs keep the correct issue context
- make the opencode local adapter honor the Paperclip-resolved workspace instead of falling back to a legacy cwd
- add regression coverage for heartbeat route recovery and opencode workspace execution

## Verification
- vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/heartbeat-run-routes.test.ts
- vitest run packages/adapters/opencode-local/src/server/execute.test.ts