### PR TITLE
fix(costs): zero costCents for subscription billing types

### DIFF
--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -58,6 +58,14 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         throw unprocessable("Agent does not belong to company");
       }
 
+      // Set costCents to 0 for subscription billing types to avoid
+      // displaying virtual "what if we paid API" costs in the dashboard
+      // when the user is actually on a flat-rate subscription.
+      const isSubscriptionBilling = SUBSCRIPTION_BILLING_TYPES.includes(
+        data.billingType as (typeof SUBSCRIPTION_BILLING_TYPES)[number],
+      );
+      const costCents = isSubscriptionBilling ? 0 : data.costCents;
+
       const event = await db
         .insert(costEvents)
         .values({
@@ -66,6 +74,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           biller: data.biller ?? data.provider,
           billingType: data.billingType ?? "unknown",
           cachedInputTokens: data.cachedInputTokens ?? 0,
+          costCents,
         })
         .returning()
         .then((rows) => rows[0]);


### PR DESCRIPTION
## Summary

`costEvents.cost_cents` is currently populated with the metered API price even when `billingType` is `subscription_included` or `subscription_overage`. On flat-rate subscriptions this turns the Costs dashboard into a "what if we paid API" simulation rather than a record of what the user actually paid.

## Reproduction

Run Paperclip against z.ai's GLM Coding Max plan ($80/month flat). After a few hours of agent activity the dashboard shows $108+ "spent" — but the user has paid exactly $80 for the month, regardless of token volume.

## Fix

In `server/src/services/costs.ts` `createEvent`, before inserting the row, check `data.billingType` against `SUBSCRIPTION_BILLING_TYPES` (already declared at the top of the file) and override `costCents` to `0` for subscription events.

Token columns (`inputTokens`, `outputTokens`, `cachedInputTokens`) are untouched, so analytics on usage volume keep working — only the dollar field reflects the actual flat-rate reality.

## Test plan

- [ ] Send a `costService.createEvent` with `billingType: "subscription_included"` and a non-zero `costCents` → row stored with `cost_cents = 0`, token columns preserved.
- [ ] Same with `billingType: "subscription_overage"` → `cost_cents = 0`.
- [ ] Same with `billingType: "metered_api"` → `cost_cents` preserved as passed.
- [ ] Costs dashboard for a subscription-only company shows $0 for the period.

## Notes

Discovered while running our internal Paperclip fork against z.ai. As a temporary downstream workaround we added a Postgres trigger that zeroes `cost_cents` on insert for subscription rows, but the right place is the service layer — once this PR merges we can drop the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)