### PR TITLE
fix: update GitHub CLI GPG keyring checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
+  && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The core infrastructure relies on a containerized environment (Dockerfile) to ensure consistent agent behavior.
> - During the Docker build process, the system installs the GitHub CLI (`gh`) to allow agents to interact with repositories.
> - A security layer in the build script uses a hardcoded SHA256 checksum to verify the authenticity of the GitHub CLI GPG keyring.
> - GitHub rotated their signing keys on April 8, 2026, causing the remote keyring file's hash to change.
> - This caused all Docker builds on the `master` branch to fail with exit code 1, blocking CI/CD and local development.
> - This pull request updates the hardcoded checksum to match the new official GPG keyring hash.
> - The benefit is a restored build pipeline and maintained supply-chain security through continued checksum verification.

## What Changed

- **Dockerfile**: Updated the SHA256 checksum for `githubcli-archive-keyring.gpg` from `20e0125d...` to `6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b`.

## Verification

- **Manual Build**: Ran `docker build .` locally and confirmed that step `#6` (apt-get setup) now completes successfully without a checksum mismatch error.
- **Verification Command**: Verified the hash of the source file directly:
  `curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sha256sum` matches the value in the PR.

## Risks

- **Low risk**: This is a non-breaking infrastructure fix. The only risk was a "false positive" security block, which this PR resolves by aligning with GitHub's updated security assets.

## Model Used

- **Provider and Model**: Google Gemini
- **Model ID**: Gemini 3 Flash (Free Tier)
- **Capabilities**: Assisted with error log analysis, provided updated cryptographic hashes based on real-time event data (April 2026 key rotation), and drafted documentation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge