### PR TITLE
fix(ui): resync bundleDraft when bundle refetches

### DIFF
--- a/ui/src/lib/bundle-draft.test.ts
+++ b/ui/src/lib/bundle-draft.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveBundleDraft, type BundleDraft } from "./bundle-draft";
+
+const persisted: BundleDraft = {
+  mode: "managed",
+  rootPath: "/agents/cto/instructions",
+  entryFile: "AGENTS.md",
+};
+
+describe("resolveBundleDraft", () => {
+  it("initializes from persisted state when current is null", () => {
+    const result = resolveBundleDraft(null, persisted);
+    expect(result).toEqual(persisted);
+  });
+
+  it("re-syncs when draft matches persisted state (no unsaved edits)", () => {
+    // Draft matches what was persisted — user didn't edit anything
+    const current: BundleDraft = { ...persisted };
+    const result = resolveBundleDraft(current, persisted);
+    expect(result).toEqual(persisted);
+    expect(result).not.toBe(current); // new object, not stale reference
+  });
+
+  it("preserves draft when user changed mode", () => {
+    const current: BundleDraft = { ...persisted, mode: "external" };
+    const result = resolveBundleDraft(current, persisted);
+    expect(result).toBe(current);
+  });
+
+  it("preserves draft when user changed rootPath", () => {
+    const current: BundleDraft = { ...persisted, rootPath: "/custom/path" };
+    const result = resolveBundleDraft(current, persisted);
+    expect(result).toBe(current);
+  });
+
+  it("preserves draft when user changed entryFile", () => {
+    const current: BundleDraft = { ...persisted, entryFile: "CUSTOM.md" };
+    const result = resolveBundleDraft(current, persisted);
+    expect(result).toBe(current);
+  });
+
+  it("re-syncs when all draft fields match persisted", () => {
+    const current: BundleDraft = {
+      mode: "managed",
+      rootPath: "/agents/cto/instructions",
+      entryFile: "AGENTS.md",
+    };
+    const result = resolveBundleDraft(current, persisted);
+    expect(result).toEqual(persisted);
+    expect(result).not.toBe(current); // fresh object
+  });
+
+  it("returns a new object (not a reference to persisted)", () => {
+    const result = resolveBundleDraft(null, persisted);
+    expect(result).not.toBe(persisted);
+  });
+});

