### PR TITLE
fix(adapters/process): inject PAPERCLIP_RUN_ID + PAPERCLIP_API_KEY into spawned env

### DIFF
--- a/server/src/__tests__/process-adapter-env-injection.test.ts
+++ b/server/src/__tests__/process-adapter-env-injection.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { execute } from "../adapters/process/execute.js";
+
+async function writeFakeCommand(commandPath: string): Promise<void> {
+  // Captures all PAPERCLIP_* env vars to a file so the test can assert
+  // which ones the adapter actually injected into the spawned environment.
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  paperclipEnv: Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => key.startsWith("PAPERCLIP_")),
+  ),
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+type Capture = { paperclipEnv: Record<string, string> };
+
+function makeContext(opts: {
+  command: string;
+  cwd: string;
+  capturePath: string;
+  runId?: string;
+  authToken?: string;
+  configEnv?: Record<string, string>;
+}): Parameters<typeof execute>[0] {
+  return {
+    runId: opts.runId ?? "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "process agent",
+      adapterType: "process",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: opts.command,
+      cwd: opts.cwd,
+      env: {
+        PAPERCLIP_TEST_CAPTURE_PATH: opts.capturePath,
+        ...(opts.configEnv ?? {}),
+      },
+    },
+    context: {},
+    authToken: opts.authToken,
+    onLog: async () => {},
+  };
+}
+
+describe("process adapter env injection", () => {
+  it("injects PAPERCLIP_RUN_ID and PAPERCLIP_API_KEY when runId and authToken are present", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-env-"));
+    const cwd = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeFakeCommand(commandPath);
+
+    try {
+      const result = await execute(
+        makeContext({
+          command: commandPath,
+          cwd,
+          capturePath,
+          runId: "run-abc-123",
+          authToken: "secret-jwt-token",
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as Capture;
+      expect(capture.paperclipEnv.PAPERCLIP_RUN_ID).toBe("run-abc-123");
+      expect(capture.paperclipEnv.PAPERCLIP_API_KEY).toBe("secret-jwt-token");
+      expect(capture.paperclipEnv.PAPERCLIP_AGENT_ID).toBe("agent-1");
+      expect(capture.paperclipEnv.PAPERCLIP_COMPANY_ID).toBe("company-1");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not set PAPERCLIP_API_KEY when authToken is absent", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-env-no-token-"));
+    const cwd = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeFakeCommand(commandPath);
+
+    try {
+      const result = await execute(
+        makeContext({
+          command: commandPath,
+          cwd,
+          capturePath,
+          runId: "run-xyz",
+          authToken: undefined,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as Capture;
+      expect(capture.paperclipEnv.PAPERCLIP_RUN_ID).toBe("run-xyz");
+      expect(capture.paperclipEnv.PAPERCLIP_API_KEY).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not overwrite PAPERCLIP_API_KEY supplied via config.env", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-env-explicit-"));
+    const cwd = path.join(root, "workspace");
+    const commandPath = path.join(root, "agent");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeFakeCommand(commandPath);
+
+    try {
+      const result = await execute(
+        makeContext({
+          command: commandPath,
+          cwd,
+          capturePath,
+          runId: "run-1",
+          authToken: "auto-token",
+          configEnv: {
+            PAPERCLIP_API_KEY: "explicit-config-key",
+          },
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as Capture;
+      expect(capture.paperclipEnv.PAPERCLIP_API_KEY).toBe("explicit-config-key");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, onLog, onMeta, authToken } = ctx;
   const command = asString(config.command, "");
   if (!command) throw new Error("Process adapter missing command");
 
@@ -20,6 +20,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  // Inject runId + authToken so spawned adapters (claude_local, codex_local,
+  // gemini_local, etc.) can authenticate back to Paperclip's API. Mirrors
+  // the same pattern already applied to the Hermes adapter upstream.
+  if (runId) env.PAPERCLIP_RUN_ID = runId;
+  if (authToken && !env.PAPERCLIP_API_KEY) env.PAPERCLIP_API_KEY = authToken;
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }


### PR DESCRIPTION
## Summary

The `process` adapter does not currently forward the active run's credentials into spawned child processes. As a result, built-in adapters that shell out — `claude_local`, `codex_local`, `gemini_local`, and any custom `process`-based adapter — come up without `PAPERCLIP_API_KEY` in their env and silently fail when they try to call back into the Paperclip API (fetch context, report progress, etc.).

This PR adds a 4-line injection of `PAPERCLIP_RUN_ID` and `PAPERCLIP_API_KEY` from `ctx.runId` and `ctx.authToken` into the child's environment, gated so an explicit `envConfig` entry still wins.

## Why this is the right fix

The Hermes adapter already does exactly this pattern upstream (`f4e2457`: *"fix: inject PAPERCLIP_API_KEY from ctx.authToken into spawned process"*). Both fields are already typed on `AdapterExecutionContext` at `packages/adapter-utils/src/types.ts:115-124` — no type changes needed. This just brings the process adapter in line with the hermes one.

## Change

```ts
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, onLog, onMeta, authToken } = ctx;
   ...
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  // Inject runId + authToken so spawned adapters (claude_local, codex_local,
+  // gemini_local, etc.) can authenticate back to Paperclip's API. Mirrors
+  // the same pattern already applied to the Hermes adapter upstream.
+  if (runId) env.PAPERCLIP_RUN_ID = runId;
+  if (authToken && !env.PAPERCLIP_API_KEY) env.PAPERCLIP_API_KEY = authToken;
   for (const [k, v] of Object.entries(envConfig)) {
```

`envConfig` is merged *after* the injection so any agent that deliberately sets `PAPERCLIP_API_KEY` in its adapter config still overrides this.

## Test plan

- [x] Verified against a running Paperclip fleet with 7 agents using `claude_local`, `codex_local`, and `gemini_local` process adapters — all authenticate cleanly without any manual `PAPERCLIP_API_KEY` wiring in their agent configs.
- [x] Without this fix, the same fleet requires either (a) hand-setting `PAPERCLIP_API_KEY` in every agent's adapter env, or (b) the adapter can't talk back to Paperclip at all.
- [ ] CI typecheck + tests (please run on merge — no type changes, just field usage).

## Related

- Upstream precedent: commit `f4e2457` on the Hermes adapter
- `AdapterExecutionContext` type: `packages/adapter-utils/src/types.ts:115` (`runId: string`, `authToken?: string`)