### PR TITLE
fix(security): redact password fields from request body logging

### DIFF
--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -4,6 +4,22 @@ import { HttpError } from "../errors.js";
 import { trackErrorHandlerCrash } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 
+const SENSITIVE_BODY_FIELDS = new Set([
+  "password",
+  "currentPassword",
+  "newPassword",
+  "confirmPassword",
+]);
+
+function sanitizeBody(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    result[key] = SENSITIVE_BODY_FIELDS.has(key) ? "[REDACTED]" : value;
+  }
+  return result;
+}
+
 export interface ErrorContext {
   error: { message: string; stack?: string; name?: string; details?: unknown; raw?: unknown };
   method: string;
@@ -23,7 +39,7 @@ function attachErrorContext(
     error: payload,
     method: req.method,
     url: req.originalUrl,
-    reqBody: req.body,
+    reqBody: sanitizeBody(req.body),
     reqParams: req.params,
     reqQuery: req.query,
   } satisfies ErrorContext;

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -28,7 +28,13 @@ const sharedOpts = {
 
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: [
+    "req.headers.authorization",
+    "reqBody.password",
+    "reqBody.currentPassword",
+    "reqBody.newPassword",
+    "reqBody.confirmPassword",
+  ],
 }, pino.transport({
   targets: [
     {

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -44,6 +44,22 @@ export const logger = pino({
   ],
 }));
 
+const SENSITIVE_BODY_FIELDS = new Set([
+  "password",
+  "currentPassword",
+  "newPassword",
+  "confirmPassword",
+]);
+
+function sanitizeBody(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    result[key] = SENSITIVE_BODY_FIELDS.has(key) ? "[REDACTED]" : value;
+  }
+  return result;
+}
+
 export const httpLogger = pinoHttp({
   logger,
   customLogLevel(_req, res, err) {
@@ -65,7 +81,7 @@ export const httpLogger = pinoHttp({
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: ctx.reqBody,
+          reqBody: sanitizeBody(ctx.reqBody),
           reqParams: ctx.reqParams,
           reqQuery: ctx.reqQuery,
         };
@@ -73,7 +89,7 @@ export const httpLogger = pinoHttp({
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = sanitizeBody(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
         props.reqParams = params;


### PR DESCRIPTION
## Summary

**Security fix** — Prevents plaintext passwords from being written to `server.log` on failed sign-in (and other 4xx) requests.

- Adds a `sanitizeBody()` helper that replaces `password`, `currentPassword`, `newPassword`, and `confirmPassword` with `[REDACTED]` before attaching `req.body` to pino log records
- Adds pino-level `redact` paths for `reqBody.password`, `reqBody.currentPassword`, `reqBody.newPassword`, `reqBody.confirmPassword` as a defence-in-depth layer
- Updates the error-handler middleware to capture a sanitized snapshot of the request body for structured error context

Resolves the vulnerability described in #3072.

## Test plan

- [ ] Deploy to a staging instance and trigger a failed login — verify `server.log` shows `[REDACTED]` instead of the actual password
- [ ] Verify valid logins still work and do not regress
- [ ] Confirm no other request body fields are inadvertently stripped

Co-Authored-By: Paperclip <noreply@paperclip.ing>