### PR TITLE
Change claimed API key path to relative path

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -363,7 +363,7 @@ function buildWakeText(
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const claimedApiKeyPath = "./paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",


### PR DESCRIPTION
The `openclaw_gateway` adapter hardcodes `~/.openclaw/workspace/paperclip-claimed-api-key.json` in the wake event message. In multi-agent OpenClaw deployments each agent has its own workspace (`~/.openclaw/workspace-{agentId}/`) with its own claimed API key — but the wake event always points agents to `main`'s copy. This one-line change switches to a relative path so each agent reads from its own workspace.

## Thinking Path

> - Paperclip orchestrates AI agents; the `openclaw_gateway` adapter connects them to an OpenClaw gateway for persistent execution
> - OpenClaw supports multi-agent routing: each agent gets an isolated workspace, session store, and auth profile, selected via `x-openclaw-agent-id` header on the WebSocket connection
> - `buildWakeText()` in `execute.ts` constructs the instructions the agent receives on each heartbeat, including where to find its Paperclip API key
> - The path is hardcoded to `~/.openclaw/workspace/paperclip-claimed-api-key.json` — the default `main` agent's workspace
> - In a multi-agent setup the per-agent workspace is `~/.openclaw/workspace-{agentId}/`, so the hardcoded path points to the wrong file (or a stale one from a different company)
> - OpenClaw already sets cwd to the active agent's workspace before execution, so switching to `./` makes it resolve correctly for every agent
> - Single-agent deployments are unaffected because `main`'s cwd *is* `~/.openclaw/workspace/`

## What Changed

- `packages/adapters/openclaw-gateway/src/server/execute.ts`: changed `claimedApiKeyPath` from absolute (`~/.openclaw/workspace/paperclip-claimed-api-key.json`) to relative (`./paperclip-claimed-api-key.json`)

## Verification

**Backwards compatibility (single agent):**
OpenClaw's default `main` agent runs with cwd `~/.openclaw/workspace/`. The relative path resolves to the same file as the old absolute path. No behaviour change.

**Multi-agent:**
Tested with 7 agents per Paperclip company, each registered in `openclaw.json` `agents.list` with separate workspaces. Agents route via `x-openclaw-agent-id` header. Before the fix, agents read `main`'s credentials and failed with a company mismatch. After the fix, each agent reads its own `./paperclip-claimed-api-key.json` and authenticates correctly.

## Risks

Low. Single string constant, no new logic. Single-agent setups resolve to the identical absolute path. Multi-agent setups gain correct per-agent credential resolution. No migration or config changes required.

## Model Used

Claude Opus 4.6 (1M context) — used for tracing the root cause through the compiled adapter source (`@paperclipai/adapter-openclaw-gateway/dist/server/execute.js` line 249). The fix itself is a one-character-class change (`~/.openclaw/workspace/` → `./`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
