### PR TITLE
fix: include routine_execution issues in agent inbox-lite

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -424,7 +424,7 @@ function buildWakeText(
     "   - If instructions require a comment, POST /api/issues/{issueId}/comments with {\"body\":\"...\"}.",
     "   - PATCH /api/issues/{issueId} with {\"status\":\"done\",\"comment\":\"what changed and why\"}.",
     "4) If issueId does not exist:",
-    "   - GET /api/companies/$PAPERCLIP_COMPANY_ID/issues?assigneeAgentId=$PAPERCLIP_AGENT_ID&status=todo,in_progress,in_review,blocked",
+    "   - GET /api/companies/$PAPERCLIP_COMPANY_ID/issues?assigneeAgentId=$PAPERCLIP_AGENT_ID&status=todo,in_progress,in_review,blocked&includeRoutineExecutions=true",
     "   - Pick in_progress first, then in_review when you were woken by a comment, then todo, then blocked, then execute step 3.",
     "",
     "Useful endpoints for issue work:",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1084,6 +1084,7 @@ export function agentRoutes(db: Db) {
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
       status: "todo,in_progress,blocked",
+      includeRoutineExecutions: true,
     });
 
     res.json(


### PR DESCRIPTION
## Thinking Path

When a routine fires, Paperclip creates an execution issue with `originKind: "routine_execution"` and wakes the assigned agent. The agent calls `GET /agents/me/inbox-lite` to check for work, but the underlying `issuesSvc.list()` filters out `routine_execution` issues by default (issues.ts line 988-990). The agent never sees the routine task.

## Changes

- Add `includeRoutineExecutions: true` to the inbox-lite query in agents.ts

## Verification

```bash
pnpm --filter @paperclipai/server typecheck
```

## Risks

- **None**: Routine-execution issues are already created and assigned — this just makes them visible in the inbox query. Agents will now see and execute routine tasks as intended.

Closes #3090