### PR TITLE
fix: use unreadForUserId filter in inbox badge hook to fix saturation at ~100

### DIFF
--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -9,7 +9,6 @@ import { issuesApi } from "../api/issues";
 import { queryKeys } from "../lib/queryKeys";
 import {
   computeInboxBadgeData,
-  getRecentTouchedIssues,
   loadDismissedInboxItems,
   saveDismissedInboxItems,
   loadReadInboxItems,
@@ -107,18 +106,16 @@ export function useInboxBadge(companyId: string | null | undefined) {
     enabled: !!companyId,
   });
 
-  const { data: mineIssuesRaw = [] } = useQuery({
-    queryKey: queryKeys.issues.listMineByMe(companyId!),
+  const { data: mineIssues = [] } = useQuery({
+    queryKey: queryKeys.issues.listUnreadTouchedByMe(companyId!),
     queryFn: () =>
       issuesApi.list(companyId!, {
-        touchedByUserId: "me",
+        unreadForUserId: "me",
         inboxArchivedByUserId: "me",
         status: INBOX_ISSUE_STATUSES,
       }),
     enabled: !!companyId,
   });
-
-  const mineIssues = useMemo(() => getRecentTouchedIssues(mineIssuesRaw), [mineIssuesRaw]);
 
   const { data: heartbeatRuns = [] } = useQuery({
     queryKey: queryKeys.heartbeats(companyId!),


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, giving each company a shared web UI with a sidebar Inbox badge showing unread/actionable items
> - The sidebar badge is computed client-side in \`useInboxBadge\` by summing approvals, join requests, failed runs, alerts, and mine-issues
> - The mine-issues component was sourced from a \`touchedByUserId=me\` query — every issue the user has ever created, assigned, commented on, or opened — not filtered to unread ones
> - Before counting, the list was client-sliced to \`RECENT_ISSUES_LIMIT = 100\`; for users with >100 touched-not-archived issues the badge saturated at ~100+ permanently
> - The server already supports an \`unreadForUserId=me\` filter (used by the Inbox > Unread tab) that returns only issues with new activity since the user's last touch — the exact set needed for the badge
> - The \`listUnreadTouchedByMe\` query key was already defined in \`queryKeys.ts\` and wired for cache invalidation in \`IssueDetail\`, \`Inbox\`, \`LiveUpdatesProvider\`, and \`NewIssueDialog\`, but had no \`useQuery\` subscriber
> - This PR adds that subscriber and removes the now-unnecessary client-side cap

## What Changed

- \`ui/src/hooks/useInboxBadge.ts\`: swap the mine-issues query from \`listMineByMe\` + \`touchedByUserId: "me"\` to \`listUnreadTouchedByMe\` + \`unreadForUserId: "me"\`; remove the intermediate \`getRecentTouchedIssues\` call and the \`RECENT_ISSUES_LIMIT = 100\` cap

## Verification

\`\`\`
npx vitest run ui/src/lib/inbox.test.ts
# All 21 tests pass
\`\`\`

Manual: on an instance with >100 touched-not-archived issues, badge now shows the real unread count instead of ~100+.

## Risks

Low risk — purely a query parameter change with no schema migration. The \`unreadForUserId\` server filter is already in production use (Inbox > Unread tab). Cache invalidation for the new query key was already in place. The \`computeInboxBadgeData\` function's \`isUnreadForMe\` filter is now redundant but harmless (all returned issues will have \`isUnreadForMe: true\`).

## Model Used

Claude Sonnet 4.6 (\`claude-sonnet-4-6\`) via Claude Code CLI — with tool use and code execution. 1M context window, standard mode (no extended thinking).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Fixes #3136