### PR TITLE
fix(claude-local): auto-retry with fresh session on image processing errors

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -30,6 +30,7 @@ import {
   detectClaudeLoginRequired,
   isClaudeMaxTurnsResult,
   isClaudeUnknownSessionError,
+  isClaudeImageProcessingError,
 } from "./parse.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
@@ -621,11 +622,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       !initial.proc.timedOut &&
       (initial.proc.exitCode ?? 0) !== 0 &&
       initial.parsed &&
-      isClaudeUnknownSessionError(initial.parsed)
+      (isClaudeUnknownSessionError(initial.parsed) || isClaudeImageProcessingError(initial.parsed))
     ) {
+      const reason = isClaudeImageProcessingError(initial.parsed)
+        ? "stale image in session context"
+        : "session unavailable";
       await onLog(
         "stdout",
-        `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+        `[paperclip] Claude resume session "${sessionId}" failed (${reason}); retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -617,16 +617,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
+    const isImageErr = initial.parsed ? isClaudeImageProcessingError(initial.parsed) : false;
+    const isSessionErr = initial.parsed ? isClaudeUnknownSessionError(initial.parsed) : false;
     if (
       sessionId &&
       !initial.proc.timedOut &&
       (initial.proc.exitCode ?? 0) !== 0 &&
       initial.parsed &&
-      (isClaudeUnknownSessionError(initial.parsed) || isClaudeImageProcessingError(initial.parsed))
+      (isSessionErr || isImageErr)
     ) {
-      const reason = isClaudeImageProcessingError(initial.parsed)
-        ? "stale image in session context"
-        : "session unavailable";
+      const reason = isImageErr ? "stale image in session context" : "session unavailable";
       await onLog(
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" failed (${reason}); retrying with a fresh session.\n`,

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -177,3 +177,14 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
     /no conversation found with session id|unknown session|session .* not found/i.test(msg),
   );
 }
+
+export function isClaudeImageProcessingError(parsed: Record<string, unknown>): boolean {
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) =>
+    /could not process image|invalid.*image|image.*too large|unsupported.*image/i.test(msg),
+  );
+}

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -185,6 +185,6 @@ export function isClaudeImageProcessingError(parsed: Record<string, unknown>): b
     .filter(Boolean);
 
   return allMessages.some((msg) =>
-    /could not process image|invalid.*image|image.*too large|unsupported.*image/i.test(msg),
+    /could not process image|image processing (failed|error)|image.*too large|unsupported.*image\s*format/i.test(msg),
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The claude_local adapter invokes Claude CLI with `--resume {sessionId}` to maintain session continuity across heartbeats
> - When a session contains a stale, corrupted, or oversized image (e.g. from Playwright screenshots or file reads), the Claude API rejects the replay with a 400 "Could not process image"
> - The agent run fails with `adapter_failed` and the agent gets stuck in `error` state, requiring manual intervention
> - An existing retry pattern already exists for `isClaudeUnknownSessionError` — session becomes unavailable, adapter retries with a fresh session
> - This PR extends that same pattern to also catch image processing errors
> - The benefit is agents automatically recover from stale images instead of getting stuck

## What Changed

- Added `isClaudeImageProcessingError()` detection function to `parse.ts`, mirroring the existing `isClaudeUnknownSessionError` pattern
- Extended the retry condition in `execute.ts` to also trigger on image processing errors
- Cached detection results to avoid double invocation in the retry block
- Improved log message to distinguish image errors from session errors

## Verification

- Applied locally via entrypoint-wrapper runtime patch, restarted container
- `grep "isClaudeImageProcessingError" parse.ts` confirms function present
- `grep "isClaudeImageProcessingError" execute.ts` confirms import + retry condition
- Agent (Creative Touch HNIC) that previously hit this error recovered on next heartbeat
- Existing `isClaudeUnknownSessionError` retry path is unchanged

## Risks

Low risk. The change only adds a new detection branch to an existing retry pattern. No new code paths are created — the retry logic (fresh session, no `--resume`) is identical to the existing unknown-session handler. False positives on the regex would result in an unnecessary session reset, which is a safe recovery action.

## Model Used

Claude Opus 4.6 (1M context) via Claude Code CLI v2.1.96. Tool use mode with codebase exploration, file editing, and bash execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #3123