--- a/ui/src/lib/bundle-draft.ts
+++ b/ui/src/lib/bundle-draft.ts
@@ -1,0 +1,28 @@
+export interface BundleDraft {
+  mode: "managed" | "external";
+  rootPath: string;
+  entryFile: string;
+}
+
+/**
+ * Decide whether to keep the user's in-progress draft or re-sync to the
+ * latest persisted bundle state.
+ *
+ * Returns `current` when the user has unsaved edits (any field differs from
+ * persisted).  Otherwise returns a fresh draft from persisted values so the
+ * UI stays in sync after a bundle refetch.
+ */
+export function resolveBundleDraft(
+  current: BundleDraft | null,
+  persisted: BundleDraft,
+): BundleDraft {
+  if (
+    current &&
+    (current.mode !== persisted.mode ||
+      current.rootPath !== persisted.rootPath ||
+      current.entryFile !== persisted.entryFile)
+  ) {
+    return current;
+  }
+  return { ...persisted };
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1868,7 +1868,16 @@ function PromptsTab({
   useEffect(() => {
     if (!bundle) return;
     setBundleDraft((current) => {
-      if (current) return current;
+      // Preserve draft only if user has unsaved edits (draft differs from persisted state)
+      if (
+        current &&
+        (current.mode !== persistedMode ||
+         current.rootPath !== persistedRootPath ||
+         current.entryFile !== bundle.entryFile)
+      ) {
+        return current;
+      }
+      // Initialize or re-sync to latest persisted state
       return {
         mode: persistedMode,
         rootPath: persistedRootPath,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -92,6 +92,7 @@ import {
 } from "@paperclipai/shared";
 import { redactHomePathUserSegments, redactHomePathUserSegmentsInValue } from "@paperclipai/adapter-utils";
 import { agentRouteRef } from "../lib/utils";
+import { resolveBundleDraft } from "../lib/bundle-draft";
 import {
   applyAgentSkillSnapshot,
   arraysEqual,
@@ -1867,23 +1868,13 @@ function PromptsTab({
 
   useEffect(() => {
     if (!bundle) return;
-    setBundleDraft((current) => {
-      // Preserve draft only if user has unsaved edits (draft differs from persisted state)
-      if (
-        current &&
-        (current.mode !== persistedMode ||
-         current.rootPath !== persistedRootPath ||
-         current.entryFile !== bundle.entryFile)
-      ) {
-        return current;
-      }
-      // Initialize or re-sync to latest persisted state
-      return {
+    setBundleDraft((current) =>
+      resolveBundleDraft(current, {
         mode: persistedMode,
         rootPath: persistedRootPath,
         entryFile: bundle.entryFile,
-      };
-    });
+      }),
+    );
   }, [bundle, persistedMode, persistedRootPath]);
 
   useEffect(() => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each agent has an instructions bundle (mode, rootPath, entryFile) configurable via the UI's PromptsTab
> - The UI maintains a local `bundleDraft` state that reflects the persisted bundle config and allows unsaved edits
> - After a bundle refetch (e.g., from another tab saving, or initial load), the `useEffect` that initializes `bundleDraft` had an unconditional `if (current) return current` guard
> - This guard prevented re-syncing to the latest persisted state, causing stale `rootPath` values that made `bundleMatchesDraft` evaluate to `false`
> - When `bundleMatchesDraft` is false, `selectedFileExists` returns false, and the UI shows a placeholder instead of file content
> - This pull request replaces the unconditional guard with a dirty-check that only preserves the draft when the user has actual unsaved edits, and extracts this logic into a testable pure function

## What Changed

- **Extracted `resolveBundleDraft` helper** (`ui/src/lib/bundle-draft.ts`): Pure function that decides whether to keep the user's in-progress draft or re-sync to the latest persisted bundle state. Returns `current` only when the user has unsaved edits (any of mode/rootPath/entryFile differs from persisted).
- **Replaced inline guard** in `AgentDetail.tsx`: The `useEffect` at line ~1870 now calls `resolveBundleDraft` instead of the inline `if (current) return current` logic.
- **Added 7 unit tests** (`ui/src/lib/bundle-draft.test.ts`): Covers initialization, re-sync on matching state, preservation on each editable field, and object identity guarantees.

## Verification

```bash
# Run the new unit tests
pnpm exec vitest run ui/src/lib/bundle-draft.test.ts

# Typecheck the UI package
pnpm --filter @paperclipai/ui typecheck
```

Manual verification:
1. Open an agent's Prompts tab → file content displays correctly
2. Switch to another agent and back → content still displays (not placeholder)
3. Edit mode/rootPath/entryFile in the UI without saving → edits are preserved across bundle refetches
4. Save the bundle config → draft resyncs to new persisted values

## Risks

- **Low risk.** The behavioral change is narrow: the only difference from the previous code is that `bundleDraft` now resyncs when it matches persisted state, instead of unconditionally returning the stale draft. The extracted function is a pure refactor of the same logic with no side effects.
- **Complementary to #2283.** PR #2283 by @googlarz addresses a different aspect of the same issue (#2068): it treats the configured entry file as present even when bundle metadata omits it from `fileOptions`. Our fix addresses the upstream cause (stale `bundleDraft` preventing `bundleMatchesDraft` from being true). Both fixes are independent and complementary — #2283 handles the file-existence check, this PR handles the draft-resync logic.

## Model Used

- **Claude Opus 4.6** (`claude-opus-4-6`)
- Context window: 200K tokens
- Extended thinking enabled, tool use (file editing, terminal, search)
- Used via Claude Code CLI within Paperclip agent orchestration

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge