### PR TITLE
fix: delete orphaned budget policies on agent removal

### DIFF
--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -15,6 +15,8 @@ import {
   issueExecutionDecisions,
   issues,
   issueComments,
+  budgetPolicies,
+  budgetIncidents,
 } from "@paperclipai/db";
 import { isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
@@ -496,6 +498,17 @@ export function agentService(db: Db) {
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.agentId, id));
+        // Delete budget incidents before policies (FK: budget_incidents.policyId → budget_policies.id)
+        await tx.delete(budgetIncidents).where(
+          inArray(
+            budgetIncidents.policyId,
+            tx.select({ id: budgetPolicies.id }).from(budgetPolicies)
+              .where(and(eq(budgetPolicies.scopeType, "agent"), eq(budgetPolicies.scopeId, id))),
+          ),
+        );
+        await tx.delete(budgetPolicies).where(
+          and(eq(budgetPolicies.scopeType, "agent"), eq(budgetPolicies.scopeId, id)),
+        );
         const deleted = await tx
           .delete(agents)
           .where(eq(agents.id, id))


### PR DESCRIPTION
## Thinking Path

Deleting an agent leaves its budget policies orphaned in `budget_policies`. The next call to `budgetService.overview()` queries the agents table for the orphaned policy scope, throws `notFound("Agent not found")`, and crashes `/dashboard` and `/sidebar-badges`.

The agent removal transaction already cleans up 11 related tables but missed `budget_policies` and `budget_incidents`.

## Changes

- Query agent-scoped `budget_policies` IDs before deletion
- Delete dependent `budget_incidents` rows first (FK on `policyId`)
- Delete the `budget_policies` rows
- Added `budgetPolicies` and `budgetIncidents` to the DB imports

## Verification

```bash
pnpm --filter @paperclipai/server typecheck
```

## Risks

- **Low**: Only affects the agent deletion transaction. Follows the same pattern as existing cleanup (explicit deletes inside the tx).

Closes #3060