### PR TITLE
fix: cancel orphaned queued runs when issue is reassigned or closed

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1301,6 +1301,26 @@ export function issueRoutes(
     }
     await routinesSvc.syncRunStatusForIssue(issue.id);
 
+    // Cancel orphaned queued/running runs when issue is reassigned or closed (#3168).
+    // Best-effort: failure is logged but does not block the issue update.
+    const wasReassigned =
+      req.body.assigneeAgentId !== undefined &&
+      req.body.assigneeAgentId !== existing.assigneeAgentId;
+    const wasClosed =
+      issue.status === "done" || issue.status === "cancelled";
+    if (wasReassigned || (wasClosed && existing.status !== "done" && existing.status !== "cancelled")) {
+      try {
+        // On reassignment, only cancel the OLD agent's queued runs — the new
+        // agent's runs must continue. On closure, cancel all agents' runs.
+        await heartbeat.cancelQueuedRunsForIssue(existing.id, {
+          agentId: wasReassigned && existing.assigneeAgentId ? existing.assigneeAgentId : undefined,
+          reason: wasReassigned ? "Issue reassigned to another agent" : "Issue closed",
+        });
+      } catch (err) {
+        logger.warn({ err, issueId: existing.id }, "failed to cancel queued runs for issue");
+      }
+    }
+
     if (actor.runId) {
       await heartbeat.reportRunActivity(actor.runId).catch((err) =>
         logger.warn({ err, runId: actor.runId }, "failed to clear detached run warning after issue activity"));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4270,6 +4270,49 @@ export function heartbeatService(db: Db) {
     return runs.length;
   }
 
+  async function cancelQueuedRunsForIssueInternal(
+    issueId: string,
+    opts?: { agentId?: string; reason?: string },
+  ) {
+    const reason = opts?.reason ?? "Issue reassigned or closed";
+    // Cancel queued runs for this issue, optionally scoped to a specific agent.
+    // On reassignment we only cancel the OLD agent's runs — the new agent's
+    // runs must not be touched. On closure we cancel all agents' runs.
+    //
+    // We loop until no matching runs remain to handle a TOCTOU race:
+    // cancelRunInternal calls startNextQueuedRunForAgent which may promote
+    // another queued run for the same issue after our initial select.
+    const buildConditions = () => {
+      const conditions = [
+        eq(heartbeatRuns.status, "queued" as const),
+        sql`${heartbeatRuns.contextSnapshot}->>'issueId' = ${issueId}`,
+      ];
+      if (opts?.agentId) {
+        conditions.push(eq(heartbeatRuns.agentId, opts.agentId));
+      }
+      return conditions;
+    };
+
+    let totalCancelled = 0;
+    const seenRunIds = new Set<string>();
+    for (let iteration = 0; iteration < 10; iteration++) {
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(and(...buildConditions()));
+
+      const freshRuns = runs.filter((r) => !seenRunIds.has(r.id));
+      if (freshRuns.length === 0) break;
+
+      for (const run of freshRuns) {
+        seenRunIds.add(run.id);
+        await cancelRunInternal(run.id, reason);
+        totalCancelled++;
+      }
+    }
+    return totalCancelled;
+  }
+
   async function cancelBudgetScopeWork(scope: BudgetEnforcementScope) {
     if (scope.scopeType === "agent") {
       await cancelActiveForAgentInternal(scope.scopeId, "Cancelled due to budget pause");
@@ -4475,6 +4518,9 @@ export function heartbeatService(db: Db) {
     cancelRun: (runId: string) => cancelRunInternal(runId),
 
     cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
+
+    cancelQueuedRunsForIssue: (issueId: string, opts?: { agentId?: string; reason?: string }) =>
+      cancelQueuedRunsForIssueInternal(issueId, opts),
 
     cancelBudgetScopeWork,
 


### PR DESCRIPTION
## Thinking Path

When multiple issues are assigned to an agent in quick succession, heartbeat runs are queued. If the issue is then reassigned to a different agent or closed, those queued runs remain in the queue permanently — blocking the agent from picking up new work.

The root cause: the issue update path clears `checkoutRunId` and `executionRunId` on reassignment/closure, but never cancels the queued heartbeat runs that reference the issue.

## Changes

- Add `cancelQueuedRunsForIssue()` to the heartbeat service — queries `heartbeatRuns` where `contextSnapshot->>issueId` matches and status is `queued`, then cancels them
- Call it from the issue PATCH handler after successful update, when the issue is reassigned or closed
- Errors are caught and logged (non-blocking) to avoid failing the issue update

## Verification

```bash
pnpm --filter @paperclipai/server typecheck
```

## Risks

- **Low**: Only cancels `queued` runs (not `running`). The cancel uses the same `setRunStatus`/`setWakeupStatus` pattern as existing cancellation logic. Wrapped in `.catch()` so a failure won't break the issue update.

Closes #3168