### PR TITLE
fix(ui): reduce IssueDetail re-renders causing input lag on long issues

### DIFF
--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -34,6 +34,7 @@ export const issuesApi = {
       executionWorkspaceId?: string;
       originKind?: string;
       originId?: string;
+      parentId?: string;
       includeRoutineExecutions?: boolean;
       q?: string;
     },
@@ -51,6 +52,7 @@ export const issuesApi = {
     if (filters?.executionWorkspaceId) params.set("executionWorkspaceId", filters.executionWorkspaceId);
     if (filters?.originKind) params.set("originKind", filters.originKind);
     if (filters?.originId) params.set("originId", filters.originId);
+    if (filters?.parentId) params.set("parentId", filters.parentId);
     if (filters?.includeRoutineExecutions) params.set("includeRoutineExecutions", "true");
     if (filters?.q) params.set("q", filters.q);
     const qs = params.toString();

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -221,7 +221,7 @@ function CopyMarkdownButton({ text }: { text: string }) {
   );
 }
 
-function CommentCard({
+const CommentCard = memo(function CommentCard({
   comment,
   agentMap,
   companyId,
@@ -371,7 +371,7 @@ function CommentCard({
       ) : null}
     </div>
   );
-}
+});
 
 type TimelineItem =
   | { kind: "comment"; id: string; createdAtMs: number; comment: CommentWithRunMeta }

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useEffect, useId, useState, type ReactNode } from "react";
+import { isValidElement, memo, useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import Markdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "../lib/utils";
@@ -91,52 +91,55 @@ function MermaidDiagramBlock({ source, darkMode }: { source: string; darkMode: b
   );
 }
 
-export function MarkdownBody({ children, className, resolveImageSrc }: MarkdownBodyProps) {
+export const MarkdownBody = memo(function MarkdownBody({ children, className, resolveImageSrc }: MarkdownBodyProps) {
   const { theme } = useTheme();
-  const components: Components = {
-    pre: ({ node: _node, children: preChildren, ...preProps }) => {
-      const mermaidSource = extractMermaidSource(preChildren);
-      if (mermaidSource) {
-        return <MermaidDiagramBlock source={mermaidSource} darkMode={theme === "dark"} />;
-      }
-      return <pre {...preProps}>{preChildren}</pre>;
-    },
-    a: ({ href, children: linkChildren }) => {
-      const parsed = href ? parseMentionChipHref(href) : null;
-      if (parsed) {
-        const targetHref = parsed.kind === "project"
-          ? `/projects/${parsed.projectId}`
-          : parsed.kind === "skill"
-            ? `/skills/${parsed.skillId}`
-            : `/agents/${parsed.agentId}`;
+  const components: Components = useMemo(() => {
+    const result: Components = {
+      pre: ({ node: _node, children: preChildren, ...preProps }) => {
+        const mermaidSource = extractMermaidSource(preChildren);
+        if (mermaidSource) {
+          return <MermaidDiagramBlock source={mermaidSource} darkMode={theme === "dark"} />;
+        }
+        return <pre {...preProps}>{preChildren}</pre>;
+      },
+      a: ({ href, children: linkChildren }) => {
+        const parsed = href ? parseMentionChipHref(href) : null;
+        if (parsed) {
+          const targetHref = parsed.kind === "project"
+            ? `/projects/${parsed.projectId}`
+            : parsed.kind === "skill"
+              ? `/skills/${parsed.skillId}`
+              : `/agents/${parsed.agentId}`;
+          return (
+            <a
+              href={targetHref}
+              className={cn(
+                "paperclip-mention-chip",
+                `paperclip-mention-chip--${parsed.kind}`,
+                parsed.kind === "project" && "paperclip-project-mention-chip",
+              )}
+              data-mention-kind={parsed.kind}
+              style={mentionChipInlineStyle(parsed)}
+            >
+              {linkChildren}
+            </a>
+          );
+        }
         return (
-          <a
-            href={targetHref}
-            className={cn(
-              "paperclip-mention-chip",
-              `paperclip-mention-chip--${parsed.kind}`,
-              parsed.kind === "project" && "paperclip-project-mention-chip",
-            )}
-            data-mention-kind={parsed.kind}
-            style={mentionChipInlineStyle(parsed)}
-          >
+          <a href={href} rel="noreferrer">
             {linkChildren}
           </a>
         );
-      }
-      return (
-        <a href={href} rel="noreferrer">
-          {linkChildren}
-        </a>
-      );
-    },
-  };
-  if (resolveImageSrc) {
-    components.img = ({ node: _node, src, alt, ...imgProps }) => {
-      const resolved = src ? resolveImageSrc(src) : null;
-      return <img {...imgProps} src={resolved ?? src} alt={alt ?? ""} />;
+      },
     };
-  }
+    if (resolveImageSrc) {
+      result.img = ({ node: _node, src, alt, ...imgProps }) => {
+        const resolved = src ? resolveImageSrc(src) : null;
+        return <img {...imgProps} src={resolved ?? src} alt={alt ?? ""} />;
+      };
+    }
+    return result;
+  }, [theme, resolveImageSrc]);
 
   return (
     <div
@@ -151,4 +154,4 @@ export function MarkdownBody({ children, className, resolveImageSrc }: MarkdownB
       </Markdown>
     </div>
   );
-}
+});

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -52,6 +52,7 @@ export const queryKeys = {
     approvals: (issueId: string) => ["issues", "approvals", issueId] as const,
     liveRuns: (issueId: string) => ["issues", "live-runs", issueId] as const,
     activeRun: (issueId: string) => ["issues", "active-run", issueId] as const,
+    children: (companyId: string, parentId: string) => ["issues", companyId, "children", parentId] as const,
     workProducts: (issueId: string) => ["issues", "work-products", issueId] as const,
   },
   routines: {

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -389,10 +389,10 @@ export function IssueDetail() {
     return (linkedRuns ?? []).filter((r) => !liveIds.has(r.runId));
   }, [linkedRuns, liveRuns, activeRun]);
 
-  const { data: allIssues } = useQuery({
-    queryKey: queryKeys.issues.list(selectedCompanyId!),
-    queryFn: () => issuesApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId,
+  const { data: childIssues } = useQuery({
+    queryKey: queryKeys.issues.children(selectedCompanyId!, issue?.id ?? ""),
+    queryFn: () => issuesApi.list(selectedCompanyId!, { parentId: issue!.id }),
+    enabled: !!selectedCompanyId && !!issue?.id,
   });
 
   const { data: agents } = useQuery({
@@ -478,12 +478,10 @@ export function IssueDetail() {
     return options;
   }, [agents, orderedProjects]);
 
-  const childIssues = useMemo(() => {
-    if (!allIssues || !issue) return [];
-    return allIssues
-      .filter((i) => i.parentId === issue.id)
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-  }, [allIssues, issue]);
+  const sortedChildIssues = useMemo(() => {
+    if (!childIssues) return [];
+    return [...childIssues].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  }, [childIssues]);
 
   const commentReassignOptions = useMemo(() => {
     const options: Array<{ id: string; label: string; searchText?: string }> = [];
@@ -519,8 +517,12 @@ export function IssueDetail() {
     [comments, optimisticComments],
   );
 
+  // Stabilize polling-derived values so commentsWithRunMeta doesn't recompute every 3s
+  const runningRunId = runningIssueRun?.id ?? null;
+  const runningRunStartedAt = runningIssueRun?.startedAt ?? runningIssueRun?.createdAt ?? null;
+
   const commentsWithRunMeta = useMemo<IssueDetailComment[]>(() => {
-    const activeRunStartedAt = runningIssueRun?.startedAt ?? runningIssueRun?.createdAt ?? null;
+    const activeRunStartedAt = runningRunStartedAt;
     const runMetaByCommentId = new Map<string, { runId: string; runAgentId: string | null; interruptedRunId: string | null }>();
     const agentIdByRunId = new Map<string, string>();
     for (const run of linkedRuns ?? []) {
@@ -541,24 +543,23 @@ export function IssueDetail() {
     }
     return threadComments.map((comment) => {
       const meta = runMetaByCommentId.get(comment.id);
-      const nextComment: IssueDetailComment = meta ? { ...comment, ...meta } : { ...comment };
-      if (
-        isQueuedIssueComment({
-          comment: nextComment,
-          activeRunStartedAt,
-          runId: meta?.runId ?? nextComment.runId ?? null,
-          interruptedRunId: meta?.interruptedRunId ?? nextComment.interruptedRunId ?? null,
-        })
-      ) {
+      const nextComment: IssueDetailComment = meta ? { ...comment, ...meta } : comment;
+      const shouldQueue = isQueuedIssueComment({
+        comment: nextComment,
+        activeRunStartedAt,
+        runId: meta?.runId ?? nextComment.runId ?? null,
+        interruptedRunId: meta?.interruptedRunId ?? nextComment.interruptedRunId ?? null,
+      });
+      if (shouldQueue) {
         return {
           ...nextComment,
           queueState: "queued" as const,
-          queueTargetRunId: runningIssueRun?.id ?? nextComment.queueTargetRunId ?? null,
+          queueTargetRunId: runningRunId ?? nextComment.queueTargetRunId ?? null,
         };
       }
       return nextComment;
     });
-  }, [activity, threadComments, linkedRuns, runningIssueRun]);
+  }, [activity, threadComments, linkedRuns, runningRunId, runningRunStartedAt]);
 
   const queuedComments = useMemo(
     () => commentsWithRunMeta.filter((comment) => comment.queueState === "queued"),
@@ -1566,11 +1567,11 @@ export function IssueDetail() {
         </TabsContent>
 
         <TabsContent value="subissues">
-          {childIssues.length === 0 ? (
+          {sortedChildIssues.length === 0 ? (
             <p className="text-xs text-muted-foreground">No sub-issues.</p>
           ) : (
             <div className="border border-border rounded-lg divide-y divide-border">
-              {childIssues.map((child) => (
+              {sortedChildIssues.map((child) => (
                 <Link
                   key={child.id}
                   to={createIssueDetailPath(child.identifier ?? child.id, location.state, location.search)}


### PR DESCRIPTION
## Summary

Fixes typing lag / input freezing on long issue detail pages (e.g. issues with many comments and active runs). The root cause is cascading re-renders triggered by 3-second polling that force every `CommentCard` to re-parse markdown via `react-markdown`.

- **Memoize `CommentCard` and `MarkdownBody`** — prevents re-running expensive markdown parsing when the comment content hasn't changed. This is the biggest single win.
- **Stabilize `commentsWithRunMeta` dependencies** — extract primitive values (`runningRunId`, `runningRunStartedAt`) instead of depending on the full `runningIssueRun` object reference, which changes every 3s due to polling. Also preserve original comment references when no run metadata applies, avoiding unnecessary object spreads.
- **Replace `allIssues` query with targeted child issues query** — the old code loaded *every issue in the company* just to filter for child issues. Now uses the server's existing `parentId` filter parameter.
- **Add `parentId` filter to `issuesApi.list` client** and corresponding `queryKeys.issues.children` cache key.

Relates to #958

## Test plan

- [ ] Open a long issue (30+ comments) with an active agent run — typing in the comment box should be responsive
- [ ] Verify sub-issues tab still shows child issues correctly
- [ ] Verify queued comments still display the "Queued" badge
- [ ] All 194 existing UI tests pass (`npx vitest run ui/src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)