### PR TITLE
Github signing key rotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
+  && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \


### PR DESCRIPTION
Dockerfile uses hardcoded sha256sum of the github signing key which has been rotated. see https://github.com/cli/cli/issues/13118.

Log of "docker build":
```
[root@web paperclip]# docker build -t paperclip-local -f Dockerfile .
[+] Building 19.8s (6/36)                                                                                                                                                                                                                                                docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                               0.1s
 => => transferring dockerfile: 3.55kB                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/node:lts-trixie-slim                                                                                                                                                                                                            0.4s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                  0.1s
 => => transferring context: 129B                                                                                                                                                                                                                                                  0.0s
 => CACHED [base 1/3] FROM docker.io/library/node:lts-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                  0.2s
 => => transferring context: 97.83kB                                                                                                                                                                                                                                               0.1s
 => ERROR [base 2/3] RUN apt-get update   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3   && mkdir -p -m 755 /etc/apt/keyrings   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://  19.2s
------
...
18.74 2026-04-09 13:19:47 URL:https://cli.github.com/packages/githubcli-archive-keyring.gpg [4528/4528] -> "/etc/apt/keyrings/githubcli-archive-keyring.gpg" [1]
18.74 /etc/apt/keyrings/githubcli-archive-keyring.gpg: FAILED
18.74 sha256sum: WARNING: 1 computed checksum did NOT match
```