### PR TITLE
feat(memory): persistent PARA memory system for all agents

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -119,6 +119,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const workspaceBranch = asString(workspaceContext.branchName, "") || null;
   const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
   const agentHome = asString(workspaceContext.agentHome, "") || null;
+  const companyKnowledgePath = asString(workspaceContext.companyKnowledgePath, "") || null;
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
@@ -215,6 +216,9 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
   if (agentHome) {
     env.AGENT_HOME = agentHome;
+  }
+  if (companyKnowledgePath) {
+    env.PAPERCLIP_COMPANY_KNOWLEDGE_PATH = companyKnowledgePath;
   }
   if (workspaceHints.length > 0) {
     env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -90,6 +90,14 @@ export function resolveManagedProjectWorkspaceDir(input: {
   );
 }
 
+export function resolveCompanyKnowledgeDir(companyId: string): string {
+  const trimmed = companyId.trim();
+  if (!trimmed) {
+    throw new Error("Company knowledge path requires a companyId.");
+  }
+  return path.resolve(resolvePaperclipInstanceRoot(), "companies", trimmed, "knowledge");
+}
+
 export function resolveHomeAwarePath(value: string): string {
   return path.resolve(expandHomePrefix(value));
 }

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -1,3 +1,21 @@
 You are an agent at Paperclip company.
 
 Keep the work moving until it's done. If you need QA to review it, ask them. If you need your boss to review it, ask them. If someone needs to unblock you, assign them the ticket with a comment asking for what you need. Don't let work just sit here. You must always update your task with a comment.
+
+## Memory
+
+You have a persistent file-based memory at `$AGENT_HOME`. Use the `para-memory-files` skill for ALL memory operations.
+
+**At the start of every run:**
+1. Read `$AGENT_HOME/MEMORY.md` for your operating patterns and lessons learned.
+2. Read `$AGENT_HOME/memory/YYYY-MM-DD.md` (today's date) for context from earlier runs today.
+3. Scan `$AGENT_HOME/life/index.md` for entities you've already tracked.
+
+**At the end of every run:**
+1. Append a timeline entry to today's daily note (`$AGENT_HOME/memory/YYYY-MM-DD.md`).
+2. Extract durable facts to the relevant entity in `$AGENT_HOME/life/` (projects, areas, resources).
+3. Update `$AGENT_HOME/MEMORY.md` if you learned a new operating pattern or lesson.
+
+**Company knowledge** (read-only): If `$PAPERCLIP_COMPANY_KNOWLEDGE_PATH` is set, read it for shared project context written by leadership.
+
+Do not skip memory steps. Your future self depends on what you persist now.

--- a/server/src/onboarding-assets/default/HEARTBEAT.md
+++ b/server/src/onboarding-assets/default/HEARTBEAT.md
@@ -1,0 +1,31 @@
+# HEARTBEAT.md -- Agent Heartbeat Checklist
+
+Run this checklist on every heartbeat.
+
+## 1. Context
+
+- Check wake context: `PAPERCLIP_TASK_ID`, `PAPERCLIP_WAKE_REASON`, `PAPERCLIP_WAKE_COMMENT_ID`.
+- If `PAPERCLIP_APPROVAL_ID` is set, review the approval first.
+
+## 2. Recall
+
+1. Read `$AGENT_HOME/MEMORY.md` for operating patterns.
+2. Read `$AGENT_HOME/memory/YYYY-MM-DD.md` for today's timeline.
+3. If `$PAPERCLIP_COMPANY_KNOWLEDGE_PATH` is set, scan it for shared context.
+
+## 3. Work
+
+- Always checkout before working: `POST /api/issues/{id}/checkout`.
+- Never retry a 409 -- that task belongs to someone else.
+- Do the work. Update status and comment when done.
+
+## 4. Persist
+
+1. Append a timeline entry to `$AGENT_HOME/memory/YYYY-MM-DD.md`.
+2. Extract durable facts to `$AGENT_HOME/life/` using the `para-memory-files` skill.
+3. Update `$AGENT_HOME/MEMORY.md` if you discovered a new operating pattern.
+
+## 5. Exit
+
+- Comment on any in_progress work before exiting.
+- If no assignments and no valid mention-handoff, exit cleanly.

--- a/server/src/services/agent-home.ts
+++ b/server/src/services/agent-home.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const PARA_DIRS = [
+  "life/projects",
+  "life/areas",
+  "life/resources",
+  "life/archives",
+  "memory",
+];
+
+const LIFE_INDEX_CONTENT = `# Knowledge Graph Index
+
+Entities discovered by this agent are stored here using the PARA method.
+`;
+
+const MEMORY_MD_CONTENT = `# Tacit Knowledge
+
+Operating patterns, preferences, and lessons learned.
+Update this file when you discover new ways of working that should persist.
+`;
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeIfAbsent(filePath: string, content: string): Promise<void> {
+  if (await fileExists(filePath)) return;
+  await fs.writeFile(filePath, content, "utf8");
+}
+
+/**
+ * Idempotently creates the PARA directory structure and seed files
+ * inside an agent's home directory. Safe to call on every heartbeat —
+ * existing files are never overwritten.
+ */
+export async function ensureAgentHomeStructure(homePath: string): Promise<void> {
+  await Promise.all(
+    PARA_DIRS.map((dir) => fs.mkdir(path.join(homePath, dir), { recursive: true })),
+  );
+
+  await Promise.all([
+    writeIfAbsent(path.join(homePath, "life", "index.md"), LIFE_INDEX_CONTENT),
+    writeIfAbsent(path.join(homePath, "MEMORY.md"), MEMORY_MD_CONTENT),
+  ]);
+}

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -35,6 +35,12 @@ import { agentService } from "./agents.js";
 import { projectService } from "./projects.js";
 import { secretService } from "./secrets.js";
 
+/**
+ * Skills that are always required for all agents, regardless of sourceKind.
+ * These provide foundational capabilities (memory, knowledge persistence).
+ */
+const CORE_REQUIRED_SKILL_SLUGS = new Set(["para-memory-files"]);
+
 type CompanySkillRow = typeof companySkills.$inferSelect;
 
 type ImportedSkill = {
@@ -2070,15 +2076,19 @@ export function companySkillService(db: Db) {
       }
       if (!source) continue;
 
-      const required = sourceKind === "paperclip_bundled";
+      const isBundled = sourceKind === "paperclip_bundled";
+      const isCoreSkill = CORE_REQUIRED_SKILL_SLUGS.has(skill.slug);
+      const required = isBundled || isCoreSkill;
       out.push({
         key: skill.key,
         runtimeName: buildSkillRuntimeName(skill.key, skill.slug),
         source,
         required,
-        requiredReason: required
+        requiredReason: isBundled
           ? "Bundled Paperclip skills are always available for local adapters."
-          : null,
+          : isCoreSkill
+            ? "Core skill required for agent memory and knowledge persistence."
+            : null,
       });
     }
 

--- a/server/src/services/default-agent-instructions.ts
+++ b/server/src/services/default-agent-instructions.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 
 const DEFAULT_AGENT_BUNDLE_FILES = {
-  default: ["AGENTS.md"],
+  default: ["AGENTS.md", "HEARTBEAT.md"],
   ceo: ["AGENTS.md", "HEARTBEAT.md", "SOUL.md", "TOOLS.md"],
 } as const;
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -28,7 +28,8 @@ import { costService } from "./costs.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
-import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { resolveDefaultAgentWorkspaceDir, resolveCompanyKnowledgeDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { ensureAgentHomeStructure } from "./agent-home.js";
 import { summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
 import {
   buildWorkspaceReadyComment,
@@ -1084,20 +1085,32 @@ export function heartbeatService(db: Db) {
       };
     }
 
-    const latestSummary = summarizeHeartbeatRunResultJson(latestRun.resultJson);
-    const latestTextSummary =
-      readNonEmptyString(latestSummary?.summary) ??
-      readNonEmptyString(latestSummary?.result) ??
-      readNonEmptyString(latestSummary?.message) ??
-      readNonEmptyString(latestRun.error);
+    const recentRuns = runs.slice(0, 5);
+    const runSummaries = recentRuns
+      .map((run, i) => {
+        const summary = summarizeHeartbeatRunResultJson(run.resultJson);
+        const text =
+          readNonEmptyString(summary?.summary) ??
+          readNonEmptyString(summary?.result) ??
+          readNonEmptyString(summary?.message) ??
+          readNonEmptyString(run.error);
+        return text ? `  ${i + 1}. ${text}` : null;
+      })
+      .filter(Boolean);
 
     const handoffMarkdown = [
       "Paperclip session handoff:",
       `- Previous session: ${sessionId}`,
       issueId ? `- Issue: ${issueId}` : "",
       `- Rotation reason: ${reason}`,
-      latestTextSummary ? `- Last run summary: ${latestTextSummary}` : "",
-      "Continue from the current task state. Rebuild only the minimum context you need.",
+      `- Session runs: ${runs.length}`,
+      runSummaries.length > 0 ? `- Recent run summaries (newest first):\n${runSummaries.join("\n")}` : "",
+      "",
+      "Recover full context from your memory files:",
+      "- Read $AGENT_HOME/memory/YYYY-MM-DD.md for today's timeline.",
+      "- Read $AGENT_HOME/MEMORY.md for operating patterns.",
+      "- Scan $AGENT_HOME/life/index.md for tracked entities.",
+      "Continue from the current task state.",
     ]
       .filter(Boolean)
       .join("\n");
@@ -2414,8 +2427,13 @@ export function heartbeatService(db: Db) {
       worktreePath: executionWorkspace.worktreePath,
       agentHome: await (async () => {
         const home = resolveDefaultAgentWorkspaceDir(agent.id);
-        await fs.mkdir(home, { recursive: true });
+        await ensureAgentHomeStructure(home);
         return home;
+      })(),
+      companyKnowledgePath: await (async () => {
+        const knowledgeDir = resolveCompanyKnowledgeDir(agent.companyId);
+        await fs.mkdir(knowledgeDir, { recursive: true });
+        return knowledgeDir;
       })(),
     };
     context.paperclipWorkspaces = resolvedWorkspace.workspaceHints;


### PR DESCRIPTION
## Summary

- **Scaffold PARA structure** (`life/`, `memory/`, `MEMORY.md`) idempotently at every heartbeat via new `agent-home.ts`
- **Default HEARTBEAT.md** with mandatory read/write memory checklist for all agents (not just CEO)
- **Richer session handoff**: last 5 run summaries + pointers to memory files
- **Company knowledge directory**: shared `PAPERCLIP_COMPANY_KNOWLEDGE_PATH` env var (CEO writes, others read)
- **`para-memory-files` marked required** via `CORE_REQUIRED_SKILL_SLUGS` in `company-skills.ts`

## Why

Agents were rediscovering the project from scratch on every heartbeat because `$AGENT_HOME` was created as an empty directory and default agents had no memory instructions. Only the CEO role had a HEARTBEAT.md with fact extraction.

## Files changed (8)

| File | Change |
|------|--------|
| `server/src/services/agent-home.ts` | **New** — `ensureAgentHomeStructure()` |
| `server/src/onboarding-assets/default/HEARTBEAT.md` | **New** — heartbeat checklist for all agents |
| `server/src/services/heartbeat.ts` | Scaffolding + enriched handoff + company knowledge |
| `server/src/onboarding-assets/default/AGENTS.md` | Added `## Memory` section |
| `server/src/services/default-agent-instructions.ts` | Added HEARTBEAT.md to default bundle |
| `server/src/home-paths.ts` | Added `resolveCompanyKnowledgeDir()` |
| `packages/adapters/claude-local/src/server/execute.ts` | Added `PAPERCLIP_COMPANY_KNOWLEDGE_PATH` env var |
| `server/src/services/company-skills.ts` | Added `CORE_REQUIRED_SKILL_SLUGS` |

## Test plan

- [ ] Trigger a heartbeat for any agent → verify `$AGENT_HOME/life/`, `memory/`, `MEMORY.md` exist
- [ ] Hire a new default agent → verify bundle contains both AGENTS.md and HEARTBEAT.md
- [ ] Force session rotation → verify handoff contains recent run summaries + memory file pointers
- [ ] Check `PAPERCLIP_COMPANY_KNOWLEDGE_PATH` env var is set in adapter execution logs
- [ ] Run 3 successive tasks with an agent → verify facts accumulate in `life/` and notes in `memory/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)