### PR TITLE
fix(heartbeat+adapters): propagate session prompt from plugin sendMessage to adapter stdin

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -412,10 +412,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const sessionPrompt = asString(context.sessionPrompt, "").trim();
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    sessionPrompt,
     renderedPrompt,
   ]);
   const promptMetrics = {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -483,11 +483,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   })();
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const sessionPrompt = asString(context.sessionPrompt, "").trim();
   const prompt = joinPromptSections([
     promptInstructionsPrefix,
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    sessionPrompt,
     renderedPrompt,
   ]);
   const promptMetrics = {

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -366,12 +366,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const sessionPrompt = asString(context.sessionPrompt, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    sessionPrompt,
     paperclipEnvNote,
     renderedPrompt,
   ]);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -307,6 +307,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const sessionPrompt = asString(context.sessionPrompt, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const apiAccessNote = renderApiAccessNote(env);
   const prompt = joinPromptSections([
@@ -314,6 +315,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    sessionPrompt,
     paperclipEnvNote,
     apiAccessNote,
     renderedPrompt,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -282,11 +282,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
     const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
     const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+    const sessionPrompt = asString(context.sessionPrompt, "").trim();
     const prompt = joinPromptSections([
       instructionsPrefix,
       renderedBootstrapPrompt,
       wakePrompt,
       sessionHandoffNote,
+      sessionPrompt,
       renderedPrompt,
     ]);
     const promptMetrics = {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -310,10 +310,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const shouldUseResumeDeltaPrompt = canResumeSession && wakePrompt.length > 0;
   const renderedHeartbeatPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const sessionPrompt = asString(context.sessionPrompt, "").trim();
   const userPrompt = joinPromptSections([
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    sessionPrompt,
     renderedHeartbeatPrompt,
   ]);
   const promptMetrics = {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -791,6 +791,13 @@ function enrichWakeContextSnapshot(input: {
   if (!readNonEmptyString(contextSnapshot["wakeTriggerDetail"]) && triggerDetail) {
     contextSnapshot.wakeTriggerDetail = triggerDetail;
   }
+  // Propagate session prompt from payload so adapters can include it in
+  // the agent's stdin.  Without this, plugins that call
+  // agents.sessions.sendMessage({ prompt }) lose the message content.
+  const sessionPrompt = readNonEmptyString(payload?.["prompt"]);
+  if (sessionPrompt && !readNonEmptyString(contextSnapshot["sessionPrompt"])) {
+    contextSnapshot.sessionPrompt = sessionPrompt;
+  }
 
   return {
     contextSnapshot,


### PR DESCRIPTION
## Thinking Path

Investigating why the Telegram plugin's `/acp spawn` + `agents.sessions.sendMessage({ prompt })` never delivered the user's message to the agent. Traced through:

1. `plugin-host-services.ts` → `sendMessage` passes `payload: { prompt }` to `heartbeat.wakeup()`
2. `heartbeat.ts` → `enrichWakeContextSnapshot` stores wake metadata but discards `payload.prompt`
3. `buildPaperclipWakePayload` returns `null` (no issue/comments) → `paperclipWake` is deleted from context
4. Adapter receives empty context → agent runs default heartbeat → "inbox empty, exiting"

The `prompt` field sent by plugins via `agents.sessions.sendMessage()` is simply never propagated to the adapter stdin.

## What Changed

- **`server/src/services/heartbeat.ts`**: `enrichWakeContextSnapshot` now copies `payload.prompt` into `contextSnapshot.sessionPrompt` so it survives through to the adapter execution context.
- **All 6 local adapters** (`claude-local`, `opencode-local`, `codex-local`, `cursor-local`, `gemini-local`, `pi-local`): Read `context.sessionPrompt` and include it in `joinPromptSections()` so the text reaches the agent's stdin.

## Verification

Deployed to a self-hosted Paperclip instance with `paperclip-plugin-telegram` installed:

1. `/acp spawn Iris` in a Telegram forum thread → session created (native transport)
2. Sent "Oi, quem é você?" → message routed to agent session
3. **Before fix**: Agent responded "No tasks assigned and no wake payload... inbox empty — exiting cleanly"
4. **After fix**: Agent responded "Oi, Zeyck! Sou a Iris, CEO da KZLA Corp..." with full contextual response

Also relevant for `paperclip-plugin-chat` (webprismdevin) and any plugin using `agents.sessions.sendMessage({ prompt })`.

## Risks

- `sessionPrompt` is only set when `payload.prompt` is a non-empty string — no change for existing heartbeat/timer/comment-wake flows
- Placed after `sessionHandoffNote` and before `renderedPrompt` in all adapters — does not interfere with existing prompt ordering
- If `sessionPrompt` is empty string, `joinPromptSections` skips it (existing behavior)

## Model Used

Claude Opus 4.6 (1M context) — Claude Code CLI

## Checklist

- [x] Behavior matches intended plugin SDK contract (`sendMessage({ prompt })` should deliver prompt to agent)
- [x] `pnpm build` passes
- [x] Contracts synced across server + all 6 adapters
- [x] No changes to DB schema, shared types, or UI
- [x] Minimal diff — 7 lines in heartbeat.ts, 2 lines per adapter

Closes #49 (partial — enables plugin-based chat with agents)
Related: #1583, #799, #472