### PR TITLE
fix: validate assigneeAgentId issue filters before querying

### DIFF
--- a/server/src/__tests__/issues-route-query-validation.test.ts
+++ b/server/src/__tests__/issues-route-query-validation.test.ts
@@ -1,0 +1,81 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+
+const listMock = vi.fn();
+
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    issueService: () => ({
+      list: listMock,
+    }),
+    accessService: () => ({}),
+    agentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    goalService: () => ({}),
+    heartbeatService: () => ({}),
+    issueApprovalService: () => ({}),
+    documentService: () => ({}),
+    logActivity: vi.fn(),
+    projectService: () => ({}),
+    routineService: () => ({}),
+    workProductService: () => ({}),
+  };
+});
+
+describe("issue routes query validation", () => {
+  beforeEach(() => {
+    listMock.mockReset();
+    listMock.mockResolvedValue([]);
+  });
+
+  it("rejects invalid assigneeAgentId query strings with a 400", async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-1",
+        source: "agent_key",
+      };
+      next();
+    });
+    app.use("/api", issueRoutes({} as any, {} as any));
+
+    const res = await request(app).get("/api/companies/company-1/issues?assigneeAgentId=null");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "assigneeAgentId must be a valid UUID",
+    });
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("passes valid UUID assigneeAgentId values through to the service", async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-1",
+        source: "agent_key",
+      };
+      next();
+    });
+    app.use("/api", issueRoutes({} as any, {} as any));
+
+    const assigneeAgentId = "11111111-1111-4111-8111-111111111111";
+    const res = await request(app).get(`/api/companies/company-1/issues?assigneeAgentId=${assigneeAgentId}`);
+
+    expect(res.status).toBe(200);
+    expect(listMock).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        assigneeAgentId,
+      }),
+    );
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -59,6 +59,19 @@ import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.
 import { applyIssueExecutionPolicyTransition, normalizeIssueExecutionPolicy } from "../services/issue-execution-policy.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const UUID_QUERY_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function normalizeOptionalUuidQuery(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  // Express parses repeated query params as arrays — treat that (and any
+  // other non-string) as invalid rather than silently dropping the filter.
+  if (typeof value !== "string") return "__invalid__";
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed === "null" || trimmed === "undefined") return "__invalid__";
+  return UUID_QUERY_RE.test(trimmed) ? trimmed : "__invalid__";
+}
+
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
@@ -374,10 +387,21 @@ export function issueRoutes(
       return;
     }
 
+    const assigneeAgentId = normalizeOptionalUuidQuery(req.query.assigneeAgentId);
+    if (assigneeAgentId === "__invalid__") {
+      res.status(400).json({ error: "assigneeAgentId must be a valid UUID" });
+      return;
+    }
+    const participantAgentId = normalizeOptionalUuidQuery(req.query.participantAgentId);
+    if (participantAgentId === "__invalid__") {
+      res.status(400).json({ error: "participantAgentId must be a valid UUID" });
+      return;
+    }
+
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId: assigneeAgentId ?? undefined,
+      participantAgentId: participantAgentId ?? undefined,
       assigneeUserId,
       touchedByUserId,
       inboxArchivedByUserId,


### PR DESCRIPTION
## Thinking Path

The `GET /api/companies/{id}/issues` endpoint accepts `assigneeAgentId` as a query parameter but passes it directly to the DB query without validation. Values like `null`, `undefined`, or non-UUID strings cause unexpected results or DB errors.

## Changes

- Add `normalizeOptionalUuidQuery()` helper that validates UUID format
- Reject invalid `assigneeAgentId` values with 400 before querying
- Add regression tests for both invalid and valid UUID paths

## Verification

```bash
pnpm --filter @paperclipai/server typecheck
pnpm vitest run issues-route-query-validation
```

## Risks

- **None**: Only adds validation before an existing query. Valid UUIDs pass through unchanged.

Closes #2257

Supersedes #2302 (which had rebase artifacts).