### PR TITLE
fix(gemini-local): handle stale session resume and dash-prefixed prompt parsing

### DIFF
--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -4,6 +4,9 @@ export const DEFAULT_GEMINI_LOCAL_MODEL = "auto";
 
 export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (Preview)" },
+  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash (Preview)" },
+  { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite (Preview)" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -339,7 +339,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--sandbox=none");
     }
     if (extraArgs.length > 0) args.push(...extraArgs);
-    args.push("--prompt", prompt);
+    args.push(`--prompt=${prompt}`);
     return args;
   };
 
@@ -351,9 +351,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         command: resolvedCommand,
         cwd,
         commandNotes,
-        commandArgs: args.map((value, index) => (
-          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
-        )),
+        commandArgs: args.map((value) =>
+          value.startsWith("--prompt=") ? `--prompt=<${prompt.length} chars>` : value
+        ),
         env: loggedEnv,
         prompt,
         promptMetrics,

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -185,7 +185,7 @@ export function isGeminiUnknownSessionError(stdout: string, stderr: string): boo
     .filter(Boolean)
     .join("\n");
 
-  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume/i.test(
+  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|error\s+resuming\s+session|invalid\s+session\s+identifier/i.test(
     haystack,
   );
 }

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -142,7 +142,7 @@ export async function testEnvironment(
         return asStringArray(config.args);
       })();
 
-      const args = ["--output-format", "stream-json", "--prompt", "Respond with hello."];
+      const args = ["--output-format", "stream-json", "--prompt=Respond with hello."];
       if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
       if (approvalMode !== "default") args.push("--approval-mode", approvalMode);
       if (sandbox) {

--- a/worklog.md
+++ b/worklog.md
@@ -1,0 +1,9 @@
+# Worklog
+
+## [2026-04-08] Initial Session Setup
+- Purpose: Initialize session and check project environment.
+- Status: In Progress
+- Tasks:
+    - [x] Create worklog.md
+    - [x] Search for CLAUDE.md
+    - [ ] Await user instructions


### PR DESCRIPTION
## Summary
- Detect `"Invalid session identifier"` / `"Error resuming session"` errors in `isGeminiUnknownSessionError` so the retry-with-fresh-session fallback triggers instead of surfacing the error to the user
- Use `--prompt=<value>` format instead of `--prompt <value>` to prevent yargs from misinterpreting dash-prefixed prompts (e.g. instructions starting with YAML frontmatter `---`) as flags, which caused `"Not enough arguments following: prompt"`
- Add Gemini 3.x preview models to the model list

## Test plan
- [x] Verified `isGeminiUnknownSessionError` matches the new error patterns
- [x] Verified `--prompt=<value>` format works with `---`-prefixed prompts via `spawn` against Gemini CLI 0.36.0
- [ ] Run existing adapter tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)