### PR TITLE
fix: inbox badge counts all issues instead of only unread ones

### DIFF
--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -319,6 +319,26 @@ describe("inbox helpers", () => {
     });
   });
 
+  it("excludes read issues from the badge mineIssues count", () => {
+    const result = computeInboxBadgeData({
+      approvals: [],
+      joinRequests: [],
+      dashboard: undefined,
+      heartbeatRuns: [],
+      mineIssues: [makeIssue("1", true), makeIssue("2", false), makeIssue("3", true)],
+      dismissed: new Set<string>(),
+    });
+
+    expect(result).toEqual({
+      inbox: 2,
+      approvals: 0,
+      failedRuns: 0,
+      joinRequests: 0,
+      mineIssues: 2,
+      alerts: 0,
+    });
+  });
+
   it("keeps read issues in the touched list but excludes them from unread counts", () => {
     const issues = [makeIssue("1", true), makeIssue("2", false)];
 

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -362,7 +362,7 @@ export function computeInboxBadgeData({
   const visibleJoinRequests = joinRequests.filter(
     (jr) => !dismissed.has(`join:${jr.id}`),
   ).length;
-  const visibleMineIssues = mineIssues.length;
+  const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;


### PR DESCRIPTION
## Summary
- The inbox badge was counting **all** touched issues (up to 100) regardless of read/unread state
- After clicking "Mark all as read", the badge would still show the total count (e.g. "100") instead of dropping to 0
- Fixed by filtering `mineIssues` by `isUnreadForMe` in `computeInboxBadgeData`

## Test plan
- [x] Added test: `excludes read issues from the badge mineIssues count`
- [x] All 21 existing inbox tests pass
- [ ] Verify in-app: mark all inbox issues as read → badge should reflect 0 unread issues