### PR TITLE
[voyager-self-improve] process_lost: require clean worktrees before fixer edits

### DIFF
--- a/voyager-runtime/skills/saturn-bug-fix-to-pr/SKILL.md
+++ b/voyager-runtime/skills/saturn-bug-fix-to-pr/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: saturn-bug-fix-to-pr
+description: Use when a Saturn bug has been confirmed and needs a fix shipped as a draft PR. Traces the 5-layer chain, writes the fix, runs tests, opens a draft PR into dev or stage, links back to the Jira ticket. Never merges, never pushes directly.
+---
+
+# Saturn Bug Fix → Draft PR
+
+Activate when triage has confirmed a genuine bug AND a human has approved a fix attempt.
+
+## Inputs
+
+- Jira ticket key (e.g., `PROD-3712`)
+- The failing signature (error, repro steps, affected service)
+- The suspected file/function from triage
+
+## Process
+
+### 1. Trace the 5-layer chain FIRST
+
+This is mandatory per Saturn's CLAUDE.md. For every endpoint, route, or feature you touch:
+
+1. Backend/Jupiter/Mars route definition — where is it registered?
+2. The view/handler — what does it return?
+3. Shuttle proxy config — does shuttle know about this path?
+4. Frontend API service file — what URL does the frontend call?
+5. Frontend component — what response shape does it expect?
+
+Read all 5 before writing code. If the bug spans layers, fix ALL affected layers in the same PR.
+
+### 2. Reproduce locally (if possible)
+
+The relevant service repo is already on disk at `/Users/bugatt/Downloads/saturn/{service}/`. Use it. If local repro is infeasible (e.g., needs a real firm's data), explain in the PR body why and rely on log-driven diagnosis.
+
+### 3. Create a branch
+
+Branch name format: `voyager/{JIRA-KEY}-{short-slug}`
+Base branch: **`dev`** (default) or **`stage`** (stabilization work). **Never `main`. Never `labs`.** If the assignment ticket specifies a base branch, use that. Otherwise default to `dev`.
+
+### 3a. Isolate the work in a clean git worktree
+
+Before editing, check `git status --short`. If the repo is dirty OR the checkout is the same one running a watched local dev server, create a separate git worktree from the target base branch and do the entire fix there. This prevents watch-mode restarts from killing the heartbeat run mid-fix and keeps unrelated local changes out of the PR.
+
+Concrete example:
+
+```bash
+git fetch origin
+git worktree add /tmp/{service}-{JIRA-KEY} origin/{base-branch} -b voyager/{JIRA-KEY}-{short-slug}
+cd /tmp/{service}-{JIRA-KEY}
+```
+
+If you cannot get to a clean isolated worktree, stop and report the blocker instead of editing the watched checkout.
+
+### 4. Write the fix
+
+- Don't add features, don't refactor code you didn't change, don't add docstrings you weren't asked for.
+- Follow existing patterns in the file you're editing.
+- If the file has tests alongside it, update or add tests.
+- For Django: **never add new top-level heavy imports** (boto3, pydub, docx, pypdf, litellm, langchain). Import inside function bodies.
+- For Mars: **GORM zero-value bool**: `db.Create()` skips `false` → default `true` applies. Fix: Create then Update.
+- For Jupiter: **MongoDB database name** baked in image as `jupiter_db`; ECS secrets don't override.
+
+### 5. Verify
+
+- Run the relevant test file (not the whole suite) with the service's test runner:
+  - Django: `cd backend && pytest {path/to/test} -x`
+  - Mars: `cd mars && go test ./{path/to/package} -run {TestName}`
+  - Jupiter: `cd jupiter && pytest {path/to/test} -x`
+  - Frontend: `cd frontend && pnpm test {pattern}`
+- If the test passes and no linter errors, proceed. If not, iterate — don't open a broken PR.
+
+### 6. Open the draft PR
+
+Use `gh pr create --draft` or the GitHub MCP. Title format:
+
+```
+[{JIRA-KEY}] {short human description}
+```
+
+PR body must include:
+
+- `## Thinking Path` — trace from PRD/problem to this change
+- `## What Changed` — bullet list of concrete changes
+- `## Verification` — how a reviewer can confirm it works (exact commands)
+- `## Risks` — what could break
+- `## Model Used` — the model that produced this change
+- `## Jira` — link back to the ticket
+
+The PR is **draft**. The human decides when to mark ready-for-review.
+
+### 7. Link both ways
+
+- Comment on the Jira ticket with the PR URL
+- Comment on the PR with the Jira URL
+- Reply in the original Slack thread with both links
+
+## Hard rules
+
+- **PR only. Only `dev` and `stage` are valid base branches. Never `main`, never `labs`. Never push directly.**
+- **Draft only.**
+- **No `--no-verify` on hooks.**
+- **No scope creep** — fix the bug, nothing else. If you see other issues, open separate Jira tickets.
+- **Every touched layer must be updated.** Changing a backend endpoint without updating shuttle + frontend is a wiring bug, not a fix.
+- **Tenant isolation** — make sure the fix doesn't leak cross-firm data.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so heartbeat reliability matters as much as the work an agent does.
> - Fixer is a Saturn bug-fix specialist whose skill should help it survive real repo conditions, not just ideal clean checkouts.
> - In the last 7 days, Fixer had one failure and it was `process_lost` (`7a74d267-e6ed-4223-b8df-6d6399758f57`), caused by the server/watch process disappearing mid-run.
> - `doc/DEVELOPING.md` explicitly says `pnpm dev` runs in watch mode and restarts on changes, so editing in a watched or dirty checkout is a plausible way to strand a heartbeat run.
> - The current `saturn-bug-fix-to-pr` skill tells Fixer how to branch, trace layers, and verify, but it does not tell Fixer to isolate work from a dirty or watched checkout first.
> - This pull request proposes a single concrete guardrail: require a clean git worktree before editing when the repo is dirty or watch mode is in play.
> - The benefit is fewer `process_lost` failures and cleaner, reviewable PRs with less accidental contamination from unrelated local changes.

## What Changed

- Added a new `### 3a. Isolate the work in a clean git worktree` section to `voyager-runtime/skills/saturn-bug-fix-to-pr/SKILL.md`.
- Made the guardrail explicit: check `git status --short`, and if the repo is dirty or the checkout is being watched by a local dev server, create a separate worktree from the target base branch before editing.
- Included a concrete `git fetch` + `git worktree add` example and a stop condition when a clean isolated worktree cannot be created.

## Verification

- Confirmed recent Fixer heartbeat runs via:
  - `curl -s "http://127.0.0.1:3100/api/companies/5b6aab3c-3721-44a5-9f39-c8dc75d63763/heartbeat-runs?agentId=18d1e2d6-aec2-41a0-9d66-26f2c7a0f3a8&limit=200" | jq '[.[] | {id,status,error,errorCode,startedAt,finishedAt}]'`
- Confirmed the only failure cluster was `process_lost` via a Python aggregation over the same endpoint.
- Read `doc/GOAL.md`, `doc/PRODUCT.md`, `doc/SPEC-implementation.md`, `doc/DEVELOPING.md`, `AGENTS.md`, and `.github/PULL_REQUEST_TEMPLATE.md` before proposing the change.
- Inspected the resulting skill file in the isolated worktree after the edit.
- No automated test suite was run because this is a docs/skill-only proposal and `voyager-runtime` is not yet present on `origin/master`.

## Risks

- Low risk, but the proposal currently lands as a new `voyager-runtime` skill file on top of `master` because `origin/dev` does not exist and `voyager-runtime/` is not yet tracked on `origin/master`.
- Reviewers may prefer replaying this exact hunk onto the eventual tracked runtime branch instead of merging it directly on `master`.

## Model Used

- OpenAI gpt-5.4 via Hermes CLI agent with tool use, shell execution, file reads/writes, and git/GitHub operations.

## Jira

- N/A — heartbeat self-improvement proposal for Fixer.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
