### PR TITLE
feat: detect Azure AI Foundry auth for billing type in claude-local adapter

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -85,8 +85,18 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
+function isFoundryAuth(env: Record<string, string>): boolean {
+  return (
+    env.CLAUDE_CODE_USE_FOUNDRY === "1" ||
+    env.CLAUDE_CODE_USE_FOUNDRY === "true" ||
+    hasNonEmptyEnvValue(env, "ANTHROPIC_FOUNDRY_BASE_URL") ||
+    hasNonEmptyEnvValue(env, "ANTHROPIC_FOUNDRY_RESOURCE")
+  );
+}
+
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
+  if (isFoundryAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
 }
 
@@ -599,7 +609,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       sessionParams: resolvedSessionParams,
       sessionDisplayId: resolvedSessionId,
       provider: "anthropic",
-      biller: isBedrockAuth(effectiveEnv) ? "aws_bedrock" : "anthropic",
+      biller: isBedrockAuth(effectiveEnv) ? "aws_bedrock" : isFoundryAuth(effectiveEnv) ? "azure_foundry" : "anthropic",
       model: parsedStream.model || asString(parsed.model, model),
       billingType,
       costUsd: parsedStream.costUsd ?? asNumber(parsed.total_cost_usd, 0),

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -104,6 +104,16 @@ export async function testEnvironment(
     isNonEmpty(env.ANTHROPIC_BEDROCK_BASE_URL) ||
     isNonEmpty(process.env.ANTHROPIC_BEDROCK_BASE_URL);
 
+  const hasFoundry =
+    env.CLAUDE_CODE_USE_FOUNDRY === "1" ||
+    env.CLAUDE_CODE_USE_FOUNDRY === "true" ||
+    process.env.CLAUDE_CODE_USE_FOUNDRY === "1" ||
+    process.env.CLAUDE_CODE_USE_FOUNDRY === "true" ||
+    isNonEmpty(env.ANTHROPIC_FOUNDRY_BASE_URL) ||
+    isNonEmpty(process.env.ANTHROPIC_FOUNDRY_BASE_URL) ||
+    isNonEmpty(env.ANTHROPIC_FOUNDRY_RESOURCE) ||
+    isNonEmpty(process.env.ANTHROPIC_FOUNDRY_RESOURCE);
+
   const configApiKey = env.ANTHROPIC_API_KEY;
   const hostApiKey = process.env.ANTHROPIC_API_KEY;
   if (hasBedrock) {
@@ -119,6 +129,21 @@ export async function testEnvironment(
       message: "AWS Bedrock auth detected. Claude will use Bedrock for inference.",
       detail: `Detected in ${source}.`,
       hint: "Ensure AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_PROFILE) and AWS_REGION are configured.",
+    });
+  } else if (hasFoundry) {
+    const source =
+      env.CLAUDE_CODE_USE_FOUNDRY === "1" ||
+      env.CLAUDE_CODE_USE_FOUNDRY === "true" ||
+      isNonEmpty(env.ANTHROPIC_FOUNDRY_BASE_URL) ||
+      isNonEmpty(env.ANTHROPIC_FOUNDRY_RESOURCE)
+        ? "adapter config env"
+        : "server environment";
+    checks.push({
+      code: "claude_foundry_auth",
+      level: "info",
+      message: "Azure AI Foundry auth detected. Claude will use Foundry for inference.",
+      detail: `Detected in ${source}.`,
+      hint: "Ensure ANTHROPIC_FOUNDRY_API_KEY or Azure default credentials are configured.",
     });
   } else if (isNonEmpty(configApiKey) || isNonEmpty(hostApiKey)) {
     const source = isNonEmpty(configApiKey) ? "adapter config env" : "server environment";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `claude-local` adapter resolves a billing type for each agent run to determine how costs are tracked in the cost ledger
> - Currently only Bedrock and direct API key auth are detected; Azure AI Foundry is not recognized
> - When `CLAUDE_CODE_USE_FOUNDRY=1` is set (without `ANTHROPIC_API_KEY`), the resolver falls through to `"subscription"`, which normalizes to `"subscription_included"` — zeroing out all costs
> - This pull request adds `isFoundryAuth()` detection so Foundry-routed sessions resolve to `"metered_api"` billing type, consistent with Bedrock
> - The benefit is accurate cost tracking for Azure AI Foundry deployments

## What Changed

- Added `isFoundryAuth()` helper in `execute.ts` that detects `CLAUDE_CODE_USE_FOUNDRY`, `ANTHROPIC_FOUNDRY_BASE_URL`, or `ANTHROPIC_FOUNDRY_RESOURCE` env vars
- Updated `resolveClaudeBillingType()` to return `"metered_api"` when Foundry auth is detected (consistent with Bedrock, since both are third-party metered services)
- Added Foundry environment detection check in `test.ts` with appropriate info message and hint

## Verification

- Deployed to a Paperclip instance with Azure AI Foundry (EastUS2) configured
- Before fix: `cost_events.billing_type = "subscription_included"`, `cost_cents = 0`
- After fix: `cost_events.billing_type = "metered_api"`, `cost_cents = 5` (correct pricing)
- Verified via direct DB query:
  ```sql
  SELECT billing_type, cost_cents, input_tokens, output_tokens, model
  FROM cost_events ORDER BY created_at DESC LIMIT 5;
  ```

## Risks

Low risk. The change only adds a new detection path before the existing fallback. Existing Bedrock and API key flows are unchanged. If Foundry env vars are not set, behavior is identical to before.

## Model Used

Claude Opus 4.6 (1M context) via Claude Code CLI, with tool use

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge