### PR TITLE
fix: redact sensitive fields from error logs

### DIFF
--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -4,6 +4,7 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
+import { sanitizeRecord } from "../redaction.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -65,21 +66,21 @@ export const httpLogger = pinoHttp({
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: ctx.reqBody,
-          reqParams: ctx.reqParams,
-          reqQuery: ctx.reqQuery,
+          reqBody: ctx.reqBody && typeof ctx.reqBody === "object" ? sanitizeRecord(ctx.reqBody) : ctx.reqBody,
+          reqParams: ctx.reqParams && typeof ctx.reqParams === "object" ? sanitizeRecord(ctx.reqParams) : ctx.reqParams,
+          reqQuery: ctx.reqQuery && typeof ctx.reqQuery === "object" ? sanitizeRecord(ctx.reqQuery) : ctx.reqQuery,
         };
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = body;
+        props.reqBody = sanitizeRecord(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
-        props.reqParams = params;
+        props.reqParams = sanitizeRecord(params);
       }
       if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = query;
+        props.reqQuery = sanitizeRecord(query);
       }
       if ((req as any).route?.path) {
         props.routePath = (req as any).route.path;


### PR DESCRIPTION
## Thinking Path

Paperclip logs request bodies on 4xx/5xx errors for debugging. The `/api/auth/sign-in/email` endpoint accepts a password field, which gets logged in plaintext to `server.log` on every failed login attempt. The codebase already has `sanitizeRecord()` in `redaction.ts` that recursively redacts keys matching a secret pattern (including `password`). The fix is to apply it before logging.

## Changes

- Import `sanitizeRecord` in `logger.ts`
- Apply `sanitizeRecord()` to `reqBody` in both the error-context and fallback logging paths

## Verification

```bash
pnpm --filter @paperclipai/server typecheck
```

## Risks

- **None**: Only affects logging output, not error handling or responses

Closes #3072