### PR TITLE
fix: remove hardcoded JWT secret fallback from auth init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DATABASE_URL=postgres://paperclip:paperclip@localhost:5432/paperclip
 PORT=3100
 SERVE_UI=false
+BETTER_AUTH_SECRET=paperclip-dev-secret

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -67,7 +67,13 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
 
 export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
-  const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET ?? "paperclip-dev-secret";
+  const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  if (!secret) {
+    throw new Error(
+      "BETTER_AUTH_SECRET (or PAPERCLIP_AGENT_JWT_SECRET) must be set. " +
+      "For local development, set BETTER_AUTH_SECRET=paperclip-dev-secret in your .env file.",
+    );
+  }
   const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);
 
   const publicUrl = process.env.PAPERCLIP_PUBLIC_URL ?? baseUrl;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -475,13 +475,6 @@ export async function startServer(): Promise<StartedServer> {
       resolveBetterAuthSession,
       resolveBetterAuthSessionFromHeaders,
     } = await import("./auth/better-auth.js");
-    const betterAuthSecret =
-      process.env.BETTER_AUTH_SECRET?.trim() ?? process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim();
-    if (!betterAuthSecret) {
-      throw new Error(
-        "authenticated mode requires BETTER_AUTH_SECRET (or PAPERCLIP_AGENT_JWT_SECRET) to be set",
-      );
-    }
     const derivedTrustedOrigins = deriveAuthTrustedOrigins(config);
     const envTrustedOrigins = (process.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "")
       .split(",")


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The server's auth subsystem uses Better Auth to issue and verify JWTs for session management
> - `createBetterAuthInstance()` silently falls back to the hardcoded string `"paperclip-dev-secret"` when `BETTER_AUTH_SECRET` is unset
> - Although guards exist in `startServer()` and Docker Compose, any code path that calls `createBetterAuthInstance()` directly bypasses them — running production with a known, guessable secret
> - This pull request moves the secret validation into `createBetterAuthInstance()` itself, making it impossible to construct an auth instance without an explicit secret
> - The benefit is defense-in-depth: the guard is co-located with the risk, and dev convenience is preserved via `.env.example`

## What Changed

- **`server/src/auth/better-auth.ts`** — Replaced the `?? "paperclip-dev-secret"` fallback with a hard throw if neither `BETTER_AUTH_SECRET` nor `PAPERCLIP_AGENT_JWT_SECRET` is set. The error message guides developers to set the value in `.env`.
- **`server/src/index.ts`** — Removed the redundant secret check in the `authenticated` block of `startServer()`, since `createBetterAuthInstance()` now handles it.
- **`.env.example`** — Added `BETTER_AUTH_SECRET=paperclip-dev-secret` so local dev setups have the value ready to copy.

## Verification

- `pnpm vitest run` in `server/` — 118/121 tests pass (3 pre-existing failures unrelated to this change)
- Start the server **without** `BETTER_AUTH_SECRET` set → confirm it throws with a clear error message
- Start with `BETTER_AUTH_SECRET=paperclip-dev-secret` → confirm it works normally

## Risks

- **Breaking for existing dev setups** that rely on the silent fallback and don't have a `.env` file. Mitigated by the clear error message pointing them to set the var, and by `.env.example` documenting the default value.
- No migration, no schema change, no behavioral change for any deployment that already sets the env var.

## Model Used

- **Provider:** Anthropic Claude
- **Model ID:** `claude-opus-4-6` (Opus 4.6)
- **Context window:** 1M tokens
- **Capabilities:** Tool use, code execution, agentic coding via Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
