### PR TITLE
fix: harden embedded postgres bootstrap and webhook raw-body handling

### DIFF
--- a/packages/db/src/embedded-postgres-bootstrap-lock.test.ts
+++ b/packages/db/src/embedded-postgres-bootstrap-lock.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireEmbeddedPostgresBootstrapLock,
+  readEmbeddedPostmasterInfo,
+} from "./embedded-postgres-bootstrap-lock.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-bootstrap-lock-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function lockPathForDataDir(dataDir: string) {
+  return path.resolve(path.dirname(dataDir), `${path.basename(dataDir)}.paperclip-embedded-postgres-bootstrap.lock`);
+}
+
+describe("acquireEmbeddedPostgresBootstrapLock", () => {
+  it("serializes concurrent bootstrap attempts for the same data dir", async () => {
+    const dataDir = makeTempDir();
+    const events: string[] = [];
+    const releaseFirst = await acquireEmbeddedPostgresBootstrapLock({ dataDir });
+
+    events.push("first-enter");
+
+    const second = (async () => {
+      const releaseSecond = await acquireEmbeddedPostgresBootstrapLock({ dataDir, timeoutMs: 5_000 });
+      events.push("second-enter");
+      await releaseSecond();
+    })();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    events.push("first-exit");
+    await releaseFirst();
+    await second;
+
+    expect(events).toEqual(["first-enter", "first-exit", "second-enter"]);
+  });
+
+  it("removes a stale bootstrap lock left by a dead process", async () => {
+    const dataDir = makeTempDir();
+    const lockPath = lockPathForDataDir(dataDir);
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 999_999,
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    );
+
+    const release = await acquireEmbeddedPostgresBootstrapLock({ dataDir, timeoutMs: 1_000, staleMs: 100 });
+    expect(fs.existsSync(lockPath)).toBe(true);
+    await release();
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not evict a fresh lock file that is still being written", async () => {
+    const dataDir = makeTempDir();
+    const lockPath = lockPathForDataDir(dataDir);
+    fs.writeFileSync(lockPath, "", "utf8");
+
+    await expect(
+      acquireEmbeddedPostgresBootstrapLock({
+        dataDir,
+        timeoutMs: 100,
+        pollIntervalMs: 20,
+        staleMs: 5_000,
+      }),
+    ).rejects.toThrow(/Timed out waiting/);
+
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it("reads pid and port from postmaster.pid", () => {
+    const dataDir = makeTempDir();
+    const pidFile = path.join(dataDir, "postmaster.pid");
+    fs.writeFileSync(pidFile, `${process.pid}\n/tmp\n17100\n54377\n`, "utf8");
+
+    expect(readEmbeddedPostmasterInfo(pidFile)).toEqual({
+      pid: process.pid,
+      port: 54377,
+    });
+  });
+});

--- a/packages/db/src/embedded-postgres-bootstrap-lock.ts
+++ b/packages/db/src/embedded-postgres-bootstrap-lock.ts
@@ -1,0 +1,142 @@
+import { promises as fs } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+type LockFilePayload = {
+  pid: number;
+  createdAt: string;
+};
+
+export interface EmbeddedPostgresBootstrapLockOptions {
+  dataDir: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  staleMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+const DEFAULT_STALE_MS = 15_000;
+const LOCK_FILE_SUFFIX = ".paperclip-embedded-postgres-bootstrap.lock";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readLockFile(lockPath: string): Promise<LockFilePayload | null> {
+  try {
+    const raw = await fs.readFile(lockPath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<LockFilePayload>;
+    if (typeof parsed.pid !== "number" || typeof parsed.createdAt !== "string") {
+      return null;
+    }
+    return { pid: parsed.pid, createdAt: parsed.createdAt };
+  } catch {
+    return null;
+  }
+}
+
+async function inspectLockFile(lockPath: string): Promise<{
+  payload: LockFilePayload | null;
+  mtimeMs: number | null;
+} | null> {
+  try {
+    const stat = await fs.stat(lockPath);
+    return {
+      payload: await readLockFile(lockPath),
+      mtimeMs: Number.isFinite(stat.mtimeMs) ? stat.mtimeMs : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function readEmbeddedPostmasterInfo(postmasterPidFile: string): {
+  pid: number | null;
+  port: number | null;
+} {
+  if (!existsSync(postmasterPidFile)) {
+    return { pid: null, port: null };
+  }
+
+  try {
+    const lines = readFileSync(postmasterPidFile, "utf8").split("\n");
+    const rawPid = Number(lines[0]?.trim());
+    const rawPort = Number(lines[3]?.trim());
+    const pid = Number.isInteger(rawPid) && rawPid > 0 && isProcessRunning(rawPid) ? rawPid : null;
+    const port = Number.isInteger(rawPort) && rawPort > 0 ? rawPort : null;
+    return { pid, port };
+  } catch {
+    return { pid: null, port: null };
+  }
+}
+
+async function removeLockFile(lockPath: string): Promise<void> {
+  await fs.rm(lockPath, { force: true });
+}
+
+export async function acquireEmbeddedPostgresBootstrapLock(
+  input: EmbeddedPostgresBootstrapLockOptions,
+): Promise<() => Promise<void>> {
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollIntervalMs = input.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const staleMs = input.staleMs ?? DEFAULT_STALE_MS;
+  const lockPath = path.resolve(
+    path.dirname(input.dataDir),
+    `${path.basename(input.dataDir)}${LOCK_FILE_SUFFIX}`,
+  );
+  const startedAt = Date.now();
+  const payload: LockFilePayload = {
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+  };
+
+  while (true) {
+    try {
+      await fs.mkdir(path.dirname(lockPath), { recursive: true });
+      await fs.writeFile(lockPath, JSON.stringify(payload), { flag: "wx" });
+      return async () => {
+        await removeLockFile(lockPath);
+      };
+    } catch (error) {
+      const maybeCode =
+        typeof error === "object" && error !== null && "code" in error
+          ? (error as { code?: unknown }).code
+          : undefined;
+      if (maybeCode !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    const existing = await inspectLockFile(lockPath);
+    const existingPayload = existing?.payload ?? null;
+    const lockAgeMs = existing?.mtimeMs != null ? Date.now() - existing.mtimeMs : staleMs + 1;
+    const stale =
+      !existing ||
+      Number.isNaN(lockAgeMs) ||
+      lockAgeMs > staleMs ||
+      (existingPayload !== null && !isProcessRunning(existingPayload.pid));
+
+    if (stale) {
+      await removeLockFile(lockPath);
+      continue;
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(
+        `Timed out waiting for embedded PostgreSQL bootstrap lock in ${input.dataDir}`,
+      );
+    }
+
+    await sleep(pollIntervalMs);
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29,5 +29,10 @@ export {
   createEmbeddedPostgresLogBuffer,
   formatEmbeddedPostgresError,
 } from "./embedded-postgres-error.js";
+export {
+  acquireEmbeddedPostgresBootstrapLock,
+  readEmbeddedPostmasterInfo,
+  type EmbeddedPostgresBootstrapLockOptions,
+} from "./embedded-postgres-bootstrap-lock.js";
 export { issueRelations } from "./schema/issue_relations.js";
 export * from "./schema/index.js";

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -1,7 +1,11 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { ensurePostgresDatabase, getPostgresDataDirectory } from "./client.js";
+import {
+  acquireEmbeddedPostgresBootstrapLock,
+  readEmbeddedPostmasterInfo,
+} from "./embedded-postgres-bootstrap-lock.js";
 import { createEmbeddedPostgresLogBuffer, formatEmbeddedPostgresError } from "./embedded-postgres-error.js";
 import { resolveDatabaseTarget } from "./runtime-config.js";
 
@@ -27,29 +31,6 @@ export type MigrationConnection = {
   source: string;
   stop: () => Promise<void>;
 };
-
-function readRunningPostmasterPid(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const pid = Number(readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
-}
-
-function readPidFilePort(postmasterPidFile: string): number | null {
-  if (!existsSync(postmasterPidFile)) return null;
-  try {
-    const lines = readFileSync(postmasterPidFile, "utf8").split("\n");
-    const port = Number(lines[3]?.trim());
-    return Number.isInteger(port) && port > 0 ? port : null;
-  } catch {
-    return null;
-  }
-}
 
 async function isPortInUse(port: number): Promise<boolean> {
   return await new Promise((resolve) => {
@@ -92,15 +73,13 @@ async function ensureEmbeddedPostgresConnection(
   preferredPort: number,
 ): Promise<MigrationConnection> {
   const EmbeddedPostgres = await loadEmbeddedPostgresCtor();
-  const selectedPort = await findAvailablePort(preferredPort);
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
   const pgVersionFile = path.resolve(dataDir, "PG_VERSION");
-  const runningPid = readRunningPostmasterPid(postmasterPidFile);
-  const runningPort = readPidFilePort(postmasterPidFile);
+  const running = readEmbeddedPostmasterInfo(postmasterPidFile);
   const preferredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${preferredPort}/postgres`;
   const logBuffer = createEmbeddedPostgresLogBuffer();
 
-  if (!runningPid && existsSync(pgVersionFile)) {
+  if (!running.pid && existsSync(pgVersionFile)) {
     try {
       const actualDataDir = await getPostgresDataDirectory(preferredAdminConnectionString);
       const matchesDataDir =
@@ -123,8 +102,8 @@ async function ensureEmbeddedPostgresConnection(
     }
   }
 
-  if (runningPid) {
-    const port = runningPort ?? preferredPort;
+  if (running.pid) {
+    const port = running.port ?? preferredPort;
     const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
     await ensurePostgresDatabase(adminConnectionString, "paperclip");
     return {
@@ -134,50 +113,68 @@ async function ensureEmbeddedPostgresConnection(
     };
   }
 
-  const instance = new EmbeddedPostgres({
-    databaseDir: dataDir,
-    user: "paperclip",
-    password: "paperclip",
-    port: selectedPort,
-    persistent: true,
-    initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
-    onLog: logBuffer.append,
-    onError: logBuffer.append,
-  });
+  const releaseBootstrapLock = await acquireEmbeddedPostgresBootstrapLock({ dataDir });
+  try {
+    const lockedRunning = readEmbeddedPostmasterInfo(postmasterPidFile);
+    if (lockedRunning.pid) {
+      const port = lockedRunning.port ?? preferredPort;
+      const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+      await ensurePostgresDatabase(adminConnectionString, "paperclip");
+      return {
+        connectionString: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
+        source: `embedded-postgres@${port}`,
+        stop: async () => {},
+      };
+    }
 
-  if (!existsSync(path.resolve(dataDir, "PG_VERSION"))) {
+    const selectedPort = await findAvailablePort(preferredPort);
+    const instance = new EmbeddedPostgres({
+      databaseDir: dataDir,
+      user: "paperclip",
+      password: "paperclip",
+      port: selectedPort,
+      persistent: true,
+      initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+      onLog: logBuffer.append,
+      onError: logBuffer.append,
+    });
+
+    if (!existsSync(path.resolve(dataDir, "PG_VERSION"))) {
+      try {
+        await instance.initialise();
+      } catch (error) {
+        throw formatEmbeddedPostgresError(error, {
+          fallbackMessage:
+            `Failed to initialize embedded PostgreSQL cluster in ${dataDir} on port ${selectedPort}`,
+          recentLogs: logBuffer.getRecentLogs(),
+        });
+      }
+    }
+    if (existsSync(postmasterPidFile)) {
+      rmSync(postmasterPidFile, { force: true });
+    }
     try {
-      await instance.initialise();
+      await instance.start();
     } catch (error) {
       throw formatEmbeddedPostgresError(error, {
-        fallbackMessage:
-          `Failed to initialize embedded PostgreSQL cluster in ${dataDir} on port ${selectedPort}`,
+        fallbackMessage: `Failed to start embedded PostgreSQL on port ${selectedPort}`,
         recentLogs: logBuffer.getRecentLogs(),
       });
     }
-  }
-  if (existsSync(postmasterPidFile)) {
-    rmSync(postmasterPidFile, { force: true });
-  }
-  try {
-    await instance.start();
-  } catch (error) {
-    throw formatEmbeddedPostgresError(error, {
-      fallbackMessage: `Failed to start embedded PostgreSQL on port ${selectedPort}`,
-      recentLogs: logBuffer.getRecentLogs(),
-    });
-  }
 
-  const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${selectedPort}/postgres`;
-  await ensurePostgresDatabase(adminConnectionString, "paperclip");
+    const adminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${selectedPort}/postgres`;
+    await ensurePostgresDatabase(adminConnectionString, "paperclip");
 
-  return {
-    connectionString: `postgres://paperclip:paperclip@127.0.0.1:${selectedPort}/paperclip`,
-    source: `embedded-postgres@${selectedPort}`,
-    stop: async () => {
-      await instance.stop();
-    },
-  };
+    return {
+      connectionString: `postgres://paperclip:paperclip@127.0.0.1:${selectedPort}/paperclip`,
+      source: `embedded-postgres@${selectedPort}`,
+      stop: async () => {
+        await instance.stop();
+      },
+    };
+  } finally {
+    await releaseBootstrapLock();
+  }
 }
 
 export async function resolveMigrationConnection(): Promise<MigrationConnection> {

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -187,5 +187,8 @@ export async function resolveMigrationConnection(): Promise<MigrationConnection>
     };
   }
 
+  // IMPORTANT: embedded startup serialization only covers cluster bootstrap and
+  // database availability. Callers must apply pending migrations immediately
+  // after acquiring this connection so concurrent boots do not drift in intent.
   return ensureEmbeddedPostgresConnection(target.dataDir, target.port);
 }

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -408,6 +408,15 @@ describe("heartbeat comment wake batching", () => {
         return runs.length === 2 && runs.every((run) => run.status === "succeeded");
       }, 30_000);
 
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+      expect(runs).toHaveLength(2);
+      expect(runs[0]?.issueCommentStatus).toBe("satisfied");
+      expect(runs[1]?.issueCommentStatus).toBe("not_applicable");
+
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toMatchObject({
         wake: {

--- a/server/src/__tests__/plugin-webhook-routes.test.ts
+++ b/server/src/__tests__/plugin-webhook-routes.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDb,
+  pluginWebhookDeliveries,
+  plugins,
+  startEmbeddedPostgresTestDatabase,
+} from "@paperclipai/db";
+import { createRawWebhookBodyParser } from "../middleware/raw-webhook-body.js";
+import { pluginRoutes } from "../routes/plugins.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+});
+
+async function createTestDb() {
+  const testDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-webhook-");
+  cleanups.push(testDb.cleanup);
+  return createDb(testDb.connectionString);
+}
+
+async function seedPlugin(db: ReturnType<typeof createDb>) {
+  const manifest = {
+    id: "demo-plugin",
+    apiVersion: 1,
+    displayName: "Demo Plugin",
+    version: "0.1.0",
+    capabilities: ["webhooks.receive"],
+    webhooks: [{ endpointKey: "demo-ingest" }],
+    entrypoints: { worker: "./dist/worker.js" },
+  } as const;
+
+  const [plugin] = await db.insert(plugins).values({
+    pluginKey: manifest.id,
+    packageName: "@paperclipai/demo-plugin",
+    version: manifest.version,
+    apiVersion: manifest.apiVersion,
+    categories: [],
+    manifestJson: manifest as any,
+    status: "ready",
+  }).returning();
+
+  return plugin;
+}
+
+function createApp(db: ReturnType<typeof createDb>, workerManager: { call: ReturnType<typeof vi.fn> }) {
+  const app = express();
+  const jsonParser = express.json({
+    verify: (req, _res, buf) => {
+      (req as unknown as { rawBody: Buffer }).rawBody = buf;
+    },
+  });
+  app.use("/api/plugins/:pluginId/webhooks/:endpointKey", createRawWebhookBodyParser());
+  app.use((req, res, next) => {
+    if ((req as unknown as { rawBodyParsed?: boolean }).rawBodyParsed) {
+      next();
+      return;
+    }
+    jsonParser(req, res, next);
+  });
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [],
+      source: "local_implicit",
+      isInstanceAdmin: true,
+    };
+    next();
+  });
+  app.use("/api", pluginRoutes(db as any, {} as any, undefined, { workerManager } as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("plugin webhook routes", () => {
+  it("preserves raw json payloads for plugin webhooks", async () => {
+    const db = await createTestDb();
+    const plugin = await seedPlugin(db);
+    const workerManager = { call: vi.fn().mockResolvedValue(undefined) };
+    const app = createApp(db, workerManager);
+
+    const res = await request(app)
+      .post(`/api/plugins/${plugin.pluginKey}/webhooks/demo-ingest`)
+      .set("content-type", "application/json")
+      .send({ hello: "world" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(workerManager.call).toHaveBeenCalledWith(
+      plugin.id,
+      "handleWebhook",
+      expect.objectContaining({
+        endpointKey: "demo-ingest",
+        rawBody: "{\"hello\":\"world\"}",
+        parsedBody: { hello: "world" },
+      }),
+    );
+  }, 15_000);
+
+  it("preserves raw non-json payloads for plugin webhooks", async () => {
+    const db = await createTestDb();
+    const plugin = await seedPlugin(db);
+    const workerManager = { call: vi.fn().mockResolvedValue(undefined) };
+    const app = createApp(db, workerManager);
+
+    const res = await request(app)
+      .post(`/api/plugins/${plugin.pluginKey}/webhooks/demo-ingest`)
+      .set("content-type", "text/plain")
+      .send("hello=world");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(workerManager.call).toHaveBeenCalledWith(
+      plugin.id,
+      "handleWebhook",
+      expect.objectContaining({
+        endpointKey: "demo-ingest",
+        rawBody: "hello=world",
+        parsedBody: undefined,
+      }),
+    );
+
+    const deliveries = await db.select().from(pluginWebhookDeliveries);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.payload).toEqual({});
+  }, 15_000);
+});

--- a/server/src/__tests__/plugin-webhook-routes.test.ts
+++ b/server/src/__tests__/plugin-webhook-routes.test.ts
@@ -129,4 +129,31 @@ describe("plugin webhook routes", () => {
     expect(deliveries).toHaveLength(1);
     expect(deliveries[0]?.payload).toEqual({});
   }, 15_000);
+
+  it("returns a structured 500 when delivery persistence yields no row", async () => {
+    const db = await createTestDb();
+    const plugin = await seedPlugin(db);
+    const originalInsert = db.insert.bind(db);
+    vi.spyOn(db, "insert").mockImplementation(((table: unknown) => {
+      if (table === pluginWebhookDeliveries) {
+        return {
+          values: () => ({
+            returning: async () => [],
+          }),
+        } as any;
+      }
+      return originalInsert(table as Parameters<typeof db.insert>[0]);
+    }) as typeof db.insert);
+    const workerManager = { call: vi.fn().mockResolvedValue(undefined) };
+    const app = createApp(db, workerManager);
+
+    const res = await request(app)
+      .post(`/api/plugins/${plugin.pluginKey}/webhooks/demo-ingest`)
+      .set("content-type", "application/json")
+      .send({ hello: "world" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(500);
+    expect(res.body).toEqual({ error: "Failed to record webhook delivery" });
+    expect(workerManager.call).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/raw-webhook-body.test.ts
+++ b/server/src/__tests__/raw-webhook-body.test.ts
@@ -1,0 +1,63 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createRawWebhookBodyParser } from "../middleware/raw-webhook-body.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+function createApp() {
+  const app = express();
+  app.use("/webhook", createRawWebhookBodyParser());
+  app.use(express.json());
+  app.post("/webhook", (req, res) => {
+    res.json({
+      rawBody: ((req as unknown as { rawBody?: Buffer }).rawBody ?? Buffer.alloc(0)).toString("utf8"),
+      body: req.body ?? null,
+    });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe("createRawWebhookBodyParser", () => {
+  it("preserves raw JSON bytes and parses the payload", async () => {
+    const app = createApp();
+
+    const res = await request(app)
+      .post("/webhook")
+      .set("content-type", "application/json")
+      .send('{"hello":"world"}');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      rawBody: '{"hello":"world"}',
+      body: { hello: "world" },
+    });
+  });
+
+  it("preserves raw bytes for non-JSON webhook payloads", async () => {
+    const app = createApp();
+
+    const res = await request(app)
+      .post("/webhook")
+      .set("content-type", "text/plain")
+      .send("hello=world");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      rawBody: "hello=world",
+      body: null,
+    });
+  });
+
+  it("returns 400 for malformed JSON bodies", async () => {
+    const app = createApp();
+
+    const res = await request(app)
+      .post("/webhook")
+      .set("content-type", "application/json")
+      .send("not-json");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid JSON body" });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,6 +8,7 @@ import type { StorageService } from "./storage/types.js";
 import { httpLogger, errorHandler } from "./middleware/index.js";
 import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
+import { createRawWebhookBodyParser } from "./middleware/raw-webhook-body.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { healthRoutes } from "./routes/health.js";
 import { companyRoutes } from "./routes/companies.js";
@@ -87,14 +88,23 @@ export async function createApp(
   },
 ) {
   const app = express();
-
-  app.use(express.json({
+  const jsonBodyParser = express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",
     verify: (req, _res, buf) => {
       (req as unknown as { rawBody: Buffer }).rawBody = buf;
     },
-  }));
+  });
+
+  app.use("/api/plugins/:pluginId/webhooks/:endpointKey", createRawWebhookBodyParser());
+  app.use("/api/routine-triggers/public/:publicId/fire", createRawWebhookBodyParser());
+  app.use((req, res, next) => {
+    if ((req as unknown as { rawBodyParsed?: boolean }).rawBodyParsed) {
+      next();
+      return;
+    }
+    jsonBodyParser(req, res, next);
+  });
   app.use(httpLogger);
   const privateHostnameGateEnabled =
     opts.deploymentMode === "authenticated" && opts.deploymentExposure === "private";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 import type { Request as ExpressRequest, RequestHandler } from "express";
 import { and, eq } from "drizzle-orm";
 import {
+  acquireEmbeddedPostgresBootstrapLock,
   createDb,
   ensurePostgresDatabase,
   formatEmbeddedPostgresError,
@@ -15,6 +16,7 @@ import {
   inspectMigrations,
   applyPendingMigrations,
   createEmbeddedPostgresLogBuffer,
+  readEmbeddedPostmasterInfo,
   reconcilePendingMigrationHistory,
   formatDatabaseBackupResult,
   runDatabaseBackup,
@@ -321,114 +323,108 @@ export async function startServer(): Promise<StartedServer> {
     const clusterVersionFile = resolve(dataDir, "PG_VERSION");
     const clusterAlreadyInitialized = existsSync(clusterVersionFile);
     const postmasterPidFile = resolve(dataDir, "postmaster.pid");
-    const isPidRunning = (pid: number): boolean => {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch {
-        return false;
-      }
-    };
-  
-    const getRunningPid = (): number | null => {
-      if (!existsSync(postmasterPidFile)) return null;
-      try {
-        const pidLine = readFileSync(postmasterPidFile, "utf8").split("\n")[0]?.trim();
-        const pid = Number(pidLine);
-        if (!Number.isInteger(pid) || pid <= 0) return null;
-        if (!isPidRunning(pid)) return null;
-        return pid;
-      } catch {
-        return null;
-      }
-    };
-  
-    const runningPid = getRunningPid();
-    if (runningPid) {
-      logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
-    } else {
-      const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
-      try {
-        const actualDataDir = await getPostgresDataDirectory(configuredAdminConnectionString);
-        if (
-          typeof actualDataDir !== "string" ||
-          resolve(actualDataDir) !== resolve(dataDir)
-        ) {
-          throw new Error("reachable postgres does not use the expected embedded data directory");
-        }
-        await ensurePostgresDatabase(configuredAdminConnectionString, "paperclip");
-        logger.warn(
-          `Embedded PostgreSQL appears to already be reachable without a pid file; reusing existing server on configured port ${configuredPort}`,
-        );
-      } catch {
-        const detectedPort = await detectPort(configuredPort);
-        if (detectedPort !== configuredPort) {
-          logger.warn(`Embedded PostgreSQL port is in use; using next free port (requestedPort=${configuredPort}, selectedPort=${detectedPort})`);
-        }
-        port = detectedPort;
-        logger.info(`Using embedded PostgreSQL because no DATABASE_URL set (dataDir=${dataDir}, port=${port})`);
-        embeddedPostgres = new EmbeddedPostgres({
-          databaseDir: dataDir,
-          user: "paperclip",
-          password: "paperclip",
-          port,
-          persistent: true,
-          initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
-          onLog: appendEmbeddedPostgresLog,
-          onError: appendEmbeddedPostgresLog,
-        });
-
-        if (!clusterAlreadyInitialized) {
-          try {
-            await embeddedPostgres.initialise();
-          } catch (err) {
-            logEmbeddedPostgresFailure("initialise", err);
-            throw formatEmbeddedPostgresError(err, {
-              fallbackMessage: `Failed to initialize embedded PostgreSQL cluster in ${dataDir} on port ${port}`,
-              recentLogs: logBuffer.getRecentLogs(),
-            });
-          }
-        } else {
-          logger.info(`Embedded PostgreSQL cluster already exists (${clusterVersionFile}); skipping init`);
-        }
-
-        if (existsSync(postmasterPidFile)) {
-          logger.warn("Removing stale embedded PostgreSQL lock file");
-          rmSync(postmasterPidFile, { force: true });
-        }
+    const running = readEmbeddedPostmasterInfo(postmasterPidFile);
+    let releaseBootstrapLock: (() => Promise<void>) | null = null;
+    try {
+      if (running.pid) {
+        port = running.port ?? port;
+        logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${running.pid}, port=${port})`);
+      } else {
+        const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
         try {
-          await embeddedPostgres.start();
-        } catch (err) {
-          logEmbeddedPostgresFailure("start", err);
-          throw formatEmbeddedPostgresError(err, {
-            fallbackMessage: `Failed to start embedded PostgreSQL on port ${port}`,
-            recentLogs: logBuffer.getRecentLogs(),
-          });
+          const actualDataDir = await getPostgresDataDirectory(configuredAdminConnectionString);
+          if (
+            typeof actualDataDir !== "string" ||
+            resolve(actualDataDir) !== resolve(dataDir)
+          ) {
+            throw new Error("reachable postgres does not use the expected embedded data directory");
+          }
+          await ensurePostgresDatabase(configuredAdminConnectionString, "paperclip");
+          logger.warn(
+            `Embedded PostgreSQL appears to already be reachable without a pid file; reusing existing server on configured port ${configuredPort}`,
+          );
+        } catch {
+          releaseBootstrapLock = await acquireEmbeddedPostgresBootstrapLock({ dataDir });
+          const lockedRunning = readEmbeddedPostmasterInfo(postmasterPidFile);
+          if (lockedRunning.pid) {
+            port = lockedRunning.port ?? configuredPort;
+            logger.warn(
+              `Embedded PostgreSQL became available during bootstrap wait; reusing existing process (pid=${lockedRunning.pid}, port=${port})`,
+            );
+          } else {
+            const detectedPort = await detectPort(configuredPort);
+            if (detectedPort !== configuredPort) {
+              logger.warn(`Embedded PostgreSQL port is in use; using next free port (requestedPort=${configuredPort}, selectedPort=${detectedPort})`);
+            }
+            port = detectedPort;
+            logger.info(`Using embedded PostgreSQL because no DATABASE_URL set (dataDir=${dataDir}, port=${port})`);
+            embeddedPostgres = new EmbeddedPostgres({
+              databaseDir: dataDir,
+              user: "paperclip",
+              password: "paperclip",
+              port,
+              persistent: true,
+              initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+              onLog: appendEmbeddedPostgresLog,
+              onError: appendEmbeddedPostgresLog,
+            });
+
+            const clusterInitializedUnderLock = existsSync(clusterVersionFile);
+            if (!clusterInitializedUnderLock) {
+              try {
+                await embeddedPostgres.initialise();
+              } catch (err) {
+                logEmbeddedPostgresFailure("initialise", err);
+                throw formatEmbeddedPostgresError(err, {
+                  fallbackMessage: `Failed to initialize embedded PostgreSQL cluster in ${dataDir} on port ${port}`,
+                  recentLogs: logBuffer.getRecentLogs(),
+                });
+              }
+            } else {
+              logger.info(`Embedded PostgreSQL cluster already exists (${clusterVersionFile}); skipping init`);
+            }
+
+            if (existsSync(postmasterPidFile)) {
+              logger.warn("Removing stale embedded PostgreSQL lock file");
+              rmSync(postmasterPidFile, { force: true });
+            }
+            try {
+              await embeddedPostgres.start();
+            } catch (err) {
+              logEmbeddedPostgresFailure("start", err);
+              throw formatEmbeddedPostgresError(err, {
+                fallbackMessage: `Failed to start embedded PostgreSQL on port ${port}`,
+                recentLogs: logBuffer.getRecentLogs(),
+              });
+            }
+            embeddedPostgresStartedByThisProcess = true;
+          }
         }
-        embeddedPostgresStartedByThisProcess = true;
       }
+    
+      const embeddedAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+      const dbStatus = await ensurePostgresDatabase(embeddedAdminConnectionString, "paperclip");
+      if (dbStatus === "created") {
+        logger.info("Created embedded PostgreSQL database: paperclip");
+      }
+    
+      const embeddedConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
+      const shouldAutoApplyFirstRunMigrations = !existsSync(clusterVersionFile) || !clusterAlreadyInitialized || dbStatus === "created";
+      if (shouldAutoApplyFirstRunMigrations) {
+        logger.info("Detected first-run embedded PostgreSQL setup; applying pending migrations automatically");
+      }
+      migrationSummary = await ensureMigrations(embeddedConnectionString, "Embedded PostgreSQL", {
+        autoApply: shouldAutoApplyFirstRunMigrations,
+      });
+    
+      db = createDb(embeddedConnectionString);
+      logger.info("Embedded PostgreSQL ready");
+      activeDatabaseConnectionString = embeddedConnectionString;
+      resolvedEmbeddedPostgresPort = port;
+      startupDbInfo = { mode: "embedded-postgres", dataDir, port };
+    } finally {
+      await releaseBootstrapLock?.();
     }
-  
-    const embeddedAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
-    const dbStatus = await ensurePostgresDatabase(embeddedAdminConnectionString, "paperclip");
-    if (dbStatus === "created") {
-      logger.info("Created embedded PostgreSQL database: paperclip");
-    }
-  
-    const embeddedConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
-    const shouldAutoApplyFirstRunMigrations = !clusterAlreadyInitialized || dbStatus === "created";
-    if (shouldAutoApplyFirstRunMigrations) {
-      logger.info("Detected first-run embedded PostgreSQL setup; applying pending migrations automatically");
-    }
-    migrationSummary = await ensureMigrations(embeddedConnectionString, "Embedded PostgreSQL", {
-      autoApply: shouldAutoApplyFirstRunMigrations,
-    });
-  
-    db = createDb(embeddedConnectionString);
-    logger.info("Embedded PostgreSQL ready");
-    activeDatabaseConnectionString = embeddedConnectionString;
-    resolvedEmbeddedPostgresPort = port;
-    startupDbInfo = { mode: "embedded-postgres", dataDir, port };
   }
   
   if (config.deploymentMode === "local_trusted" && !isLoopbackHost(config.host)) {

--- a/server/src/middleware/raw-webhook-body.ts
+++ b/server/src/middleware/raw-webhook-body.ts
@@ -1,0 +1,47 @@
+import express, { type RequestHandler } from "express";
+import { badRequest } from "../errors.js";
+
+const BODY_LIMIT = "10mb";
+
+function isJsonContentType(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+  const normalized = contentType.toLowerCase();
+  return normalized.includes("application/json") || normalized.includes("+json");
+}
+
+export function createRawWebhookBodyParser(): RequestHandler {
+  const rawParser = express.raw({ type: "*/*", limit: BODY_LIMIT });
+
+  return (req, res, next) => {
+    rawParser(req, res, (error) => {
+      if (error) {
+        next(error);
+        return;
+      }
+
+      const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+      (req as unknown as { rawBody: Buffer; rawBodyParsed: boolean }).rawBody = rawBody;
+      (req as unknown as { rawBodyParsed: boolean }).rawBodyParsed = true;
+
+      if (rawBody.length === 0) {
+        req.body = undefined;
+        next();
+        return;
+      }
+
+      if (isJsonContentType(req.header("content-type"))) {
+        try {
+          req.body = JSON.parse(rawBody.toString("utf8"));
+        } catch {
+          next(badRequest("Invalid JSON body"));
+          return;
+        }
+        next();
+        return;
+      }
+
+      req.body = undefined;
+      next();
+    });
+  };
+}

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -21,7 +21,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { Router } from "express";
+import express, { Router } from "express";
 import type { Request } from "express";
 import { and, desc, eq, gte } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
@@ -243,6 +243,36 @@ export interface PluginRouteBridgeDeps {
   workerManager: PluginWorkerManager;
   /** Optional stream bus for SSE push from worker to UI. */
   streamBus?: PluginStreamBus;
+}
+
+function buildWebhookPayload(req: Request): {
+  rawBody: string;
+  parsedBody: unknown;
+  payload: Record<string, unknown>;
+} {
+  const stashedRaw = (req as unknown as { rawBody?: Buffer }).rawBody;
+  if (stashedRaw) {
+    return {
+      rawBody: stashedRaw.toString("utf-8"),
+      parsedBody: req.body as unknown,
+      payload: ((req.body as Record<string, unknown> | undefined) ?? {}),
+    };
+  }
+
+  if (Buffer.isBuffer(req.body)) {
+    const rawBody = req.body.toString("utf-8");
+    return {
+      rawBody,
+      parsedBody: rawBody,
+      payload: { rawBody },
+    };
+  }
+
+  return {
+    rawBody: "",
+    parsedBody: req.body as unknown,
+    payload: ((req.body as Record<string, unknown> | undefined) ?? {}),
+  };
 }
 
 /** Request body for POST /api/plugins/tools/execute */
@@ -1893,12 +1923,12 @@ export function pluginRoutes(
    * - 502 if the worker is unavailable or the RPC call fails
    */
   router.post("/plugins/:pluginId/webhooks/:endpointKey", async (req, res) => {
-    if (!webhookDeps) {
-      res.status(501).json({ error: "Webhook ingestion is not enabled" });
-      return;
-    }
+      if (!webhookDeps) {
+        res.status(501).json({ error: "Webhook ingestion is not enabled" });
+        return;
+      }
 
-    const { pluginId, endpointKey } = req.params;
+      const { pluginId, endpointKey } = req.params;
 
     // Step 1: Resolve the plugin
     const plugin = await resolvePlugin(registry, pluginId);
@@ -1956,10 +1986,7 @@ export function pluginRoutes(
     // Use the raw buffer stashed by the express.json() `verify` callback.
     // This preserves the exact bytes the provider signed, whereas
     // JSON.stringify(req.body) would re-serialize and break HMAC verification.
-    const stashedRaw = (req as unknown as { rawBody?: Buffer }).rawBody;
-    const rawBody = stashedRaw ? stashedRaw.toString("utf-8") : "";
-    const parsedBody = req.body as unknown;
-    const payload = (req.body as Record<string, unknown> | undefined) ?? {};
+      const { rawBody, parsedBody, payload } = buildWebhookPayload(req);
 
     // Step 6: Record the delivery in the database
     const startedAt = new Date();
@@ -2023,7 +2050,7 @@ export function pluginRoutes(
         error: errorMessage,
       });
     }
-  });
+    });
 
   // ===========================================================================
   // Plugin health dashboard — aggregated diagnostics for the settings page

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1923,12 +1923,12 @@ export function pluginRoutes(
    * - 502 if the worker is unavailable or the RPC call fails
    */
   router.post("/plugins/:pluginId/webhooks/:endpointKey", async (req, res) => {
-      if (!webhookDeps) {
-        res.status(501).json({ error: "Webhook ingestion is not enabled" });
-        return;
-      }
+    if (!webhookDeps) {
+      res.status(501).json({ error: "Webhook ingestion is not enabled" });
+      return;
+    }
 
-      const { pluginId, endpointKey } = req.params;
+    const { pluginId, endpointKey } = req.params;
 
     // Step 1: Resolve the plugin
     const plugin = await resolvePlugin(registry, pluginId);
@@ -1986,7 +1986,7 @@ export function pluginRoutes(
     // Use the raw buffer stashed by the express.json() `verify` callback.
     // This preserves the exact bytes the provider signed, whereas
     // JSON.stringify(req.body) would re-serialize and break HMAC verification.
-      const { rawBody, parsedBody, payload } = buildWebhookPayload(req);
+    const { rawBody, parsedBody, payload } = buildWebhookPayload(req);
 
     // Step 6: Record the delivery in the database
     const startedAt = new Date();
@@ -2001,6 +2001,11 @@ export function pluginRoutes(
         startedAt,
       })
       .returning({ id: pluginWebhookDeliveries.id });
+
+    if (!delivery) {
+      res.status(500).json({ error: "Failed to record webhook delivery" });
+      return;
+    }
 
     // Step 7: Dispatch to the worker via handleWebhook RPC
     try {
@@ -2050,7 +2055,7 @@ export function pluginRoutes(
         error: errorMessage,
       });
     }
-    });
+  });
 
   // ===========================================================================
   // Plugin health dashboard — aggregated diagnostics for the settings page

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1986,6 +1986,7 @@ export function heartbeatService(db: Db) {
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const wakeReason = readNonEmptyString(contextSnapshot.wakeReason);
     if (!issueId) {
       if (run.issueCommentStatus !== "not_applicable") {
         await patchRunIssueCommentStatus(run.id, {
@@ -2005,6 +2006,15 @@ export function heartbeatService(db: Db) {
         issueCommentRetryQueuedAt: null,
       });
       return { outcome: "satisfied" as const, queuedRun: null };
+    }
+
+    if (wakeReason === "issue_commented" || wakeReason === "issue_comment_mentioned") {
+      await patchRunIssueCommentStatus(run.id, {
+        issueCommentStatus: "not_applicable",
+        issueCommentSatisfiedByCommentId: null,
+        issueCommentRetryQueuedAt: null,
+      });
+      return { outcome: "not_applicable" as const, queuedRun: null };
     }
 
     if (readNonEmptyString(contextSnapshot.retryReason) === "missing_issue_comment") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so local development has to boot reliably and inbound adapter/plugin webhooks have to preserve the original request contract.
> - This change sits in the server bootstrap path and plugin webhook ingress path, both of which are critical to keeping agent companies operable.
> - TEAMCAL-33 release verification exposed runtime blockers rather than product-feature bugs: embedded Postgres startup could race under concurrent boot, webhook consumers could lose access to the raw body they need for signature verification, and comment-triggered heartbeat wakes were spuriously queuing comment-enforcement retries.
> - Those failures break operator trust because the app can fail before the board can use it, plugin integrations can reject valid webhook traffic, and verify can fail on a branch whose intended behavior is otherwise correct.
> - This pull request hardens embedded Postgres bootstrap with a lock-based single-flight path, preserves raw webhook bodies, and exempts comment-triggered wakes from the missing-comment retry policy.
> - It also adds regression tests around the startup lock, webhook request handling, and batched comment wake behavior so the release branch is protected against the same runtime failures.
> - The benefit is that the release candidate can be exercised in a live environment without the known startup race, raw-body regression, or comment-wake verify blocker holding up QA.

## What Changed

- Added an embedded Postgres bootstrap lock and tests to serialize concurrent initialization in `packages/db`.
- Refactored migration/bootstrap wiring so runtime startup reuses the guarded initialization path, and documented the caller contract around migration application.
- Added raw webhook body middleware and updated plugin routes/app wiring so webhook handlers can access the unmodified request body for JSON and non-JSON deliveries.
- Guarded plugin webhook delivery persistence so an empty insert result returns a structured `500` instead of crashing on `delivery.id`.
- Skipped missing-comment retry enforcement for comment-triggered wakes, which keeps batched issue-comment wakeups at the expected two-run flow instead of spawning an unintended retry run.
- Added regression coverage for plugin webhook routes, raw-body handling, and heartbeat comment wake batching.

## Verification

- `pnpm -r typecheck`
- `pnpm build`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-webhook-routes.test.ts src/__tests__/heartbeat-comment-wake-batching.test.ts --reporter=dot`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-comment-wake-batching.test.ts --reporter=dot` repeated 5x to confirm the batched-comment flow no longer flaps into a third retry run
- `pnpm test:run` currently still reports unrelated local-suite failures outside this diff (`worktree-config.test.ts`, `cli-auth-routes.test.ts`) in this environment; the original `heartbeat-comment-wake-batching` verify blocker is resolved locally and the webhook regressions are green
- Live repro: `text/plain` plugin webhook now reaches runtime with `rawBody = "hello=world"`
- Live repro: concurrent fresh `tsx src/index.ts` startup on the same instance no longer races embedded Postgres bootstrap/migrations; the second process reuses Postgres and only hits expected HTTP `EADDRINUSE`

## Risks

- Medium: startup-path changes can affect local boot if the lock path misses an environment-specific edge case.
- Medium: webhook body handling changes request parsing order, so integrations that rely on unusual content-type behavior should be watched during QA.
- Low: comment-triggered wake policy now treats missing agent comments as `not_applicable`; QA should confirm this matches the expected operator experience for issue comment wakes.

## Model Used

- OpenAI GPT-5.4 via Codex local agent, reasoning effort `medium`, with repository tool use, shell execution, and patch application.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
