### PR TITLE
fix: strip paperclip payload from agent params

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -54,6 +54,7 @@ The agent request is built as:
 - optional additions:
   - all `payloadTemplate` fields merged in
   - `agentId` from config if set and not already in template
+  - `payloadTemplate.paperclip` is always stripped before sending because OpenClaw rejects that top-level field
 
 ## Timeouts
 

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -42,11 +42,10 @@ Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
-Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+Standard outbound payload behavior:
+- Paperclip does not send a top-level paperclip object in gateway agent params.
+- Paperclip embeds wake context in the message field and exports PAPERCLIP_* env hints there.
+- Any payloadTemplate.paperclip field is stripped before the gateway request is sent.
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -458,63 +458,6 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
   ].filter((entry) => entry.trim().length > 0);
   return sections.join("\n");
 }
-
-function buildStandardPaperclipPayload(
-  ctx: AdapterExecutionContext,
-  wakePayload: WakePayload,
-  paperclipEnv: Record<string, string>,
-  payloadTemplate: Record<string, unknown>,
-): Record<string, unknown> {
-  const templatePaperclip = parseObject(payloadTemplate.paperclip);
-  const workspace = asRecord(ctx.context.paperclipWorkspace);
-  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
-    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
-    : [];
-  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
-  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
-    ? ctx.context.paperclipRuntimeServiceIntents.filter(
-        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
-      )
-    : [];
-
-  const standardPaperclip: Record<string, unknown> = {
-    runId: ctx.runId,
-    companyId: ctx.agent.companyId,
-    agentId: ctx.agent.id,
-    agentName: ctx.agent.name,
-    taskId: wakePayload.taskId,
-    issueId: wakePayload.issueId,
-    issueIds: wakePayload.issueIds,
-    wakeReason: wakePayload.wakeReason,
-    wakeCommentId: wakePayload.wakeCommentId,
-    approvalId: wakePayload.approvalId,
-    approvalStatus: wakePayload.approvalStatus,
-    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
-  };
-  const structuredWake = parseObject(ctx.context.paperclipWake);
-  if (Object.keys(structuredWake).length > 0) {
-    standardPaperclip.wake = structuredWake;
-  }
-
-  if (workspace) {
-    standardPaperclip.workspace = workspace;
-  }
-  if (workspaces.length > 0) {
-    standardPaperclip.workspaces = workspaces;
-  }
-  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
-    standardPaperclip.workspaceRuntime = {
-      ...configuredWorkspaceRuntime,
-      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
-    };
-  }
-
-  return {
-    ...templatePaperclip,
-    ...standardPaperclip,
-  };
-}
-
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1123,8 +1066,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
-
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
     message,
@@ -1132,7 +1073,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -448,6 +448,62 @@ function appendWakeText(baseText: string, wakeText: string): string {
   return trimmedBase.length > 0 ? `${trimmedBase}\n\n${wakeText}` : wakeText;
 }
 
+function buildStandardPaperclipPayload(
+  ctx: AdapterExecutionContext,
+  wakePayload: WakePayload,
+  paperclipEnv: Record<string, string>,
+  payloadTemplate: Record<string, unknown>,
+): Record<string, unknown> {
+  const templatePaperclip = parseObject(payloadTemplate.paperclip);
+  const workspace = asRecord(ctx.context.paperclipWorkspace);
+  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
+    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
+    : [];
+  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
+  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
+    ? ctx.context.paperclipRuntimeServiceIntents.filter(
+        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
+      )
+    : [];
+
+  const standardPaperclip: Record<string, unknown> = {
+    runId: ctx.runId,
+    companyId: ctx.agent.companyId,
+    agentId: ctx.agent.id,
+    agentName: ctx.agent.name,
+    taskId: wakePayload.taskId,
+    issueId: wakePayload.issueId,
+    issueIds: wakePayload.issueIds,
+    wakeReason: wakePayload.wakeReason,
+    wakeCommentId: wakePayload.wakeCommentId,
+    approvalId: wakePayload.approvalId,
+    approvalStatus: wakePayload.approvalStatus,
+    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
+  };
+  const structuredWake = parseObject(ctx.context.paperclipWake);
+  if (Object.keys(structuredWake).length > 0) {
+    standardPaperclip.wake = structuredWake;
+  }
+
+  if (workspace) {
+    standardPaperclip.workspace = workspace;
+  }
+  if (workspaces.length > 0) {
+    standardPaperclip.workspaces = workspaces;
+  }
+  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
+    standardPaperclip.workspaceRuntime = {
+      ...configuredWorkspaceRuntime,
+      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
+    };
+  }
+
+  return {
+    ...templatePaperclip,
+    ...standardPaperclip,
+  };
+}
+
 function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJson: string): string {
   const sections = [
     structuredWakePrompt.trim(),
@@ -457,6 +513,15 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
     "```",
   ].filter((entry) => entry.trim().length > 0);
   return sections.join("\n");
+}
+
+function joinPaperclipContextSection(paperclipContext: Record<string, unknown>): string {
+  return [
+    "Paperclip context JSON:",
+    "```json",
+    JSON.stringify(paperclipContext, null, 2),
+    "```",
+  ].join("\n");
 }
 function normalizeUrl(input: string): URL | null {
   try {
@@ -1044,14 +1109,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
+  const paperclipContext = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
   const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
   const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
   const wakeText = buildWakeText(
     wakePayload,
     paperclipEnv,
-    structuredWakeJson
-      ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
-      : structuredWakePrompt,
+    [
+      structuredWakeJson
+        ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
+        : structuredWakePrompt,
+      joinPaperclipContextSection(paperclipContext),
+    ]
+      .filter((entry) => entry.trim().length > 0)
+      .join("\n\n"),
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -414,15 +414,11 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [comment2.id, comment3.id],
-          latestCommentId: comment3.id,
-        },
-      });
       expect(String(secondPayload.message ?? "")).toContain("Second comment");
       expect(String(secondPayload.message ?? "")).toContain("Third comment");
       expect(String(secondPayload.message ?? "")).not.toContain("First comment");
+      expect(String(secondPayload.message ?? "")).toContain(`"commentIds":["${comment2.id}","${comment3.id}"]`);
+      expect(String(secondPayload.message ?? "")).toContain(`"latestCommentId":"${comment3.id}"`);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -594,21 +590,12 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-        },
-      });
       expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
+      expect(String(secondPayload.message ?? "")).toContain('"reason":"issue_commented"');
+      expect(String(secondPayload.message ?? "")).toContain(`"commentIds":["${comment2.id}"]`);
+      expect(String(secondPayload.message ?? "")).toContain(`"latestCommentId":"${comment2.id}"`);
+      expect(String(secondPayload.message ?? "")).toContain(`"id":"${issueId}"`);
+      expect(String(secondPayload.message ?? "")).toContain(`"identifier":"${issuePrefix}-1"`);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -680,20 +667,6 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_assigned",
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Require a comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-          checkedOutByHarness: true,
-          commentIds: [],
-        },
-      });
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");
       expect(String(firstPayload.message ?? "")).toContain("- checkout: already claimed by the harness for this run");
@@ -715,6 +688,10 @@ describe("heartbeat comment wake batching", () => {
         checkoutRunId: firstRun?.id,
         executionRunId: firstRun?.id,
       });
+      expect(String(firstPayload.message ?? "")).toContain('"reason":"issue_assigned"');
+      expect(String(firstPayload.message ?? "")).toContain(`"id":"${issueId}"`);
+      expect(String(firstPayload.message ?? "")).toContain(`"identifier":"${issuePrefix}-1"`);
+      expect(String(firstPayload.message ?? "")).toContain('"commentIds":[]');
       gateway.releaseFirstWait();
       await waitFor(async () => {
         const runs = await db

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -494,6 +494,10 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
       expect(String(payload?.message ?? "")).toContain("## Paperclip Wake Payload");
+      expect(String(payload?.message ?? "")).toContain("Paperclip context JSON:");
+      expect(String(payload?.message ?? "")).toContain('"agentName": "OpenClaw Gateway Agent"');
+      expect(String(payload?.message ?? "")).toContain('"cwd": "/tmp/worktrees/pap-123"');
+      expect(String(payload?.message ?? "")).toContain('"name": "preview"');
       expect(String(payload?.message ?? "")).toContain(
         "Treat this wake payload as the highest-priority change for the current heartbeat.",
       );
@@ -571,6 +575,11 @@ describe("openclaw gateway adapter execute", () => {
       const payload = gateway.getAgentPayload();
       expect(payload).toBeTruthy();
       expect(payload).not.toHaveProperty("paperclip");
+      expect(String(payload?.message ?? "")).toContain("Paperclip context JSON:");
+      expect(String(payload?.message ?? "")).toContain('"agentName": "OpenClaw Gateway Agent"');
+      expect(String(payload?.message ?? "")).toContain('"apiUrl": "http://localhost:3100"');
+      expect(String(payload?.message ?? "")).toContain('"workspace": {');
+      expect(String(payload?.message ?? "")).toContain('"/tmp/persisted-workspace"');
       expect(String(payload?.message ?? "")).toContain('"latestCommentId":"comment-123"');
     } finally {
       await gateway.close();

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -515,6 +515,36 @@ describe("openclaw gateway adapter execute", () => {
     }
   });
 
+  it("strips payloadTemplate.paperclip before sending agent params", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+            paperclip: {
+              injected: true,
+            },
+          },
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(payload).not.toHaveProperty("paperclip");
+    } finally {
+      await gateway.close();
+    }
+  });
+
   it("fails fast when url is missing", async () => {
     const result = await execute(buildContext({}));
     expect(result.exitCode).toBe(1);

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -502,12 +502,7 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      expect(String(payload?.message ?? "")).toContain("\"latestCommentId\":\"comment-2\"");
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -510,24 +510,60 @@ describe("openclaw gateway adapter execute", () => {
     }
   });
 
-  it("strips payloadTemplate.paperclip before sending agent params", async () => {
+  it("strips a persisted legacy payloadTemplate.paperclip fixture before sending agent params", async () => {
     const gateway = await createMockGatewayServer();
 
     try {
       const result = await execute(
-        buildContext({
-          url: gateway.url,
-          headers: {
-            "x-openclaw-token": "gateway-token",
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            payloadTemplate: {
+              message: "wake now",
+              paperclip: {
+                runId: "persisted-run-id",
+                companyId: "persisted-company-id",
+                agentId: "persisted-agent-id",
+                agentName: "Persisted OpenClaw Agent",
+                taskId: "persisted-task-id",
+                issueId: "persisted-issue-id",
+                issueIds: ["persisted-issue-id"],
+                wakeReason: "missing_issue_comment",
+                wakeCommentId: "persisted-comment-id",
+                approvalId: null,
+                approvalStatus: null,
+                apiUrl: "https://paperclip.example",
+                wake: {
+                  reason: "issue_commented",
+                  latestCommentId: "persisted-comment-id",
+                  commentIds: ["persisted-comment-id"],
+                },
+                workspace: {
+                  cwd: "/tmp/persisted-workspace",
+                  strategy: "git_worktree",
+                },
+              },
+            },
+            waitTimeoutMs: 2000,
           },
-          payloadTemplate: {
-            message: "wake now",
-            paperclip: {
-              injected: true,
+          {
+            context: {
+              taskId: "task-123",
+              issueId: "issue-123",
+              wakeReason: "issue_commented",
+              wakeCommentId: "comment-123",
+              issueIds: ["issue-123"],
+              paperclipWake: {
+                reason: "issue_commented",
+                latestCommentId: "comment-123",
+                commentIds: ["comment-123"],
+              },
             },
           },
-          waitTimeoutMs: 2000,
-        }),
+        ),
       );
 
       expect(result.exitCode).toBe(0);
@@ -535,6 +571,7 @@ describe("openclaw gateway adapter execute", () => {
       const payload = gateway.getAgentPayload();
       expect(payload).toBeTruthy();
       expect(payload).not.toHaveProperty("paperclip");
+      expect(String(payload?.message ?? "")).toContain('"latestCommentId":"comment-123"');
     } finally {
       await gateway.close();
     }


### PR DESCRIPTION
Submitted by Codex on behalf of @jodok.

Addresses #617, #3089, and #3208.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The `openclaw_gateway` adapter is the control-plane bridge that turns Paperclip heartbeat runs into OpenClaw gateway `agent` requests.
> - OpenClaw validates `agent` params strictly and rejects unknown root-level fields.
> - Legacy and persisted `payloadTemplate.paperclip` data can still reintroduce that rejected root field into outbound requests.
> - At the same time, the Paperclip wake payload and execution context are still useful to the OpenClaw agent and should keep flowing through an accepted transport field.
> - This pull request fixes the schema error by stripping the root-level `paperclip` field while preserving the Paperclip context inside the generated `message` payload.
> - The benefit is that OpenClaw runs no longer fail on `unexpected property 'paperclip'`, without losing the run, issue, wake, workspace, and runtime context that the agent uses to act.

## What Changed

- Strip `agentParams.paperclip` unconditionally before sending the OpenClaw gateway `agent` request.
- Rebuild the standard Paperclip context payload and append it to the generated `message` as JSON, so the accepted transport still carries run, issue, wake, workspace, and runtime context.
- Preserve current live execution values when they conflict with stale persisted `payloadTemplate.paperclip` config, while still carrying legacy-only fields forward in the message context.
- Update the regression tests to assert both behaviors together: the root `paperclip` field is absent and the Paperclip context remains present in `message`.

## Verification

- `pnpm --filter @paperclipai/adapter-openclaw-gateway build`
- `pnpm test:run server/src/__tests__/openclaw-gateway-adapter.test.ts`

## Risks

- Low risk. This change remains scoped to the OpenClaw gateway adapter request shape.
- The main behavioral shift is that OpenClaw now receives Paperclip context only through `message`, not as a root-level structured `paperclip` param.
- Because the message now intentionally carries richer JSON context again, the practical risk is message-size growth if future wake/context payloads become significantly larger.

## Model Used

- OpenAI Codex desktop agent
- GPT-5 family coding model with tool use, shell execution, git operations, and repository editing in Codex
- Reasoning mode: default Codex reasoning for multi-step code changes, rebases, and PR prep
- Context source: local checkout plus GitHub CLI issue/PR inspection

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
