### PR TITLE
feat(openclaw-gateway): derive claimed api key path per agent

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import { resolveClaimedApiKeyPath, resolveSessionKey } from "./execute.js";
+
+describe("resolveClaimedApiKeyPath", () => {
+  it("uses an explicit claimed API key path when configured", () => {
+    expect(resolveClaimedApiKeyPath("~/custom/paperclip-claimed-api-key.json", "meridian")).toBe(
+      "~/custom/paperclip-claimed-api-key.json",
+    );
+  });
+
+  it("derives a per-agent workspace path when agentId is configured", () => {
+    expect(resolveClaimedApiKeyPath(null, "meridian")).toBe(
+      "~/.openclaw/workspace-meridian/paperclip-claimed-api-key.json",
+    );
+  });
+
+  it("falls back to the default workspace path for main", () => {
+    expect(resolveClaimedApiKeyPath(null, "main")).toBe("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
+});
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -332,8 +332,16 @@ function resolvePaperclipApiUrlOverride(value: unknown): string | null {
 
 const DEFAULT_CLAIMED_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
 
-function resolveClaimedApiKeyPath(value: unknown): string {
-  return nonEmpty(value) ?? DEFAULT_CLAIMED_API_KEY_PATH;
+export function resolveClaimedApiKeyPath(value: unknown, agentId: unknown): string {
+  const configuredPath = nonEmpty(value);
+  if (configuredPath) return configuredPath;
+
+  const configuredAgentId = nonEmpty(agentId);
+  if (configuredAgentId && configuredAgentId !== "main") {
+    return `~/.openclaw/workspace-${configuredAgentId}/paperclip-claimed-api-key.json`;
+  }
+
+  return DEFAULT_CLAIMED_API_KEY_PATH;
 }
 
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
@@ -362,8 +370,8 @@ function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
+  claimedApiKeyPath: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1109,6 +1117,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
+    resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath, ctx.config.agentId),
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);


### PR DESCRIPTION
## Summary
- derive the claimed API key path from `agentId` when no explicit `claimedApiKeyPath` is configured
- keep the existing main workspace path as the backward-compatible fallback
- add focused tests for explicit path, per-agent path, and main fallback behavior

## Why
Multi-agent OpenClaw deployments often store each agent's claimed API key in its own workspace directory. This keeps the default behavior unchanged while allowing adapters to resolve the correct per-agent path automatically.

## Testing
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- `pnpm exec vitest run --config /tmp/paperclip-upstream-pr/vitest.openclaw-gateway.temp.mts`
