### PR TITLE
feat(memory): add mempalace integration with memory adapter framework

### DIFF
--- a/doc/MEMPALACE.md
+++ b/doc/MEMPALACE.md
@@ -1,0 +1,316 @@
+# Mempalace Integration
+
+Mempalace provides semantic memory for Paperclip agents. Agents don't interact with mempalace directly — the Paperclip server queries and writes to mempalace automatically via lifecycle hooks on each agent run.
+
+## How It Works
+
+1. **Pre-run hydration** — before each agent run, the server queries mempalace for context relevant to the task and injects it into the agent's context window.
+2. **Post-run capture** — after each run completes, the server writes a summary of what happened into mempalace for future recall.
+
+Both hooks are controlled by **memory bindings** — database records that configure which memory provider to use, for which agents, and what hooks are enabled.
+
+## Architecture
+
+```
+agent ← heartbeat context ← paperclip server ← MCP over HTTP ← mempalace container
+                                              → MCP over HTTP → mempalace container
+```
+
+Agents never access mempalace data directly. The paperclip server handles all memory operations and injects the results into the agent's context.
+
+## Setup
+
+### Prerequisites
+
+- A running Paperclip instance
+- Docker or Podman (for remote mode) or Python 3.13+ (for local mode)
+
+### Option A: Remote Mode (Docker / Podman) — Recommended
+
+Run mempalace as a separate container. This is the recommended approach for production and multi-container deployments.
+
+#### 1. Build the mempalace container
+
+```bash
+cd docker/mempalace
+docker build -t mempalace .
+```
+
+#### 2. Run it
+
+```bash
+docker run -d \
+  --name mempalace \
+  -p 8080:8080 \
+  -v mempalace-data:/data/mempalace \
+  mempalace
+```
+
+Or with Docker Compose — see `docker/mempalace/docker-compose.mempalace.yml`:
+
+```yaml
+services:
+  paperclip:
+    image: your-paperclip-image
+    environment:
+      MEMPALACE_URL: http://mempalace:8080/mcp
+    depends_on:
+      mempalace:
+        condition: service_healthy
+
+  mempalace:
+    build: docker/mempalace
+    volumes:
+      - mempalace-data:/data/mempalace
+    environment:
+      MEMPALACE_PALACE_PATH: /data/mempalace
+      MEMPALACE_PORT: 8080
+
+volumes:
+  mempalace-data:
+```
+
+#### 3. Point Paperclip at it
+
+Set the environment variable on the Paperclip server:
+
+```
+MEMPALACE_URL=http://mempalace:8080/mcp
+```
+
+If running outside compose (e.g. Podman pod), use `http://localhost:8080/mcp` or the appropriate network address.
+
+#### 4. Verify connection
+
+In the Paperclip server logs at startup, look for:
+
+```
+mempalace remote adapter connected and registered {"url":"http://mempalace:8080/mcp"}
+```
+
+### Option B: Local Sidecar Mode
+
+Run mempalace as a child process of the Paperclip server. Suitable for single-host or development setups.
+
+#### 1. Install mempalace
+
+```bash
+pip install mempalace
+```
+
+Ensure `python` is on the PATH and can import `mempalace`.
+
+#### 2. Enable the sidecar
+
+Set environment variables on the Paperclip server:
+
+```
+MEMPALACE_ENABLED=true
+MEMPALACE_PALACE_DIR=/path/to/palace/data    # optional, defaults to $CWD/.mempalace
+MEMPALACE_PYTHON_COMMAND=python               # optional, defaults to "python"
+```
+
+#### 3. Verify
+
+In the Paperclip server logs at startup:
+
+```
+mempalace sidecar started and adapter registered {"palaceDir":"/path/to/palace/data"}
+```
+
+The sidecar includes health checks (every 30s) and auto-restart with exponential backoff (up to 5 attempts).
+
+## Creating a Memory Binding
+
+The adapter being registered is not enough — you need a **memory binding** to tell the system to use it. Without a binding, no memory operations will fire.
+
+### Via the UI
+
+Navigate to **Memory Settings** in the Paperclip sidebar. Create a new binding with:
+
+- **Key**: a unique name, e.g. `mempalace-default`
+- **Provider**: `mempalace`
+- **Hooks**: enable pre-run hydration and/or post-run capture
+
+Then add a **target** — either the whole company (all agents) or a specific agent.
+
+### Via the API
+
+#### 1. Create the binding
+
+```bash
+curl -X POST $PAPERCLIP_API_URL/api/companies/$COMPANY_ID/memory-bindings \
+  -H 'Authorization: Bearer $TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "key": "mempalace-default",
+    "providerKey": "mempalace",
+    "config": {
+      "hooks": {
+        "preRunHydrate": { "enabled": true, "topK": 5 },
+        "postRunCapture": { "enabled": true, "captureDepth": "full" }
+      }
+    }
+  }'
+```
+
+#### 2. Target it at the company (all agents)
+
+```bash
+curl -X POST $PAPERCLIP_API_URL/api/memory-bindings/$BINDING_ID/targets \
+  -H 'Authorization: Bearer $TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "targetType": "company",
+    "targetId": "'$COMPANY_ID'"
+  }'
+```
+
+Or target a specific agent:
+
+```bash
+curl -X POST $PAPERCLIP_API_URL/api/memory-bindings/$BINDING_ID/targets \
+  -H 'Authorization: Bearer $TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "targetType": "agent",
+    "targetId": "'$AGENT_ID'"
+  }'
+```
+
+### Hook Configuration
+
+| Hook | Purpose | Config |
+|------|---------|--------|
+| `preRunHydrate` | Query mempalace before each run, inject relevant context | `enabled`: boolean, `topK`: max snippets (default 5) |
+| `postRunCapture` | Write run summary to mempalace after each run | `enabled`: boolean, `captureDepth`: `"summary"` or `"full"` |
+
+- **`summary`** — captures metadata only: agent name, task title, run ID, outcome, timestamp.
+- **`full`** — captures metadata plus the adapter's result JSON (the agent's actual output), capped at 4000 chars. Recommended for building useful memory.
+
+## Verifying It Works
+
+After creating a binding and running an agent, you should see:
+
+### Paperclip server logs
+
+```
+memory context hydrated for run {"bindingsQueried":1,"snippetCount":3}
+memory capture completed {"bindingsCaptured":1}
+```
+
+### Mempalace container logs
+
+```
+POST /mcp HTTP/1.1 200 OK    # mempalace_search (pre-run hydration)
+POST /mcp HTTP/1.1 200 OK    # mempalace_add_drawer (post-run capture)
+```
+
+### Memory Operations page
+
+In the Paperclip UI, the Memory Operations page shows logged operations with latency, success status, and provider details.
+
+### Mempalace data directory
+
+ChromaDB files should appear in the configured palace directory (e.g. `/data/mempalace/`).
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMPALACE_URL` | — | Remote mempalace MCP server URL. Takes precedence over local mode. |
+| `MEMPALACE_ENABLED` | — | Set to `true` to start local sidecar mode. Ignored when `MEMPALACE_URL` is set. |
+| `MEMPALACE_PALACE_DIR` | `$CWD/.mempalace` | Palace data directory for local sidecar mode. |
+| `MEMPALACE_PYTHON_COMMAND` | `python` | Python binary for local sidecar mode. |
+| `MEMPALACE_PORT` | `8080` | HTTP port for the mempalace container. |
+| `MEMPALACE_PALACE_PATH` | `/data/mempalace` | Palace data path inside the mempalace container. |
+
+## Error Handling
+
+Mempalace failures never block agent runs. The system has 4 layers of defense:
+
+1. **Adapter level** — auto-reconnect on call failure (handles container restarts)
+2. **Sidecar level** (local mode) — health checks every 30s, auto-restart with exponential backoff
+3. **Memory hooks level** — each binding operation is individually try/caught, failures logged to the `memory_operations` table
+4. **Heartbeat level** — entire memory hydration and capture blocks are try/caught; runs proceed without memory context on failure
+
+## Backfilling Historical Runs
+
+If mempalace was enabled after agents had already been running, you can backfill previous run data into mempalace using the CLI script.
+
+### Usage
+
+From the repo root:
+
+```bash
+pnpm -w run backfill:mempalace -- [options]
+```
+
+Or directly:
+
+```bash
+pnpm --filter @paperclipai/server exec tsx scripts/backfill-mempalace.ts [options]
+```
+
+Inside a running container:
+
+```bash
+pnpm --filter @paperclipai/server exec tsx scripts/backfill-mempalace.ts [options]
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--company-id <id>` | all | Filter by company UUID |
+| `--agent-id <id>` | all | Filter by agent UUID |
+| `--since <date>` | all time | Only runs after this ISO date |
+| `--until <date>` | now | Only runs before this ISO date |
+| `--dry-run` | — | Preview what would be written without writing |
+| `--batch-size <n>` | 100 | Runs per batch |
+| `--capture-depth <d>` | full | `"summary"` or `"full"` |
+
+### Environment
+
+The script requires the same environment variables as the Paperclip server:
+
+- `DATABASE_URL` — Postgres connection string (required)
+- `MEMPALACE_URL` — remote mempalace URL, **or** `MEMPALACE_ENABLED=true` for local sidecar
+
+### Examples
+
+Preview all backfill-able runs:
+
+```bash
+pnpm -w run backfill:mempalace -- --dry-run
+```
+
+Backfill a specific company's runs from the last 30 days:
+
+```bash
+pnpm -w run backfill:mempalace -- --company-id <uuid> --since 2026-03-09
+```
+
+Backfill inside a container:
+
+```bash
+podman exec paperclip pnpm --filter @paperclipai/server exec tsx scripts/backfill-mempalace.ts --dry-run
+```
+
+## Troubleshooting
+
+**Adapter registered but no memory operations during runs**
+- Check that a memory binding exists with the correct `providerKey` (`mempalace`)
+- Check that the binding has a target pointing to the company or agent
+- Check that hooks are enabled in the binding config
+
+**Mempalace container starts then dies after ~2 minutes**
+- Ensure the container uses the HTTP wrapper (`serve_http.py`), not `python -m mempalace.mcp_server` directly. The native MCP server only supports stdio transport.
+
+**Connection refused / adapter not registered**
+- Verify the mempalace container is running and healthy: `curl http://localhost:8080/health`
+- Check the `MEMPALACE_URL` matches the container's address and port
+- In compose, ensure `depends_on` with `condition: service_healthy`
+
+**Empty palace data directory**
+- This is expected until the first post-run capture fires. Run an agent on a task with a binding configured, then check again.

--- a/doc/MEMPALACE.md
+++ b/doc/MEMPALACE.md
@@ -314,3 +314,58 @@ podman exec paperclip pnpm --filter @paperclipai/server exec tsx scripts/backfil
 
 **Empty palace data directory**
 - This is expected until the first post-run capture fires. Run an agent on a task with a binding configured, then check again.
+
+
+## How does the work align with the doc `memory-landscape.md`?
+
+The doc proposes a two-layer memory model. Here's how the implementation maps:
+
+### Layer 1: Memory binding + control plane ✅ Strong alignment
+
+The doc says Paperclip should own:
+
+| Doc requirement | Implementation | Status |
+|---|---|---|
+| Binding provider to company, optionally per-agent | `memory_bindings` + `memory_binding_targets` tables, with target types `company` and `agent` | ✅ Done |
+| Mapping Paperclip entities into provider scopes | `MemoryScope` type carries `companyId`, `agentId`, `projectId`, `issueId`, `runId` | ✅ Done |
+| Provenance back to issues, comments, documents, runs | `sourceRef` jsonb on `memory_operations`, `buildSourceFile()` in adapter | ✅ Done |
+| Cost / latency reporting | `memory_operations` table with `latency_ms`, `usage` jsonb, `success` flag | ✅ Done |
+| Browse and inspect UI | `MemoryOperations.tsx` (operation log) + `MemorySettings.tsx` (binding management) | ✅ Done |
+| Governance on destructive operations | Operation logging for all write/query/forget calls | ⚠️ Partial — logging exists but no approval gate on forget |
+
+### Layer 2: Provider adapter ✅ Strong alignment
+
+The doc says providers should own extraction, indexing, ranking, profile synthesis, and storage.
+
+| Doc requirement | Implementation | Status |
+|---|---|---|
+| Required portable core (write, query, get, forget) | `MemoryAdapter` interface with `write()`, `query()`, `get()`, `forget()` | ✅ Done |
+| Optional capability flags | `MemoryAdapterCapabilities` with `profile`, `browse`, `correction`, `asyncIngestion`, `multimodal`, `providerManagedExtraction` | ✅ Done |
+| Provider-native IDs without flattening | `MemoryRecordHandle` with `providerKey` + `providerRecordId` | ✅ Done |
+| Plugin-supplied adapters (not only built-ins) | Interface in `@paperclipai/plugin-sdk`, plugins can implement | ✅ Done |
+| Built-in local-first baseline | PARA adapter (file-based, zero-config) | ✅ Done |
+| Support for richer external systems | Mempalace adapter (MCP-based, stdio or remote HTTP) | ✅ Done |
+
+### Common primitives coverage
+
+The doc identifies 6 convergent primitives:
+
+| Primitive | Coverage |
+|---|---|
+| `ingest` (write) | ✅ `MemoryAdapter.write()` + `postRunCapture` hook |
+| `query` (search/recall) | ✅ `MemoryAdapter.query()` + `preRunHydrate` hook |
+| `scope` (partition) | ✅ `MemoryScope` with entity hierarchy |
+| `provenance` | ✅ `sourceRef` + operation logging |
+| `maintenance` (forget/correct) | ⚠️ `forget()` exists, but no dedupe/compact/correct |
+| `context assembly` | ✅ `MemoryContextBundle` with snippets + profileSummary |
+
+### Gaps vs the doc
+
+1. **Correction workflow** — the doc mentions correction as a capability flag; we have the flag (`correction: false` on both adapters) but no correction API endpoint.
+2. **Governance on destructive ops** — the doc calls for governance on forget; we log everything but don't gate through approvals.
+3. **Dedupe/compact/maintenance** — the doc mentions these under maintenance; not implemented.
+4. **Profile synthesis** — the capability flag exists and the query response supports `profileSummary`, but neither built-in adapter synthesizes profiles.
+
+These are all follow-up work and don't contradict the architecture — the capability flag system was designed exactly to handle providers that don't support these yet.
+
+**Bottom line:** The implementation aligns well with the doc's architecture and covers the core contract it recommends. The gaps are in advanced capabilities that the doc explicitly calls optional.

--- a/docker/mempalace/Dockerfile
+++ b/docker/mempalace/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.13-slim
 
-RUN pip install --no-cache-dir mempalace starlette
+RUN pip install --no-cache-dir "mempalace>=0.3,<1" "starlette>=0.40,<1" "uvicorn>=0.30,<1"
 
+RUN useradd -r -m -s /usr/sbin/nologin mempalace
 COPY serve_http.py /app/serve_http.py
 
 ENV MEMPALACE_PALACE_PATH=/data/mempalace
@@ -9,6 +10,9 @@ ENV MEMPALACE_PORT=8080
 EXPOSE 8080
 
 VOLUME ["/data/mempalace"]
+RUN mkdir -p /data/mempalace && chown mempalace:mempalace /data/mempalace
+
+USER mempalace
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1

--- a/docker/mempalace/Dockerfile
+++ b/docker/mempalace/Dockerfile
@@ -1,20 +1,33 @@
 FROM python:3.13-slim
 
-RUN pip install --no-cache-dir "mempalace>=0.3,<1" "starlette>=0.40,<1" "uvicorn>=0.30,<1"
+ARG USER_UID=1000
+ARG USER_GID=1000
 
-RUN useradd -r -m -s /usr/sbin/nologin mempalace
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gosu \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir "mempalace>=2,<4" "starlette>=0.40,<1" "uvicorn>=0.30,<1"
+
+# Create a mempalace user with configurable UID/GID to match host user
+RUN groupadd -g $USER_GID mempalace \
+  && useradd -u $USER_UID -g $USER_GID -m -s /usr/sbin/nologin mempalace
+
 COPY serve_http.py /app/serve_http.py
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV MEMPALACE_PALACE_PATH=/data/mempalace
 ENV MEMPALACE_PORT=8080
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
 EXPOSE 8080
 
 VOLUME ["/data/mempalace"]
 RUN mkdir -p /data/mempalace && chown mempalace:mempalace /data/mempalace
 
-USER mempalace
-
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["python", "/app/serve_http.py"]

--- a/docker/mempalace/Dockerfile
+++ b/docker/mempalace/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.13-slim
+
+RUN pip install --no-cache-dir mempalace starlette
+
+COPY serve_http.py /app/serve_http.py
+
+ENV MEMPALACE_PALACE_PATH=/data/mempalace
+ENV MEMPALACE_PORT=8080
+EXPOSE 8080
+
+VOLUME ["/data/mempalace"]
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+CMD ["python", "/app/serve_http.py"]

--- a/docker/mempalace/docker-compose.mempalace.yml
+++ b/docker/mempalace/docker-compose.mempalace.yml
@@ -9,12 +9,18 @@ services:
         condition: service_healthy
 
   mempalace:
-    build: .
+    build:
+      context: .
+      args:
+        USER_UID: ${USER_UID:-1000}
+        USER_GID: ${USER_GID:-1000}
     volumes:
       - mempalace-data:/data/mempalace
     environment:
       MEMPALACE_PALACE_PATH: /data/mempalace
       MEMPALACE_PORT: 8080
+      USER_UID: ${USER_UID:-1000}
+      USER_GID: ${USER_GID:-1000}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
       interval: 30s

--- a/docker/mempalace/docker-compose.mempalace.yml
+++ b/docker/mempalace/docker-compose.mempalace.yml
@@ -1,0 +1,25 @@
+services:
+  paperclip:
+    image: your-paperclip-image
+    environment:
+      # other paperclip env vars..
+      MEMPALACE_URL: http://mempalace:8080/mcp
+    depends_on:
+      mempalace:
+        condition: service_healthy
+
+  mempalace:
+    build: .
+    volumes:
+      - mempalace-data:/data/mempalace
+    environment:
+      MEMPALACE_PALACE_PATH: /data/mempalace
+      MEMPALACE_PORT: 8080
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  mempalace-data:

--- a/docker/mempalace/docker-entrypoint.sh
+++ b/docker/mempalace/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# Capture runtime UID/GID from environment variables, defaulting to 1000
+PUID=${USER_UID:-1000}
+PGID=${USER_GID:-1000}
+
+# Adjust the mempalace user's UID/GID if they differ from the runtime request
+# and fix volume ownership only when a remap is needed
+changed=0
+
+if [ "$(id -u mempalace)" -ne "$PUID" ]; then
+    echo "Updating mempalace UID to $PUID"
+    usermod -o -u "$PUID" mempalace
+    changed=1
+fi
+
+if [ "$(id -g mempalace)" -ne "$PGID" ]; then
+    echo "Updating mempalace GID to $PGID"
+    groupmod -o -g "$PGID" mempalace
+    usermod -g "$PGID" mempalace
+    changed=1
+fi
+
+if [ "$changed" = "1" ]; then
+    chown -R mempalace:mempalace /data/mempalace
+fi
+
+exec gosu mempalace "$@"

--- a/docker/mempalace/serve_http.py
+++ b/docker/mempalace/serve_http.py
@@ -1,0 +1,67 @@
+"""
+Thin HTTP wrapper around mempalace's MCP server.
+
+Exposes mempalace's handle_request over HTTP so it can run as a standalone
+container (Docker Compose / Podman pod) instead of requiring stdio transport.
+
+Usage:
+    python serve_http.py                    # defaults: 0.0.0.0:8080, /mcp
+    MEMPALACE_PORT=9090 python serve_http.py
+
+The paperclip server connects with:
+    MEMPALACE_URL=http://mempalace:8080/mcp
+"""
+
+import os
+import json
+import logging
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from mempalace.mcp_server import handle_request
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger("mempalace-http")
+
+PORT = int(os.environ.get("MEMPALACE_PORT", "8080"))
+PATH = os.environ.get("MEMPALACE_PATH", "/mcp")
+
+
+async def mcp_endpoint(request: Request) -> Response:
+    """Accept a JSON-RPC request and return the response."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}},
+            status_code=400,
+        )
+
+    response = handle_request(body)
+    if response is None:
+        # Notification — no response expected
+        return Response(status_code=204)
+
+    return JSONResponse(response)
+
+
+async def health(request: Request) -> Response:
+    return JSONResponse({"status": "ok"})
+
+
+app = Starlette(
+    routes=[
+        Route(PATH, mcp_endpoint, methods=["POST"]),
+        Route("/health", health, methods=["GET"]),
+    ],
+)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    logger.info(f"Starting mempalace HTTP server on 0.0.0.0:{PORT}{PATH}")
+    uvicorn.run(app, host="0.0.0.0", port=PORT, log_level="info")

--- a/docker/mempalace/serve_http.py
+++ b/docker/mempalace/serve_http.py
@@ -12,6 +12,7 @@ The paperclip server connects with:
     MEMPALACE_URL=http://mempalace:8080/mcp
 """
 
+import asyncio
 import os
 import json
 import logging
@@ -40,7 +41,7 @@ async def mcp_endpoint(request: Request) -> Response:
             status_code=400,
         )
 
-    response = handle_request(body)
+    response = await asyncio.to_thread(handle_request, body)
     if response is None:
         # Notification — no response expected
         return Response(status_code=204)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "evals:smoke": "cd evals/promptfoo && npx promptfoo@0.103.3 eval",
     "test:release-smoke": "npx playwright test --config tests/release-smoke/playwright.config.ts",
     "test:release-smoke:headed": "npx playwright test --config tests/release-smoke/playwright.config.ts --headed",
-    "metrics:paperclip-commits": "tsx scripts/paperclip-commit-metrics.ts"
+    "metrics:paperclip-commits": "tsx scripts/paperclip-commit-metrics.ts",
+    "backfill:mempalace": "pnpm --filter @paperclipai/server exec tsx scripts/backfill-mempalace.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/packages/db/src/migrations/0053_memory_bindings_and_operations.sql
+++ b/packages/db/src/migrations/0053_memory_bindings_and_operations.sql
@@ -1,0 +1,52 @@
+CREATE TABLE "memory_binding_targets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"binding_id" uuid NOT NULL,
+	"target_type" text NOT NULL,
+	"target_id" uuid NOT NULL,
+	"priority" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "memory_bindings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"key" text NOT NULL,
+	"provider_key" text NOT NULL,
+	"plugin_id" uuid,
+	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"capabilities" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "memory_operations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"binding_id" uuid NOT NULL,
+	"operation_type" text NOT NULL,
+	"agent_id" uuid,
+	"project_id" uuid,
+	"issue_id" uuid,
+	"run_id" uuid,
+	"source_ref" jsonb,
+	"usage" jsonb,
+	"latency_ms" integer,
+	"success" boolean DEFAULT true NOT NULL,
+	"error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "memory_binding_targets" ADD CONSTRAINT "memory_binding_targets_binding_id_memory_bindings_id_fk" FOREIGN KEY ("binding_id") REFERENCES "public"."memory_bindings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "memory_bindings" ADD CONSTRAINT "memory_bindings_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "memory_bindings" ADD CONSTRAINT "memory_bindings_plugin_id_plugins_id_fk" FOREIGN KEY ("plugin_id") REFERENCES "public"."plugins"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "memory_operations" ADD CONSTRAINT "memory_operations_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "memory_operations" ADD CONSTRAINT "memory_operations_binding_id_memory_bindings_id_fk" FOREIGN KEY ("binding_id") REFERENCES "public"."memory_bindings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "memory_binding_targets_binding_idx" ON "memory_binding_targets" USING btree ("binding_id");--> statement-breakpoint
+CREATE INDEX "memory_binding_targets_target_idx" ON "memory_binding_targets" USING btree ("target_type","target_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "memory_binding_targets_unique_idx" ON "memory_binding_targets" USING btree ("binding_id","target_type","target_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "memory_bindings_company_key_idx" ON "memory_bindings" USING btree ("company_id","key");--> statement-breakpoint
+CREATE INDEX "memory_bindings_company_idx" ON "memory_bindings" USING btree ("company_id");--> statement-breakpoint
+CREATE INDEX "memory_operations_company_binding_idx" ON "memory_operations" USING btree ("company_id","binding_id");--> statement-breakpoint
+CREATE INDEX "memory_operations_company_agent_date_idx" ON "memory_operations" USING btree ("company_id","agent_id","created_at");--> statement-breakpoint
+CREATE INDEX "memory_operations_company_date_idx" ON "memory_operations" USING btree ("company_id","created_at");

--- a/packages/db/src/migrations/meta/0053_snapshot.json
+++ b/packages/db/src/migrations/meta/0053_snapshot.json
@@ -1,0 +1,13306 @@
+{
+  "id": "3cd7ffaa-2a05-409d-b39b-2dc269cabd8a",
+  "prevId": "fb74b316-b3b6-43f5-a6d6-a7d310064a68",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_log_company_created_idx": {
+          "name": "activity_log_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_run_id_idx": {
+          "name": "activity_log_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_entity_type_id_idx": {
+          "name": "activity_log_entity_type_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_company_id_companies_id_fk": {
+          "name": "activity_log_company_id_companies_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_agent_id_agents_id_fk": {
+          "name": "activity_log_agent_id_agents_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_run_id_heartbeat_runs_id_fk": {
+          "name": "activity_log_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_api_keys": {
+      "name": "agent_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_api_keys_key_hash_idx": {
+          "name": "agent_api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_api_keys_company_agent_idx": {
+          "name": "agent_api_keys_company_agent_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_api_keys_agent_id_agents_id_fk": {
+          "name": "agent_api_keys_agent_id_agents_id_fk",
+          "tableFrom": "agent_api_keys",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_api_keys_company_id_companies_id_fk": {
+          "name": "agent_api_keys_company_id_companies_id_fk",
+          "tableFrom": "agent_api_keys",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_revisions": {
+      "name": "agent_config_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'patch'"
+        },
+        "rolled_back_from_revision_id": {
+          "name": "rolled_back_from_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "before_config": {
+          "name": "before_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_config": {
+          "name": "after_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_revisions_company_agent_created_idx": {
+          "name": "agent_config_revisions_company_agent_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_revisions_agent_created_idx": {
+          "name": "agent_config_revisions_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_revisions_company_id_companies_id_fk": {
+          "name": "agent_config_revisions_company_id_companies_id_fk",
+          "tableFrom": "agent_config_revisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_config_revisions_agent_id_agents_id_fk": {
+          "name": "agent_config_revisions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_revisions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_revisions_created_by_agent_id_agents_id_fk": {
+          "name": "agent_config_revisions_created_by_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_revisions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runtime_state": {
+      "name": "agent_runtime_state",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_json": {
+          "name": "state_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cached_input_tokens": {
+          "name": "total_cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runtime_state_company_agent_idx": {
+          "name": "agent_runtime_state_company_agent_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runtime_state_company_updated_idx": {
+          "name": "agent_runtime_state_company_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runtime_state_agent_id_agents_id_fk": {
+          "name": "agent_runtime_state_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_state",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_runtime_state_company_id_companies_id_fk": {
+          "name": "agent_runtime_state_company_id_companies_id_fk",
+          "tableFrom": "agent_runtime_state",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_task_sessions": {
+      "name": "agent_task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_params_json": {
+          "name": "session_params_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_display_id": {
+          "name": "session_display_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_task_sessions_company_agent_adapter_task_uniq": {
+          "name": "agent_task_sessions_company_agent_adapter_task_uniq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "adapter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_task_sessions_company_agent_updated_idx": {
+          "name": "agent_task_sessions_company_agent_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_task_sessions_company_task_updated_idx": {
+          "name": "agent_task_sessions_company_task_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_task_sessions_company_id_companies_id_fk": {
+          "name": "agent_task_sessions_company_id_companies_id_fk",
+          "tableFrom": "agent_task_sessions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_task_sessions_agent_id_agents_id_fk": {
+          "name": "agent_task_sessions_agent_id_agents_id_fk",
+          "tableFrom": "agent_task_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_task_sessions_last_run_id_heartbeat_runs_id_fk": {
+          "name": "agent_task_sessions_last_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "agent_task_sessions",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_wakeup_requests": {
+      "name": "agent_wakeup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "coalesced_count": {
+          "name": "coalesced_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_id": {
+          "name": "requested_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_wakeup_requests_company_agent_status_idx": {
+          "name": "agent_wakeup_requests_company_agent_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_wakeup_requests_company_requested_idx": {
+          "name": "agent_wakeup_requests_company_requested_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_wakeup_requests_agent_requested_idx": {
+          "name": "agent_wakeup_requests_agent_requested_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_wakeup_requests_company_id_companies_id_fk": {
+          "name": "agent_wakeup_requests_company_id_companies_id_fk",
+          "tableFrom": "agent_wakeup_requests",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_wakeup_requests_agent_id_agents_id_fk": {
+          "name": "agent_wakeup_requests_agent_id_agents_id_fk",
+          "tableFrom": "agent_wakeup_requests",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "reports_to": {
+          "name": "reports_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'process'"
+        },
+        "adapter_config": {
+          "name": "adapter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "budget_monthly_cents": {
+          "name": "budget_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spent_monthly_cents": {
+          "name": "spent_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_company_status_idx": {
+          "name": "agents_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_company_reports_to_idx": {
+          "name": "agents_company_reports_to_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reports_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_company_id_companies_id_fk": {
+          "name": "agents_company_id_companies_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_reports_to_agents_id_fk": {
+          "name": "agents_reports_to_agents_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "reports_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_comments": {
+      "name": "approval_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_agent_id": {
+          "name": "author_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_comments_company_idx": {
+          "name": "approval_comments_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_comments_approval_idx": {
+          "name": "approval_comments_approval_idx",
+          "columns": [
+            {
+              "expression": "approval_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_comments_approval_created_idx": {
+          "name": "approval_comments_approval_created_idx",
+          "columns": [
+            {
+              "expression": "approval_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_comments_company_id_companies_id_fk": {
+          "name": "approval_comments_company_id_companies_id_fk",
+          "tableFrom": "approval_comments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approval_comments_approval_id_approvals_id_fk": {
+          "name": "approval_comments_approval_id_approvals_id_fk",
+          "tableFrom": "approval_comments",
+          "tableTo": "approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approval_comments_author_agent_id_agents_id_fk": {
+          "name": "approval_comments_author_agent_id_agents_id_fk",
+          "tableFrom": "approval_comments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "author_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approvals": {
+      "name": "approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_agent_id": {
+          "name": "requested_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approvals_company_status_type_idx": {
+          "name": "approvals_company_status_type_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approvals_company_id_companies_id_fk": {
+          "name": "approvals_company_id_companies_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approvals_requested_by_agent_id_agents_id_fk": {
+          "name": "approvals_requested_by_agent_id_agents_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "requested_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_company_created_idx": {
+          "name": "assets_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_company_provider_idx": {
+          "name": "assets_company_provider_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_company_object_key_uq": {
+          "name": "assets_company_object_key_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_company_id_companies_id_fk": {
+          "name": "assets_company_id_companies_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_created_by_agent_id_agents_id_fk": {
+          "name": "assets_created_by_agent_id_agents_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_api_keys": {
+      "name": "board_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_api_keys_key_hash_idx": {
+          "name": "board_api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_api_keys_user_idx": {
+          "name": "board_api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_api_keys_user_id_user_id_fk": {
+          "name": "board_api_keys_user_id_user_id_fk",
+          "tableFrom": "board_api_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_incidents": {
+      "name": "budget_incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_type": {
+          "name": "threshold_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_limit": {
+          "name": "amount_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_observed": {
+          "name": "amount_observed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_incidents_company_status_idx": {
+          "name": "budget_incidents_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_incidents_company_scope_idx": {
+          "name": "budget_incidents_company_scope_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_incidents_policy_window_threshold_idx": {
+          "name": "budget_incidents_policy_window_threshold_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "threshold_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"budget_incidents\".\"status\" <> 'dismissed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_incidents_company_id_companies_id_fk": {
+          "name": "budget_incidents_company_id_companies_id_fk",
+          "tableFrom": "budget_incidents",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budget_incidents_policy_id_budget_policies_id_fk": {
+          "name": "budget_incidents_policy_id_budget_policies_id_fk",
+          "tableFrom": "budget_incidents",
+          "tableTo": "budget_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budget_incidents_approval_id_approvals_id_fk": {
+          "name": "budget_incidents_approval_id_approvals_id_fk",
+          "tableFrom": "budget_incidents",
+          "tableTo": "approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_policies": {
+      "name": "budget_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'billed_cents'"
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "warn_percent": {
+          "name": "warn_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "hard_stop_enabled": {
+          "name": "hard_stop_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_enabled": {
+          "name": "notify_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_policies_company_scope_active_idx": {
+          "name": "budget_policies_company_scope_active_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_policies_company_window_idx": {
+          "name": "budget_policies_company_window_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_policies_company_scope_metric_unique_idx": {
+          "name": "budget_policies_company_scope_metric_unique_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_policies_company_id_companies_id_fk": {
+          "name": "budget_policies_company_id_companies_id_fk",
+          "tableFrom": "budget_policies",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_auth_challenges": {
+      "name": "cli_auth_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_access": {
+          "name": "requested_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'board'"
+        },
+        "requested_company_id": {
+          "name": "requested_company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_key_hash": {
+          "name": "pending_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_key_name": {
+          "name": "pending_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_api_key_id": {
+          "name": "board_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cli_auth_challenges_secret_hash_idx": {
+          "name": "cli_auth_challenges_secret_hash_idx",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_auth_challenges_approved_by_idx": {
+          "name": "cli_auth_challenges_approved_by_idx",
+          "columns": [
+            {
+              "expression": "approved_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_auth_challenges_requested_company_idx": {
+          "name": "cli_auth_challenges_requested_company_idx",
+          "columns": [
+            {
+              "expression": "requested_company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_auth_challenges_requested_company_id_companies_id_fk": {
+          "name": "cli_auth_challenges_requested_company_id_companies_id_fk",
+          "tableFrom": "cli_auth_challenges",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "requested_company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_auth_challenges_approved_by_user_id_user_id_fk": {
+          "name": "cli_auth_challenges_approved_by_user_id_user_id_fk",
+          "tableFrom": "cli_auth_challenges",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_auth_challenges_board_api_key_id_board_api_keys_id_fk": {
+          "name": "cli_auth_challenges_board_api_key_id_board_api_keys_id_fk",
+          "tableFrom": "cli_auth_challenges",
+          "tableTo": "board_api_keys",
+          "columnsFrom": [
+            "board_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_prefix": {
+          "name": "issue_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PAP'"
+        },
+        "issue_counter": {
+          "name": "issue_counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "budget_monthly_cents": {
+          "name": "budget_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spent_monthly_cents": {
+          "name": "spent_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "require_board_approval_for_new_agents": {
+          "name": "require_board_approval_for_new_agents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "feedback_data_sharing_enabled": {
+          "name": "feedback_data_sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback_data_sharing_consent_at": {
+          "name": "feedback_data_sharing_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_data_sharing_consent_by_user_id": {
+          "name": "feedback_data_sharing_consent_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_data_sharing_terms_version": {
+          "name": "feedback_data_sharing_terms_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "companies_issue_prefix_idx": {
+          "name": "companies_issue_prefix_idx",
+          "columns": [
+            {
+              "expression": "issue_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_logos": {
+      "name": "company_logos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_logos_company_uq": {
+          "name": "company_logos_company_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_logos_asset_uq": {
+          "name": "company_logos_asset_uq",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_logos_company_id_companies_id_fk": {
+          "name": "company_logos_company_id_companies_id_fk",
+          "tableFrom": "company_logos",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "company_logos_asset_id_assets_id_fk": {
+          "name": "company_logos_asset_id_assets_id_fk",
+          "tableFrom": "company_logos",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_memberships": {
+      "name": "company_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "membership_role": {
+          "name": "membership_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_memberships_company_principal_unique_idx": {
+          "name": "company_memberships_company_principal_unique_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_memberships_principal_status_idx": {
+          "name": "company_memberships_principal_status_idx",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_memberships_company_status_idx": {
+          "name": "company_memberships_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_memberships_company_id_companies_id_fk": {
+          "name": "company_memberships_company_id_companies_id_fk",
+          "tableFrom": "company_memberships",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_secret_versions": {
+      "name": "company_secret_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "material": {
+          "name": "material",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_sha256": {
+          "name": "value_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_secret_versions_secret_idx": {
+          "name": "company_secret_versions_secret_idx",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secret_versions_value_sha256_idx": {
+          "name": "company_secret_versions_value_sha256_idx",
+          "columns": [
+            {
+              "expression": "value_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secret_versions_secret_version_uq": {
+          "name": "company_secret_versions_secret_version_uq",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_secret_versions_secret_id_company_secrets_id_fk": {
+          "name": "company_secret_versions_secret_id_company_secrets_id_fk",
+          "tableFrom": "company_secret_versions",
+          "tableTo": "company_secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "company_secret_versions_created_by_agent_id_agents_id_fk": {
+          "name": "company_secret_versions_created_by_agent_id_agents_id_fk",
+          "tableFrom": "company_secret_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_secrets": {
+      "name": "company_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local_encrypted'"
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_secrets_company_idx": {
+          "name": "company_secrets_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secrets_company_provider_idx": {
+          "name": "company_secrets_company_provider_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secrets_company_name_uq": {
+          "name": "company_secrets_company_name_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_secrets_company_id_companies_id_fk": {
+          "name": "company_secrets_company_id_companies_id_fk",
+          "tableFrom": "company_secrets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_secrets_created_by_agent_id_agents_id_fk": {
+          "name": "company_secrets_created_by_agent_id_agents_id_fk",
+          "tableFrom": "company_secrets",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_skills": {
+      "name": "company_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local_path'"
+        },
+        "source_locator": {
+          "name": "source_locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trust_level": {
+          "name": "trust_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'markdown_only'"
+        },
+        "compatibility": {
+          "name": "compatibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compatible'"
+        },
+        "file_inventory": {
+          "name": "file_inventory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_skills_company_key_idx": {
+          "name": "company_skills_company_key_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_skills_company_name_idx": {
+          "name": "company_skills_company_name_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_skills_company_id_companies_id_fk": {
+          "name": "company_skills_company_id_companies_id_fk",
+          "tableFrom": "company_skills",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cost_events": {
+      "name": "cost_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_run_id": {
+          "name": "heartbeat_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_code": {
+          "name": "billing_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "biller": {
+          "name": "biller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cost_events_company_occurred_idx": {
+          "name": "cost_events_company_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_events_company_agent_occurred_idx": {
+          "name": "cost_events_company_agent_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_events_company_provider_occurred_idx": {
+          "name": "cost_events_company_provider_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_events_company_biller_occurred_idx": {
+          "name": "cost_events_company_biller_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "biller",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_events_company_heartbeat_run_idx": {
+          "name": "cost_events_company_heartbeat_run_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cost_events_company_id_companies_id_fk": {
+          "name": "cost_events_company_id_companies_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_agent_id_agents_id_fk": {
+          "name": "cost_events_agent_id_agents_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_issue_id_issues_id_fk": {
+          "name": "cost_events_issue_id_issues_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_project_id_projects_id_fk": {
+          "name": "cost_events_project_id_projects_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_goal_id_goals_id_fk": {
+          "name": "cost_events_goal_id_goals_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_heartbeat_run_id_heartbeat_runs_id_fk": {
+          "name": "cost_events_heartbeat_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "heartbeat_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_revisions": {
+      "name": "document_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_number": {
+          "name": "revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'markdown'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_revisions_document_revision_uq": {
+          "name": "document_revisions_document_revision_uq",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_revisions_company_document_created_idx": {
+          "name": "document_revisions_company_document_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_revisions_company_id_companies_id_fk": {
+          "name": "document_revisions_company_id_companies_id_fk",
+          "tableFrom": "document_revisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_revisions_document_id_documents_id_fk": {
+          "name": "document_revisions_document_id_documents_id_fk",
+          "tableFrom": "document_revisions",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_revisions_created_by_agent_id_agents_id_fk": {
+          "name": "document_revisions_created_by_agent_id_agents_id_fk",
+          "tableFrom": "document_revisions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "document_revisions_created_by_run_id_heartbeat_runs_id_fk": {
+          "name": "document_revisions_created_by_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "document_revisions",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "created_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'markdown'"
+        },
+        "latest_body": {
+          "name": "latest_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_revision_id": {
+          "name": "latest_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_revision_number": {
+          "name": "latest_revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_agent_id": {
+          "name": "updated_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_company_updated_idx": {
+          "name": "documents_company_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_company_created_idx": {
+          "name": "documents_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_company_id_companies_id_fk": {
+          "name": "documents_company_id_companies_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_created_by_agent_id_agents_id_fk": {
+          "name": "documents_created_by_agent_id_agents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "documents_updated_by_agent_id_agents_id_fk": {
+          "name": "documents_updated_by_agent_id_agents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "updated_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_workspaces": {
+      "name": "execution_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_workspace_id": {
+          "name": "project_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_issue_id": {
+          "name": "source_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy_type": {
+          "name": "strategy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local_fs'"
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_from_execution_workspace_id": {
+          "name": "derived_from_execution_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_eligible_at": {
+          "name": "cleanup_eligible_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_reason": {
+          "name": "cleanup_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "execution_workspaces_company_project_status_idx": {
+          "name": "execution_workspaces_company_project_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_workspaces_company_project_workspace_status_idx": {
+          "name": "execution_workspaces_company_project_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_workspaces_company_source_issue_idx": {
+          "name": "execution_workspaces_company_source_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_workspaces_company_last_used_idx": {
+          "name": "execution_workspaces_company_last_used_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_workspaces_company_branch_idx": {
+          "name": "execution_workspaces_company_branch_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_workspaces_company_id_companies_id_fk": {
+          "name": "execution_workspaces_company_id_companies_id_fk",
+          "tableFrom": "execution_workspaces",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "execution_workspaces_project_id_projects_id_fk": {
+          "name": "execution_workspaces_project_id_projects_id_fk",
+          "tableFrom": "execution_workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "execution_workspaces_project_workspace_id_project_workspaces_id_fk": {
+          "name": "execution_workspaces_project_workspace_id_project_workspaces_id_fk",
+          "tableFrom": "execution_workspaces",
+          "tableTo": "project_workspaces",
+          "columnsFrom": [
+            "project_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "execution_workspaces_source_issue_id_issues_id_fk": {
+          "name": "execution_workspaces_source_issue_id_issues_id_fk",
+          "tableFrom": "execution_workspaces",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "source_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "execution_workspaces_derived_from_execution_workspace_id_execution_workspaces_id_fk": {
+          "name": "execution_workspaces_derived_from_execution_workspace_id_execution_workspaces_id_fk",
+          "tableFrom": "execution_workspaces",
+          "tableTo": "execution_workspaces",
+          "columnsFrom": [
+            "derived_from_execution_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_exports": {
+      "name": "feedback_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_vote_id": {
+          "name": "feedback_vote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local_only'"
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'paperclip-feedback-envelope-v2'"
+        },
+        "bundle_version": {
+          "name": "bundle_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'paperclip-feedback-bundle-v2'"
+        },
+        "payload_version": {
+          "name": "payload_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'paperclip-feedback-v1'"
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_snapshot": {
+          "name": "payload_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_summary": {
+          "name": "target_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redaction_summary": {
+          "name": "redaction_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_exports_feedback_vote_idx": {
+          "name": "feedback_exports_feedback_vote_idx",
+          "columns": [
+            {
+              "expression": "feedback_vote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_exports_company_created_idx": {
+          "name": "feedback_exports_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_exports_company_status_idx": {
+          "name": "feedback_exports_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_exports_company_issue_idx": {
+          "name": "feedback_exports_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_exports_company_project_idx": {
+          "name": "feedback_exports_company_project_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_exports_company_author_idx": {
+          "name": "feedback_exports_company_author_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_exports_company_id_companies_id_fk": {
+          "name": "feedback_exports_company_id_companies_id_fk",
+          "tableFrom": "feedback_exports",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_exports_feedback_vote_id_feedback_votes_id_fk": {
+          "name": "feedback_exports_feedback_vote_id_feedback_votes_id_fk",
+          "tableFrom": "feedback_exports",
+          "tableTo": "feedback_votes",
+          "columnsFrom": [
+            "feedback_vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_exports_issue_id_issues_id_fk": {
+          "name": "feedback_exports_issue_id_issues_id_fk",
+          "tableFrom": "feedback_exports",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_exports_project_id_projects_id_fk": {
+          "name": "feedback_exports_project_id_projects_id_fk",
+          "tableFrom": "feedback_exports",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_votes": {
+      "name": "feedback_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_with_labs": {
+          "name": "shared_with_labs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "shared_at": {
+          "name": "shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redaction_summary": {
+          "name": "redaction_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_votes_company_issue_idx": {
+          "name": "feedback_votes_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_votes_issue_target_idx": {
+          "name": "feedback_votes_issue_target_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_votes_author_idx": {
+          "name": "feedback_votes_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_votes_company_target_author_idx": {
+          "name": "feedback_votes_company_target_author_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_votes_company_id_companies_id_fk": {
+          "name": "feedback_votes_company_id_companies_id_fk",
+          "tableFrom": "feedback_votes",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_votes_issue_id_issues_id_fk": {
+          "name": "feedback_votes_issue_id_issues_id_fk",
+          "tableFrom": "feedback_votes",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finance_events": {
+      "name": "finance_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_run_id": {
+          "name": "heartbeat_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_event_id": {
+          "name": "cost_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_code": {
+          "name": "billing_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'debit'"
+        },
+        "biller": {
+          "name": "biller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_adapter_type": {
+          "name": "execution_adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_tier": {
+          "name": "pricing_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "estimated": {
+          "name": "estimated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_invoice_id": {
+          "name": "external_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "finance_events_company_occurred_idx": {
+          "name": "finance_events_company_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "finance_events_company_biller_occurred_idx": {
+          "name": "finance_events_company_biller_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "biller",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "finance_events_company_kind_occurred_idx": {
+          "name": "finance_events_company_kind_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "finance_events_company_direction_occurred_idx": {
+          "name": "finance_events_company_direction_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "finance_events_company_heartbeat_run_idx": {
+          "name": "finance_events_company_heartbeat_run_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "finance_events_company_cost_event_idx": {
+          "name": "finance_events_company_cost_event_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "finance_events_company_id_companies_id_fk": {
+          "name": "finance_events_company_id_companies_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_events_agent_id_agents_id_fk": {
+          "name": "finance_events_agent_id_agents_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_events_issue_id_issues_id_fk": {
+          "name": "finance_events_issue_id_issues_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_events_project_id_projects_id_fk": {
+          "name": "finance_events_project_id_projects_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_events_goal_id_goals_id_fk": {
+          "name": "finance_events_goal_id_goals_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_events_heartbeat_run_id_heartbeat_runs_id_fk": {
+          "name": "finance_events_heartbeat_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "heartbeat_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "finance_events_cost_event_id_cost_events_id_fk": {
+          "name": "finance_events_cost_event_id_cost_events_id_fk",
+          "tableFrom": "finance_events",
+          "tableTo": "cost_events",
+          "columnsFrom": [
+            "cost_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'task'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "goals_company_idx": {
+          "name": "goals_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_company_id_companies_id_fk": {
+          "name": "goals_company_id_companies_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "goals_parent_id_goals_id_fk": {
+          "name": "goals_parent_id_goals_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "goals_owner_agent_id_agents_id_fk": {
+          "name": "goals_owner_agent_id_agents_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heartbeat_run_events": {
+      "name": "heartbeat_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "heartbeat_run_events_run_seq_idx": {
+          "name": "heartbeat_run_events_run_seq_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "heartbeat_run_events_company_run_idx": {
+          "name": "heartbeat_run_events_company_run_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "heartbeat_run_events_company_created_idx": {
+          "name": "heartbeat_run_events_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "heartbeat_run_events_company_id_companies_id_fk": {
+          "name": "heartbeat_run_events_company_id_companies_id_fk",
+          "tableFrom": "heartbeat_run_events",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_run_events_run_id_heartbeat_runs_id_fk": {
+          "name": "heartbeat_run_events_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "heartbeat_run_events",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_run_events_agent_id_agents_id_fk": {
+          "name": "heartbeat_run_events_agent_id_agents_id_fk",
+          "tableFrom": "heartbeat_run_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heartbeat_runs": {
+      "name": "heartbeat_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invocation_source": {
+          "name": "invocation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_demand'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wakeup_request_id": {
+          "name": "wakeup_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_before": {
+          "name": "session_id_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_after": {
+          "name": "session_id_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_store": {
+          "name": "log_store",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_ref": {
+          "name": "log_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_bytes": {
+          "name": "log_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_sha256": {
+          "name": "log_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_compressed": {
+          "name": "log_compressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stdout_excerpt": {
+          "name": "stdout_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stderr_excerpt": {
+          "name": "stderr_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process_pid": {
+          "name": "process_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process_started_at": {
+          "name": "process_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_of_run_id": {
+          "name": "retry_of_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process_loss_retry_count": {
+          "name": "process_loss_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "heartbeat_runs_company_agent_started_idx": {
+          "name": "heartbeat_runs_company_agent_started_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "heartbeat_runs_company_id_companies_id_fk": {
+          "name": "heartbeat_runs_company_id_companies_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_runs_agent_id_agents_id_fk": {
+          "name": "heartbeat_runs_agent_id_agents_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_runs_wakeup_request_id_agent_wakeup_requests_id_fk": {
+          "name": "heartbeat_runs_wakeup_request_id_agent_wakeup_requests_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "agent_wakeup_requests",
+          "columnsFrom": [
+            "wakeup_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_runs_retry_of_run_id_heartbeat_runs_id_fk": {
+          "name": "heartbeat_runs_retry_of_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "retry_of_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "singleton_key": {
+          "name": "singleton_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "general": {
+          "name": "general",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "experimental": {
+          "name": "experimental",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_settings_singleton_key_idx": {
+          "name": "instance_settings_singleton_key_idx",
+          "columns": [
+            {
+              "expression": "singleton_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_user_roles": {
+      "name": "instance_user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instance_admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_user_roles_user_role_unique_idx": {
+          "name": "instance_user_roles_user_role_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instance_user_roles_role_idx": {
+          "name": "instance_user_roles_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_type": {
+          "name": "invite_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'company_join'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_join_types": {
+          "name": "allowed_join_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "defaults_payload": {
+          "name": "defaults_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_hash_unique_idx": {
+          "name": "invites_token_hash_unique_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_company_invite_state_idx": {
+          "name": "invites_company_invite_state_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_company_id_companies_id_fk": {
+          "name": "invites_company_id_companies_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_approvals": {
+      "name": "issue_approvals",
+      "schema": "",
+      "columns": {
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_by_agent_id": {
+          "name": "linked_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_by_user_id": {
+          "name": "linked_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_approvals_issue_idx": {
+          "name": "issue_approvals_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_approvals_approval_idx": {
+          "name": "issue_approvals_approval_idx",
+          "columns": [
+            {
+              "expression": "approval_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_approvals_company_idx": {
+          "name": "issue_approvals_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_approvals_company_id_companies_id_fk": {
+          "name": "issue_approvals_company_id_companies_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_approvals_issue_id_issues_id_fk": {
+          "name": "issue_approvals_issue_id_issues_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_approvals_approval_id_approvals_id_fk": {
+          "name": "issue_approvals_approval_id_approvals_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_approvals_linked_by_agent_id_agents_id_fk": {
+          "name": "issue_approvals_linked_by_agent_id_agents_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "linked_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_approvals_pk": {
+          "name": "issue_approvals_pk",
+          "columns": [
+            "issue_id",
+            "approval_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_attachments": {
+      "name": "issue_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_comment_id": {
+          "name": "issue_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachments_company_issue_idx": {
+          "name": "issue_attachments_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_attachments_issue_comment_idx": {
+          "name": "issue_attachments_issue_comment_idx",
+          "columns": [
+            {
+              "expression": "issue_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_attachments_asset_uq": {
+          "name": "issue_attachments_asset_uq",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachments_company_id_companies_id_fk": {
+          "name": "issue_attachments_company_id_companies_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_attachments_issue_id_issues_id_fk": {
+          "name": "issue_attachments_issue_id_issues_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_attachments_asset_id_assets_id_fk": {
+          "name": "issue_attachments_asset_id_assets_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_attachments_issue_comment_id_issue_comments_id_fk": {
+          "name": "issue_attachments_issue_comment_id_issue_comments_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "issue_comments",
+          "columnsFrom": [
+            "issue_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_comments": {
+      "name": "issue_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_agent_id": {
+          "name": "author_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_comments_issue_idx": {
+          "name": "issue_comments_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_company_idx": {
+          "name": "issue_comments_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_company_issue_created_at_idx": {
+          "name": "issue_comments_company_issue_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_company_author_issue_created_at_idx": {
+          "name": "issue_comments_company_author_issue_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_body_search_idx": {
+          "name": "issue_comments_body_search_idx",
+          "columns": [
+            {
+              "expression": "body",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_comments_company_id_companies_id_fk": {
+          "name": "issue_comments_company_id_companies_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_comments_issue_id_issues_id_fk": {
+          "name": "issue_comments_issue_id_issues_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_comments_author_agent_id_agents_id_fk": {
+          "name": "issue_comments_author_agent_id_agents_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "author_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_comments_created_by_run_id_heartbeat_runs_id_fk": {
+          "name": "issue_comments_created_by_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "created_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_documents": {
+      "name": "issue_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_documents_company_issue_key_uq": {
+          "name": "issue_documents_company_issue_key_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_documents_document_uq": {
+          "name": "issue_documents_document_uq",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_documents_company_issue_updated_idx": {
+          "name": "issue_documents_company_issue_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_documents_company_id_companies_id_fk": {
+          "name": "issue_documents_company_id_companies_id_fk",
+          "tableFrom": "issue_documents",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_documents_issue_id_issues_id_fk": {
+          "name": "issue_documents_issue_id_issues_id_fk",
+          "tableFrom": "issue_documents",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_documents_document_id_documents_id_fk": {
+          "name": "issue_documents_document_id_documents_id_fk",
+          "tableFrom": "issue_documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_inbox_archives": {
+      "name": "issue_inbox_archives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_inbox_archives_company_issue_idx": {
+          "name": "issue_inbox_archives_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_inbox_archives_company_user_idx": {
+          "name": "issue_inbox_archives_company_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_inbox_archives_company_issue_user_idx": {
+          "name": "issue_inbox_archives_company_issue_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_inbox_archives_company_id_companies_id_fk": {
+          "name": "issue_inbox_archives_company_id_companies_id_fk",
+          "tableFrom": "issue_inbox_archives",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_inbox_archives_issue_id_issues_id_fk": {
+          "name": "issue_inbox_archives_issue_id_issues_id_fk",
+          "tableFrom": "issue_inbox_archives",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_labels": {
+      "name": "issue_labels",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_labels_issue_idx": {
+          "name": "issue_labels_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_labels_label_idx": {
+          "name": "issue_labels_label_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_labels_company_idx": {
+          "name": "issue_labels_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_labels_issue_id_issues_id_fk": {
+          "name": "issue_labels_issue_id_issues_id_fk",
+          "tableFrom": "issue_labels",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_labels_label_id_labels_id_fk": {
+          "name": "issue_labels_label_id_labels_id_fk",
+          "tableFrom": "issue_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_labels_company_id_companies_id_fk": {
+          "name": "issue_labels_company_id_companies_id_fk",
+          "tableFrom": "issue_labels",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_labels_pk": {
+          "name": "issue_labels_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_read_states": {
+      "name": "issue_read_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_read_states_company_issue_idx": {
+          "name": "issue_read_states_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_read_states_company_user_idx": {
+          "name": "issue_read_states_company_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_read_states_company_issue_user_idx": {
+          "name": "issue_read_states_company_issue_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_read_states_company_id_companies_id_fk": {
+          "name": "issue_read_states_company_id_companies_id_fk",
+          "tableFrom": "issue_read_states",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_read_states_issue_id_issues_id_fk": {
+          "name": "issue_read_states_issue_id_issues_id_fk",
+          "tableFrom": "issue_read_states",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_relations": {
+      "name": "issue_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_issue_id": {
+          "name": "related_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_relations_company_issue_idx": {
+          "name": "issue_relations_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_relations_company_related_issue_idx": {
+          "name": "issue_relations_company_related_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_relations_company_type_idx": {
+          "name": "issue_relations_company_type_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_relations_company_edge_uq": {
+          "name": "issue_relations_company_edge_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_relations_company_id_companies_id_fk": {
+          "name": "issue_relations_company_id_companies_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_relations_issue_id_issues_id_fk": {
+          "name": "issue_relations_issue_id_issues_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_relations_related_issue_id_issues_id_fk": {
+          "name": "issue_relations_related_issue_id_issues_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "related_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_relations_created_by_agent_id_agents_id_fk": {
+          "name": "issue_relations_created_by_agent_id_agents_id_fk",
+          "tableFrom": "issue_relations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_work_products": {
+      "name": "issue_work_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_workspace_id": {
+          "name": "execution_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_service_id": {
+          "name": "runtime_service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_state": {
+          "name": "review_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_work_products_company_issue_type_idx": {
+          "name": "issue_work_products_company_issue_type_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_work_products_company_execution_workspace_type_idx": {
+          "name": "issue_work_products_company_execution_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_work_products_company_provider_external_id_idx": {
+          "name": "issue_work_products_company_provider_external_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_work_products_company_updated_idx": {
+          "name": "issue_work_products_company_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_work_products_company_id_companies_id_fk": {
+          "name": "issue_work_products_company_id_companies_id_fk",
+          "tableFrom": "issue_work_products",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_work_products_project_id_projects_id_fk": {
+          "name": "issue_work_products_project_id_projects_id_fk",
+          "tableFrom": "issue_work_products",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_work_products_issue_id_issues_id_fk": {
+          "name": "issue_work_products_issue_id_issues_id_fk",
+          "tableFrom": "issue_work_products",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_work_products_execution_workspace_id_execution_workspaces_id_fk": {
+          "name": "issue_work_products_execution_workspace_id_execution_workspaces_id_fk",
+          "tableFrom": "issue_work_products",
+          "tableTo": "execution_workspaces",
+          "columnsFrom": [
+            "execution_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_work_products_runtime_service_id_workspace_runtime_services_id_fk": {
+          "name": "issue_work_products_runtime_service_id_workspace_runtime_services_id_fk",
+          "tableFrom": "issue_work_products",
+          "tableTo": "workspace_runtime_services",
+          "columnsFrom": [
+            "runtime_service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_work_products_created_by_run_id_heartbeat_runs_id_fk": {
+          "name": "issue_work_products_created_by_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "issue_work_products",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "created_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_workspace_id": {
+          "name": "project_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "assignee_agent_id": {
+          "name": "assignee_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkout_run_id": {
+          "name": "checkout_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_run_id": {
+          "name": "execution_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_agent_name_key": {
+          "name": "execution_agent_name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_locked_at": {
+          "name": "execution_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_depth": {
+          "name": "request_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "billing_code": {
+          "name": "billing_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_adapter_overrides": {
+          "name": "assignee_adapter_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_workspace_id": {
+          "name": "execution_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_workspace_preference": {
+          "name": "execution_workspace_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_workspace_settings": {
+          "name": "execution_workspace_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_company_status_idx": {
+          "name": "issues_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_assignee_status_idx": {
+          "name": "issues_company_assignee_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_assignee_user_status_idx": {
+          "name": "issues_company_assignee_user_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_parent_idx": {
+          "name": "issues_company_parent_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_project_idx": {
+          "name": "issues_company_project_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_origin_idx": {
+          "name": "issues_company_origin_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_project_workspace_idx": {
+          "name": "issues_company_project_workspace_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_execution_workspace_idx": {
+          "name": "issues_company_execution_workspace_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_identifier_idx": {
+          "name": "issues_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_title_search_idx": {
+          "name": "issues_title_search_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "issues_identifier_search_idx": {
+          "name": "issues_identifier_search_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "issues_description_search_idx": {
+          "name": "issues_description_search_idx",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "issues_open_routine_execution_uq": {
+          "name": "issues_open_routine_execution_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issues\".\"origin_kind\" = 'routine_execution'\n          and \"issues\".\"origin_id\" is not null\n          and \"issues\".\"hidden_at\" is null\n          and \"issues\".\"execution_run_id\" is not null\n          and \"issues\".\"status\" in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_company_id_companies_id_fk": {
+          "name": "issues_company_id_companies_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_project_workspace_id_project_workspaces_id_fk": {
+          "name": "issues_project_workspace_id_project_workspaces_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "project_workspaces",
+          "columnsFrom": [
+            "project_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issues_goal_id_goals_id_fk": {
+          "name": "issues_goal_id_goals_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_parent_id_issues_id_fk": {
+          "name": "issues_parent_id_issues_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_assignee_agent_id_agents_id_fk": {
+          "name": "issues_assignee_agent_id_agents_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "assignee_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_checkout_run_id_heartbeat_runs_id_fk": {
+          "name": "issues_checkout_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "checkout_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issues_execution_run_id_heartbeat_runs_id_fk": {
+          "name": "issues_execution_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "execution_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issues_created_by_agent_id_agents_id_fk": {
+          "name": "issues_created_by_agent_id_agents_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_execution_workspace_id_execution_workspaces_id_fk": {
+          "name": "issues_execution_workspace_id_execution_workspaces_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "execution_workspaces",
+          "columnsFrom": [
+            "execution_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.join_requests": {
+      "name": "join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_approval'"
+        },
+        "request_ip": {
+          "name": "request_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requesting_user_id": {
+          "name": "requesting_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_email_snapshot": {
+          "name": "request_email_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_defaults_payload": {
+          "name": "agent_defaults_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_secret_hash": {
+          "name": "claim_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_secret_expires_at": {
+          "name": "claim_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_secret_consumed_at": {
+          "name": "claim_secret_consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_agent_id": {
+          "name": "created_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "join_requests_invite_unique_idx": {
+          "name": "join_requests_invite_unique_idx",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "join_requests_company_status_type_created_idx": {
+          "name": "join_requests_company_status_type_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "join_requests_invite_id_invites_id_fk": {
+          "name": "join_requests_invite_id_invites_id_fk",
+          "tableFrom": "join_requests",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "join_requests_company_id_companies_id_fk": {
+          "name": "join_requests_company_id_companies_id_fk",
+          "tableFrom": "join_requests",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "join_requests_created_agent_id_agents_id_fk": {
+          "name": "join_requests_created_agent_id_agents_id_fk",
+          "tableFrom": "join_requests",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_company_idx": {
+          "name": "labels_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_company_name_idx": {
+          "name": "labels_company_name_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_company_id_companies_id_fk": {
+          "name": "labels_company_id_companies_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_company_settings": {
+      "name": "plugin_company_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_company_settings_company_idx": {
+          "name": "plugin_company_settings_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_company_settings_plugin_idx": {
+          "name": "plugin_company_settings_plugin_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_company_settings_company_plugin_uq": {
+          "name": "plugin_company_settings_company_plugin_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_company_settings_company_id_companies_id_fk": {
+          "name": "plugin_company_settings_company_id_companies_id_fk",
+          "tableFrom": "plugin_company_settings",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plugin_company_settings_plugin_id_plugins_id_fk": {
+          "name": "plugin_company_settings_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_company_settings",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_config": {
+      "name": "plugin_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_config_plugin_id_idx": {
+          "name": "plugin_config_plugin_id_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_config_plugin_id_plugins_id_fk": {
+          "name": "plugin_config_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_config",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_entities": {
+      "name": "plugin_entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_entities_plugin_idx": {
+          "name": "plugin_entities_plugin_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_entities_type_idx": {
+          "name": "plugin_entities_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_entities_scope_idx": {
+          "name": "plugin_entities_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_entities_external_idx": {
+          "name": "plugin_entities_external_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_entities_plugin_id_plugins_id_fk": {
+          "name": "plugin_entities_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_entities",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_job_runs": {
+      "name": "plugin_job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_job_runs_job_idx": {
+          "name": "plugin_job_runs_job_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_job_runs_plugin_idx": {
+          "name": "plugin_job_runs_plugin_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_job_runs_status_idx": {
+          "name": "plugin_job_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_job_runs_job_id_plugin_jobs_id_fk": {
+          "name": "plugin_job_runs_job_id_plugin_jobs_id_fk",
+          "tableFrom": "plugin_job_runs",
+          "tableTo": "plugin_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plugin_job_runs_plugin_id_plugins_id_fk": {
+          "name": "plugin_job_runs_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_job_runs",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_jobs": {
+      "name": "plugin_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_key": {
+          "name": "job_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_jobs_plugin_idx": {
+          "name": "plugin_jobs_plugin_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_jobs_next_run_idx": {
+          "name": "plugin_jobs_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_jobs_unique_idx": {
+          "name": "plugin_jobs_unique_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_jobs_plugin_id_plugins_id_fk": {
+          "name": "plugin_jobs_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_jobs",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_logs": {
+      "name": "plugin_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_logs_plugin_time_idx": {
+          "name": "plugin_logs_plugin_time_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_logs_level_idx": {
+          "name": "plugin_logs_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_logs_plugin_id_plugins_id_fk": {
+          "name": "plugin_logs_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_logs",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_state": {
+      "name": "plugin_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_state_plugin_scope_idx": {
+          "name": "plugin_state_plugin_scope_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_state_plugin_id_plugins_id_fk": {
+          "name": "plugin_state_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_state",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugin_state_unique_entry_idx": {
+          "name": "plugin_state_unique_entry_idx",
+          "nullsNotDistinct": true,
+          "columns": [
+            "plugin_id",
+            "scope_kind",
+            "scope_id",
+            "namespace",
+            "state_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_webhook_deliveries": {
+      "name": "plugin_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_key": {
+          "name": "webhook_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugin_webhook_deliveries_plugin_idx": {
+          "name": "plugin_webhook_deliveries_plugin_idx",
+          "columns": [
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_webhook_deliveries_status_idx": {
+          "name": "plugin_webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugin_webhook_deliveries_key_idx": {
+          "name": "plugin_webhook_deliveries_key_idx",
+          "columns": [
+            {
+              "expression": "webhook_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plugin_webhook_deliveries_plugin_id_plugins_id_fk": {
+          "name": "plugin_webhook_deliveries_plugin_id_plugins_id_fk",
+          "tableFrom": "plugin_webhook_deliveries",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plugin_key": {
+          "name": "plugin_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "manifest_json": {
+          "name": "manifest_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installed'"
+        },
+        "install_order": {
+          "name": "install_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_path": {
+          "name": "package_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plugins_plugin_key_idx": {
+          "name": "plugins_plugin_key_idx",
+          "columns": [
+            {
+              "expression": "plugin_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plugins_status_idx": {
+          "name": "plugins_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_permission_grants": {
+      "name": "principal_permission_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_key": {
+          "name": "permission_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_permission_grants_unique_idx": {
+          "name": "principal_permission_grants_unique_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_permission_grants_company_permission_idx": {
+          "name": "principal_permission_grants_company_permission_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_permission_grants_company_id_companies_id_fk": {
+          "name": "principal_permission_grants_company_id_companies_id_fk",
+          "tableFrom": "principal_permission_grants",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_goals": {
+      "name": "project_goals",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_goals_project_idx": {
+          "name": "project_goals_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_goals_goal_idx": {
+          "name": "project_goals_goal_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_goals_company_idx": {
+          "name": "project_goals_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_goals_project_id_projects_id_fk": {
+          "name": "project_goals_project_id_projects_id_fk",
+          "tableFrom": "project_goals",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_goals_goal_id_goals_id_fk": {
+          "name": "project_goals_goal_id_goals_id_fk",
+          "tableFrom": "project_goals",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_goals_company_id_companies_id_fk": {
+          "name": "project_goals_company_id_companies_id_fk",
+          "tableFrom": "project_goals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_goals_project_id_goal_id_pk": {
+          "name": "project_goals_project_id_goal_id_pk",
+          "columns": [
+            "project_id",
+            "goal_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_workspaces": {
+      "name": "project_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local_path'"
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_ref": {
+          "name": "default_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "setup_command": {
+          "name": "setup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_command": {
+          "name": "cleanup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_provider": {
+          "name": "remote_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_workspace_ref": {
+          "name": "remote_workspace_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_workspace_key": {
+          "name": "shared_workspace_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_workspaces_company_project_idx": {
+          "name": "project_workspaces_company_project_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_workspaces_project_primary_idx": {
+          "name": "project_workspaces_project_primary_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_workspaces_project_source_type_idx": {
+          "name": "project_workspaces_project_source_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_workspaces_company_shared_key_idx": {
+          "name": "project_workspaces_company_shared_key_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shared_workspace_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_workspaces_project_remote_ref_idx": {
+          "name": "project_workspaces_project_remote_ref_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_workspace_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_workspaces_company_id_companies_id_fk": {
+          "name": "project_workspaces_company_id_companies_id_fk",
+          "tableFrom": "project_workspaces",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_workspaces_project_id_projects_id_fk": {
+          "name": "project_workspaces_project_id_projects_id_fk",
+          "tableFrom": "project_workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "lead_agent_id": {
+          "name": "lead_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_reason": {
+          "name": "pause_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_workspace_policy": {
+          "name": "execution_workspace_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_company_idx": {
+          "name": "projects_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_company_id_companies_id_fk": {
+          "name": "projects_company_id_companies_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_goal_id_goals_id_fk": {
+          "name": "projects_goal_id_goals_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_lead_agent_id_agents_id_fk": {
+          "name": "projects_lead_agent_id_agents_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "lead_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_runs": {
+      "name": "routine_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_issue_id": {
+          "name": "linked_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coalesced_into_run_id": {
+          "name": "coalesced_into_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routine_runs_company_routine_idx": {
+          "name": "routine_runs_company_routine_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_runs_trigger_idx": {
+          "name": "routine_runs_trigger_idx",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_runs_linked_issue_idx": {
+          "name": "routine_runs_linked_issue_idx",
+          "columns": [
+            {
+              "expression": "linked_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_runs_trigger_idempotency_idx": {
+          "name": "routine_runs_trigger_idempotency_idx",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_company_id_companies_id_fk": {
+          "name": "routine_runs_company_id_companies_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_runs_trigger_id_routine_triggers_id_fk": {
+          "name": "routine_runs_trigger_id_routine_triggers_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routine_triggers",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "routine_runs_linked_issue_id_issues_id_fk": {
+          "name": "routine_runs_linked_issue_id_issues_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "linked_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_triggers": {
+      "name": "routine_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_mode": {
+          "name": "signing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_window_sec": {
+          "name": "replay_window_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rotated_at": {
+          "name": "last_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_agent_id": {
+          "name": "updated_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routine_triggers_company_routine_idx": {
+          "name": "routine_triggers_company_routine_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_triggers_company_kind_idx": {
+          "name": "routine_triggers_company_kind_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_triggers_next_run_idx": {
+          "name": "routine_triggers_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_triggers_public_id_idx": {
+          "name": "routine_triggers_public_id_idx",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routine_triggers_public_id_uq": {
+          "name": "routine_triggers_public_id_uq",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_triggers_company_id_companies_id_fk": {
+          "name": "routine_triggers_company_id_companies_id_fk",
+          "tableFrom": "routine_triggers",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_triggers_routine_id_routines_id_fk": {
+          "name": "routine_triggers_routine_id_routines_id_fk",
+          "tableFrom": "routine_triggers",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_triggers_secret_id_company_secrets_id_fk": {
+          "name": "routine_triggers_secret_id_company_secrets_id_fk",
+          "tableFrom": "routine_triggers",
+          "tableTo": "company_secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "routine_triggers_created_by_agent_id_agents_id_fk": {
+          "name": "routine_triggers_created_by_agent_id_agents_id_fk",
+          "tableFrom": "routine_triggers",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "routine_triggers_updated_by_agent_id_agents_id_fk": {
+          "name": "routine_triggers_updated_by_agent_id_agents_id_fk",
+          "tableFrom": "routine_triggers",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "updated_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routines": {
+      "name": "routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_issue_id": {
+          "name": "parent_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_agent_id": {
+          "name": "assignee_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "concurrency_policy": {
+          "name": "concurrency_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'coalesce_if_active'"
+        },
+        "catch_up_policy": {
+          "name": "catch_up_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip_missed'"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_agent_id": {
+          "name": "updated_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routines_company_status_idx": {
+          "name": "routines_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routines_company_assignee_idx": {
+          "name": "routines_company_assignee_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "routines_company_project_idx": {
+          "name": "routines_company_project_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routines_company_id_companies_id_fk": {
+          "name": "routines_company_id_companies_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routines_project_id_projects_id_fk": {
+          "name": "routines_project_id_projects_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routines_goal_id_goals_id_fk": {
+          "name": "routines_goal_id_goals_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "routines_parent_issue_id_issues_id_fk": {
+          "name": "routines_parent_issue_id_issues_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "routines_assignee_agent_id_agents_id_fk": {
+          "name": "routines_assignee_agent_id_agents_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "assignee_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "routines_created_by_agent_id_agents_id_fk": {
+          "name": "routines_created_by_agent_id_agents_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "routines_updated_by_agent_id_agents_id_fk": {
+          "name": "routines_updated_by_agent_id_agents_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "updated_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_operations": {
+      "name": "workspace_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_workspace_id": {
+          "name": "execution_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_run_id": {
+          "name": "heartbeat_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_store": {
+          "name": "log_store",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_ref": {
+          "name": "log_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_bytes": {
+          "name": "log_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_sha256": {
+          "name": "log_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_compressed": {
+          "name": "log_compressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stdout_excerpt": {
+          "name": "stdout_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stderr_excerpt": {
+          "name": "stderr_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_operations_company_run_started_idx": {
+          "name": "workspace_operations_company_run_started_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_operations_company_workspace_started_idx": {
+          "name": "workspace_operations_company_workspace_started_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_operations_company_id_companies_id_fk": {
+          "name": "workspace_operations_company_id_companies_id_fk",
+          "tableFrom": "workspace_operations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workspace_operations_execution_workspace_id_execution_workspaces_id_fk": {
+          "name": "workspace_operations_execution_workspace_id_execution_workspaces_id_fk",
+          "tableFrom": "workspace_operations",
+          "tableTo": "execution_workspaces",
+          "columnsFrom": [
+            "execution_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_operations_heartbeat_run_id_heartbeat_runs_id_fk": {
+          "name": "workspace_operations_heartbeat_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "workspace_operations",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "heartbeat_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_runtime_services": {
+      "name": "workspace_runtime_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_workspace_id": {
+          "name": "project_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_workspace_id": {
+          "name": "execution_workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reuse_key": {
+          "name": "reuse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_by_run_id": {
+          "name": "started_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_policy": {
+          "name": "stop_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_runtime_services_company_workspace_status_idx": {
+          "name": "workspace_runtime_services_company_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_runtime_services_company_execution_workspace_status_idx": {
+          "name": "workspace_runtime_services_company_execution_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_runtime_services_company_project_status_idx": {
+          "name": "workspace_runtime_services_company_project_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_runtime_services_run_idx": {
+          "name": "workspace_runtime_services_run_idx",
+          "columns": [
+            {
+              "expression": "started_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_runtime_services_company_updated_idx": {
+          "name": "workspace_runtime_services_company_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_runtime_services_company_id_companies_id_fk": {
+          "name": "workspace_runtime_services_company_id_companies_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workspace_runtime_services_project_id_projects_id_fk": {
+          "name": "workspace_runtime_services_project_id_projects_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_runtime_services_project_workspace_id_project_workspaces_id_fk": {
+          "name": "workspace_runtime_services_project_workspace_id_project_workspaces_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "project_workspaces",
+          "columnsFrom": [
+            "project_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_runtime_services_execution_workspace_id_execution_workspaces_id_fk": {
+          "name": "workspace_runtime_services_execution_workspace_id_execution_workspaces_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "execution_workspaces",
+          "columnsFrom": [
+            "execution_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_runtime_services_issue_id_issues_id_fk": {
+          "name": "workspace_runtime_services_issue_id_issues_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_runtime_services_owner_agent_id_agents_id_fk": {
+          "name": "workspace_runtime_services_owner_agent_id_agents_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_runtime_services_started_by_run_id_heartbeat_runs_id_fk": {
+          "name": "workspace_runtime_services_started_by_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "workspace_runtime_services",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "started_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_bindings": {
+      "name": "memory_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_bindings_company_key_idx": {
+          "name": "memory_bindings_company_key_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_bindings_company_idx": {
+          "name": "memory_bindings_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_bindings_company_id_companies_id_fk": {
+          "name": "memory_bindings_company_id_companies_id_fk",
+          "tableFrom": "memory_bindings",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_bindings_plugin_id_plugins_id_fk": {
+          "name": "memory_bindings_plugin_id_plugins_id_fk",
+          "tableFrom": "memory_bindings",
+          "tableTo": "plugins",
+          "columnsFrom": [
+            "plugin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_binding_targets": {
+      "name": "memory_binding_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "binding_id": {
+          "name": "binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_binding_targets_binding_idx": {
+          "name": "memory_binding_targets_binding_idx",
+          "columns": [
+            {
+              "expression": "binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_binding_targets_target_idx": {
+          "name": "memory_binding_targets_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_binding_targets_unique_idx": {
+          "name": "memory_binding_targets_unique_idx",
+          "columns": [
+            {
+              "expression": "binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_binding_targets_binding_id_memory_bindings_id_fk": {
+          "name": "memory_binding_targets_binding_id_memory_bindings_id_fk",
+          "tableFrom": "memory_binding_targets",
+          "tableTo": "memory_bindings",
+          "columnsFrom": [
+            "binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_operations": {
+      "name": "memory_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_id": {
+          "name": "binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_operations_company_binding_idx": {
+          "name": "memory_operations_company_binding_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_operations_company_agent_date_idx": {
+          "name": "memory_operations_company_agent_date_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_operations_company_date_idx": {
+          "name": "memory_operations_company_date_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_operations_company_id_companies_id_fk": {
+          "name": "memory_operations_company_id_companies_id_fk",
+          "tableFrom": "memory_operations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_operations_binding_id_memory_bindings_id_fk": {
+          "name": "memory_operations_binding_id_memory_bindings_id_fk",
+          "tableFrom": "memory_operations",
+          "tableTo": "memory_bindings",
+          "columnsFrom": [
+            "binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1775571715162,
       "tag": "0052_mushy_trauma",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1775583142484,
+      "tag": "0053_memory_bindings_and_operations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -60,3 +60,6 @@ export { pluginEntities } from "./plugin_entities.js";
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { memoryBindings } from "./memory_bindings.js";
+export { memoryBindingTargets } from "./memory_binding_targets.js";
+export { memoryOperations } from "./memory_operations.js";

--- a/packages/db/src/schema/memory_binding_targets.ts
+++ b/packages/db/src/schema/memory_binding_targets.ts
@@ -1,0 +1,46 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { memoryBindings } from "./memory_bindings.js";
+
+/**
+ * `memory_binding_targets` table — assignment join that maps a memory binding
+ * to a target entity (company-wide or a specific agent).
+ *
+ * Priority determines resolution order when multiple bindings match the same
+ * target scope.
+ */
+export const memoryBindingTargets = pgTable(
+  "memory_binding_targets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    bindingId: uuid("binding_id")
+      .notNull()
+      .references(() => memoryBindings.id, { onDelete: "cascade" }),
+    /** Target scope: "company" or "agent". */
+    targetType: text("target_type").notNull(),
+    /** UUID of the target entity (company ID or agent ID). */
+    targetId: uuid("target_id").notNull(),
+    /** Lower value = higher priority when resolving overlapping bindings. */
+    priority: integer("priority").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    bindingIdx: index("memory_binding_targets_binding_idx").on(table.bindingId),
+    targetIdx: index("memory_binding_targets_target_idx").on(
+      table.targetType,
+      table.targetId,
+    ),
+    uniqueAssignment: uniqueIndex("memory_binding_targets_unique_idx").on(
+      table.bindingId,
+      table.targetType,
+      table.targetId,
+    ),
+  }),
+);

--- a/packages/db/src/schema/memory_bindings.ts
+++ b/packages/db/src/schema/memory_bindings.ts
@@ -1,0 +1,54 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  jsonb,
+  boolean,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { plugins } from "./plugins.js";
+
+/**
+ * `memory_bindings` table — company-scoped configuration records that bind a
+ * memory provider (e.g. vector store, knowledge graph) to a company.
+ *
+ * Each binding carries provider-specific config and a capabilities manifest
+ * describing what the provider supports (write, query, forget, browse, correct).
+ */
+export const memoryBindings = pgTable(
+  "memory_bindings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id")
+      .notNull()
+      .references(() => companies.id, { onDelete: "cascade" }),
+    /** Unique key within the company (e.g. "default", "long-term", "project-kb"). */
+    key: text("key").notNull(),
+    /** Identifies the provider implementation (e.g. "pinecone", "qdrant", "pg-vector"). */
+    providerKey: text("provider_key").notNull(),
+    /** Optional FK to the plugin that registered this binding. */
+    pluginId: uuid("plugin_id").references(() => plugins.id, {
+      onDelete: "set null",
+    }),
+    /** Provider-specific configuration (connection strings, model params, etc.). */
+    config: jsonb("config").$type<Record<string, unknown>>().notNull().default({}),
+    /** Capability manifest describing supported operations. */
+    capabilities: jsonb("capabilities")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyKeyIdx: uniqueIndex("memory_bindings_company_key_idx").on(
+      table.companyId,
+      table.key,
+    ),
+    companyIdx: index("memory_bindings_company_idx").on(table.companyId),
+  }),
+);

--- a/packages/db/src/schema/memory_operations.ts
+++ b/packages/db/src/schema/memory_operations.ts
@@ -1,0 +1,67 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  timestamp,
+  jsonb,
+  boolean,
+  index,
+} from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { memoryBindings } from "./memory_bindings.js";
+
+/**
+ * `memory_operations` table — audit log for all memory service operations.
+ *
+ * Records every write, query, forget, browse, and correct operation with
+ * scope context (agent, project, issue, run) and performance metrics.
+ */
+export const memoryOperations = pgTable(
+  "memory_operations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id")
+      .notNull()
+      .references(() => companies.id, { onDelete: "cascade" }),
+    bindingId: uuid("binding_id")
+      .notNull()
+      .references(() => memoryBindings.id, { onDelete: "cascade" }),
+    /** Operation type: write, query, forget, browse, correct. */
+    operationType: text("operation_type").notNull(),
+    /** Agent that initiated the operation (nullable for system-initiated ops). */
+    agentId: uuid("agent_id"),
+    /** Project scope context. */
+    projectId: uuid("project_id"),
+    /** Issue scope context. */
+    issueId: uuid("issue_id"),
+    /** Heartbeat run scope context. */
+    runId: uuid("run_id"),
+    /** Provider-specific source reference (e.g. vector IDs, document keys). */
+    sourceRef: jsonb("source_ref").$type<Record<string, unknown>>(),
+    /** Usage metrics from the provider (tokens, embeddings, etc.). */
+    usage: jsonb("usage").$type<Record<string, unknown>>(),
+    /** Round-trip latency in milliseconds. */
+    latencyMs: integer("latency_ms"),
+    /** Whether the operation completed successfully. */
+    success: boolean("success").notNull().default(true),
+    /** Error message if the operation failed. */
+    error: text("error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyBindingIdx: index("memory_operations_company_binding_idx").on(
+      table.companyId,
+      table.bindingId,
+    ),
+    companyAgentDateIdx: index("memory_operations_company_agent_date_idx").on(
+      table.companyId,
+      table.agentId,
+      table.createdAt,
+    ),
+    companyDateIdx: index("memory_operations_company_date_idx").on(
+      table.companyId,
+      table.createdAt,
+    ),
+  }),
+);

--- a/packages/plugins/sdk/src/index.ts
+++ b/packages/plugins/sdk/src/index.ts
@@ -207,6 +207,20 @@ export type {
   Goal,
 } from "./types.js";
 
+// Memory adapter contract types
+export type {
+  MemoryAdapterCapabilities,
+  MemoryScope,
+  MemorySourceRef,
+  MemoryUsage,
+  MemoryWriteRequest,
+  MemoryRecordHandle,
+  MemoryQueryRequest,
+  MemorySnippet,
+  MemoryContextBundle,
+  MemoryAdapter,
+} from "./types.js";
+
 // Manifest and constant types re-exported from @paperclipai/shared
 // Plugin authors import manifest types from here so they have a single
 // dependency (@paperclipai/plugin-sdk) for all plugin authoring needs.

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -1092,6 +1092,154 @@ export interface PluginStreamsClient {
 }
 
 // ---------------------------------------------------------------------------
+// Memory adapter contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Declares optional capabilities a memory adapter supports beyond the
+ * required `write` / `query` / `get` / `forget` surface.
+ *
+ * @see doc/plans/2026-03-17-memory-service-surface-api.md — Required Adapter Contract
+ */
+export interface MemoryAdapterCapabilities {
+  profile?: boolean;
+  browse?: boolean;
+  correction?: boolean;
+  asyncIngestion?: boolean;
+  multimodal?: boolean;
+  providerManagedExtraction?: boolean;
+}
+
+/**
+ * Normalized Paperclip scope passed into every memory operation so the
+ * provider knows which company / agent / project / run the request belongs to.
+ */
+export interface MemoryScope {
+  companyId: string;
+  agentId?: string;
+  projectId?: string;
+  issueId?: string;
+  runId?: string;
+  subjectId?: string;
+}
+
+/**
+ * Provenance handle that explains where a memory came from.
+ */
+export interface MemorySourceRef {
+  kind:
+    | "issue_comment"
+    | "issue_document"
+    | "issue"
+    | "run"
+    | "activity"
+    | "manual_note"
+    | "external_document";
+  companyId: string;
+  issueId?: string;
+  commentId?: string;
+  documentKey?: string;
+  runId?: string;
+  activityId?: string;
+  externalRef?: string;
+}
+
+/**
+ * Usage / cost telemetry returned by a memory adapter after an operation.
+ */
+export interface MemoryUsage {
+  provider: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  embeddingTokens?: number;
+  costCents?: number;
+  latencyMs?: number;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * A request to write content into memory via a binding.
+ */
+export interface MemoryWriteRequest {
+  bindingKey: string;
+  scope: MemoryScope;
+  source: MemorySourceRef;
+  content: string;
+  metadata?: Record<string, unknown>;
+  mode?: "append" | "upsert" | "summarize";
+}
+
+/**
+ * Opaque handle referencing a record inside a specific memory provider.
+ */
+export interface MemoryRecordHandle {
+  providerKey: string;
+  providerRecordId: string;
+}
+
+/**
+ * A request to query memory via a binding.
+ */
+export interface MemoryQueryRequest {
+  bindingKey: string;
+  scope: MemoryScope;
+  query: string;
+  topK?: number;
+  intent?: "agent_preamble" | "answer" | "browse";
+  metadataFilter?: Record<string, unknown>;
+}
+
+/**
+ * A single memory retrieval result returned by a provider.
+ */
+export interface MemorySnippet {
+  handle: MemoryRecordHandle;
+  text: string;
+  score?: number;
+  summary?: string;
+  source?: MemorySourceRef;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Bundle of memory context returned by a `query` call, including optional
+ * profile summary and usage telemetry.
+ */
+export interface MemoryContextBundle {
+  snippets: MemorySnippet[];
+  profileSummary?: string;
+  usage?: MemoryUsage[];
+}
+
+/**
+ * The adapter interface that memory provider plugins must implement.
+ *
+ * This contract is intentionally small — it fits local markdown providers,
+ * mem0, supermemory, MemOS, and similar backends without forcing providers
+ * to expose internal graph, filesystem, or ontology details.
+ *
+ * @see doc/plans/2026-03-17-memory-service-surface-api.md — Required Adapter Contract
+ */
+export interface MemoryAdapter {
+  /** Stable key identifying this provider inside a company. */
+  key: string;
+  /** Declares which optional surfaces this adapter supports. */
+  capabilities: MemoryAdapterCapabilities;
+  /** Write content into memory. */
+  write(req: MemoryWriteRequest): Promise<{
+    records?: MemoryRecordHandle[];
+    usage?: MemoryUsage[];
+  }>;
+  /** Query memory for relevant context. */
+  query(req: MemoryQueryRequest): Promise<MemoryContextBundle>;
+  /** Retrieve a single record by handle. */
+  get(handle: MemoryRecordHandle, scope: MemoryScope): Promise<MemorySnippet | null>;
+  /** Delete one or more records by handle. */
+  forget(handles: MemoryRecordHandle[], scope: MemoryScope): Promise<{ usage?: MemoryUsage[] }>;
+}
+
+// ---------------------------------------------------------------------------
 // Full plugin context
 // ---------------------------------------------------------------------------
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -612,6 +612,18 @@ export {
   type PluginStateScopeKey,
   type SetPluginState,
   type ListPluginState,
+  createMemoryBindingSchema,
+  updateMemoryBindingSchema,
+  createMemoryBindingTargetSchema,
+  memoryWriteSchema,
+  memoryQuerySchema,
+  memoryForgetSchema,
+  type CreateMemoryBinding,
+  type UpdateMemoryBinding,
+  type CreateMemoryBindingTarget,
+  type MemoryWrite,
+  type MemoryQuery,
+  type MemoryForget,
 } from "./validators/index.js";
 
 export { API_PREFIX, API } from "./api.js";

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -302,3 +302,18 @@ export {
   type SetPluginState,
   type ListPluginState,
 } from "./plugin.js";
+
+export {
+  createMemoryBindingSchema,
+  updateMemoryBindingSchema,
+  createMemoryBindingTargetSchema,
+  memoryWriteSchema,
+  memoryQuerySchema,
+  memoryForgetSchema,
+  type CreateMemoryBinding,
+  type UpdateMemoryBinding,
+  type CreateMemoryBindingTarget,
+  type MemoryWrite,
+  type MemoryQuery,
+  type MemoryForget,
+} from "./memory-binding.js";

--- a/packages/shared/src/validators/memory-binding.ts
+++ b/packages/shared/src/validators/memory-binding.ts
@@ -81,7 +81,7 @@ export type MemoryWrite = z.infer<typeof memoryWriteSchema>;
 
 export const memoryQuerySchema = z.object({
   scope: memoryScopeSchema,
-  query: z.string().min(1),
+  query: z.string().min(1).max(10_000),
   topK: z.number().int().positive().max(100).optional(),
   intent: z.enum(["agent_preamble", "answer", "browse"]).optional(),
   metadataFilter: z.record(z.unknown()).optional(),
@@ -91,7 +91,7 @@ export type MemoryQuery = z.infer<typeof memoryQuerySchema>;
 
 export const memoryForgetSchema = z.object({
   scope: memoryScopeSchema,
-  handles: z.array(memoryRecordHandleSchema).min(1),
+  handles: z.array(memoryRecordHandleSchema).min(1).max(100),
 });
 
 export type MemoryForget = z.infer<typeof memoryForgetSchema>;

--- a/packages/shared/src/validators/memory-binding.ts
+++ b/packages/shared/src/validators/memory-binding.ts
@@ -72,7 +72,7 @@ const memoryRecordHandleSchema = z.object({
 export const memoryWriteSchema = z.object({
   scope: memoryScopeSchema,
   source: memorySourceRefSchema,
-  content: z.string().min(1),
+  content: z.string().min(1).max(100_000),
   metadata: z.record(z.unknown()).optional(),
   mode: z.enum(["append", "upsert", "summarize"]).optional(),
 });
@@ -82,7 +82,7 @@ export type MemoryWrite = z.infer<typeof memoryWriteSchema>;
 export const memoryQuerySchema = z.object({
   scope: memoryScopeSchema,
   query: z.string().min(1),
-  topK: z.number().int().positive().optional(),
+  topK: z.number().int().positive().max(100).optional(),
   intent: z.enum(["agent_preamble", "answer", "browse"]).optional(),
   metadataFilter: z.record(z.unknown()).optional(),
 });

--- a/packages/shared/src/validators/memory-binding.ts
+++ b/packages/shared/src/validators/memory-binding.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+// ── Memory Binding CRUD ──────────────────────────────────────────────
+
+export const createMemoryBindingSchema = z.object({
+  key: z.string().min(1).max(128),
+  providerKey: z.string().min(1).max(128),
+  pluginId: z.string().uuid().optional().nullable(),
+  config: z.record(z.unknown()).optional(),
+  capabilities: z.record(z.unknown()).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export type CreateMemoryBinding = z.infer<typeof createMemoryBindingSchema>;
+
+export const updateMemoryBindingSchema = z.object({
+  key: z.string().min(1).max(128).optional(),
+  providerKey: z.string().min(1).max(128).optional(),
+  pluginId: z.string().uuid().optional().nullable(),
+  config: z.record(z.unknown()).optional(),
+  capabilities: z.record(z.unknown()).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export type UpdateMemoryBinding = z.infer<typeof updateMemoryBindingSchema>;
+
+// ── Binding Target CRUD ──────────────────────────────────────────────
+
+export const createMemoryBindingTargetSchema = z.object({
+  targetType: z.enum(["company", "agent"]),
+  targetId: z.string().uuid(),
+  priority: z.number().int().optional(),
+});
+
+export type CreateMemoryBindingTarget = z.infer<typeof createMemoryBindingTargetSchema>;
+
+// ── Memory Operations ──────────────────────────────────────────────
+
+const memoryScopeSchema = z.object({
+  companyId: z.string().uuid(),
+  agentId: z.string().uuid().optional(),
+  projectId: z.string().uuid().optional(),
+  issueId: z.string().uuid().optional(),
+  runId: z.string().uuid().optional(),
+  subjectId: z.string().uuid().optional(),
+});
+
+const memorySourceRefSchema = z.object({
+  kind: z.enum([
+    "issue_comment",
+    "issue_document",
+    "issue",
+    "run",
+    "activity",
+    "manual_note",
+    "external_document",
+  ]),
+  companyId: z.string().uuid(),
+  issueId: z.string().uuid().optional(),
+  commentId: z.string().uuid().optional(),
+  documentKey: z.string().optional(),
+  runId: z.string().uuid().optional(),
+  activityId: z.string().uuid().optional(),
+  externalRef: z.string().optional(),
+});
+
+const memoryRecordHandleSchema = z.object({
+  providerKey: z.string().min(1).max(128),
+  providerRecordId: z.string().min(1),
+});
+
+export const memoryWriteSchema = z.object({
+  scope: memoryScopeSchema,
+  source: memorySourceRefSchema,
+  content: z.string().min(1),
+  metadata: z.record(z.unknown()).optional(),
+  mode: z.enum(["append", "upsert", "summarize"]).optional(),
+});
+
+export type MemoryWrite = z.infer<typeof memoryWriteSchema>;
+
+export const memoryQuerySchema = z.object({
+  scope: memoryScopeSchema,
+  query: z.string().min(1),
+  topK: z.number().int().positive().optional(),
+  intent: z.enum(["agent_preamble", "answer", "browse"]).optional(),
+  metadataFilter: z.record(z.unknown()).optional(),
+});
+
+export type MemoryQuery = z.infer<typeof memoryQuerySchema>;
+
+export const memoryForgetSchema = z.object({
+  scope: memoryScopeSchema,
+  handles: z.array(memoryRecordHandleSchema).min(1),
+});
+
+export type MemoryForget = z.infer<typeof memoryForgetSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.994.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",

--- a/server/scripts/backfill-mempalace.ts
+++ b/server/scripts/backfill-mempalace.ts
@@ -277,7 +277,7 @@ async function main() {
           bindingKey: "backfill",
           scope,
           source: {
-            kind: "backfill",
+            kind: "run",
             companyId: run.companyId,
             runId: run.id,
             issueId,

--- a/server/scripts/backfill-mempalace.ts
+++ b/server/scripts/backfill-mempalace.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env tsx
+/**
+ * backfill-mempalace — Replay historical agent runs into mempalace.
+ *
+ * Usage (from repo root):
+ *   pnpm --filter @paperclipai/server exec tsx scripts/backfill-mempalace.ts [options]
+ *   — or —
+ *   pnpm -w run backfill:mempalace -- [options]
+ *
+ * Inside a container:
+ *   pnpm --filter @paperclipai/server exec tsx scripts/backfill-mempalace.ts [options]
+ *
+ * Options:
+ *   --company-id <id>   Filter by company (default: all companies)
+ *   --agent-id <id>     Filter by agent (default: all agents)
+ *   --since <date>      Only runs after this ISO date (default: all time)
+ *   --until <date>      Only runs before this ISO date (default: now)
+ *   --dry-run           Preview what would be written without writing
+ *   --batch-size <n>    Runs per batch (default: 100)
+ *   --capture-depth <d> "summary" or "full" (default: full)
+ *
+ * Requires:
+ *   DATABASE_URL        Postgres connection string
+ *   MEMPALACE_URL       Remote mempalace MCP server URL
+ *     — or —
+ *   MEMPALACE_ENABLED=true (+ optional MEMPALACE_PALACE_DIR, MEMPALACE_PYTHON_COMMAND)
+ */
+
+import { and, eq, gte, lte, desc, sql } from "drizzle-orm";
+import { createDb } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+import { agents } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { createMempalaceMemoryAdapter } from "../src/services/memory-adapters/mempalace.js";
+import { createMempalaceSidecar } from "../src/services/memory-adapters/mempalace-sidecar.js";
+import type { MemoryAdapter, MemoryScope } from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function arg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  return idx !== -1 && idx + 1 < process.argv.length ? process.argv[idx + 1] : undefined;
+}
+
+const flag = (name: string) => process.argv.includes(name);
+
+const companyIdFilter = arg("--company-id");
+const agentIdFilter = arg("--agent-id");
+const sinceFilter = arg("--since");
+const untilFilter = arg("--until");
+const dryRun = flag("--dry-run");
+const batchSize = parseInt(arg("--batch-size") ?? "100", 10);
+const captureDepth = (arg("--capture-depth") ?? "full") as "summary" | "full";
+
+// ---------------------------------------------------------------------------
+// Capture content builder (mirrors memory-hooks.ts buildCaptureContent)
+// ---------------------------------------------------------------------------
+
+function buildCaptureContent(params: {
+  outcome: string;
+  agentName?: string;
+  taskSummary?: string;
+  runId: string;
+  issueId?: string;
+  resultJson?: Record<string, unknown> | null;
+  startedAt?: string;
+}, depth: "summary" | "full"): string {
+  const lines: string[] = [];
+
+  lines.push(`## Run ${params.outcome}`);
+  if (params.agentName) lines.push(`Agent: ${params.agentName}`);
+  if (params.taskSummary) lines.push(`Task: ${params.taskSummary}`);
+  lines.push(`Run: ${params.runId}`);
+  if (params.issueId) lines.push(`Issue: ${params.issueId}`);
+  lines.push(`Outcome: ${params.outcome}`);
+  lines.push(`Captured: ${params.startedAt ?? new Date().toISOString()} (backfill)`);
+
+  if (depth === "full" && params.resultJson) {
+    lines.push("");
+    lines.push("### Result");
+    const resultStr = JSON.stringify(params.resultJson, null, 2);
+    const maxLen = 4000;
+    lines.push(resultStr.length > maxLen ? resultStr.slice(0, maxLen) + "\n..." : resultStr);
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  const mempalaceUrl = process.env.MEMPALACE_URL;
+  const mempalaceEnabled = process.env.MEMPALACE_ENABLED === "true";
+
+  if (!mempalaceUrl && !mempalaceEnabled && !dryRun) {
+    console.error("Either MEMPALACE_URL or MEMPALACE_ENABLED=true is required (or use --dry-run)");
+    process.exit(1);
+  }
+
+  const db = createDb(dbUrl);
+
+  // ── Connect to mempalace ───────────────────────────────────────────
+
+  let adapter: MemoryAdapter | null = null;
+  let sidecar: ReturnType<typeof createMempalaceSidecar> | null = null;
+
+  if (!dryRun) {
+    if (mempalaceUrl) {
+      const mcpAdapter = createMempalaceMemoryAdapter({
+        url: mempalaceUrl,
+        connectTimeoutMs: 15_000,
+        callTimeoutMs: 30_000,
+      });
+      await mcpAdapter.connect();
+      adapter = mcpAdapter;
+      console.log(`Connected to mempalace at ${mempalaceUrl}`);
+    } else {
+      const palaceDir = process.env.MEMPALACE_PALACE_DIR ?? process.cwd() + "/.mempalace";
+      const pythonCommand = process.env.MEMPALACE_PYTHON_COMMAND ?? "python";
+      sidecar = createMempalaceSidecar({ palaceDir, pythonCommand });
+      await sidecar.start();
+      adapter = sidecar.adapter;
+      console.log(`Started local mempalace sidecar at ${palaceDir}`);
+    }
+  }
+
+  // ── Build agent lookup ─────────────────────────────────────────────
+
+  const allAgents = await db.select({ id: agents.id, name: agents.name, companyId: agents.companyId }).from(agents);
+  const agentMap = new Map(allAgents.map((a) => [a.id, a]));
+
+  // ── Load checkpoint (tracks already-backfilled run IDs) ─────────────
+
+  const checkpointPath = join(process.cwd(), ".backfill-mempalace-checkpoint.json");
+  const alreadyBackfilled = new Set<string>();
+  if (existsSync(checkpointPath)) {
+    try {
+      const data = JSON.parse(readFileSync(checkpointPath, "utf-8"));
+      if (Array.isArray(data.runIds)) {
+        for (const id of data.runIds) alreadyBackfilled.add(id);
+      }
+      console.log(`Loaded checkpoint: ${alreadyBackfilled.size} previously backfilled runs (will skip)`);
+    } catch {
+      console.warn("Could not parse checkpoint file — starting fresh");
+    }
+  }
+
+  function saveCheckpoint() {
+    writeFileSync(checkpointPath, JSON.stringify({ runIds: [...alreadyBackfilled] }), "utf-8");
+  }
+
+  // ── Query runs ─────────────────────────────────────────────────────
+
+  const terminalStatuses = ["succeeded", "failed", "cancelled", "timed_out"];
+  const conditions = [sql`${heartbeatRuns.status} IN (${sql.join(terminalStatuses.map(s => sql`${s}`), sql`, `)})`];
+  if (companyIdFilter) conditions.push(eq(heartbeatRuns.companyId, companyIdFilter));
+  if (agentIdFilter) conditions.push(eq(heartbeatRuns.agentId, agentIdFilter));
+  if (sinceFilter) conditions.push(gte(heartbeatRuns.startedAt, new Date(sinceFilter)));
+  if (untilFilter) conditions.push(lte(heartbeatRuns.startedAt, new Date(untilFilter)));
+
+  // Count first
+  const countResult = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(heartbeatRuns)
+    .where(and(...conditions));
+  const totalRuns = Number(countResult[0]?.count ?? 0);
+
+  console.log(`\nFound ${totalRuns} completed runs to backfill${dryRun ? " (dry run)" : ""}`);
+  let processed = 0;
+  let written = 0;
+  let skipped = 0;
+  let errors = 0;
+  let offset = 0;
+
+  if (totalRuns === 0) {
+    console.log("Nothing to do.");
+    await cleanup();
+    return;
+  }
+
+  // ── Process in batches ─────────────────────────────────────────────
+
+  while (offset < totalRuns) {
+    const runs = await db
+      .select({
+        id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
+        status: heartbeatRuns.status,
+        resultJson: heartbeatRuns.resultJson,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        startedAt: heartbeatRuns.startedAt,
+        finishedAt: heartbeatRuns.finishedAt,
+        exitCode: heartbeatRuns.exitCode,
+      })
+      .from(heartbeatRuns)
+      .where(and(...conditions))
+      .orderBy(desc(heartbeatRuns.startedAt))
+      .limit(batchSize)
+      .offset(offset);
+
+    for (const run of runs) {
+      processed++;
+
+      // Dedup: skip runs already backfilled in a previous invocation
+      if (alreadyBackfilled.has(run.id)) {
+        skipped++;
+        continue;
+      }
+
+      const agent = agentMap.get(run.agentId);
+      const ctx = (run.contextSnapshot ?? {}) as Record<string, unknown>;
+      const issueId = (ctx.issueId as string) ?? (ctx.taskId as string) ?? undefined;
+      const taskKey = (ctx.taskKey as string) ?? undefined;
+
+      // Use the actual run status as the outcome
+      const outcome = run.status;
+
+      // Try to get task summary from issue title
+      let taskSummary = taskKey;
+      if (issueId && !taskSummary) {
+        try {
+          const issue = await db
+            .select({ title: issues.title })
+            .from(issues)
+            .where(eq(issues.id, issueId))
+            .then((rows) => rows[0]);
+          if (issue) taskSummary = issue.title;
+        } catch {
+          // issue may have been deleted
+        }
+      }
+
+      const content = buildCaptureContent({
+        outcome,
+        agentName: agent?.name,
+        taskSummary,
+        runId: run.id,
+        issueId,
+        resultJson: captureDepth === "full" ? run.resultJson : null,
+        startedAt: run.startedAt?.toISOString(),
+      }, captureDepth);
+
+      if (dryRun) {
+        console.log(`[${processed}/${totalRuns}] would write run ${run.id} (${outcome}, agent=${agent?.name ?? run.agentId}, task=${taskSummary ?? "unknown"})`);
+        written++;
+        continue;
+      }
+
+      // Skip runs with no meaningful content
+      if (!run.resultJson && captureDepth === "full") {
+        skipped++;
+        continue;
+      }
+
+      const scope: MemoryScope = {
+        companyId: run.companyId,
+        agentId: run.agentId,
+        issueId,
+        runId: run.id,
+      };
+
+      try {
+        await adapter!.write({
+          bindingKey: "backfill",
+          scope,
+          source: {
+            kind: "backfill",
+            companyId: run.companyId,
+            runId: run.id,
+            issueId,
+          },
+          content,
+          mode: "append",
+        });
+
+        alreadyBackfilled.add(run.id);
+        written++;
+
+        // Save checkpoint every 10 writes so progress survives interruption
+        if (written % 10 === 0) {
+          saveCheckpoint();
+          console.log(`[${processed}/${totalRuns}] ${written} written, ${skipped} skipped, ${errors} errors`);
+        }
+      } catch (err) {
+        errors++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[${processed}/${totalRuns}] error writing run ${run.id}: ${msg}`);
+      }
+    }
+
+    offset += batchSize;
+  }
+
+  // Final checkpoint save
+  if (written > 0 && !dryRun) {
+    saveCheckpoint();
+  }
+
+  console.log(`\nBackfill complete:`);
+  console.log(`  Processed: ${processed}`);
+  console.log(`  Written:   ${written}`);
+  console.log(`  Skipped:   ${skipped}`);
+  console.log(`  Errors:    ${errors}`);
+  if (!dryRun) {
+    console.log(`  Checkpoint: ${checkpointPath}`);
+  }
+
+  await cleanup();
+
+  async function cleanup() {
+    if (sidecar) {
+      await sidecar.stop();
+    }
+    process.exit(errors > 0 ? 1 : 0);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/server/src/__tests__/memory-hooks.test.ts
+++ b/server/src/__tests__/memory-hooks.test.ts
@@ -271,7 +271,7 @@ describe("memoryHooksService", () => {
       expect(adapter.query).not.toHaveBeenCalled();
     });
 
-    it("queries adapter with agent_preamble intent and returns snippets", async () => {
+    it("queries adapter with task summary and returns snippets", async () => {
       const adapter = createFakeAdapter("mempalace");
       mockGetMemoryAdapter.mockReturnValue(adapter);
 

--- a/server/src/__tests__/memory-hooks.test.ts
+++ b/server/src/__tests__/memory-hooks.test.ts
@@ -1,0 +1,646 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// We test memory-hooks at the unit level by mocking the DB layer and the
+// adapter registry. The service resolves bindings → looks up adapters →
+// calls adapter.query / adapter.write, all of which we intercept.
+// ---------------------------------------------------------------------------
+
+// Mock getMemoryAdapter from memory-operations
+const mockGetMemoryAdapter = vi.fn();
+vi.mock("../services/memory-operations.js", () => ({
+  getMemoryAdapter: (...args: unknown[]) => mockGetMemoryAdapter(...args),
+  getRegisteredMemoryAdapters: () => [],
+}));
+
+// Mock logger to suppress output
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fake DB layer
+// ---------------------------------------------------------------------------
+
+interface FakeRow {
+  [key: string]: unknown;
+}
+
+function createFakeDb(opts: {
+  targets?: FakeRow[];
+  bindings?: FakeRow[];
+}) {
+  const { targets = [], bindings = [] } = opts;
+
+  const insertedOps: FakeRow[] = [];
+
+  // Track which select call we're on: first = targets, second = bindings
+  let selectCallCount = 0;
+
+  const fakeDb = {
+    select: vi.fn().mockImplementation(() => {
+      selectCallCount++;
+      const callNum = selectCallCount;
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            // First select is for targets (has .orderBy)
+            if (callNum % 2 === 1) {
+              return {
+                orderBy: vi.fn().mockResolvedValue(targets),
+              };
+            }
+            // Second select is for bindings (direct resolve)
+            return Promise.resolve(bindings);
+          }),
+        }),
+      };
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockImplementation((row: FakeRow) => {
+        insertedOps.push(row);
+        return Promise.resolve();
+      }),
+    }),
+    _insertedOps: insertedOps,
+  };
+
+  return fakeDb;
+}
+
+// ---------------------------------------------------------------------------
+// Fake adapter
+// ---------------------------------------------------------------------------
+
+function createFakeAdapter(key: string, overrides?: {
+  queryResult?: unknown;
+  writeResult?: unknown;
+  queryError?: Error;
+  writeError?: Error;
+}) {
+  return {
+    key,
+    capabilities: {
+      profile: false,
+      browse: true,
+      correction: false,
+      asyncIngestion: true,
+      multimodal: false,
+      providerManagedExtraction: true,
+    },
+    query: overrides?.queryError
+      ? vi.fn().mockRejectedValue(overrides.queryError)
+      : vi.fn().mockResolvedValue(overrides?.queryResult ?? {
+          snippets: [
+            {
+              handle: { providerKey: key, providerRecordId: "rec-1" },
+              text: "Some remembered context",
+              score: 0.85,
+              metadata: {},
+            },
+          ],
+          profileSummary: "Agent profile from memory",
+          usage: [{ provider: key, latencyMs: 42, details: {} }],
+        }),
+    write: overrides?.writeError
+      ? vi.fn().mockRejectedValue(overrides.writeError)
+      : vi.fn().mockResolvedValue(overrides?.writeResult ?? {
+          records: [{ providerKey: key, providerRecordId: "new-rec-1" }],
+          usage: [{ provider: key, latencyMs: 30, details: {} }],
+        }),
+    get: vi.fn().mockResolvedValue(null),
+    forget: vi.fn().mockResolvedValue({ usage: [] }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Import service under test (after mocks are set up)
+// ---------------------------------------------------------------------------
+
+import { memoryHooksService } from "../services/memory-hooks.js";
+import type { HydrateRunContextParams, CaptureRunResultParams } from "../services/memory-hooks.js";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+const AGENT_ID = "22222222-2222-2222-2222-222222222222";
+const RUN_ID = "33333333-3333-3333-3333-333333333333";
+const BINDING_ID = "44444444-4444-4444-4444-444444444444";
+const BINDING_ID_2 = "55555555-5555-5555-5555-555555555555";
+
+function makeBinding(id: string, key: string, providerKey: string, hooks: Record<string, unknown>) {
+  return {
+    id,
+    companyId: COMPANY_ID,
+    key,
+    providerKey,
+    pluginId: null,
+    config: { hooks },
+    capabilities: {},
+    enabled: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function makeTarget(bindingId: string, targetType: string, targetId: string, priority: number) {
+  return {
+    bindingId,
+    targetType,
+    targetId,
+    priority,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("memoryHooksService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── resolveBindingsForAgent ──────────────────────────────────────
+
+  describe("resolveBindingsForAgent", () => {
+    it("returns empty when no targets match", async () => {
+      const db = createFakeDb({ targets: [], bindings: [] });
+      const svc = memoryHooksService(db as any);
+      const result = await svc.resolveBindingsForAgent(COMPANY_ID, AGENT_ID);
+      expect(result).toEqual([]);
+    });
+
+    it("resolves agent-targeted bindings with registered adapters", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockImplementation((key: string) =>
+        key === "mempalace" ? adapter : undefined,
+      );
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.resolveBindingsForAgent(COMPANY_ID, AGENT_ID);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].bindingKey).toBe("default");
+      expect(result[0].providerKey).toBe("mempalace");
+      expect(result[0].hooks.preRunHydrate?.enabled).toBe(true);
+    });
+
+    it("skips bindings with no registered adapter", async () => {
+      mockGetMemoryAdapter.mockReturnValue(undefined);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "unregistered-provider", {}),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.resolveBindingsForAgent(COMPANY_ID, AGENT_ID);
+
+      expect(result).toEqual([]);
+    });
+
+    it("deduplicates bindings when both agent and company targets match", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [
+          makeTarget(BINDING_ID, "agent", AGENT_ID, 0),
+          makeTarget(BINDING_ID, "company", COMPANY_ID, 10),
+        ],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {}),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.resolveBindingsForAgent(COMPANY_ID, AGENT_ID);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // ── hydrateRunContext ────────────────────────────────────────────
+
+  describe("hydrateRunContext", () => {
+    const baseParams: HydrateRunContextParams = {
+      companyId: COMPANY_ID,
+      agentId: AGENT_ID,
+      runId: RUN_ID,
+      taskSummary: "Fix the login bug",
+    };
+
+    it("returns empty when no bindings have hydrate enabled", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            postRunCapture: { enabled: true },
+            // preRunHydrate not set
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.hydrateRunContext(baseParams);
+
+      expect(result.bindingsQueried).toBe(0);
+      expect(result.snippets).toEqual([]);
+      expect(adapter.query).not.toHaveBeenCalled();
+    });
+
+    it("queries adapter with agent_preamble intent and returns snippets", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true, topK: 3 },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.hydrateRunContext(baseParams);
+
+      expect(result.bindingsQueried).toBe(1);
+      expect(result.snippets).toHaveLength(1);
+      expect(result.snippets[0].text).toBe("Some remembered context");
+      expect(result.profileSummary).toBe("Agent profile from memory");
+
+      // Verify the adapter was called with correct params
+      expect(adapter.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bindingKey: "default",
+          scope: expect.objectContaining({
+            companyId: COMPANY_ID,
+            agentId: AGENT_ID,
+            runId: RUN_ID,
+          }),
+          query: "Fix the login bug",
+          topK: 3,
+          intent: "agent_preamble",
+        }),
+      );
+    });
+
+    it("uses default topK of 5 when not configured", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      await svc.hydrateRunContext(baseParams);
+
+      expect(adapter.query).toHaveBeenCalledWith(
+        expect.objectContaining({ topK: 5 }),
+      );
+    });
+
+    it("aggregates snippets from multiple bindings", async () => {
+      const adapter1 = createFakeAdapter("mempalace", {
+        queryResult: {
+          snippets: [
+            { handle: { providerKey: "mempalace", providerRecordId: "r1" }, text: "Snippet 1", score: 0.9 },
+          ],
+          usage: [{ provider: "mempalace", latencyMs: 10 }],
+        },
+      });
+      const adapter2 = createFakeAdapter("pinecone", {
+        queryResult: {
+          snippets: [
+            { handle: { providerKey: "pinecone", providerRecordId: "r2" }, text: "Snippet 2", score: 0.8 },
+          ],
+          profileSummary: "From pinecone",
+          usage: [{ provider: "pinecone", latencyMs: 20 }],
+        },
+      });
+
+      mockGetMemoryAdapter.mockImplementation((key: string) => {
+        if (key === "mempalace") return adapter1;
+        if (key === "pinecone") return adapter2;
+        return undefined;
+      });
+
+      const db = createFakeDb({
+        targets: [
+          makeTarget(BINDING_ID, "agent", AGENT_ID, 0),
+          makeTarget(BINDING_ID_2, "agent", AGENT_ID, 1),
+        ],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true },
+          }),
+          makeBinding(BINDING_ID_2, "secondary", "pinecone", {
+            preRunHydrate: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.hydrateRunContext(baseParams);
+
+      expect(result.bindingsQueried).toBe(2);
+      expect(result.snippets).toHaveLength(2);
+      expect(result.snippets[0].text).toBe("Snippet 1");
+      expect(result.snippets[1].text).toBe("Snippet 2");
+      expect(result.usage).toHaveLength(2);
+    });
+
+    it("continues with remaining bindings when one fails", async () => {
+      const failingAdapter = createFakeAdapter("mempalace", {
+        queryError: new Error("Connection refused"),
+      });
+      const workingAdapter = createFakeAdapter("pinecone");
+
+      mockGetMemoryAdapter.mockImplementation((key: string) => {
+        if (key === "mempalace") return failingAdapter;
+        if (key === "pinecone") return workingAdapter;
+        return undefined;
+      });
+
+      const db = createFakeDb({
+        targets: [
+          makeTarget(BINDING_ID, "agent", AGENT_ID, 0),
+          makeTarget(BINDING_ID_2, "agent", AGENT_ID, 1),
+        ],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true },
+          }),
+          makeBinding(BINDING_ID_2, "secondary", "pinecone", {
+            preRunHydrate: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.hydrateRunContext(baseParams);
+
+      // First binding failed, second succeeded
+      expect(result.bindingsQueried).toBe(1);
+      expect(result.snippets).toHaveLength(1);
+      expect(result.snippets[0].handle.providerKey).toBe("pinecone");
+    });
+
+    it("uses 'agent context' as fallback query when no taskSummary", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      await svc.hydrateRunContext({ ...baseParams, taskSummary: undefined });
+
+      expect(adapter.query).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "agent context" }),
+      );
+    });
+  });
+
+  // ── captureRunResult ────────────────────────────────────────────
+
+  describe("captureRunResult", () => {
+    const baseParams: CaptureRunResultParams = {
+      companyId: COMPANY_ID,
+      agentId: AGENT_ID,
+      runId: RUN_ID,
+      outcome: "succeeded",
+      taskSummary: "Fix the login bug",
+      agentName: "CTO",
+    };
+
+    it("returns empty when no bindings have capture enabled", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            preRunHydrate: { enabled: true },
+            // postRunCapture not set
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.captureRunResult(baseParams);
+
+      expect(result.bindingsCaptured).toBe(0);
+      expect(adapter.write).not.toHaveBeenCalled();
+    });
+
+    it("writes summary content to adapter with correct source ref", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            postRunCapture: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.captureRunResult(baseParams);
+
+      expect(result.bindingsCaptured).toBe(1);
+      expect(adapter.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bindingKey: "default",
+          scope: expect.objectContaining({
+            companyId: COMPANY_ID,
+            agentId: AGENT_ID,
+            runId: RUN_ID,
+          }),
+          source: expect.objectContaining({
+            kind: "run",
+            companyId: COMPANY_ID,
+            runId: RUN_ID,
+          }),
+          mode: "append",
+        }),
+      );
+
+      // Content should include summary
+      const callArgs = (adapter.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.content).toContain("Run succeeded");
+      expect(callArgs.content).toContain("Agent: CTO");
+      expect(callArgs.content).toContain("Fix the login bug");
+    });
+
+    it("includes resultJson in full capture depth", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            postRunCapture: { enabled: true, captureDepth: "full" },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      await svc.captureRunResult({
+        ...baseParams,
+        resultJson: { filesChanged: 3, testsRun: 12 },
+      });
+
+      const callArgs = (adapter.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.content).toContain("### Result");
+      expect(callArgs.content).toContain("filesChanged");
+    });
+
+    it("excludes resultJson in summary capture depth (default)", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            postRunCapture: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      await svc.captureRunResult({
+        ...baseParams,
+        resultJson: { filesChanged: 3 },
+      });
+
+      const callArgs = (adapter.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.content).not.toContain("### Result");
+      expect(callArgs.content).not.toContain("filesChanged");
+    });
+
+    it("continues with remaining bindings when one write fails", async () => {
+      const failingAdapter = createFakeAdapter("mempalace", {
+        writeError: new Error("Write failed"),
+      });
+      const workingAdapter = createFakeAdapter("pinecone");
+
+      mockGetMemoryAdapter.mockImplementation((key: string) => {
+        if (key === "mempalace") return failingAdapter;
+        if (key === "pinecone") return workingAdapter;
+        return undefined;
+      });
+
+      const db = createFakeDb({
+        targets: [
+          makeTarget(BINDING_ID, "agent", AGENT_ID, 0),
+          makeTarget(BINDING_ID_2, "agent", AGENT_ID, 1),
+        ],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            postRunCapture: { enabled: true },
+          }),
+          makeBinding(BINDING_ID_2, "secondary", "pinecone", {
+            postRunCapture: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      const result = await svc.captureRunResult(baseParams);
+
+      expect(result.bindingsCaptured).toBe(1);
+      expect(failingAdapter.write).toHaveBeenCalled();
+      expect(workingAdapter.write).toHaveBeenCalled();
+    });
+
+    it("captures failed runs", async () => {
+      const adapter = createFakeAdapter("mempalace");
+      mockGetMemoryAdapter.mockReturnValue(adapter);
+
+      const db = createFakeDb({
+        targets: [makeTarget(BINDING_ID, "agent", AGENT_ID, 0)],
+        bindings: [
+          makeBinding(BINDING_ID, "default", "mempalace", {
+            postRunCapture: { enabled: true },
+          }),
+        ],
+      });
+
+      const svc = memoryHooksService(db as any);
+      await svc.captureRunResult({ ...baseParams, outcome: "failed" });
+
+      const callArgs = (adapter.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.content).toContain("Run failed");
+      expect(callArgs.content).toContain("Outcome: failed");
+    });
+  });
+
+  // ── No bindings at all ──────────────────────────────────────────
+
+  describe("no-op when no bindings exist", () => {
+    it("hydrate returns empty without DB errors", async () => {
+      const db = createFakeDb({ targets: [], bindings: [] });
+      const svc = memoryHooksService(db as any);
+      const result = await svc.hydrateRunContext({
+        companyId: COMPANY_ID,
+        agentId: AGENT_ID,
+        runId: RUN_ID,
+      });
+      expect(result.bindingsQueried).toBe(0);
+      expect(result.snippets).toEqual([]);
+    });
+
+    it("capture returns empty without DB errors", async () => {
+      const db = createFakeDb({ targets: [], bindings: [] });
+      const svc = memoryHooksService(db as any);
+      const result = await svc.captureRunResult({
+        companyId: COMPANY_ID,
+        agentId: AGENT_ID,
+        runId: RUN_ID,
+        outcome: "succeeded",
+      });
+      expect(result.bindingsCaptured).toBe(0);
+    });
+  });
+});

--- a/server/src/__tests__/memory-hooks.test.ts
+++ b/server/src/__tests__/memory-hooks.test.ts
@@ -303,7 +303,6 @@ describe("memoryHooksService", () => {
           }),
           query: "Fix the login bug",
           topK: 3,
-          intent: "agent_preamble",
         }),
       );
     });

--- a/server/src/__tests__/mempalace-integration.test.ts
+++ b/server/src/__tests__/mempalace-integration.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { createMempalaceMemoryAdapter } from "../services/memory-adapters/mempalace.js";
+import { createMempalaceSidecar } from "../services/memory-adapters/mempalace-sidecar.js";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { MemoryScope, MemorySourceRef } from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Integration tests — spawn a real mempalace MCP sidecar process.
+//
+// Requires: mempalace Python package installed.
+// These tests are slower (real ChromaDB embeddings) and are skipped in CI
+// unless MEMPALACE_INTEGRATION=1 is set.
+// ---------------------------------------------------------------------------
+
+const PYTHON_CMD = process.env.MEMPALACE_PYTHON ?? "/tmp/mempalace-venv/bin/python";
+const RUN_INTEGRATION = process.env.MEMPALACE_INTEGRATION === "1" || process.env.CI === undefined;
+
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+// Shared test fixtures
+const scope: MemoryScope = { companyId: "test-co", agentId: "agent-a", projectId: "proj-1" };
+const source: MemorySourceRef = { kind: "integration_test", companyId: "test-co" };
+
+describeIntegration("Mempalace Integration", () => {
+  let palaceDir: string;
+  let adapter: ReturnType<typeof createMempalaceMemoryAdapter>;
+
+  beforeAll(async () => {
+    palaceDir = mkdtempSync(join(tmpdir(), "mempalace-test-"));
+
+    adapter = createMempalaceMemoryAdapter({
+      command: PYTHON_CMD,
+      args: ["-m", "mempalace.mcp_server"],
+      cwd: palaceDir,
+      env: { MEMPALACE_PALACE_PATH: palaceDir },
+      connectTimeoutMs: 30_000,
+      callTimeoutMs: 30_000,
+    });
+
+    await adapter.connect();
+  }, 60_000);
+
+  afterAll(async () => {
+    await adapter.disconnect();
+    try {
+      rmSync(palaceDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  // ── Write → Query round-trip ─────────────────────────────────────
+
+  it("write then query retrieves the stored content", async () => {
+    const writeResult = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "The auth service was migrated to OAuth2 on March 15th. All endpoints now require bearer tokens.",
+    });
+
+    expect(writeResult.records).toHaveLength(1);
+    expect(writeResult.records![0].providerKey).toBe("mempalace");
+    expect(writeResult.records![0].providerRecordId).toBeTruthy();
+    expect(writeResult.usage).toHaveLength(1);
+    expect(writeResult.usage![0].latencyMs).toBeGreaterThan(0);
+
+    // Query for the content we just stored
+    const queryResult = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "OAuth2 authentication migration",
+      topK: 3,
+    });
+
+    expect(queryResult.snippets.length).toBeGreaterThanOrEqual(1);
+    const match = queryResult.snippets[0];
+    expect(match.text).toContain("auth service");
+    expect(match.text).toContain("OAuth2");
+    expect(match.score).toBeGreaterThan(0);
+    expect(queryResult.usage).toHaveLength(1);
+    expect(queryResult.usage![0].latencyMs).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("write returns a valid drawer_id in the handle", async () => {
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Database connection pool size increased from 10 to 50.",
+    });
+
+    const handle = result.records![0];
+    expect(handle.providerRecordId).toMatch(/drawer_/);
+  }, 15_000);
+
+  // ── Scope isolation (wing separation) ────────────────────────────
+
+  it("wing-scoped queries only return content from that wing", async () => {
+    // Write to wing A (project-1)
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "test-co", projectId: "wing-aaa" },
+      source,
+      content: "Wing A exclusive: quantum computing research notes for project alpha.",
+    });
+
+    // Write to wing B (project-2)
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "test-co", projectId: "wing-bbb" },
+      source,
+      content: "Wing B exclusive: mobile app deployment checklist for project beta.",
+    });
+
+    // Query wing A — should find quantum computing, not mobile app
+    const resultA = await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "test-co", projectId: "wing-aaa" },
+      query: "research notes",
+      topK: 5,
+    });
+
+    const textsA = resultA.snippets.map((s) => s.text).join(" ");
+    expect(textsA).toContain("quantum computing");
+
+    // Query wing B — should find mobile app, not quantum computing
+    const resultB = await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "test-co", projectId: "wing-bbb" },
+      query: "deployment checklist",
+      topK: 5,
+    });
+
+    const textsB = resultB.snippets.map((s) => s.text).join(" ");
+    expect(textsB).toContain("mobile app");
+  }, 30_000);
+
+  // ── Company isolation (separate palace directories) ──────────────
+
+  it("separate palace dirs create isolated stores", async () => {
+    const palaceDir2 = mkdtempSync(join(tmpdir(), "mempalace-test-co2-"));
+
+    const adapter2 = createMempalaceMemoryAdapter({
+      command: PYTHON_CMD,
+      args: ["-m", "mempalace.mcp_server"],
+      cwd: palaceDir2,
+      env: { MEMPALACE_PALACE_PATH: palaceDir2 },
+      connectTimeoutMs: 30_000,
+      callTimeoutMs: 30_000,
+    });
+
+    try {
+      await adapter2.connect();
+
+      // Write to company 2's palace
+      await adapter2.write({
+        bindingKey: "default",
+        scope: { companyId: "co-2", projectId: "proj-2" },
+        source: { kind: "test", companyId: "co-2" },
+        content: "Company 2 secret: launch date is July 4th.",
+      });
+
+      // Query company 1's palace for company 2's content — should not find it
+      const result1 = await adapter.query({
+        bindingKey: "default",
+        scope: { companyId: "test-co" },
+        query: "launch date July",
+        topK: 5,
+      });
+
+      const texts1 = result1.snippets.map((s) => s.text).join(" ");
+      expect(texts1).not.toContain("Company 2 secret");
+    } finally {
+      await adapter2.disconnect();
+      try {
+        rmSync(palaceDir2, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }, 45_000);
+
+  // ── Forget ───────────────────────────────────────────────────────
+
+  it("forget deletes drawers so they are no longer returned", async () => {
+    // Write a unique piece of content
+    const writeResult = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Ephemeral secret: the password is swordfish. Delete me immediately.",
+    });
+
+    const handle = writeResult.records![0];
+
+    // Verify it exists via query
+    const beforeForget = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "password swordfish",
+      topK: 3,
+    });
+    expect(beforeForget.snippets.some((s) => s.text.includes("swordfish"))).toBe(true);
+
+    // Forget it
+    const forgetResult = await adapter.forget([handle], scope);
+    expect(forgetResult.usage).toHaveLength(1);
+    expect(forgetResult.usage![0].details?.drawersDeleted).toBe(1);
+
+    // Verify it's gone
+    const afterForget = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "password swordfish",
+      topK: 3,
+    });
+    const stillHasSwordfish = afterForget.snippets.some((s) => s.text.includes("swordfish"));
+    expect(stillHasSwordfish).toBe(false);
+  }, 30_000);
+
+  // ── Sidecar lifecycle ────────────────────────────────────────────
+
+  it("sidecar start/stop/restart lifecycle", async () => {
+    const sidecarDir = mkdtempSync(join(tmpdir(), "mempalace-sidecar-test-"));
+    const statuses: string[] = [];
+
+    const sidecar = createMempalaceSidecar({
+      palaceDir: sidecarDir,
+      pythonCommand: PYTHON_CMD,
+      healthCheckIntervalMs: 60_000, // don't trigger during test
+      onStatusChange: (s) => statuses.push(s),
+    });
+
+    try {
+      expect(sidecar.status).toBe("stopped");
+
+      // Start
+      await sidecar.start();
+      expect(sidecar.status).toBe("running");
+      expect(statuses).toContain("starting");
+      expect(statuses).toContain("running");
+
+      // Adapter should be usable
+      const writeResult = await sidecar.adapter.write({
+        bindingKey: "default",
+        scope: { companyId: "sidecar-co" },
+        source: { kind: "test", companyId: "sidecar-co" },
+        content: "Sidecar lifecycle test content.",
+      });
+      expect(writeResult.records).toHaveLength(1);
+
+      // Stop
+      await sidecar.stop();
+      expect(sidecar.status).toBe("stopped");
+      expect(statuses).toContain("stopped");
+    } finally {
+      await sidecar.stop();
+      try {
+        rmSync(sidecarDir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }, 60_000);
+
+  // ── Error handling ───────────────────────────────────────────────
+
+  it("adapter throws when not connected", async () => {
+    const disconnected = createMempalaceMemoryAdapter({
+      command: PYTHON_CMD,
+    });
+
+    await expect(
+      disconnected.write({ bindingKey: "default", scope, source, content: "test" }),
+    ).rejects.toThrow("not connected");
+  });
+
+  it("sidecar fails gracefully with bad python command", async () => {
+    const badDir = mkdtempSync(join(tmpdir(), "mempalace-bad-"));
+    const sidecar = createMempalaceSidecar({
+      palaceDir: badDir,
+      pythonCommand: "/nonexistent/python",
+    });
+
+    try {
+      await expect(sidecar.start()).rejects.toThrow();
+      expect(sidecar.status).toBe("failed");
+    } finally {
+      await sidecar.stop();
+      try {
+        rmSync(badDir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }, 30_000);
+
+  // ── Usage tracking ───────────────────────────────────────────────
+
+  it("write returns usage with latency and method details", async () => {
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Usage tracking test: monitoring latency metrics.",
+    });
+
+    expect(result.usage).toHaveLength(1);
+    const usage = result.usage![0];
+    expect(usage.provider).toBe("mempalace");
+    expect(usage.latencyMs).toBeGreaterThan(0);
+    expect(usage.details?.method).toBe("add_drawer");
+    expect(usage.details?.wing).toBeDefined();
+    expect(usage.details?.room).toBeDefined();
+  }, 15_000);
+
+  it("query returns usage with latency, method, and result count", async () => {
+    const result = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "monitoring",
+      topK: 3,
+    });
+
+    expect(result.usage).toHaveLength(1);
+    const usage = result.usage![0];
+    expect(usage.provider).toBe("mempalace");
+    expect(usage.latencyMs).toBeGreaterThan(0);
+    expect(usage.details?.method).toBe("mempalace_search");
+    expect(typeof usage.details?.resultCount).toBe("number");
+  }, 15_000);
+
+  it("forget returns usage with delete counts", async () => {
+    const writeResult = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Temporary content for usage tracking delete test.",
+    });
+
+    const result = await adapter.forget([writeResult.records![0]], scope);
+    expect(result.usage).toHaveLength(1);
+    const usage = result.usage![0];
+    expect(usage.provider).toBe("mempalace");
+    expect(usage.latencyMs).toBeGreaterThan(0);
+    expect(usage.details?.drawersDeleted).toBe(1);
+    expect(usage.details?.drawersRequested).toBe(1);
+  }, 15_000);
+});

--- a/server/src/__tests__/mempalace-memory-adapter.test.ts
+++ b/server/src/__tests__/mempalace-memory-adapter.test.ts
@@ -123,10 +123,10 @@ describe("MempalaceMemoryAdapter", () => {
     expect(callArgs.arguments.room).toBe("custom-room");
   });
 
-  it("write: upsert does delete then add", async () => {
+  it("write: upsert adds first then deletes old drawer", async () => {
     mockCallTool
-      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-existing" })) // delete
-      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-new" })); // add
+      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-new" })) // add
+      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-existing" })); // delete
 
     await adapter.write({
       bindingKey: "default",
@@ -138,19 +138,19 @@ describe("MempalaceMemoryAdapter", () => {
     });
 
     expect(mockCallTool).toHaveBeenCalledTimes(2);
-    const [deleteCall] = mockCallTool.mock.calls[0];
-    expect(deleteCall.name).toBe("mempalace_delete_drawer");
-    expect(deleteCall.arguments.drawer_id).toBe("d-existing");
-
-    const [addCall] = mockCallTool.mock.calls[1];
+    const [addCall] = mockCallTool.mock.calls[0];
     expect(addCall.name).toBe("mempalace_add_drawer");
     expect(addCall.arguments.content).toBe("Updated content");
+
+    const [deleteCall] = mockCallTool.mock.calls[1];
+    expect(deleteCall.name).toBe("mempalace_delete_drawer");
+    expect(deleteCall.arguments.drawer_id).toBe("d-existing");
   });
 
-  it("write: upsert continues if delete fails (drawer does not exist yet)", async () => {
+  it("write: upsert succeeds even if old drawer delete fails", async () => {
     mockCallTool
-      .mockRejectedValueOnce(new Error("Drawer not found")) // delete fails
-      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-new" })); // add succeeds
+      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-new" })) // add succeeds
+      .mockRejectedValueOnce(new Error("Drawer not found")); // delete fails (best-effort)
 
     const result = await adapter.write({
       bindingKey: "default",

--- a/server/src/__tests__/mempalace-memory-adapter.test.ts
+++ b/server/src/__tests__/mempalace-memory-adapter.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { createMempalaceMemoryAdapter } from "../services/memory-adapters/mempalace.js";
+import type { MemoryScope, MemorySourceRef } from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Mock the MCP SDK — we cannot spawn a real mempalace sidecar in unit tests.
+// Integration tests with a live sidecar are in mempalace-integration.test.ts.
+// ---------------------------------------------------------------------------
+
+const mockCallTool = vi.fn();
+const mockConnect = vi.fn();
+const mockClose = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    close: mockClose,
+    callTool: mockCallTool,
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+const scope: MemoryScope = { companyId: "co-1", agentId: "agent-1", projectId: "proj-1" };
+const source: MemorySourceRef = { kind: "manual_note", companyId: "co-1" };
+
+function textResult(text: string) {
+  return { content: [{ type: "text", text }] };
+}
+
+function jsonResult(data: unknown) {
+  return textResult(JSON.stringify(data));
+}
+
+/** Builds a mempalace-style search response. */
+function searchResult(results: Array<{ text: string; wing?: string; room?: string; similarity?: number; source_file?: string }>) {
+  return jsonResult({ query: "test", filters: {}, results });
+}
+
+describe("MempalaceMemoryAdapter", () => {
+  let adapter: ReturnType<typeof createMempalaceMemoryAdapter>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+    adapter = createMempalaceMemoryAdapter({ command: "python", args: ["-m", "mempalace.mcp_server"] });
+    await adapter.connect();
+  });
+
+  afterEach(async () => {
+    mockClose.mockResolvedValue(undefined);
+    await adapter.disconnect();
+  });
+
+  // ── Identity ────────────────────────────────────────────────────────
+
+  it("has key 'mempalace' and declares browse/async/extraction capabilities", () => {
+    expect(adapter.key).toBe("mempalace");
+    expect(adapter.capabilities).toEqual({
+      profile: false,
+      browse: true,
+      correction: false,
+      asyncIngestion: true,
+      multimodal: false,
+      providerManagedExtraction: true,
+    });
+  });
+
+  it("reports connected state correctly", async () => {
+    expect(adapter.connected).toBe(true);
+    mockClose.mockResolvedValue(undefined);
+    await adapter.disconnect();
+    expect(adapter.connected).toBe(false);
+  });
+
+  // ── Write ───────────────────────────────────────────────────────────
+
+  it("write: calls mempalace_add_drawer with wing/room/source_file/added_by", async () => {
+    mockCallTool.mockResolvedValue(
+      jsonResult({ success: true, drawer_id: "d-001", wing: "project-proj-1", room: "default" }),
+    );
+
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Meeting notes about auth redesign",
+    });
+
+    expect(mockCallTool).toHaveBeenCalledTimes(1);
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_add_drawer");
+    expect(callArgs.arguments.content).toBe("Meeting notes about auth redesign");
+    expect(callArgs.arguments.wing).toBe("project-proj-1");
+    expect(callArgs.arguments.room).toBe("default"); // no issueId → default room
+    expect(callArgs.arguments.source_file).toBeDefined();
+    expect(callArgs.arguments.added_by).toBe("paperclip");
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records![0].providerKey).toBe("mempalace");
+    expect(result.records![0].providerRecordId).toContain("d-001");
+    expect(result.usage).toHaveLength(1);
+    expect(result.usage![0].provider).toBe("mempalace");
+  });
+
+  it("write: uses metadata.wing/room overrides when provided", async () => {
+    mockCallTool.mockResolvedValue(
+      jsonResult({ success: true, drawer_id: "d-002" }),
+    );
+
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Custom wing content",
+      metadata: { wing: "custom-wing", room: "custom-room" },
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.arguments.wing).toBe("custom-wing");
+    expect(callArgs.arguments.room).toBe("custom-room");
+  });
+
+  it("write: upsert does delete then add", async () => {
+    mockCallTool
+      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-existing" })) // delete
+      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-new" })); // add
+
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Updated content",
+      mode: "upsert",
+      metadata: { drawerId: "d-existing" },
+    });
+
+    expect(mockCallTool).toHaveBeenCalledTimes(2);
+    const [deleteCall] = mockCallTool.mock.calls[0];
+    expect(deleteCall.name).toBe("mempalace_delete_drawer");
+    expect(deleteCall.arguments.drawer_id).toBe("d-existing");
+
+    const [addCall] = mockCallTool.mock.calls[1];
+    expect(addCall.name).toBe("mempalace_add_drawer");
+    expect(addCall.arguments.content).toBe("Updated content");
+  });
+
+  it("write: upsert continues if delete fails (drawer does not exist yet)", async () => {
+    mockCallTool
+      .mockRejectedValueOnce(new Error("Drawer not found")) // delete fails
+      .mockResolvedValueOnce(jsonResult({ success: true, drawer_id: "d-new" })); // add succeeds
+
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "New content via upsert",
+      mode: "upsert",
+      metadata: { drawerId: "d-missing" },
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.usage![0].details?.method).toBe("upsert_drawer");
+  });
+
+  it("write: includes source provenance as source_file", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-003" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source: { kind: "issue_comment", companyId: "co-1", issueId: "issue-99" },
+      content: "Comment content",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.arguments.source_file).toContain("issue_comment");
+    expect(callArgs.arguments.source_file).toContain("issue:issue-99");
+  });
+
+  it("write: defaults wing to 'general' and room to 'default' when scope has no project/agent/issue", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-004" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1" },
+      source,
+      content: "Global content",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.arguments.wing).toBe("general");
+    expect(callArgs.arguments.room).toBe("default");
+  });
+
+  // ── Query ───────────────────────────────────────────────────────────
+
+  it("query: uses mempalace_status for agent_preamble intent", async () => {
+    mockCallTool.mockResolvedValue(
+      textResult("Palace: 42 drawers, 3 wings, 7 rooms"),
+    );
+
+    const result = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "",
+      intent: "agent_preamble",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_status");
+
+    expect(result.snippets).toHaveLength(1);
+    expect(result.snippets[0].text).toContain("42 drawers");
+    expect(result.profileSummary).toContain("42 drawers");
+  });
+
+  it("query: uses mempalace_search for global search", async () => {
+    mockCallTool.mockResolvedValue(
+      searchResult([
+        { text: "Auth service deployment", similarity: 0.95, wing: "proj-a", room: "deploys" },
+        { text: "Auth migration notes", similarity: 0.82, wing: "proj-a", room: "notes" },
+      ]),
+    );
+
+    const result = await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "co-1" },
+      query: "authentication deployment",
+      topK: 5,
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_search");
+    expect(callArgs.arguments.query).toBe("authentication deployment");
+    expect(callArgs.arguments.limit).toBe(5);
+    // No wing/room when scope only has companyId
+    expect(callArgs.arguments.wing).toBeUndefined();
+
+    expect(result.snippets).toHaveLength(2);
+    expect(result.snippets[0].text).toBe("Auth service deployment");
+    expect(result.snippets[0].score).toBe(0.95);
+    expect(result.snippets[0].handle.providerKey).toBe("mempalace");
+  });
+
+  it("query: passes wing filter when project scope available", async () => {
+    mockCallTool.mockResolvedValue(searchResult([]));
+
+    await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "co-1", projectId: "proj-1" },
+      query: "test query",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_search");
+    expect(callArgs.arguments.wing).toBe("project-proj-1");
+    expect(callArgs.arguments.room).toBeUndefined();
+  });
+
+  it("query: passes wing and room filters when issue scope available", async () => {
+    mockCallTool.mockResolvedValue(searchResult([]));
+
+    await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "co-1", projectId: "proj-1", issueId: "iss-1" },
+      query: "test query",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_search");
+    expect(callArgs.arguments.wing).toBe("project-proj-1");
+    expect(callArgs.arguments.room).toBe("issue-iss-1");
+  });
+
+  it("query: falls back to single snippet for non-JSON response", async () => {
+    mockCallTool.mockResolvedValue(textResult("Plain text search results here"));
+
+    const result = await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "co-1" },
+      query: "something",
+    });
+
+    expect(result.snippets).toHaveLength(1);
+    expect(result.snippets[0].text).toBe("Plain text search results here");
+  });
+
+  it("query: respects metadataFilter overrides for wing/room", async () => {
+    mockCallTool.mockResolvedValue(searchResult([]));
+
+    await adapter.query({
+      bindingKey: "default",
+      scope: { companyId: "co-1" },
+      query: "query",
+      metadataFilter: { wing: "override-wing", room: "override-room" },
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_search");
+    expect(callArgs.arguments.wing).toBe("override-wing");
+    expect(callArgs.arguments.room).toBe("override-room");
+  });
+
+  // ── Get ─────────────────────────────────────────────────────────────
+
+  it("get: retrieves a drawer via search with results wrapper", async () => {
+    mockCallTool.mockResolvedValue(
+      searchResult([{ text: "Drawer content here", wing: "w1", room: "r1", similarity: 0.99 }]),
+    );
+
+    const snippet = await adapter.get(
+      { providerKey: "mempalace", providerRecordId: "w1/r1/d-10" },
+      scope,
+    );
+
+    expect(snippet).not.toBeNull();
+    expect(snippet!.text).toBe("Drawer content here");
+    expect(snippet!.metadata?.drawer_id).toBe("d-10");
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.name).toBe("mempalace_search");
+    expect(callArgs.arguments.wing).toBe("w1");
+    expect(callArgs.arguments.room).toBe("r1");
+  });
+
+  it("get: returns null when search returns empty results", async () => {
+    mockCallTool.mockResolvedValue(searchResult([]));
+
+    const snippet = await adapter.get(
+      { providerKey: "mempalace", providerRecordId: "nonexistent" },
+      scope,
+    );
+    expect(snippet).toBeNull();
+  });
+
+  it("get: returns null on error", async () => {
+    mockCallTool.mockRejectedValue(new Error("Connection lost"));
+
+    const snippet = await adapter.get(
+      { providerKey: "mempalace", providerRecordId: "d-bad" },
+      scope,
+    );
+    expect(snippet).toBeNull();
+  });
+
+  // ── Forget ──────────────────────────────────────────────────────────
+
+  it("forget: calls mempalace_delete_drawer with only drawer_id", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true }));
+
+    const result = await adapter.forget(
+      [
+        { providerKey: "mempalace", providerRecordId: "w1/r1/d-10" },
+        { providerKey: "mempalace", providerRecordId: "d-20" },
+      ],
+      scope,
+    );
+
+    expect(mockCallTool).toHaveBeenCalledTimes(2);
+
+    const [call1] = mockCallTool.mock.calls[0];
+    expect(call1.name).toBe("mempalace_delete_drawer");
+    expect(call1.arguments.drawer_id).toBe("d-10");
+    expect(call1.arguments.wing).toBeUndefined();
+    expect(call1.arguments.room).toBeUndefined();
+
+    const [call2] = mockCallTool.mock.calls[1];
+    expect(call2.name).toBe("mempalace_delete_drawer");
+    expect(call2.arguments.drawer_id).toBe("d-20");
+
+    expect(result.usage![0].details?.drawersDeleted).toBe(2);
+    expect(result.usage![0].details?.drawersRequested).toBe(2);
+  });
+
+  it("forget: continues on individual delete errors", async () => {
+    mockCallTool
+      .mockRejectedValueOnce(new Error("Not found"))
+      .mockResolvedValueOnce(jsonResult({ success: true }));
+
+    const result = await adapter.forget(
+      [
+        { providerKey: "mempalace", providerRecordId: "d-bad" },
+        { providerKey: "mempalace", providerRecordId: "d-good" },
+      ],
+      scope,
+    );
+
+    expect(result.usage![0].details?.drawersDeleted).toBe(1);
+    expect(result.usage![0].details?.drawersRequested).toBe(2);
+  });
+
+  // ── Connection lifecycle ────────────────────────────────────────────
+
+  it("throws when calling operations before connect", async () => {
+    const disconnected = createMempalaceMemoryAdapter({ command: "python" });
+
+    await expect(
+      disconnected.write({ bindingKey: "default", scope, source, content: "test" }),
+    ).rejects.toThrow("not connected");
+  });
+
+  it("connect is idempotent", async () => {
+    // adapter is already connected from beforeEach
+    await adapter.connect();
+    expect(mockConnect).toHaveBeenCalledTimes(1); // only the initial connect
+  });
+
+  it("disconnect is idempotent", async () => {
+    mockClose.mockResolvedValue(undefined);
+    await adapter.disconnect();
+    await adapter.disconnect();
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Handle encoding ─────────────────────────────────────────────────
+
+  it("encodes handles with wing/room/drawerId", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "abc" }));
+
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1", projectId: "proj-1", issueId: "iss-1" },
+      source,
+      content: "test",
+    });
+
+    const handle = result.records![0];
+    expect(handle.providerRecordId).toBe("project-proj-1/issue-iss-1/abc");
+  });
+
+  // ── Scope mapping ──────────────────────────────────────────────────
+
+  it("maps projectId to wing, issueId to room", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-1" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1", projectId: "proj-abc", issueId: "iss-xyz" },
+      source,
+      content: "test",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.arguments.wing).toBe("project-proj-abc");
+    expect(callArgs.arguments.room).toBe("issue-iss-xyz");
+  });
+
+  it("maps agentId to wing when no projectId", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-1" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1", agentId: "agent-abc" },
+      source,
+      content: "test",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.arguments.wing).toBe("agent-agent-ab");
+  });
+
+  it("companyId alone defaults wing to 'general' (process-level isolation)", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-1" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1" },
+      source,
+      content: "test",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    expect(callArgs.arguments.wing).toBe("general");
+  });
+
+  it("runId is passed in source_file provenance, not as room", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-1" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1", projectId: "proj-1", runId: "run-abc123" },
+      source: { kind: "manual_note", companyId: "co-1", runId: "run-abc123" },
+      content: "test",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    // runId should not map to room
+    expect(callArgs.arguments.room).toBe("default");
+    // runId should appear in source_file provenance
+    expect(callArgs.arguments.source_file).toContain("run:run-abc1");
+  });
+
+  it("builds source_file provenance from scope and source", async () => {
+    mockCallTool.mockResolvedValue(jsonResult({ success: true, drawer_id: "d-1" }));
+
+    await adapter.write({
+      bindingKey: "default",
+      scope: { companyId: "co-1", agentId: "agent-x" },
+      source: { kind: "issue_comment", companyId: "co-1", issueId: "iss-1" },
+      content: "test",
+    });
+
+    const [callArgs] = mockCallTool.mock.calls[0];
+    const sourceFile = callArgs.arguments.source_file as string;
+    expect(sourceFile).toContain("issue_comment");
+    expect(sourceFile).toContain("issue:iss-1");
+    expect(sourceFile).toContain("agent:agent-x");
+  });
+});

--- a/server/src/__tests__/mempalace-sidecar.test.ts
+++ b/server/src/__tests__/mempalace-sidecar.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { createMempalaceSidecar, type SidecarStatus } from "../services/memory-adapters/mempalace-sidecar.js";
+
+// ---------------------------------------------------------------------------
+// Mock the MCP SDK so we don't spawn real processes
+// ---------------------------------------------------------------------------
+
+const mockCallTool = vi.fn();
+const mockConnect = vi.fn();
+const mockClose = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    close: mockClose,
+    callTool: mockCallTool,
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe("MempalaceSidecar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockConnect.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── Lifecycle ───────────────────────────────────────────────────────
+
+  it("starts in stopped state", () => {
+    const sidecar = createMempalaceSidecar({ palaceDir: "/tmp/palace" });
+    expect(sidecar.status).toBe("stopped");
+    expect(sidecar.restartCount).toBe(0);
+  });
+
+  it("start transitions to running", async () => {
+    const statuses: SidecarStatus[] = [];
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      onStatusChange: (s) => statuses.push(s),
+    });
+
+    await sidecar.start();
+
+    expect(sidecar.status).toBe("running");
+    expect(statuses).toEqual(["starting", "running"]);
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    await sidecar.stop();
+  });
+
+  it("start is idempotent when already running", async () => {
+    const sidecar = createMempalaceSidecar({ palaceDir: "/tmp/palace" });
+    await sidecar.start();
+    await sidecar.start();
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    await sidecar.stop();
+  });
+
+  it("stop transitions to stopped and disconnects", async () => {
+    const sidecar = createMempalaceSidecar({ palaceDir: "/tmp/palace" });
+    await sidecar.start();
+    await sidecar.stop();
+
+    expect(sidecar.status).toBe("stopped");
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop is idempotent", async () => {
+    const sidecar = createMempalaceSidecar({ palaceDir: "/tmp/palace" });
+    await sidecar.start();
+    await sidecar.stop();
+    await sidecar.stop();
+
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("start fails and sets status to failed on connect error", async () => {
+    mockConnect.mockRejectedValue(new Error("Python not found"));
+
+    const sidecar = createMempalaceSidecar({ palaceDir: "/tmp/palace" });
+    await expect(sidecar.start()).rejects.toThrow("Python not found");
+
+    expect(sidecar.status).toBe("failed");
+  });
+
+  // ── Per-company isolation ───────────────────────────────────────────
+
+  it("passes palaceDir as cwd and MEMPALACE_PALACE_DIR env", async () => {
+    const { StdioClientTransport } = await import(
+      "@modelcontextprotocol/sdk/client/stdio.js"
+    );
+
+    createMempalaceSidecar({ palaceDir: "/data/company-abc" });
+
+    // The adapter constructor creates the transport config — verify via mock
+    // The transport is created lazily on connect, but the config is set up
+    // We can verify by starting and checking the transport was created correctly
+    // Since StdioClientTransport is mocked, we check the constructor call
+    // after start() triggers adapter.connect()
+  });
+
+  // ── Health checking ─────────────────────────────────────────────────
+
+  it("health check succeeds when query works", async () => {
+    mockCallTool.mockResolvedValue({
+      content: [{ type: "text", text: "[]" }],
+    });
+
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      healthCheckIntervalMs: 1000,
+    });
+    await sidecar.start();
+
+    // Advance past health check interval
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(sidecar.status).toBe("running");
+    expect(mockCallTool).toHaveBeenCalled();
+
+    await sidecar.stop();
+  });
+
+  it("health check failure triggers restart schedule", async () => {
+    mockCallTool.mockRejectedValue(new Error("connection dead"));
+
+    const logs: string[] = [];
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      healthCheckIntervalMs: 1000,
+      restartBaseDelayMs: 500,
+      onLog: (_stream, msg) => logs.push(msg),
+    });
+    await sidecar.start();
+
+    // Trigger health check failure
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(sidecar.status).toBe("unhealthy");
+    expect(logs.some((l) => l.includes("scheduling restart"))).toBe(true);
+
+    await sidecar.stop();
+  });
+
+  // ── Restart with backoff ────────────────────────────────────────────
+
+  it("restarts with exponential backoff on failure", async () => {
+    mockCallTool.mockRejectedValue(new Error("dead"));
+
+    const statuses: SidecarStatus[] = [];
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      healthCheckIntervalMs: 1000,
+      restartBaseDelayMs: 2000, // longer than health check so we can observe unhealthy
+      maxRestartAttempts: 3,
+      onStatusChange: (s) => statuses.push(s),
+    });
+    await sidecar.start();
+
+    // Trigger health check failure → status goes unhealthy, restart scheduled at 2000ms
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(sidecar.status).toBe("unhealthy");
+
+    // Restart #1 succeeds (re-connect works)
+    mockConnect.mockResolvedValue(undefined);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sidecar.restartCount).toBe(0); // reset on success
+    expect(sidecar.status).toBe("running");
+
+    await sidecar.stop();
+  });
+
+  it("marks as failed after max restart attempts", async () => {
+    mockCallTool.mockRejectedValue(new Error("dead"));
+    // Make connect fail on restarts too
+    let connectCalls = 0;
+    mockConnect.mockImplementation(() => {
+      connectCalls++;
+      if (connectCalls > 1) return Promise.reject(new Error("still dead"));
+      return Promise.resolve();
+    });
+
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      healthCheckIntervalMs: 500,
+      restartBaseDelayMs: 100,
+      restartMaxDelayMs: 400,
+      maxRestartAttempts: 3,
+    });
+    await sidecar.start();
+
+    // Health check fails → restart #1 at 100ms
+    await vi.advanceTimersByTimeAsync(600);
+    // Restart #1 fails → restart #2 at 200ms
+    await vi.advanceTimersByTimeAsync(200);
+    // Restart #2 fails → restart #3 at 400ms (capped)
+    await vi.advanceTimersByTimeAsync(400);
+    // Restart #3 fails → max attempts exceeded → failed
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sidecar.status).toBe("failed");
+
+    await sidecar.stop();
+  });
+
+  it("stop cancels pending restarts", async () => {
+    mockCallTool.mockRejectedValue(new Error("dead"));
+
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      healthCheckIntervalMs: 500,
+      restartBaseDelayMs: 5000,
+    });
+    await sidecar.start();
+
+    // Health check fails → schedules restart at 5000ms
+    await vi.advanceTimersByTimeAsync(600);
+    expect(sidecar.status).toBe("unhealthy");
+
+    // Stop before restart fires
+    await sidecar.stop();
+    expect(sidecar.status).toBe("stopped");
+
+    // Advance past restart time — should not attempt reconnect
+    const connectCallsBefore = mockConnect.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(mockConnect.mock.calls.length).toBe(connectCallsBefore);
+  });
+
+  // ── Logging ─────────────────────────────────────────────────────────
+
+  it("emits structured log messages with sidecar prefix", async () => {
+    const logs: Array<{ stream: string; msg: string }> = [];
+    const sidecar = createMempalaceSidecar({
+      palaceDir: "/tmp/palace",
+      onLog: (stream, msg) => logs.push({ stream, msg }),
+    });
+
+    await sidecar.start();
+    await sidecar.stop();
+
+    expect(logs.some((l) => l.msg.includes("[mempalace-sidecar]"))).toBe(true);
+    expect(logs.some((l) => l.msg.includes("running"))).toBe(true);
+    expect(logs.some((l) => l.msg.includes("stopped"))).toBe(true);
+  });
+
+  // ── Adapter access ─────────────────────────────────────────────────
+
+  it("exposes the underlying adapter", async () => {
+    const sidecar = createMempalaceSidecar({ palaceDir: "/tmp/palace" });
+
+    expect(sidecar.adapter).toBeDefined();
+    expect(sidecar.adapter.key).toBe("mempalace");
+    expect(sidecar.adapter.capabilities.browse).toBe(true);
+  });
+});

--- a/server/src/__tests__/mempalace-sidecar.test.ts
+++ b/server/src/__tests__/mempalace-sidecar.test.ts
@@ -8,12 +8,14 @@ import { createMempalaceSidecar, type SidecarStatus } from "../services/memory-a
 const mockCallTool = vi.fn();
 const mockConnect = vi.fn();
 const mockClose = vi.fn();
+const mockPing = vi.fn();
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
   Client: vi.fn().mockImplementation(() => ({
     connect: mockConnect,
     close: mockClose,
     callTool: mockCallTool,
+    ping: mockPing,
   })),
 }));
 
@@ -111,10 +113,8 @@ describe("MempalaceSidecar", () => {
 
   // ── Health checking ─────────────────────────────────────────────────
 
-  it("health check succeeds when query works", async () => {
-    mockCallTool.mockResolvedValue({
-      content: [{ type: "text", text: "[]" }],
-    });
+  it("health check succeeds when ping works", async () => {
+    mockPing.mockResolvedValue(undefined);
 
     const sidecar = createMempalaceSidecar({
       palaceDir: "/tmp/palace",
@@ -126,13 +126,13 @@ describe("MempalaceSidecar", () => {
     await vi.advanceTimersByTimeAsync(1100);
 
     expect(sidecar.status).toBe("running");
-    expect(mockCallTool).toHaveBeenCalled();
+    expect(mockPing).toHaveBeenCalled();
 
     await sidecar.stop();
   });
 
   it("health check failure triggers restart schedule", async () => {
-    mockCallTool.mockRejectedValue(new Error("connection dead"));
+    mockPing.mockRejectedValue(new Error("connection dead"));
 
     const logs: string[] = [];
     const sidecar = createMempalaceSidecar({
@@ -155,7 +155,7 @@ describe("MempalaceSidecar", () => {
   // ── Restart with backoff ────────────────────────────────────────────
 
   it("restarts with exponential backoff on failure", async () => {
-    mockCallTool.mockRejectedValue(new Error("dead"));
+    mockPing.mockRejectedValue(new Error("dead"));
 
     const statuses: SidecarStatus[] = [];
     const sidecar = createMempalaceSidecar({
@@ -182,7 +182,7 @@ describe("MempalaceSidecar", () => {
   });
 
   it("marks as failed after max restart attempts", async () => {
-    mockCallTool.mockRejectedValue(new Error("dead"));
+    mockPing.mockRejectedValue(new Error("dead"));
     // Make connect fail on restarts too
     let connectCalls = 0;
     mockConnect.mockImplementation(() => {

--- a/server/src/__tests__/para-memory-adapter.test.ts
+++ b/server/src/__tests__/para-memory-adapter.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createParaMemoryAdapter } from "../services/memory-adapters/para.js";
+import type { MemoryScope, MemorySourceRef } from "@paperclipai/plugin-sdk";
+
+function makeTempDir() {
+  return mkdtempSync(join(tmpdir(), "para-test-"));
+}
+
+const scope: MemoryScope = { companyId: "co-1", agentId: "agent-1" };
+const source: MemorySourceRef = { kind: "manual_note", companyId: "co-1" };
+
+describe("ParaMemoryAdapter", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("has key 'para' and declares no optional capabilities", () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    expect(adapter.key).toBe("para");
+    expect(adapter.capabilities).toEqual({
+      profile: false,
+      browse: false,
+      correction: false,
+      asyncIngestion: false,
+      multimodal: false,
+      providerManagedExtraction: false,
+    });
+  });
+
+  // ── Write ────────────────────────────────────────────────────────────
+
+  it("write: creates a daily note by default", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Shipped the feature",
+      metadata: { date: "2026-04-07" },
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records![0].providerKey).toBe("para");
+    expect(result.records![0].providerRecordId).toContain("memory/2026-04-07.md");
+    expect(result.usage).toHaveLength(1);
+    expect(result.usage![0].provider).toBe("para");
+
+    const content = readFileSync(join(dir, "memory", "2026-04-07.md"), "utf8");
+    expect(content).toContain("Shipped the feature");
+  });
+
+  it("write: creates an entity fact in items.yaml", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const result = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Works on infrastructure team",
+      metadata: { layer: "entity", entityPath: "areas/people/alice", category: "status" },
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records![0].providerRecordId).toContain("#");
+
+    const yaml = readFileSync(join(dir, "life", "areas", "people", "alice", "items.yaml"), "utf8");
+    expect(yaml).toContain("Works on infrastructure team");
+    expect(yaml).toContain("status: active");
+  });
+
+  it("write: upserts an existing entity fact", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+
+    // First write
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Original fact",
+      metadata: { layer: "entity", entityPath: "areas/people/bob", factId: "bob-001" },
+    });
+
+    // Upsert same factId
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Updated fact",
+      metadata: { layer: "entity", entityPath: "areas/people/bob", factId: "bob-001" },
+      mode: "upsert",
+    });
+
+    const yaml = readFileSync(join(dir, "life", "areas", "people", "bob", "items.yaml"), "utf8");
+    expect(yaml).toContain("Updated fact");
+    // Should not have duplicated the fact
+    expect(yaml.match(/bob-001/g)?.length).toBe(1);
+  });
+
+  it("write: appends to tacit knowledge (MEMORY.md)", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "User prefers terse output",
+      metadata: { layer: "tacit" },
+    });
+
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "User is a morning person",
+      metadata: { layer: "tacit" },
+    });
+
+    const content = readFileSync(join(dir, "MEMORY.md"), "utf8");
+    expect(content).toContain("User prefers terse output");
+    expect(content).toContain("User is a morning person");
+  });
+
+  // ── Get ──────────────────────────────────────────────────────────────
+
+  it("get: retrieves a daily note by handle", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const { records } = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Met with client",
+      metadata: { date: "2026-04-07" },
+    });
+
+    const snippet = await adapter.get(records![0], scope);
+    expect(snippet).not.toBeNull();
+    expect(snippet!.text).toContain("Met with client");
+  });
+
+  it("get: retrieves a single entity fact by handle", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const { records } = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Leads the platform team",
+      metadata: { layer: "entity", entityPath: "areas/people/carol", factId: "carol-001" },
+    });
+
+    const snippet = await adapter.get(records![0], scope);
+    expect(snippet).not.toBeNull();
+    expect(snippet!.text).toBe("Leads the platform team");
+    expect(snippet!.metadata?.id).toBe("carol-001");
+    expect(snippet!.metadata?.status).toBe("active");
+  });
+
+  it("get: returns null for missing file", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const snippet = await adapter.get(
+      { providerKey: "para", providerRecordId: "nonexistent.md" },
+      scope,
+    );
+    expect(snippet).toBeNull();
+  });
+
+  // ── Query ────────────────────────────────────────────────────────────
+
+  it("query: keyword search finds matching content", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Deployed the authentication service",
+      metadata: { date: "2026-04-06" },
+    });
+    await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Fixed database migration bug",
+      metadata: { date: "2026-04-07" },
+    });
+
+    const result = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "authentication service",
+      topK: 5,
+    });
+
+    expect(result.snippets.length).toBeGreaterThanOrEqual(1);
+    expect(result.snippets[0].text).toContain("authentication");
+    expect(result.usage).toHaveLength(1);
+  });
+
+  it("query: returns empty for no matches", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const result = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "quantum entanglement",
+      topK: 5,
+    });
+    expect(result.snippets).toHaveLength(0);
+  });
+
+  // ── Forget ───────────────────────────────────────────────────────────
+
+  it("forget: supersedes an entity fact (never deletes)", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const { records } = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Outdated fact",
+      metadata: { layer: "entity", entityPath: "areas/people/dave", factId: "dave-001" },
+    });
+
+    const result = await adapter.forget(records!, scope);
+    expect(result.usage).toHaveLength(1);
+    expect(result.usage![0].details?.factsSuperseded).toBe(1);
+
+    // The fact should still exist but be superseded
+    const snippet = await adapter.get(records![0], scope);
+    expect(snippet).not.toBeNull();
+    expect(snippet!.metadata?.status).toBe("superseded");
+
+    // The file should still exist
+    expect(existsSync(join(dir, "life", "areas", "people", "dave", "items.yaml"))).toBe(true);
+  });
+
+  it("forget: is idempotent for already-superseded facts", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+    const { records } = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Old info",
+      metadata: { layer: "entity", entityPath: "resources/misc", factId: "misc-001" },
+    });
+
+    await adapter.forget(records!, scope);
+    const result = await adapter.forget(records!, scope);
+    expect(result.usage![0].details?.factsSuperseded).toBe(0);
+  });
+
+  // ── Full roundtrip ──────────────────────────────────────────────────
+
+  it("validates full path: write → get → query → forget", async () => {
+    const adapter = createParaMemoryAdapter({ basePath: dir });
+
+    // Write
+    const { records } = await adapter.write({
+      bindingKey: "default",
+      scope,
+      source,
+      content: "Paperclip memory integration works end-to-end",
+      metadata: { layer: "entity", entityPath: "projects/paperclip", factId: "pap-001" },
+    });
+    expect(records).toHaveLength(1);
+
+    // Get
+    const snippet = await adapter.get(records![0], scope);
+    expect(snippet!.text).toBe("Paperclip memory integration works end-to-end");
+
+    // Query
+    const queryResult = await adapter.query({
+      bindingKey: "default",
+      scope,
+      query: "paperclip memory integration",
+    });
+    expect(queryResult.snippets.length).toBeGreaterThanOrEqual(1);
+
+    // Forget
+    const forgetResult = await adapter.forget(records!, scope);
+    expect(forgetResult.usage![0].details?.factsSuperseded).toBe(1);
+
+    // Verify superseded
+    const after = await adapter.get(records![0], scope);
+    expect(after!.metadata?.status).toBe("superseded");
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -30,6 +30,12 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { memoryBindingRoutes } from "./routes/memory-bindings.js";
+import { memoryOperationRoutes } from "./routes/memory-operations.js";
+import { registerMemoryAdapter } from "./services/memory-operations.js";
+import { createParaMemoryAdapter } from "./services/memory-adapters/index.js";
+import { createMempalaceMemoryAdapter } from "./services/memory-adapters/index.js";
+import { createMempalaceSidecar, type MempalaceSidecar } from "./services/memory-adapters/index.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
@@ -163,6 +169,65 @@ export async function createApp(
   api.use(approvalRoutes(db));
   api.use(secretRoutes(db));
   api.use(costRoutes(db));
+  api.use(memoryBindingRoutes(db));
+  api.use(memoryOperationRoutes(db));
+
+  // Register built-in memory adapters
+  registerMemoryAdapter(createParaMemoryAdapter({ basePath: process.cwd() }));
+
+  // Optionally enable mempalace — two modes:
+  //   MEMPALACE_URL  → remote: connect to an existing mempalace MCP server (Docker/Podman)
+  //   MEMPALACE_ENABLED=true → local: spawn a child-process sidecar
+  let mempalaceSidecar: MempalaceSidecar | null = null;
+  const mempalaceUrl = process.env.MEMPALACE_URL;
+  if (mempalaceUrl) {
+    // Remote mode: connect to mempalace running in another container / host
+    const adapter = createMempalaceMemoryAdapter({
+      url: mempalaceUrl,
+      connectTimeoutMs: 15_000,
+      callTimeoutMs: 30_000,
+    });
+    try {
+      await adapter.connect();
+      registerMemoryAdapter(adapter);
+      logger.info({ url: mempalaceUrl }, "mempalace remote adapter connected and registered");
+    } catch (err) {
+      logger.error(
+        { err, url: mempalaceUrl },
+        "mempalace remote connection failed — mempalace adapter will not be available",
+      );
+    }
+  } else if (process.env.MEMPALACE_ENABLED === "true") {
+    // Local mode: spawn mempalace as a child process
+    const palaceDir = process.env.MEMPALACE_PALACE_DIR ?? path.join(process.cwd(), ".mempalace");
+    const pythonCommand = process.env.MEMPALACE_PYTHON_COMMAND ?? "python";
+    mempalaceSidecar = createMempalaceSidecar({
+      palaceDir,
+      pythonCommand,
+      onLog: (stream, data) => {
+        if (stream === "stderr") {
+          logger.warn({ sidecar: "mempalace" }, data);
+        } else {
+          logger.info({ sidecar: "mempalace" }, data);
+        }
+      },
+      onStatusChange: (status, error) => {
+        logger.info({ sidecar: "mempalace", status, error }, "mempalace sidecar status changed");
+      },
+    });
+    try {
+      await mempalaceSidecar.start();
+      registerMemoryAdapter(mempalaceSidecar.adapter);
+      logger.info({ palaceDir, pythonCommand }, "mempalace sidecar started and adapter registered");
+    } catch (err) {
+      logger.error(
+        { err, palaceDir, pythonCommand },
+        "mempalace sidecar failed to start — mempalace adapter will not be available",
+      );
+      mempalaceSidecar = null;
+    }
+  }
+
   api.use(activityRoutes(db));
   api.use(dashboardRoutes(db));
   api.use(sidebarBadgeRoutes(db));
@@ -336,6 +401,9 @@ export async function createApp(
   process.once("exit", () => {
     if (feedbackExportTimer) clearInterval(feedbackExportTimer);
     devWatcher?.close();
+    if (mempalaceSidecar) {
+      void mempalaceSidecar.stop();
+    }
     hostServiceCleanup.disposeAll();
     hostServiceCleanup.teardown();
   });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -398,12 +398,24 @@ export async function createApp(
   }).catch((err) => {
     logger.error({ err }, "Failed to load ready plugins on startup");
   });
+  // Async cleanup for mempalace sidecar — must happen before process.exit().
+  // The "exit" event is synchronous and cannot await promises, so we use
+  // signal handlers that fire before the index.ts shutdown calls process.exit(0).
+  const stopMempalace = async () => {
+    if (mempalaceSidecar) {
+      try {
+        await mempalaceSidecar.stop();
+      } catch (err) {
+        logger.warn({ err }, "mempalace sidecar stop failed during shutdown");
+      }
+    }
+  };
+  process.on("SIGTERM", () => { void stopMempalace(); });
+  process.on("SIGINT", () => { void stopMempalace(); });
+
   process.once("exit", () => {
     if (feedbackExportTimer) clearInterval(feedbackExportTimer);
     devWatcher?.close();
-    if (mempalaceSidecar) {
-      void mempalaceSidecar.stop();
-    }
     hostServiceCleanup.disposeAll();
     hostServiceCleanup.teardown();
   });

--- a/server/src/routes/memory-bindings.ts
+++ b/server/src/routes/memory-bindings.ts
@@ -174,6 +174,10 @@ export function memoryBindingRoutes(db: Db) {
           return;
         }
       }
+      if (req.body.targetType === "company" && req.body.targetId !== binding.companyId) {
+        res.status(403).json({ error: "Company target must match the binding's company" });
+        return;
+      }
 
       let target;
       try {

--- a/server/src/routes/memory-bindings.ts
+++ b/server/src/routes/memory-bindings.ts
@@ -1,0 +1,230 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import {
+  createMemoryBindingSchema,
+  updateMemoryBindingSchema,
+  createMemoryBindingTargetSchema,
+} from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { logActivity, memoryBindingService } from "../services/index.js";
+
+export function memoryBindingRoutes(db: Db) {
+  const router = Router();
+  const svc = memoryBindingService(db);
+
+  // ── Bindings (company-scoped) ────────────────────────────────────
+
+  /** List all memory bindings for a company. */
+  router.get("/companies/:companyId/memory-bindings", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const bindings = await svc.list(companyId);
+    res.json(bindings);
+  });
+
+  /** Create a new memory binding. */
+  router.post(
+    "/companies/:companyId/memory-bindings",
+    validate(createMemoryBindingSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+
+      const binding = await svc.create(companyId, req.body);
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "memory_binding.created",
+        entityType: "memory_binding",
+        entityId: binding.id,
+        details: { key: binding.key, providerKey: binding.providerKey },
+      });
+
+      res.status(201).json(binding);
+    },
+  );
+
+  // ── Bindings (by ID) ─────────────────────────────────────────────
+
+  /** Get a single memory binding by ID. */
+  router.get("/memory-bindings/:id", async (req, res) => {
+    const id = req.params.id as string;
+    const binding = await svc.getById(id);
+    if (!binding) {
+      res.status(404).json({ error: "Memory binding not found" });
+      return;
+    }
+    assertCompanyAccess(req, binding.companyId);
+    res.json(binding);
+  });
+
+  /** Update a memory binding. */
+  router.patch(
+    "/memory-bindings/:id",
+    validate(updateMemoryBindingSchema),
+    async (req, res) => {
+      const id = req.params.id as string;
+      const existing = await svc.getById(id);
+      if (!existing) {
+        res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+      assertCompanyAccess(req, existing.companyId);
+
+      const binding = await svc.update(id, req.body);
+      if (!binding) {
+        res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: binding.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "memory_binding.updated",
+        entityType: "memory_binding",
+        entityId: binding.id,
+        details: req.body,
+      });
+
+      res.json(binding);
+    },
+  );
+
+  /** Delete a memory binding. */
+  router.delete("/memory-bindings/:id", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Memory binding not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+
+    const removed = await svc.remove(id);
+    if (!removed) {
+      res.status(404).json({ error: "Memory binding not found" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: removed.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "memory_binding.deleted",
+      entityType: "memory_binding",
+      entityId: removed.id,
+      details: { key: removed.key },
+    });
+
+    res.json({ ok: true });
+  });
+
+  // ── Binding Targets ──────────────────────────────────────────────
+
+  /** List targets for a binding. */
+  router.get("/memory-bindings/:bindingId/targets", async (req, res) => {
+    const bindingId = req.params.bindingId as string;
+    const binding = await svc.getById(bindingId);
+    if (!binding) {
+      res.status(404).json({ error: "Memory binding not found" });
+      return;
+    }
+    assertCompanyAccess(req, binding.companyId);
+
+    const targets = await svc.listTargets(bindingId);
+    res.json(targets);
+  });
+
+  /** Add a target assignment to a binding. */
+  router.post(
+    "/memory-bindings/:bindingId/targets",
+    validate(createMemoryBindingTargetSchema),
+    async (req, res) => {
+      const bindingId = req.params.bindingId as string;
+      const binding = await svc.getById(bindingId);
+      if (!binding) {
+        res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+      assertCompanyAccess(req, binding.companyId);
+
+      const target = await svc.addTarget(bindingId, req.body);
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: binding.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "memory_binding_target.created",
+        entityType: "memory_binding_target",
+        entityId: target.id,
+        details: {
+          bindingId,
+          targetType: target.targetType,
+          targetId: target.targetId,
+        },
+      });
+
+      res.status(201).json(target);
+    },
+  );
+
+  /** Remove a target assignment. */
+  router.delete("/memory-binding-targets/:targetId", async (req, res) => {
+    const targetId = req.params.targetId as string;
+    const target = await svc.getTargetById(targetId);
+    if (!target) {
+      res.status(404).json({ error: "Memory binding target not found" });
+      return;
+    }
+
+    const binding = await svc.getById(target.bindingId);
+    if (!binding) {
+      res.status(404).json({ error: "Memory binding not found" });
+      return;
+    }
+    assertCompanyAccess(req, binding.companyId);
+
+    const removed = await svc.removeTarget(targetId);
+    if (!removed) {
+      res.status(404).json({ error: "Memory binding target not found" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: binding.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "memory_binding_target.deleted",
+      entityType: "memory_binding_target",
+      entityId: removed.id,
+      details: {
+        bindingId: removed.bindingId,
+        targetType: removed.targetType,
+        targetId: removed.targetId,
+      },
+    });
+
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/server/src/routes/memory-bindings.ts
+++ b/server/src/routes/memory-bindings.ts
@@ -161,7 +161,16 @@ export function memoryBindingRoutes(db: Db) {
       }
       assertCompanyAccess(req, binding.companyId);
 
-      const target = await svc.addTarget(bindingId, req.body);
+      let target;
+      try {
+        target = await svc.addTarget(bindingId, req.body);
+      } catch (err) {
+        if ((err as { code?: string }).code === "23505") {
+          res.status(409).json({ error: "This target is already assigned to the binding" });
+          return;
+        }
+        throw err;
+      }
 
       const actor = getActorInfo(req);
       await logActivity(db, {

--- a/server/src/routes/memory-bindings.ts
+++ b/server/src/routes/memory-bindings.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
+import { eq, and } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
+import { agents } from "@paperclipai/db";
 import {
   createMemoryBindingSchema,
   updateMemoryBindingSchema,
@@ -160,6 +162,18 @@ export function memoryBindingRoutes(db: Db) {
         return;
       }
       assertCompanyAccess(req, binding.companyId);
+
+      // Prevent cross-company target assignments
+      if (req.body.targetType === "agent") {
+        const [agent] = await db
+          .select({ companyId: agents.companyId })
+          .from(agents)
+          .where(eq(agents.id, req.body.targetId));
+        if (!agent || agent.companyId !== binding.companyId) {
+          res.status(403).json({ error: "Target agent does not belong to this company" });
+          return;
+        }
+      }
 
       let target;
       try {

--- a/server/src/routes/memory-operations.ts
+++ b/server/src/routes/memory-operations.ts
@@ -116,6 +116,10 @@ export function memoryOperationRoutes(db: Db) {
         res.status(403).json({ error: "Scope companyId does not match binding company" });
         return;
       }
+      if (req.body.source.companyId !== binding.companyId) {
+        res.status(403).json({ error: "Source companyId does not match binding company" });
+        return;
+      }
 
       const result = await opSvc.write(binding.id, req.body);
 

--- a/server/src/routes/memory-operations.ts
+++ b/server/src/routes/memory-operations.ts
@@ -36,8 +36,22 @@ export function memoryOperationRoutes(db: Db) {
     if (agentId) conditions.push(eq(memoryOperations.agentId, agentId as string));
     if (operationType) conditions.push(eq(memoryOperations.operationType, operationType as string));
     if (success !== undefined) conditions.push(eq(memoryOperations.success, success === "true"));
-    if (from) conditions.push(gte(memoryOperations.createdAt, new Date(from as string)));
-    if (to) conditions.push(lte(memoryOperations.createdAt, new Date(to as string)));
+    if (from) {
+      const fromDate = new Date(from as string);
+      if (isNaN(fromDate.getTime())) {
+        res.status(400).json({ error: "Invalid 'from' date" });
+        return;
+      }
+      conditions.push(gte(memoryOperations.createdAt, fromDate));
+    }
+    if (to) {
+      const toDate = new Date(to as string);
+      if (isNaN(toDate.getTime())) {
+        res.status(400).json({ error: "Invalid 'to' date" });
+        return;
+      }
+      conditions.push(lte(memoryOperations.createdAt, toDate));
+    }
 
     const where = and(...conditions);
 

--- a/server/src/routes/memory-operations.ts
+++ b/server/src/routes/memory-operations.ts
@@ -98,6 +98,10 @@ export function memoryOperationRoutes(db: Db) {
         res.status(404).json({ error: "Memory binding not found" });
         return;
       }
+      if (req.body.scope.companyId !== binding.companyId) {
+        res.status(403).json({ error: "Scope companyId does not match binding company" });
+        return;
+      }
 
       const result = await opSvc.write(binding.id, req.body);
 
@@ -132,6 +136,10 @@ export function memoryOperationRoutes(db: Db) {
         res.status(404).json({ error: "Memory binding not found" });
         return;
       }
+      if (req.body.scope.companyId !== binding.companyId) {
+        res.status(403).json({ error: "Scope companyId does not match binding company" });
+        return;
+      }
 
       const result = await opSvc.query(binding.id, req.body);
 
@@ -164,6 +172,10 @@ export function memoryOperationRoutes(db: Db) {
       const binding = await resolveAndAuthorize(req);
       if (!binding) {
         res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+      if (req.body.scope.companyId !== binding.companyId) {
+        res.status(403).json({ error: "Scope companyId does not match binding company" });
         return;
       }
 

--- a/server/src/routes/memory-operations.ts
+++ b/server/src/routes/memory-operations.ts
@@ -1,0 +1,193 @@
+import { Router } from "express";
+import { and, eq, desc, gte, lte, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { memoryOperations, memoryBindings } from "@paperclipai/db";
+import {
+  memoryWriteSchema,
+  memoryQuerySchema,
+  memoryForgetSchema,
+} from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import {
+  logActivity,
+  memoryBindingService,
+  memoryOperationService,
+} from "../services/index.js";
+
+export function memoryOperationRoutes(db: Db) {
+  const router = Router();
+  const bindingSvc = memoryBindingService(db);
+  const opSvc = memoryOperationService(db);
+
+  // ── List operations (audit log) ─────────────────────────────────
+
+  /** List memory operations for a company with optional filters. */
+  router.get("/companies/:companyId/memory-operations", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const { bindingId, agentId, operationType, success, from, to } = req.query;
+
+    const conditions = [eq(memoryOperations.companyId, companyId)];
+    if (bindingId) conditions.push(eq(memoryOperations.bindingId, bindingId as string));
+    if (agentId) conditions.push(eq(memoryOperations.agentId, agentId as string));
+    if (operationType) conditions.push(eq(memoryOperations.operationType, operationType as string));
+    if (success !== undefined) conditions.push(eq(memoryOperations.success, success === "true"));
+    if (from) conditions.push(gte(memoryOperations.createdAt, new Date(from as string)));
+    if (to) conditions.push(lte(memoryOperations.createdAt, new Date(to as string)));
+
+    const where = and(...conditions);
+
+    const [rows, countResult] = await Promise.all([
+      db
+        .select({
+          id: memoryOperations.id,
+          bindingId: memoryOperations.bindingId,
+          bindingKey: memoryBindings.key,
+          providerKey: memoryBindings.providerKey,
+          operationType: memoryOperations.operationType,
+          agentId: memoryOperations.agentId,
+          projectId: memoryOperations.projectId,
+          issueId: memoryOperations.issueId,
+          runId: memoryOperations.runId,
+          sourceRef: memoryOperations.sourceRef,
+          usage: memoryOperations.usage,
+          latencyMs: memoryOperations.latencyMs,
+          success: memoryOperations.success,
+          error: memoryOperations.error,
+          createdAt: memoryOperations.createdAt,
+        })
+        .from(memoryOperations)
+        .leftJoin(memoryBindings, eq(memoryOperations.bindingId, memoryBindings.id))
+        .where(where)
+        .orderBy(desc(memoryOperations.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(memoryOperations)
+        .where(where)
+        .then((r) => r[0]),
+    ]);
+
+    res.json({ items: rows, total: countResult?.count ?? 0, limit, offset });
+  });
+
+  /** Helper: look up binding, assert company access, return binding. */
+  async function resolveAndAuthorize(req: import("express").Request) {
+    const bindingId = req.params.bindingId as string;
+    const binding = await bindingSvc.getById(bindingId);
+    if (!binding) {
+      return null;
+    }
+    assertCompanyAccess(req, binding.companyId);
+    return binding;
+  }
+
+  // ── Write ────────────────────────────────────────────────────────
+
+  router.post(
+    "/memory-bindings/:bindingId/write",
+    validate(memoryWriteSchema),
+    async (req, res) => {
+      const binding = await resolveAndAuthorize(req);
+      if (!binding) {
+        res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+
+      const result = await opSvc.write(binding.id, req.body);
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: binding.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "memory_operation.write",
+        entityType: "memory_binding",
+        entityId: binding.id,
+        details: {
+          recordCount: result.records.length,
+          latencyMs: result.latencyMs,
+        },
+      });
+
+      res.json(result);
+    },
+  );
+
+  // ── Query ────────────────────────────────────────────────────────
+
+  router.post(
+    "/memory-bindings/:bindingId/query",
+    validate(memoryQuerySchema),
+    async (req, res) => {
+      const binding = await resolveAndAuthorize(req);
+      if (!binding) {
+        res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+
+      const result = await opSvc.query(binding.id, req.body);
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: binding.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "memory_operation.query",
+        entityType: "memory_binding",
+        entityId: binding.id,
+        details: {
+          snippetCount: result.snippets.length,
+          latencyMs: result.latencyMs,
+        },
+      });
+
+      res.json(result);
+    },
+  );
+
+  // ── Forget ───────────────────────────────────────────────────────
+
+  router.post(
+    "/memory-bindings/:bindingId/forget",
+    validate(memoryForgetSchema),
+    async (req, res) => {
+      const binding = await resolveAndAuthorize(req);
+      if (!binding) {
+        res.status(404).json({ error: "Memory binding not found" });
+        return;
+      }
+
+      const result = await opSvc.forget(binding.id, req.body);
+
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: binding.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "memory_operation.forget",
+        entityType: "memory_binding",
+        entityId: binding.id,
+        details: {
+          handleCount: req.body.handles.length,
+          latencyMs: result.latencyMs,
+        },
+      });
+
+      res.json(result);
+    },
+  );
+
+  return router;
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3453,7 +3453,7 @@ export function heartbeatService(db: Db) {
           runId: run.id,
           outcome,
           taskSummary: issueContext?.title ?? readNonEmptyString(context.taskKey) ?? undefined,
-          resultJson: adapterResult.resultJson as Record<string, unknown> | null ?? null,
+          resultJson: (adapterResult.resultJson as Record<string, unknown> | null) ?? null,
           agentName: agent.name,
         });
         if (captureResult.bindingsCaptured > 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -33,6 +33,7 @@ import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import { buildHeartbeatRunIssueComment, summarizeHeartbeatRunResultJson } from "./heartbeat-run-summary.js";
+import { memoryHooksService } from "./memory-hooks.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -3130,6 +3131,83 @@ export function heartbeatService(db: Db) {
         });
       };
 
+      // ── Memory: pre-run hydration ──────────────────────────────────
+      try {
+        const memHooks = memoryHooksService(db);
+        const hydrateResult = await memHooks.hydrateRunContext({
+          companyId: agent.companyId,
+          agentId: agent.id,
+          projectId: issueContext?.projectId ?? undefined,
+          issueId: issueId ?? undefined,
+          runId: run.id,
+          taskSummary: issueContext?.title ?? readNonEmptyString(context.taskKey) ?? undefined,
+        });
+        if (hydrateResult.bindingsQueried > 0) {
+          context.paperclipMemoryContext = {
+            snippets: hydrateResult.snippets.map((s) => ({
+              text: s.text,
+              provider: s.handle.providerKey,
+              score: s.score,
+            })),
+            profileSummary: hydrateResult.profileSummary,
+            bindingsQueried: hydrateResult.bindingsQueried,
+          };
+
+          // Render memory snippets into markdown and inject into the prompt
+          // via paperclipSessionHandoffMarkdown (read by all adapters)
+          if (hydrateResult.snippets.length > 0 || hydrateResult.profileSummary) {
+            const memoryLines: string[] = [];
+            memoryLines.push("<memory-context>");
+            memoryLines.push("The following context was retrieved from the agent's memory system. Use it to inform your work but do not mention it unless relevant.");
+            memoryLines.push("");
+            if (hydrateResult.profileSummary) {
+              memoryLines.push("## Profile");
+              memoryLines.push(hydrateResult.profileSummary);
+              memoryLines.push("");
+            }
+            if (hydrateResult.snippets.length > 0) {
+              memoryLines.push("## Relevant Context");
+              for (const snippet of hydrateResult.snippets) {
+                memoryLines.push(`- ${snippet.text}`);
+              }
+              memoryLines.push("");
+            }
+            memoryLines.push("</memory-context>");
+            const memoryMarkdown = memoryLines.join("\n");
+            const existingHandoff = typeof context.paperclipSessionHandoffMarkdown === "string"
+              ? context.paperclipSessionHandoffMarkdown
+              : "";
+            context.paperclipSessionHandoffMarkdown = existingHandoff
+              ? `${existingHandoff}\n\n${memoryMarkdown}`
+              : memoryMarkdown;
+          }
+
+          logger.info(
+            {
+              companyId: agent.companyId,
+              agentId: agent.id,
+              runId: run.id,
+              bindingsQueried: hydrateResult.bindingsQueried,
+              snippetCount: hydrateResult.snippets.length,
+            },
+            "memory context hydrated for run",
+          );
+          await onLog(
+            "stdout",
+            `[paperclip:memory] pre-run hydration: ${hydrateResult.snippets.length} snippet(s) from ${hydrateResult.bindingsQueried} binding(s) injected into context\n`,
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          { err, companyId: agent.companyId, agentId: agent.id, runId: run.id },
+          "memory hydration failed — continuing without memory context",
+        );
+        await onLog(
+          "stderr",
+          `[paperclip:memory] pre-run hydration failed: ${err instanceof Error ? err.message : String(err)} — continuing without memory context\n`,
+        );
+      }
+
       const adapter = getServerAdapter(agent.adapterType);
       const authToken = adapter.supportsLocalAgentJwt
         ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)
@@ -3362,6 +3440,47 @@ export function heartbeatService(db: Db) {
         }
       }
       await finalizeAgentStatus(agent.id, outcome);
+
+      // ── Memory: post-run capture ──────────────────────────────────
+      try {
+        const memHooks = memoryHooksService(db);
+        const captureResult = await memHooks.captureRunResult({
+          companyId: agent.companyId,
+          agentId: agent.id,
+          projectId: issueContext?.projectId ?? undefined,
+          issueId: issueId ?? undefined,
+          runId: run.id,
+          outcome,
+          taskSummary: issueContext?.title ?? readNonEmptyString(context.taskKey) ?? undefined,
+          resultJson: adapterResult.resultJson as Record<string, unknown> | null ?? null,
+          agentName: agent.name,
+        });
+        if (captureResult.bindingsCaptured > 0) {
+          logger.info(
+            {
+              companyId: agent.companyId,
+              agentId: agent.id,
+              runId: run.id,
+              outcome,
+              bindingsCaptured: captureResult.bindingsCaptured,
+            },
+            "run result captured to memory",
+          );
+          await onLog(
+            "stdout",
+            `[paperclip:memory] post-run capture: outcome="${outcome}" written to ${captureResult.bindingsCaptured} binding(s)\n`,
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          { err, companyId: agent.companyId, agentId: agent.id, runId: run.id },
+          "memory capture failed — run completed but memory not updated",
+        );
+        await onLog(
+          "stderr",
+          `[paperclip:memory] post-run capture failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3131,9 +3131,11 @@ export function heartbeatService(db: Db) {
         });
       };
 
+      // ── Memory hooks (shared across pre-run hydration and post-run capture)
+      const memHooks = memoryHooksService(db);
+
       // ── Memory: pre-run hydration ──────────────────────────────────
       try {
-        const memHooks = memoryHooksService(db);
         const hydrateResult = await memHooks.hydrateRunContext({
           companyId: agent.companyId,
           agentId: agent.id,
@@ -3443,7 +3445,6 @@ export function heartbeatService(db: Db) {
 
       // ── Memory: post-run capture ──────────────────────────────────
       try {
-        const memHooks = memoryHooksService(db);
         const captureResult = await memHooks.captureRunResult({
           companyId: agent.companyId,
           agentId: agent.id,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -31,3 +31,22 @@ export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
 export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
 export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";
+export { memoryBindingService } from "./memory-bindings.js";
+export {
+  memoryOperationService,
+  registerMemoryAdapter,
+  unregisterMemoryAdapter,
+  getRegisteredMemoryAdapters,
+  getMemoryAdapter,
+} from "./memory-operations.js";
+export { memoryHooksService } from "./memory-hooks.js";
+export type {
+  HydrateRunContextParams,
+  HydrateRunContextResult,
+  CaptureRunResultParams,
+  CaptureRunResultResult,
+  MemoryHooksConfig,
+} from "./memory-hooks.js";
+export { createParaMemoryAdapter, type ParaAdapterConfig } from "./memory-adapters/index.js";
+export { createMempalaceMemoryAdapter, type MempalaceAdapterConfig } from "./memory-adapters/index.js";
+export { createMempalaceSidecar, type MempalaceSidecarConfig, type MempalaceSidecar, type SidecarStatus } from "./memory-adapters/index.js";

--- a/server/src/services/memory-adapters/index.ts
+++ b/server/src/services/memory-adapters/index.ts
@@ -1,0 +1,3 @@
+export { createParaMemoryAdapter, type ParaAdapterConfig } from "./para.js";
+export { createMempalaceMemoryAdapter, type MempalaceAdapterConfig } from "./mempalace.js";
+export { createMempalaceSidecar, type MempalaceSidecarConfig, type MempalaceSidecar, type SidecarStatus } from "./mempalace-sidecar.js";

--- a/server/src/services/memory-adapters/mempalace-sidecar.ts
+++ b/server/src/services/memory-adapters/mempalace-sidecar.ts
@@ -98,14 +98,8 @@ export function createMempalaceSidecar(config: MempalaceSidecarConfig): Mempalac
     _healthCheckTimer = setInterval(async () => {
       if (_status !== "running" || _stopping) return;
       try {
-        // Use a lightweight query as a liveness probe —
-        // the MCP SDK will throw if the connection is dead.
-        await mcpAdapter.query({
-          bindingKey: "__health__",
-          scope: { companyId: "__health__" },
-          query: "__ping__",
-          topK: 1,
-        });
+        // Lightweight MCP protocol-level liveness probe.
+        await mcpAdapter.ping();
       } catch {
         if (_stopping) return;
         setStatus("unhealthy");

--- a/server/src/services/memory-adapters/mempalace-sidecar.ts
+++ b/server/src/services/memory-adapters/mempalace-sidecar.ts
@@ -1,0 +1,222 @@
+import { createMempalaceMemoryAdapter, type MempalaceAdapterConfig } from "./mempalace.js";
+import type { MemoryAdapter } from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Mempalace Sidecar Lifecycle Manager
+//
+// Wraps the mempalace MCP adapter with production lifecycle concerns:
+// - Health checking via MCP ping
+// - Crash detection and restart with exponential backoff
+// - Per-company palace directory isolation
+// - Structured logging for stdout/stderr
+// - Clean shutdown
+// ---------------------------------------------------------------------------
+
+export type SidecarStatus = "stopped" | "starting" | "running" | "unhealthy" | "failed";
+
+export interface MempalaceSidecarConfig {
+  /** Palace data directory — each company should have its own directory. */
+  palaceDir: string;
+  /** Python command (default: "python"). */
+  pythonCommand?: string;
+  /** Additional environment variables for the mempalace process. */
+  env?: Record<string, string>;
+  /** Health check interval in ms (default: 30_000). */
+  healthCheckIntervalMs?: number;
+  /** Max consecutive restart attempts before marking as failed (default: 5). */
+  maxRestartAttempts?: number;
+  /** Base delay for restart backoff in ms (default: 1_000). Doubles each attempt. */
+  restartBaseDelayMs?: number;
+  /** Max restart delay cap in ms (default: 60_000). */
+  restartMaxDelayMs?: number;
+  /** MCP connection timeout in ms (default: 15_000). */
+  connectTimeoutMs?: number;
+  /** Per-tool-call timeout in ms (default: 30_000). */
+  callTimeoutMs?: number;
+  /** Callback for log output from the sidecar process. */
+  onLog?: (stream: "stdout" | "stderr", data: string) => void;
+  /** Callback when sidecar status changes. */
+  onStatusChange?: (status: SidecarStatus, error?: string) => void;
+}
+
+export interface MempalaceSidecar {
+  /** Start the sidecar and connect the adapter. */
+  start(): Promise<void>;
+  /** Stop the sidecar gracefully. */
+  stop(): Promise<void>;
+  /** Current sidecar status. */
+  readonly status: SidecarStatus;
+  /** Number of times the sidecar has been restarted since last successful start. */
+  readonly restartCount: number;
+  /** The underlying MemoryAdapter — only usable when status is "running". */
+  readonly adapter: MemoryAdapter;
+}
+
+export function createMempalaceSidecar(config: MempalaceSidecarConfig): MempalaceSidecar {
+  const pythonCommand = config.pythonCommand ?? "python";
+  const healthCheckIntervalMs = config.healthCheckIntervalMs ?? 30_000;
+  const maxRestartAttempts = config.maxRestartAttempts ?? 5;
+  const restartBaseDelayMs = config.restartBaseDelayMs ?? 1_000;
+  const restartMaxDelayMs = config.restartMaxDelayMs ?? 60_000;
+  const onLog = config.onLog;
+  const onStatusChange = config.onStatusChange;
+
+  let _status: SidecarStatus = "stopped";
+  let _restartCount = 0;
+  let _healthCheckTimer: ReturnType<typeof setInterval> | null = null;
+  let _restartTimer: ReturnType<typeof setTimeout> | null = null;
+  let _stopping = false;
+
+  // Build adapter config with per-company palace directory
+  const adapterConfig: MempalaceAdapterConfig = {
+    command: pythonCommand,
+    args: ["-m", "mempalace.mcp_server"],
+    cwd: config.palaceDir,
+    env: {
+      ...config.env,
+      MEMPALACE_PALACE_PATH: config.palaceDir,
+    },
+    connectTimeoutMs: config.connectTimeoutMs,
+    callTimeoutMs: config.callTimeoutMs,
+  };
+
+  const mcpAdapter = createMempalaceMemoryAdapter(adapterConfig);
+
+  function setStatus(status: SidecarStatus, error?: string) {
+    if (_status === status) return;
+    _status = status;
+    onStatusChange?.(status, error);
+    if (onLog) {
+      onLog("stdout", `[mempalace-sidecar] status → ${status}${error ? `: ${error}` : ""}`);
+    }
+  }
+
+  // ── Health checking ─────────────────────────────────────────────────
+
+  function startHealthChecks() {
+    stopHealthChecks();
+    _healthCheckTimer = setInterval(async () => {
+      if (_status !== "running" || _stopping) return;
+      try {
+        // Use a lightweight query as a liveness probe —
+        // the MCP SDK will throw if the connection is dead.
+        await mcpAdapter.query({
+          bindingKey: "__health__",
+          scope: { companyId: "__health__" },
+          query: "__ping__",
+          topK: 1,
+        });
+      } catch {
+        if (_stopping) return;
+        setStatus("unhealthy");
+        scheduleRestart();
+      }
+    }, healthCheckIntervalMs);
+  }
+
+  function stopHealthChecks() {
+    if (_healthCheckTimer) {
+      clearInterval(_healthCheckTimer);
+      _healthCheckTimer = null;
+    }
+  }
+
+  // ── Restart with exponential backoff ────────────────────────────────
+
+  function scheduleRestart() {
+    if (_stopping) return;
+    if (_restartCount >= maxRestartAttempts) {
+      setStatus("failed", `max restart attempts (${maxRestartAttempts}) exceeded`);
+      stopHealthChecks();
+      return;
+    }
+
+    const delay = Math.min(
+      restartBaseDelayMs * Math.pow(2, _restartCount),
+      restartMaxDelayMs,
+    );
+    _restartCount++;
+
+    if (onLog) {
+      onLog("stdout", `[mempalace-sidecar] scheduling restart #${_restartCount} in ${delay}ms`);
+    }
+
+    _restartTimer = setTimeout(async () => {
+      _restartTimer = null;
+      if (_stopping) return;
+
+      try {
+        // Disconnect existing connection (best-effort)
+        try {
+          await mcpAdapter.disconnect();
+        } catch {
+          // ignore
+        }
+
+        setStatus("starting");
+        await mcpAdapter.connect();
+        setStatus("running");
+        // Reset restart count on successful reconnection
+        _restartCount = 0;
+        startHealthChecks();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (onLog) {
+          onLog("stderr", `[mempalace-sidecar] restart failed: ${message}`);
+        }
+        scheduleRestart();
+      }
+    }, delay);
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────────
+
+  async function start(): Promise<void> {
+    if (_status === "running" && mcpAdapter.connected) return;
+
+    _stopping = false;
+    _restartCount = 0;
+    setStatus("starting");
+
+    try {
+      await mcpAdapter.connect();
+      setStatus("running");
+      startHealthChecks();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setStatus("failed", message);
+      throw err;
+    }
+  }
+
+  async function stop(): Promise<void> {
+    _stopping = true;
+    stopHealthChecks();
+
+    if (_restartTimer) {
+      clearTimeout(_restartTimer);
+      _restartTimer = null;
+    }
+
+    try {
+      await mcpAdapter.disconnect();
+    } catch {
+      // best-effort
+    }
+
+    _restartCount = 0;
+    setStatus("stopped");
+  }
+
+  return {
+    start,
+    stop,
+    get status() {
+      return _status;
+    },
+    get restartCount() {
+      return _restartCount;
+    },
+    adapter: mcpAdapter,
+  };
+}

--- a/server/src/services/memory-adapters/mempalace.ts
+++ b/server/src/services/memory-adapters/mempalace.ts
@@ -226,23 +226,37 @@ export function createMempalaceMemoryAdapter(
     name: string,
     args_: Record<string, unknown>,
   ): Promise<ToolCallResult> {
-    const tryCall = (c: Client) =>
-      c.callTool({ name, arguments: args_ }, undefined, { timeout: callTimeoutMs });
+    const tryCall = async (c: Client) => {
+      const result = await c.callTool(
+        { name, arguments: args_ },
+        undefined,
+        { timeout: callTimeoutMs },
+      );
+      const typed = result as ToolCallResult;
+      if (typed.isError) {
+        const msg = extractText(typed) || `MCP tool "${name}" returned an error`;
+        throw new Error(msg);
+      }
+      return typed;
+    };
+
+    const isTransportError = (err: unknown): boolean =>
+      err instanceof Error &&
+      (/ECONN|EPIPE|ENETUNREACH|socket hang up/i.test(err.message) ||
+        err.name === "AbortError");
 
     try {
       const c = ensureConnected();
-      const result = await tryCall(c);
-      return result as ToolCallResult;
+      return await tryCall(c);
     } catch (err) {
-      // Attempt a single reconnect on connection-level failures
+      // Only retry on transport-level failures to avoid duplicate writes
+      if (!isTransportError(err)) throw err;
       try {
         await disconnect();
         await connect();
         const c = ensureConnected();
-        const result = await tryCall(c);
-        return result as ToolCallResult;
+        return await tryCall(c);
       } catch {
-        // Reconnect failed — throw the original error
         throw err;
       }
     }
@@ -369,8 +383,9 @@ export function createMempalaceMemoryAdapter(
       for (const r of results.slice(0, topK)) {
         const rWing = (r.wing as string) ?? wing;
         const rRoom = (r.room as string) ?? room;
-        // mempalace search results don't include drawer_id
-        const syntheticId = `${rWing ?? "global"}/${rRoom ?? "default"}/${snippets.length}`;
+        // mempalace search results don't include drawer_id — prefix with
+        // __search__ so forget()/get() can detect and skip these handles
+        const syntheticId = `__search__/${rWing ?? "global"}/${rRoom ?? "default"}/${snippets.length}`;
 
         snippets.push({
           handle: { providerKey: PROVIDER_KEY, providerRecordId: syntheticId },
@@ -409,6 +424,9 @@ export function createMempalaceMemoryAdapter(
     handle: MemoryRecordHandle,
     _scope: MemoryScope,
   ): Promise<MemorySnippet | null> {
+    // Synthetic handles from search results can't be resolved to a specific drawer
+    if (handle.providerRecordId.startsWith("__search__")) return null;
+
     const { drawerId, wing, room } = decodeHandle(handle);
 
     // Use mempalace_search with wing/room filters and drawerId as query
@@ -456,6 +474,8 @@ export function createMempalaceMemoryAdapter(
 
     for (const handle of handles) {
       if (handle.providerKey !== PROVIDER_KEY) continue;
+      // Skip synthetic handles from search results — no real drawer_id to delete
+      if (handle.providerRecordId.startsWith("__search__")) continue;
       const { drawerId } = decodeHandle(handle);
 
       try {

--- a/server/src/services/memory-adapters/mempalace.ts
+++ b/server/src/services/memory-adapters/mempalace.ts
@@ -455,6 +455,7 @@ export function createMempalaceMemoryAdapter(
     const start = Date.now();
 
     for (const handle of handles) {
+      if (handle.providerKey !== PROVIDER_KEY) continue;
       const { drawerId } = decodeHandle(handle);
 
       try {

--- a/server/src/services/memory-adapters/mempalace.ts
+++ b/server/src/services/memory-adapters/mempalace.ts
@@ -151,6 +151,8 @@ export function createMempalaceMemoryAdapter(
   connect(): Promise<void>;
   /** Disconnect from the mempalace MCP server and kill the sidecar. */
   disconnect(): Promise<void>;
+  /** Lightweight liveness check using MCP protocol ping. */
+  ping(): Promise<void>;
   /** Whether the adapter is currently connected. */
   readonly connected: boolean;
 } {
@@ -484,6 +486,11 @@ export function createMempalaceMemoryAdapter(
     providerManagedExtraction: true,
   };
 
+  async function ping(): Promise<void> {
+    const c = ensureConnected();
+    await c.ping({ timeout: callTimeoutMs });
+  }
+
   return {
     key: PROVIDER_KEY,
     capabilities,
@@ -493,6 +500,7 @@ export function createMempalaceMemoryAdapter(
     forget,
     connect,
     disconnect,
+    ping,
     get connected() {
       return _connected;
     },

--- a/server/src/services/memory-adapters/mempalace.ts
+++ b/server/src/services/memory-adapters/mempalace.ts
@@ -277,13 +277,8 @@ export function createMempalaceMemoryAdapter(
     const start = Date.now();
 
     if (req.mode === "upsert" && req.metadata?.drawerId) {
-      // mempalace has no update — delete then re-add
-      try {
-        await callTool("mempalace_delete_drawer", { drawer_id: req.metadata.drawerId });
-      } catch {
-        // drawer may not exist yet, continue with add
-      }
-
+      // Add new drawer first, then delete old — if add fails the old
+      // drawer is preserved (no data loss from non-atomic upsert)
       const result = await callTool("mempalace_add_drawer", {
         wing,
         room,
@@ -294,10 +289,17 @@ export function createMempalaceMemoryAdapter(
       const latency = Date.now() - start;
       const text = extractText(result);
       const parsed = tryParseJson(text) as Record<string, unknown> | null;
-      const drawerId = (parsed?.drawer_id as string) ?? (req.metadata.drawerId as string);
+      const newDrawerId = (parsed?.drawer_id as string) ?? (req.metadata.drawerId as string);
+
+      // Best-effort delete of old drawer after new one is confirmed
+      try {
+        await callTool("mempalace_delete_drawer", { drawer_id: req.metadata.drawerId });
+      } catch {
+        // old drawer deletion is best-effort
+      }
 
       return {
-        records: [encodeHandle(drawerId, wing, room)],
+        records: [encodeHandle(newDrawerId, wing, room)],
         usage: [{
           provider: PROVIDER_KEY,
           latencyMs: latency,

--- a/server/src/services/memory-adapters/mempalace.ts
+++ b/server/src/services/memory-adapters/mempalace.ts
@@ -1,0 +1,500 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type {
+  MemoryAdapter,
+  MemoryAdapterCapabilities,
+  MemoryWriteRequest,
+  MemoryQueryRequest,
+  MemoryRecordHandle,
+  MemoryScope,
+  MemorySnippet,
+  MemoryContextBundle,
+  MemoryUsage,
+} from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROVIDER_KEY = "mempalace";
+
+// ---------------------------------------------------------------------------
+// Handle encoding helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Encodes a mempalace drawer reference as a MemoryRecordHandle.
+ * Format: "wing/room/drawerId" or just "drawerId" for global references.
+ */
+function encodeHandle(drawerId: string, wing?: string, room?: string): MemoryRecordHandle {
+  const parts: string[] = [];
+  if (wing) parts.push(wing);
+  if (room) parts.push(room);
+  parts.push(drawerId);
+  return { providerKey: PROVIDER_KEY, providerRecordId: parts.join("/") };
+}
+
+function decodeHandle(handle: MemoryRecordHandle): {
+  drawerId: string;
+  wing?: string;
+  room?: string;
+} {
+  const parts = handle.providerRecordId.split("/");
+  if (parts.length === 3) {
+    return { wing: parts[0], room: parts[1], drawerId: parts[2] };
+  }
+  if (parts.length === 2) {
+    return { wing: parts[0], drawerId: parts[1] };
+  }
+  return { drawerId: parts[0] };
+}
+
+// ---------------------------------------------------------------------------
+// Scope → mempalace hierarchy mapping
+//
+// Company isolation: each company gets its own mempalace sidecar process
+// with a separate palace directory. Isolation is enforced at the process
+// level (RED-47), not by wing naming. The adapter therefore does not
+// encode companyId into the wing — it is implicit in which sidecar the
+// adapter is connected to.
+//
+// Hierarchy:
+//   projectId  → wing   (e.g. "project-{short-id}")
+//   agentId    → wing   (e.g. "agent-{short-id}"), used when no project
+//   issueId    → room   (e.g. "issue-{short-id}")
+//   runId      → metadata tag on drawers, not a room
+//   subjectId  → metadata tag, passed through to drawer tags
+// ---------------------------------------------------------------------------
+
+function scopeToWing(scope: MemoryScope): string | undefined {
+  if (scope.projectId) return `project-${scope.projectId.slice(0, 8)}`;
+  if (scope.agentId) return `agent-${scope.agentId.slice(0, 8)}`;
+  return undefined;
+}
+
+function scopeToRoom(scope: MemoryScope): string | undefined {
+  if (scope.issueId) return `issue-${scope.issueId.slice(0, 8)}`;
+  return undefined;
+}
+
+/**
+ * Builds a source_file provenance string from scope and source.
+ * mempalace stores this in drawer metadata for traceability.
+ */
+function buildSourceFile(
+  scope: MemoryScope,
+  source?: { kind: string; issueId?: string; runId?: string; commentId?: string; documentKey?: string; companyId: string; activityId?: string; externalRef?: string },
+): string {
+  const parts: string[] = [];
+  if (source?.kind) parts.push(source.kind);
+  if (source?.issueId) parts.push(`issue:${source.issueId.slice(0, 8)}`);
+  if (source?.runId) parts.push(`run:${source.runId.slice(0, 8)}`);
+  if (scope.agentId) parts.push(`agent:${scope.agentId.slice(0, 8)}`);
+  return parts.join("/") || "paperclip";
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool call helpers
+// ---------------------------------------------------------------------------
+
+interface ToolCallResult {
+  content: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  isError?: boolean;
+}
+
+function extractText(result: ToolCallResult): string {
+  return result.content
+    .filter((c) => c.type === "text" && c.text)
+    .map((c) => c.text!)
+    .join("\n");
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mempalace Memory Adapter
+// ---------------------------------------------------------------------------
+
+export interface MempalaceAdapterConfig {
+  /**
+   * Remote MCP server URL (e.g. "http://mempalace:8080/mcp").
+   * When set, the adapter connects over Streamable HTTP instead of spawning
+   * a local child process. This is the expected mode for Docker Compose /
+   * Podman pod deployments where mempalace runs as a separate container.
+   */
+  url?: string;
+  /** Command to start the mempalace MCP server (default: "python"). Ignored when `url` is set. */
+  command?: string;
+  /** Arguments for the command (default: ["-m", "mempalace.mcp_server"]). Ignored when `url` is set. */
+  args?: string[];
+  /** Working directory for the mempalace process. Ignored when `url` is set. */
+  cwd?: string;
+  /** Environment variables for the mempalace process. Ignored when `url` is set. */
+  env?: Record<string, string>;
+  /** Connection timeout in ms (default: 15000). */
+  connectTimeoutMs?: number;
+  /** Per-tool-call timeout in ms (default: 30000). */
+  callTimeoutMs?: number;
+}
+
+export function createMempalaceMemoryAdapter(
+  config: MempalaceAdapterConfig,
+): MemoryAdapter & {
+  /** Connect to the mempalace MCP server. Must be called before any operations. */
+  connect(): Promise<void>;
+  /** Disconnect from the mempalace MCP server and kill the sidecar. */
+  disconnect(): Promise<void>;
+  /** Whether the adapter is currently connected. */
+  readonly connected: boolean;
+} {
+  const remoteUrl = config.url;
+  const command = config.command ?? "python";
+  const args = config.args ?? ["-m", "mempalace.mcp_server"];
+  const cwd = config.cwd;
+  const env = config.env;
+  const connectTimeoutMs = config.connectTimeoutMs ?? 15_000;
+  const callTimeoutMs = config.callTimeoutMs ?? 30_000;
+
+  let client: Client | null = null;
+  let transport: StdioClientTransport | StreamableHTTPClientTransport | null = null;
+  let _connected = false;
+
+  // ── Connection lifecycle ────────────────────────────────────────────
+
+  async function connect(): Promise<void> {
+    if (_connected) return;
+
+    if (remoteUrl) {
+      transport = new StreamableHTTPClientTransport(new URL(remoteUrl));
+    } else {
+      transport = new StdioClientTransport({
+        command,
+        args,
+        cwd,
+        env,
+        stderr: "pipe",
+      });
+    }
+
+    client = new Client(
+      { name: "paperclip-mempalace", version: "1.0.0" },
+    );
+
+    await client.connect(transport, {
+      timeout: connectTimeoutMs,
+    });
+    _connected = true;
+  }
+
+  async function disconnect(): Promise<void> {
+    if (!_connected || !client) return;
+    try {
+      await client.close();
+    } catch {
+      // best-effort cleanup
+    }
+    client = null;
+    transport = null;
+    _connected = false;
+  }
+
+  function ensureConnected(): Client {
+    if (!_connected || !client) {
+      throw new Error("Mempalace adapter is not connected. Call connect() first.");
+    }
+    return client;
+  }
+
+  /**
+   * Call a mempalace MCP tool with timeout.
+   *
+   * If the call fails with a connection-level error, attempt a single
+   * reconnect before propagating the failure. This handles the case where
+   * a remote mempalace container or local sidecar crashes and restarts
+   * while the paperclip server keeps running.
+   */
+  async function callTool(
+    name: string,
+    args_: Record<string, unknown>,
+  ): Promise<ToolCallResult> {
+    const tryCall = (c: Client) =>
+      c.callTool({ name, arguments: args_ }, undefined, { timeout: callTimeoutMs });
+
+    try {
+      const c = ensureConnected();
+      const result = await tryCall(c);
+      return result as ToolCallResult;
+    } catch (err) {
+      // Attempt a single reconnect on connection-level failures
+      try {
+        await disconnect();
+        await connect();
+        const c = ensureConnected();
+        const result = await tryCall(c);
+        return result as ToolCallResult;
+      } catch {
+        // Reconnect failed — throw the original error
+        throw err;
+      }
+    }
+  }
+
+  // ── Write ───────────────────────────────────────────────────────────
+
+  async function write(req: MemoryWriteRequest): Promise<{
+    records?: MemoryRecordHandle[];
+    usage?: MemoryUsage[];
+  }> {
+    // wing and room are required by mempalace_add_drawer
+    const wing = (req.metadata?.wing as string) ?? scopeToWing(req.scope) ?? "general";
+    const room = (req.metadata?.room as string) ?? scopeToRoom(req.scope) ?? "default";
+
+    const sourceFile = buildSourceFile(req.scope, req.source);
+
+    const start = Date.now();
+
+    if (req.mode === "upsert" && req.metadata?.drawerId) {
+      // mempalace has no update — delete then re-add
+      try {
+        await callTool("mempalace_delete_drawer", { drawer_id: req.metadata.drawerId });
+      } catch {
+        // drawer may not exist yet, continue with add
+      }
+
+      const result = await callTool("mempalace_add_drawer", {
+        wing,
+        room,
+        content: req.content,
+        source_file: sourceFile,
+        added_by: "paperclip",
+      });
+      const latency = Date.now() - start;
+      const text = extractText(result);
+      const parsed = tryParseJson(text) as Record<string, unknown> | null;
+      const drawerId = (parsed?.drawer_id as string) ?? (req.metadata.drawerId as string);
+
+      return {
+        records: [encodeHandle(drawerId, wing, room)],
+        usage: [{
+          provider: PROVIDER_KEY,
+          latencyMs: latency,
+          details: { method: "upsert_drawer", wing, room },
+        }],
+      };
+    }
+
+    // Default: add new drawer
+    const result = await callTool("mempalace_add_drawer", {
+      wing,
+      room,
+      content: req.content,
+      source_file: sourceFile,
+      added_by: "paperclip",
+    });
+    const latency = Date.now() - start;
+    const text = extractText(result);
+    const parsed = tryParseJson(text) as Record<string, unknown> | null;
+
+    // mempalace returns the drawer_id in the response
+    const drawerId = (parsed?.drawer_id as string) ?? `drawer-${Date.now()}`;
+
+    return {
+      records: [encodeHandle(drawerId, wing, room)],
+      usage: [{
+        provider: PROVIDER_KEY,
+        latencyMs: latency,
+        details: { method: "add_drawer", wing, room },
+      }],
+    };
+  }
+
+  // ── Query ───────────────────────────────────────────────────────────
+
+  async function query(req: MemoryQueryRequest): Promise<MemoryContextBundle> {
+    const start = Date.now();
+
+    // For preamble intent, use mempalace_status for a palace overview
+    if (req.intent === "agent_preamble") {
+      const result = await callTool("mempalace_status", {});
+      const latency = Date.now() - start;
+      const text = extractText(result);
+
+      return {
+        snippets: [{
+          handle: { providerKey: PROVIDER_KEY, providerRecordId: "__status__" },
+          text,
+          score: 1.0,
+          metadata: { method: "status", intent: "agent_preamble" },
+        }],
+        profileSummary: text,
+        usage: [{
+          provider: PROVIDER_KEY,
+          latencyMs: latency,
+          details: { method: "status" },
+        }],
+      };
+    }
+
+    // mempalace has a single mempalace_search tool with optional wing/room filters
+    const wing = (req.metadataFilter?.wing as string) ?? scopeToWing(req.scope);
+    const room = (req.metadataFilter?.room as string) ?? scopeToRoom(req.scope);
+    const topK = req.topK ?? 5;
+
+    const toolArgs: Record<string, unknown> = {
+      query: req.query,
+      limit: topK,
+    };
+    if (wing) toolArgs.wing = wing;
+    if (room) toolArgs.room = room;
+
+    const result = await callTool("mempalace_search", toolArgs);
+    const latency = Date.now() - start;
+    const text = extractText(result);
+    const parsed = tryParseJson(text) as Record<string, unknown> | null;
+
+    const snippets: MemorySnippet[] = [];
+
+    // mempalace returns { query, filters, results: [{text, wing, room, similarity, source_file}] }
+    const results = parsed?.results;
+    if (Array.isArray(results)) {
+      for (const r of results.slice(0, topK)) {
+        const rWing = (r.wing as string) ?? wing;
+        const rRoom = (r.room as string) ?? room;
+        // mempalace search results don't include drawer_id
+        const syntheticId = `${rWing ?? "global"}/${rRoom ?? "default"}/${snippets.length}`;
+
+        snippets.push({
+          handle: { providerKey: PROVIDER_KEY, providerRecordId: syntheticId },
+          text: (r.text as string) ?? (r.content as string) ?? "",
+          score: (r.similarity as number) ?? (r.score as number) ?? undefined,
+          metadata: {
+            wing: rWing,
+            room: rRoom,
+            source_file: r.source_file as string,
+          },
+        });
+      }
+    } else if (text) {
+      // Fallback: treat the full text response as a single snippet
+      snippets.push({
+        handle: { providerKey: PROVIDER_KEY, providerRecordId: "__search__" },
+        text,
+        score: 1.0,
+        metadata: { method: "mempalace_search", wing, room },
+      });
+    }
+
+    return {
+      snippets,
+      usage: [{
+        provider: PROVIDER_KEY,
+        latencyMs: latency,
+        details: { method: "mempalace_search", wing, room, resultCount: snippets.length },
+      }],
+    };
+  }
+
+  // ── Get ─────────────────────────────────────────────────────────────
+
+  async function get(
+    handle: MemoryRecordHandle,
+    _scope: MemoryScope,
+  ): Promise<MemorySnippet | null> {
+    const { drawerId, wing, room } = decodeHandle(handle);
+
+    // Use mempalace_search with wing/room filters and drawerId as query
+    const toolArgs: Record<string, unknown> = {
+      query: drawerId,
+      limit: 1,
+    };
+    if (wing) toolArgs.wing = wing;
+    if (room) toolArgs.room = room;
+
+    try {
+      const result = await callTool("mempalace_search", toolArgs);
+      const text = extractText(result);
+      const parsed = tryParseJson(text) as Record<string, unknown> | null;
+
+      // mempalace returns { results: [...] }
+      const results = parsed?.results;
+      if (Array.isArray(results) && results.length > 0) {
+        const r = results[0];
+        return {
+          handle,
+          text: (r.text as string) ?? (r.content as string) ?? "",
+          metadata: {
+            wing: (r.wing as string) ?? wing,
+            room: (r.room as string) ?? room,
+            drawer_id: drawerId,
+          },
+        };
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Forget ──────────────────────────────────────────────────────────
+
+  async function forget(
+    handles: MemoryRecordHandle[],
+    _scope: MemoryScope,
+  ): Promise<{ usage?: MemoryUsage[] }> {
+    let deleted = 0;
+    const start = Date.now();
+
+    for (const handle of handles) {
+      const { drawerId } = decodeHandle(handle);
+
+      try {
+        await callTool("mempalace_delete_drawer", { drawer_id: drawerId });
+        deleted++;
+      } catch {
+        // best-effort: continue with remaining handles
+      }
+    }
+
+    const latency = Date.now() - start;
+    return {
+      usage: [{
+        provider: PROVIDER_KEY,
+        latencyMs: latency,
+        details: { drawersDeleted: deleted, drawersRequested: handles.length },
+      }],
+    };
+  }
+
+  // ── Adapter ─────────────────────────────────────────────────────────
+
+  const capabilities: MemoryAdapterCapabilities = {
+    profile: false,
+    browse: true,
+    correction: false,
+    asyncIngestion: true,
+    multimodal: false,
+    providerManagedExtraction: true,
+  };
+
+  return {
+    key: PROVIDER_KEY,
+    capabilities,
+    write,
+    query,
+    get,
+    forget,
+    connect,
+    disconnect,
+    get connected() {
+      return _connected;
+    },
+  };
+}

--- a/server/src/services/memory-adapters/para.ts
+++ b/server/src/services/memory-adapters/para.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readdir, stat, readFile } from "node:fs/promises";
 import { join, relative, resolve, dirname, extname, basename } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -151,34 +152,29 @@ function serializeItemsYaml(facts: ParaFact[]): string {
 // File-system walking helpers
 // ---------------------------------------------------------------------------
 
-function walkFiles(dir: string, maxDepth = 5): string[] {
+async function walkFiles(dir: string, maxDepth = 5): Promise<string[]> {
   const results: string[] = [];
-  function walk(current: string, depth: number) {
+  async function walk(current: string, depth: number) {
     if (depth > maxDepth) return;
-    let entries: string[];
+    let entries;
     try {
-      entries = readdirSync(current);
+      entries = await readdir(current, { withFileTypes: true });
     } catch {
       return;
     }
     for (const entry of entries) {
-      const full = join(current, entry);
-      try {
-        const stat = statSync(full);
-        if (stat.isDirectory()) {
-          walk(full, depth + 1);
-        } else if (stat.isFile()) {
-          const ext = extname(full);
-          if (ext === ".md" || ext === ".yaml" || ext === ".yml" || ext === ".txt") {
-            results.push(full);
-          }
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, depth + 1);
+      } else if (entry.isFile()) {
+        const ext = extname(full);
+        if (ext === ".md" || ext === ".yaml" || ext === ".yml" || ext === ".txt") {
+          results.push(full);
         }
-      } catch {
-        // skip inaccessible
       }
     }
   }
-  walk(dir, 0);
+  await walk(dir, 0);
   return results;
 }
 
@@ -401,13 +397,13 @@ export function createParaMemoryAdapter(config: ParaAdapterConfig): MemoryAdapte
       return { snippets: [], usage: [{ provider: PROVIDER_KEY, details: { method: "none" } }] };
     }
 
-    const files = walkFiles(basePath);
+    const files = await walkFiles(basePath);
     const scored: { path: string; text: string; score: number }[] = [];
 
     for (const filePath of files) {
       let content: string;
       try {
-        content = readFileSync(filePath, "utf8");
+        content = await readFile(filePath, "utf8");
       } catch {
         continue;
       }

--- a/server/src/services/memory-adapters/para.ts
+++ b/server/src/services/memory-adapters/para.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, resolve, dirname, extname, basename } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 import type {
   MemoryAdapter,
   MemoryAdapterCapabilities,
@@ -186,11 +189,11 @@ function walkFiles(dir: string, maxDepth = 5): string[] {
 let qmdChecked = false;
 let qmdAvailable = false;
 
-function isQmdAvailable(): boolean {
+async function isQmdAvailable(): Promise<boolean> {
   if (qmdChecked) return qmdAvailable;
   qmdChecked = true;
   try {
-    execFileSync("qmd", ["--version"], { stdio: "pipe", timeout: 3000 });
+    await execFileAsync("qmd", ["--version"], { timeout: 3000 });
     qmdAvailable = true;
   } catch {
     qmdAvailable = false;
@@ -216,7 +219,11 @@ export function createParaMemoryAdapter(config: ParaAdapterConfig): MemoryAdapte
   }
 
   function toAbsolutePath(relPath: string): string {
-    return resolve(basePath, relPath);
+    const abs = resolve(basePath, relPath);
+    if (!abs.startsWith(basePath + "/") && abs !== basePath) {
+      throw new Error(`Path traversal detected: ${relPath}`);
+    }
+    return abs;
   }
 
   function toRelativePath(absPath: string): string {
@@ -346,15 +353,15 @@ export function createParaMemoryAdapter(config: ParaAdapterConfig): MemoryAdapte
     const snippets: MemorySnippet[] = [];
 
     // Try qmd first for semantic search
-    if (isQmdAvailable()) {
+    if (await isQmdAvailable()) {
       try {
         const subcommand = req.intent === "browse" ? "vsearch" : "query";
-        const raw = execFileSync(
+        const { stdout: raw } = await execFileAsync(
           "qmd",
           [subcommand, req.query, "--limit", String(topK), "--json"],
-          { cwd: basePath, stdio: ["pipe", "pipe", "pipe"], timeout: 10_000 },
+          { cwd: basePath, timeout: 10_000 },
         );
-        const results = JSON.parse(raw.toString("utf8"));
+        const results = JSON.parse(raw);
         if (Array.isArray(results)) {
           for (const r of results.slice(0, topK)) {
             const filePath = r.file ?? r.path ?? "";

--- a/server/src/services/memory-adapters/para.ts
+++ b/server/src/services/memory-adapters/para.ts
@@ -1,0 +1,550 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve, dirname, extname, basename } from "node:path";
+import { execFileSync } from "node:child_process";
+import type {
+  MemoryAdapter,
+  MemoryAdapterCapabilities,
+  MemoryWriteRequest,
+  MemoryQueryRequest,
+  MemoryRecordHandle,
+  MemoryScope,
+  MemorySnippet,
+  MemoryContextBundle,
+  MemoryUsage,
+} from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Handle encoding helpers
+// ---------------------------------------------------------------------------
+
+const PROVIDER_KEY = "para";
+
+function encodeHandle(relativePath: string, factId?: string): MemoryRecordHandle {
+  const id = factId ? `${relativePath}#${factId}` : relativePath;
+  return { providerKey: PROVIDER_KEY, providerRecordId: id };
+}
+
+function decodeHandle(handle: MemoryRecordHandle): { path: string; factId?: string } {
+  const idx = handle.providerRecordId.indexOf("#");
+  if (idx === -1) return { path: handle.providerRecordId };
+  return {
+    path: handle.providerRecordId.slice(0, idx),
+    factId: handle.providerRecordId.slice(idx + 1),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight YAML fact helpers (avoids a full YAML parser dependency)
+//
+// These parse and serialise the simple items.yaml format used by PARA:
+//   - id: entity-001
+//     fact: "The actual fact"
+//     status: active
+//     ...
+// ---------------------------------------------------------------------------
+
+interface ParaFact {
+  id: string;
+  fact: string;
+  category?: string;
+  timestamp?: string;
+  source?: string;
+  status: string;
+  superseded_by?: string | null;
+  related_entities?: string[];
+  last_accessed?: string;
+  access_count?: number;
+  [key: string]: unknown;
+}
+
+/** Minimal parser for the PARA items.yaml array-of-maps format. */
+function parseItemsYaml(raw: string): ParaFact[] {
+  const facts: ParaFact[] = [];
+  let current: Record<string, unknown> | null = null;
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (trimmed.startsWith("- ")) {
+      // new item
+      if (current) facts.push(current as unknown as ParaFact);
+      current = {};
+      const kv = trimmed.slice(2).trim();
+      const colonIdx = kv.indexOf(":");
+      if (colonIdx !== -1) {
+        const k = kv.slice(0, colonIdx).trim();
+        const v = kv.slice(colonIdx + 1).trim();
+        current[k] = unquote(v);
+      }
+    } else if (current && trimmed.startsWith("  ")) {
+      const kv = trimmed.trim();
+      if (kv.startsWith("- ")) {
+        // array continuation — find the last key that was an array
+        const lastArrayKey = Object.keys(current)
+          .reverse()
+          .find((k) => Array.isArray(current![k]));
+        if (lastArrayKey) {
+          (current[lastArrayKey] as unknown[]).push(unquote(kv.slice(2).trim()));
+        }
+      } else {
+        const colonIdx = kv.indexOf(":");
+        if (colonIdx !== -1) {
+          const k = kv.slice(0, colonIdx).trim();
+          let v = kv.slice(colonIdx + 1).trim();
+          if (v === "" || v === "null") {
+            current[k] = null;
+          } else if (v === "[]") {
+            current[k] = [];
+          } else if (/^\d+$/.test(v)) {
+            current[k] = Number(v);
+          } else {
+            current[k] = unquote(v);
+          }
+        }
+      }
+    }
+  }
+  if (current) facts.push(current as unknown as ParaFact);
+
+  return facts;
+}
+
+function unquote(v: string): string {
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+function serializeItemsYaml(facts: ParaFact[]): string {
+  const lines: string[] = [];
+  for (const fact of facts) {
+    let first = true;
+    for (const [k, v] of Object.entries(fact)) {
+      if (v === undefined) continue;
+      const prefix = first ? "- " : "  ";
+      first = false;
+      if (Array.isArray(v)) {
+        if (v.length === 0) {
+          lines.push(`${prefix}${k}: []`);
+        } else {
+          lines.push(`${prefix}${k}:`);
+          for (const item of v) {
+            lines.push(`    - ${item}`);
+          }
+        }
+      } else if (v === null) {
+        lines.push(`${prefix}${k}: null`);
+      } else if (typeof v === "string" && /[:#\[\]{},"']/.test(v)) {
+        lines.push(`${prefix}${k}: "${v}"`);
+      } else {
+        lines.push(`${prefix}${k}: ${v}`);
+      }
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// File-system walking helpers
+// ---------------------------------------------------------------------------
+
+function walkFiles(dir: string, maxDepth = 5): string[] {
+  const results: string[] = [];
+  function walk(current: string, depth: number) {
+    if (depth > maxDepth) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(current, entry);
+      try {
+        const stat = statSync(full);
+        if (stat.isDirectory()) {
+          walk(full, depth + 1);
+        } else if (stat.isFile()) {
+          const ext = extname(full);
+          if (ext === ".md" || ext === ".yaml" || ext === ".yml" || ext === ".txt") {
+            results.push(full);
+          }
+        }
+      } catch {
+        // skip inaccessible
+      }
+    }
+  }
+  walk(dir, 0);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// qmd availability check
+// ---------------------------------------------------------------------------
+
+let qmdChecked = false;
+let qmdAvailable = false;
+
+function isQmdAvailable(): boolean {
+  if (qmdChecked) return qmdAvailable;
+  qmdChecked = true;
+  try {
+    execFileSync("qmd", ["--version"], { stdio: "pipe", timeout: 3000 });
+    qmdAvailable = true;
+  } catch {
+    qmdAvailable = false;
+  }
+  return qmdAvailable;
+}
+
+// ---------------------------------------------------------------------------
+// PARA Memory Adapter
+// ---------------------------------------------------------------------------
+
+export interface ParaAdapterConfig {
+  /** Root directory for PARA files (the $AGENT_HOME equivalent). */
+  basePath: string;
+}
+
+export function createParaMemoryAdapter(config: ParaAdapterConfig): MemoryAdapter {
+  const basePath = resolve(config.basePath);
+
+  function ensureDir(filePath: string) {
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  function toAbsolutePath(relPath: string): string {
+    return resolve(basePath, relPath);
+  }
+
+  function toRelativePath(absPath: string): string {
+    return relative(basePath, absPath);
+  }
+
+  // Today's date for daily notes
+  function today(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  // ── Write ──────────────────────────────────────────────────────────────
+
+  async function write(req: MemoryWriteRequest): Promise<{
+    records?: MemoryRecordHandle[];
+    usage?: MemoryUsage[];
+  }> {
+    const layer = (req.metadata?.layer as string) ?? "daily";
+    const records: MemoryRecordHandle[] = [];
+    const bytesWritten: number[] = [];
+
+    if (layer === "entity") {
+      // Write to an entity's items.yaml
+      const entityPath = (req.metadata?.entityPath as string) ?? "resources/general";
+      const entityDir = toAbsolutePath(join("life", entityPath));
+      const itemsFile = join(entityDir, "items.yaml");
+      ensureDir(itemsFile);
+
+      let facts: ParaFact[] = [];
+      if (existsSync(itemsFile)) {
+        facts = parseItemsYaml(readFileSync(itemsFile, "utf8"));
+      }
+
+      const factId =
+        (req.metadata?.factId as string) ??
+        `${basename(entityPath)}-${String(facts.length + 1).padStart(3, "0")}`;
+
+      if (req.mode === "upsert" && req.metadata?.factId) {
+        const existing = facts.find((f) => f.id === req.metadata!.factId);
+        if (existing) {
+          existing.fact = req.content;
+          existing.timestamp = today();
+          existing.last_accessed = today();
+        } else {
+          facts.push({
+            id: factId,
+            fact: req.content,
+            category: (req.metadata?.category as string) ?? "status",
+            timestamp: today(),
+            source: today(),
+            status: "active",
+            superseded_by: null,
+            related_entities: (req.metadata?.relatedEntities as string[]) ?? [],
+            last_accessed: today(),
+            access_count: 0,
+          });
+        }
+      } else {
+        facts.push({
+          id: factId,
+          fact: req.content,
+          category: (req.metadata?.category as string) ?? "status",
+          timestamp: today(),
+          source: today(),
+          status: "active",
+          superseded_by: null,
+          related_entities: (req.metadata?.relatedEntities as string[]) ?? [],
+          last_accessed: today(),
+          access_count: 0,
+        });
+      }
+
+      const yaml = serializeItemsYaml(facts);
+      writeFileSync(itemsFile, yaml, "utf8");
+      bytesWritten.push(Buffer.byteLength(yaml));
+      records.push(encodeHandle(toRelativePath(itemsFile), factId));
+    } else if (layer === "tacit") {
+      // Write to MEMORY.md
+      const memFile = toAbsolutePath("MEMORY.md");
+      ensureDir(memFile);
+      let existing = "";
+      if (existsSync(memFile)) existing = readFileSync(memFile, "utf8");
+
+      if (req.mode === "upsert") {
+        writeFileSync(memFile, req.content, "utf8");
+      } else {
+        const appended = existing ? `${existing.trimEnd()}\n\n${req.content}\n` : `${req.content}\n`;
+        writeFileSync(memFile, appended, "utf8");
+      }
+
+      bytesWritten.push(Buffer.byteLength(req.content));
+      records.push(encodeHandle("MEMORY.md"));
+    } else {
+      // Default: daily notes
+      const dateStr = (req.metadata?.date as string) ?? today();
+      const dailyFile = toAbsolutePath(join("memory", `${dateStr}.md`));
+      ensureDir(dailyFile);
+
+      let existing = "";
+      if (existsSync(dailyFile)) existing = readFileSync(dailyFile, "utf8");
+
+      const timestamp = new Date().toISOString().slice(11, 16);
+      const entry = `\n- **${timestamp}** — ${req.content}`;
+      const header = existing ? "" : `# ${dateStr}\n`;
+      const updated = `${header}${existing.trimEnd()}${entry}\n`;
+      writeFileSync(dailyFile, updated, "utf8");
+      bytesWritten.push(Buffer.byteLength(entry));
+      records.push(encodeHandle(toRelativePath(dailyFile)));
+    }
+
+    const totalBytes = bytesWritten.reduce((a, b) => a + b, 0);
+    return {
+      records,
+      usage: [
+        {
+          provider: PROVIDER_KEY,
+          details: { bytesWritten: totalBytes, layer },
+        },
+      ],
+    };
+  }
+
+  // ── Query ──────────────────────────────────────────────────────────────
+
+  async function query(req: MemoryQueryRequest): Promise<MemoryContextBundle> {
+    const topK = req.topK ?? 5;
+    const snippets: MemorySnippet[] = [];
+
+    // Try qmd first for semantic search
+    if (isQmdAvailable()) {
+      try {
+        const subcommand = req.intent === "browse" ? "vsearch" : "query";
+        const raw = execFileSync(
+          "qmd",
+          [subcommand, req.query, "--limit", String(topK), "--json"],
+          { cwd: basePath, stdio: ["pipe", "pipe", "pipe"], timeout: 10_000 },
+        );
+        const results = JSON.parse(raw.toString("utf8"));
+        if (Array.isArray(results)) {
+          for (const r of results.slice(0, topK)) {
+            const filePath = r.file ?? r.path ?? "";
+            const relPath = filePath.startsWith("/")
+              ? toRelativePath(filePath)
+              : filePath;
+            snippets.push({
+              handle: encodeHandle(relPath),
+              text: r.text ?? r.content ?? "",
+              score: r.score ?? r.rank ?? undefined,
+              metadata: { file: relPath },
+            });
+          }
+        }
+
+        return {
+          snippets,
+          usage: [
+            {
+              provider: PROVIDER_KEY,
+              details: { method: "qmd", subcommand, resultCount: snippets.length },
+            },
+          ],
+        };
+      } catch {
+        // Fall through to file-system search
+      }
+    }
+
+    // Fallback: keyword search across PARA files
+    const queryTerms = req.query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 2);
+
+    if (queryTerms.length === 0) {
+      return { snippets: [], usage: [{ provider: PROVIDER_KEY, details: { method: "none" } }] };
+    }
+
+    const files = walkFiles(basePath);
+    const scored: { path: string; text: string; score: number }[] = [];
+
+    for (const filePath of files) {
+      let content: string;
+      try {
+        content = readFileSync(filePath, "utf8");
+      } catch {
+        continue;
+      }
+      const lower = content.toLowerCase();
+      let matchCount = 0;
+      for (const term of queryTerms) {
+        // Count occurrences of each term
+        let idx = 0;
+        while ((idx = lower.indexOf(term, idx)) !== -1) {
+          matchCount++;
+          idx += term.length;
+        }
+      }
+      if (matchCount > 0) {
+        // Extract a relevant snippet around the first match
+        const firstTermIdx = lower.indexOf(queryTerms[0]);
+        const snippetStart = Math.max(0, firstTermIdx - 100);
+        const snippetEnd = Math.min(content.length, firstTermIdx + 300);
+        const text = content.slice(snippetStart, snippetEnd).trim();
+        scored.push({
+          path: filePath,
+          text,
+          score: matchCount / queryTerms.length,
+        });
+      }
+    }
+
+    // Sort by score descending, take topK
+    scored.sort((a, b) => b.score - a.score);
+    for (const item of scored.slice(0, topK)) {
+      const relPath = toRelativePath(item.path);
+      snippets.push({
+        handle: encodeHandle(relPath),
+        text: item.text,
+        score: item.score,
+        metadata: { file: relPath },
+      });
+    }
+
+    return {
+      snippets,
+      usage: [
+        {
+          provider: PROVIDER_KEY,
+          details: { method: "keyword", filesScanned: files.length, resultCount: snippets.length },
+        },
+      ],
+    };
+  }
+
+  // ── Get ────────────────────────────────────────────────────────────────
+
+  async function get(
+    handle: MemoryRecordHandle,
+    _scope: MemoryScope,
+  ): Promise<MemorySnippet | null> {
+    const { path: relPath, factId } = decodeHandle(handle);
+    const absPath = toAbsolutePath(relPath);
+
+    if (!existsSync(absPath)) return null;
+
+    const content = readFileSync(absPath, "utf8");
+
+    if (factId && (relPath.endsWith(".yaml") || relPath.endsWith(".yml"))) {
+      const facts = parseItemsYaml(content);
+      const fact = facts.find((f) => f.id === factId);
+      if (!fact) return null;
+      return {
+        handle,
+        text: fact.fact,
+        metadata: {
+          id: fact.id,
+          category: fact.category,
+          status: fact.status,
+          timestamp: fact.timestamp,
+          accessCount: fact.access_count,
+        },
+      };
+    }
+
+    return {
+      handle,
+      text: content,
+      metadata: { file: relPath },
+    };
+  }
+
+  // ── Forget ─────────────────────────────────────────────────────────────
+
+  async function forget(
+    handles: MemoryRecordHandle[],
+    _scope: MemoryScope,
+  ): Promise<{ usage?: MemoryUsage[] }> {
+    let superseded = 0;
+
+    for (const handle of handles) {
+      const { path: relPath, factId } = decodeHandle(handle);
+      const absPath = toAbsolutePath(relPath);
+
+      if (!existsSync(absPath)) continue;
+
+      if (factId && (relPath.endsWith(".yaml") || relPath.endsWith(".yml"))) {
+        // PARA principle: never delete, only supersede
+        const content = readFileSync(absPath, "utf8");
+        const facts = parseItemsYaml(content);
+        const fact = facts.find((f) => f.id === factId);
+        if (fact && fact.status !== "superseded") {
+          fact.status = "superseded";
+          fact.superseded_by = "forgotten";
+          writeFileSync(absPath, serializeItemsYaml(facts), "utf8");
+          superseded++;
+        }
+      }
+      // For non-YAML files (daily notes, MEMORY.md), we don't delete per PARA rules.
+      // The caller can overwrite via a write(mode=upsert) if needed.
+    }
+
+    return {
+      usage: [
+        {
+          provider: PROVIDER_KEY,
+          details: { factsSuperseded: superseded },
+        },
+      ],
+    };
+  }
+
+  // ── Adapter ────────────────────────────────────────────────────────────
+
+  const capabilities: MemoryAdapterCapabilities = {
+    profile: false,
+    browse: false,
+    correction: false,
+    asyncIngestion: false,
+    multimodal: false,
+    providerManagedExtraction: false,
+  };
+
+  return {
+    key: PROVIDER_KEY,
+    capabilities,
+    write,
+    query,
+    get,
+    forget,
+  };
+}

--- a/server/src/services/memory-bindings.ts
+++ b/server/src/services/memory-bindings.ts
@@ -1,0 +1,104 @@
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { memoryBindings, memoryBindingTargets } from "@paperclipai/db";
+import type { CreateMemoryBinding, UpdateMemoryBinding, CreateMemoryBindingTarget } from "@paperclipai/shared";
+
+export function memoryBindingService(db: Db) {
+  return {
+    // ── Bindings ──────────────────────────────────────────────────────
+
+    list: async (companyId: string) => {
+      return db
+        .select()
+        .from(memoryBindings)
+        .where(eq(memoryBindings.companyId, companyId));
+    },
+
+    getById: async (id: string) => {
+      return db
+        .select()
+        .from(memoryBindings)
+        .where(eq(memoryBindings.id, id))
+        .then((rows) => rows[0] ?? null);
+    },
+
+    create: async (companyId: string, data: CreateMemoryBinding) => {
+      return db
+        .insert(memoryBindings)
+        .values({
+          companyId,
+          key: data.key,
+          providerKey: data.providerKey,
+          pluginId: data.pluginId ?? null,
+          config: data.config ?? {},
+          capabilities: data.capabilities ?? {},
+          enabled: data.enabled ?? true,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+    },
+
+    update: async (id: string, data: UpdateMemoryBinding) => {
+      const sets: Record<string, unknown> = { updatedAt: new Date() };
+      if (data.key !== undefined) sets.key = data.key;
+      if (data.providerKey !== undefined) sets.providerKey = data.providerKey;
+      if (data.pluginId !== undefined) sets.pluginId = data.pluginId;
+      if (data.config !== undefined) sets.config = data.config;
+      if (data.capabilities !== undefined) sets.capabilities = data.capabilities;
+      if (data.enabled !== undefined) sets.enabled = data.enabled;
+
+      return db
+        .update(memoryBindings)
+        .set(sets)
+        .where(eq(memoryBindings.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+
+    remove: async (id: string) => {
+      return db
+        .delete(memoryBindings)
+        .where(eq(memoryBindings.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+
+    // ── Binding Targets ──────────────────────────────────────────────
+
+    listTargets: async (bindingId: string) => {
+      return db
+        .select()
+        .from(memoryBindingTargets)
+        .where(eq(memoryBindingTargets.bindingId, bindingId));
+    },
+
+    addTarget: async (bindingId: string, data: CreateMemoryBindingTarget) => {
+      return db
+        .insert(memoryBindingTargets)
+        .values({
+          bindingId,
+          targetType: data.targetType,
+          targetId: data.targetId,
+          priority: data.priority ?? 0,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+    },
+
+    getTargetById: async (targetId: string) => {
+      return db
+        .select()
+        .from(memoryBindingTargets)
+        .where(eq(memoryBindingTargets.id, targetId))
+        .then((rows) => rows[0] ?? null);
+    },
+
+    removeTarget: async (targetId: string) => {
+      return db
+        .delete(memoryBindingTargets)
+        .where(eq(memoryBindingTargets.id, targetId))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    },
+  };
+}

--- a/server/src/services/memory-hooks.ts
+++ b/server/src/services/memory-hooks.ts
@@ -118,7 +118,11 @@ async function resolveBindingsForAgent(
     if (!adapter) continue;
 
     const config = (binding.config ?? {}) as Record<string, unknown>;
-    const hooks = (config.hooks ?? {}) as MemoryHooksConfig;
+    const rawHooks = config.hooks;
+    const hooks: MemoryHooksConfig =
+      rawHooks && typeof rawHooks === "object" && !Array.isArray(rawHooks)
+        ? (rawHooks as MemoryHooksConfig)
+        : {};
 
     resolved.push({
       bindingId: binding.id,
@@ -195,6 +199,7 @@ async function hydrateRunContext(
   for (const binding of hydrateBindings) {
     const topK = binding.hooks.preRunHydrate?.topK ?? 5;
 
+    const adapterStart = Date.now();
     try {
       const result: MemoryContextBundle = await binding.adapter.query({
         bindingKey: binding.bindingKey,
@@ -203,6 +208,7 @@ async function hydrateRunContext(
         topK,
         intent: "agent_preamble",
       });
+      const adapterLatencyMs = Date.now() - adapterStart;
 
       allSnippets.push(...result.snippets);
       if (result.usage) allUsage.push(...result.usage);
@@ -217,10 +223,12 @@ async function hydrateRunContext(
         operationType: "query",
         scope,
         usage: result.usage,
+        latencyMs: adapterLatencyMs,
         success: true,
         hookName: "preRunHydrate",
-      }).catch(() => {});
+      }).catch((err) => { logger.warn({ err }, "failed to log memory hook operation"); });
     } catch (err) {
+      const adapterLatencyMs = Date.now() - adapterStart;
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(
         {
@@ -238,10 +246,11 @@ async function hydrateRunContext(
         bindingId: binding.bindingId,
         operationType: "query",
         scope,
+        latencyMs: adapterLatencyMs,
         success: false,
         error: message,
         hookName: "preRunHydrate",
-      }).catch(() => {});
+      }).catch((err) => { logger.warn({ err }, "failed to log memory hook operation"); });
     }
   }
 
@@ -308,6 +317,7 @@ async function captureRunResult(
     const captureDepth = binding.hooks.postRunCapture?.captureDepth ?? "summary";
     const content = buildCaptureContent(params, captureDepth);
 
+    const adapterStart = Date.now();
     try {
       const result = await binding.adapter.write({
         bindingKey: binding.bindingKey,
@@ -321,6 +331,7 @@ async function captureRunResult(
         content,
         mode: "append",
       });
+      const adapterLatencyMs = Date.now() - adapterStart;
 
       if (result.usage) allUsage.push(...result.usage);
       bindingsCaptured++;
@@ -331,10 +342,12 @@ async function captureRunResult(
         operationType: "write",
         scope,
         usage: result.usage,
+        latencyMs: adapterLatencyMs,
         success: true,
         hookName: "postRunCapture",
-      }).catch(() => {});
+      }).catch((err) => { logger.warn({ err }, "failed to log memory hook operation"); });
     } catch (err) {
+      const adapterLatencyMs = Date.now() - adapterStart;
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(
         {
@@ -352,10 +365,11 @@ async function captureRunResult(
         bindingId: binding.bindingId,
         operationType: "write",
         scope,
+        latencyMs: adapterLatencyMs,
         success: false,
         error: message,
         hookName: "postRunCapture",
-      }).catch(() => {});
+      }).catch((err) => { logger.warn({ err }, "failed to log memory hook operation"); });
     }
   }
 
@@ -385,7 +399,14 @@ function buildCaptureContent(
     lines.push("### Result");
     const resultStr = JSON.stringify(params.resultJson, null, 2);
     const maxLen = 4000;
-    lines.push(resultStr.length > maxLen ? resultStr.slice(0, maxLen) + "\n..." : resultStr);
+    if (resultStr.length > maxLen) {
+      lines.push("```");
+      lines.push(resultStr.slice(0, maxLen));
+      lines.push("```");
+      lines.push(`(truncated — ${resultStr.length} chars total)`);
+    } else {
+      lines.push(resultStr);
+    }
   }
 
   return lines.join("\n");
@@ -403,12 +424,12 @@ async function logHookOperation(
     operationType: string;
     scope: MemoryScope;
     usage?: MemoryUsage[];
+    latencyMs: number;
     success: boolean;
     error?: string;
     hookName: string;
   },
 ) {
-  const start = Date.now();
   await db.insert(memoryOperations).values({
     companyId: params.companyId,
     bindingId: params.bindingId,
@@ -419,7 +440,7 @@ async function logHookOperation(
     runId: params.scope.runId ?? null,
     sourceRef: { hook: params.hookName },
     usage: params.usage ? (params.usage as unknown as Record<string, unknown>) : null,
-    latencyMs: Date.now() - start,
+    latencyMs: params.latencyMs,
     success: params.success,
     error: params.error ?? null,
   });

--- a/server/src/services/memory-hooks.ts
+++ b/server/src/services/memory-hooks.ts
@@ -206,7 +206,6 @@ async function hydrateRunContext(
         scope,
         query,
         topK,
-        intent: "agent_preamble",
       });
       const adapterLatencyMs = Date.now() - adapterStart;
 

--- a/server/src/services/memory-hooks.ts
+++ b/server/src/services/memory-hooks.ts
@@ -98,6 +98,7 @@ async function resolveBindingsForAgent(
     .where(
       and(
         inArray(memoryBindings.id, bindingIds),
+        eq(memoryBindings.companyId, companyId),
         eq(memoryBindings.enabled, true),
       ),
     );

--- a/server/src/services/memory-hooks.ts
+++ b/server/src/services/memory-hooks.ts
@@ -1,0 +1,443 @@
+import { and, eq, inArray, or, asc } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { memoryBindings, memoryBindingTargets, memoryOperations } from "@paperclipai/db";
+import type {
+  MemoryAdapter,
+  MemoryScope,
+  MemoryContextBundle,
+  MemorySnippet,
+  MemoryUsage,
+} from "@paperclipai/plugin-sdk";
+import { getMemoryAdapter } from "./memory-operations.js";
+import { logger } from "../middleware/logger.js";
+
+// ---------------------------------------------------------------------------
+// Hook configuration types
+//
+// Hook config lives inside the binding's `config` jsonb under the `hooks` key.
+// Example binding config:
+// {
+//   "hooks": {
+//     "preRunHydrate": { "enabled": true, "topK": 5 },
+//     "postRunCapture": { "enabled": true, "captureDepth": "summary" }
+//   }
+// }
+// ---------------------------------------------------------------------------
+
+export interface PreRunHydrateHookConfig {
+  enabled: boolean;
+  /** Max snippets to retrieve (default: 5). */
+  topK?: number;
+}
+
+export interface PostRunCaptureHookConfig {
+  enabled: boolean;
+  /** What to capture: "summary" (issue title + outcome) or "full" (include run result). Default: "summary". */
+  captureDepth?: "summary" | "full";
+}
+
+export interface MemoryHooksConfig {
+  preRunHydrate?: PreRunHydrateHookConfig;
+  postRunCapture?: PostRunCaptureHookConfig;
+}
+
+/** Parsed binding with resolved hook config. */
+interface ResolvedBinding {
+  bindingId: string;
+  bindingKey: string;
+  providerKey: string;
+  config: Record<string, unknown>;
+  hooks: MemoryHooksConfig;
+  adapter: MemoryAdapter;
+  targetPriority: number;
+}
+
+// ---------------------------------------------------------------------------
+// Binding resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve all enabled memory bindings that target a given agent or its company,
+ * ordered by target priority (lower = higher priority, agent-scoped first).
+ *
+ * Returns only bindings whose adapter is currently registered.
+ */
+async function resolveBindingsForAgent(
+  db: Db,
+  companyId: string,
+  agentId: string,
+): Promise<ResolvedBinding[]> {
+  const targets = await db
+    .select({
+      bindingId: memoryBindingTargets.bindingId,
+      targetType: memoryBindingTargets.targetType,
+      targetId: memoryBindingTargets.targetId,
+      priority: memoryBindingTargets.priority,
+    })
+    .from(memoryBindingTargets)
+    .where(
+      or(
+        and(
+          eq(memoryBindingTargets.targetType, "agent"),
+          eq(memoryBindingTargets.targetId, agentId),
+        ),
+        and(
+          eq(memoryBindingTargets.targetType, "company"),
+          eq(memoryBindingTargets.targetId, companyId),
+        ),
+      ),
+    )
+    .orderBy(asc(memoryBindingTargets.priority));
+
+  if (targets.length === 0) return [];
+
+  const bindingIds = [...new Set(targets.map((t) => t.bindingId))];
+  const bindings = await db
+    .select()
+    .from(memoryBindings)
+    .where(
+      and(
+        inArray(memoryBindings.id, bindingIds),
+        eq(memoryBindings.enabled, true),
+      ),
+    );
+
+  const bindingMap = new Map(bindings.map((b) => [b.id, b]));
+
+  const resolved: ResolvedBinding[] = [];
+  const seenBindings = new Set<string>();
+
+  for (const target of targets) {
+    if (seenBindings.has(target.bindingId)) continue;
+    seenBindings.add(target.bindingId);
+
+    const binding = bindingMap.get(target.bindingId);
+    if (!binding) continue;
+
+    const adapter = getMemoryAdapter(binding.providerKey);
+    if (!adapter) continue;
+
+    const config = (binding.config ?? {}) as Record<string, unknown>;
+    const hooks = (config.hooks ?? {}) as MemoryHooksConfig;
+
+    resolved.push({
+      bindingId: binding.id,
+      bindingKey: binding.key,
+      providerKey: binding.providerKey,
+      config,
+      hooks,
+      adapter,
+      targetPriority: target.priority,
+    });
+  }
+
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Pre-run hydration
+// ---------------------------------------------------------------------------
+
+export interface HydrateRunContextParams {
+  companyId: string;
+  agentId: string;
+  projectId?: string;
+  issueId?: string;
+  runId: string;
+  /** Issue title or task summary — used as the query for semantic search. */
+  taskSummary?: string;
+}
+
+export interface HydrateRunContextResult {
+  /** Combined snippets from all bindings, ready for injection into context. */
+  snippets: MemorySnippet[];
+  /** Profile summary from the first binding that provides one. */
+  profileSummary?: string;
+  /** Aggregated usage across all bindings. */
+  usage: MemoryUsage[];
+  /** How many bindings were queried. */
+  bindingsQueried: number;
+}
+
+/**
+ * Query all applicable memory bindings with preRunHydrate enabled
+ * and return combined context snippets for injection into the run.
+ */
+async function hydrateRunContext(
+  db: Db,
+  params: HydrateRunContextParams,
+): Promise<HydrateRunContextResult> {
+  const bindings = await resolveBindingsForAgent(db, params.companyId, params.agentId);
+
+  const hydrateBindings = bindings.filter(
+    (b) => b.hooks.preRunHydrate?.enabled === true,
+  );
+
+  if (hydrateBindings.length === 0) {
+    return { snippets: [], usage: [], bindingsQueried: 0 };
+  }
+
+  const scope: MemoryScope = {
+    companyId: params.companyId,
+    agentId: params.agentId,
+    projectId: params.projectId,
+    issueId: params.issueId,
+    runId: params.runId,
+  };
+
+  const query = params.taskSummary ?? "agent context";
+
+  const allSnippets: MemorySnippet[] = [];
+  const allUsage: MemoryUsage[] = [];
+  let profileSummary: string | undefined;
+  let bindingsQueried = 0;
+
+  for (const binding of hydrateBindings) {
+    const topK = binding.hooks.preRunHydrate?.topK ?? 5;
+
+    try {
+      const result: MemoryContextBundle = await binding.adapter.query({
+        bindingKey: binding.bindingKey,
+        scope,
+        query,
+        topK,
+        intent: "agent_preamble",
+      });
+
+      allSnippets.push(...result.snippets);
+      if (result.usage) allUsage.push(...result.usage);
+      if (!profileSummary && result.profileSummary) {
+        profileSummary = result.profileSummary;
+      }
+      bindingsQueried++;
+
+      await logHookOperation(db, {
+        companyId: params.companyId,
+        bindingId: binding.bindingId,
+        operationType: "query",
+        scope,
+        usage: result.usage,
+        success: true,
+        hookName: "preRunHydrate",
+      }).catch(() => {});
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        {
+          companyId: params.companyId,
+          agentId: params.agentId,
+          runId: params.runId,
+          bindingKey: binding.bindingKey,
+          error: message,
+        },
+        "memory hydration failed for binding — skipping",
+      );
+
+      await logHookOperation(db, {
+        companyId: params.companyId,
+        bindingId: binding.bindingId,
+        operationType: "query",
+        scope,
+        success: false,
+        error: message,
+        hookName: "preRunHydrate",
+      }).catch(() => {});
+    }
+  }
+
+  return { snippets: allSnippets, profileSummary, usage: allUsage, bindingsQueried };
+}
+
+// ---------------------------------------------------------------------------
+// Post-run capture
+// ---------------------------------------------------------------------------
+
+export interface CaptureRunResultParams {
+  companyId: string;
+  agentId: string;
+  projectId?: string;
+  issueId?: string;
+  runId: string;
+  /** Run outcome: succeeded, failed, timed_out, cancelled. */
+  outcome: string;
+  /** Issue title or task summary. */
+  taskSummary?: string;
+  /** Structured run result (from adapter). */
+  resultJson?: Record<string, unknown> | null;
+  /** Agent name for readable summaries. */
+  agentName?: string;
+}
+
+export interface CaptureRunResultResult {
+  /** Number of bindings that received captured content. */
+  bindingsCaptured: number;
+  /** Aggregated usage across all captures. */
+  usage: MemoryUsage[];
+}
+
+/**
+ * After a run completes, capture a summary of what happened into all
+ * applicable memory bindings with postRunCapture enabled.
+ */
+async function captureRunResult(
+  db: Db,
+  params: CaptureRunResultParams,
+): Promise<CaptureRunResultResult> {
+  const bindings = await resolveBindingsForAgent(db, params.companyId, params.agentId);
+
+  const captureBindings = bindings.filter(
+    (b) => b.hooks.postRunCapture?.enabled === true,
+  );
+
+  if (captureBindings.length === 0) {
+    return { bindingsCaptured: 0, usage: [] };
+  }
+
+  const scope: MemoryScope = {
+    companyId: params.companyId,
+    agentId: params.agentId,
+    projectId: params.projectId,
+    issueId: params.issueId,
+    runId: params.runId,
+  };
+
+  const allUsage: MemoryUsage[] = [];
+  let bindingsCaptured = 0;
+
+  for (const binding of captureBindings) {
+    const captureDepth = binding.hooks.postRunCapture?.captureDepth ?? "summary";
+    const content = buildCaptureContent(params, captureDepth);
+
+    try {
+      const result = await binding.adapter.write({
+        bindingKey: binding.bindingKey,
+        scope,
+        source: {
+          kind: "run",
+          companyId: params.companyId,
+          runId: params.runId,
+          issueId: params.issueId,
+        },
+        content,
+        mode: "append",
+      });
+
+      if (result.usage) allUsage.push(...result.usage);
+      bindingsCaptured++;
+
+      await logHookOperation(db, {
+        companyId: params.companyId,
+        bindingId: binding.bindingId,
+        operationType: "write",
+        scope,
+        usage: result.usage,
+        success: true,
+        hookName: "postRunCapture",
+      }).catch(() => {});
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        {
+          companyId: params.companyId,
+          agentId: params.agentId,
+          runId: params.runId,
+          bindingKey: binding.bindingKey,
+          error: message,
+        },
+        "memory capture failed for binding — skipping",
+      );
+
+      await logHookOperation(db, {
+        companyId: params.companyId,
+        bindingId: binding.bindingId,
+        operationType: "write",
+        scope,
+        success: false,
+        error: message,
+        hookName: "postRunCapture",
+      }).catch(() => {});
+    }
+  }
+
+  return { bindingsCaptured, usage: allUsage };
+}
+
+// ---------------------------------------------------------------------------
+// Capture content builder
+// ---------------------------------------------------------------------------
+
+function buildCaptureContent(
+  params: CaptureRunResultParams,
+  depth: "summary" | "full",
+): string {
+  const lines: string[] = [];
+
+  lines.push(`## Run ${params.outcome}`);
+  if (params.agentName) lines.push(`Agent: ${params.agentName}`);
+  if (params.taskSummary) lines.push(`Task: ${params.taskSummary}`);
+  lines.push(`Run: ${params.runId}`);
+  if (params.issueId) lines.push(`Issue: ${params.issueId}`);
+  lines.push(`Outcome: ${params.outcome}`);
+  lines.push(`Captured: ${new Date().toISOString()}`);
+
+  if (depth === "full" && params.resultJson) {
+    lines.push("");
+    lines.push("### Result");
+    const resultStr = JSON.stringify(params.resultJson, null, 2);
+    const maxLen = 4000;
+    lines.push(resultStr.length > maxLen ? resultStr.slice(0, maxLen) + "\n..." : resultStr);
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Operation logging helper
+// ---------------------------------------------------------------------------
+
+async function logHookOperation(
+  db: Db,
+  params: {
+    companyId: string;
+    bindingId: string;
+    operationType: string;
+    scope: MemoryScope;
+    usage?: MemoryUsage[];
+    success: boolean;
+    error?: string;
+    hookName: string;
+  },
+) {
+  const start = Date.now();
+  await db.insert(memoryOperations).values({
+    companyId: params.companyId,
+    bindingId: params.bindingId,
+    operationType: params.operationType,
+    agentId: params.scope.agentId ?? null,
+    projectId: params.scope.projectId ?? null,
+    issueId: params.scope.issueId ?? null,
+    runId: params.scope.runId ?? null,
+    sourceRef: { hook: params.hookName },
+    usage: params.usage ? (params.usage as unknown as Record<string, unknown>) : null,
+    latencyMs: Date.now() - start,
+    success: params.success,
+    error: params.error ?? null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Service factory
+// ---------------------------------------------------------------------------
+
+export function memoryHooksService(db: Db) {
+  return {
+    resolveBindingsForAgent: (companyId: string, agentId: string) =>
+      resolveBindingsForAgent(db, companyId, agentId),
+
+    hydrateRunContext: (params: HydrateRunContextParams) =>
+      hydrateRunContext(db, params),
+
+    captureRunResult: (params: CaptureRunResultParams) =>
+      captureRunResult(db, params),
+  };
+}

--- a/server/src/services/memory-operations.ts
+++ b/server/src/services/memory-operations.ts
@@ -11,6 +11,7 @@ import type {
   MemoryContextBundle,
 } from "@paperclipai/plugin-sdk";
 import { notFound, badRequest } from "../errors.js";
+import { logger } from "../middleware/logger.js";
 
 // ---------------------------------------------------------------------------
 // In-memory adapter registry — plugins register adapters at startup, the
@@ -143,7 +144,7 @@ export function memoryOperationService(db: Db) {
           success: false,
           error: message,
           sourceRef: body.source as unknown as Record<string, unknown>,
-        }).catch(() => {}); // best-effort log on failure path
+        }).catch((err) => { logger.warn({ err }, "failed to log memory operation"); });
 
         throw err;
       }

--- a/server/src/services/memory-operations.ts
+++ b/server/src/services/memory-operations.ts
@@ -201,7 +201,7 @@ export function memoryOperationService(db: Db) {
           latencyMs,
           success: false,
           error: message,
-        }).catch(() => {});
+        }).catch((err2) => { logger.warn({ err: err2 }, "failed to log memory query operation"); });
 
         throw err;
       }
@@ -246,7 +246,7 @@ export function memoryOperationService(db: Db) {
           latencyMs,
           success: false,
           error: message,
-        }).catch(() => {});
+        }).catch((err2) => { logger.warn({ err: err2 }, "failed to log memory forget operation"); });
 
         throw err;
       }

--- a/server/src/services/memory-operations.ts
+++ b/server/src/services/memory-operations.ts
@@ -1,0 +1,254 @@
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { memoryBindings, memoryOperations } from "@paperclipai/db";
+import type {
+  MemoryAdapter,
+  MemoryWriteRequest,
+  MemoryQueryRequest,
+  MemoryRecordHandle,
+  MemoryScope,
+  MemoryUsage,
+  MemoryContextBundle,
+} from "@paperclipai/plugin-sdk";
+import { notFound, badRequest } from "../errors.js";
+
+// ---------------------------------------------------------------------------
+// In-memory adapter registry — plugins register adapters at startup, the
+// operations service resolves them by providerKey at call time.
+// ---------------------------------------------------------------------------
+
+const adapterRegistry = new Map<string, MemoryAdapter>();
+
+export function registerMemoryAdapter(adapter: MemoryAdapter) {
+  adapterRegistry.set(adapter.key, adapter);
+}
+
+export function unregisterMemoryAdapter(key: string) {
+  adapterRegistry.delete(key);
+}
+
+export function getRegisteredMemoryAdapters(): string[] {
+  return [...adapterRegistry.keys()];
+}
+
+export function getMemoryAdapter(key: string): MemoryAdapter | undefined {
+  return adapterRegistry.get(key);
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export function memoryOperationService(db: Db) {
+  /** Look up the binding row and resolve its adapter. */
+  async function resolveBinding(bindingId: string) {
+    const binding = await db
+      .select()
+      .from(memoryBindings)
+      .where(eq(memoryBindings.id, bindingId))
+      .then((rows) => rows[0] ?? null);
+
+    if (!binding) throw notFound("Memory binding not found");
+    if (!binding.enabled) throw badRequest("Memory binding is disabled");
+
+    const adapter = adapterRegistry.get(binding.providerKey);
+    if (!adapter) {
+      throw badRequest(
+        `No memory adapter registered for provider "${binding.providerKey}"`,
+      );
+    }
+
+    return { binding, adapter };
+  }
+
+  /** Persist an operation log row. */
+  async function logOperation(params: {
+    companyId: string;
+    bindingId: string;
+    operationType: string;
+    scope: MemoryScope;
+    usage?: MemoryUsage[];
+    latencyMs: number;
+    success: boolean;
+    error?: string;
+    sourceRef?: Record<string, unknown>;
+  }) {
+    await db.insert(memoryOperations).values({
+      companyId: params.companyId,
+      bindingId: params.bindingId,
+      operationType: params.operationType,
+      agentId: params.scope.agentId ?? null,
+      projectId: params.scope.projectId ?? null,
+      issueId: params.scope.issueId ?? null,
+      runId: params.scope.runId ?? null,
+      sourceRef: params.sourceRef ?? null,
+      usage: params.usage ? (params.usage as unknown as Record<string, unknown>) : null,
+      latencyMs: params.latencyMs,
+      success: params.success,
+      error: params.error ?? null,
+    });
+  }
+
+  return {
+    // ── Write ──────────────────────────────────────────────────────────
+
+    write: async (
+      bindingId: string,
+      body: {
+        scope: MemoryScope;
+        source: MemoryWriteRequest["source"];
+        content: string;
+        metadata?: Record<string, unknown>;
+        mode?: "append" | "upsert" | "summarize";
+      },
+    ) => {
+      const { binding, adapter } = await resolveBinding(bindingId);
+
+      const req: MemoryWriteRequest = {
+        bindingKey: binding.key,
+        scope: body.scope,
+        source: body.source,
+        content: body.content,
+        metadata: body.metadata,
+        mode: body.mode,
+      };
+
+      const start = Date.now();
+      try {
+        const result = await adapter.write(req);
+        const latencyMs = Date.now() - start;
+
+        await logOperation({
+          companyId: binding.companyId,
+          bindingId: binding.id,
+          operationType: "write",
+          scope: body.scope,
+          usage: result.usage,
+          latencyMs,
+          success: true,
+          sourceRef: body.source as unknown as Record<string, unknown>,
+        });
+
+        return { records: result.records ?? [], usage: result.usage ?? [], latencyMs };
+      } catch (err) {
+        const latencyMs = Date.now() - start;
+        const message = err instanceof Error ? err.message : String(err);
+
+        await logOperation({
+          companyId: binding.companyId,
+          bindingId: binding.id,
+          operationType: "write",
+          scope: body.scope,
+          latencyMs,
+          success: false,
+          error: message,
+          sourceRef: body.source as unknown as Record<string, unknown>,
+        }).catch(() => {}); // best-effort log on failure path
+
+        throw err;
+      }
+    },
+
+    // ── Query ─────────────────────────────────────────────────────────
+
+    query: async (
+      bindingId: string,
+      body: {
+        scope: MemoryScope;
+        query: string;
+        topK?: number;
+        intent?: "agent_preamble" | "answer" | "browse";
+        metadataFilter?: Record<string, unknown>;
+      },
+    ) => {
+      const { binding, adapter } = await resolveBinding(bindingId);
+
+      const req: MemoryQueryRequest = {
+        bindingKey: binding.key,
+        scope: body.scope,
+        query: body.query,
+        topK: body.topK,
+        intent: body.intent,
+        metadataFilter: body.metadataFilter,
+      };
+
+      const start = Date.now();
+      try {
+        const result: MemoryContextBundle = await adapter.query(req);
+        const latencyMs = Date.now() - start;
+
+        await logOperation({
+          companyId: binding.companyId,
+          bindingId: binding.id,
+          operationType: "query",
+          scope: body.scope,
+          usage: result.usage,
+          latencyMs,
+          success: true,
+        });
+
+        return { ...result, latencyMs };
+      } catch (err) {
+        const latencyMs = Date.now() - start;
+        const message = err instanceof Error ? err.message : String(err);
+
+        await logOperation({
+          companyId: binding.companyId,
+          bindingId: binding.id,
+          operationType: "query",
+          scope: body.scope,
+          latencyMs,
+          success: false,
+          error: message,
+        }).catch(() => {});
+
+        throw err;
+      }
+    },
+
+    // ── Forget ────────────────────────────────────────────────────────
+
+    forget: async (
+      bindingId: string,
+      body: {
+        scope: MemoryScope;
+        handles: MemoryRecordHandle[];
+      },
+    ) => {
+      const { binding, adapter } = await resolveBinding(bindingId);
+
+      const start = Date.now();
+      try {
+        const result = await adapter.forget(body.handles, body.scope);
+        const latencyMs = Date.now() - start;
+
+        await logOperation({
+          companyId: binding.companyId,
+          bindingId: binding.id,
+          operationType: "forget",
+          scope: body.scope,
+          usage: result.usage,
+          latencyMs,
+          success: true,
+        });
+
+        return { usage: result.usage ?? [], latencyMs };
+      } catch (err) {
+        const latencyMs = Date.now() - start;
+        const message = err instanceof Error ? err.message : String(err);
+
+        await logOperation({
+          companyId: binding.companyId,
+          bindingId: binding.id,
+          operationType: "forget",
+          scope: body.scope,
+          latencyMs,
+          success: false,
+          error: message,
+        }).catch(() => {});
+
+        throw err;
+      }
+    },
+  };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -37,6 +37,8 @@ import { PluginSettings } from "./pages/PluginSettings";
 import { AdapterManager } from "./pages/AdapterManager";
 import { PluginPage } from "./pages/PluginPage";
 import { IssueChatUxLab } from "./pages/IssueChatUxLab";
+import { MemorySettings } from "./pages/MemorySettings";
+import { MemoryOperations } from "./pages/MemoryOperations";
 import { RunTranscriptUxLab } from "./pages/RunTranscriptUxLab";
 import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
@@ -167,6 +169,8 @@ function boardRoutes() {
       <Route path="approvals/pending" element={<Approvals />} />
       <Route path="approvals/all" element={<Approvals />} />
       <Route path="approvals/:approvalId" element={<ApprovalDetail />} />
+      <Route path="memory" element={<MemorySettings />} />
+      <Route path="memory/operations" element={<MemoryOperations />} />
       <Route path="costs" element={<Costs />} />
       <Route path="activity" element={<Activity />} />
       <Route path="inbox" element={<InboxRootRedirect />} />
@@ -350,6 +354,8 @@ export function App() {
           <Route path="projects/:projectId/configuration" element={<UnprefixedBoardRedirect />} />
           <Route path="execution-workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
           <Route path="tests/ux/chat" element={<UnprefixedBoardRedirect />} />
+          <Route path="memory" element={<UnprefixedBoardRedirect />} />
+          <Route path="memory/operations" element={<UnprefixedBoardRedirect />} />
           <Route path="tests/ux/runs" element={<UnprefixedBoardRedirect />} />
           <Route path=":companyPrefix" element={<Layout />}>
             {boardRoutes()}

--- a/ui/src/api/memory.ts
+++ b/ui/src/api/memory.ts
@@ -1,0 +1,118 @@
+import { api } from "./client";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface MemoryBinding {
+  id: string;
+  companyId: string;
+  key: string;
+  providerKey: string;
+  pluginId: string | null;
+  config: Record<string, unknown>;
+  capabilities: Record<string, unknown>;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MemoryBindingTarget {
+  id: string;
+  bindingId: string;
+  targetType: "company" | "agent";
+  targetId: string;
+  priority: number;
+  createdAt: string;
+}
+
+export interface MemoryOperation {
+  id: string;
+  bindingId: string;
+  bindingKey: string | null;
+  providerKey: string | null;
+  operationType: string;
+  agentId: string | null;
+  projectId: string | null;
+  issueId: string | null;
+  runId: string | null;
+  sourceRef: Record<string, unknown> | null;
+  usage: Record<string, unknown> | null;
+  latencyMs: number | null;
+  success: boolean;
+  error: string | null;
+  createdAt: string;
+}
+
+export interface MemoryOperationListResult {
+  items: MemoryOperation[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// ── API ───────────────────────────────────────────────────────────
+
+export const memoryApi = {
+  // Bindings
+  listBindings: (companyId: string) =>
+    api.get<MemoryBinding[]>(`/companies/${companyId}/memory-bindings`),
+
+  getBinding: (bindingId: string) =>
+    api.get<MemoryBinding>(`/memory-bindings/${bindingId}`),
+
+  createBinding: (companyId: string, data: {
+    key: string;
+    providerKey: string;
+    pluginId?: string | null;
+    config?: Record<string, unknown>;
+    capabilities?: Record<string, unknown>;
+    enabled?: boolean;
+  }) => api.post<MemoryBinding>(`/companies/${companyId}/memory-bindings`, data),
+
+  updateBinding: (bindingId: string, data: {
+    key?: string;
+    providerKey?: string;
+    pluginId?: string | null;
+    config?: Record<string, unknown>;
+    capabilities?: Record<string, unknown>;
+    enabled?: boolean;
+  }) => api.patch<MemoryBinding>(`/memory-bindings/${bindingId}`, data),
+
+  deleteBinding: (bindingId: string) =>
+    api.delete<{ ok: true }>(`/memory-bindings/${bindingId}`),
+
+  // Binding targets
+  listTargets: (bindingId: string) =>
+    api.get<MemoryBindingTarget[]>(`/memory-bindings/${bindingId}/targets`),
+
+  addTarget: (bindingId: string, data: {
+    targetType: "company" | "agent";
+    targetId: string;
+    priority?: number;
+  }) => api.post<MemoryBindingTarget>(`/memory-bindings/${bindingId}/targets`, data),
+
+  removeTarget: (targetId: string) =>
+    api.delete<{ ok: true }>(`/memory-binding-targets/${targetId}`),
+
+  // Operations (audit log)
+  listOperations: (companyId: string, params?: {
+    bindingId?: string;
+    agentId?: string;
+    operationType?: string;
+    success?: string;
+    from?: string;
+    to?: string;
+    limit?: number;
+    offset?: number;
+  }) => {
+    const search = new URLSearchParams();
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        if (v !== undefined) search.set(k, String(v));
+      }
+    }
+    const qs = search.toString();
+    return api.get<MemoryOperationListResult>(
+      `/companies/${companyId}/memory-operations${qs ? `?${qs}` : ""}`,
+    );
+  },
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Boxes,
   Repeat,
   Settings,
+  Brain,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -109,6 +110,7 @@ export function Sidebar() {
 
         <SidebarSection label="Company">
           <SidebarNavItem to="/org" label="Org" icon={Network} />
+          <SidebarNavItem to="/memory" label="Memory" icon={Brain} />
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -98,6 +98,13 @@ export const queryKeys = {
     schedulerHeartbeats: ["instance", "scheduler-heartbeats"] as const,
     experimentalSettings: ["instance", "experimental-settings"] as const,
   },
+  memory: {
+    bindings: (companyId: string) => ["memory", "bindings", companyId] as const,
+    bindingDetail: (bindingId: string) => ["memory", "bindings", "detail", bindingId] as const,
+    targets: (bindingId: string) => ["memory", "targets", bindingId] as const,
+    operations: (companyId: string, filters?: Record<string, string | number | undefined>) =>
+      ["memory", "operations", companyId, filters ?? {}] as const,
+  },
   health: ["health"] as const,
   secrets: {
     list: (companyId: string) => ["secrets", companyId] as const,

--- a/ui/src/pages/MemoryOperations.tsx
+++ b/ui/src/pages/MemoryOperations.tsx
@@ -1,0 +1,347 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  ChevronLeft,
+  ChevronRight,
+  CheckCircle2,
+  XCircle,
+  Filter,
+} from "lucide-react";
+import { Link } from "@/lib/router";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { memoryApi, type MemoryOperation } from "../api/memory";
+import { agentsApi } from "../api/agents";
+import { queryKeys } from "../lib/queryKeys";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+const PAGE_SIZE = 50;
+
+const OP_TYPE_COLORS: Record<string, string> = {
+  write: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  query: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  forget: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  browse: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  correct: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+};
+
+function formatTime(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function OperationRow({
+  op,
+  agentName,
+}: {
+  op: MemoryOperation;
+  agentName: string | null;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-accent/30 transition-colors text-left"
+      >
+        {op.success ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />
+        ) : (
+          <XCircle className="h-3.5 w-3.5 text-red-500 shrink-0" />
+        )}
+        <span
+          className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium ${OP_TYPE_COLORS[op.operationType] ?? "bg-muted text-muted-foreground"}`}
+        >
+          {op.operationType}
+        </span>
+        <span className="text-muted-foreground truncate max-w-[120px]">
+          {op.bindingKey ?? op.bindingId.slice(0, 8)}
+        </span>
+        {agentName && (
+          <span className="text-muted-foreground truncate max-w-[120px]">
+            {agentName}
+          </span>
+        )}
+        {op.latencyMs != null && (
+          <span className="text-xs text-muted-foreground">{op.latencyMs}ms</span>
+        )}
+        <span className="ml-auto text-xs text-muted-foreground whitespace-nowrap">
+          {formatTime(op.createdAt)}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-3 pt-1 text-xs space-y-1.5 bg-muted/20">
+          <div className="grid grid-cols-[100px_1fr] gap-1">
+            <span className="text-muted-foreground">Operation ID</span>
+            <span className="font-mono">{op.id}</span>
+
+            <span className="text-muted-foreground">Binding</span>
+            <span>
+              {op.bindingKey ?? "—"}{" "}
+              <span className="text-muted-foreground">({op.providerKey ?? "—"})</span>
+            </span>
+
+            {op.agentId && (
+              <>
+                <span className="text-muted-foreground">Agent</span>
+                <span>{agentName ?? op.agentId}</span>
+              </>
+            )}
+
+            {op.issueId && (
+              <>
+                <span className="text-muted-foreground">Issue</span>
+                <Link to={`/issues/${op.issueId}`} className="text-primary hover:underline">
+                  {op.issueId.slice(0, 8)}
+                </Link>
+              </>
+            )}
+
+            {op.runId && (
+              <>
+                <span className="text-muted-foreground">Run</span>
+                <span className="font-mono">{op.runId.slice(0, 8)}</span>
+              </>
+            )}
+
+            {op.error && (
+              <>
+                <span className="text-muted-foreground">Error</span>
+                <span className="text-destructive">{op.error}</span>
+              </>
+            )}
+
+            {op.sourceRef && (
+              <>
+                <span className="text-muted-foreground">Source</span>
+                <span className="font-mono break-all">
+                  {JSON.stringify(op.sourceRef)}
+                </span>
+              </>
+            )}
+
+            {op.usage && (
+              <>
+                <span className="text-muted-foreground">Usage</span>
+                <span className="font-mono break-all">
+                  {JSON.stringify(op.usage)}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function MemoryOperations() {
+  const { selectedCompany, selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [page, setPage] = useState(0);
+  const [filterType, setFilterType] = useState<string>("");
+  const [filterSuccess, setFilterSuccess] = useState<string>("");
+  const [filterBindingId, setFilterBindingId] = useState<string>("");
+  const [filterAgentId, setFilterAgentId] = useState<string>("");
+  const [showFilters, setShowFilters] = useState(false);
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
+      { label: "Memory", href: "/memory" },
+      { label: "Operations" },
+    ]);
+  }, [selectedCompany, setBreadcrumbs]);
+
+  const filters: Record<string, string | number | undefined> = {
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    ...(filterType ? { operationType: filterType } : {}),
+    ...(filterSuccess ? { success: filterSuccess } : {}),
+    ...(filterBindingId ? { bindingId: filterBindingId } : {}),
+    ...(filterAgentId ? { agentId: filterAgentId } : {}),
+  };
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.memory.operations(selectedCompanyId!, filters),
+    queryFn: () => memoryApi.listOperations(selectedCompanyId!, filters),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 15_000,
+  });
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const { data: bindings } = useQuery({
+    queryKey: queryKeys.memory.bindings(selectedCompanyId!),
+    queryFn: () => memoryApi.listBindings(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const agentMap = new Map((agents ?? []).map((a: { id: string; name: string }) => [a.id, a.name]));
+
+  const totalPages = Math.ceil((data?.total ?? 0) / PAGE_SIZE);
+
+  if (!selectedCompanyId) return null;
+
+  return (
+    <div className="mx-auto max-w-4xl py-8 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Activity className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Memory Operations</h1>
+          {data && (
+            <span className="text-sm text-muted-foreground">
+              {data.total} total
+            </span>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowFilters(!showFilters)}
+        >
+          <Filter className="h-3.5 w-3.5 mr-1" /> Filters
+        </Button>
+      </div>
+
+      {showFilters && (
+        <div className="flex flex-wrap items-center gap-3 mb-4 p-3 rounded-lg border border-border bg-muted/20">
+          <div className="flex items-center gap-1.5">
+            <label className="text-xs text-muted-foreground">Type</label>
+            <select
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+              value={filterType}
+              onChange={(e) => { setFilterType(e.target.value); setPage(0); }}
+            >
+              <option value="">All</option>
+              <option value="write">write</option>
+              <option value="query">query</option>
+              <option value="forget">forget</option>
+              <option value="browse">browse</option>
+              <option value="correct">correct</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <label className="text-xs text-muted-foreground">Status</label>
+            <select
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+              value={filterSuccess}
+              onChange={(e) => { setFilterSuccess(e.target.value); setPage(0); }}
+            >
+              <option value="">All</option>
+              <option value="true">Success</option>
+              <option value="false">Failed</option>
+            </select>
+          </div>
+          {bindings && bindings.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-muted-foreground">Binding</label>
+              <select
+                className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+                value={filterBindingId}
+                onChange={(e) => { setFilterBindingId(e.target.value); setPage(0); }}
+              >
+                <option value="">All</option>
+                {bindings.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.key}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {agents && (agents as { id: string; name: string }[]).length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-muted-foreground">Agent</label>
+              <select
+                className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+                value={filterAgentId}
+                onChange={(e) => { setFilterAgentId(e.target.value); setPage(0); }}
+              >
+                <option value="">All</option>
+                {(agents as { id: string; name: string }[]).map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setFilterType("");
+              setFilterSuccess("");
+              setFilterBindingId("");
+              setFilterAgentId("");
+              setPage(0);
+            }}
+          >
+            Clear
+          </Button>
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border bg-card overflow-hidden">
+        {isLoading && (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            Loading operations...
+          </div>
+        )}
+
+        {!isLoading && data?.items.length === 0 && (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No operations found
+          </div>
+        )}
+
+        {data?.items.map((op) => (
+          <OperationRow
+            key={op.id}
+            op={op}
+            agentName={op.agentId ? agentMap.get(op.agentId) ?? null : null}
+          />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 0}
+            onClick={() => setPage(page - 1)}
+          >
+            <ChevronLeft className="h-4 w-4 mr-1" /> Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {page + 1} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages - 1}
+            onClick={() => setPage(page + 1)}
+          >
+            Next <ChevronRight className="h-4 w-4 ml-1" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/MemorySettings.tsx
+++ b/ui/src/pages/MemorySettings.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Brain,
+  Plus,
+  Trash2,
+  Pencil,
+  Check,
+  X,
+  ChevronDown,
+  ChevronRight,
+  Activity,
+} from "lucide-react";
+import { Link } from "@/lib/router";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useToast } from "../context/ToastContext";
+import { memoryApi, type MemoryBinding, type MemoryBindingTarget } from "../api/memory";
+import { agentsApi } from "../api/agents";
+import { queryKeys } from "../lib/queryKeys";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+
+// ── Create / Edit Dialog ──────────────────────────────────────────
+
+function BindingDialog({
+  open,
+  onOpenChange,
+  companyId,
+  existing,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  existing?: MemoryBinding | null;
+}) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const [key, setKey] = useState("");
+  const [providerKey, setProviderKey] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [hooksPreRunEnabled, setHooksPreRunEnabled] = useState(true);
+  const [hooksPreRunTopK, setHooksPreRunTopK] = useState(5);
+  const [hooksPostRunEnabled, setHooksPostRunEnabled] = useState(true);
+  const [hooksPostRunDepth, setHooksPostRunDepth] = useState<"summary" | "full">("summary");
+
+  useEffect(() => {
+    if (open) {
+      if (existing) {
+        setKey(existing.key);
+        setProviderKey(existing.providerKey);
+        setEnabled(existing.enabled);
+        const hooks = (existing.config as { hooks?: Record<string, unknown> })?.hooks as {
+          preRunHydrate?: { enabled?: boolean; topK?: number };
+          postRunCapture?: { enabled?: boolean; captureDepth?: string };
+        } | undefined;
+        setHooksPreRunEnabled(hooks?.preRunHydrate?.enabled ?? true);
+        setHooksPreRunTopK(hooks?.preRunHydrate?.topK ?? 5);
+        setHooksPostRunEnabled(hooks?.postRunCapture?.enabled ?? true);
+        setHooksPostRunDepth((hooks?.postRunCapture?.captureDepth as "summary" | "full") ?? "summary");
+      } else {
+        setKey("");
+        setProviderKey("");
+        setEnabled(true);
+        setHooksPreRunEnabled(true);
+        setHooksPreRunTopK(5);
+        setHooksPostRunEnabled(true);
+        setHooksPostRunDepth("summary");
+      }
+    }
+  }, [open, existing]);
+
+  const createMutation = useMutation({
+    mutationFn: (data: Parameters<typeof memoryApi.createBinding>[1]) =>
+      memoryApi.createBinding(companyId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memory.bindings(companyId) });
+      pushToast({ title: "Binding created", tone: "success" });
+      onOpenChange(false);
+    },
+    onError: (err) => pushToast({ title: (err as Error).message, tone: "error" }),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: Parameters<typeof memoryApi.updateBinding>[1]) =>
+      memoryApi.updateBinding(existing!.id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memory.bindings(companyId) });
+      pushToast({ title: "Binding updated", tone: "success" });
+      onOpenChange(false);
+    },
+    onError: (err) => pushToast({ title: (err as Error).message, tone: "error" }),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const config = {
+      hooks: {
+        preRunHydrate: { enabled: hooksPreRunEnabled, topK: hooksPreRunTopK },
+        postRunCapture: { enabled: hooksPostRunEnabled, captureDepth: hooksPostRunDepth },
+      },
+    };
+    const payload = { key, providerKey, enabled, config };
+    if (existing) {
+      updateMutation.mutate(payload);
+    } else {
+      createMutation.mutate(payload);
+    }
+  }
+
+  const saving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{existing ? "Edit Binding" : "New Memory Binding"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Key</label>
+            <input
+              className="rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              placeholder="e.g. default, long-term"
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Provider Key</label>
+            <input
+              className="rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              value={providerKey}
+              onChange={(e) => setProviderKey(e.target.value)}
+              placeholder="e.g. mempalace, para"
+              required
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium">Enabled</label>
+            <ToggleSwitch checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+
+          <div className="border-t border-border pt-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              Hook Configuration
+            </p>
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm">Pre-run hydration</span>
+                <ToggleSwitch checked={hooksPreRunEnabled} onCheckedChange={setHooksPreRunEnabled} />
+              </div>
+              {hooksPreRunEnabled && (
+                <div className="flex items-center gap-2 pl-4">
+                  <label className="text-xs text-muted-foreground">Top K</label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={50}
+                    className="w-16 rounded-md border border-border bg-background px-2 py-1 text-sm"
+                    value={hooksPreRunTopK}
+                    onChange={(e) => setHooksPreRunTopK(parseInt(e.target.value) || 5)}
+                  />
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <span className="text-sm">Post-run capture</span>
+                <ToggleSwitch checked={hooksPostRunEnabled} onCheckedChange={setHooksPostRunEnabled} />
+              </div>
+              {hooksPostRunEnabled && (
+                <div className="flex items-center gap-2 pl-4">
+                  <label className="text-xs text-muted-foreground">Depth</label>
+                  <select
+                    className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+                    value={hooksPostRunDepth}
+                    onChange={(e) => setHooksPostRunDepth(e.target.value as "summary" | "full")}
+                  >
+                    <option value="summary">Summary</option>
+                    <option value="full">Full</option>
+                  </select>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={saving || !key || !providerKey}>
+              {saving ? "Saving..." : existing ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Binding Target Row ────────────────────────────────────────────
+
+function TargetRow({
+  target,
+  agents,
+  companyName,
+  onRemove,
+}: {
+  target: MemoryBindingTarget;
+  agents: { id: string; name: string }[];
+  companyName: string;
+  onRemove: () => void;
+}) {
+  const label =
+    target.targetType === "company"
+      ? `Company: ${companyName}`
+      : `Agent: ${agents.find((a) => a.id === target.targetId)?.name ?? target.targetId.slice(0, 8)}`;
+
+  return (
+    <div className="flex items-center justify-between py-1.5 pl-4 text-sm">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" className="text-[10px]">
+          {target.targetType}
+        </Badge>
+        <span>{label}</span>
+        {target.priority !== 0 && (
+          <span className="text-xs text-muted-foreground">priority {target.priority}</span>
+        )}
+      </div>
+      <Button variant="ghost" size="icon-sm" onClick={onRemove}>
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+
+// ── Binding Card ──────────────────────────────────────────────────
+
+function BindingCard({
+  binding,
+  companyId,
+  companyName,
+  agents,
+  onEdit,
+}: {
+  binding: MemoryBinding;
+  companyId: string;
+  companyName: string;
+  agents: { id: string; name: string }[];
+  onEdit: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const [expanded, setExpanded] = useState(false);
+  const [addTargetType, setAddTargetType] = useState<"company" | "agent">("company");
+  const [addTargetId, setAddTargetId] = useState("");
+  const [showAddTarget, setShowAddTarget] = useState(false);
+
+  const { data: targets } = useQuery({
+    queryKey: queryKeys.memory.targets(binding.id),
+    queryFn: () => memoryApi.listTargets(binding.id),
+    enabled: expanded,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => memoryApi.deleteBinding(binding.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memory.bindings(companyId) });
+      pushToast({ title: "Binding deleted", tone: "success" });
+    },
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: (enabled: boolean) => memoryApi.updateBinding(binding.id, { enabled }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memory.bindings(companyId) });
+    },
+  });
+
+  const addTargetMutation = useMutation({
+    mutationFn: (data: { targetType: "company" | "agent"; targetId: string }) =>
+      memoryApi.addTarget(binding.id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memory.targets(binding.id) });
+      setShowAddTarget(false);
+      setAddTargetId("");
+      pushToast({ title: "Target added", tone: "success" });
+    },
+    onError: (err) => pushToast({ title: (err as Error).message, tone: "error" }),
+  });
+
+  const removeTargetMutation = useMutation({
+    mutationFn: (targetId: string) => memoryApi.removeTarget(targetId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memory.targets(binding.id) });
+      pushToast({ title: "Target removed", tone: "success" });
+    },
+  });
+
+  const hooks = (binding.config as { hooks?: Record<string, unknown> })?.hooks as {
+    preRunHydrate?: { enabled?: boolean };
+    postRunCapture?: { enabled?: boolean };
+  } | undefined;
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm">{binding.key}</span>
+            <Badge variant="secondary" className="text-[10px]">
+              {binding.providerKey}
+            </Badge>
+            {!binding.enabled && (
+              <Badge variant="outline" className="text-[10px] text-muted-foreground">
+                disabled
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground">
+            {hooks?.preRunHydrate?.enabled && <span>hydrate</span>}
+            {hooks?.postRunCapture?.enabled && <span>capture</span>}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <ToggleSwitch
+            checked={binding.enabled}
+            onCheckedChange={(v) => toggleMutation.mutate(v)}
+          />
+          <Button variant="ghost" size="icon-sm" onClick={onEdit}>
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="text-destructive"
+            onClick={() => {
+              if (confirm("Delete this memory binding?")) deleteMutation.mutate();
+            }}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-border px-4 py-3">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Targets
+            </span>
+            <Button variant="ghost" size="sm" onClick={() => setShowAddTarget(!showAddTarget)}>
+              <Plus className="h-3 w-3 mr-1" /> Add
+            </Button>
+          </div>
+
+          {targets && targets.length === 0 && (
+            <p className="text-xs text-muted-foreground pl-4">No targets assigned</p>
+          )}
+          {targets?.map((t) => (
+            <TargetRow
+              key={t.id}
+              target={t}
+              agents={agents}
+              companyName={companyName}
+              onRemove={() => removeTargetMutation.mutate(t.id)}
+            />
+          ))}
+
+          {showAddTarget && (
+            <div className="flex items-center gap-2 mt-2 pl-4">
+              <select
+                className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+                value={addTargetType}
+                onChange={(e) => {
+                  setAddTargetType(e.target.value as "company" | "agent");
+                  setAddTargetId(e.target.value === "company" ? companyId : "");
+                }}
+              >
+                <option value="company">Company</option>
+                <option value="agent">Agent</option>
+              </select>
+              {addTargetType === "agent" ? (
+                <select
+                  className="rounded-md border border-border bg-background px-2 py-1 text-sm flex-1"
+                  value={addTargetId}
+                  onChange={(e) => setAddTargetId(e.target.value)}
+                >
+                  <option value="">Select agent...</option>
+                  {agents.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <span className="text-sm text-muted-foreground">{companyName} (all agents)</span>
+              )}
+              <Button
+                size="sm"
+                disabled={addTargetMutation.isPending || (!addTargetId && addTargetType === "agent")}
+                onClick={() =>
+                  addTargetMutation.mutate({
+                    targetType: addTargetType,
+                    targetId: addTargetType === "company" ? companyId : addTargetId,
+                  })
+                }
+              >
+                <Check className="h-3 w-3" />
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────
+
+export function MemorySettings() {
+  const { selectedCompany, selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editBinding, setEditBinding] = useState<MemoryBinding | null>(null);
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
+      { label: "Memory" },
+    ]);
+  }, [selectedCompany, setBreadcrumbs]);
+
+  const { data: bindings, isLoading } = useQuery({
+    queryKey: queryKeys.memory.bindings(selectedCompanyId!),
+    queryFn: () => memoryApi.listBindings(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const agentList = (agents ?? []).map((a: { id: string; name: string }) => ({
+    id: a.id,
+    name: a.name,
+  }));
+
+  if (!selectedCompanyId) return null;
+
+  return (
+    <div className="mx-auto max-w-3xl py-8 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Brain className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Memory Providers</h1>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => {
+            setEditBinding(null);
+            setDialogOpen(true);
+          }}
+        >
+          <Plus className="h-4 w-4 mr-1" /> New Binding
+        </Button>
+      </div>
+
+      <p className="text-sm text-muted-foreground mb-6">
+        Memory bindings connect provider backends (mempalace, PARA, etc.) to your company and
+        agents. Configure hooks to automatically hydrate agent context before runs and capture
+        outcomes after.
+      </p>
+
+      {isLoading && (
+        <p className="text-sm text-muted-foreground">Loading bindings...</p>
+      )}
+
+      {!isLoading && bindings?.length === 0 && (
+        <div className="rounded-lg border border-dashed border-border p-8 text-center">
+          <Brain className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+          <p className="text-sm text-muted-foreground">No memory bindings configured</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => {
+              setEditBinding(null);
+              setDialogOpen(true);
+            }}
+          >
+            Create first binding
+          </Button>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3">
+        {bindings?.map((b) => (
+          <BindingCard
+            key={b.id}
+            binding={b}
+            companyId={selectedCompanyId}
+            companyName={selectedCompany?.name ?? ""}
+            agents={agentList}
+            onEdit={() => {
+              setEditBinding(b);
+              setDialogOpen(true);
+            }}
+          />
+        ))}
+      </div>
+
+      <div className="mt-8 pt-6 border-t border-border">
+        <Link
+          to="/memory/operations"
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <Activity className="h-4 w-4" />
+          View operation log
+        </Link>
+      </div>
+
+      <BindingDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        companyId={selectedCompanyId}
+        existing={editBinding}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents accumulate knowledge across runs — issue outcomes, decision patterns, project context — but today this knowledge is lost between sessions
> - The memory landscape analysis (RED-31) identified that agents need a pluggable memory system with semantic recall, not just raw transcript replay
> - So we need a memory adapter framework that lets different providers (vector stores, knowledge graphs, file-based) plug in with a common interface
> - This pull request adds the full memory adapter framework with mempalace (ChromaDB-backed MCP server) as the first semantic memory provider, alongside a PARA file-based adapter as a zero-config baseline
> - Pre-run hydration queries memory and injects relevant context into agent prompts; post-run capture writes run outcomes back to memory
> - The benefit is agents build institutional memory over time — reducing repeated mistakes, enabling cross-issue learning, and laying the groundwork for heartbeat context compression (estimated ~80% token reduction on comment thread replay)

## What Changed

- **Memory Adapter interface** (`packages/plugins/sdk/src/types.ts`): `MemoryAdapter` with `write()`, `query()`, `get()`, `forget()` operations, `MemoryScope` for entity-scoped isolation, `MemoryContextBundle` for query results, and `MemoryAdapterCapabilities` for feature negotiation
- **Mempalace adapter** (`server/src/services/memory-adapters/mempalace.ts`): MCP-based adapter supporting both stdio (local sidecar) and Streamable HTTP (Docker/Podman) transports, with auto-reconnect on connection failure
- **Mempalace sidecar** (`server/src/services/memory-adapters/mempalace-sidecar.ts`): lifecycle manager with health checking via MCP ping, crash detection, and exponential backoff restart
- **PARA adapter** (`server/src/services/memory-adapters/para.ts`): file-based adapter using Tiago Forte's PARA method with optional `qmd` semantic search, zero external dependencies
- **Memory hooks** (`server/src/services/memory-hooks.ts`): binding-driven hook system — `preRunHydrate` queries all applicable bindings and returns combined snippets; `postRunCapture` writes run summaries after completion
- **Memory operations service** (`server/src/services/memory-operations.ts`): adapter registry + write/query/forget operations with full audit trail in `memory_operations` table
- **Memory bindings service** (`server/src/services/memory-bindings.ts`): company-scoped binding CRUD with target assignment (company-wide or per-agent)
- **Heartbeat integration** (`server/src/services/heartbeat.ts`): pre-run hydration injects memory snippets into `<memory-context>` tags via `paperclipSessionHandoffMarkdown`; post-run capture writes outcomes; both log to run transcripts via `onLog()`
- **API routes** (`server/src/routes/memory-bindings.ts`, `memory-operations.ts`): full REST API for binding management, target assignment, and memory write/query/forget operations with cross-company scope validation
- **Database schema** (`packages/db/src/schema/`): three new tables — `memory_bindings`, `memory_binding_targets`, `memory_operations` — with proper indexes, FKs, and unique constraints
- **Validators** (`packages/shared/src/validators/memory-binding.ts`): Zod schemas for all memory API payloads
- **UI** (`ui/src/pages/MemorySettings.tsx`, `MemoryOperations.tsx`): settings page for binding management with hook configuration, and an operation audit log with filtering/pagination
- **Docker** (`docker/mempalace/`): container for running mempalace as a Streamable HTTP MCP server, with gosu-based UID/GID remapping matching the main Paperclip Dockerfile pattern
- **Backfill script** (`server/scripts/backfill-mempalace.ts`): CLI tool to replay historical runs into mempalace with checkpoint-based idempotency
- **Tests**: 5 test suites — mempalace adapter, sidecar lifecycle, memory hooks, PARA adapter, integration tests (~2k lines)
- **Documentation** (`doc/MEMPALACE.md`): architecture guide, setup instructions, troubleshooting

## Verification

**Automated tests:**
```bash
pnpm -C server exec vitest run -- memory
pnpm -C server exec vitest run -- mempalace
pnpm -C server exec vitest run -- para
```

**Type checking:**
```bash
pnpm -C server exec tsc --noEmit
```

**Manual verification (requires mempalace Python package):**
1. Set `MEMPALACE_ENABLED=true` or `MEMPALACE_URL=http://localhost:8080/mcp` in env
2. Create a memory binding in the UI (Settings → Memory → New Binding, provider key: `mempalace`)
3. Assign a target (company-wide or specific agent)
4. Run an agent heartbeat — check transcripts for `[paperclip:memory] pre-run hydration` and `post-run capture` log lines
5. Check the Memory Operations page for audit trail entries

**Docker verification:**
```bash
cd docker/mempalace
docker build -t mempalace-test .
docker run -e USER_UID=$(id -u) -e USER_GID=$(id -g) -v /tmp/mempalace-test:/data/mempalace mempalace-test
# Health check: curl http://localhost:8080/health
```

## Risks

- **Medium: New external dependency** — mempalace is a Python package running as a sidecar/container. Failure is isolated: if mempalace is unavailable, hooks log warnings and continue without memory context. No impact on core heartbeat execution.
- **Low: Schema migration** — Adds 3 new tables with no modifications to existing tables. Migration is additive and safe to roll back (drop tables).
- **Low: Token budget** — Pre-run hydration adds memory snippets to agent context. Capped by `topK` (default: 5 snippets) and binding configuration. Operators control this via hook settings.
- **None: Breaking changes** — All new code paths. Memory hooks only fire when bindings exist and have targets assigned. Zero impact on instances without memory configuration.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Opus 4.6 (`claude-opus-4-6`)
- **Context window:** 200K tokens
- **Capabilities:** Extended thinking, tool use (file read/write/edit, bash, grep, glob), multi-agent orchestration via Claude Code Agent SDK
- **Usage:** Full implementation including architecture design, adapter framework, MCP integration, Docker setup, tests, and iterative code review with fix application

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

> **Note on screenshots:** The UI changes add two new pages (Memory Settings and Memory Operations) accessible from the sidebar. Screenshots will be provided in follow-up comments once the PR is open and reviewable.

## Screenshots

### Sidebar menu before / after (memory link added)
<img width="336" height="370" alt="menu-before" src="https://github.com/user-attachments/assets/d5cdd4b0-2a5c-45b5-bc08-3162fddff6fd" />
<img width="311" height="397" alt="menu-after" src="https://github.com/user-attachments/assets/a0a19dc0-5cd1-4240-9083-0ab3cea4d9e7" />

### Adding a provider
<img width="1372" height="752" alt="mem-provider1" src="https://github.com/user-attachments/assets/cb14a26b-75e0-4c7f-b297-e7a5a5275ba9" />
<img width="746" height="717" alt="mem-dialog" src="https://github.com/user-attachments/assets/0533fbd1-c72b-4e6d-8425-aff5e7e78634" />
<img width="1415" height="597" alt="mem-provider2" src="https://github.com/user-attachments/assets/7700a334-ca3b-4eeb-bb8a-235c9862297a" />

### Operations log
<img width="1340" height="444" alt="mem-ops-log" src="https://github.com/user-attachments/assets/7186dc3a-61b5-41aa-8338-b39e2e1ca7fb" />
