### PR TITLE
fix: use Drizzle operators for issue comments keyset pagination

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, lte, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, lte, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -1381,14 +1381,20 @@ export function issueService(db: Db) {
         if (!anchor) return [];
         conditions.push(
           order === "asc"
-            ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
-              )`
-            : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
-              )`,
+            ? or(
+                gt(issueComments.createdAt, anchor.createdAt),
+                and(
+                  eq(issueComments.createdAt, anchor.createdAt),
+                  gt(issueComments.id, anchor.id),
+                ),
+              )!
+            : or(
+                lt(issueComments.createdAt, anchor.createdAt),
+                and(
+                  eq(issueComments.createdAt, anchor.createdAt),
+                  lt(issueComments.id, anchor.id),
+                ),
+              )!,
         );
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue comments support cursor-based pagination via `afterCommentId` query param on `GET /api/issues/:id/comments`
> - The `listComments` service function used raw `sql` template literals for keyset pagination conditions (`>` / `<` on `createdAt` and `id`)
> - Drizzle ORM does not correctly interpolate JavaScript Date and UUID values inside raw `sql` template literals for comparison operators, causing an unhandled database error
> - The result is HTTP 500 on any `GET /api/issues/:id/comments?after={commentId}` call
> - This broke downstream integrations that poll for new comments using cursor pagination
> - The fix replaces raw SQL template comparisons with native Drizzle operators (`gt`, `lt`, `eq`, `or`, `and`) which handle type casting correctly

## What Changed

- **`server/src/services/issues.ts`**: Replaced raw `sql<boolean>` template literal conditions in `listComments` keyset pagination with Drizzle's built-in `gt()`, `lt()`, `eq()`, `or()`, and `and()` operators
- Added `gt`, `gte`, `lt`, `lte` to the Drizzle ORM import

## How to Reproduce (before fix)

```bash
# Returns HTTP 500
curl "http://localhost:3100/api/issues/{issueId}/comments?order=asc&after={commentId}" \
  -H "Authorization: Bearer {apiKey}"
```

## After Fix

```bash
# Returns HTTP 200 with comments after the cursor
curl "http://localhost:3100/api/issues/{issueId}/comments?order=asc&after={commentId}" \
  -H "Authorization: Bearer {apiKey}"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)