### PR TITLE
[voyager-self-improve] hallucinated-api: require contract verification before API/MCP calls

### DIFF
--- a/voyager-runtime/skills/saturn-bug-fix-to-pr/SKILL.md
+++ b/voyager-runtime/skills/saturn-bug-fix-to-pr/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: saturn-bug-fix-to-pr
+description: Use when a Saturn bug has been confirmed and needs a fix shipped as a draft PR. Traces the 5-layer chain, writes the fix, runs tests, opens a draft PR into dev or stage, links back to the Jira ticket. Never merges, never pushes directly.
+---
+
+# Saturn Bug Fix → Draft PR
+
+Activate when triage has confirmed a genuine bug AND a human has approved a fix attempt.
+
+## Inputs
+
+- Jira ticket key (e.g., `PROD-3712`)
+- The failing signature (error, repro steps, affected service)
+- The suspected file/function from triage
+
+## Process
+
+### 0. Confirm every external contract before you act
+
+Before calling Jira, GitHub, Slack, Paperclip, or MCP methods as part of the fix flow, read the local source or tool schema that defines the contract. Do not guess endpoint paths, payload keys, response wrappers, or Atlassian identifiers.
+
+- For Paperclip: read the route file first (for example `server/src/routes/issues.ts`) before scripting API calls.
+- For MCP tools: inspect `voyager-runtime/mcp-config.json` and list/call the tool schema before using a method.
+- Bad: assume `/companies/:companyId/issues` returns `{items:[...]}` or pass a Jira site URL where the MCP expects a cloud ID.
+- Good: verify the exact route + schema, then make the call.
+
+### 1. Trace the 5-layer chain FIRST
+
+This is mandatory per Saturn's CLAUDE.md. For every endpoint, route, or feature you touch:
+
+1. Backend/Jupiter/Mars route definition — where is it registered?
+2. The view/handler — what does it return?
+3. Shuttle proxy config — does shuttle know about this path?
+4. Frontend API service file — what URL does the frontend call?
+5. Frontend component — what response shape does it expect?
+
+Read all 5 before writing code. If the bug spans layers, fix ALL affected layers in the same PR.
+
+### 2. Reproduce locally (if possible)
+
+The relevant service repo is already on disk at `/Users/bugatt/Downloads/saturn/{service}/`. Use it. If local repro is infeasible (e.g., needs a real firm's data), explain in the PR body why and rely on log-driven diagnosis.
+
+### 3. Create a branch
+
+Branch name format: `voyager/{JIRA-KEY}-{short-slug}`
+Base branch: **`dev`** (default) or **`stage`** (stabilization work). **Never `main`. Never `labs`.** If the assignment ticket specifies a base branch, use that. Otherwise default to `dev`.
+
+### 4. Write the fix
+
+- Don't add features, don't refactor code you didn't change, don't add docstrings you weren't asked for.
+- Follow existing patterns in the file you're editing.
+- If the file has tests alongside it, update or add tests.
+- For Django: **never add new top-level heavy imports** (boto3, pydub, docx, pypdf, litellm, langchain). Import inside function bodies.
+- For Mars: **GORM zero-value bool**: `db.Create()` skips `false` → default `true` applies. Fix: Create then Update.
+- For Jupiter: **MongoDB database name** baked in image as `jupiter_db`; ECS secrets don't override.
+
+### 5. Verify
+
+- Run the relevant test file (not the whole suite) with the service's test runner:
+  - Django: `cd backend && pytest {path/to/test} -x`
+  - Mars: `cd mars && go test ./{path/to/package} -run {TestName}`
+  - Jupiter: `cd jupiter && pytest {path/to/test} -x`
+  - Frontend: `cd frontend && pnpm test {pattern}`
+- If the test passes and no linter errors, proceed. If not, iterate — don't open a broken PR.
+
+### 6. Open the draft PR
+
+Use `gh pr create --draft` or the GitHub MCP. Title format:
+
+```
+[{JIRA-KEY}] {short human description}
+```
+
+PR body must include:
+
+- `## Thinking Path` — trace from PRD/problem to this change
+- `## What Changed` — bullet list of concrete changes
+- `## Verification` — how a reviewer can confirm it works (exact commands)
+- `## Risks` — what could break
+- `## Model Used` — the model that produced this change
+- `## Jira` — link back to the ticket
+
+The PR is **draft**. The human decides when to mark ready-for-review.
+
+### 7. Link both ways
+
+- Comment on the Jira ticket with the PR URL
+- Comment on the PR with the Jira URL
+- Reply in the original Slack thread with both links
+
+## Hard rules
+
+- **PR only. Only `dev` and `stage` are valid base branches. Never `main`, never `labs`. Never push directly.**
+- **Draft only.**
+- **No `--no-verify` on hooks.**
+- **No scope creep** — fix the bug, nothing else. If you see other issues, open separate Jira tickets.
+- **Every touched layer must be updated.** Changing a backend endpoint without updating shuttle + frontend is a wiring bug, not a fix.
+- **Tenant isolation** — make sure the fix doesn't leak cross-firm data.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents, and Voyager/Fixer are using it to manage Saturn bug-fix work.
> - Fixer heartbeats are supposed to self-improve the `saturn-bug-fix-to-pr` skill when recent runs show a repeatable failure pattern.
> - I reviewed Fixer's last 30 heartbeat runs and found one actual failure in the sample window: run `7a74d267-e6ed-4223-b8df-6d6399758f57`.
> - The failed run log showed repeated guessed API/tool usage during fallback work (`/companies/:companyId/issues` response shape assumptions and Atlassian cloud-id guessing) before the process was lost, so the clearest preventable cluster was `hallucinated-api`.
> - The missing guardrail was explicit: confirm Paperclip route contracts and MCP method schemas from source before making side-effecting calls.
> - This pull request proposes a single reviewable skill edit that adds that guardrail, with concrete bad/good examples, so future Fixer runs read the contract first instead of improvising it.
> - The benefit is tighter diagnosis, fewer wasted turns, and lower odds of blocker/comment logic failing because the wrong API shape was assumed.
> - Repo note: `dev` does not exist on `paperclipai/paperclip`, so this draft PR targets `master` as the closest available review branch.

## What Changed

- Added a new `### 0. Confirm every external contract before you act` step to `voyager-runtime/skills/saturn-bug-fix-to-pr/SKILL.md`.
- Required Fixer to read local Paperclip route definitions and MCP schemas before calling Jira, GitHub, Slack, Paperclip, or other MCP methods.
- Added concrete anti-pattern examples for the observed failure cluster: guessed `/companies/:companyId/issues` response wrappers and guessed Atlassian identifiers.

## Verification

- Reviewed recent Fixer heartbeat runs:
  `curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "http://127.0.0.1:3100/api/companies/5b6aab3c-3721-44a5-9f39-c8dc75d63763/heartbeat-runs?agentId=18d1e2d6-aec2-41a0-9d66-26f2c7a0f3a8&limit=30" | jq '[.[] | {id,status,error,errorCode,startedAt,finishedAt}]'`
- Inspected the failed run details and log:
  `curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "http://127.0.0.1:3100/api/heartbeat-runs/7a74d267-e6ed-4223-b8df-6d6399758f57/log" | jq '.'`
- Verified the Paperclip issue routes exist in source:
  `rg -n 'router\.(get|post|patch)\("/companies/:companyId/issues|router\.(get|post|patch)\("/issues/' server/src/routes/issues.ts`
- Verified the branch contains only the proposed skill file addition.

## Risks

- Low risk: this is skill/prompt guidance only.
- Minor risk: the example references `voyager-runtime/mcp-config.json`, which should stay accurate if that file moves.
- Procedural risk: because upstream has no `dev` branch, this review is against `master`; maintainers may prefer to transplant it elsewhere.

## Model Used

- OpenAI gpt-5.4 via Hermes/OpenClaw, with tool use enabled (terminal, file search/read/write, patching, git, GitHub CLI).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
