### PR TITLE
fix: normalize managed AGENTS.md companion links

### DIFF
--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -193,6 +193,119 @@ describe("agent instructions service", () => {
     expect(exported.files).toEqual({ "AGENTS.md": "# Recovered Agent\n" });
   });
 
+  it("heals legacy AGENT_HOME companion references in managed AGENTS.md without touching other files", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-heal-managed-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(managedRoot, "AGENTS.md"),
+      [
+        "# Agent",
+        "",
+        "- `$AGENT_HOME/HEARTBEAT.md`",
+        "- `$AGENT_HOME/SOUL.md`",
+        "- `$AGENT_HOME/TOOLS.md`",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(managedRoot, "TOOLS.md"),
+      "Keep `$AGENT_HOME/TOOLS.md` as-is in non-entry files.\n",
+      "utf8",
+    );
+
+    const svc = agentInstructionsService();
+    const bundle = await svc.getBundle(makeAgent({}));
+    const exported = await svc.exportFiles(makeAgent({}));
+
+    expect(bundle.mode).toBe("managed");
+    expect(bundle.files.map((file) => file.path)).toEqual(["AGENTS.md", "TOOLS.md"]);
+    expect(exported.files["AGENTS.md"]).toContain("`./HEARTBEAT.md`");
+    expect(exported.files["AGENTS.md"]).toContain("`./SOUL.md`");
+    expect(exported.files["AGENTS.md"]).toContain("`./TOOLS.md`");
+    expect(exported.files["AGENTS.md"]).not.toContain("$AGENT_HOME/HEARTBEAT.md");
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toContain("`./HEARTBEAT.md`");
+    await expect(fs.readFile(path.join(managedRoot, "TOOLS.md"), "utf8")).resolves.toBe(
+      "Keep `$AGENT_HOME/TOOLS.md` as-is in non-entry files.\n",
+    );
+  });
+
+  it("does not rewrite legacy AGENT_HOME references for external bundles", async () => {
+    const externalRoot = await makeTempDir("paperclip-agent-instructions-external-legacy-");
+    cleanupDirs.add(externalRoot);
+
+    const agentsBody = [
+      "# External Agent",
+      "",
+      "- `$AGENT_HOME/HEARTBEAT.md`",
+      "",
+    ].join("\n");
+    await fs.writeFile(path.join(externalRoot, "AGENTS.md"), agentsBody, "utf8");
+
+    const svc = agentInstructionsService();
+    const agent = makeAgent({
+      instructionsBundleMode: "external",
+      instructionsRootPath: externalRoot,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(externalRoot, "AGENTS.md"),
+    });
+
+    const bundle = await svc.getBundle(agent);
+    const exported = await svc.exportFiles(agent);
+
+    expect(bundle.mode).toBe("external");
+    expect(exported.files["AGENTS.md"]).toContain("$AGENT_HOME/HEARTBEAT.md");
+    await expect(fs.readFile(path.join(externalRoot, "AGENTS.md"), "utf8")).resolves.toBe(agentsBody);
+  });
+
+  it("leaves already-normalized managed AGENTS.md content unchanged", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-heal-idempotent-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const agentsBody = [
+      "# Agent",
+      "",
+      "- `./HEARTBEAT.md`",
+      "- `./SOUL.md`",
+      "- `./TOOLS.md`",
+      "",
+    ].join("\n");
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), agentsBody, "utf8");
+
+    const svc = agentInstructionsService();
+    const exported = await svc.exportFiles(makeAgent({}));
+
+    expect(exported.files["AGENTS.md"]).toBe(agentsBody);
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toBe(agentsBody);
+  });
+
   it("prefers the managed bundle on disk when managed metadata points at a stale root", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-stale-managed-");
     const staleRoot = await makeTempDir("paperclip-agent-instructions-stale-root-");

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -412,6 +412,13 @@ describe("agent skill routes", () => {
       }),
       { entryFile: "AGENTS.md", replaceExisting: false },
     );
