### PR TITLE
fix(docker): update GitHub CLI GPG keyring SHA256 hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
+  && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  # Hash must be updated when GitHub rotates the keyring (no versioned URL available)
   && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Docker image build installs GitHub CLI via apt with GPG keyring verification
> - GitHub rotated the GPG keyring file, invalidating the hardcoded SHA256 hash
> - Docker builds fail at the `sha256sum -c` step with checksum mismatch
> - This PR updates the hash to match the current upstream keyring
> - The benefit is unblocking Docker image builds

## What Changed

Updated the SHA256 checksum for `githubcli-archive-keyring.gpg` in `Dockerfile` and added a maintenance comment noting the hash must be updated on keyring rotation.

## Verification

Confirmed new hash is a valid 64-char SHA256 hex string matching the current upstream keyring at `https://cli.github.com/packages/githubcli-archive-keyring.gpg`.

## Risks

Minimal — single hash value change. If the upstream keyring rotates again the build will fail, but that is the intended behavior of the integrity check.

## Model Used

- Claude Opus 4.6 (1M context) via Claude Code CLI

## Checklist

- [x] Change is minimal and scoped
- [x] No security regression (hash verification preserved)
- [x] Test plan: `docker build .` passes keyring verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)