### PR TITLE
fix(heartbeat): kill orphaned agent processes after server restart

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -168,7 +168,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
 
-  it("keeps a local run active when the recorded pid is still alive", async () => {
+  it("kills orphaned process and reaps the run when recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);
     expect(child.pid).toBeTypeOf("number");
@@ -180,10 +180,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reapOrphanedRuns();
-    expect(result.reaped).toBe(0);
+    expect(result.reaped).toBe(1);
 
     const run = await heartbeat.getRun(runId);
-    expect(run?.status).toBe("running");
+    expect(run?.status).toBe("failed");
     expect(run?.errorCode).toBe("process_detached");
     expect(run?.error).toContain(String(child.pid));
 
@@ -192,7 +192,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(agentWakeupRequests)
       .where(eq(agentWakeupRequests.id, wakeupRequestId))
       .then((rows) => rows[0] ?? null);
-    expect(wakeup?.status).toBe("claimed");
+    expect(wakeup?.status).toBe("failed");
   });
 
   it("queues exactly one retry when the recorded local pid is dead", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1032,7 +1032,7 @@ function killOrphanedPid(pid: number | null | undefined, graceMs = 5_000) {
         process.kill(numPid, "SIGKILL");
       } catch { /* already gone */ }
     }
-  }, graceMs);
+  }, graceMs).unref();
 }
 
 function truncateDisplayId(value: string | null | undefined, max = 128) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1014,6 +1014,27 @@ function isProcessAlive(pid: number | null | undefined) {
   }
 }
 
+/**
+ * Best-effort kill of an orphaned child process by raw PID.
+ * Used when the in-memory ChildProcess handle was lost (e.g. after a server
+ * restart) but the OS process is still alive.  Sends SIGTERM first, then
+ * SIGKILL after `graceMs`.
+ */
+function killOrphanedPid(pid: number | null | undefined, graceMs = 5_000) {
+  if (!isProcessAlive(pid)) return;
+  const numPid = pid as number;
+  try {
+    process.kill(numPid, "SIGTERM");
+  } catch { /* already gone */ }
+  setTimeout(() => {
+    if (isProcessAlive(numPid)) {
+      try {
+        process.kill(numPid, "SIGKILL");
+      } catch { /* already gone */ }
+    }
+  }, graceMs);
+}
+
 function truncateDisplayId(value: string | null | undefined, max = 128) {
   if (!value) return null;
   return value.length > max ? value.slice(0, max) : value;
@@ -2346,24 +2367,33 @@ export function heartbeatService(db: Db) {
 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       if (tracksLocalChild && run.processPid && isProcessAlive(run.processPid)) {
-        if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
-          const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
-          const detachedRun = await setRunStatus(run.id, "running", {
-            error: detachedMessage,
-            errorCode: DETACHED_PROCESS_ERROR_CODE,
+        // Kill the orphaned OS process and mark the run as failed so it
+        // doesn't linger indefinitely.  Previous behaviour only logged a
+        // warning and left the process (and run) alive.
+        killOrphanedPid(run.processPid);
+        const detachedMessage = `Killed orphaned child pid ${run.processPid} (in-memory handle lost after server restart)`;
+        const detachedRun = await setRunStatus(run.id, "failed", {
+          error: detachedMessage,
+          errorCode: DETACHED_PROCESS_ERROR_CODE,
+          finishedAt: now,
+        });
+        await setWakeupStatus(run.wakeupRequestId, "failed", {
+          finishedAt: now,
+          error: detachedMessage,
+        });
+        if (detachedRun) {
+          await appendRunEvent(detachedRun, await nextRunEventSeq(detachedRun.id), {
+            eventType: "lifecycle",
+            stream: "system",
+            level: "warn",
+            message: detachedMessage,
+            payload: {
+              processPid: run.processPid,
+            },
           });
-          if (detachedRun) {
-            await appendRunEvent(detachedRun, await nextRunEventSeq(detachedRun.id), {
-              eventType: "lifecycle",
-              stream: "system",
-              level: "warn",
-              message: detachedMessage,
-              payload: {
-                processPid: run.processPid,
-              },
-            });
-          }
+          await releaseIssueExecutionAndPromote(detachedRun);
         }
+        reaped.push(run.id);
         continue;
       }
 
@@ -4238,6 +4268,8 @@ export function heartbeatService(db: Db) {
           running.child.kill("SIGKILL");
         }
       }, graceMs);
+    } else if (run.processPid && isProcessAlive(run.processPid)) {
+      killOrphanedPid(run.processPid);
     }
 
     const cancelled = await setRunStatus(run.id, "cancelled", {
@@ -4289,6 +4321,8 @@ export function heartbeatService(db: Db) {
       if (running) {
         running.child.kill("SIGTERM");
         runningProcesses.delete(run.id);
+      } else if (run.processPid && isProcessAlive(run.processPid)) {
+        killOrphanedPid(run.processPid);
       }
       await releaseIssueExecutionAndPromote(run);
     }


### PR DESCRIPTION
## Summary

Fixes #3215

- Adds `killOrphanedPid()` helper that sends SIGTERM then SIGKILL (after 5s grace) to a raw PID
- `cancelRunInternal` now falls back to `killOrphanedPid(run.processPid)` when the in-memory `ChildProcess` handle is missing
- `cancelActiveForAgentInternal` gets the same fallback
- The stale-run reaper now kills orphaned processes and marks runs as `failed` (instead of leaving them in `running` with a warning log)
- Updated test to match new behavior: orphaned-but-alive processes are reaped, not preserved

## Test plan

- [x] `heartbeat-process-recovery.test.ts` — all 5 tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: restart server during active run, confirm orphan is killed on next reaper cycle
- [ ] Manual: cancel a detached run via API, confirm OS process is terminated


🤖 Generated with [Claude Code](https://claude.com/claude-code)