+    const materializedFiles = mockAgentInstructionsService.materializeManagedBundle.mock.calls.at(-1)?.[1] as
+      | Record<string, string>
+      | undefined;
+    expect(materializedFiles?.["AGENTS.md"]).toContain("`./HEARTBEAT.md`");
+    expect(materializedFiles?.["AGENTS.md"]).toContain("`./SOUL.md`");
+    expect(materializedFiles?.["AGENTS.md"]).toContain("`./TOOLS.md`");
+    expect(materializedFiles?.["AGENTS.md"]).not.toContain("$AGENT_HOME/HEARTBEAT.md");
   });
 
   it("materializes the bundled default instruction set for non-CEO agents with no prompt template", async () => {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -12,6 +12,11 @@ const PROMPT_KEY = "promptTemplate";
 /** @deprecated Use the managed instructions bundle system instead. */
 const BOOTSTRAP_PROMPT_KEY = "bootstrapPromptTemplate";
 const LEGACY_PROMPT_TEMPLATE_PATH = "promptTemplate.legacy.md";
+const MANAGED_AGENTS_REFERENCE_REWRITES = [
+  ["$AGENT_HOME/HEARTBEAT.md", "./HEARTBEAT.md"],
+  ["$AGENT_HOME/SOUL.md", "./SOUL.md"],
+  ["$AGENT_HOME/TOOLS.md", "./TOOLS.md"],
+] as const;
 const IGNORED_INSTRUCTIONS_FILE_NAMES = new Set([".DS_Store", "Thumbs.db", "Desktop.ini"]);
 const IGNORED_INSTRUCTIONS_DIRECTORY_NAMES = new Set([
   ".git",
@@ -139,6 +144,29 @@ function resolveManagedInstructionsRoot(agent: AgentLike): string {
     agent.id,
     "instructions",
   );
+}
+
+function normalizeManagedBundleFileContent(relativePath: string, content: string): string {
+  if (normalizeRelativeFilePath(relativePath) !== ENTRY_FILE_DEFAULT) {
+    return content;
+  }
+
+  let nextContent = content;
+  for (const [legacyReference, normalizedReference] of MANAGED_AGENTS_REFERENCE_REWRITES) {
+    nextContent = nextContent.replaceAll(legacyReference, normalizedReference);
+  }
+  return nextContent;
+}
+
+async function healManagedBundleContent(rootPath: string): Promise<void> {
+  const agentsPath = resolvePathWithinRoot(rootPath, ENTRY_FILE_DEFAULT);
+  const currentContent = await fs.readFile(agentsPath, "utf8").catch(() => null);
+  if (currentContent === null) return;
+
+  const normalizedContent = normalizeManagedBundleFileContent(ENTRY_FILE_DEFAULT, currentContent);
+  if (normalizedContent === currentContent) return;
+
+  await fs.writeFile(agentsPath, normalizedContent, "utf8");
 }
 
 function resolveLegacyInstructionsPath(candidatePath: string, config: Record<string, unknown>): string {
@@ -287,46 +315,64 @@ async function recoverManagedBundleState(agent: AgentLike, state: BundleState): 
       ? ENTRY_FILE_DEFAULT
       : files[0]!;
 
+  let nextState: BundleState;
+
   if (!state.rootPath) {
-    return {
+    nextState = {
       ...state,
       mode: "managed",
       rootPath: managedRootPath,
       entryFile: recoveredEntryFile,
       resolvedEntryPath: path.resolve(managedRootPath, recoveredEntryFile),
     };
+  } else if (state.mode === "external") {
+    nextState = state;
+  } else {
+    const resolvedConfiguredRoot = path.resolve(state.rootPath);
+    const configuredRootMatchesManaged = resolvedConfiguredRoot === managedRootPath;
+    const hasEntryMismatch = recoveredEntryFile !== state.entryFile;
+
+    if (configuredRootMatchesManaged && !hasEntryMismatch) {
+      nextState = state;
+    } else {
+      const warnings = [...state.warnings];
+      if (!configuredRootMatchesManaged) {
+        warnings.push(
+          `Recovered managed instructions from disk at ${managedRootPath}; ignoring stale configured root ${state.rootPath}.`,
+        );
+      }
+      if (hasEntryMismatch) {
+        warnings.push(
+          `Recovered managed instructions entry file from disk as ${recoveredEntryFile}; previous entry ${state.entryFile} was missing.`,
+        );
+      }
+
+      nextState = {
+        ...state,
+        mode: "managed",
+        rootPath: managedRootPath,
+        entryFile: recoveredEntryFile,
+        resolvedEntryPath: path.resolve(managedRootPath, recoveredEntryFile),
+        warnings,
+      };
+    }
   }
 
-  if (state.mode === "external") return state;
-
-  const resolvedConfiguredRoot = path.resolve(state.rootPath);
-  const configuredRootMatchesManaged = resolvedConfiguredRoot === managedRootPath;
-  const hasEntryMismatch = recoveredEntryFile !== state.entryFile;
-
-  if (configuredRootMatchesManaged && !hasEntryMismatch) {
-    return state;
+  if (nextState.mode === "managed" && nextState.rootPath) {
+    try {
+      await healManagedBundleContent(nextState.rootPath);
+    } catch (err) {
+      nextState = {
+        ...nextState,
+        warnings: [
+          ...nextState.warnings,
+          `Failed to normalize managed AGENTS.md: ${err instanceof Error ? err.message : String(err)}`,
+        ],
+      };
+    }
   }
 
-  const warnings = [...state.warnings];
-  if (!configuredRootMatchesManaged) {
-    warnings.push(
-      `Recovered managed instructions from disk at ${managedRootPath}; ignoring stale configured root ${state.rootPath}.`,
-    );
-  }
-  if (hasEntryMismatch) {
-    warnings.push(
-      `Recovered managed instructions entry file from disk as ${recoveredEntryFile}; previous entry ${state.entryFile} was missing.`,
-    );
-  }
-
-  return {
-    ...state,
-    mode: "managed",
-    rootPath: managedRootPath,
-    entryFile: recoveredEntryFile,
-    resolvedEntryPath: path.resolve(managedRootPath, recoveredEntryFile),
-    warnings,
-  };
+  return nextState;
 }
 
 function toBundle(agent: AgentLike, state: BundleState, files: AgentInstructionsFileSummary[]): AgentInstructionsBundle {
@@ -417,7 +463,7 @@ function buildPersistedBundleConfig(
 async function writeBundleFiles(
   rootPath: string,
   files: Record<string, string>,
-  options?: { overwriteExisting?: boolean },
+  options?: { overwriteExisting?: boolean; normalizeManagedBundle?: boolean },
 ) {
   for (const [relativePath, content] of Object.entries(files)) {
     const normalizedPath = normalizeRelativeFilePath(relativePath);
@@ -425,7 +471,13 @@ async function writeBundleFiles(
     const existingStat = await statIfExists(absolutePath);
     if (existingStat?.isFile() && !options?.overwriteExisting) continue;
     await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-    await fs.writeFile(absolutePath, content, "utf8");
+    await fs.writeFile(
+      absolutePath,
+      options?.normalizeManagedBundle
+        ? normalizeManagedBundleFileContent(normalizedPath, content)
+        : content,
+      "utf8",
+    );
   }
 }
 
@@ -535,7 +587,11 @@ export function agentInstructionsService() {
       const legacyInstructions = await readLegacyInstructions(agent, current.config);
       if (legacyInstructions.trim().length > 0) {
         await fs.mkdir(path.dirname(entryPath), { recursive: true });
-        await fs.writeFile(entryPath, legacyInstructions, "utf8");
+        await fs.writeFile(
+          entryPath,
+          normalizeManagedBundleFileContent(entryFile, legacyInstructions),
+          "utf8",
+        );
       }
     }
 
@@ -578,12 +634,16 @@ export function agentInstructionsService() {
     const existingFiles = await listFilesRecursive(nextRootPath);
     const exported = await exportFiles(agent);
     if (existingFiles.length === 0) {
-      await writeBundleFiles(nextRootPath, exported.files);
+      await writeBundleFiles(nextRootPath, exported.files, {
+        normalizeManagedBundle: nextMode === "managed",
+      });
     }
     const refreshedFiles = existingFiles.length === 0 ? await listFilesRecursive(nextRootPath) : existingFiles;
     if (!refreshedFiles.includes(nextEntryFile)) {
       const nextEntryContent = exported.files[nextEntryFile] ?? exported.files[exported.entryFile] ?? "";
-      await writeBundleFiles(nextRootPath, { [nextEntryFile]: nextEntryContent });
+      await writeBundleFiles(nextRootPath, { [nextEntryFile]: nextEntryContent }, {
+        normalizeManagedBundle: nextMode === "managed",
+      });
     }
 
     const nextConfig = applyBundleConfig(state.config, {
@@ -701,7 +761,7 @@ export function agentInstructionsService() {
 
     const normalizedEntries = Object.entries(files).map(([relativePath, content]) => [
       normalizeRelativeFilePath(relativePath),
-      content,
+      normalizeManagedBundleFileContent(relativePath, content),
     ] as const);
     for (const [relativePath, content] of normalizedEntries) {
       const absolutePath = resolvePathWithinRoot(rootPath, relativePath);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local adapters rely on agent instruction bundles so the runtime can load AGENTS.md plus companion files like HEARTBEAT.md, SOUL.md, and TOOLS.md
> - Managed instruction bundles are materialized and recovered by shared server-side bundle code, not by one adapter-specific implementation
> - We hit a bug while using `opencode_local` where `AGENTS.md` could still contain legacy `$AGENT_HOME/...` companion links even though the managed bundle files existed on disk
> - That legacy form breaks downstream resolution in flows that expect bundle-relative paths like `./HEARTBEAT.md`
> - This pull request normalizes those legacy companion references only for managed bundles during recovery, export/materialization, and entry-file writes
> - The benefit is that managed instruction bundles become self-consistent and companion files resolve correctly without changing external bundle behavior

## What Changed

- Added managed-bundle normalization for legacy `AGENTS.md` companion references from `$AGENT_HOME/...` to `./...`
- Healed already-materialized managed bundles during recovery when `AGENTS.md` still contains legacy references
- Applied the same normalization when writing/materializing managed bundle entry files so new managed bundles do not preserve the legacy form
- Left external instruction bundles unchanged
- Added regression tests for managed healing, external no-op behavior, idempotent normalized content, and route-level materialization

## Verification

- `pnpm vitest run server/src/__tests__/agent-instructions-service.test.ts server/src/__tests__/agent-skills-routes.test.ts`
- `pnpm test:run`
- `pnpm -r typecheck` currently fails in this workspace because `packages/mcp-server` is missing installed dependencies (`@modelcontextprotocol/sdk`, `zod`, and local package resolution), not because of this change
- `pnpm build` currently fails for the same pre-existing `packages/mcp-server` dependency/install issue

## Risks

- Low risk: the rewrite is intentionally limited to managed bundle `AGENTS.md` content and does not touch non-entry files or external bundles
- If any workflow intentionally depended on `$AGENT_HOME/...` inside a managed `AGENTS.md`, this change will rewrite it to bundle-relative links, but that appears to be the correct managed-bundle contract

## Model Used

- OpenAI gpt-5.4 (`openai/gpt-5.4`), tool-enabled coding agent with repository inspection, shell execution, file reads, patch application, and GitHub CLI usage. Context window size not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #3191