### PR TITLE
feat(web): add issue ID sort option to dashboard

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -43,7 +43,7 @@ export type IssueViewState = {
   assignees: string[];
   labels: string[];
   projects: string[];
-  sortField: "status" | "priority" | "title" | "created" | "updated";
+  sortField: "id" | "status" | "priority" | "title" | "created" | "updated";
   sortDir: "asc" | "desc";
   groupBy: "status" | "priority" | "assignee" | "none";
   viewMode: "list" | "board";
@@ -118,6 +118,15 @@ function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
   const dir = state.sortDir === "asc" ? 1 : -1;
   sorted.sort((a, b) => {
     switch (state.sortField) {
+      case "id": {
+        const numFromId = (val: string | null | undefined) => {
+          if (!val) return Number.POSITIVE_INFINITY;
+          const idx = val.lastIndexOf("-");
+          const n = Number(idx >= 0 ? val.slice(idx + 1) : val);
+          return Number.isFinite(n) ? n : Number.POSITIVE_INFINITY;
+        };
+        return dir * (numFromId(a.identifier) - numFromId(b.identifier));
+      }
       case "status":
         return dir * (statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status));
       case "priority":
@@ -558,6 +567,7 @@ export function IssuesList({
               <PopoverContent align="end" className="w-48 p-0">
                 <div className="p-2 space-y-0.5">
                   {([
+                    ["id", "ID"],
                     ["status", "Status"],
                     ["priority", "Priority"],
                     ["title", "Title"],


### PR DESCRIPTION
## Thinking Path

> The issues list supports sorting by status, priority, title, created, and updated
> But there is no option to sort by issue ID (e.g. ANY-826)
> Issue IDs encode creation sequence as {PREFIX}-{number}
> Sorting by ID gives operators a stable chronological sort they intuitively expect
> This is a client-side-only change to the sort dropdown and comparator in IssuesList.tsx

## Problem

The issues list sort dropdown does not include an option to sort by issue ID. Operators managing large backlogs often want to see issues in creation order by ID number, which is not possible with the current sort options (status, priority, title, created, updated).

## Solution

Added "ID" as a sort option in `IssuesList.tsx`. The comparator extracts the numeric suffix from `issue.identifier` (everything after the last `-`) and sorts numerically rather than lexicographically, so `ANY-10` correctly sorts after `ANY-9`. Supports both ascending and descending sort direction.

## Changes

- `ui/src/components/IssuesList.tsx` — Added `"id"` to the `sortField` union type, added `["id", "ID"]` as the first entry in the sort dropdown options, and added a numeric sort comparator case that parses the identifier suffix

## Model Used

Claude Code (claude-opus-4-6)

## Risks

- Low risk. Client-side only, additive change. No server-side modifications, no new dependencies, no schema changes.
- Falls back gracefully: if an identifier does not contain `-`, `parseInt` returns `NaN` and the sort treats them as equal.

## Testing

- `npx tsc --noEmit` in `ui/` — clean, no errors
- Manually verified sort dropdown shows "ID" option and issues sort correctly by numeric identifier in both ascending and descending order

## Checklist

- [x] `pnpm typecheck` passes
- [x] No new dependencies added
- [x] Changes are backward compatible