### PR TITLE
fix(ui): resync bundleDraft when bundle refetches

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1868,7 +1868,16 @@ function PromptsTab({
   useEffect(() => {
     if (!bundle) return;
     setBundleDraft((current) => {
-      if (current) return current;
+      // Preserve draft only if user has unsaved edits (draft differs from persisted state)
+      if (
+        current &&
+        (current.mode !== persistedMode ||
+         current.rootPath !== persistedRootPath ||
+         current.entryFile !== bundle.entryFile)
+      ) {
+        return current;
+      }
+      // Initialize or re-sync to latest persisted state
       return {
         mode: persistedMode,
         rootPath: persistedRootPath,


### PR DESCRIPTION
## Summary

The `bundleDraft` initialization effect in `AgentDetail.tsx` had an unconditional `if (current) return current` guard that prevented re-syncing to the latest persisted state after a bundle refetch. This caused stale `rootPath` values, making `bundleMatchesDraft` evaluate to `false` and disabling file content display (showing placeholder instead).

## Changes

- Replace the unconditional guard with a dirty-check: only preserve `bundleDraft` when the user has unsaved edits (draft differs from persisted values)
- When draft matches persisted state, re-sync to the latest values from the refetched bundle

## How to reproduce

1. Create an agent with instructions configured
2. Navigate to agent detail page
3. The instructions file content shows placeholder text instead of actual file content
4. After this fix, file content displays correctly after bundle refetches

Fixes #2068