### PR TITLE
fix(claude-local): use global Bedrock inference profiles

### DIFF
--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -26,8 +26,10 @@ export async function listClaudeModels(): Promise<AdapterModel[]> {
   return isBedrockEnv() ? BEDROCK_MODELS : DIRECT_MODELS;
 }
 
-/** Check whether a model ID is a Bedrock-native identifier (not an Anthropic API short name). */
-/** Matches global IDs (global.anthropic.*), cross-region IDs (us.anthropic.*), and ARNs. */
+/**
+ * Check whether a model ID is a Bedrock-native identifier (not an Anthropic API short name).
+ * Matches global IDs (global.anthropic.*), cross-region IDs (us.anthropic.*), and ARNs.
+ */
 export function isBedrockModelId(model: string): boolean {
   return /^\w+\.anthropic\./.test(model) || model.startsWith("arn:aws:bedrock:");
 }

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -4,7 +4,7 @@ import { models as DIRECT_MODELS } from "../index.js";
 /** AWS Bedrock model IDs — global inference profile identifiers that work in any region. */
 const BEDROCK_MODELS: AdapterModel[] = [
   { id: "global.anthropic.claude-opus-4-6-v1", label: "Bedrock Opus 4.6" },
-  { id: "global.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
+  { id: "global.anthropic.claude-sonnet-4-6", label: "Bedrock Sonnet 4.6" },
   { id: "global.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
 ];
 

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -1,11 +1,11 @@
 import type { AdapterModel } from "@paperclipai/adapter-utils";
 import { models as DIRECT_MODELS } from "../index.js";
 
-/** AWS Bedrock model IDs — region-qualified identifiers required by the Bedrock API. */
+/** AWS Bedrock model IDs — global inference profile identifiers that work in any region. */
 const BEDROCK_MODELS: AdapterModel[] = [
-  { id: "us.anthropic.claude-opus-4-6-v1", label: "Bedrock Opus 4.6" },
-  { id: "us.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
-  { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
+  { id: "global.anthropic.claude-opus-4-6-v1", label: "Bedrock Opus 4.6" },
+  { id: "global.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
+  { id: "global.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
 ];
 
 function isBedrockEnv(): boolean {
@@ -27,7 +27,7 @@ export async function listClaudeModels(): Promise<AdapterModel[]> {
 }
 
 /** Check whether a model ID is a Bedrock-native identifier (not an Anthropic API short name). */
-/** Bedrock model IDs use region-qualified prefixes (e.g. us.anthropic.*, eu.anthropic.*) or ARNs. */
+/** Matches global IDs (global.anthropic.*), cross-region IDs (us.anthropic.*), and ARNs. */
 export function isBedrockModelId(model: string): boolean {
   return /^\w+\.anthropic\./.test(model) || model.startsWith("arn:aws:bedrock:");
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents run on different LLM providers, including AWS Bedrock
> - PR #3033 added Bedrock model selection, but hardcoded `us.anthropic.*` model IDs
> - This means EU/AP region Bedrock users get `400 invalid model identifier` errors
> - Rather than adding region detection logic (reading AWS_REGION, mapping prefixes), AWS provides global inference profiles
> - This pull request switches to `global.anthropic.*` model IDs that route to any commercial AWS region automatically
> - The benefit is one static model list works everywhere — no runtime region logic, no per-region edge cases

## What Changed

### Model IDs: `us.` region-locked → `global.` inference profiles

| Model | Before (PR #3033) | After |
|---|---|---|
| Opus 4.6 | `us.anthropic.claude-opus-4-6-v1` | `global.anthropic.claude-opus-4-6-v1` |
| Sonnet | `us.anthropic.claude-sonnet-4-5-20250929-v2:0` | `global.anthropic.claude-sonnet-4-6` |
| Haiku 4.5 | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | `global.anthropic.claude-haiku-4-5-20251001-v1:0` |

- **Sonnet 4.5 → 4.6**: Sonnet 4.6 is now available on Bedrock
- **JSDoc cleanup**: Merged duplicate `/** */` blocks on `isBedrockModelId()` into one (Greptile P2)

## Verification

- `pnpm -r typecheck` — all packages pass
- `pnpm -r test` — all tests pass
- `isBedrockModelId()` regex `^\w+\.anthropic\.` already matches `global.anthropic.*` — no additional changes needed
- No UI changes

## Risks

- **Low risk.** This is a 1-file, 3-line ID change. Non-Bedrock users are completely unaffected. Global inference profiles are a stable AWS Bedrock feature supported across all commercial regions.

## Model Used

- Claude Opus 4.6 (`claude-opus-4-6`, 1M context window) via Claude Code CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge