### PR TITLE
feat(adapter): add ollama_local adapter for local LLM support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
+COPY packages/adapters/ollama-local/package.json packages/adapters/ollama-local/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
 COPY packages/plugins/sdk/package.json packages/plugins/sdk/

--- a/cli/package.json
+++ b/cli/package.json
@@ -42,6 +42,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { printOllamaStreamEvent } from "@paperclipai/adapter-ollama-local/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -44,6 +45,11 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const ollamaLocalCLIAdapter: CLIAdapterModule = {
+  type: "ollama_local",
+  formatStdoutEvent: printOllamaStreamEvent,
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
@@ -53,6 +59,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     cursorLocalCLIAdapter,
     geminiLocalCLIAdapter,
     openclawGatewayCLIAdapter,
+    ollamaLocalCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,
   ].map((a) => [a.type, a]),

--- a/packages/adapters/ollama-local/package.json
+++ b/packages/adapters/ollama-local/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-ollama-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/ollama-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/ollama-local/src/cli/format-event.ts
+++ b/packages/adapters/ollama-local/src/cli/format-event.ts
@@ -1,0 +1,64 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function printOllamaStreamEvent(raw: string, debug: boolean): void {
+  const trimmed = raw.trim();
+  if (!trimmed) return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    if (debug) console.log(pc.gray(trimmed));
+    return;
+  }
+
+  const rec = asRecord(parsed);
+  if (!rec) {
+    if (debug) console.log(pc.gray(trimmed));
+    return;
+  }
+
+  const type = asString(rec.type);
+
+  if (type === "chunk") {
+    const content = asString(rec.content);
+    if (content) process.stdout.write(pc.green(content));
+    return;
+  }
+
+  if (type === "done") {
+    const model = asString(rec.model, "ollama");
+    const inputTokens = asNumber(rec.prompt_eval_count, 0);
+    const outputTokens = asNumber(rec.eval_count, 0);
+    console.log();
+    console.log(
+      pc.gray(
+        `[ollama] done — model: ${model}, tokens: ${inputTokens} in / ${outputTokens} out`,
+      ),
+    );
+    return;
+  }
+
+  if (type === "error") {
+    const message = asString(rec.message, "Unknown error");
+    console.log(pc.red(`[ollama] error: ${message}`));
+    return;
+  }
+
+  if (debug) {
+    console.log(pc.gray(trimmed));
+  }
+}

--- a/packages/adapters/ollama-local/src/cli/index.ts
+++ b/packages/adapters/ollama-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printOllamaStreamEvent } from "./format-event.js";

--- a/packages/adapters/ollama-local/src/index.ts
+++ b/packages/adapters/ollama-local/src/index.ts
@@ -1,0 +1,56 @@
+export const type = "ollama_local";
+export const label = "Ollama (local)";
+
+export const DEFAULT_OLLAMA_MODEL = "llama3.2";
+export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+export const DEFAULT_OLLAMA_TIMEOUT_SEC = 900;
+/** Maximum number of prior user+assistant turn-pairs to keep in session history. */
+export const DEFAULT_OLLAMA_MAX_HISTORY_TURNS = 20;
+
+export const models = [
+  { id: DEFAULT_OLLAMA_MODEL, label: "Llama 3.2" },
+  { id: "llama3.1", label: "Llama 3.1" },
+  { id: "codellama", label: "Code Llama" },
+  { id: "deepseek-coder-v2", label: "DeepSeek Coder V2" },
+  { id: "mistral", label: "Mistral" },
+  { id: "phi4", label: "Phi 4" },
+  { id: "qwen3.5", label: "Qwen 3.5" },
+  { id: "qwen2.5-coder", label: "Qwen 2.5 Coder" },
+];
+
+export const agentConfigurationDoc = `# ollama_local agent configuration
+
+Adapter: ollama_local
+
+Use when:
+- You want to run a free/local LLM via Ollama on the host machine
+- You need open-source models like Llama, Mistral, CodeLlama, DeepSeek, or Phi
+- You have a GPU-equipped machine with Ollama installed and want zero API cost
+- Privacy is critical and you cannot send data to external LLM providers
+- You want to use any custom or fine-tuned model available in the Ollama registry
+
+Don't use when:
+- You need a coding agent that autonomously writes files and runs tools (use claude_local, codex_local, or gemini_local instead)
+- The task requires tool use / code-execution capabilities (Ollama models lack agent tooling)
+- You need subscription-based or cloud LLMs (use claude_local, codex_local, etc.)
+- Ollama is not installed or the model has not been pulled locally
+
+Core fields:
+- baseUrl (string, optional): Ollama server base URL. Defaults to http://localhost:11434.
+- model (string, optional): Ollama model to use. Defaults to llama3.2. Must be available via \`ollama pull <model>\`.
+- promptTemplate (string, optional): run prompt template supporting {{agent.*}}, {{context.*}}, etc.
+- system (string, optional): system prompt injected as the first message.
+- temperature (number, optional): sampling temperature (0.0–2.0). Uses model default when omitted.
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds. Defaults to 900 (15 minutes). Set 0 for no timeout.
+- graceSec (number, optional): kept for API compatibility; unused (no subprocess).
+
+Notes:
+- Ollama must be running before the agent executes: \`ollama serve\`
+- Pull models before first use: \`ollama pull llama3.2\`
+- Large local models can take over a minute per run, so the default timeout is intentionally higher than the CLI adapters.
+- Conversation history is stored in sessionParams and replayed across runs for context continuity.
+- This adapter calls the Ollama HTTP API directly (POST /api/chat), not via subprocess.
+- No API key is required for local Ollama.
+`;

--- a/packages/adapters/ollama-local/src/server/execute.ts
+++ b/packages/adapters/ollama-local/src/server/execute.ts
@@ -320,8 +320,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (buffer.trim()) {
       try {
         const parsed = JSON.parse(buffer.trim()) as Record<string, unknown>;
-        if (typeof parsed.response === "string") {
-          assistantContent += parsed.response;
+        // /api/chat uses message.content; /api/generate uses response
+        const msg = parsed.message as Record<string, unknown> | undefined;
+        const chunk = typeof msg?.content === "string" ? msg.content : typeof parsed.response === "string" ? parsed.response : null;
+        if (chunk) {
+          assistantContent += chunk;
         }
         if (parsed.done === true) {
           promptEvalCount += asNumber(parsed.prompt_eval_count, 0);

--- a/packages/adapters/ollama-local/src/server/execute.ts
+++ b/packages/adapters/ollama-local/src/server/execute.ts
@@ -1,0 +1,422 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  buildPaperclipEnv,
+  parseObject,
+  renderTemplate,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MAX_HISTORY_TURNS, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_TIMEOUT_SEC } from "../index.js";
+
+export interface OllamaMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface OllamaChunkLine {
+  type: "chunk";
+  content: string;
+}
+
+export interface OllamaDoneLine {
+  type: "done";
+  model: string;
+  prompt_eval_count: number;
+  eval_count: number;
+  total_duration_ns: number;
+}
+
+export interface OllamaErrorLine {
+  type: "error";
+  message: string;
+}
+
+export type OllamaStdoutLine = OllamaChunkLine | OllamaDoneLine | OllamaErrorLine;
+
+const DEFAULT_SYSTEM_PROMPT =
+  "You are a helpful AI assistant integrated into the Paperclip control plane. Respond concisely and helpfully.";
+
+function buildContextNote(context: Record<string, unknown>): string {
+  const parts: string[] = [];
+  const taskId =
+    (typeof context.taskId === "string" && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim()
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim()
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim()
+      ? context.approvalStatus.trim()
+      : null;
+  if (taskId) parts.push(`Task ID: ${taskId}`);
+  if (wakeReason) parts.push(`Wake reason: ${wakeReason}`);
+  if (wakeCommentId) parts.push(`Wake comment ID: ${wakeCommentId}`);
+  if (approvalId) parts.push(`Approval ID: ${approvalId}`);
+  if (approvalStatus) parts.push(`Approval status: ${approvalStatus}`);
+  return parts.join("\n");
+}
+
+/**
+ * Try to resolve a possibly-untagged model name (e.g. "llama3.2") to the exact
+ * name Ollama has installed (e.g. "llama3.2:3b").  Falls back to the original
+ * name if the tags API is unavailable or no match is found.
+ */
+async function resolveModelName(baseUrl: string, requested: string): Promise<string> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return requested;
+    const body = (await res.json()) as Record<string, unknown>;
+    if (!Array.isArray(body.models)) return requested;
+    const names: string[] = (body.models as Record<string, unknown>[])
+      .filter((m) => typeof m.name === "string")
+      .map((m) => m.name as string);
+
+    // 1. Exact match
+    if (names.includes(requested)) return requested;
+
+    // 2. Exact match ignoring case
+    const lower = requested.toLowerCase();
+    const exact = names.find((n) => n.toLowerCase() === lower);
+    if (exact) return exact;
+
+    // 3. Base-name fallback — only when the requested model has no explicit tag.
+    //    A tagged request like "qwen2.5-coder:32b" must not silently resolve
+    //    to "qwen2.5-coder:7b" just because it was installed first.
+    if (!requested.includes(":")) {
+      const requestedBase = requested.toLowerCase();
+      const baseMatch = names.find(
+        (n) => n.split(":")[0].toLowerCase() === requestedBase,
+      );
+      if (baseMatch) return baseMatch;
+    }
+  } catch {
+    // network error / timeout — continue with original name
+  }
+  return requested;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta } = ctx;
+
+  const baseUrl = asString(config.baseUrl, DEFAULT_OLLAMA_BASE_URL).replace(/\/$/, "");
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: `Invalid Ollama base URL: "${baseUrl}". Only http:// and https:// are allowed.`,
+      provider: "ollama",
+      model: asString(config.model, DEFAULT_OLLAMA_MODEL),
+    };
+  }
+  const rawModel = asString(config.model, DEFAULT_OLLAMA_MODEL).trim();
+  const timeoutSec = asNumber(config.timeoutSec, DEFAULT_OLLAMA_TIMEOUT_SEC);
+  const temperature =
+    typeof config.temperature === "number" && Number.isFinite(config.temperature)
+      ? config.temperature
+      : undefined;
+  const systemPrompt = asString(config.system, DEFAULT_SYSTEM_PROMPT);
+
+  // Resolve the model name against what Ollama actually has installed.
+  // e.g. config says "llama3.2" but Ollama stores it as "llama3.2:3b".
+  const model = await resolveModelName(baseUrl, rawModel);
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId },
+    context,
+  };
+  const renderedPrompt = renderTemplate(promptTemplate, templateData);
+
+  // Annotate user message with Paperclip context
+  const contextNote = buildContextNote(context);
+  const userContent = contextNote.length > 0 ? `${contextNote}\n\n${renderedPrompt}` : renderedPrompt;
+
+  // Rehydrate prior conversation history from session, capped to prevent
+  // unbounded growth.  Keep the most recent N turn-pairs (user+assistant).
+  const maxHistoryTurns = asNumber(config.maxHistoryTurns, DEFAULT_OLLAMA_MAX_HISTORY_TURNS);
+  const sessionParams = parseObject(runtime.sessionParams);
+  const priorMessages: OllamaMessage[] = (() => {
+    if (!Array.isArray(sessionParams.messages)) return [];
+    const all = (sessionParams.messages as unknown[]).filter(
+      (m): m is OllamaMessage =>
+        typeof m === "object" &&
+        m !== null &&
+        !Array.isArray(m) &&
+        (typeof (m as Record<string, unknown>).role === "string") &&
+        (typeof (m as Record<string, unknown>).content === "string"),
+    );
+    // Keep only the last maxHistoryTurns * 2 messages (each turn is user+assistant)
+    if (maxHistoryTurns > 0 && all.length > maxHistoryTurns * 2) {
+      return all.slice(-maxHistoryTurns * 2);
+    }
+    return all;
+  })();
+
+  const messages: OllamaMessage[] = [
+    { role: "system", content: systemPrompt },
+    ...priorMessages,
+    { role: "user", content: userContent },
+  ];
+
+  // Emit Paperclip-standard env vars for logging/meta (no subprocess, but agent needs context)
+  const paperclipEnv = buildPaperclipEnv(agent);
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "ollama_local",
+      command: `POST ${baseUrl}/api/chat`,
+      cwd: process.cwd(),
+      commandNotes: [
+        `Model: ${model}`,
+        `Prior conversation turns: ${Math.floor(priorMessages.length / 2)}`,
+        `Streaming: true`,
+      ],
+      commandArgs: [],
+      env: {
+        PAPERCLIP_AGENT_ID: paperclipEnv.PAPERCLIP_AGENT_ID ?? agent.id,
+        PAPERCLIP_COMPANY_ID: paperclipEnv.PAPERCLIP_COMPANY_ID ?? agent.companyId,
+      },
+      prompt: userContent,
+      promptMetrics: {
+        promptChars: userContent.length,
+        heartbeatPromptChars: renderedPrompt.length,
+      },
+      context,
+    });
+  }
+
+  // Set up AbortController for timeout
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeoutHandle =
+    timeoutSec > 0
+      ? setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, timeoutSec * 1000)
+      : null;
+
+  let assistantContent = "";
+  let promptEvalCount = 0;
+  let evalCount = 0;
+  let exitCode: number | null = null;
+  let errorMessage: string | null = null;
+
+  try {
+    const requestBody: Record<string, unknown> = {
+      model,
+      messages,
+      stream: true,
+    };
+    if (temperature !== undefined) {
+      requestBody.options = { temperature };
+    }
+
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const bodyText = await response.text().catch(() => "");
+      const errMsg = bodyText.trim() || `HTTP ${response.status} ${response.statusText}`;
+      const errLine: OllamaErrorLine = { type: "error", message: errMsg };
+      await onLog("stderr", JSON.stringify(errLine) + "\n");
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `Ollama returned ${response.status}: ${errMsg}`,
+        provider: "ollama",
+        model,
+        resultJson: { error: errMsg },
+      };
+    }
+
+    if (!response.body) {
+      throw new Error("Ollama response has no body");
+    }
+
+    const reader = response.body.getReader();
+    try {
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          await onLog("stdout", line + "\n");
+          continue;
+        }
+
+        const isDone = parsed.done === true;
+        const messageObj =
+          typeof parsed.message === "object" && parsed.message !== null
+            ? (parsed.message as Record<string, unknown>)
+            : null;
+        const contentChunk =
+          typeof messageObj?.content === "string" ? messageObj.content : "";
+
+        if (!isDone && contentChunk) {
+          assistantContent += contentChunk;
+          const chunkLine: OllamaChunkLine = { type: "chunk", content: contentChunk };
+          await onLog("stdout", JSON.stringify(chunkLine) + "\n");
+        }
+
+        if (isDone) {
+          promptEvalCount =
+            typeof parsed.prompt_eval_count === "number" ? parsed.prompt_eval_count : 0;
+          evalCount = typeof parsed.eval_count === "number" ? parsed.eval_count : 0;
+          const totalDurationNs =
+            typeof parsed.total_duration === "number" ? parsed.total_duration : 0;
+          const doneLine: OllamaDoneLine = {
+            type: "done",
+            model: typeof parsed.model === "string" ? parsed.model : model,
+            prompt_eval_count: promptEvalCount,
+            eval_count: evalCount,
+            total_duration_ns: totalDurationNs,
+          };
+          await onLog("stdout", JSON.stringify(doneLine) + "\n");
+        }
+      }
+    }
+
+    // Parse any trailing data left in the buffer after EOF
+    if (buffer.trim()) {
+      try {
+        const parsed = JSON.parse(buffer.trim()) as Record<string, unknown>;
+        if (typeof parsed.response === "string") {
+          assistantContent += parsed.response;
+        }
+        if (parsed.done === true) {
+          promptEvalCount += asNumber(parsed.prompt_eval_count, 0);
+          evalCount += asNumber(parsed.eval_count, 0);
+        }
+      } catch {
+        // malformed trailing data — ignore
+      }
+    }
+
+    } finally {
+      reader.cancel().catch(() => {});
+    }
+
+    exitCode = 0;
+  } catch (err) {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    if (timedOut) {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        provider: "ollama",
+        model,
+      };
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      msg.includes("ECONNREFUSED") ||
+      msg.includes("fetch failed") ||
+      msg.includes("connect EREFUSED") ||
+      msg.includes("Failed to fetch")
+    ) {
+      const errLine: OllamaErrorLine = {
+        type: "error",
+        message: `Cannot reach Ollama at ${baseUrl}: ${msg}`,
+      };
+      await onLog("stderr", JSON.stringify(errLine) + "\n");
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `Cannot reach Ollama at ${baseUrl}. Is Ollama running? Run: ollama serve`,
+        errorCode: "ollama_not_running",
+        provider: "ollama",
+        model,
+      };
+    }
+    const errLine: OllamaErrorLine = { type: "error", message: msg };
+    await onLog("stderr", JSON.stringify(errLine) + "\n");
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: msg,
+      provider: "ollama",
+      model,
+    };
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+
+  // Guard against race where timeout fires just as the stream finishes
+  if (timedOut) {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: true,
+      errorMessage: `Timed out after ${timeoutSec}s`,
+      provider: "ollama",
+      model,
+    };
+  }
+
+  // Build updated session params with appended message history
+  const updatedMessages: OllamaMessage[] = [
+    ...priorMessages,
+    { role: "user", content: userContent },
+    ...(assistantContent ? [{ role: "assistant" as const, content: assistantContent }] : []),
+  ];
+
+  return {
+    exitCode,
+    signal: null,
+    timedOut: false,
+    errorMessage: exitCode === 0 ? null : (errorMessage ?? `Ollama exited with code ${exitCode}`),
+    usage:
+      promptEvalCount || evalCount
+        ? { inputTokens: promptEvalCount, outputTokens: evalCount }
+        : undefined,
+    provider: "ollama",
+    model,
+    billingType: "subscription",
+    sessionParams: updatedMessages.length > 0 ? { messages: updatedMessages } : null,
+    summary: assistantContent.trim() || null,
+  };
+}

--- a/packages/adapters/ollama-local/src/server/index.ts
+++ b/packages/adapters/ollama-local/src/server/index.ts
@@ -1,0 +1,42 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { listOllamaModels } from "./models.js";
+
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+import type { OllamaMessage } from "./execute.js";
+
+function isOllamaMessage(value: unknown): value is OllamaMessage {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const rec = value as Record<string, unknown>;
+  return (
+    (rec.role === "system" || rec.role === "user" || rec.role === "assistant") &&
+    typeof rec.content === "string"
+  );
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    if (!Array.isArray(record.messages)) return null;
+    const messages = (record.messages as unknown[]).filter(isOllamaMessage);
+    if (messages.length === 0) return null;
+    return { messages };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    if (!Array.isArray(params.messages)) return null;
+    const messages = (params.messages as unknown[]).filter(isOllamaMessage);
+    if (messages.length === 0) return null;
+    return { messages };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    if (!Array.isArray(params.messages)) return null;
+    const userTurns = (params.messages as unknown[]).filter(
+      (m) => isOllamaMessage(m) && m.role === "user",
+    ).length;
+    if (userTurns === 0) return null;
+    return `${userTurns} prior turn${userTurns !== 1 ? "s" : ""}`;
+  },
+};

--- a/packages/adapters/ollama-local/src/server/models.ts
+++ b/packages/adapters/ollama-local/src/server/models.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_OLLAMA_BASE_URL, models as staticModels } from "../index.js";
+
+export async function listOllamaModels(opts?: { baseUrl?: string }): Promise<{ id: string; label: string }[]> {
+  const baseUrl = (opts?.baseUrl ?? DEFAULT_OLLAMA_BASE_URL).replace(/\/$/, "");
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return staticModels;
+    const body = (await res.json()) as Record<string, unknown>;
+    if (!Array.isArray(body.models)) return staticModels;
+    const dynamic = (body.models as Record<string, unknown>[])
+      .filter((m) => typeof m.name === "string")
+      .map((m) => {
+        const name = m.name as string;
+        const base = name.split(":")[0];
+        const tag = name.includes(":") ? name.split(":")[1] : null;
+        const label = tag && tag !== "latest" ? `${base} (${tag})` : base;
+        return { id: name, label };
+      });
+    return dynamic.length > 0 ? dynamic : staticModels;
+  } catch {
+    return staticModels;
+  }
+}

--- a/packages/adapters/ollama-local/src/server/test.ts
+++ b/packages/adapters/ollama-local/src/server/test.ts
@@ -1,0 +1,172 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL } from "../index.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const baseUrl = asString(config.baseUrl, DEFAULT_OLLAMA_BASE_URL).replace(/\/$/, "");
+  const model = asString(config.model, DEFAULT_OLLAMA_MODEL).trim();
+
+  checks.push({
+    code: "ollama_base_url",
+    level: "info",
+    message: `Ollama base URL: ${baseUrl}`,
+  });
+
+  // Check 1: Is Ollama reachable?
+  try {
+    const versionRes = await fetch(`${baseUrl}/api/version`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (versionRes.ok) {
+      const body = (await versionRes.json().catch(() => ({}))) as Record<string, unknown>;
+      const version = typeof body.version === "string" ? ` v${body.version}` : "";
+      checks.push({
+        code: "ollama_reachable",
+        level: "info",
+        message: `Ollama is running${version} at ${baseUrl}`,
+      });
+    } else {
+      checks.push({
+        code: "ollama_unreachable",
+        level: "error",
+        message: `Ollama returned HTTP ${versionRes.status} at ${baseUrl}/api/version`,
+        hint: "Ensure Ollama is running: ollama serve",
+      });
+      return {
+        adapterType: ctx.adapterType,
+        status: "fail",
+        checks,
+        testedAt: new Date().toISOString(),
+      };
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    checks.push({
+      code: "ollama_unreachable",
+      level: "error",
+      message: `Cannot reach Ollama at ${baseUrl}: ${msg}`,
+      hint: "Start Ollama with: ollama serve",
+    });
+    return {
+      adapterType: ctx.adapterType,
+      status: "fail",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  // Check 2: Is the configured model available?
+  let modelFound = false;
+  try {
+    const tagsRes = await fetch(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (tagsRes.ok) {
+      const body = (await tagsRes.json().catch(() => ({ models: [] }))) as Record<
+        string,
+        unknown
+      >;
+      const installedNames: string[] = Array.isArray(body.models)
+        ? (body.models as Record<string, unknown>[])
+            .filter((m) => typeof m.name === "string")
+            .map((m) => m.name as string)
+        : [];
+      const isTagged = model.includes(":");
+      const found = isTagged
+        ? installedNames.some((n) => n.toLowerCase() === model.toLowerCase())
+        : installedNames.some((n) => n.split(":")[0].toLowerCase() === model.toLowerCase());
+      modelFound = found;
+      if (found) {
+        checks.push({
+          code: "ollama_model_available",
+          level: "info",
+          message: `Model "${model}" is available locally.`,
+        });
+      } else {
+        checks.push({
+          code: "ollama_model_missing",
+          level: "warn",
+          message: `Model "${model}" was not found in the local Ollama model list.`,
+          detail:
+            installedNames.length > 0
+              ? `Installed models: ${installedNames.slice(0, 10).join(", ")}`
+              : "No models installed.",
+          hint: `Run: ollama pull ${model}`,
+        });
+      }
+    } else {
+      checks.push({
+        code: "ollama_tags_unavailable",
+        level: "warn",
+        message: `Could not fetch model list from Ollama (HTTP ${tagsRes.status}).`,
+      });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    checks.push({
+      code: "ollama_tags_error",
+      level: "warn",
+      message: `Could not fetch Ollama model list: ${msg}`,
+    });
+  }
+
+  // 3. Hello probe — send a minimal /api/chat request to verify generation works
+  if (modelFound) {
+    try {
+      const chatRes = await fetch(`${baseUrl}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: "Say hello in one word." }],
+          stream: false,
+          options: { num_predict: 10 },
+        }),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (chatRes.ok) {
+        checks.push({
+          code: "ollama_chat_ok",
+          level: "info",
+          message: `Model "${model}" responded successfully to a test prompt.`,
+        });
+      } else {
+        const errBody = await chatRes.text().catch(() => "");
+        checks.push({
+          code: "ollama_chat_error",
+          level: "warn",
+          message: `Model "${model}" returned HTTP ${chatRes.status} on test prompt.`,
+          detail: errBody.slice(0, 200) || undefined,
+        });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      checks.push({
+        code: "ollama_chat_error",
+        level: "warn",
+        message: `Hello probe failed: ${msg}`,
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/ollama-local/src/ui/build-config.ts
+++ b/packages/adapters/ollama-local/src/ui/build-config.ts
@@ -1,0 +1,31 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_TIMEOUT_SEC,
+} from "../index.js";
+
+export function buildOllamaLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ext = v as unknown as Record<string, unknown>;
+  const ac: Record<string, unknown> = {};
+
+  const baseUrl =
+    typeof ext.baseUrl === "string" && ext.baseUrl.trim()
+      ? ext.baseUrl.trim()
+      : DEFAULT_OLLAMA_BASE_URL;
+  ac.baseUrl = baseUrl;
+  ac.model = v.model || DEFAULT_OLLAMA_MODEL;
+
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+
+  const system = typeof ext.system === "string" && ext.system.trim() ? ext.system.trim() : "";
+  if (system) ac.system = system;
+
+  const temperature = typeof ext.temperature === "number" ? ext.temperature : NaN;
+  if (!Number.isNaN(temperature) && Number.isFinite(temperature)) ac.temperature = temperature;
+
+  ac.timeoutSec = DEFAULT_OLLAMA_TIMEOUT_SEC;
+  ac.graceSec = 15;
+
+  return ac;
+}

--- a/packages/adapters/ollama-local/src/ui/index.ts
+++ b/packages/adapters/ollama-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseOllamaStdoutLine } from "./parse-stdout.js";
+export { buildOllamaLocalConfig } from "./build-config.js";

--- a/packages/adapters/ollama-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/ollama-local/src/ui/parse-stdout.ts
@@ -1,0 +1,70 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function parseOllamaStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  const parsed = safeJsonParse(trimmed);
+  const rec = asRecord(parsed);
+
+  if (!rec) {
+    return [{ kind: "stdout", ts, text: trimmed }];
+  }
+
+  const type = asString(rec.type);
+
+  if (type === "chunk") {
+    const content = asString(rec.content);
+    if (!content) return [];
+    return [{ kind: "assistant", ts, text: content, delta: true }];
+  }
+
+  if (type === "done") {
+    const model = asString(rec.model, "ollama");
+    const inputTokens = asNumber(rec.prompt_eval_count, 0);
+    const outputTokens = asNumber(rec.eval_count, 0);
+    if (inputTokens === 0 && outputTokens === 0) return [];
+    return [
+      {
+        kind: "result" as const,
+        ts,
+        text: `Completed — model: ${model}, tokens: ${inputTokens} in / ${outputTokens} out`,
+        inputTokens,
+        outputTokens,
+        cachedTokens: 0,
+        costUsd: 0,
+        subtype: "done",
+        isError: false,
+        errors: [],
+      },
+    ];
+  }
+
+  if (type === "error") {
+    const message = asString(rec.message, "Unknown Ollama error");
+    return [{ kind: "stdout", ts, text: `[error] ${message}` }];
+  }
+
+  return [{ kind: "stdout", ts, text: trimmed }];
+}

--- a/packages/adapters/ollama-local/tsconfig.json
+++ b/packages/adapters/ollama-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "ollama_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
 

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -10,6 +10,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "opencode_local",
   "pi_local",
   "hermes_local",
+  "ollama_local",
   "process",
   "http",
 ]);

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -80,6 +80,16 @@ import {
   agentConfigurationDoc as hermesAgentConfigurationDoc,
   models as hermesModels,
 } from "hermes-paperclip-adapter";
+import {
+  execute as ollamaExecute,
+  testEnvironment as ollamaTestEnvironment,
+  sessionCodec as ollamaSessionCodec,
+  listOllamaModels,
+} from "@paperclipai/adapter-ollama-local/server";
+import {
+  agentConfigurationDoc as ollamaAgentConfigurationDoc,
+  models as ollamaModels,
+} from "@paperclipai/adapter-ollama-local";
 import { BUILTIN_ADAPTER_TYPES } from "./builtin-adapter-types.js";
 import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
@@ -193,6 +203,18 @@ const hermesLocalAdapter: ServerAdapterModule = {
   detectModel: () => detectModelFromHermes(),
 };
 
+const ollamaLocalAdapter: ServerAdapterModule = {
+  type: "ollama_local",
+  execute: ollamaExecute,
+  testEnvironment: ollamaTestEnvironment,
+  sessionCodec: ollamaSessionCodec,
+  sessionManagement: getAdapterSessionManagement("ollama_local") ?? undefined,
+  models: ollamaModels,
+  listModels: listOllamaModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: ollamaAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>();
 
 // For builtin types that are overridden by an external adapter, we keep the
@@ -214,6 +236,7 @@ function registerBuiltInAdapters() {
     geminiLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,
+    ollamaLocalAdapter,
     processAdapter,
     httpAdapter,
   ]) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/shared": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -79,6 +79,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Local Hermes CLI agent",
     icon: HermesIcon,
   },
+  ollama_local: {
+    label: "Ollama",
+    description: "Free local LLM agent via Ollama",
+    icon: Cpu,
+  },
   pi_local: {
     label: "Pi",
     description: "Local Pi agent",

--- a/ui/src/adapters/ollama-local/build-config.test.ts
+++ b/ui/src/adapters/ollama-local/build-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_TIMEOUT_SEC,
+} from "@paperclipai/adapter-ollama-local";
+import { buildOllamaLocalConfig } from "@paperclipai/adapter-ollama-local/ui";
+
+describe("buildOllamaLocalConfig", () => {
+  it("uses Ollama-friendly defaults for create mode", () => {
+    expect(buildOllamaLocalConfig({} as never)).toEqual({
+      baseUrl: DEFAULT_OLLAMA_BASE_URL,
+      model: DEFAULT_OLLAMA_MODEL,
+      timeoutSec: DEFAULT_OLLAMA_TIMEOUT_SEC,
+      graceSec: 15,
+    });
+  });
+
+  it("preserves explicit config overrides", () => {
+    expect(
+      buildOllamaLocalConfig({
+        model: "qwen3.5",
+        promptTemplate: "Summarize {{agent.name}}",
+        baseUrl: "http://ollama.internal:11434",
+        system: "Be brief.",
+        temperature: 0.2,
+      } as never),
+    ).toEqual({
+      baseUrl: "http://ollama.internal:11434",
+      model: "qwen3.5",
+      promptTemplate: "Summarize {{agent.name}}",
+      system: "Be brief.",
+      temperature: 0.2,
+      timeoutSec: DEFAULT_OLLAMA_TIMEOUT_SEC,
+      graceSec: 15,
+    });
+  });
+});

--- a/ui/src/adapters/ollama-local/config-fields.tsx
+++ b/ui/src/adapters/ollama-local/config-fields.tsx
@@ -66,7 +66,6 @@ export function OllamaLocalConfigFields({
           installedModels={models}
           value={currentModel}
           onChange={setModel}
-          onRefresh={undefined}
           baseUrl={currentBaseUrl || DEFAULT_OLLAMA_BASE_URL}
         />
       </Field>

--- a/ui/src/adapters/ollama-local/config-fields.tsx
+++ b/ui/src/adapters/ollama-local/config-fields.tsx
@@ -1,0 +1,95 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { DraftInput, DraftTextarea, Field } from "../../components/agent-config-primitives";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL } from "@paperclipai/adapter-ollama-local";
+import { OllamaModelPicker } from "./model-picker";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function asExt(v: CreateConfigValues | null): Record<string, unknown> {
+  return (v as unknown as Record<string, unknown>) ?? {};
+}
+
+export function OllamaLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+}: AdapterConfigFieldsProps) {
+  const currentModel = isCreate
+    ? (values?.model ?? "")
+    : eff("adapterConfig", "model", String(config.model ?? ""));
+
+  const currentBaseUrl = isCreate
+    ? (asExt(values).baseUrl as string) ?? ""
+    : eff("adapterConfig", "baseUrl", String(config.baseUrl ?? ""));
+
+  function setModel(v: string) {
+    if (isCreate) {
+      set!({ model: v });
+    } else {
+      mark("adapterConfig", "model", v || undefined);
+    }
+  }
+
+  return (
+    <>
+      <Field
+        label="Base URL"
+        hint={`Ollama server URL. Defaults to ${DEFAULT_OLLAMA_BASE_URL}. Change only if Ollama is running on a non-standard port or remote host.`}
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? (asExt(values).baseUrl as string) ?? ""
+              : eff("adapterConfig", "baseUrl", String(config.baseUrl ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ ...asExt(values), baseUrl: v } as unknown as Partial<CreateConfigValues>)
+              : mark("adapterConfig", "baseUrl", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder={DEFAULT_OLLAMA_BASE_URL}
+        />
+      </Field>
+      <Field
+        label="Model"
+        hint={`Choose from installed models or copy the pull command for ones you want to download. Defaults to ${DEFAULT_OLLAMA_MODEL}.`}
+      >
+        <OllamaModelPicker
+          installedModels={models}
+          value={currentModel}
+          onChange={setModel}
+          onRefresh={undefined}
+          baseUrl={currentBaseUrl || DEFAULT_OLLAMA_BASE_URL}
+        />
+      </Field>
+      <Field
+        label="System prompt"
+        hint="Optional system prompt injected as the first message. Leave blank to use the default."
+      >
+        <DraftTextarea
+          value={
+            isCreate
+              ? (asExt(values).system as string) ?? ""
+              : eff("adapterConfig", "system", String(config.system ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ ...asExt(values), system: v } as unknown as Partial<CreateConfigValues>)
+              : mark("adapterConfig", "system", v || undefined)
+          }
+          immediate
+          placeholder="You are a helpful AI assistant..."
+          minRows={3}
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/ollama-local/index.ts
+++ b/ui/src/adapters/ollama-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseOllamaStdoutLine } from "@paperclipai/adapter-ollama-local/ui";
+import { buildOllamaLocalConfig } from "@paperclipai/adapter-ollama-local/ui";
+import { OllamaLocalConfigFields } from "./config-fields";
+
+export const ollamaLocalUIAdapter: UIAdapterModule = {
+  type: "ollama_local",
+  label: "Ollama (local)",
+  parseStdoutLine: parseOllamaStdoutLine,
+  ConfigFields: OllamaLocalConfigFields,
+  buildAdapterConfig: buildOllamaLocalConfig,
+};

--- a/ui/src/adapters/ollama-local/model-picker.tsx
+++ b/ui/src/adapters/ollama-local/model-picker.tsx
@@ -252,6 +252,11 @@ export function OllamaModelPicker({
   // picker always reflects the right server, even when the server-side
   // listOllamaModels() defaults to localhost.
   const [clientModels, setClientModels] = useState<{ id: string; label: string }[]>([]);
+  const [refreshTick, setRefreshTick] = useState(0);
+  const refreshModels = useCallback(() => {
+    setRefreshTick((n) => n + 1);
+    onRefreshRef.current?.();
+  }, []);
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -276,7 +281,7 @@ export function OllamaModelPicker({
       }
     })();
     return () => { cancelled = true; };
-  }, [effectiveBaseUrl]);
+  }, [effectiveBaseUrl, refreshTick]);
 
   // Merge server-provided and client-fetched models, deduplicating by id
   const mergedInstalled = useMemo(() => {
@@ -350,6 +355,7 @@ export function OllamaModelPicker({
           if (obj.status === "success") {
             setDownloadState(key, { status: "done", statusText: "Installed!", percent: 100 });
             _globalAborts.delete(key);
+            setRefreshTick((n) => n + 1);
             onRefreshRef.current?.();
             return;
           }
@@ -373,12 +379,17 @@ export function OllamaModelPicker({
           if (obj.status === "success") {
             setDownloadState(key, { status: "done", statusText: "Installed!", percent: 100 });
             _globalAborts.delete(key);
+            setRefreshTick((n) => n + 1);
             onRefreshRef.current?.();
             return;
           }
         } catch (e) {
-          if (e instanceof Error && e.message !== buffer.trim()) throw e;
-          // parse error on trailing buffer — fall through
+          // Re-throw Ollama errors; swallow JSON parse errors
+          if (e instanceof SyntaxError) {
+            // malformed trailing data — fall through
+          } else {
+            throw e;
+          }
         }
       }
 

--- a/ui/src/adapters/ollama-local/model-picker.tsx
+++ b/ui/src/adapters/ollama-local/model-picker.tsx
@@ -1,0 +1,708 @@
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { Check, Download, Loader2, RefreshCw, Zap, AlertCircle, X, XCircle } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { DEFAULT_OLLAMA_BASE_URL } from "@paperclipai/adapter-ollama-local";
+
+// ---------------------------------------------------------------------------
+// Module-level persistent download state — survives component unmount/remount
+// so navigating away and back keeps progress intact.
+// ---------------------------------------------------------------------------
+type DownloadStatus = "idle" | "pulling" | "done" | "error";
+
+interface DownloadState {
+  status: DownloadStatus;
+  /** Human-readable status, e.g. "Downloading…", "Installed!" */
+  statusText: string;
+  /** 0–100 */
+  percent: number;
+  error?: string;
+}
+
+const _globalDownloads = new Map<string, DownloadState>();
+const _globalAborts = new Map<string, AbortController>();
+/** Listeners so components can re-render when module-level state changes */
+const _listeners = new Set<() => void>();
+
+/** Composite key to avoid collisions when the same model name is used on different servers. */
+function downloadKey(modelId: string, baseUrl?: string): string {
+  return baseUrl ? `${baseUrl}::${modelId}` : modelId;
+}
+
+function notifyListeners() {
+  _listeners.forEach((fn) => fn());
+}
+
+function setDownloadState(key: string, state: DownloadState) {
+  _globalDownloads.set(key, state);
+  notifyListeners();
+}
+
+function deleteDownloadState(key: string) {
+  _globalDownloads.delete(key);
+  notifyListeners();
+}
+
+/** Returns a snapshot of the global downloads map for rendering */
+function useGlobalDownloads(): Record<string, DownloadState> {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const fn = () => tick((n) => n + 1);
+    _listeners.add(fn);
+    return () => { _listeners.delete(fn); };
+  }, []);
+  return Object.fromEntries(_globalDownloads.entries());
+}
+
+interface ModelEntry {
+  id: string;
+  label: string;
+  desc: string;
+  size: string;
+  /** Tags: "tool-use" = supports function/tool calling; "code" = code-specialized; "reasoning" = reasoning-optimized */
+  tags: string[];
+}
+
+/** Curated list of free Ollama models known to support agentic tasks (tool calling, instruction following, code). */
+const AGENTIC_MODELS: ModelEntry[] = [
+  // --- Fast & small — good for local machines ---
+  {
+    id: "llama3.2:3b",
+    label: "Llama 3.2 3B",
+    desc: "Meta · fast, tool calling",
+    size: "2 GB",
+    tags: ["tool-use", "fast"],
+  },
+  {
+    id: "phi4-mini",
+    label: "Phi 4 Mini 3.8B",
+    desc: "Microsoft · smart small model, tool calling",
+    size: "2.5 GB",
+    tags: ["tool-use", "fast"],
+  },
+  {
+    id: "gemma3:4b",
+    label: "Gemma 3 4B",
+    desc: "Google · efficient, follows instructions well",
+    size: "3.3 GB",
+    tags: ["tool-use", "fast"],
+  },
+  // --- Balanced — great everyday agents ---
+  {
+    id: "llama3.1:8b",
+    label: "Llama 3.1 8B",
+    desc: "Meta · strong tool calling, great for agents",
+    size: "4.7 GB",
+    tags: ["tool-use"],
+  },
+  {
+    id: "qwen2.5:7b",
+    label: "Qwen 2.5 7B",
+    desc: "Alibaba · excellent tool calling",
+    size: "4.4 GB",
+    tags: ["tool-use"],
+  },
+  {
+    id: "mistral-nemo",
+    label: "Mistral NeMo 12B",
+    desc: "Mistral · efficient, tool calling support",
+    size: "7.1 GB",
+    tags: ["tool-use"],
+  },
+  {
+    id: "deepseek-r1:8b",
+    label: "DeepSeek R1 8B",
+    desc: "DeepSeek · reasoning + agentic tasks",
+    size: "4.9 GB",
+    tags: ["reasoning", "tool-use"],
+  },
+  // --- Code agents ---
+  {
+    id: "qwen2.5-coder:7b",
+    label: "Qwen 2.5 Coder 7B",
+    desc: "Alibaba · code-specialized agent, tool calling",
+    size: "4.7 GB",
+    tags: ["code", "tool-use"],
+  },
+  {
+    id: "deepseek-coder-v2",
+    label: "DeepSeek Coder V2",
+    desc: "DeepSeek · excellent code generation",
+    size: "8.9 GB",
+    tags: ["code", "tool-use"],
+  },
+  {
+    id: "qwen2.5-coder:32b",
+    label: "Qwen 2.5 Coder 32B",
+    desc: "Alibaba · best local code agent, tool calling",
+    size: "20 GB",
+    tags: ["code", "tool-use"],
+  },
+  // --- High quality ---
+  {
+    id: "phi4",
+    label: "Phi 4 14B",
+    desc: "Microsoft · excellent reasoning & tool calling",
+    size: "9.1 GB",
+    tags: ["tool-use", "reasoning"],
+  },
+  {
+    id: "qwen2.5:14b",
+    label: "Qwen 2.5 14B",
+    desc: "Alibaba · powerful, reliable tool calling",
+    size: "9 GB",
+    tags: ["tool-use"],
+  },
+  {
+    id: "deepseek-r1:14b",
+    label: "DeepSeek R1 14B",
+    desc: "DeepSeek · strong reasoning model",
+    size: "9 GB",
+    tags: ["reasoning", "tool-use"],
+  },
+  // --- Large & powerful ---
+  {
+    id: "llama3.3:70b",
+    label: "Llama 3.3 70B",
+    desc: "Meta · best open-source agentic model",
+    size: "43 GB",
+    tags: ["tool-use"],
+  },
+  {
+    id: "llama3.1:70b",
+    label: "Llama 3.1 70B",
+    desc: "Meta · powerful, excellent tool calling",
+    size: "40 GB",
+    tags: ["tool-use"],
+  },
+];
+
+interface OllamaModelPickerProps {
+  /** Currently installed models from the adapter models API */
+  installedModels: { id: string; label: string }[];
+  /** Currently selected model id/name */
+  value: string;
+  onChange: (model: string) => void;
+  /** Whether to show a loading state for the installed models list */
+  loading?: boolean;
+  /** Allow manual refresh of the installed models list */
+  onRefresh?: () => void;
+  /** Ollama base URL — defaults to http://localhost:11434 */
+  baseUrl?: string;
+}
+
+const TAG_LABELS: Record<string, string> = {
+  "tool-use": "Tool Calling",
+  code: "Code Agent",
+  reasoning: "Reasoning",
+  fast: "Fast",
+};
+
+function isModelInstalled(
+  modelId: string,
+  installedModels: { id: string; label: string }[],
+): boolean {
+  const lower = modelId.toLowerCase();
+  const isTagged = modelId.includes(":");
+  return installedModels.some((m) => {
+    const mLower = m.id.toLowerCase();
+    // Exact match always works
+    if (mLower === lower) return true;
+    // Base-name fallback only for untagged requests
+    if (!isTagged) {
+      return mLower.split(":")[0] === lower || mLower === lower + ":latest";
+    }
+    return false;
+  });
+}
+
+function getInstalledId(
+  modelId: string,
+  installedModels: { id: string; label: string }[],
+): string {
+  const lower = modelId.toLowerCase();
+  const isTagged = modelId.includes(":");
+  const match = installedModels.find((m) => {
+    const mLower = m.id.toLowerCase();
+    if (mLower === lower) return true;
+    if (!isTagged) {
+      return mLower.split(":")[0] === lower || mLower === lower + ":latest";
+    }
+    return false;
+  });
+  return match?.id ?? modelId;
+}
+
+export function OllamaModelPicker({
+  installedModels,
+  value,
+  onChange,
+  loading,
+  onRefresh,
+  baseUrl,
+}: OllamaModelPickerProps) {
+  const downloads = useGlobalDownloads();
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  const effectiveBaseUrl = (baseUrl ?? DEFAULT_OLLAMA_BASE_URL).replace(/\/$/, "");
+  const effectiveBaseUrlRef = useRef(effectiveBaseUrl);
+  effectiveBaseUrlRef.current = effectiveBaseUrl;
+
+  // Fetch installed models directly from the configured Ollama host so the
+  // picker always reflects the right server, even when the server-side
+  // listOllamaModels() defaults to localhost.
+  const [clientModels, setClientModels] = useState<{ id: string; label: string }[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${effectiveBaseUrl}/api/tags`, {
+          signal: AbortSignal.timeout(4000),
+        });
+        if (!res.ok || cancelled) return;
+        const body = (await res.json()) as Record<string, unknown>;
+        if (cancelled || !Array.isArray(body.models)) return;
+        const models = (body.models as Record<string, unknown>[])
+          .filter((m) => typeof m.name === "string")
+          .map((m) => {
+            const name = m.name as string;
+            const base = name.split(":")[0];
+            const tag = name.includes(":") ? name.split(":")[1] : null;
+            return { id: name, label: tag && tag !== "latest" ? `${base} (${tag})` : base };
+          });
+        setClientModels(models);
+      } catch {
+        // ignore — fall back to server-provided models
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [effectiveBaseUrl]);
+
+  // Merge server-provided and client-fetched models, deduplicating by id
+  const mergedInstalled = useMemo(() => {
+    const seen = new Set<string>();
+    const result: { id: string; label: string }[] = [];
+    for (const m of [...clientModels, ...installedModels]) {
+      if (!seen.has(m.id)) {
+        seen.add(m.id);
+        result.push(m);
+      }
+    }
+    return result;
+  }, [installedModels, clientModels]);
+
+  // Extra installed models not already covered by the agentic catalog
+  const extraInstalled = mergedInstalled.filter(
+    (m) => !AGENTIC_MODELS.some((p) => isModelInstalled(p.id, [m])),
+  );
+
+  const startDownload = useCallback(async (modelId: string) => {
+    const key = downloadKey(modelId, effectiveBaseUrlRef.current);
+    // Cancel any existing download for this model
+    _globalAborts.get(key)?.abort();
+
+    const controller = new AbortController();
+    _globalAborts.set(key, controller);
+
+    setDownloadState(key, { status: "pulling", statusText: "Starting…", percent: 0 });
+
+    try {
+      const res = await fetch(`${effectiveBaseUrlRef.current}/api/pull`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: modelId, stream: true }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        throw new Error(`Ollama responded with ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value: chunk } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          let obj: { status?: string; total?: number; completed?: number; error?: string };
+          try {
+            obj = JSON.parse(trimmed) as typeof obj;
+          } catch {
+            // non-fatal JSON parse errors — skip malformed lines
+            continue;
+          }
+
+          if (obj.error) throw new Error(obj.error);
+
+          let percent = _globalDownloads.get(key)?.percent ?? 0;
+          if (obj.total && obj.completed) {
+            percent = Math.round((obj.completed / obj.total) * 100);
+          }
+
+          if (obj.status === "success") {
+            setDownloadState(key, { status: "done", statusText: "Installed!", percent: 100 });
+            _globalAborts.delete(key);
+            onRefreshRef.current?.();
+            return;
+          }
+
+          // Filter out raw hash lines like "pulling 60e05f2100…"
+          const rawStatus = obj.status ?? "Downloading…";
+          const isHashLine = /^pulling\s+[0-9a-f]{8,}/i.test(rawStatus);
+          const statusText = isHashLine
+            ? (_globalDownloads.get(key)?.statusText ?? "Downloading…")
+            : rawStatus;
+
+          setDownloadState(key, { status: "pulling", statusText, percent });
+        }
+      }
+
+      // Parse any trailing data left in buffer after stream EOF
+      if (buffer.trim()) {
+        try {
+          const obj = JSON.parse(buffer.trim()) as { status?: string; error?: string };
+          if (obj.error) throw new Error(obj.error);
+          if (obj.status === "success") {
+            setDownloadState(key, { status: "done", statusText: "Installed!", percent: 100 });
+            _globalAborts.delete(key);
+            onRefreshRef.current?.();
+            return;
+          }
+        } catch (e) {
+          if (e instanceof Error && e.message !== buffer.trim()) throw e;
+          // parse error on trailing buffer — fall through
+        }
+      }
+
+      // Stream ended without explicit "success" status — treat as incomplete
+      setDownloadState(key, {
+        status: "error",
+        statusText: "Download ended without confirmation. Try again.",
+        percent: _globalDownloads.get(key)?.percent ?? 0,
+      });
+      _globalAborts.delete(key);
+    } catch (err) {
+      if ((err as Error).name === "AbortError") {
+        // Cancelled by user — clean up state
+        deleteDownloadState(key);
+        _globalAborts.delete(key);
+        return;
+      }
+      setDownloadState(key, {
+        status: "error",
+        statusText: "Failed",
+        percent: 0,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      _globalAborts.delete(key);
+    }
+  }, []);
+
+  function cancelDownload(modelId: string) {
+    const key = downloadKey(modelId, effectiveBaseUrlRef.current);
+    _globalAborts.get(key)?.abort();
+  }
+
+  function dismissError(modelId: string) {
+    const key = downloadKey(modelId, effectiveBaseUrlRef.current);
+    deleteDownloadState(key);
+  }
+
+  function selectModel(installedId: string) {
+    onChange(installedId === value ? "" : installedId);
+  }
+
+  const installedCount =
+    AGENTIC_MODELS.filter((m) => isModelInstalled(m.id, mergedInstalled)).length +
+    extraInstalled.length;
+
+  return (
+    <div className="space-y-3">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Zap className="h-3 w-3 text-yellow-500" />
+          <span className="text-xs font-medium">Agentic models</span>
+          {installedCount > 0 && (
+            <span className="text-[10px] text-green-600 dark:text-green-400">
+              ({installedCount} installed)
+            </span>
+          )}
+        </div>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+            title="Refresh installed models"
+          >
+            <RefreshCw className={cn("h-3 w-3", loading && "animate-spin")} />
+            Refresh
+          </button>
+        )}
+      </div>
+
+      {/* Loading state */}
+      {loading && mergedInstalled.length === 0 && (
+        <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Checking Ollama for installed models…
+        </div>
+      )}
+
+      {/* Agentic models list */}
+      <div className="grid grid-cols-1 gap-1.5">
+        {AGENTIC_MODELS.map((m) => {
+          const installed = isModelInstalled(m.id, mergedInstalled);
+          const dl = downloads[downloadKey(m.id, effectiveBaseUrl)];
+          const installedId = installed
+            ? getInstalledId(m.id, mergedInstalled)
+            : m.id;
+          const selected =
+            value === installedId ||
+            value === m.id ||
+            // Only do base-name matching when the current value is untagged
+            (installed &&
+              !value.includes(":") &&
+              value.toLowerCase() === m.id.split(":")[0].toLowerCase());
+
+          return (
+            <div
+              key={m.id}
+              className={cn(
+                "flex items-start gap-3 rounded-md border px-3 py-2 text-xs transition-colors",
+                installed
+                  ? selected
+                    ? "border-green-500/60 bg-green-500/10 cursor-pointer"
+                    : "border-border hover:border-green-500/40 hover:bg-green-500/5 cursor-pointer"
+                  : "border-border/40",
+              )}
+              onClick={() => installed && selectModel(installedId)}
+            >
+              {/* Status indicator */}
+              <div className="shrink-0 mt-0.5">
+                {installed ? (
+                  <div
+                    className={cn(
+                      "h-4 w-4 rounded-full flex items-center justify-center",
+                      selected
+                        ? "bg-green-500 text-white"
+                        : "bg-green-500/20 text-green-600",
+                    )}
+                  >
+                    <Check className="h-2.5 w-2.5" />
+                  </div>
+                ) : (
+                  <div className="h-4 w-4 rounded-full bg-muted/60 flex items-center justify-center">
+                    <Download className="h-2.5 w-2.5 text-muted-foreground/60" />
+                  </div>
+                )}
+              </div>
+
+              {/* Model info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <span
+                    className={cn(
+                      "font-medium",
+                      selected && "text-green-700 dark:text-green-400",
+                      !installed && "text-muted-foreground",
+                    )}
+                  >
+                    {m.label}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground/50 shrink-0">
+                    {m.size}
+                  </span>
+                </div>
+                <div className="text-[10px] text-muted-foreground truncate mt-0.5">
+                  {m.desc}
+                </div>
+                <div className="flex items-center gap-1 mt-1 flex-wrap">
+                  {m.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className={cn(
+                        "inline-block px-1 py-0 rounded text-[9px] font-medium leading-4",
+                        tag === "tool-use"
+                          ? "bg-blue-500/10 text-blue-600 dark:text-blue-400"
+                          : tag === "code"
+                            ? "bg-purple-500/10 text-purple-600 dark:text-purple-400"
+                            : tag === "reasoning"
+                              ? "bg-orange-500/10 text-orange-600 dark:text-orange-400"
+                              : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      {TAG_LABELS[tag] ?? tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Action */}
+              <div className="shrink-0 mt-0.5 min-w-[80px] flex justify-end">
+                {installed ? (
+                  <span
+                    className={cn(
+                      "text-[10px] font-medium",
+                      selected
+                        ? "text-green-600 dark:text-green-400"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {selected ? "Selected" : "Use"}
+                  </span>
+                ) : dl?.status === "done" ? (
+                  <span className="text-[10px] font-medium text-green-600 dark:text-green-400 flex items-center gap-1">
+                    <Check className="h-2.5 w-2.5" />
+                    Installed!
+                  </span>
+                ) : dl?.status === "pulling" ? (
+                  <div className="flex flex-col items-end gap-0.5 w-full">
+                    <div className="flex items-center justify-between w-full">
+                      <span className="text-[10px] text-muted-foreground flex items-center gap-1">
+                        <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                        {dl.percent > 0 ? `${dl.percent}%` : "…"}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); cancelDownload(m.id); }}
+                        className="text-[9px] text-muted-foreground hover:text-destructive flex items-center gap-0.5 transition-colors"
+                        title="Cancel download"
+                      >
+                        <XCircle className="h-3 w-3" />
+                      </button>
+                    </div>
+                    <div className="w-full bg-muted rounded-full h-1 overflow-hidden">
+                      <div
+                        className="bg-blue-500 h-1 rounded-full transition-all duration-300"
+                        style={{ width: `${dl.percent}%` }}
+                      />
+                    </div>
+                  </div>
+                ) : dl?.status === "error" ? (
+                  <div className="flex flex-col items-end gap-0.5">
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); dismissError(m.id); }}
+                      className="text-[9px] text-destructive flex items-center gap-0.5 hover:underline"
+                      title={dl.error}
+                    >
+                      <AlertCircle className="h-2.5 w-2.5" />
+                      Failed
+                      <X className="h-2 w-2" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); void startDownload(m.id); }}
+                      className="text-[9px] text-muted-foreground hover:text-foreground underline"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void startDownload(m.id);
+                    }}
+                    className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] bg-blue-500/10 text-blue-600 dark:text-blue-400 hover:bg-blue-500/20 transition-colors border border-blue-500/20"
+                    title={`Download ${m.label} (${m.size})`}
+                  >
+                    <Download className="h-2.5 w-2.5" />
+                    Download
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Extra installed models not in the agentic catalog */}
+        {extraInstalled.map((m) => {
+          const selected = value === m.id;
+          return (
+            <div
+              key={m.id}
+              className={cn(
+                "flex items-center gap-3 rounded-md border px-3 py-2 text-xs transition-colors cursor-pointer",
+                selected
+                  ? "border-green-500/60 bg-green-500/10"
+                  : "border-border hover:border-green-500/40 hover:bg-green-500/5",
+              )}
+              onClick={() => selectModel(m.id)}
+            >
+              <div className="shrink-0">
+                <div
+                  className={cn(
+                    "h-4 w-4 rounded-full flex items-center justify-center",
+                    selected
+                      ? "bg-green-500 text-white"
+                      : "bg-green-500/20 text-green-600",
+                  )}
+                >
+                  <Check className="h-2.5 w-2.5" />
+                </div>
+              </div>
+              <div className="flex-1 min-w-0">
+                <div
+                  className={cn(
+                    "font-medium",
+                    selected && "text-green-700 dark:text-green-400",
+                  )}
+                >
+                  {m.label}
+                </div>
+                <div className="text-[10px] text-muted-foreground">
+                  Installed locally
+                </div>
+              </div>
+              <span
+                className={cn(
+                  "shrink-0 text-[10px] font-medium",
+                  selected
+                    ? "text-green-600 dark:text-green-400"
+                    : "text-muted-foreground",
+                )}
+              >
+                {selected ? "Selected" : "Use"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* No Ollama hint */}
+      {!loading && mergedInstalled.length === 0 && Object.keys(downloads).length === 0 && (
+        <p className="text-[11px] text-muted-foreground bg-muted/50 rounded px-2.5 py-2">
+          Ollama not detected or no models installed. Click{" "}
+          <strong className="font-medium text-foreground">Download</strong>{" "}
+          next to any model to install it from Ollama.
+        </p>
+      )}
+
+      {/* Manual override input */}
+      <div className="pt-1">
+        <label className="text-[10px] text-muted-foreground mb-1 block">
+          Or enter a model name manually
+        </label>
+        <input
+          type="text"
+          className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-xs font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/40"
+          placeholder="e.g. llama3.1:8b or qwen2.5-coder:7b"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -7,6 +7,7 @@ import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
+import { ollamaLocalUIAdapter } from "./ollama-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 import { loadDynamicParser, invalidateDynamicParser } from "./dynamic-loader";
@@ -51,6 +52,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
     hermesLocalUIAdapter,
+    ollamaLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -38,6 +38,7 @@ import {
   DEFAULT_CODEX_LOCAL_MODEL
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_OLLAMA_MODEL } from "@paperclipai/adapter-ollama-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
@@ -220,6 +221,7 @@ export function OnboardingWizard() {
     pi_local: "pi",
     cursor: "agent",
     opencode_local: "opencode",
+    ollama_local: "ollama",
   };
   const effectiveAdapterCommand =
     command.trim() ||
@@ -321,6 +323,8 @@ export function OnboardingWizard() {
             ? model || DEFAULT_GEMINI_LOCAL_MODEL
           : adapterType === "cursor"
           ? model || DEFAULT_CURSOR_LOCAL_MODEL
+          : adapterType === "ollama_local"
+          ? model || DEFAULT_OLLAMA_MODEL
           : model,
       command,
       args,


### PR DESCRIPTION
## Thinking Path

Paperclip orchestrates AI agents, but every supported adapter today requires either a cloud API or a proprietary CLI binary. The most requested feature (#187 — 41 upvotes, 25 comments) is native Ollama support so users can run agents with free, local, open-source LLMs like Llama, Qwen, DeepSeek, and Gemma — no API keys, no cloud dependency, fully private.

Ollama exposes a stable HTTP API, so unlike other local adapters that shell out to a CLI binary, this adapter talks directly to Ollama over HTTP streaming. This avoids process lifecycle complexity while still supporting streaming responses, session continuity, and the full adapter contract.

## Changes

- New adapter package `@paperclipai/adapter-ollama-local` with:
  - HTTP streaming execution via Ollama `/api/generate`
  - Model discovery via `/api/tags` with curated agentic model catalog
  - Environment probe: `/api/version` + `/api/tags` + live `/api/chat` hello
  - Session continuity via capped message history (last 20 turn-pairs)
  - CLI stdout event formatting
- UI components:
  - Config fields (base URL, model picker, system prompt)
  - Model picker with one-click download, real-time progress, install tracking
  - Client-side model fetch from configured Ollama host (not just localhost)
- Registered as first-class builtin across server, CLI, UI, and onboarding wizard
- Added to `BUILTIN_ADAPTER_TYPES` and `AGENT_ADAPTER_TYPES`

## Key Design Decisions

- **Tagged model resolution**: exact match for tagged requests (`qwen2.5-coder:32b` won't silently resolve to `:7b`). Base-name fallback only for untagged.
- **baseUrl validation**: rejects non-http(s) schemes to prevent SSRF
- **Session cap**: 20 turn-pairs max (configurable via `maxHistoryTurns`) to prevent unbounded growth — other adapters use opaque session IDs, but Ollama has no built-in session persistence
- **Download error handling**: requires explicit `success` status from Ollama pull stream; EOF without confirmation shows error instead of false "Installed!"
- **Reader cleanup**: stream reader released in try/finally to prevent connection leaks

## Verification

```bash
pnpm typecheck          # all packages pass
pnpm vitest run         # ollama build-config tests pass
```

Manual testing: full onboarding wizard flow with Ollama + llama3.2

## Risks

- **Low**: New adapter, no changes to existing adapter behavior
- Ollama must be running locally (or at configured baseUrl) — clear error messages guide users to `ollama serve`
- `listModels` in the server registry doesn't thread per-agent `baseUrl` (registry interface limitation) — mitigated by client-side model fetch in the picker

## Model Used

- Claude Opus 4.6 (Anthropic) for review assistance

## Checklist

- [x] Thinking path documented
- [x] Model specified
- [x] Tests pass locally (typecheck + vitest)
- [x] Test coverage for adapter config builder
- [x] Security: baseUrl validation, no command injection (HTTP-only adapter)
- [x] Resource safety: reader cleanup, timeout handling, session cap
- [x] Registered in all 3 registries (server, CLI, UI) + builtin types + display registry
- [x] Risk analysis included

Closes #187