### PR TITLE
fix(server): skip post-run summary comment when agent already posted

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3347,9 +3347,12 @@ export function heartbeatService(db: Db) {
         });
         if (issueId && outcome === "succeeded") {
           try {
-            const issueComment = buildHeartbeatRunIssueComment(adapterResult.resultJson ?? null);
-            if (issueComment) {
-              await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: finalizedRun.id });
+            const existingComment = await findRunIssueComment(finalizedRun.id, agent.companyId, issueId);
+            if (!existingComment) {
+              const issueComment = buildHeartbeatRunIssueComment(adapterResult.resultJson ?? null);
+              if (issueComment) {
+                await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: finalizedRun.id });
+              }
             }
           } catch (err) {
             await onLog(


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents communicate progress by posting comments on issues
> - The heartbeat system finalizes runs and posts a summary comment from `resultJson.result` or `.summary` after every successful run
> - But adapters like `claude_local` produce agents (Claude Code) that post their own comments during the run via the Paperclip API
> - This results in duplicate comments on every issue — one from the agent mid-run, one from the heartbeat post-run summary
> - The `findRunIssueComment` helper already exists (used by `finalizeIssueCommentPolicy`) to check if an agent commented during a run
> - This PR checks for an existing run comment before posting the summary, skipping it if the agent already commented
> - The benefit is eliminating duplicate comments for all adapters whose agents post their own comments

## What Changed

- **heartbeat.ts**: Before posting the post-run summary comment, call `findRunIssueComment()` to check if the agent already posted a comment for this run. If a comment exists, skip the summary. The check uses the same query already used by `finalizeIssueCommentPolicy`.

## Verification

- Existing heartbeat-run-summary tests pass
- Manual: trigger a claude_local agent run on an issue — only one comment should appear instead of two
- Agents that do NOT post their own comments (e.g. generic process adapters) will still get the summary comment as before

## Risks

Low risk. The only behavioral change is suppressing a redundant comment. The `findRunIssueComment` query is already battle-tested in `finalizeIssueCommentPolicy`. Agents that don't post their own comments are unaffected — the summary still posts when no existing comment is found.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.6 (`claude-opus-4-6`)
- Context window: 1M tokens
- Capabilities: Tool use (file read/edit, grep, bash)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)